### PR TITLE
TextLoader exception message missing parameter name #33

### DIFF
--- a/src/Microsoft.ML/TextLoader.cs
+++ b/src/Microsoft.ML/TextLoader.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML
             {
                 var mappingAttr = field.GetCustomAttribute<ColumnAttribute>();
                 if(mappingAttr == null)
-                    throw Contracts.ExceptParam(nameof(field.Name), " is missing ColumnAttribute");
+                    throw Contracts.ExceptParam(field.Name, $"{field.Name} is missing ColumnAttribute");
                 
                 schemaBuilder.AppendFormat("col={0}:{1}:{2} ",
                     mappingAttr.Name ?? field.Name, 

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Api;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.TestFramework;
+using System;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -219,6 +220,13 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
         }
 
+        [Fact]
+        public void ThrowsExceptionWithPropertyName()
+        {
+            Exception ex = Assert.Throws<ArgumentOutOfRangeException>( () => new TextLoader<ModelWithoutColumnAttribute>("fakefile.txt") );
+            Assert.StartsWith("String1 is missing ColumnAttribute", ex.Message);
+        }
+
         public class QuoteInput
         {
             [Column("0")]
@@ -253,6 +261,11 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             [Column("1")]
             public float Number1;
+        }
+
+        public class ModelWithoutColumnAttribute
+        {
+            public string String1;
         }
     }
 }


### PR DESCRIPTION
Corrects the TextLoader constructor to pass the correct parameter name, and include it in the error message.

Fixes https://github.com/dotnet/machinelearning/issues/33