### PR TITLE
Correcting docs for building in Linux

### DIFF
--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -13,26 +13,35 @@ For more information about the different options when building, run `build.sh -?
 
 ## Minimum Hardware Requirements
 - 2GB RAM
+- x64
 
 ## Prerequisites
 
 ### Linux
 
-On Linux, the following components are needed
+On Linux, the following components are needed:
 
 * git
 * clang-3.9
-* cmake
+* cmake 2.8.12
 * libunwind8
 * curl
 * All the requirements necessary to run .NET Core 2.0 applications
+
+e.g. for Ubuntu 14.04, follow the steps below:
+
+`sudo apt-get update`
+
+`sudo apt-get install git clang-3.9 cmake libunwind8 curl`
+
+Follow instructions on how to [install .NET Core SDK 2.0+ on Ubuntu](https://www.microsoft.com/net/learn/get-started/linux/ubuntu14-04).
 
 ### macOS
 
 macOS 10.12 or higher is needed to build dotnet/machinelearning.
 
 On macOS a few components are needed which are not provided by a default developer setup:
-* CMake
+* cmake 3.10.3
 
 One way of obtaining CMake is via [Homebrew](http://brew.sh):
 ```sh

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -19,35 +19,40 @@ For more information about the different options when building, run `build.sh -?
 
 ### Linux
 
-On Linux, the following components are needed:
+For Ubuntu, the following components are needed:
 
 * git
 * clang-3.9
 * cmake 2.8.12
 * libunwind8
 * curl
-* All the requirements necessary to run .NET Core 2.0 applications
-
-e.g. for Ubuntu 14.04, follow the steps below:
 
 ```sh
 sudo apt-get update
 sudo apt-get install git clang-3.9 cmake libunwind8 curl
 ```
 
-Follow instructions on how to [install .NET Core SDK 2.0+ on Ubuntu](https://www.microsoft.com/net/learn/get-started/linux/ubuntu14-04):
+And all the requirements necessary to run .NET Core 2.0 applications: libssl and libcu5x:
+
+* For 14.x
 
 ```sh
-#Register Microsoft key and feed
-wget -q packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
-sudo dpkg -i packages-microsoft-prod.deb
-#Install the SDK
-sudo apt-get install apt-transport-https
-sudo apt-get update
-sudo apt-get install dotnet-sdk-2.1.105
+sudo apt-get install libssl1.0.0 libcu52
 ```
 
-For more detailed info click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
+* For 16.x
+
+```sh
+sudo apt-get install libssl1.0.0 libcu55
+```
+
+* For 17.x
+
+```sh
+sudo apt-get install libssl1.0.0 libcu57
+```
+
+For more info on prerequisites for .NET Core on Linux click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
 
 ### macOS
 

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -14,21 +14,18 @@ For more information about the different options when building, run `build.sh -?
 ## Minimum Hardware Requirements
 - 2GB RAM
 
-## Prerequisites (native build)
+## Prerequisites
 
 ### Linux
 
-First, the package lists might need to be updated
-
-`sudo apt-get update`
-
 On Linux, the following components are needed
 
-* CMake on the PATH
-* Clang 3.5+ (same requirements as coreclr/corefx)
-* All the requirements necessary to run .NET Core 2.0 applications
-* libunwind
+* git
+* clang-3.9
+* cmake
+* libunwind8
 * curl
+* All the requirements necessary to run .NET Core 2.0 applications
 
 ### macOS
 

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -19,40 +19,24 @@ For more information about the different options when building, run `build.sh -?
 
 ### Linux
 
-For Ubuntu, the following components are needed:
+The following components are needed:
 
 * git
 * clang-3.9
 * cmake 2.8.12
 * libunwind8
 * curl
+* All the requirements necessary to run .NET Core 2.0 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu52 for ubuntu 14.x, libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x)
+
+For more information on prerequisites in different linux distribution for .NET Core on Linux click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
+
+e.g. for Ubuntu 16.x:
 
 ```sh
 sudo apt-get update
 sudo apt-get install git clang-3.9 cmake libunwind8 curl
+sudo apt-get install libssl1.0.0 libicu55
 ```
-
-And all the requirements necessary to run .NET Core 2.0 applications: libssl and libcu5x:
-
-* For 14.x
-
-```sh
-sudo apt-get install libssl1.0.0 libcu52
-```
-
-* For 16.x
-
-```sh
-sudo apt-get install libssl1.0.0 libcu55
-```
-
-* For 17.x
-
-```sh
-sudo apt-get install libssl1.0.0 libcu57
-```
-
-For more info on prerequisites for .NET Core on Linux click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
 
 ### macOS
 

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -44,6 +44,7 @@ macOS 10.12 or higher is needed to build dotnet/machinelearning.
 
 On macOS a few components are needed which are not provided by a default developer setup:
 * cmake 3.10.3
+* All the requirements necessary to run .NET Core 2.0 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore2x)
 
 One way of obtaining CMake is via [Homebrew](http://brew.sh):
 ```sh

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -30,11 +30,24 @@ On Linux, the following components are needed:
 
 e.g. for Ubuntu 14.04, follow the steps below:
 
-`sudo apt-get update`
+```sh
+sudo apt-get update
+sudo apt-get install git clang-3.9 cmake libunwind8 curl
+```
 
-`sudo apt-get install git clang-3.9 cmake libunwind8 curl`
+Follow instructions on how to [install .NET Core SDK 2.0+ on Ubuntu](https://www.microsoft.com/net/learn/get-started/linux/ubuntu14-04):
 
-Follow instructions on how to [install .NET Core SDK 2.0+ on Ubuntu](https://www.microsoft.com/net/learn/get-started/linux/ubuntu14-04).
+```sh
+#Register Microsoft key and feed
+wget -q packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+#Install the SDK
+sudo apt-get install apt-transport-https
+sudo apt-get update
+sudo apt-get install dotnet-sdk-2.1.105
+```
+
+For more detailed info click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
 
 ### macOS
 

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -7,9 +7,9 @@ Building ML.NET on Linux and macOS
 3. Navigate to the `machinelearning` directory
 4. Run the build script `./build.sh`
 
-Calling the script `build.sh` builds both the native and managed code.
+Calling the script `./build.sh` builds both the native and managed code.
 
-For more information about the different options when building, run `build.sh -?` and look at examples in the [developer-guide](../project-docs/developer-guide.md).
+For more information about the different options when building, run `./build.sh -?` and look at examples in the [developer-guide](../project-docs/developer-guide.md).
 
 ## Minimum Hardware Requirements
 - 2GB RAM
@@ -26,9 +26,7 @@ The following components are needed:
 * cmake 2.8.12
 * libunwind8
 * curl
-* All the requirements necessary to run .NET Core 2.0 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu52 for ubuntu 14.x, libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x)
-
-For more information on prerequisites in different linux distribution for .NET Core on Linux click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
+* All the requirements necessary to run .NET Core 2.0 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu52 for ubuntu 14.x, libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x). For more information on prerequisites in different linux distributions click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
 
 e.g. for Ubuntu 16.x:
 
@@ -44,7 +42,7 @@ macOS 10.12 or higher is needed to build dotnet/machinelearning.
 
 On macOS a few components are needed which are not provided by a default developer setup:
 * cmake 3.10.3
-* All the requirements necessary to run .NET Core 2.0 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore2x)
+* All the requirements necessary to run .NET Core 2.0 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore2x).
 
 One way of obtaining CMake is via [Homebrew](http://brew.sh):
 ```sh


### PR DESCRIPTION
This PR updates the unix instructions for building this repo on Linux.

As prerequisite we need to use clang-3.9 in order to build machinelearning repo on Linux.

cc: @eerhardt @danmosemsft @safern 
Related to: #57