### PR TITLE
Support NuGet packages.config

### DIFF
--- a/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
+++ b/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
@@ -14,4 +14,7 @@
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="build\**\*" Pack="true" PackagePath="build" />
+  </ItemGroup>
 </Project>

--- a/pkg/Microsoft.ML/build/Microsoft.ML.props
+++ b/pkg/Microsoft.ML/build/Microsoft.ML.props
@@ -1,0 +1,17 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+  NuGet packages.config doesn't support native assemblies automatically,
+  so copy the native assemblies to the output directory.
+  -->
+  <ItemGroup Condition="Exists('packages.config') OR
+                        Exists('$(MSBuildProjectName).packages.config') OR
+                        Exists('packages.$(MSBuildProjectName).config')">
+    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\*.dll"
+             Condition="'$(PlatformTarget)' == 'x64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/pkg/Microsoft.ML/build/Microsoft.ML.targets
+++ b/pkg/Microsoft.ML/build/Microsoft.ML.targets
@@ -1,0 +1,22 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <EnableMLUnsupportedPlatformTargetCheck Condition="'$(EnableMLUnsupportedPlatformTargetCheck)' == ''">true</EnableMLUnsupportedPlatformTargetCheck>
+  </PropertyGroup>
+
+  <Target Name="_CheckForUnsupportedPlatformTarget"
+          Condition="'$(EnableMLUnsupportedPlatformTargetCheck)' == 'true'"
+          AfterTargets="_CheckForInvalidConfigurationAndPlatform">
+
+    <!--
+    Special case .NET Core portable applications.  When building a portable .NET Core app,
+    the PlatformTarget is empty, and you don't know until runtime (i.e. which dotnet.exe)
+    what processor architecture will be used.
+    -->
+    <Error Condition="'$(PlatformTarget)' != 'x64' AND
+                      ('$(OutputType)' == 'Exe' OR '$(OutputType)'=='WinExe') AND
+                      !('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(PlatformTarget)' == '')"
+           Text="Microsoft.ML currently supports 'x64' processor architectures. Please ensure your application is targeting 'x64'." />
+  </Target>
+  
+</Project>


### PR DESCRIPTION
Copy our native assemblies using MSBuild when a consumer is using NuGet packages.config, since NuGet doesn't do this automatically.

Also, add an error when a consumer isn't targeting x64 to tell them ML.NET only supports x64.

Fix #93


