### PR TITLE
`Stream` subclasses now have `Close` call `base.Close` to ensure disposal.

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
+++ b/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
@@ -121,8 +121,6 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     var overflow = _overflowStream;
                     _overflowStream = null;
                     overflow.Dispose();
-                    Contracts.AssertValue(_overflowPath);
-                    _overflowPath = null;
                 }
                 _disposed = true;
                 AssertInvariants();

--- a/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
+++ b/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
@@ -123,7 +123,6 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     _overflowStream = null;
                     overflow.Dispose();
                     Contracts.AssertValue(_overflowPath);
-                    File.Delete(_overflowPath);
                     _overflowPath = null;
                 }
                 _disposed = true;
@@ -135,7 +134,6 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         public override void Close()
         {
             AssertInvariants();
-            MyStream?.Close();
             // The base Stream class Close will call Dispose(bool).
             base.Close();
         }
@@ -166,7 +164,8 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
 
             Contracts.Assert(_overflowPath == null);
             _overflowPath = Path.GetTempFileName();
-            _overflowStream = new FileStream(_overflowPath, FileMode.Open, FileAccess.ReadWrite);
+            _overflowStream = new FileStream(_overflowPath, FileMode.Open, FileAccess.ReadWrite,
+                FileShare.None, bufferSize: 4096, FileOptions.DeleteOnClose);
 
             // The documentation is not clear on this point, but the source code for
             // memory stream makes clear that this buffer is exposable for a memory

--- a/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
+++ b/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
@@ -19,7 +19,6 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
     {
         private MemoryStream _memStream;
         private Stream _overflowStream;
-        private string _overflowPath;
         private readonly int _overflowBoundary;
         private const int _defaultMaxLen = 1 << 30;
 
@@ -162,9 +161,8 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             // been closed.
             Contracts.Check(_memStream.CanRead, "attempt to perform operation on closed stream");
 
-            Contracts.Assert(_overflowPath == null);
-            _overflowPath = Path.GetTempFileName();
-            _overflowStream = new FileStream(_overflowPath, FileMode.Open, FileAccess.ReadWrite,
+            string overflowPath = Path.GetTempFileName();
+            _overflowStream = new FileStream(overflowPath, FileMode.Open, FileAccess.ReadWrite,
                 FileShare.None, bufferSize: 4096, FileOptions.DeleteOnClose);
 
             // The documentation is not clear on this point, but the source code for

--- a/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
+++ b/src/Microsoft.ML.Core/Utilities/HybridMemoryStream.cs
@@ -25,20 +25,19 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
 
         private bool _disposed;
 
-        private Stream MyStream { get { return _memStream ?? _overflowStream; } }
+        private Stream MyStream => _memStream ?? _overflowStream;
 
-        private bool IsMemory { get { return _memStream != null; } }
+        private bool IsMemory => _memStream != null;
 
-        public override long Position
-        {
-            get { return MyStream.Position; }
-            set { Seek(value, SeekOrigin.Begin); }
+        public override long Position {
+            get => MyStream.Position;
+            set => Seek(value, SeekOrigin.Begin);
         }
 
-        public override long Length { get { return MyStream.Length; } }
-        public override bool CanWrite { get { return MyStream.CanWrite; } }
-        public override bool CanSeek { get { return MyStream.CanSeek; } }
-        public override bool CanRead { get { return MyStream.CanRead; } }
+        public override long Length => MyStream.Length;
+        public override bool CanWrite => MyStream.CanWrite;
+        public override bool CanSeek => MyStream.CanSeek;
+        public override bool CanRead => MyStream.CanRead;
 
         /// <summary>
         /// Constructs an initially empty read-write stream. Once the number of
@@ -129,21 +128,22 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 }
                 _disposed = true;
                 AssertInvariants();
+                base.Dispose(disposing);
             }
         }
 
         public override void Close()
         {
             AssertInvariants();
-            if (MyStream != null)
-                MyStream.Close();
+            MyStream?.Close();
+            // The base Stream class Close will call Dispose(bool).
+            base.Close();
         }
 
         public override void Flush()
         {
             AssertInvariants();
-            if (MyStream != null)
-                MyStream.Flush();
+            MyStream?.Flush();
             AssertInvariants();
         }
 

--- a/src/Microsoft.ML.Core/Utilities/TextReaderStream.cs
+++ b/src/Microsoft.ML.Core/Utilities/TextReaderStream.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
     /// compensates by inserting <c>\n</c> line feed characters at the end of every
     /// input line, including the last one.
     /// </summary>
-    public class TextReaderStream : Stream
+    public sealed class TextReaderStream : Stream
     {
         private readonly TextReader _baseReader;
         private readonly Encoding _encoding;
@@ -38,19 +38,11 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         public override bool CanWrite => false;
 
         public override long Length
-        {
-            get
-            {
-                throw Contracts.ExceptNotSupp("Stream cannot determine length.");
-            }
-        }
+            => throw Contracts.ExceptNotSupp("Stream cannot determine length.");
 
         public override long Position
         {
-            get
-            {
-                return _position;
-            }
+            get => _position;
             set
             {
                 if (value != Position)
@@ -96,6 +88,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         protected override void Dispose(bool disposing)
         {
             _baseReader.Dispose();
+            base.Dispose(disposing);
         }
 
         public override void Flush()
@@ -182,18 +175,12 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         }
 
         public override long Seek(long offset, SeekOrigin origin)
-        {
-            throw Contracts.ExceptNotSupp("Stream cannot seek.");
-        }
+            => throw Contracts.ExceptNotSupp("Stream cannot seek.");
 
         public override void Write(byte[] buffer, int offset, int count)
-        {
-            throw Contracts.ExceptNotSupp("Stream is not writable.");
-        }
+            => throw Contracts.ExceptNotSupp("Stream is not writable.");
 
         public override void SetLength(long value)
-        {
-            throw Contracts.ExceptNotSupp("Stream is not writable.");
-        }
+            => throw Contracts.ExceptNotSupp("Stream is not writable.");
     }
 }


### PR DESCRIPTION
Fixes #367.

Also while I was at it C# 7.x-ified the file.