### PR TITLE
Fix a bug with group Id column in CV macro and add NameColumn argument to CV and TrainTest macros

### DIFF
--- a/src/Microsoft.ML/CSharpApi.cs
+++ b/src/Microsoft.ML/CSharpApi.cs
@@ -2510,6 +2510,11 @@ namespace Microsoft.ML
             public Microsoft.ML.Runtime.EntryPoints.Optional<string> GroupColumn { get; set; }
 
             /// <summary>
+            /// Name column name
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> NameColumn { get; set; }
+
+            /// <summary>
             /// Specifies the trainer kind, which determines the evaluator to be used.
             /// </summary>
             public MacroUtilsTrainerKinds Kind { get; set; } = MacroUtilsTrainerKinds.SignatureBinaryClassifierTrainer;
@@ -2628,6 +2633,11 @@ namespace Microsoft.ML
             /// Column to use for grouping
             /// </summary>
             public Microsoft.ML.Runtime.EntryPoints.Optional<string> GroupColumn { get; set; }
+
+            /// <summary>
+            /// Name column name
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> NameColumn { get; set; }
 
 
             public sealed class Output
@@ -4019,6 +4029,11 @@ namespace Microsoft.ML
             /// Column to use for grouping
             /// </summary>
             public Microsoft.ML.Runtime.EntryPoints.Optional<string> GroupColumn { get; set; }
+
+            /// <summary>
+            /// Name column name
+            /// </summary>
+            public Microsoft.ML.Runtime.EntryPoints.Optional<string> NameColumn { get; set; }
 
 
             public sealed class Output

--- a/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
@@ -78,16 +78,16 @@ namespace Microsoft.ML.Runtime.EntryPoints
             [Argument(ArgumentType.Required, HelpText = "Specifies the trainer kind, which determines the evaluator to be used.", SortOrder = 8)]
             public MacroUtils.TrainerKinds Kind = MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 10)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 9)]
             public string LabelColumn = DefaultColumnNames.Label;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 11)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 10)]
             public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 11)]
             public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 6)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 12)]
             public Optional<string> NameColumn = Optional<string>.Implicit(DefaultColumnNames.Name);
         }
 
@@ -130,19 +130,19 @@ namespace Microsoft.ML.Runtime.EntryPoints
             [Argument(ArgumentType.Multiple, HelpText = "Warning datasets", SortOrder = 4)]
             public IDataView[] Warnings;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "The label column name", ShortName = "Label", SortOrder = 5)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "The label column name", ShortName = "Label", SortOrder = 6)]
             public string LabelColumn = DefaultColumnNames.Label;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 6)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 7)]
             public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 8)]
             public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 6)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 9)]
             public Optional<string> NameColumn = Optional<string>.Implicit(DefaultColumnNames.Name);
 
-            [Argument(ArgumentType.Required, HelpText = "Specifies the trainer kind, which determines the evaluator to be used.", SortOrder = 6)]
+            [Argument(ArgumentType.Required, HelpText = "Specifies the trainer kind, which determines the evaluator to be used.", SortOrder = 5)]
             public MacroUtils.TrainerKinds Kind = MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer;
         }
 
@@ -496,22 +496,22 @@ namespace Microsoft.ML.Runtime.EntryPoints
         {
             switch (kind)
             {
-            case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
-                return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
-                return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
-                return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureRankerTrainer:
-                return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
-                return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
-                return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
-            case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
-                return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
-            default:
-                throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
+                case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
+                    return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
+                    return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
+                    return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureRankerTrainer:
+                    return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
+                    return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
+                    return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
+                case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
+                    return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
+                default:
+                    throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
             }
         }
     }

--- a/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
@@ -66,11 +66,11 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             // For splitting the data into folds, this column is used for grouping rows and makes sure
             // that a group of rows is not split among folds.
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for stratification", ShortName = "strat", SortOrder = 6)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for stratification", ShortName = "strat", SortOrder = 6)]
             public string StratificationColumn;
 
             // The number of folds to generate.
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of folds in k-fold cross-validation", ShortName = "k", SortOrder = 7)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Number of folds in k-fold cross-validation", ShortName = "k", SortOrder = 7)]
             public int NumFolds = 2;
 
             // REVIEW: suggest moving to subcomponents for evaluators, to allow for different parameters on the evaluators
@@ -78,14 +78,17 @@ namespace Microsoft.ML.Runtime.EntryPoints
             [Argument(ArgumentType.Required, HelpText = "Specifies the trainer kind, which determines the evaluator to be used.", SortOrder = 8)]
             public MacroUtils.TrainerKinds Kind = MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer;
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 10)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 10)]
             public string LabelColumn = DefaultColumnNames.Label;
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 11)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 11)]
             public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
             public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
+
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 6)]
+            public Optional<string> NameColumn = Optional<string>.Implicit(DefaultColumnNames.Name);
         }
 
         // REVIEW: This output would be much better as an array of CommonOutputs.ClassificationEvaluateOutput,
@@ -130,11 +133,14 @@ namespace Microsoft.ML.Runtime.EntryPoints
             [Argument(ArgumentType.AtMostOnce, HelpText = "The label column name", ShortName = "Label", SortOrder = 5)]
             public string LabelColumn = DefaultColumnNames.Label;
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 6)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 6)]
             public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
             public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
+
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 6)]
+            public Optional<string> NameColumn = Optional<string>.Implicit(DefaultColumnNames.Name);
 
             [Argument(ArgumentType.Required, HelpText = "Specifies the trainer kind, which determines the evaluator to be used.", SortOrder = 6)]
             public MacroUtils.TrainerKinds Kind = MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer;
@@ -206,7 +212,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     TransformModel = null,
                     LabelColumn = input.LabelColumn,
                     GroupColumn = input.GroupColumn,
-                    WeightColumn = input.WeightColumn
+                    WeightColumn = input.WeightColumn,
+                    NameColumn = input.NameColumn
                 };
 
                 if (transformModelVarName != null)
@@ -377,6 +384,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             combineArgs.LabelColumn = input.LabelColumn;
             combineArgs.WeightColumn = input.WeightColumn;
             combineArgs.GroupColumn = input.GroupColumn;
+            combineArgs.NameColumn = input.NameColumn;
 
             // Set the input bindings for the CombineMetrics entry point.
             var combineInputBindingMap = new Dictionary<string, List<ParameterBinding>>();
@@ -429,7 +437,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 {
                     RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, input.LabelColumn),
                     RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Weight, input.WeightColumn.Value),
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Group, input.GroupColumn.Value)
+                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Group, input.GroupColumn.Value),
+                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Name, input.NameColumn.Value)
                 })).ToArray(),
                 out var variableSizeVectorColumnNames);
 
@@ -487,22 +496,22 @@ namespace Microsoft.ML.Runtime.EntryPoints
         {
             switch (kind)
             {
-                case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
-                    return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
-                    return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
-                    return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureRankerTrainer:
-                    return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
-                    return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
-                    return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
-                case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
-                    return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
-                default:
-                    throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
+            case MacroUtils.TrainerKinds.SignatureBinaryClassifierTrainer:
+                return new BinaryClassifierMamlEvaluator(env, new BinaryClassifierMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureMultiClassClassifierTrainer:
+                return new MultiClassMamlEvaluator(env, new MultiClassMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureRegressorTrainer:
+                return new RegressionMamlEvaluator(env, new RegressionMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureRankerTrainer:
+                return new RankerMamlEvaluator(env, new RankerMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureAnomalyDetectorTrainer:
+                return new AnomalyDetectionMamlEvaluator(env, new AnomalyDetectionMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureClusteringTrainer:
+                return new ClusteringMamlEvaluator(env, new ClusteringMamlEvaluator.Arguments());
+            case MacroUtils.TrainerKinds.SignatureMultiOutputRegressorTrainer:
+                return new MultiOutputRegressionMamlEvaluator(env, new MultiOutputRegressionMamlEvaluator.Arguments());
+            default:
+                throw env.ExceptParam(nameof(kind), $"Trainer kind {kind} does not have an evaluator");
             }
         }
     }

--- a/src/Microsoft.ML/Runtime/EntryPoints/TrainTestMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/TrainTestMacro.cs
@@ -63,14 +63,17 @@ namespace Microsoft.ML.Runtime.EntryPoints
             [Argument(ArgumentType.AtMostOnce, HelpText = "Indicates whether to include and output training dataset metrics.", SortOrder = 9)]
             public Boolean IncludeTrainingMetrics = false;
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 10)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for labels", ShortName = "lab", SortOrder = 10)]
             public string LabelColumn = DefaultColumnNames.Label;
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 11)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 11)]
             public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
             public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
+
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 6)]
+            public Optional<string> NameColumn = Optional<string>.Implicit(DefaultColumnNames.Name);
         }
 
         public sealed class Output
@@ -120,7 +123,9 @@ namespace Microsoft.ML.Runtime.EntryPoints
             // Parse the subgraph.
             var subGraphRunContext = new RunContext(env);
             var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, node.Catalog, input.LabelColumn,
-                input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null, input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null);
+                input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null,
+                input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null,
+                input.NameColumn.IsExplicit ? input.NameColumn.Value : null);
 
             // Change the subgraph to use the training data as input.
             var varName = input.Inputs.Data.VarName;
@@ -221,7 +226,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
             {
                 LabelColumn = input.LabelColumn,
                 WeightColumn = input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null,
-                GroupColumn = input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null
+                GroupColumn = input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null,
+                NameColumn = input.NameColumn.IsExplicit ? input.NameColumn.Value : null
             };
 
             string outVariableName;

--- a/src/Microsoft.ML/Runtime/EntryPoints/TrainTestMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/TrainTestMacro.cs
@@ -72,7 +72,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for grouping", ShortName = "group", SortOrder = 12)]
             public Optional<string> GroupColumn = Optional<string>.Implicit(DefaultColumnNames.GroupId);
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 6)]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Name column name", ShortName = "name", SortOrder = 13)]
             public Optional<string> NameColumn = Optional<string>.Implicit(DefaultColumnNames.Name);
         }
 

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -1513,6 +1513,18 @@
           "Default": "Weight"
         },
         {
+          "Name": "NameColumn",
+          "Type": "String",
+          "Desc": "Name column name",
+          "Aliases": [
+            "name"
+          ],
+          "Required": false,
+          "SortOrder": 6.0,
+          "IsNullable": false,
+          "Default": "Name"
+        },
+        {
           "Name": "Kind",
           "Type": {
             "Kind": "Enum",
@@ -1663,6 +1675,18 @@
           "SortOrder": 6.0,
           "IsNullable": false,
           "Default": null
+        },
+        {
+          "Name": "NameColumn",
+          "Type": "String",
+          "Desc": "Name column name",
+          "Aliases": [
+            "name"
+          ],
+          "Required": false,
+          "SortOrder": 6.0,
+          "IsNullable": false,
+          "Default": "Name"
         },
         {
           "Name": "NumFolds",
@@ -3588,6 +3612,18 @@
           "Required": true,
           "SortOrder": 6.0,
           "IsNullable": false
+        },
+        {
+          "Name": "NameColumn",
+          "Type": "String",
+          "Desc": "Name column name",
+          "Aliases": [
+            "name"
+          ],
+          "Required": false,
+          "SortOrder": 6.0,
+          "IsNullable": false,
+          "Default": "Name"
         },
         {
           "Name": "Kind",

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -1489,42 +1489,6 @@
           "Default": null
         },
         {
-          "Name": "LabelColumn",
-          "Type": "String",
-          "Desc": "The label column name",
-          "Aliases": [
-            "Label"
-          ],
-          "Required": false,
-          "SortOrder": 5.0,
-          "IsNullable": false,
-          "Default": "Label"
-        },
-        {
-          "Name": "WeightColumn",
-          "Type": "String",
-          "Desc": "Column to use for example weight",
-          "Aliases": [
-            "weight"
-          ],
-          "Required": false,
-          "SortOrder": 6.0,
-          "IsNullable": false,
-          "Default": "Weight"
-        },
-        {
-          "Name": "NameColumn",
-          "Type": "String",
-          "Desc": "Name column name",
-          "Aliases": [
-            "name"
-          ],
-          "Required": false,
-          "SortOrder": 6.0,
-          "IsNullable": false,
-          "Default": "Name"
-        },
-        {
           "Name": "Kind",
           "Type": {
             "Kind": "Enum",
@@ -1540,9 +1504,33 @@
           },
           "Desc": "Specifies the trainer kind, which determines the evaluator to be used.",
           "Required": true,
-          "SortOrder": 6.0,
+          "SortOrder": 5.0,
           "IsNullable": false,
           "Default": "SignatureBinaryClassifierTrainer"
+        },
+        {
+          "Name": "LabelColumn",
+          "Type": "String",
+          "Desc": "The label column name",
+          "Aliases": [
+            "Label"
+          ],
+          "Required": false,
+          "SortOrder": 6.0,
+          "IsNullable": false,
+          "Default": "Label"
+        },
+        {
+          "Name": "WeightColumn",
+          "Type": "String",
+          "Desc": "Column to use for example weight",
+          "Aliases": [
+            "weight"
+          ],
+          "Required": false,
+          "SortOrder": 7.0,
+          "IsNullable": false,
+          "Default": "Weight"
         },
         {
           "Name": "GroupColumn",
@@ -1552,9 +1540,21 @@
             "group"
           ],
           "Required": false,
-          "SortOrder": 12.0,
+          "SortOrder": 8.0,
           "IsNullable": false,
           "Default": "GroupId"
+        },
+        {
+          "Name": "NameColumn",
+          "Type": "String",
+          "Desc": "Name column name",
+          "Aliases": [
+            "name"
+          ],
+          "Required": false,
+          "SortOrder": 9.0,
+          "IsNullable": false,
+          "Default": "Name"
         }
       ],
       "Outputs": [
@@ -1677,18 +1677,6 @@
           "Default": null
         },
         {
-          "Name": "NameColumn",
-          "Type": "String",
-          "Desc": "Name column name",
-          "Aliases": [
-            "name"
-          ],
-          "Required": false,
-          "SortOrder": 6.0,
-          "IsNullable": false,
-          "Default": "Name"
-        },
-        {
           "Name": "NumFolds",
           "Type": "Int",
           "Desc": "Number of folds in k-fold cross-validation",
@@ -1728,7 +1716,7 @@
             "lab"
           ],
           "Required": false,
-          "SortOrder": 10.0,
+          "SortOrder": 9.0,
           "IsNullable": false,
           "Default": "Label"
         },
@@ -1740,7 +1728,7 @@
             "weight"
           ],
           "Required": false,
-          "SortOrder": 11.0,
+          "SortOrder": 10.0,
           "IsNullable": false,
           "Default": "Weight"
         },
@@ -1752,9 +1740,21 @@
             "group"
           ],
           "Required": false,
-          "SortOrder": 12.0,
+          "SortOrder": 11.0,
           "IsNullable": false,
           "Default": "GroupId"
+        },
+        {
+          "Name": "NameColumn",
+          "Type": "String",
+          "Desc": "Name column name",
+          "Aliases": [
+            "name"
+          ],
+          "Required": false,
+          "SortOrder": 12.0,
+          "IsNullable": false,
+          "Default": "Name"
         }
       ],
       "Outputs": [
@@ -3614,18 +3614,6 @@
           "IsNullable": false
         },
         {
-          "Name": "NameColumn",
-          "Type": "String",
-          "Desc": "Name column name",
-          "Aliases": [
-            "name"
-          ],
-          "Required": false,
-          "SortOrder": 6.0,
-          "IsNullable": false,
-          "Default": "Name"
-        },
-        {
           "Name": "Kind",
           "Type": {
             "Kind": "Enum",
@@ -3698,6 +3686,18 @@
           "SortOrder": 12.0,
           "IsNullable": false,
           "Default": "GroupId"
+        },
+        {
+          "Name": "NameColumn",
+          "Type": "String",
+          "Desc": "Name column name",
+          "Aliases": [
+            "name"
+          ],
+          "Required": false,
+          "SortOrder": 13.0,
+          "IsNullable": false,
+          "Default": "Name"
         }
       ],
       "Outputs": [

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data;
@@ -761,6 +762,7 @@ namespace Microsoft.ML.Runtime.RunTests
                     TransformModel = null,
                     LabelColumn = "Label1",
                     GroupColumn = "GroupId1",
+                    NameColumn = "Workclass",
                     Kind = Models.MacroUtilsTrainerKinds.SignatureRankerTrainer
                 };
                 crossValidate.Inputs.Data = textToKey.Data;
@@ -797,9 +799,9 @@ namespace Microsoft.ML.Runtime.RunTests
                     getter(ref stdev);
                     foldGetter(ref fold);
                     Assert.True(fold.EqualsStr("Standard Deviation"));
-                    Assert.Equal(5.247, stdev.Values[0], 3);
-                    Assert.Equal(4.703, stdev.Values[1], 3);
-                    Assert.Equal(3.844, stdev.Values[2], 3);
+                    Assert.Equal(2.462, stdev.Values[0], 3);
+                    Assert.Equal(2.763, stdev.Values[1], 3);
+                    Assert.Equal(3.273, stdev.Values[2], 3);
 
                     var sumBldr = new BufferBuilder<double>(R8Adder.Instance);
                     sumBldr.Reset(avg.Length, true);
@@ -819,6 +821,21 @@ namespace Microsoft.ML.Runtime.RunTests
                         Assert.Equal(avg.Values[i], sum.Values[i] / 2);
                     b = cursor.MoveNext();
                     Assert.False(b);
+                }
+
+                data = experiment.GetOutput(crossValidateOutput.PerInstanceMetrics);
+                Assert.True(data.Schema.TryGetColumnIndex("Instance", out int nameCol));
+                using (var cursor = data.GetRowCursor(col => col == nameCol))
+                {
+                    var getter = cursor.GetGetter<DvText>(nameCol);
+                    while (cursor.MoveNext())
+                    {
+                        DvText name = default;
+                        getter(ref name);
+                        Assert.Subset(new HashSet<DvText>() { new DvText("Private"), new DvText("?"), new DvText("Federal-gov") }, new HashSet<DvText>() { name });
+                        if (cursor.Position > 4)
+                            break;
+                    }
                 }
             }
         }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -373,9 +373,9 @@ namespace Microsoft.ML.Runtime.RunTests
                         foldGetter(ref fold);
                         Assert.True(fold.EqualsStr("Standard Deviation"));
                         if (w == 1)
-                            Assert.Equal(0.002827, stdev, 6);
+                            Assert.Equal(0.004557, stdev, 6);
                         else
-                            Assert.Equal(0.002376, stdev, 6);
+                            Assert.Equal(0.000393, stdev, 6);
                         isWeightedGetter(ref isWeighted);
                         Assert.True(isWeighted.IsTrue == (w == 1));
                     }


### PR DESCRIPTION
This PR fixes bug #456, and also introduces a NameColumn argument to the TrainTest and CV macros, to enable the evaluator to use it in the per-instance results.
Fixes #456 
Fixes #466 
