### PR TITLE
Update release notes link to use aka.ms.

### DIFF
--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -24,7 +24,7 @@
     <PackageLicenseUrl>https://github.com/dotnet/machinelearning/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://dot.net/ml</PackageProjectUrl>
     <PackageIconUrl>https://aka.ms/mlnetlogo</PackageIconUrl>
-    <PackageReleaseNotes>https://github.com/dotnet/machinelearning/tree/master/Documentation/release-notes</PackageReleaseNotes>
+    <PackageReleaseNotes>https://aka.ms/mlnetreleasenotes</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our release notes link is broken because the `Documentation` was renamed to `docs`. Fix this for the future to use a redirection link.

I will also port this change to the release branch so it gets updated in v0.2.