### PR TITLE
Remove special case for Logistic Regression in MacroUtils.cs

### DIFF
--- a/src/Microsoft.ML/Runtime/EntryPoints/MacroUtils.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/MacroUtils.cs
@@ -197,12 +197,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
         public static bool IsTrainerOfKind(Type type, TrainerKinds trainerKind)
         {
-            if (type == typeof(Trainers.LogisticRegressionBinaryClassifier))
-                return trainerKind == TrainerKinds.SignatureBinaryClassifierTrainer;
-
-            if (type == typeof(Trainers.LogisticRegressionClassifier))
-                return trainerKind == TrainerKinds.SignatureMultiClassClassifierTrainer;
-
             if (trainerKind != TrainerKinds.SignatureMultiClassClassifierTrainer && trainerKind != TrainerKinds.SignatureMultiOutputRegressorTrainer)
                 return type.Name.EndsWith(GetTrainerName(trainerKind));
 


### PR DESCRIPTION
We had a special case for LR in MacroUtils since its entry point name didn't match the pattern of the other classifiers (of ending with either "Classifier" or "BinaryClassifier"). Now that this is fixed, we can remove this special case.
