### PR TITLE
Remove label requirement for PCA anomaly detector entry point.

### DIFF
--- a/ZBaselines/Common/EntryPoints/core_manifest.json
+++ b/ZBaselines/Common/EntryPoints/core_manifest.json
@@ -10586,18 +10586,6 @@
           "Default": "Features"
         },
         {
-          "Name": "LabelColumn",
-          "Type": "String",
-          "Desc": "Column to use for labels",
-          "Aliases": [
-            "lab"
-          ],
-          "Required": false,
-          "SortOrder": 3.0,
-          "IsNullable": false,
-          "Default": "Label"
-        },
-        {
           "Name": "WeightColumn",
           "Type": "String",
           "Desc": "Column to use for example weight",
@@ -10727,8 +10715,6 @@
         }
       ],
       "InputKind": [
-        "ITrainerInputWithWeight",
-        "ITrainerInputWithLabel",
         "ITrainerInput"
       ],
       "OutputKind": [

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Runtime.PCA
         internal const string Summary = "This algorithm trains an approximate PCA using Randomized SVD algorithm. "
             + "This PCA can be made into Kernel PCA by using Random Fourier Features transform.";
 
-        public class Arguments : LearnerInputBaseWithWeight
+        public class Arguments : LearnerInputBase
         {
             [Argument(ArgumentType.AtMostOnce, HelpText = "The number of components in the PCA", ShortName = "k", SortOrder = 50)]
             [TGUI(SuggestedSweeps = "10,20,40,80")]
@@ -62,11 +62,14 @@ namespace Microsoft.ML.Runtime.PCA
             public int Oversampling = 20;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "If enabled, data is centered to be zero mean", ShortName = "center")]
-            [TlcModule.SweepableDiscreteParam("Center", null, isBool:true)]
+            [TlcModule.SweepableDiscreteParam("Center", null, isBool: true)]
             public bool Center = true;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The seed for random number generation", ShortName = "seed")]
             public int? Seed;
+
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 4, Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
+            public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
         }
 
         private int _dimension;
@@ -294,8 +297,7 @@ namespace Microsoft.ML.Runtime.PCA
 
             return LearnerEntryPointsUtils.Train<Arguments, CommonOutputs.AnomalyDetectionOutput>(host, input,
                 () => new RandomizedPcaTrainer(host, input),
-                () => LearnerEntryPointsUtils.FindColumn(host, input.TrainingData.Schema, input.LabelColumn),
-                () => LearnerEntryPointsUtils.FindColumn(host, input.TrainingData.Schema, input.WeightColumn));
+                getWeight: () => LearnerEntryPointsUtils.FindColumn(host, input.TrainingData.Schema, input.WeightColumn));
         }
     }
 

--- a/src/Microsoft.ML/CSharpApi.cs
+++ b/src/Microsoft.ML/CSharpApi.cs
@@ -550,6 +550,18 @@ namespace Microsoft.ML
                 _jsonNodes.Add(Serialize("Trainers.OrdinaryLeastSquaresRegressor", input, output));
             }
 
+            public Microsoft.ML.Trainers.PcaAnomalyDetector.Output Add(Microsoft.ML.Trainers.PcaAnomalyDetector input)
+            {
+                var output = new Microsoft.ML.Trainers.PcaAnomalyDetector.Output();
+                Add(input, output);
+                return output;
+            }
+
+            public void Add(Microsoft.ML.Trainers.PcaAnomalyDetector input, Microsoft.ML.Trainers.PcaAnomalyDetector.Output output)
+            {
+                _jsonNodes.Add(Serialize("Trainers.PcaAnomalyDetector", input, output));
+            }
+
             public Microsoft.ML.Trainers.PoissonRegressor.Output Add(Microsoft.ML.Trainers.PoissonRegressor input)
             {
                 var output = new Microsoft.ML.Trainers.PoissonRegressor.Output();
@@ -1088,6 +1100,18 @@ namespace Microsoft.ML
             public void Add(Microsoft.ML.Transforms.OptionalColumnCreator input, Microsoft.ML.Transforms.OptionalColumnCreator.Output output)
             {
                 _jsonNodes.Add(Serialize("Transforms.OptionalColumnCreator", input, output));
+            }
+
+            public Microsoft.ML.Transforms.PcaCalculator.Output Add(Microsoft.ML.Transforms.PcaCalculator input)
+            {
+                var output = new Microsoft.ML.Transforms.PcaCalculator.Output();
+                Add(input, output);
+                return output;
+            }
+
+            public void Add(Microsoft.ML.Transforms.PcaCalculator input, Microsoft.ML.Transforms.PcaCalculator.Output output)
+            {
+                _jsonNodes.Add(Serialize("Transforms.PcaCalculator", input, output));
             }
 
             public Microsoft.ML.Transforms.PredictedLabelColumnOriginalValueConverter.Output Add(Microsoft.ML.Transforms.PredictedLabelColumnOriginalValueConverter input)
@@ -6743,6 +6767,97 @@ namespace Microsoft.ML
     {
 
         /// <summary>
+        /// Train an PCA Anomaly model.
+        /// </summary>
+        public sealed partial class PcaAnomalyDetector : Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInput, Microsoft.ML.ILearningPipelineItem
+        {
+
+
+            /// <summary>
+            /// The number of components in the PCA
+            /// </summary>
+            [TlcModule.SweepableDiscreteParamAttribute("Rank", new object[]{10, 20, 40, 80})]
+            public int Rank { get; set; } = 20;
+
+            /// <summary>
+            /// Oversampling parameter for randomized PCA training
+            /// </summary>
+            [TlcModule.SweepableDiscreteParamAttribute("Oversampling", new object[]{10, 20, 40})]
+            public int Oversampling { get; set; } = 20;
+
+            /// <summary>
+            /// If enabled, data is centered to be zero mean
+            /// </summary>
+            [TlcModule.SweepableDiscreteParamAttribute("Center", new object[]{false, true})]
+            public bool Center { get; set; } = true;
+
+            /// <summary>
+            /// The seed for random number generation
+            /// </summary>
+            public int? Seed { get; set; }
+
+            /// <summary>
+            /// Column to use for example weight
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> WeightColumn { get; set; }
+
+            /// <summary>
+            /// The data to be used for training
+            /// </summary>
+            public Var<Microsoft.ML.Runtime.Data.IDataView> TrainingData { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
+
+            /// <summary>
+            /// Column to use for features
+            /// </summary>
+            public string FeatureColumn { get; set; } = "Features";
+
+            /// <summary>
+            /// Normalize option for the feature column
+            /// </summary>
+            public Models.NormalizeOption NormalizeFeatures { get; set; } = Models.NormalizeOption.Auto;
+
+            /// <summary>
+            /// Whether learner should cache input training data
+            /// </summary>
+            public Models.CachingOptions Caching { get; set; } = Models.CachingOptions.Auto;
+
+
+            public sealed class Output : Microsoft.ML.Runtime.EntryPoints.CommonOutputs.IAnomalyDetectionOutput, Microsoft.ML.Runtime.EntryPoints.CommonOutputs.ITrainerOutput
+            {
+                /// <summary>
+                /// The trained model
+                /// </summary>
+                public Var<Microsoft.ML.Runtime.EntryPoints.IPredictorModel> PredictorModel { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IPredictorModel>();
+
+            }
+            public ILearningPipelineStep ApplyStep(ILearningPipelineStep previousStep, Experiment experiment)
+            {
+                if (!(previousStep is ILearningPipelineDataStep dataStep))
+                {
+                    throw new InvalidOperationException($"{ nameof(PcaAnomalyDetector)} only supports an { nameof(ILearningPipelineDataStep)} as an input.");
+                }
+
+                TrainingData = dataStep.Data;
+                Output output = experiment.Add(this);
+                return new PcaAnomalyDetectorPipelineStep(output);
+            }
+
+            private class PcaAnomalyDetectorPipelineStep : ILearningPipelinePredictorStep
+            {
+                public PcaAnomalyDetectorPipelineStep(Output output)
+                {
+                    Model = output.PredictorModel;
+                }
+
+                public Var<IPredictorModel> Model { get; }
+            }
+        }
+    }
+
+    namespace Trainers
+    {
+
+        /// <summary>
         /// Train an Poisson regression model.
         /// </summary>
         public sealed partial class PoissonRegressor : Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInputWithWeight, Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInputWithLabel, Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInput, Microsoft.ML.ILearningPipelineItem
@@ -11406,6 +11521,170 @@ namespace Microsoft.ML
             private class OptionalColumnCreatorPipelineStep : ILearningPipelineDataStep
             {
                 public OptionalColumnCreatorPipelineStep(Output output)
+                {
+                    Data = output.OutputData;
+                    Model = output.Model;
+                }
+
+                public Var<IDataView> Data { get; }
+                public Var<ITransformModel> Model { get; }
+            }
+        }
+    }
+
+    namespace Transforms
+    {
+
+        public sealed partial class PcaTransformColumn : OneToOneColumn<PcaTransformColumn>, IOneToOneColumn
+        {
+            /// <summary>
+            /// The name of the weight column
+            /// </summary>
+            public string WeightColumn { get; set; }
+
+            /// <summary>
+            /// The number of components in the PCA
+            /// </summary>
+            public int? Rank { get; set; }
+
+            /// <summary>
+            /// Oversampling parameter for randomized PCA training
+            /// </summary>
+            public int? Oversampling { get; set; }
+
+            /// <summary>
+            /// If enabled, data is centered to be zero mean
+            /// </summary>
+            public bool? Center { get; set; }
+
+            /// <summary>
+            /// The seed for random number generation
+            /// </summary>
+            public int? Seed { get; set; }
+
+            /// <summary>
+            /// Name of the new column
+            /// </summary>
+            public string Name { get; set; }
+
+            /// <summary>
+            /// Name of the source column
+            /// </summary>
+            public string Source { get; set; }
+
+        }
+
+        /// <summary>
+        /// Train an PCA Anomaly model.
+        /// </summary>
+        public sealed partial class PcaCalculator : Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITransformInput, Microsoft.ML.ILearningPipelineItem
+        {
+
+            public PcaCalculator()
+            {
+            }
+            
+            public PcaCalculator(params string[] inputColumns)
+            {
+                if (inputColumns != null)
+                {
+                    foreach (string input in inputColumns)
+                    {
+                        AddColumn(input);
+                    }
+                }
+            }
+            
+            public PcaCalculator(params ValueTuple<string, string>[] inputOutputColumns)
+            {
+                if (inputOutputColumns != null)
+                {
+                    foreach (ValueTuple<string, string> inputOutput in inputOutputColumns)
+                    {
+                        AddColumn(inputOutput.Item2, inputOutput.Item1);
+                    }
+                }
+            }
+            
+            public void AddColumn(string source)
+            {
+                var list = Column == null ? new List<Transforms.PcaTransformColumn>() : new List<Transforms.PcaTransformColumn>(Column);
+                list.Add(OneToOneColumn<Transforms.PcaTransformColumn>.Create(source));
+                Column = list.ToArray();
+            }
+
+            public void AddColumn(string name, string source)
+            {
+                var list = Column == null ? new List<Transforms.PcaTransformColumn>() : new List<Transforms.PcaTransformColumn>(Column);
+                list.Add(OneToOneColumn<Transforms.PcaTransformColumn>.Create(name, source));
+                Column = list.ToArray();
+            }
+
+
+            /// <summary>
+            /// New column definition(s) (optional form: name:src)
+            /// </summary>
+            public Transforms.PcaTransformColumn[] Column { get; set; }
+
+            /// <summary>
+            /// The name of the weight column
+            /// </summary>
+            public string WeightColumn { get; set; }
+
+            /// <summary>
+            /// The number of components in the PCA
+            /// </summary>
+            public int Rank { get; set; } = 20;
+
+            /// <summary>
+            /// Oversampling parameter for randomized PCA training
+            /// </summary>
+            public int Oversampling { get; set; } = 20;
+
+            /// <summary>
+            /// If enabled, data is centered to be zero mean
+            /// </summary>
+            public bool Center { get; set; } = true;
+
+            /// <summary>
+            /// The seed for random number generation
+            /// </summary>
+            public int Seed { get; set; }
+
+            /// <summary>
+            /// Input dataset
+            /// </summary>
+            public Var<Microsoft.ML.Runtime.Data.IDataView> Data { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
+
+
+            public sealed class Output : Microsoft.ML.Runtime.EntryPoints.CommonOutputs.ITransformOutput
+            {
+                /// <summary>
+                /// Transformed dataset
+                /// </summary>
+                public Var<Microsoft.ML.Runtime.Data.IDataView> OutputData { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
+
+                /// <summary>
+                /// Transform model
+                /// </summary>
+                public Var<Microsoft.ML.Runtime.EntryPoints.ITransformModel> Model { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.ITransformModel>();
+
+            }
+            public ILearningPipelineStep ApplyStep(ILearningPipelineStep previousStep, Experiment experiment)
+            {
+                if (!(previousStep is ILearningPipelineDataStep dataStep))
+                {
+                    throw new InvalidOperationException($"{ nameof(PcaCalculator)} only supports an { nameof(ILearningPipelineDataStep)} as an input.");
+                }
+
+                Data = dataStep.Data;
+                Output output = experiment.Add(this);
+                return new PcaCalculatorPipelineStep(output);
+            }
+
+            private class PcaCalculatorPipelineStep : ILearningPipelineDataStep
+            {
+                public PcaCalculatorPipelineStep(Output output)
                 {
                     Data = output.OutputData;
                     Model = output.Model;

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -1083,7 +1083,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [Fact]
         public void EntryPointPcaAnomaly()
         {
-            TestEntryPointRoutine("MNIST.Train.0-class.tiny.txt", "Trainers.PcaAnomalyDetector");
+            TestEntryPointRoutine("MNIST.Train.0-class.tiny.txt", "Trainers.PcaAnomalyDetector", "col=Features:R4:1-784");
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
+++ b/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.ML.PCA\Microsoft.ML.PCA.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.PipelineInference\Microsoft.ML.PipelineInference.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.StandardLearners\Microsoft.ML.StandardLearners.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML\Microsoft.ML.csproj" />


### PR DESCRIPTION
Fixes #220 . PCA trainer should not require a label column.