### PR TITLE
Fixes build errors on Windows when project path contains spaces

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
-@call %~dp0run.cmd build %*
+@call "%~dp0run.cmd" build %*
 @exit /b %ERRORLEVEL%

--- a/run.cmd
+++ b/run.cmd
@@ -11,7 +11,7 @@ set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 set DOTNET_MULTILEVEL_LOOKUP=0
 
 :: Restore the Tools directory
-call %~dp0init-tools.cmd
+call "%~dp0init-tools.cmd"
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 
 set _toolRuntime=%~dp0Tools
@@ -21,8 +21,8 @@ set _json=%~dp0config.json
 :: run.exe depends on running in the root directory, notably because the config.json specifies
 :: a relative path to the binclash logger
 
-pushd %~dp0
-call %_dotnet% %_toolRuntime%\run.exe "%_json%" %*
+pushd "%~dp0"
+call "%_dotnet%" "%_toolRuntime%\run.exe" "%_json%" %*
 popd
 
 exit /b %ERRORLEVEL%

--- a/src/Native/build.cmd
+++ b/src/Native/build.cmd
@@ -27,7 +27,6 @@ shift
 goto :Arg_Loop
 
 :ToolsVersion
-
 if defined VisualStudioVersion goto :RunVCVars
 
 set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -37,7 +36,8 @@ if exist %_VSWHERE% (
 if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
 if not exist "%_VSCOMNTOOLS%" goto :MissingVersion
 
-set VSCMD_START_DIR="%__currentScriptDir%"
+
+set "VSCMD_START_DIR=%__currentScriptDir%"
 call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :RunVCVars
@@ -92,8 +92,8 @@ if not exist "%__IntermediatesDir%" md "%__IntermediatesDir%"
 
 :: Regenerate the VS solution
 
-set __gen-buildsys-win-path=%__currentScriptDir%\gen-buildsys-win.bat
-set __source-code-path=%__currentScriptDir%
+set "__gen-buildsys-win-path=%__currentScriptDir%\gen-buildsys-win.bat"
+set "__source-code-path=%__currentScriptDir%"
 
 echo Calling "%__gen-buildsys-win-path%" "%__source-code-path%" "%__VSVersion%" %__BuildArch%
 pushd "%__IntermediatesDir%"

--- a/src/Native/build.proj
+++ b/src/Native/build.proj
@@ -44,7 +44,7 @@
 
     <!-- Run script that invokes Cmake to create VS files, and then calls msbuild to compile them -->
     <Message Text="$(MSBuildProjectDirectory)\build.cmd $(BuildArgs)" Importance="High"/>
-    <Exec Command="$(MSBuildProjectDirectory)\build.cmd $(BuildArgs)" />
+    <Exec Command="&quot;$(MSBuildProjectDirectory)\build.cmd&quot; $(BuildArgs)" />
 
   </Target>
 


### PR DESCRIPTION
Fixes #191 

The problem seemed to be that `%~dp0` was used in the batch scripts without proper quoting.
