### PR TITLE
Replaced calls to DateTime.Now with DateTime.UtcNow to be locale agnostic

### DIFF
--- a/src/Microsoft.ML.Core/Data/ProgressReporter.cs
+++ b/src/Microsoft.ML.Core/Data/ProgressReporter.cs
@@ -359,7 +359,7 @@ namespace Microsoft.ML.Runtime.Data
                     Index = index;
                     Name = name;
                     PendingCheckpoints = new ConcurrentQueue<KeyValuePair<DateTime, ProgressEntry>>();
-                    StartTime = DateTime.Now;
+                    StartTime = DateTime.UtcNow;
                     Channel = channel;
                 }
             }
@@ -584,7 +584,7 @@ namespace Microsoft.ML.Runtime.Data
                 Index = index;
                 Name = name;
                 StartTime = startTime;
-                EventTime = DateTime.Now;
+                EventTime = DateTime.UtcNow;
                 Kind = EventKind.Progress;
                 ProgressEntry = entry;
             }
@@ -597,7 +597,7 @@ namespace Microsoft.ML.Runtime.Data
                 Index = index;
                 Name = name;
                 StartTime = startTime;
-                EventTime = DateTime.Now;
+                EventTime = DateTime.UtcNow;
                 Kind = kind;
                 ProgressEntry = null;
             }

--- a/src/Microsoft.ML.Data/Utilities/TimerScope.cs
+++ b/src/Microsoft.ML.Data/Utilities/TimerScope.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
 
             // REVIEW: This is \n\n is to prevent changes across bunch of baseline files.
             // Ideally we should change our comparison method to ignore empty lines.
-            _ch.Info("{0}\t Time elapsed(s): {1}\n\n", DateTime.Now, elapsedSeconds);
+            _ch.Info("{0}\t Time elapsed(s): {1}\n\n", DateTime.UtcNow, elapsedSeconds);
 
             using (var pipe = _host.StartPipe<TelemetryMessage>("TelemetryPipe"))
             {

--- a/src/Microsoft.ML.FastTree/Training/EnsembleCompression/LassoBasedEnsembleCompressor.cs
+++ b/src/Microsoft.ML.FastTree/Training/EnsembleCompression/LassoBasedEnsembleCompressor.cs
@@ -164,7 +164,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
 
         private LassoFit GetLassoFit(IChannel ch, int maxAllowedFeaturesPerModel)
         {
-            DateTime startTime = DateTime.Now;
+            DateTime startTime = DateTime.UtcNow;
 
             if (maxAllowedFeaturesPerModel < 0)
             {
@@ -450,7 +450,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
             // First lambda was infinity; fixing it
             fit.Lambdas[0] = Math.Exp(2 * Math.Log(fit.Lambdas[1]) - Math.Log(fit.Lambdas[2]));
 
-            TimeSpan duration = DateTime.Now - startTime;
+            TimeSpan duration = DateTime.UtcNow - startTime;
             ch.Info("Elapsed time for compression: {0}", duration);
 
             return fit;

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/Ensemble.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/Ensemble.cs
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
 
         protected int AppendComments(StringBuilder sb, string trainingParams)
         {
-            sb.AppendFormat("\n\n[Comments]\nC:0=Regression Tree Ensemble\nC:1=Generated using FastTree\nC:2=Created on {0}\n", DateTime.Now);
+            sb.AppendFormat("\n\n[Comments]\nC:0=Regression Tree Ensemble\nC:1=Generated using FastTree\nC:2=Created on {0}\n", DateTime.UtcNow);
 
             string[] trainingParamsList = trainingParams.Split(new char[] { '\n' });
             int i = 0;

--- a/src/Microsoft.ML.Maml/MAML.cs
+++ b/src/Microsoft.ML.Maml/MAML.cs
@@ -145,7 +145,7 @@ namespace Microsoft.ML.Runtime.Tools
                         Path.GetTempPath(),
                         "TLC");
                     var dumpFilePath = Path.Combine(dumpFileDir,
-                        string.Format(CultureInfo.InvariantCulture, "Error_{0:yyyyMMdd_HHmmss}_{1}.log", DateTime.Now, Guid.NewGuid()));
+                        string.Format(CultureInfo.InvariantCulture, "Error_{0:yyyyMMdd_HHmmss}_{1}.log", DateTime.UtcNow, Guid.NewGuid()));
                     bool isDumpSaved = false;
                     try
                     {

--- a/src/Microsoft.ML.ResultProcessor/ResultProcessor.cs
+++ b/src/Microsoft.ML.ResultProcessor/ResultProcessor.cs
@@ -584,7 +584,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn.ResultProcessor
                 Results = runResults,
                 PerFoldResults = foldResults,
                 Time = 0,
-                ExecutionDate = DateTime.Now.ToString()
+                ExecutionDate = DateTime.UtcNow.ToString()
             };
         }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Runtime.Learners
             Contracts.Assert(Iteration == 0);
             Contracts.Assert(Bias == 0);
 
-            ch.Trace("{0} Initializing {1} on {2} features", DateTime.Now, Name, numFeatures);
+            ch.Trace("{0} Initializing {1} on {2} features", DateTime.UtcNow, Name, numFeatures);
             NumFeatures = numFeatures;
 
             // We want a dense vector, to prevent memory creation during training
@@ -253,13 +253,13 @@ namespace Microsoft.ML.Runtime.Learners
             Iteration++;
             NumIterExamples = 0;
 
-            ch.Trace("{0} Starting training iteration {1}", DateTime.Now, Iteration);
+            ch.Trace("{0} Starting training iteration {1}", DateTime.UtcNow, Iteration);
             // #if OLD_TRACING // REVIEW: How should this be ported?
             if (Iteration % 20 == 0)
             {
                 Console.Write('.');
                 if (Iteration % 1000 == 0)
-                    Console.WriteLine(" {0}  \t{1}", Iteration, DateTime.Now);
+                    Console.WriteLine(" {0}  \t{1}", Iteration, DateTime.UtcNow);
             }
             // #endif
         }
@@ -269,7 +269,7 @@ namespace Microsoft.ML.Runtime.Learners
             Contracts.Check(NumIterExamples > 0, NoTrainingInstancesMessage);
 
             ch.Trace("{0} Finished training iteration {1}; iterated over {2} examples.",
-                DateTime.Now, Iteration, NumIterExamples);
+                DateTime.UtcNow, Iteration, NumIterExamples);
 
             ScaleWeights();
 #if OLD_TRACING // REVIEW: How should this be ported?
@@ -378,7 +378,7 @@ namespace Microsoft.ML.Runtime.Learners
                         if (_numIterExamples % 5000000 == 0)
                         {
                             Host.StdOut.Write(" ");
-                            Host.StdOut.Write(DateTime.Now);
+                            Host.StdOut.Write(DateTime.UtcNow);
                         }
                         Host.StdOut.WriteLine();
                     }


### PR DESCRIPTION
The codebase now uses DateTime.UtcNow, instead of DateTime.Now, to be locale agnostic.
Fixes #110 