### PR TITLE
removing extraneous character that broke the linux build, and with it the unnecessary cmake version requirement

### DIFF
--- a/src/Native/FactorizationMachineNative/CMakeLists.txt
+++ b/src/Native/FactorizationMachineNative/CMakeLists.txt
@@ -1,5 +1,4 @@
-﻿cmake_minimum_required (VERSION 3.2)
-project (FactorizationMachineNative)
+﻿project (FactorizationMachineNative)
 
 set(SOURCES
     FactorizationMachineCore.cpp


### PR DESCRIPTION
The cmake file for the FactorizationMachineNative folder contained a character in the first line, that was causing the build to fail. 

Deleting that, and deleting the first line, which was requiring a version of cmake higher than 3.2. 

There are no issues with this PR, as this is to fix the Linux build. 



