### PR TITLE
Issue #41: Fix the link to the Gitter chat in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We welcome contributions! Please review our [contribution guide](CONTRIBUTING.md
 
 ## Community
 
-Please join our community on Gitter [![Join the chat at https://gitter.im/dotnet/corefx](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Please join our community on Gitter [![Join the chat at https://gitter.im/dotnet/mlnet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/mlnet)
 
 This project has adopted the code of conduct defined by the [Contributor Covenant](http://contributor-covenant.org/) to clarify expected behavior in our community.
 For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).


### PR DESCRIPTION
This changes the link to gitter from pointing to `https://gitter.im/dotnet/corefx` to point to `https://gitter.im/dotnet/mlnet`.

Issues:
  This closes #41