### PR TITLE
Fix a DllImport issue for frameworks that do not add the ".dll" suffix automatically

### DIFF
--- a/src/Microsoft.ML.FastTree/Dataset/DenseIntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/DenseIntArray.cs
@@ -69,13 +69,13 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
         }
 
 #if USE_FASTTREENATIVE
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int C_Sumup_float(
             int numBits, byte* pData, int* pIndices, float* pSampleOutputs, double* pSampleOutputWeights,
             FloatType* pSumTargetsByBin, double* pSumTargets2ByBin, int* pCountByBin,
             int totalCount, double totalSampleOutputs, double totalSampleOutputWeights);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int C_Sumup_double(
             int numBits, byte* pData, int* pIndices, double* pSampleOutputs, double* pSampleOutputWeights,
             FloatType* pSumTargetsByBin, double* pSumTargets2ByBin, int* pCountByBin,

--- a/src/Microsoft.ML.FastTree/Dataset/IntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/IntArray.cs
@@ -23,6 +23,12 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
     /// </summary>
     public abstract class IntArray : IEnumerable<int>
     {
+#if USE_DLL_SUFFIX
+        public const string NativeDll = "FastTreeNative.dll";
+#else
+        public const string NativeDll = "FastTreeNative";
+#endif
+
         // The level of compression to use with features.
         // 0x1 - Use 10 bit.
         // 0x2 -

--- a/src/Microsoft.ML.FastTree/Dataset/SegmentIntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/SegmentIntArray.cs
@@ -493,29 +493,29 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
         }
 
 #pragma warning disable TLC_GeneralName // Externs follow their own rules.
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         private unsafe static extern void C_SegmentFindOptimalPath21(uint* valv, int valc, long* pBits, int* pTransitions);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         private unsafe static extern void C_SegmentFindOptimalPath15(uint* valv, int valc, long* pBits, int* pTransitions);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         private unsafe static extern void C_SegmentFindOptimalPath7(uint* valv, int valc, long* pBits, int* pTransitions);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         private unsafe static extern void C_SegmentFindOptimalCost15(uint* valv, int valc, long* pBits);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         private unsafe static extern void C_SegmentFindOptimalCost31(uint* valv, int valc, long* pBits);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int C_SumupSegment_float(
             uint* pData, byte* pSegType, int* pSegLength, int* pIndices,
             float* pSampleOutputs, double* pSampleOutputWeights,
             float* pSumTargetsByBin, double* pSumWeightsByBin,
             int* pCountByBin, int totalCount, double totalSampleOutputs);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int C_SumupSegment_double(
             uint* pData, byte* pSegType, int* pSegLength, int* pIndices,
             double* pSampleOutputs, double* pSampleOutputWeights,

--- a/src/Microsoft.ML.FastTree/Dataset/SparseIntArray.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/SparseIntArray.cs
@@ -489,12 +489,12 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
         }
 
 #if USE_FASTTREENATIVE
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int C_SumupDeltaSparse_float(int numBits, byte* pValues, byte* pDeltas, int numDeltas, int* pIndices, float* pSampleOutputs, double* pSampleOutputWeights,
                                   float* pSumTargetsByBin, double* pSumTargets2ByBin, int* pCountByBin,
                                   int totalCount, double totalSampleOutputs, double totalSampleOutputWeights);
 
-        [DllImport("FastTreeNative", CallingConvention = CallingConvention.StdCall)]
+        [DllImport(NativeDll, CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int C_SumupDeltaSparse_double(int numBits, byte* pValues, byte* pDeltas, int numDeltas, int* pIndices, double* pSampleOutputs, double* pSampleOutputWeights,
                                   double* pSumTargetsByBin, double* pSumTargets2ByBin, int* pCountByBin,
                                   int totalCount, double totalSampleOutputs, double totalSampleOutputWeights);

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.ML.Runtime.FastTree
                     }));
             }
 
-            [DllImport("FastTreeNative", EntryPoint = "C_GetDerivatives", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+            [DllImport(IntArray.NativeDll, EntryPoint = "C_GetDerivatives", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Ansi)]
             private unsafe static extern void GetDerivatives(
                 int numDocuments, int begin, int* pPermutation, short* pLabels,
                 double* pScores, double* pLambdas, double* pWeights, double* pDiscount,


### PR DESCRIPTION
In some cases, the ".dll" suffix is not added, causing the DllImportAttribute to not find the dll on Linux machines.
