### PR TITLE
Reverted 'new' modifier to be first in statement.

### DIFF
--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Runtime.Learners
         internal const string UserNameValue = "Poisson Regression";
         internal const string ShortName = "PR";
         internal const string Summary = "Poisson Regression assumes the unknown function, denoted Y has a Poisson distribution.";
-        internal new const string Remarks = @"<remarks>
+        new internal const string Remarks = @"<remarks>
 <a href='https://en.wikipedia.org/wiki/Poisson_regression'>Poisson regression</a> is a parameterized regression method. 
 It assumes that the log of the conditional mean of the dependent variable follows a linear function of the dependent variables. 
 Assuming that the dependent variable follows a Poisson distribution, the parameters of the regressor can be estimated by maximizing the likelihood of the obtained observations.


### PR DESCRIPTION
This is a small fix left over from PR 478. Following [C# documentation](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/435f1dw2(v%3dvs.100)), placing 'new' modifier to be first in the statement.