### PR TITLE
Update release notes link to use aka.ms. (#294)

### DIFF
--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -24,7 +24,7 @@
     <PackageLicenseUrl>https://github.com/dotnet/machinelearning/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://dot.net/ml</PackageProjectUrl>
     <PackageIconUrl>https://aka.ms/mlnetlogo</PackageIconUrl>
-    <PackageReleaseNotes>https://github.com/dotnet/machinelearning/tree/master/Documentation/release-notes</PackageReleaseNotes>
+    <PackageReleaseNotes>https://aka.ms/mlnetreleasenotes</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our release notes link is broken because the `Documentation` was renamed to `docs`. Fix this for the future to use a redirection link.

Porting #294 to `release/preview`.

