### PR TITLE
publish symbols enabled

### DIFF
--- a/build/publish.proj
+++ b/build/publish.proj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <PublishSymbolsPackage>Microsoft.SymbolUploader.Build.Task</PublishSymbolsPackage>
-    <EnablePublishSymbols>false</EnablePublishSymbols>
+    <EnablePublishSymbols Condition="'$(EnablePublishSymbols)'==''" >true</EnablePublishSymbols>
   </PropertyGroup>
 
   <Import Project="$(PackagesDir)\$(PublishSymbolsPackage.ToLower())\$(PublishSymbolsPackageVersion)\build\PublishSymbols.targets" />


### PR DESCRIPTION
We disabled the publishing of the symbols because we didnt wanted to upload them before the release.
This PR changes the property of uploading symbols from false to true.
I started a build in the build definations where we can see the log output of publishing the symbols.

cc @eerhardt @safern 