### PR TITLE
Fix SupportedMetric.ByName() method

### DIFF
--- a/src/Microsoft.ML.PipelineInference/AutoInference.cs
+++ b/src/Microsoft.ML.PipelineInference/AutoInference.cs
@@ -98,8 +98,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             public static SupportedMetric ByName(string name)
             {
                 var fields =
-                    typeof(SupportedMetric).GetFields(BindingFlags.Static | BindingFlags.Public)
-                    .Where(s => s.MemberType == MemberTypes.Field);
+                    typeof(SupportedMetric).GetFields(BindingFlags.Static | BindingFlags.Public);
 
                 foreach (var field in fields)
                 {

--- a/src/Microsoft.ML.PipelineInference/AutoInference.cs
+++ b/src/Microsoft.ML.PipelineInference/AutoInference.cs
@@ -98,12 +98,14 @@ namespace Microsoft.ML.Runtime.PipelineInference
             public static SupportedMetric ByName(string name)
             {
                 var fields =
-                    typeof(SupportedMetric).GetMembers(BindingFlags.Static | BindingFlags.Public)
+                    typeof(SupportedMetric).GetFields(BindingFlags.Static | BindingFlags.Public)
                     .Where(s => s.MemberType == MemberTypes.Field);
+
                 foreach (var field in fields)
                 {
-                    if (name.Equals(field.Name, StringComparison.OrdinalIgnoreCase))
-                        return (SupportedMetric)typeof(SupportedMetric).GetField(field.Name).GetValue(null);
+                    var metric = (SupportedMetric)field.GetValue(Auc);
+                    if (name.Equals(metric.Name, StringComparison.OrdinalIgnoreCase))
+                        return metric;
                 }
                 throw new NotSupportedException($"Metric '{name}' not supported.");
             }

--- a/test/Microsoft.ML.Predictor.Tests/TestAutoInference.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestAutoInference.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.EntryPoints;
@@ -408,6 +409,27 @@ namespace Microsoft.ML.Runtime.RunTests
                 // Make sure second object's set of changes didn't overwrite first object's
                 env.Check(!lr1.PipelineNode.SweepParams[0].RawValue.Equals(lr2.PipelineNode.SweepParams[0].RawValue));
                 env.Check(!sdca2.PipelineNode.SweepParams[0].RawValue.Equals(sdca1.PipelineNode.SweepParams[0].RawValue));
+            }
+        }
+
+        [Fact]
+        public void TestSupportedMetricsByName()
+        {
+            var names = new List<string>()
+            {
+                AutoInference.SupportedMetric.AccuracyMacro.Name,
+                AutoInference.SupportedMetric.AccuracyMicro.Name,
+                AutoInference.SupportedMetric.Auc.Name,
+                AutoInference.SupportedMetric.AuPrc.Name,
+                AutoInference.SupportedMetric.Dbi.Name,
+                AutoInference.SupportedMetric.F1.Name,
+                AutoInference.SupportedMetric.LogLossReduction.Name
+            };
+
+            foreach (var name in names)
+            {
+                var metric = AutoInference.SupportedMetric.ByName(name);
+                Assert.Equal(metric.Name, name);
             }
         }
 


### PR DESCRIPTION
This is a fix for Issue #279, where the PipelineInference/AutoInference.cs/SupportedMetric.ByName() no longer functions since changes were made to metric names. This is a simple issue with a simple fix (using the values of the SupportedMetrics names rather than the name of the fields).