### PR TITLE
Decimal separator different in different windows language pack

### DIFF
--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -8,6 +8,7 @@ using Microsoft.ML.Runtime.Tools;
 using Microsoft.ML.TestFramework;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -615,7 +616,8 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private static void GetNumbersFromFile(ref string firstString, ref string secondString, decimal precision)
         {
-            Regex _matchNumer = new Regex(@"\b[0-9]+\.?[0-9]*\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            string decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+            Regex _matchNumer = new Regex(@"\b[0-9]+\" + decimalSeparator + "?[0-9]*\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
             MatchCollection firstCollection = _matchNumer.Matches(firstString);
             MatchCollection secondCollection = _matchNumer.Matches(secondString);
 

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -8,7 +8,6 @@ using Microsoft.ML.Runtime.Tools;
 using Microsoft.ML.TestFramework;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -616,8 +615,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private static void GetNumbersFromFile(ref string firstString, ref string secondString, decimal precision)
         {
-            string decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-            Regex _matchNumer = new Regex(@"\b[0-9]+\" + decimalSeparator + "?[0-9]*\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            Regex _matchNumer = new Regex(@"\b[0-9]+[\.,]?[0-9]*\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
             MatchCollection firstCollection = _matchNumer.Matches(firstString);
             MatchCollection secondCollection = _matchNumer.Matches(secondString);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/74

The decimal separators are different for different language packs eg "," is a decimal separator for spanish. the output written to these files will include comma instead of decimal as in our zbaseline files.
The problem could be avoided by improving our number regular expression to use decimal separator dynamically which will allow us to pick these values as numbers and match them as numbers rather than strings

@veikkoeeva can you please test this pr on your machine. I currently dont have access to the non-english windows

cc @eerhardt @danmosemsft @codemzs 
