### PR TITLE
ML.NET-242: FastTreeRanking per-iteration loss metrics are empty

### DIFF
--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -343,6 +343,9 @@ namespace Microsoft.ML.Runtime.FastTree
         /// <returns>standard test for the dataset</returns>
         private Test CreateStandardTest(Dataset dataset)
         {
+            if (Utils.Size(dataset.MaxDcg) == 0)
+                dataset.Skeleton.RecomputeMaxDcg(10);
+
             return new NdcgTest(
                 ConstructScoreTracker(dataset),
                 dataset.Ratings,


### PR DESCRIPTION
When training a FastTreeRanker using the `testFrequency` parameter, it is expected that NDCG is printed every testFrequency iterations. However, instead of NDCG, only empty strings are printed.

The root cause was that the `MaxDCG` property of the dataset was never calculated, so the NDCG calculation is aborted, leaving an empty string as a result.

This PR fixes the problem by computing the `MaxDCG` for the dataset when the Tests are defined (so that if the tests are not defined, the `MaxDCG` will never be calculated). Here, the `truncationLevel` of the `MaxDCG` calculation is hardcoded to 10, which is a nice round number, and within the range of the `DiscountMap` (11).

Fixes #242