### PR TITLE
Added Block Size Checks for ParquetLoader

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/MathUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/MathUtils.cs
@@ -880,7 +880,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// <returns></returns>
         public static long DivisionCeiling(long numerator, long denomenator)
         {
-            return (numerator + denomenator - 1) / denomenator;
+            return (checked(numerator + denomenator) - 1) / denomenator;
         }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/MathUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/MathUtils.cs
@@ -871,5 +871,16 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             var res = Math.Cos(a);
             return Math.Abs(res) > 1 ? double.NaN : res;
         }
+
+        /// <summary>
+        /// Returns the smallest integral value that is greater than or equal to the result of the division.
+        /// </summary>
+        /// <param name="numerator">Number to be divided.</param>
+        /// <param name="denomenator">Number with which to divide the numerator.</param>
+        /// <returns></returns>
+        public static long DivisionCeiling(long numerator, long denomenator)
+        {
+            return (numerator + denomenator - 1) / denomenator;
+        }
     }
 }

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -396,14 +396,9 @@ namespace Microsoft.ML.Runtime.Data
                     int[] blockOrder = _rand == null ? Utils.GetIdentityPermutation(numBlocks) : Utils.GetRandomPermutation(rand, numBlocks);
                     _blockEnumerator = blockOrder.GetEnumerator();
                 }
-                catch (Exception e)
+                catch (Exception e) when (e is OutOfMemoryException || e is OverflowException)
                 {
-                    if (e is OutOfMemoryException || e is OverflowException)
-                    {
-                        throw new InvalidDataException("Error due to too many blocks. Try increasing block size.", e);
-                    }
-
-                    throw;
+                    parent._host.Except(e, "Error due to too many blocks. Try increasing block size.");
                 }
 
                 _dataSetEnumerator = new int[0].GetEnumerator(); // Initialize an empty enumerator to get started
@@ -504,14 +499,9 @@ namespace Microsoft.ML.Runtime.Data
                         _dataSetEnumerator = dataSetOrder.GetEnumerator();
                         _curDataSetRow = dataSetOrder[0];
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (e is OutOfMemoryException)
                     {
-                        if (e is OutOfMemoryException)
-                        {
-                            throw new InvalidDataException("Error caused because block size too big. Try decreasing block size.", e);
-                        }
-
-                        throw;
+                        throw new InvalidDataException("Error caused because block size is too big. Try decreasing block size.", e);
                     }
 
                     // Cache list for each active column


### PR DESCRIPTION
Fixes #118
Originally [PR#12](https://github.com/dotnet/machinelearning/pull/12)

In order to enable shuffling for both the {rows in a block} and {blocks}, both sizes have to (1) be smaller than int.MaxValue, and (2) fit in an int array, making the upper limit for both {rows in a block} and {number of blocks} around 300M. If either value throws an exception when assigned, the library will suggest adjusting the block size as a potential fix.

Also changed the default block size to 1M to minimize the chance of OutOfMemory and Overflow exceptions happening in the first place, and addressed comments in original PR. 

