### PR TITLE
Get the cross validation macro to work with non-default column names

### DIFF
--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -190,6 +190,8 @@ namespace Microsoft.ML.Runtime.Data
             public ValueGetter<TValue> GetGetter<TValue>(int col)
             {
                 Ch.Check(IsColumnActive(col), "The column must be active against the defined predicate.");
+                if (!(Getters[col] is ValueGetter<TValue>))
+                    throw Ch.Except($"Invalid TValue in GetGetter: '{typeof(TValue)}'");
                 return Getters[col] as ValueGetter<TValue>;
             }
 

--- a/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
@@ -429,81 +429,81 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
             {
                 switch (dt)
                 {
-                case TlcModule.DataKind.Bool:
-                    return value.Value<bool>();
-                case TlcModule.DataKind.String:
-                    return value.Value<string>();
-                case TlcModule.DataKind.Char:
-                    return value.Value<char>();
-                case TlcModule.DataKind.Enum:
-                    if (!Enum.IsDefined(type, value.Value<string>()))
-                        throw ectx.Except($"Requested value '{value.Value<string>()}' is not a member of the Enum type '{type.Name}'");
-                    return Enum.Parse(type, value.Value<string>());
-                case TlcModule.DataKind.Float:
-                    if (type == typeof(double))
-                        return value.Value<double>();
-                    else if (type == typeof(float))
-                        return value.Value<float>();
-                    else
-                    {
+                    case TlcModule.DataKind.Bool:
+                        return value.Value<bool>();
+                    case TlcModule.DataKind.String:
+                        return value.Value<string>();
+                    case TlcModule.DataKind.Char:
+                        return value.Value<char>();
+                    case TlcModule.DataKind.Enum:
+                        if (!Enum.IsDefined(type, value.Value<string>()))
+                            throw ectx.Except($"Requested value '{value.Value<string>()}' is not a member of the Enum type '{type.Name}'");
+                        return Enum.Parse(type, value.Value<string>());
+                    case TlcModule.DataKind.Float:
+                        if (type == typeof(double))
+                            return value.Value<double>();
+                        else if (type == typeof(float))
+                            return value.Value<float>();
+                        else
+                        {
+                            ectx.Assert(false);
+                            throw ectx.ExceptNotSupp();
+                        }
+                    case TlcModule.DataKind.Array:
+                        var ja = value as JArray;
+                        ectx.Check(ja != null, "Expected array value");
+                        Func<IExceptionContext, JArray, Attributes, ModuleCatalog, object> makeArray = MakeArray<int>;
+                        return Utils.MarshalInvoke(makeArray, type.GetElementType(), ectx, ja, attributes, catalog);
+                    case TlcModule.DataKind.Int:
+                        if (type == typeof(long))
+                            return value.Value<long>();
+                        if (type == typeof(int))
+                            return value.Value<int>();
                         ectx.Assert(false);
                         throw ectx.ExceptNotSupp();
-                    }
-                case TlcModule.DataKind.Array:
-                    var ja = value as JArray;
-                    ectx.Check(ja != null, "Expected array value");
-                    Func<IExceptionContext, JArray, Attributes, ModuleCatalog, object> makeArray = MakeArray<int>;
-                    return Utils.MarshalInvoke(makeArray, type.GetElementType(), ectx, ja, attributes, catalog);
-                case TlcModule.DataKind.Int:
-                    if (type == typeof(long))
-                        return value.Value<long>();
-                    if (type == typeof(int))
-                        return value.Value<int>();
-                    ectx.Assert(false);
-                    throw ectx.ExceptNotSupp();
-                case TlcModule.DataKind.UInt:
-                    if (type == typeof(ulong))
-                        return value.Value<ulong>();
-                    if (type == typeof(uint))
-                        return value.Value<uint>();
-                    ectx.Assert(false);
-                    throw ectx.ExceptNotSupp();
-                case TlcModule.DataKind.Dictionary:
-                    ectx.Check(value is JObject, "Expected object value");
-                    Func<IExceptionContext, JObject, Attributes, ModuleCatalog, object> makeDict = MakeDictionary<int>;
-                    return Utils.MarshalInvoke(makeDict, type.GetGenericArguments()[1], ectx, (JObject)value, attributes, catalog);
-                case TlcModule.DataKind.Component:
-                    var jo = value as JObject;
-                    ectx.Check(jo != null, "Expected object value");
-                    // REVIEW: consider accepting strings alone.
-                    var jName = jo[FieldNames.Name];
-                    ectx.Check(jName != null, "Field '" + FieldNames.Name + "' is required for component.");
-                    ectx.Check(jName is JValue, "Expected '" + FieldNames.Name + "' field to be a string.");
-                    var name = jName.Value<string>();
-                    ectx.Check(jo[FieldNames.Settings] == null || jo[FieldNames.Settings] is JObject,
-                        "Expected '" + FieldNames.Settings + "' field to be an object");
-                    return GetComponentJson(ectx, type, name, jo[FieldNames.Settings] as JObject, catalog);
-                default:
-                    var settings = value as JObject;
-                    ectx.Check(settings != null, "Expected object value");
-                    var inputBuilder = new InputBuilder(ectx, type, catalog);
+                    case TlcModule.DataKind.UInt:
+                        if (type == typeof(ulong))
+                            return value.Value<ulong>();
+                        if (type == typeof(uint))
+                            return value.Value<uint>();
+                        ectx.Assert(false);
+                        throw ectx.ExceptNotSupp();
+                    case TlcModule.DataKind.Dictionary:
+                        ectx.Check(value is JObject, "Expected object value");
+                        Func<IExceptionContext, JObject, Attributes, ModuleCatalog, object> makeDict = MakeDictionary<int>;
+                        return Utils.MarshalInvoke(makeDict, type.GetGenericArguments()[1], ectx, (JObject)value, attributes, catalog);
+                    case TlcModule.DataKind.Component:
+                        var jo = value as JObject;
+                        ectx.Check(jo != null, "Expected object value");
+                        // REVIEW: consider accepting strings alone.
+                        var jName = jo[FieldNames.Name];
+                        ectx.Check(jName != null, "Field '" + FieldNames.Name + "' is required for component.");
+                        ectx.Check(jName is JValue, "Expected '" + FieldNames.Name + "' field to be a string.");
+                        var name = jName.Value<string>();
+                        ectx.Check(jo[FieldNames.Settings] == null || jo[FieldNames.Settings] is JObject,
+                            "Expected '" + FieldNames.Settings + "' field to be an object");
+                        return GetComponentJson(ectx, type, name, jo[FieldNames.Settings] as JObject, catalog);
+                    default:
+                        var settings = value as JObject;
+                        ectx.Check(settings != null, "Expected object value");
+                        var inputBuilder = new InputBuilder(ectx, type, catalog);
 
-                    if (inputBuilder._fields.Length == 0)
-                        throw ectx.Except($"Unsupported input type: {dt}");
+                        if (inputBuilder._fields.Length == 0)
+                            throw ectx.Except($"Unsupported input type: {dt}");
 
-                    if (settings != null)
-                    {
-                        foreach (var pair in settings)
+                        if (settings != null)
                         {
-                            if (!inputBuilder.TrySetValueJson(pair.Key, pair.Value))
-                                throw ectx.Except($"Unexpected value for component '{type}', field '{pair.Key}': '{pair.Value}'");
+                            foreach (var pair in settings)
+                            {
+                                if (!inputBuilder.TrySetValueJson(pair.Key, pair.Value))
+                                    throw ectx.Except($"Unexpected value for component '{type}', field '{pair.Key}': '{pair.Value}'");
+                            }
                         }
-                    }
 
-                    var missing = inputBuilder.GetMissingValues().ToArray();
-                    if (missing.Length > 0)
-                        throw ectx.Except($"The following required inputs were not provided for component '{type}': {string.Join(", ", missing)}");
-                    return inputBuilder.GetInstance();
+                        var missing = inputBuilder.GetMissingValues().ToArray();
+                        if (missing.Length > 0)
+                            throw ectx.Except($"The following required inputs were not provided for component '{type}': {string.Join(", ", missing)}");
+                        return inputBuilder.GetInstance();
                 }
             }
             catch (FormatException ex)

--- a/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Internal.Utilities;
-using Microsoft.ML.Runtime.Data;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
@@ -405,7 +404,11 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
                 return null;
 
             if (type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(Optional<>) || type.GetGenericTypeDefinition() == typeof(Nullable<>)))
+            {
+                if (type.GetGenericTypeDefinition() == typeof(Optional<>) && value.HasValues)
+                    value = value.Values().FirstOrDefault();
                 type = type.GetGenericArguments()[0];
+            }
 
             if (type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(Var<>)))
             {
@@ -426,81 +429,81 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
             {
                 switch (dt)
                 {
-                    case TlcModule.DataKind.Bool:
-                        return value.Value<bool>();
-                    case TlcModule.DataKind.String:
-                        return value.Value<string>();
-                    case TlcModule.DataKind.Char:
-                        return value.Value<char>();
-                    case TlcModule.DataKind.Enum:
-                        if (!Enum.IsDefined(type, value.Value<string>()))
-                            throw ectx.Except($"Requested value '{value.Value<string>()}' is not a member of the Enum type '{type.Name}'");
-                        return Enum.Parse(type, value.Value<string>());
-                    case TlcModule.DataKind.Float:
-                        if (type == typeof(double))
-                            return value.Value<double>();
-                        else if (type == typeof(float))
-                            return value.Value<float>();
-                        else
-                        {
-                            ectx.Assert(false);
-                            throw ectx.ExceptNotSupp();
-                        }
-                    case TlcModule.DataKind.Array:
-                        var ja = value as JArray;
-                        ectx.Check(ja != null, "Expected array value");
-                        Func<IExceptionContext, JArray, Attributes, ModuleCatalog, object> makeArray = MakeArray<int>;
-                        return Utils.MarshalInvoke(makeArray, type.GetElementType(), ectx, ja, attributes, catalog);
-                    case TlcModule.DataKind.Int:
-                        if (type == typeof(long))
-                            return value.Value<long>();
-                        if (type == typeof(int))
-                            return value.Value<int>();
+                case TlcModule.DataKind.Bool:
+                    return value.Value<bool>();
+                case TlcModule.DataKind.String:
+                    return value.Value<string>();
+                case TlcModule.DataKind.Char:
+                    return value.Value<char>();
+                case TlcModule.DataKind.Enum:
+                    if (!Enum.IsDefined(type, value.Value<string>()))
+                        throw ectx.Except($"Requested value '{value.Value<string>()}' is not a member of the Enum type '{type.Name}'");
+                    return Enum.Parse(type, value.Value<string>());
+                case TlcModule.DataKind.Float:
+                    if (type == typeof(double))
+                        return value.Value<double>();
+                    else if (type == typeof(float))
+                        return value.Value<float>();
+                    else
+                    {
                         ectx.Assert(false);
                         throw ectx.ExceptNotSupp();
-                    case TlcModule.DataKind.UInt:
-                        if (type == typeof(ulong))
-                            return value.Value<ulong>();
-                        if (type == typeof(uint))
-                            return value.Value<uint>();
-                        ectx.Assert(false);
-                        throw ectx.ExceptNotSupp();
-                    case TlcModule.DataKind.Dictionary:
-                        ectx.Check(value is JObject, "Expected object value");
-                        Func<IExceptionContext, JObject, Attributes, ModuleCatalog, object> makeDict = MakeDictionary<int>;
-                        return Utils.MarshalInvoke(makeDict, type.GetGenericArguments()[1], ectx, (JObject)value, attributes, catalog);
-                    case TlcModule.DataKind.Component:
-                        var jo = value as JObject;
-                        ectx.Check(jo != null, "Expected object value");
-                        // REVIEW: consider accepting strings alone.
-                        var jName = jo[FieldNames.Name];
-                        ectx.Check(jName != null, "Field '" + FieldNames.Name + "' is required for component.");
-                        ectx.Check(jName is JValue, "Expected '" + FieldNames.Name + "' field to be a string.");
-                        var name = jName.Value<string>();
-                        ectx.Check(jo[FieldNames.Settings] == null || jo[FieldNames.Settings] is JObject,
-                            "Expected '" + FieldNames.Settings + "' field to be an object");
-                        return GetComponentJson(ectx, type, name, jo[FieldNames.Settings] as JObject, catalog);
-                    default:
-                        var settings = value as JObject;
-                        ectx.Check(settings != null, "Expected object value");
-                        var inputBuilder = new InputBuilder(ectx, type, catalog);
+                    }
+                case TlcModule.DataKind.Array:
+                    var ja = value as JArray;
+                    ectx.Check(ja != null, "Expected array value");
+                    Func<IExceptionContext, JArray, Attributes, ModuleCatalog, object> makeArray = MakeArray<int>;
+                    return Utils.MarshalInvoke(makeArray, type.GetElementType(), ectx, ja, attributes, catalog);
+                case TlcModule.DataKind.Int:
+                    if (type == typeof(long))
+                        return value.Value<long>();
+                    if (type == typeof(int))
+                        return value.Value<int>();
+                    ectx.Assert(false);
+                    throw ectx.ExceptNotSupp();
+                case TlcModule.DataKind.UInt:
+                    if (type == typeof(ulong))
+                        return value.Value<ulong>();
+                    if (type == typeof(uint))
+                        return value.Value<uint>();
+                    ectx.Assert(false);
+                    throw ectx.ExceptNotSupp();
+                case TlcModule.DataKind.Dictionary:
+                    ectx.Check(value is JObject, "Expected object value");
+                    Func<IExceptionContext, JObject, Attributes, ModuleCatalog, object> makeDict = MakeDictionary<int>;
+                    return Utils.MarshalInvoke(makeDict, type.GetGenericArguments()[1], ectx, (JObject)value, attributes, catalog);
+                case TlcModule.DataKind.Component:
+                    var jo = value as JObject;
+                    ectx.Check(jo != null, "Expected object value");
+                    // REVIEW: consider accepting strings alone.
+                    var jName = jo[FieldNames.Name];
+                    ectx.Check(jName != null, "Field '" + FieldNames.Name + "' is required for component.");
+                    ectx.Check(jName is JValue, "Expected '" + FieldNames.Name + "' field to be a string.");
+                    var name = jName.Value<string>();
+                    ectx.Check(jo[FieldNames.Settings] == null || jo[FieldNames.Settings] is JObject,
+                        "Expected '" + FieldNames.Settings + "' field to be an object");
+                    return GetComponentJson(ectx, type, name, jo[FieldNames.Settings] as JObject, catalog);
+                default:
+                    var settings = value as JObject;
+                    ectx.Check(settings != null, "Expected object value");
+                    var inputBuilder = new InputBuilder(ectx, type, catalog);
 
-                        if (inputBuilder._fields.Length == 0)
-                            throw ectx.Except($"Unsupported input type: {dt}");
+                    if (inputBuilder._fields.Length == 0)
+                        throw ectx.Except($"Unsupported input type: {dt}");
 
-                        if (settings != null)
+                    if (settings != null)
+                    {
+                        foreach (var pair in settings)
                         {
-                            foreach (var pair in settings)
-                            {
-                                if (!inputBuilder.TrySetValueJson(pair.Key, pair.Value))
-                                    throw ectx.Except($"Unexpected value for component '{type}', field '{pair.Key}': '{pair.Value}'");
-                            }
+                            if (!inputBuilder.TrySetValueJson(pair.Key, pair.Value))
+                                throw ectx.Except($"Unexpected value for component '{type}', field '{pair.Key}': '{pair.Value}'");
                         }
+                    }
 
-                        var missing = inputBuilder.GetMissingValues().ToArray();
-                        if (missing.Length > 0)
-                            throw ectx.Except($"The following required inputs were not provided for component '{type}': {string.Join(", ", missing)}");
-                        return inputBuilder.GetInstance();
+                    var missing = inputBuilder.GetMissingValues().ToArray();
+                    if (missing.Length > 0)
+                        throw ectx.Except($"The following required inputs were not provided for component '{type}': {string.Join(", ", missing)}");
+                    return inputBuilder.GetInstance();
                 }
             }
             catch (FormatException ex)
@@ -833,35 +836,35 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
         public static class PipelineSweeperSupportedMetrics
         {
             public new static string ToString() => "SupportedMetric";
-            public const string Auc = BinaryClassifierEvaluator.Auc;
-            public const string AccuracyMicro = Data.MultiClassClassifierEvaluator.AccuracyMicro;
-            public const string AccuracyMacro = MultiClassClassifierEvaluator.AccuracyMacro;
-            public const string F1 = BinaryClassifierEvaluator.F1;
-            public const string AuPrc = BinaryClassifierEvaluator.AuPrc;
-            public const string TopKAccuracy = MultiClassClassifierEvaluator.TopKAccuracy;
-            public const string L1 = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.L1;
-            public const string L2 = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.L2;
-            public const string Rms = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.Rms;
-            public const string LossFn = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.Loss;
-            public const string RSquared = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.RSquared;
-            public const string LogLoss = BinaryClassifierEvaluator.LogLoss;
-            public const string LogLossReduction = BinaryClassifierEvaluator.LogLossReduction;
-            public const string Ndcg = RankerEvaluator.Ndcg;
-            public const string Dcg = RankerEvaluator.Dcg;
-            public const string PositivePrecision = BinaryClassifierEvaluator.PosPrecName;
-            public const string PositiveRecall = BinaryClassifierEvaluator.PosRecallName;
-            public const string NegativePrecision = BinaryClassifierEvaluator.NegPrecName;
-            public const string NegativeRecall = BinaryClassifierEvaluator.NegRecallName;
-            public const string DrAtK = AnomalyDetectionEvaluator.OverallMetrics.DrAtK;
-            public const string DrAtPFpr = AnomalyDetectionEvaluator.OverallMetrics.DrAtPFpr;
-            public const string DrAtNumPos = AnomalyDetectionEvaluator.OverallMetrics.DrAtNumPos;
-            public const string NumAnomalies = AnomalyDetectionEvaluator.OverallMetrics.NumAnomalies;
-            public const string ThreshAtK = AnomalyDetectionEvaluator.OverallMetrics.ThreshAtK;
-            public const string ThreshAtP = AnomalyDetectionEvaluator.OverallMetrics.ThreshAtP;
-            public const string ThreshAtNumPos = AnomalyDetectionEvaluator.OverallMetrics.ThreshAtNumPos;
-            public const string Nmi = ClusteringEvaluator.Nmi;
-            public const string AvgMinScore = ClusteringEvaluator.AvgMinScore;
-            public const string Dbi = ClusteringEvaluator.Dbi;
+            public const string Auc = "AUC";
+            public const string AccuracyMicro = "AccuracyMicro";
+            public const string AccuracyMacro = "AccuracyMacro";
+            public const string F1 = "F1";
+            public const string AuPrc = "AUPRC";
+            public const string TopKAccuracy = "TopKAccuracy";
+            public const string L1 = "L1";
+            public const string L2 = "L2";
+            public const string Rms = "RMS";
+            public const string LossFn = "LossFn";
+            public const string RSquared = "RSquared";
+            public const string LogLoss = "LogLoss";
+            public const string LogLossReduction = "LogLossReduction";
+            public const string Ndcg = "NDCG";
+            public const string Dcg = "DCG";
+            public const string PositivePrecision = "PositivePrecision";
+            public const string PositiveRecall = "PositiveRecall";
+            public const string NegativePrecision = "NegativePrecision";
+            public const string NegativeRecall = "NegativeRecall";
+            public const string DrAtK = "DrAtK";
+            public const string DrAtPFpr = "DrAtPFpr";
+            public const string DrAtNumPos = "DrAtNumPos";
+            public const string NumAnomalies = "NumAnomalies";
+            public const string ThreshAtK = "ThreshAtK";
+            public const string ThreshAtP = "ThreshAtP";
+            public const string ThreshAtNumPos = "ThreshAtNumPos";
+            public const string Nmi = "NMI";
+            public const string AvgMinScore = "AvgMinScore";
+            public const string Dbi = "DBI";
         }
     }
 }

--- a/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.ML.Runtime.CommandLine;
+using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Newtonsoft.Json.Linq;
 
@@ -836,35 +836,35 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
         public static class PipelineSweeperSupportedMetrics
         {
             public new static string ToString() => "SupportedMetric";
-            public const string Auc = "AUC";
-            public const string AccuracyMicro = "AccuracyMicro";
-            public const string AccuracyMacro = "AccuracyMacro";
-            public const string F1 = "F1";
-            public const string AuPrc = "AUPRC";
-            public const string TopKAccuracy = "TopKAccuracy";
-            public const string L1 = "L1";
-            public const string L2 = "L2";
-            public const string Rms = "RMS";
-            public const string LossFn = "LossFn";
-            public const string RSquared = "RSquared";
-            public const string LogLoss = "LogLoss";
-            public const string LogLossReduction = "LogLossReduction";
-            public const string Ndcg = "NDCG";
-            public const string Dcg = "DCG";
-            public const string PositivePrecision = "PositivePrecision";
-            public const string PositiveRecall = "PositiveRecall";
-            public const string NegativePrecision = "NegativePrecision";
-            public const string NegativeRecall = "NegativeRecall";
-            public const string DrAtK = "DrAtK";
-            public const string DrAtPFpr = "DrAtPFpr";
-            public const string DrAtNumPos = "DrAtNumPos";
-            public const string NumAnomalies = "NumAnomalies";
-            public const string ThreshAtK = "ThreshAtK";
-            public const string ThreshAtP = "ThreshAtP";
-            public const string ThreshAtNumPos = "ThreshAtNumPos";
-            public const string Nmi = "NMI";
-            public const string AvgMinScore = "AvgMinScore";
-            public const string Dbi = "DBI";
+            public const string Auc = BinaryClassifierEvaluator.Auc;
+            public const string AccuracyMicro = Data.MultiClassClassifierEvaluator.AccuracyMicro;
+            public const string AccuracyMacro = MultiClassClassifierEvaluator.AccuracyMacro;
+            public const string F1 = BinaryClassifierEvaluator.F1;
+            public const string AuPrc = BinaryClassifierEvaluator.AuPrc;
+            public const string TopKAccuracy = MultiClassClassifierEvaluator.TopKAccuracy;
+            public const string L1 = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.L1;
+            public const string L2 = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.L2;
+            public const string Rms = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.Rms;
+            public const string LossFn = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.Loss;
+            public const string RSquared = RegressionLossEvaluatorBase<MultiOutputRegressionEvaluator.Aggregator>.RSquared;
+            public const string LogLoss = BinaryClassifierEvaluator.LogLoss;
+            public const string LogLossReduction = BinaryClassifierEvaluator.LogLossReduction;
+            public const string Ndcg = RankerEvaluator.Ndcg;
+            public const string Dcg = RankerEvaluator.Dcg;
+            public const string PositivePrecision = BinaryClassifierEvaluator.PosPrecName;
+            public const string PositiveRecall = BinaryClassifierEvaluator.PosRecallName;
+            public const string NegativePrecision = BinaryClassifierEvaluator.NegPrecName;
+            public const string NegativeRecall = BinaryClassifierEvaluator.NegRecallName;
+            public const string DrAtK = AnomalyDetectionEvaluator.OverallMetrics.DrAtK;
+            public const string DrAtPFpr = AnomalyDetectionEvaluator.OverallMetrics.DrAtPFpr;
+            public const string DrAtNumPos = AnomalyDetectionEvaluator.OverallMetrics.DrAtNumPos;
+            public const string NumAnomalies = AnomalyDetectionEvaluator.OverallMetrics.NumAnomalies;
+            public const string ThreshAtK = AnomalyDetectionEvaluator.OverallMetrics.ThreshAtK;
+            public const string ThreshAtP = AnomalyDetectionEvaluator.OverallMetrics.ThreshAtP;
+            public const string ThreshAtNumPos = AnomalyDetectionEvaluator.OverallMetrics.ThreshAtNumPos;
+            public const string Nmi = ClusteringEvaluator.Nmi;
+            public const string AvgMinScore = ClusteringEvaluator.AvgMinScore;
+            public const string Dbi = ClusteringEvaluator.Dbi;
         }
     }
 }

--- a/src/Microsoft.ML/CSharpApi.cs
+++ b/src/Microsoft.ML/CSharpApi.cs
@@ -2166,6 +2166,16 @@ namespace Microsoft.ML
             public string LabelColumn { get; set; } = "Label";
 
             /// <summary>
+            /// Column to use for example weight
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> WeightColumn { get; set; }
+
+            /// <summary>
+            /// Column to use for grouping
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> GroupColumn { get; set; }
+
+            /// <summary>
             /// Specifies the trainer kind, which determines the evaluator to be used.
             /// </summary>
             public Models.MacroUtilsTrainerKinds Kind { get; set; } = Models.MacroUtilsTrainerKinds.SignatureBinaryClassifierTrainer;

--- a/src/Microsoft.ML/CSharpApi.cs
+++ b/src/Microsoft.ML/CSharpApi.cs
@@ -2270,6 +2270,21 @@ namespace Microsoft.ML
             /// </summary>
             public Models.MacroUtilsTrainerKinds Kind { get; set; } = Models.MacroUtilsTrainerKinds.SignatureBinaryClassifierTrainer;
 
+            /// <summary>
+            /// Column to use for labels
+            /// </summary>
+            public string LabelColumn { get; set; } = "Label";
+
+            /// <summary>
+            /// Column to use for example weight
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> WeightColumn { get; set; }
+
+            /// <summary>
+            /// Column to use for grouping
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> GroupColumn { get; set; }
+
 
             public sealed class Output
             {
@@ -3455,6 +3470,21 @@ namespace Microsoft.ML
             /// Indicates whether to include and output training dataset metrics.
             /// </summary>
             public bool IncludeTrainingMetrics { get; set; } = false;
+
+            /// <summary>
+            /// Column to use for labels
+            /// </summary>
+            public string LabelColumn { get; set; } = "Label";
+
+            /// <summary>
+            /// Column to use for example weight
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> WeightColumn { get; set; }
+
+            /// <summary>
+            /// Column to use for grouping
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> GroupColumn { get; set; }
 
 
             public sealed class Output
@@ -6173,7 +6203,7 @@ namespace Microsoft.ML
         /// <summary>
         /// K-means is a popular clustering algorithm. With K-means, the data is clustered into a specified number of clusters in order to minimize the within-cluster sum of squares. K-means++ improves upon K-means by using a better method for choosing the initial cluster centers.
         /// </summary>
-        public sealed partial class KMeansPlusPlusClusterer : Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInput, Microsoft.ML.ILearningPipelineItem
+        public sealed partial class KMeansPlusPlusClusterer : Microsoft.ML.Runtime.EntryPoints.CommonInputs.IUnsupervisedTrainerWithWeight, Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInput, Microsoft.ML.ILearningPipelineItem
         {
 
 
@@ -6207,6 +6237,11 @@ namespace Microsoft.ML
             /// Degree of lock-free parallelism. Defaults to automatic. Determinism not guaranteed.
             /// </summary>
             public int? NumThreads { get; set; }
+
+            /// <summary>
+            /// Column to use for example weight
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> WeightColumn { get; set; }
 
             /// <summary>
             /// The data to be used for training
@@ -7024,7 +7059,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Train an PCA Anomaly model.
         /// </summary>
-        public sealed partial class PcaAnomalyDetector : Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInput, Microsoft.ML.ILearningPipelineItem
+        public sealed partial class PcaAnomalyDetector : Microsoft.ML.Runtime.EntryPoints.CommonInputs.IUnsupervisedTrainerWithWeight, Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITrainerInput, Microsoft.ML.ILearningPipelineItem
         {
 
 

--- a/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
@@ -205,8 +205,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     Nodes = new JArray(graph.Select(n => n.ToJson()).ToArray()),
                     TransformModel = null,
                     LabelColumn = input.LabelColumn,
-                    GroupColumn = input.GroupColumn.IsExplicit ? input.GroupColumn : Optional<string>.Implicit(DefaultColumnNames.GroupId),
-                    WeightColumn = input.WeightColumn.IsExplicit ? input.WeightColumn : Optional<string>.Implicit(DefaultColumnNames.Weight)
+                    GroupColumn = input.GroupColumn,
+                    WeightColumn = input.WeightColumn
                 };
 
                 if (transformModelVarName != null)
@@ -409,7 +409,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 var combineConfusionMatrix = new Var<IDataView>();
                 combineConfusionMatrix.VarName = node.GetOutputVariableName(nameof(Output.ConfusionMatrix));
                 combineOutputMap.Add(nameof(TrainTestMacro.Output.ConfusionMatrix), combineConfusionMatrix.VarName);
-
             }
             subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
             subGraphNodes.Add(EntryPointNode.Create(env, "Models.CrossValidationResultsCombiner", combineArgs, node.Catalog, node.Context, combineInputBindingMap, combineInputMap, combineOutputMap));
@@ -484,22 +483,22 @@ namespace Microsoft.ML.Runtime.EntryPoints
         {
             switch (kind)
             {
-            case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
-                return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
-                return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
-                return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureRankerTrainer:
-                return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
-                return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
-                return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
-                return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
-            default:
-                throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
+                case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
+                    return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
+                    return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
+                    return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureRankerTrainer:
+                    return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
+                    return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
+                    return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
+                    return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
+                default:
+                    throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
             }
         }
     }

--- a/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
@@ -375,6 +375,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var combineArgs = new CombineMetricsInput();
             combineArgs.Kind = input.Kind;
             combineArgs.LabelColumn = input.LabelColumn;
+            combineArgs.WeightColumn = input.WeightColumn;
+            combineArgs.GroupColumn = input.GroupColumn;
 
             // Set the input bindings for the CombineMetrics entry point.
             var combineInputBindingMap = new Dictionary<string, List<ParameterBinding>>();
@@ -420,7 +422,12 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var eval = GetEvaluator(env, input.Kind);
 
             var perInst = EvaluateUtils.ConcatenatePerInstanceDataViews(env, eval, true, true, input.PerInstanceMetrics.Select(
-                idv => RoleMappedData.Create(idv, RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, input.LabelColumn))).ToArray(),
+                idv => RoleMappedData.CreateOpt(idv, new[]
+                {
+                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, input.LabelColumn),
+                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Weight, input.WeightColumn.Value),
+                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Group, input.GroupColumn.Value)
+                })).ToArray(),
                 out var variableSizeVectorColumnNames);
 
             var warnings = input.Warnings != null ? new List<IDataView>(input.Warnings) : new List<IDataView>();
@@ -477,22 +484,22 @@ namespace Microsoft.ML.Runtime.EntryPoints
         {
             switch (kind)
             {
-                case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
-                    return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
-                    return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
-                    return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureRankerTrainer:
-                    return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
-                    return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
-                    return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
-                    return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
-                default:
-                    throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
+            case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
+                return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
+                return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
+                return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureRankerTrainer:
+                return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
+                return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
+                return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
+                return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
+            default:
+                throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
             }
         }
     }

--- a/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
@@ -77,6 +77,15 @@ namespace Microsoft.ML.Runtime.EntryPoints
             // (and the same for the TrainTest macro). I currently do not know how to do this, so this should be revisited in the future.
             [Argument(ArgumentType.Required, HelpText = "Specifies the trainer kind, which determines the evaluator to be used.", SortOrder = 8)]
             public MacroUtils.TrainerKinds Kind = MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer;
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 10)]
+            public string LabelColumn = DefaultColumnNames.Label;
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 11)]
+            public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
         }
 
         // REVIEW: This output would be much better as an array of CommonOutputs.ClassificationEvaluateOutput,
@@ -120,6 +129,12 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The label column name", ShortName = "Label", SortOrder = 5)]
             public string LabelColumn = DefaultColumnNames.Label;
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 6)]
+            public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
 
             [Argument(ArgumentType.Required, HelpText = "Specifies the trainer kind, which determines the evaluator to be used.", SortOrder = 6)]
             public MacroUtils.TrainerKinds Kind = MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer;
@@ -188,7 +203,10 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 var args = new TrainTestMacro.Arguments
                 {
                     Nodes = new JArray(graph.Select(n => n.ToJson()).ToArray()),
-                    TransformModel = null
+                    TransformModel = null,
+                    LabelColumn = input.LabelColumn,
+                    GroupColumn = input.GroupColumn.IsExplicit ? input.GroupColumn : Optional<string>.Implicit(DefaultColumnNames.GroupId),
+                    WeightColumn = input.WeightColumn.IsExplicit ? input.WeightColumn : Optional<string>.Implicit(DefaultColumnNames.Weight)
                 };
 
                 if (transformModelVarName != null)
@@ -356,6 +374,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             var combineArgs = new CombineMetricsInput();
             combineArgs.Kind = input.Kind;
+            combineArgs.LabelColumn = input.LabelColumn;
 
             // Set the input bindings for the CombineMetrics entry point.
             var combineInputBindingMap = new Dictionary<string, List<ParameterBinding>>();
@@ -383,10 +402,13 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var combineInstanceMetric = new Var<IDataView>();
             combineInstanceMetric.VarName = node.GetOutputVariableName(nameof(Output.PerInstanceMetrics));
             combineOutputMap.Add(nameof(Output.PerInstanceMetrics), combineInstanceMetric.VarName);
-            var combineConfusionMatrix = new Var<IDataView>();
-            combineConfusionMatrix.VarName = node.GetOutputVariableName(nameof(Output.ConfusionMatrix));
-            combineOutputMap.Add(nameof(TrainTestMacro.Output.ConfusionMatrix), combineConfusionMatrix.VarName);
+            if (confusionMatricesOutput != null)
+            {
+                var combineConfusionMatrix = new Var<IDataView>();
+                combineConfusionMatrix.VarName = node.GetOutputVariableName(nameof(Output.ConfusionMatrix));
+                combineOutputMap.Add(nameof(TrainTestMacro.Output.ConfusionMatrix), combineConfusionMatrix.VarName);
 
+            }
             subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
             subGraphNodes.Add(EntryPointNode.Create(env, "Models.CrossValidationResultsCombiner", combineArgs, node.Catalog, node.Context, combineInputBindingMap, combineInputMap, combineOutputMap));
             return new CommonOutputs.MacroOutput<Output>() { Nodes = subGraphNodes };

--- a/src/Microsoft.ML/Runtime/EntryPoints/MacroUtils.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/MacroUtils.cs
@@ -30,9 +30,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
         {
             public string LabelColumn { get; set; }
             public string NameColumn { get; set; }
-            public string ScoreColumn { get; set; }
-            public string[] StratColumn { get; set; }
             public string WeightColumn { get; set; }
+            public string GroupColumn { get; set; }
             public string FeatureColumn { get; set; }
 
             public EvaluatorSettings()
@@ -61,8 +60,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             LabelColumn = settings.LabelColumn,
                             NameColumn = settings.NameColumn,
-                            ScoreColumn = settings.ScoreColumn,
-                            StratColumn = settings.StratColumn,
                             WeightColumn = settings.WeightColumn
                         },
                         EvaluatorOutput = () => new Models.BinaryClassificationEvaluator.Output()
@@ -77,8 +74,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             LabelColumn = settings.LabelColumn,
                             NameColumn = settings.NameColumn,
-                            ScoreColumn = settings.ScoreColumn,
-                            StratColumn = settings.StratColumn,
                             WeightColumn = settings.WeightColumn
                         },
                         EvaluatorOutput = () => new Models.ClassificationEvaluator.Output()
@@ -93,9 +88,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             LabelColumn = settings.LabelColumn,
                             NameColumn = settings.NameColumn,
-                            ScoreColumn = settings.ScoreColumn,
-                            StratColumn = settings.StratColumn,
-                            WeightColumn = settings.WeightColumn
+                            WeightColumn = settings.WeightColumn,
+                            GroupIdColumn = settings.GroupColumn
                         },
                         EvaluatorOutput = () => new Models.RankerEvaluator.Output()
                     }
@@ -109,8 +103,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             LabelColumn = settings.LabelColumn,
                             NameColumn = settings.NameColumn,
-                            ScoreColumn = settings.ScoreColumn,
-                            StratColumn = settings.StratColumn,
                             WeightColumn = settings.WeightColumn
                         },
                         EvaluatorOutput = () => new Models.RegressionEvaluator.Output()
@@ -125,8 +117,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             LabelColumn = settings.LabelColumn,
                             NameColumn = settings.NameColumn,
-                            ScoreColumn = settings.ScoreColumn,
-                            StratColumn = settings.StratColumn,
                             WeightColumn = settings.WeightColumn,
                         },
                         EvaluatorOutput = () => new Models.MultiOutputRegressionEvaluator.Output()
@@ -141,8 +131,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             LabelColumn = settings.LabelColumn,
                             NameColumn = settings.NameColumn,
-                            ScoreColumn = settings.ScoreColumn,
-                            StratColumn = settings.StratColumn,
                             WeightColumn = settings.WeightColumn
                         },
                         EvaluatorOutput = () => new Models.AnomalyDetectionEvaluator.Output()
@@ -157,8 +145,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             LabelColumn = settings.LabelColumn,
                             NameColumn = settings.NameColumn,
-                            ScoreColumn = settings.ScoreColumn,
-                            StratColumn = settings.StratColumn,
                             WeightColumn = settings.WeightColumn,
                             FeatureColumn = settings.FeatureColumn
                         },

--- a/src/Microsoft.ML/Runtime/EntryPoints/TrainTestMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/TrainTestMacro.cs
@@ -62,6 +62,15 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Indicates whether to include and output training dataset metrics.", SortOrder = 9)]
             public Boolean IncludeTrainingMetrics = false;
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 10)]
+            public string LabelColumn = DefaultColumnNames.Label;
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 11)]
+            public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
+
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
         }
 
         public sealed class Output
@@ -110,7 +119,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             // Parse the subgraph.
             var subGraphRunContext = new RunContext(env);
-            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, node.Catalog);
+            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, node.Catalog, input.LabelColumn,
+                input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null, input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null);
 
             // Change the subgraph to use the training data as input.
             var varName = input.Inputs.Data.VarName;
@@ -206,11 +216,13 @@ namespace Microsoft.ML.Runtime.EntryPoints
             // Do not double-add previous nodes.
             exp.Reset();
 
-            // REVIEW: we need to extract the proper label column name here to pass to the evaluators.
-            // This is where you would add code to do it.
+
+            // REVIEW: add similar support for NameColumn and FeatureColumn.
             var settings = new MacroUtils.EvaluatorSettings
             {
-                LabelColumn = DefaultColumnNames.Label
+                LabelColumn = input.LabelColumn,
+                WeightColumn = input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null,
+                GroupColumn = input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null
             };
 
             string outVariableName;

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -1334,6 +1334,18 @@
           "Default": "Label"
         },
         {
+          "Name": "WeightColumn",
+          "Type": "String",
+          "Desc": "Column to use for example weight",
+          "Aliases": [
+            "weight"
+          ],
+          "Required": false,
+          "SortOrder": 6.0,
+          "IsNullable": false,
+          "Default": "Weight"
+        },
+        {
           "Name": "Kind",
           "Type": {
             "Kind": "Enum",
@@ -1352,6 +1364,18 @@
           "SortOrder": 6.0,
           "IsNullable": false,
           "Default": "SignatureBinaryClassifierTrainer"
+        },
+        {
+          "Name": "GroupColumn",
+          "Type": "String",
+          "Desc": "Column to use for grouping",
+          "Aliases": [
+            "group"
+          ],
+          "Required": false,
+          "SortOrder": 12.0,
+          "IsNullable": false,
+          "Default": "GroupId"
         }
       ],
       "Outputs": [
@@ -1504,6 +1528,42 @@
           "SortOrder": 8.0,
           "IsNullable": false,
           "Default": "SignatureBinaryClassifierTrainer"
+        },
+        {
+          "Name": "LabelColumn",
+          "Type": "String",
+          "Desc": "Column to use for labels",
+          "Aliases": [
+            "lab"
+          ],
+          "Required": false,
+          "SortOrder": 10.0,
+          "IsNullable": false,
+          "Default": "Label"
+        },
+        {
+          "Name": "WeightColumn",
+          "Type": "String",
+          "Desc": "Column to use for example weight",
+          "Aliases": [
+            "weight"
+          ],
+          "Required": false,
+          "SortOrder": 11.0,
+          "IsNullable": false,
+          "Default": "Weight"
+        },
+        {
+          "Name": "GroupColumn",
+          "Type": "String",
+          "Desc": "Column to use for grouping",
+          "Aliases": [
+            "group"
+          ],
+          "Required": false,
+          "SortOrder": 12.0,
+          "IsNullable": false,
+          "Default": "GroupId"
         }
       ],
       "Outputs": [
@@ -3107,6 +3167,42 @@
           "SortOrder": 9.0,
           "IsNullable": false,
           "Default": false
+        },
+        {
+          "Name": "LabelColumn",
+          "Type": "String",
+          "Desc": "Column to use for labels",
+          "Aliases": [
+            "lab"
+          ],
+          "Required": false,
+          "SortOrder": 10.0,
+          "IsNullable": false,
+          "Default": "Label"
+        },
+        {
+          "Name": "WeightColumn",
+          "Type": "String",
+          "Desc": "Column to use for example weight",
+          "Aliases": [
+            "weight"
+          ],
+          "Required": false,
+          "SortOrder": 11.0,
+          "IsNullable": false,
+          "Default": "Weight"
+        },
+        {
+          "Name": "GroupColumn",
+          "Type": "String",
+          "Desc": "Column to use for grouping",
+          "Aliases": [
+            "group"
+          ],
+          "Required": false,
+          "SortOrder": 12.0,
+          "IsNullable": false,
+          "Default": "GroupId"
         }
       ],
       "Outputs": [

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -681,9 +681,9 @@ namespace Microsoft.ML.Runtime.RunTests
                     getter(ref stdev);
                     foldGetter(ref fold);
                     Assert.True(fold.EqualsStr("Standard Deviation"));
-                    Assert.Equal(10.87, stdev.Values[0], 3);
-                    Assert.Equal(6.804, stdev.Values[1], 3);
-                    Assert.Equal(7.568, stdev.Values[2], 3);
+                    Assert.Equal(2.462, stdev.Values[0], 3);
+                    Assert.Equal(2.763, stdev.Values[1], 3);
+                    Assert.Equal(3.273, stdev.Values[2], 3);
 
                     var sumBldr = new BufferBuilder<double>(R8Adder.Instance);
                     sumBldr.Reset(avg.Length, true);


### PR DESCRIPTION
When the label/weight/group Id column has a non-default name, we need to know how to pass that name to the evaluator in the CV macro.
Fixes #292 .