### PR TITLE
Role mapped improvements

### DIFF
--- a/src/Microsoft.ML.Api/ComponentCreation.cs
+++ b/src/Microsoft.ML.Api/ComponentCreation.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Runtime.Api
             env.CheckValueOrNull(weight);
             env.CheckValueOrNull(custom);
 
-            return TrainUtils.CreateExamples(data, label, features, group, weight, name: null, custom: custom);
+            return new RoleMappedData(data, label, features, group, weight, name: null, custom: custom);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Api/GenerateCodeCommand.cs
+++ b/src/Microsoft.ML.Api/GenerateCodeCommand.cs
@@ -108,7 +108,7 @@ namespace Microsoft.ML.Runtime.Api
                 {
                     var roles = ModelFileUtils.LoadRoleMappingsOrNull(_host, fs);
                     scorer = roles != null
-                        ? _host.CreateDefaultScorer(RoleMappedData.CreateOpt(transformPipe, roles), pred)
+                        ? _host.CreateDefaultScorer(new RoleMappedData(transformPipe, roles, opt: true), pred)
                         : _host.CreateDefaultScorer(_host.CreateExamples(transformPipe, "Features"), pred);
                 }
 

--- a/src/Microsoft.ML.Api/GenerateCodeCommand.cs
+++ b/src/Microsoft.ML.Api/GenerateCodeCommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Runtime.Api
                     var roles = ModelFileUtils.LoadRoleMappingsOrNull(_host, fs);
                     scorer = roles != null
                         ? _host.CreateDefaultScorer(new RoleMappedData(transformPipe, roles, opt: true), pred)
-                        : _host.CreateDefaultScorer(_host.CreateExamples(transformPipe, "Features"), pred);
+                        : _host.CreateDefaultScorer(new RoleMappedData(transformPipe, label: null, "Features"), pred);
                 }
 
                 var nonScoreSb = new StringBuilder();

--- a/src/Microsoft.ML.Api/PredictionEngine.cs
+++ b/src/Microsoft.ML.Api/PredictionEngine.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Runtime.Api
             {
                 var roles = ModelFileUtils.LoadRoleMappingsOrNull(env, modelStream);
                 pipe = roles != null
-                    ? env.CreateDefaultScorer(RoleMappedData.CreateOpt(pipe, roles), predictor)
+                    ? env.CreateDefaultScorer(new RoleMappedData(pipe, roles, opt: true), predictor)
                     : env.CreateDefaultScorer(env.CreateExamples(pipe, "Features"), predictor);
             }
 

--- a/src/Microsoft.ML.Api/PredictionEngine.cs
+++ b/src/Microsoft.ML.Api/PredictionEngine.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Runtime.Api
                 var roles = ModelFileUtils.LoadRoleMappingsOrNull(env, modelStream);
                 pipe = roles != null
                     ? env.CreateDefaultScorer(new RoleMappedData(pipe, roles, opt: true), predictor)
-                    : env.CreateDefaultScorer(env.CreateExamples(pipe, "Features"), predictor);
+                    : env.CreateDefaultScorer(new RoleMappedData(pipe, label: null, "Features"), predictor);
             }
 
             _pipeEngine = new PipeEngine<TDst>(env, pipe, ignoreMissingColumns, outputSchemaDefinition);

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -312,7 +312,6 @@ namespace Microsoft.ML.Runtime.Data
         public static void GetSlotNames(RoleMappedSchema schema, RoleMappedSchema.ColumnRole role, int vectorSize, ref VBuffer<DvText> slotNames)
         {
             Contracts.CheckValueOrNull(schema);
-            Contracts.CheckValue(role.Value, nameof(role));
             Contracts.CheckParam(vectorSize >= 0, nameof(vectorSize));
 
             IReadOnlyList<ColumnInfo> list;

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Runtime.Data
         private const string FeatureContributionsString = "FeatureContributions";
 
         /// <summary>
-        /// Instances of this are the keys of a <see cref="RoleMappedSchema"/>. This class also some holds important
+        /// Instances of this are the keys of a <see cref="RoleMappedSchema"/>. This class also holds some important
         /// commonly used pre-defined instances available (e.g., <see cref="Label"/>, <see cref="Feature"/>) that should
         /// be used when possible for consistency reasons. However, practitioners should not be afraid to declare custom
         /// roles if approppriate for their task.

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -380,15 +380,6 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Constructor from the given schema with no column role assignments.
-        /// </summary>
-        /// <param name="schema">The schema over which no roles are defined</param>
-        public RoleMappedSchema(ISchema schema)
-            : this(Contracts.CheckRef(schema, nameof(schema)), new Dictionary<string, List<ColumnInfo>>())
-        {
-        }
-
-        /// <summary>
         /// Constructor from the given schema and role/column-name pairs.
         /// This skips null or empty column-names. It will also skip column-names that are not
         /// found in the schema if <paramref name="opt"/> is true.
@@ -398,7 +389,7 @@ namespace Microsoft.ML.Runtime.Data
         /// values for the column names that does not appear in <paramref name="schema"/> will result iin an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         /// <param name="roles">The column role to column name mappings</param>
-        public RoleMappedSchema(ISchema schema, bool opt, params KeyValuePair<ColumnRole, string>[] roles)
+        public RoleMappedSchema(ISchema schema, bool opt = false, params KeyValuePair<ColumnRole, string>[] roles)
             : this(Contracts.CheckRef(schema, nameof(schema)), Contracts.CheckRef(roles, nameof(roles)), opt)
         {
         }
@@ -466,52 +457,6 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValueOrNull(name);
             Contracts.CheckValueOrNull(custom);
         }
-
-        /// <summary>
-        /// Creates a RoleMappedSchema from the given schema with no column role assignments.
-        /// </summary>
-        [Obsolete("Please shift to using the constructor")]
-        public static RoleMappedSchema Create(ISchema schema)
-        {
-            Contracts.CheckValue(schema, nameof(schema));
-            return new RoleMappedSchema(schema, new Dictionary<string, List<ColumnInfo>>());
-        }
-
-        /// <summary>
-        /// Creates a RoleMappedSchema from the given schema and role/column-name pairs.
-        /// This skips null or empty column-names.
-        /// </summary>
-        [Obsolete("Please shift to using the constructor with opt: false")]
-        public static RoleMappedSchema Create(ISchema schema, params KeyValuePair<ColumnRole, string>[] roles)
-        {
-            Contracts.CheckValue(schema, nameof(schema));
-            Contracts.CheckValue(roles, nameof(roles));
-            return new RoleMappedSchema(schema, MapFromNames(schema, roles));
-        }
-
-        /// <summary>
-        /// Creates a RoleMappedSchema from the given schema and role/column-name pairs.
-        /// This skips null or empty column-names.
-        /// </summary>
-        [Obsolete("Please shift to using the constructor")]
-        public static RoleMappedSchema Create(ISchema schema, IEnumerable<KeyValuePair<ColumnRole, string>> roles)
-        {
-            Contracts.CheckValue(schema, nameof(schema));
-            Contracts.CheckValue(roles, nameof(roles));
-            return new RoleMappedSchema(schema, MapFromNames(schema, roles));
-        }
-
-        /// <summary>
-        /// Creates a RoleMappedSchema from the given schema and role/column-name pairs.
-        /// This skips null or empty column-names, or column-names that are not found in the schema.
-        /// </summary>
-        [Obsolete("Please shift to using the constructor with opt: true")]
-        public static RoleMappedSchema CreateOpt(ISchema schema, IEnumerable<KeyValuePair<ColumnRole, string>> roles)
-        {
-            Contracts.CheckValue(schema, nameof(schema));
-            Contracts.CheckValue(roles, nameof(roles));
-            return new RoleMappedSchema(schema, MapFromNames(schema, roles, opt: true));
-        }
     }
 
     /// <summary>
@@ -542,15 +487,6 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Constructor for the given schema with no column role assignments.
-        /// </summary>
-        /// <param name="data">The data over which no roles are defined</param>
-        public RoleMappedData(IDataView data)
-            : this(Contracts.CheckRef(data, nameof(data)), new RoleMappedSchema(data.Schema))
-        {
-        }
-
-        /// <summary>
         /// Constructor from the given data and role/column-name pairs.
         /// This skips null or empty column-names. It will also skip column-names that are not
         /// found in the schema if <paramref name="opt"/> is true.
@@ -560,7 +496,7 @@ namespace Microsoft.ML.Runtime.Data
         /// values for the column names that does not appear in <paramref name="data"/>'s schema will result iin an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         /// <param name="roles">The column role to column name mappings</param>
-        public RoleMappedData(IDataView data, bool opt, params KeyValuePair<RoleMappedSchema.ColumnRole, string>[] roles)
+        public RoleMappedData(IDataView data, bool opt = false, params KeyValuePair<RoleMappedSchema.ColumnRole, string>[] roles)
             : this(Contracts.CheckRef(data, nameof(data)), new RoleMappedSchema(data.Schema, Contracts.CheckRef(roles, nameof(roles)), opt))
         {
         }
@@ -606,52 +542,6 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValueOrNull(weight);
             Contracts.CheckValueOrNull(name);
             Contracts.CheckValueOrNull(custom);
-        }
-
-        /// <summary>
-        /// Creates a RoleMappedData from the given data with no column role assignments.
-        /// </summary>
-        [Obsolete("Use the corresponding constructor instead")]
-        public static RoleMappedData Create(IDataView data)
-        {
-            Contracts.CheckValue(data, nameof(data));
-            return new RoleMappedData(data, RoleMappedSchema.Create(data.Schema));
-        }
-
-        /// <summary>
-        /// Creates a RoleMappedData from the given schema and role/column-name pairs.
-        /// This skips null or empty column-names.
-        /// </summary>
-        [Obsolete("Use the corresponding constructor instead")]
-        public static RoleMappedData Create(IDataView data, params KeyValuePair<RoleMappedSchema.ColumnRole, string>[] roles)
-        {
-            Contracts.CheckValue(data, nameof(data));
-            Contracts.CheckValue(roles, nameof(roles));
-            return new RoleMappedData(data, RoleMappedSchema.Create(data.Schema, roles));
-        }
-
-        /// <summary>
-        /// Creates a RoleMappedData from the given schema and role/column-name pairs.
-        /// This skips null or empty column-names.
-        /// </summary>
-        [Obsolete("Use the corresponding constructor instead")]
-        public static RoleMappedData Create(IDataView data, IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> roles)
-        {
-            Contracts.CheckValue(data, nameof(data));
-            Contracts.CheckValue(roles, nameof(roles));
-            return new RoleMappedData(data, RoleMappedSchema.Create(data.Schema, roles));
-        }
-
-        /// <summary>
-        /// Creates a RoleMappedData from the given schema and role/column-name pairs.
-        /// This skips null or empty column-names, or column-names that are not found in the schema.
-        /// </summary>
-        [Obsolete("Use the corresponding constructor instead with opt: false")]
-        public static RoleMappedData CreateOpt(IDataView data, IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> roles)
-        {
-            Contracts.CheckValue(data, nameof(data));
-            Contracts.CheckValue(roles, nameof(roles));
-            return new RoleMappedData(data, RoleMappedSchema.CreateOpt(data.Schema, roles));
         }
     }
 }

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.ML.Runtime.Internal.Utilities;
 
 namespace Microsoft.ML.Runtime.Data
@@ -35,8 +33,7 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         public static ColumnInfo CreateFromName(ISchema schema, string name, string descName)
         {
-            ColumnInfo colInfo;
-            if (!TryCreateFromName(schema, name, out colInfo))
+            if (!TryCreateFromName(schema, name, out var colInfo))
                 throw Contracts.ExceptParam(nameof(name), $"{descName} column '{name}' not found");
 
             return colInfo;
@@ -52,8 +49,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckNonEmpty(name, nameof(name));
 
             colInfo = null;
-            int index;
-            if (!schema.TryGetColumnIndex(name, out index))
+            if (!schema.TryGetColumnIndex(name, out int index))
                 return false;
 
             colInfo = new ColumnInfo(name, index, schema.GetColumnType(index));
@@ -311,9 +307,7 @@ namespace Microsoft.ML.Runtime.Data
         /// it returns null.
         /// </summary>
         public IReadOnlyList<ColumnInfo> GetColumns(ColumnRole role)
-        {
-            return _map.TryGetValue(role.Value, out var list) ? list : null;
-        }
+            => _map.TryGetValue(role.Value, out var list) ? list : null;
 
         /// <summary>
         /// An enumerable over all role-column associations within this object.
@@ -380,13 +374,13 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Constructor from the given schema and role/column-name pairs.
+        /// Constructor given a schema, and mapping pairs of roles to columns in the schema.
         /// This skips null or empty column-names. It will also skip column-names that are not
         /// found in the schema if <paramref name="opt"/> is true.
         /// </summary>
         /// <param name="schema">The schema over which roles are defined</param>
         /// <param name="opt">Whether to consider the column names specified "optional" or not. If <c>false</c> then any non-empty
-        /// values for the column names that does not appear in <paramref name="schema"/> will result iin an exception being thrown,
+        /// values for the column names that does not appear in <paramref name="schema"/> will result in an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         /// <param name="roles">The column role to column name mappings</param>
         public RoleMappedSchema(ISchema schema, bool opt = false, params KeyValuePair<ColumnRole, string>[] roles)
@@ -395,14 +389,14 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Constructor from the given schema and role/column-name pairs.
-        /// This skips null or empty column-names. It will also skip column-names that are not
+        /// Constructor given a schema, and mapping pairs of roles to columns in the schema.
+        /// This skips null or empty column names. It will also skip column-names that are not
         /// found in the schema if <paramref name="opt"/> is true.
         /// </summary>
         /// <param name="schema">The schema over which roles are defined</param>
         /// <param name="roles">The column role to column name mappings</param>
         /// <param name="opt">Whether to consider the column names specified "optional" or not. If <c>false</c> then any non-empty
-        /// values for the column names that does not appear in <paramref name="schema"/> will result iin an exception being thrown,
+        /// values for the column names that does not appear in <paramref name="schema"/> will result in an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         public RoleMappedSchema(ISchema schema, IEnumerable<KeyValuePair<ColumnRole, string>> roles, bool opt = false)
             : this(Contracts.CheckRef(schema, nameof(schema)),
@@ -443,7 +437,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="name">The column name that will be mapped to the <see cref="ColumnRole.Name"/> role</param>
         /// <param name="custom">Any additional desired custom column role mappings</param>
         /// <param name="opt">Whether to consider the column names specified "optional" or not. If <c>false</c> then any non-empty
-        /// values for the column names that does not appear in <paramref name="schema"/> will result iin an exception being thrown,
+        /// values for the column names that does not appear in <paramref name="schema"/> will result in an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         public RoleMappedSchema(ISchema schema, string label, string feature,
             string group = null, string weight = null, string name = null,
@@ -487,13 +481,13 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Constructor from the given data and role/column-name pairs.
+        /// Constructor given a data view, and mapping pairs of roles to columns in the data view's schema.
         /// This skips null or empty column-names. It will also skip column-names that are not
         /// found in the schema if <paramref name="opt"/> is true.
         /// </summary>
         /// <param name="data">The data over which roles are defined</param>
         /// <param name="opt">Whether to consider the column names specified "optional" or not. If <c>false</c> then any non-empty
-        /// values for the column names that does not appear in <paramref name="data"/>'s schema will result iin an exception being thrown,
+        /// values for the column names that does not appear in <paramref name="data"/>'s schema will result in an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         /// <param name="roles">The column role to column name mappings</param>
         public RoleMappedData(IDataView data, bool opt = false, params KeyValuePair<RoleMappedSchema.ColumnRole, string>[] roles)
@@ -502,14 +496,14 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Constructor from the given data and role/column-name pairs.
+        /// Constructor given a data view, and mapping pairs of roles to columns in the data view's schema.
         /// This skips null or empty column-names. It will also skip column-names that are not
         /// found in the schema if <paramref name="opt"/> is true.
         /// </summary>
         /// <param name="data">The schema over which roles are defined</param>
         /// <param name="roles">The column role to column name mappings</param>
         /// <param name="opt">Whether to consider the column names specified "optional" or not. If <c>false</c> then any non-empty
-        /// values for the column names that does not appear in <paramref name="data"/>'s schema will result iin an exception being thrown,
+        /// values for the column names that does not appear in <paramref name="data"/>'s schema will result in an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         public RoleMappedData(IDataView data, IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> roles, bool opt = false)
             : this(Contracts.CheckRef(data, nameof(data)), new RoleMappedSchema(data.Schema, Contracts.CheckRef(roles, nameof(roles)), opt))
@@ -528,7 +522,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="name">The column name that will be mapped to the <see cref="RoleMappedSchema.ColumnRole.Name"/> role</param>
         /// <param name="custom">Any additional desired custom column role mappings</param>
         /// <param name="opt">Whether to consider the column names specified "optional" or not. If <c>false</c> then any non-empty
-        /// values for the column names that does not appear in <paramref name="data"/>'s schema will result iin an exception being thrown,
+        /// values for the column names that does not appear in <paramref name="data"/>'s schema will result in an exception being thrown,
         /// but if <c>true</c> such values will be ignored</param>
         public RoleMappedData(IDataView data, string label, string feature,
             string group = null, string weight = null, string name = null,

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -109,10 +109,10 @@ namespace Microsoft.ML.Runtime.Data
         private const string FeatureContributionsString = "FeatureContributions";
 
         /// <summary>
-        /// Instances of this are the keys of a <see cref="RoleMappedSchema"/>. This class also some important commonly used
-        /// pre-defined instances available (e.g., <see cref="Label"/>, <see cref="Feature"/>) that should be used when
-        /// possible for consistency reasons. However, practitioners should not be afraid to declare custom roles if
-        /// approppriate for their task.
+        /// Instances of this are the keys of a <see cref="RoleMappedSchema"/>. This class also some holds important
+        /// commonly used pre-defined instances available (e.g., <see cref="Label"/>, <see cref="Feature"/>) that should
+        /// be used when possible for consistency reasons. However, practitioners should not be afraid to declare custom
+        /// roles if approppriate for their task.
         /// </summary>
         public struct ColumnRole
         {
@@ -137,7 +137,17 @@ namespace Microsoft.ML.Runtime.Data
             /// to a particular example.
             /// </summary>
             public static ColumnRole Weight => WeightString;
+
+            /// <summary>
+            /// Role for sample names. Useful for informational and tracking purposes when scoring, but typically
+            /// without affecting results.
+            /// </summary>
             public static ColumnRole Name => NameString;
+
+            // REVIEW: Does this really belong here?
+            /// <summary>
+            /// Role for feature contributions. Useful for specific diagnostic functionality.
+            /// </summary>
             public static ColumnRole FeatureContributions => FeatureContributionsString;
 
             /// <summary>

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML.Runtime.Internal.Utilities;
 
 namespace Microsoft.ML.Runtime.Data
@@ -360,6 +361,40 @@ namespace Microsoft.ML.Runtime.Data
         {
         }
 
+        private static IEnumerable<KeyValuePair<ColumnRole, string>> Strange(
+            string label, string feature, string group, string weight, string name,
+            IEnumerable<KeyValuePair<ColumnRole, string>> custom = null)
+        {
+            if (!string.IsNullOrWhiteSpace(label))
+                yield return ColumnRole.Label.Bind(label);
+            if (!string.IsNullOrWhiteSpace(feature))
+                yield return ColumnRole.Feature.Bind(feature);
+            if (!string.IsNullOrWhiteSpace(group))
+                yield return ColumnRole.Group.Bind(group);
+            if (!string.IsNullOrWhiteSpace(weight))
+                yield return ColumnRole.Weight.Bind(weight);
+            if (!string.IsNullOrWhiteSpace(name))
+                yield return ColumnRole.Name.Bind(name);
+            if (custom != null)
+            {
+                foreach (var role in custom)
+                    yield return role;
+            }
+        }
+
+        public RoleMappedSchema(ISchema schema, string label, string feature,
+            string group = null, string weight = null, string name = null,
+            IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> custom = null, bool opt = false)
+            : this(Contracts.CheckRef(schema, nameof(schema)), Strange(label, feature, group, weight, name, custom), opt)
+        {
+            Contracts.CheckValueOrNull(label);
+            Contracts.CheckValueOrNull(feature);
+            Contracts.CheckValueOrNull(group);
+            Contracts.CheckValueOrNull(weight);
+            Contracts.CheckValueOrNull(name);
+            Contracts.CheckValueOrNull(custom);
+        }
+
         /// <summary>
         /// Creates a RoleMappedSchema from the given schema with no column role assignments.
         /// </summary>
@@ -422,7 +457,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <summary>
         /// The role mapped schema. Note that Schema.Schema is guaranteed to be the same as Data.Schema.
         /// </summary>
-        public readonly RoleMappedSchema Schema;
+        public RoleMappedSchema Schema { get; }
 
         private RoleMappedData(IDataView data, RoleMappedSchema schema)
         {
@@ -434,7 +469,7 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Creates a RoleMappedData from the given data with no column role assignments.
+        /// Constructor from the given data with no column role assignments.
         /// </summary>
         public RoleMappedData(IDataView data)
             : this(Contracts.CheckRef(data, nameof(data)), new RoleMappedSchema(data.Schema))
@@ -459,6 +494,20 @@ namespace Microsoft.ML.Runtime.Data
         public RoleMappedData(IDataView data, IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> roles, bool opt = false)
             : this(Contracts.CheckRef(data, nameof(data)), new RoleMappedSchema(data.Schema, Contracts.CheckRef(roles, nameof(roles)), opt))
         {
+        }
+
+        public RoleMappedData(IDataView data, string label, string feature,
+            string group = null, string weight = null, string name = null,
+            IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> custom = null, bool opt = false)
+            : this(Contracts.CheckRef(data, nameof(data)),
+                  new RoleMappedSchema(data.Schema, label, feature, group, weight, name, custom, opt))
+        {
+            Contracts.CheckValueOrNull(label);
+            Contracts.CheckValueOrNull(feature);
+            Contracts.CheckValueOrNull(group);
+            Contracts.CheckValueOrNull(weight);
+            Contracts.CheckValueOrNull(name);
+            Contracts.CheckValueOrNull(custom);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -254,7 +254,7 @@ namespace Microsoft.ML.Runtime.Data
             RoleMappedData srcData, IDataView marker)
         {
             var pipe = ApplyTransformUtils.ApplyAllTransformsToData(env, srcData.Data, dstData, marker);
-            return RoleMappedData.Create(pipe, srcData.Schema.GetColumnRoleNames());
+            return new RoleMappedData(pipe, srcData.Schema.GetColumnRoleNames());
         }
 
         /// <summary>
@@ -568,7 +568,7 @@ namespace Microsoft.ML.Runtime.Data
                     {
                         using (var file = host.CreateOutputFile(modelFileName))
                         {
-                            var rmd = RoleMappedData.Create(
+                            var rmd = new RoleMappedData(
                                 CompositeDataLoader.ApplyTransform(host, _loader, null, null,
                                 (e, newSource) => ApplyTransformUtils.ApplyAllTransformsToData(e, trainData.Data, newSource)),
                                 trainData.Schema.GetColumnRoleNames());
@@ -581,17 +581,17 @@ namespace Microsoft.ML.Runtime.Data
                     if (!evalComp.IsGood())
                         evalComp = EvaluateUtils.GetEvaluatorType(ch, scorePipe.Schema);
                     var eval = evalComp.CreateInstance(host);
-                    // Note that this doesn't require the provided columns to exist (because of "Opt").
+                    // Note that this doesn't require the provided columns to exist (because of the "opt" parameter).
                     // We don't normally expect the scorer to drop columns, but if it does, we should not require
                     // all the columns in the test pipeline to still be present.
-                    var dataEval = RoleMappedData.CreateOpt(scorePipe, testData.Schema.GetColumnRoleNames());
+                    var dataEval = new RoleMappedData(scorePipe, testData.Schema.GetColumnRoleNames(), opt: true);
 
                     var dict = eval.Evaluate(dataEval);
                     RoleMappedData perInstance = null;
                     if (_savePerInstance)
                     {
                         var perInst = eval.GetPerInstanceMetrics(dataEval);
-                        perInstance = RoleMappedData.CreateOpt(perInst, dataEval.Schema.GetColumnRoleNames());
+                        perInstance = new RoleMappedData(perInst, dataEval.Schema.GetColumnRoleNames(), opt: true);
                     }
                     ch.Done();
                     return new FoldResult(dict, dataEval.Schema.Schema, perInstance, trainData.Schema);

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -277,7 +277,7 @@ namespace Microsoft.ML.Runtime.Data
             // Training pipe and examples.
             var customCols = TrainUtils.CheckAndGenerateCustomColumns(ch, Args.CustomColumn);
 
-            return TrainUtils.CreateExamples(data, label, features, group, weight, name, customCols);
+            return new RoleMappedData(data, label, features, group, weight, name, customCols);
         }
 
         private string GetSplitColumn(IChannel ch, IDataView input, ref IDataView output)

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -305,7 +305,7 @@ namespace Microsoft.ML.Runtime.Data
                             // can be loaded with no data at all, to get their schemas.
                             if (trainPipe == null)
                                 trainPipe = ModelFileUtils.LoadLoader(Host, rep, new MultiFileSource(null), loadTransforms: true);
-                            trainSchema = RoleMappedSchema.Create(trainPipe.Schema, trainRoleMappings);
+                            trainSchema = new RoleMappedSchema(trainPipe.Schema, trainRoleMappings);
                         }
                         // If the role mappings are null, an alternative would be to fail. However the idea
                         // is that the scorer should always still succeed, although perhaps with reduced

--- a/src/Microsoft.ML.Data/Commands/EvaluateCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/EvaluateCommand.cs
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Runtime.Data
                     evalComp = EvaluateUtils.GetEvaluatorType(ch, input.Schema);
 
                 var eval = evalComp.CreateInstance(env);
-                var data = TrainUtils.CreateExamples(input, label, null, group, weight, null, customCols);
+                var data = new RoleMappedData(input, label, null, group, weight, null, customCols);
                 return eval.GetPerInstanceMetrics(data);
             }
         }
@@ -236,7 +236,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!evalComp.IsGood())
                 evalComp = EvaluateUtils.GetEvaluatorType(ch, view.Schema);
             var evaluator = evalComp.CreateInstance(Host);
-            var data = TrainUtils.CreateExamples(view, label, null, group, weight, name, customCols);
+            var data = new RoleMappedData(view, label, null, group, weight, name, customCols);
             var metrics = evaluator.Evaluate(data);
             MetricWriter.PrintWarnings(ch, metrics);
             evaluator.PrintFoldResults(ch, metrics);
@@ -248,7 +248,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!string.IsNullOrWhiteSpace(Args.OutputDataFile))
             {
                 var perInst = evaluator.GetPerInstanceMetrics(data);
-                var perInstData = TrainUtils.CreateExamples(perInst, label, null, group, weight, name, customCols);
+                var perInstData = new RoleMappedData(perInst, label, null, group, weight, name, customCols);
                 var idv = evaluator.GetPerInstanceDataViewToSave(perInstData);
                 MetricWriter.SavePerInstance(Host, ch, Args.OutputDataFile, idv);
             }

--- a/src/Microsoft.ML.Data/Commands/SavePredictorCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/SavePredictorCommand.cs
@@ -219,7 +219,7 @@ namespace Microsoft.ML.Runtime.Tools
                     if (roles != null)
                     {
                         var emptyView = ModelFileUtils.LoadPipeline(env, rep, new MultiFileSource(null));
-                        schema = RoleMappedSchema.CreateOpt(emptyView.Schema, roles);
+                        schema = new RoleMappedSchema(emptyView.Schema, roles, opt: true);
                     }
                     else
                     {

--- a/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
@@ -97,10 +97,7 @@ namespace Microsoft.ML.Runtime.Data
 
             ch.Trace("Creating loader");
 
-            IPredictor predictor;
-            IDataLoader loader;
-            RoleMappedSchema trainSchema;
-            LoadModelObjects(ch, true, out predictor, true, out trainSchema, out loader);
+            LoadModelObjects(ch, true, out IPredictor predictor, true, out RoleMappedSchema trainSchema, out IDataLoader loader);
             ch.AssertValue(predictor);
             ch.AssertValueOrNull(trainSchema);
             ch.AssertValue(loader);
@@ -116,7 +113,7 @@ namespace Microsoft.ML.Runtime.Data
             string group = TrainUtils.MatchNameOrDefaultOrNull(ch, loader.Schema,
                 nameof(Args.GroupColumn), Args.GroupColumn, DefaultColumnNames.GroupId);
             var customCols = TrainUtils.CheckAndGenerateCustomColumns(ch, Args.CustomColumn);
-            var schema = TrainUtils.CreateRoleMappedSchemaOpt(loader.Schema, feat, group, customCols);
+            var schema = new RoleMappedSchema(loader.Schema, label: null, feature: feat, group: group, custom: customCols, opt: true);
             var mapper = bindable.Bind(Host, schema);
 
             if (!scorer.IsGood())
@@ -159,16 +156,14 @@ namespace Microsoft.ML.Runtime.Data
             {
                 foreach (var outCol in Args.OutputColumn)
                 {
-                    int dummyColIndex;
-                    if (!loader.Schema.TryGetColumnIndex(outCol, out dummyColIndex))
+                    if (!loader.Schema.TryGetColumnIndex(outCol, out int dummyColIndex))
                         throw ch.ExceptUserArg(nameof(Arguments.OutputColumn), "Column '{0}' not found.", outCol);
                 }
             }
 
-            int colMax;
             uint maxScoreId = 0;
             if (!outputAllColumns)
-                maxScoreId = loader.Schema.GetMaxMetadataKind(out colMax, MetadataUtils.Kinds.ScoreColumnSetId);
+                maxScoreId = loader.Schema.GetMaxMetadataKind(out int colMax, MetadataUtils.Kinds.ScoreColumnSetId);
             ch.Assert(outputAllColumns || maxScoreId > 0); // score set IDs are one-based
             var cols = new List<int>();
             for (int i = 0; i < loader.Schema.ColumnCount; i++)
@@ -211,12 +206,12 @@ namespace Microsoft.ML.Runtime.Data
             {
                 switch (schema.GetColumnName(i))
                 {
-                case "Label":
-                case "Name":
-                case "Names":
-                    return true;
-                default:
-                    break;
+                    case "Label":
+                    case "Name":
+                    case "Names":
+                        return true;
+                    default:
+                        break;
                 }
             }
             if (Args.OutputColumn != null && Array.FindIndex(Args.OutputColumn, schema.GetColumnName(i).Equals) >= 0)
@@ -229,8 +224,7 @@ namespace Microsoft.ML.Runtime.Data
     {
         public static IDataScorerTransform GetScorer(IPredictor predictor, RoleMappedData data, IHostEnvironment env, RoleMappedSchema trainSchema)
         {
-            ISchemaBoundMapper mapper;
-            var sc = GetScorerComponentAndMapper(predictor, null, data.Schema, env, out mapper);
+            var sc = GetScorerComponentAndMapper(predictor, null, data.Schema, env, out ISchemaBoundMapper mapper);
             return sc.CreateInstance(env, data.Data, mapper, trainSchema);
         }
 
@@ -247,9 +241,8 @@ namespace Microsoft.ML.Runtime.Data
             env.CheckValueOrNull(customColumns);
             env.CheckValueOrNull(trainSchema);
 
-            var schema = TrainUtils.CreateRoleMappedSchemaOpt(input.Schema, featureColName, groupColName, customColumns);
-            ISchemaBoundMapper mapper;
-            var sc = GetScorerComponentAndMapper(predictor, scorer, schema, env, out mapper);
+            var schema = new RoleMappedSchema(input.Schema, label: null, feature: featureColName, group: groupColName, opt: true);
+            var sc = GetScorerComponentAndMapper(predictor, scorer, schema, env, out ISchemaBoundMapper mapper);
             return sc.CreateInstance(env, input, mapper, trainSchema);
         }
 
@@ -280,7 +273,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.AssertValue(mapper);
 
             string loadName = null;
-            DvText scoreKind = default(DvText);
+            DvText scoreKind = default;
             if (mapper.OutputSchema.ColumnCount > 0 &&
                 mapper.OutputSchema.TryGetMetadata(TextType.Instance, MetadataUtils.Kinds.ScoreColumnKind, 0, ref scoreKind) &&
                 scoreKind.HasChars)
@@ -311,10 +304,8 @@ namespace Microsoft.ML.Runtime.Data
             env.CheckValue(predictor, nameof(predictor));
             env.CheckValueOrNull(scorerSettings);
 
-            ISchemaBindableMapper bindable;
-
             // See if we can instantiate a mapper using scorer arguments.
-            if (scorerSettings.IsGood() && TryCreateBindableFromScorer(env, predictor, scorerSettings, out bindable))
+            if (scorerSettings.IsGood() && TryCreateBindableFromScorer(env, predictor, scorerSettings, out ISchemaBindableMapper bindable))
                 return bindable;
 
             // The easy case is that the predictor implements the interface.

--- a/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
@@ -241,7 +241,7 @@ namespace Microsoft.ML.Runtime.Data
             env.CheckValueOrNull(customColumns);
             env.CheckValueOrNull(trainSchema);
 
-            var schema = new RoleMappedSchema(input.Schema, label: null, feature: featureColName, group: groupColName, opt: true);
+            var schema = new RoleMappedSchema(input.Schema, label: null, feature: featureColName, group: groupColName, custom: customColumns, opt: true);
             var sc = GetScorerComponentAndMapper(predictor, scorer, schema, env, out var mapper);
             return sc.CreateInstance(env, input, mapper, trainSchema);
         }

--- a/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Runtime.Data
 
             ch.Trace("Creating loader");
 
-            LoadModelObjects(ch, true, out IPredictor predictor, true, out RoleMappedSchema trainSchema, out IDataLoader loader);
+            LoadModelObjects(ch, true, out var predictor, true, out var trainSchema, out var loader);
             ch.AssertValue(predictor);
             ch.AssertValueOrNull(trainSchema);
             ch.AssertValue(loader);
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Runtime.Data
                 Args.OutputAllColumns == true || Utils.Size(Args.OutputColumn) == 0;
 
             if (Args.OutputAllColumns == true && Utils.Size(Args.OutputColumn) != 0)
-                ch.Warning("outputAllColumns=+ always writes all columns irrespective of outputColumn specified.");
+                ch.Warning(nameof(Args.OutputAllColumns) + "=+ always writes all columns irrespective of " + nameof(Args.OutputColumn) + " specified.");
 
             if (!outputAllColumns && Utils.Size(Args.OutputColumn) != 0)
             {
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Runtime.Data
     {
         public static IDataScorerTransform GetScorer(IPredictor predictor, RoleMappedData data, IHostEnvironment env, RoleMappedSchema trainSchema)
         {
-            var sc = GetScorerComponentAndMapper(predictor, null, data.Schema, env, out ISchemaBoundMapper mapper);
+            var sc = GetScorerComponentAndMapper(predictor, null, data.Schema, env, out var mapper);
             return sc.CreateInstance(env, data.Data, mapper, trainSchema);
         }
 
@@ -242,7 +242,7 @@ namespace Microsoft.ML.Runtime.Data
             env.CheckValueOrNull(trainSchema);
 
             var schema = new RoleMappedSchema(input.Schema, label: null, feature: featureColName, group: groupColName, opt: true);
-            var sc = GetScorerComponentAndMapper(predictor, scorer, schema, env, out ISchemaBoundMapper mapper);
+            var sc = GetScorerComponentAndMapper(predictor, scorer, schema, env, out var mapper);
             return sc.CreateInstance(env, input, mapper, trainSchema);
         }
 
@@ -305,7 +305,7 @@ namespace Microsoft.ML.Runtime.Data
             env.CheckValueOrNull(scorerSettings);
 
             // See if we can instantiate a mapper using scorer arguments.
-            if (scorerSettings.IsGood() && TryCreateBindableFromScorer(env, predictor, scorerSettings, out ISchemaBindableMapper bindable))
+            if (scorerSettings.IsGood() && TryCreateBindableFromScorer(env, predictor, scorerSettings, out var bindable))
                 return bindable;
 
             // The easy case is that the predictor implements the interface.

--- a/src/Microsoft.ML.Data/Commands/TestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TestCommand.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!evalComp.IsGood())
                 evalComp = EvaluateUtils.GetEvaluatorType(ch, scorePipe.Schema);
             var evaluator = evalComp.CreateInstance(Host);
-            var data = TrainUtils.CreateExamples(scorePipe, label, null, group, weight, name, customCols);
+            var data = new RoleMappedData(scorePipe, label, null, group, weight, name, customCols);
             var metrics = evaluator.Evaluate(data);
             MetricWriter.PrintWarnings(ch, metrics);
             evaluator.PrintFoldResults(ch, metrics);
@@ -128,7 +128,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!string.IsNullOrWhiteSpace(Args.OutputDataFile))
             {
                 var perInst = evaluator.GetPerInstanceMetrics(data);
-                var perInstData = TrainUtils.CreateExamples(perInst, label, null, group, weight, name, customCols);
+                var perInstData = new RoleMappedData(perInst, label, null, group, weight, name, customCols);
                 var idv = evaluator.GetPerInstanceDataViewToSave(perInstData);
                 MetricWriter.SavePerInstance(Host, ch, Args.OutputDataFile, idv);
             }

--- a/src/Microsoft.ML.Data/Commands/TrainCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainCommand.cs
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Runtime.Data
                     ch.Trace("Constructing the validation pipeline");
                     IDataView validPipe = CreateRawLoader(dataFile: Args.ValidationFile);
                     validPipe = ApplyTransformUtils.ApplyAllTransformsToData(Host, view, validPipe);
-                    validData = RoleMappedData.Create(validPipe, data.Schema.GetColumnRoleNames());
+                    validData = new RoleMappedData(validPipe, data.Schema.GetColumnRoleNames());
                 }
             }
 
@@ -550,7 +550,7 @@ namespace Microsoft.ML.Runtime.Data
                 var prefetch = data.Schema.GetColumnRoles().Select(kc => kc.Value.Index).ToArray();
                 var cacheView = new CacheDataView(env, data.Data, prefetch);
                 // Because the prefetching worked, we know that these are valid columns.
-                data = RoleMappedData.Create(cacheView, data.Schema.GetColumnRoleNames());
+                data = new RoleMappedData(cacheView, data.Schema.GetColumnRoleNames());
             }
             else
                 ch.Trace("Not caching");
@@ -590,7 +590,7 @@ namespace Microsoft.ML.Runtime.Data
             if (custom != null)
                 list.AddRange(custom);
 
-            return RoleMappedSchema.CreateOpt(schema, list);
+            return new RoleMappedSchema(schema, list, opt: true);
         }
 
         /// <summary>
@@ -623,7 +623,7 @@ namespace Microsoft.ML.Runtime.Data
             if (custom != null)
                 list.AddRange(custom);
 
-            return RoleMappedData.Create(view, list);
+            return new RoleMappedData(view, list);
         }
 
         /// <summary>
@@ -656,7 +656,7 @@ namespace Microsoft.ML.Runtime.Data
             if (custom != null)
                 list.AddRange(custom);
 
-            return RoleMappedData.CreateOpt(view, list);
+            return new RoleMappedData(view, list, opt: true);
         }
 
         private static KeyValuePair<ColumnRole, T> Pair<T>(ColumnRole kind, T value)

--- a/src/Microsoft.ML.Data/Commands/TrainCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainCommand.cs
@@ -571,45 +571,5 @@ namespace Microsoft.ML.Runtime.Data
             }
             return customColumnArg.Select(kindName => new ColumnRole(kindName.Key).Bind(kindName.Value));
         }
-
-        /// <summary>
-        /// Given a view and a bunch of column names, create the RoleMappedData object. Any or all of the column
-        /// names may be null or whitespace, in which case they are ignored. Any columns that are specified must
-        /// be valid columns of the schema.
-        /// </summary>
-        [Obsolete("Please use the constructor on " + nameof(RoleMappedData) + " directly")]
-        public static RoleMappedData CreateExamples(IDataView view, string label, string feature,
-            string group = null, string weight = null, string name = null,
-            IEnumerable<KeyValuePair<ColumnRole, string>> custom = null)
-        {
-            Contracts.CheckValueOrNull(label);
-            Contracts.CheckValueOrNull(feature);
-            Contracts.CheckValueOrNull(group);
-            Contracts.CheckValueOrNull(weight);
-            Contracts.CheckValueOrNull(name);
-            Contracts.CheckValueOrNull(custom);
-
-            return new RoleMappedData(view, label, feature, group, weight, name, custom);
-        }
-
-        /// <summary>
-        /// Given a view and a bunch of column names, create the RoleMappedData object. Any or all of the column
-        /// names may be null or whitespace, in which case they are ignored. Any columns that are specified but not
-        /// valid columns of the schema are also ignored.
-        /// </summary>
-        [Obsolete("Please use the constructor on " + nameof(RoleMappedData) + " directly with opt: true")]
-        public static RoleMappedData CreateExamplesOpt(IDataView view, string label, string feature,
-            string group = null, string weight = null, string name = null,
-            IEnumerable<KeyValuePair<ColumnRole, string>> custom = null)
-        {
-            Contracts.CheckValueOrNull(label);
-            Contracts.CheckValueOrNull(feature);
-            Contracts.CheckValueOrNull(group);
-            Contracts.CheckValueOrNull(weight);
-            Contracts.CheckValueOrNull(name);
-            Contracts.CheckValueOrNull(custom);
-
-            return new RoleMappedData(view, label, feature, group, weight, name, custom, opt: true);
-        }
     }
 }

--- a/src/Microsoft.ML.Data/Commands/TrainCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainCommand.cs
@@ -157,7 +157,7 @@ namespace Microsoft.ML.Runtime.Data
             ch.Trace("Binding columns");
 
             var customCols = TrainUtils.CheckAndGenerateCustomColumns(ch, Args.CustomColumn);
-            var data = TrainUtils.CreateExamples(view, label, feature, group, weight, name, customCols);
+            var data = new RoleMappedData(view, label, feature, group, weight, name, customCols);
 
             // REVIEW: Unify the code that creates validation examples in Train, TrainTest and CV commands.
             RoleMappedData validData = null;
@@ -573,31 +573,11 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Given a schema and a bunch of column names, create the BoundSchema object. Any or all of the column
-        /// names may be null or whitespace, in which case they are ignored. Any columns that are specified but not
-        /// valid columns of the schema are also ignored.
-        /// </summary>
-        public static RoleMappedSchema CreateRoleMappedSchemaOpt(ISchema schema, string feature, string group, IEnumerable<KeyValuePair<ColumnRole, string>> custom = null)
-        {
-            Contracts.CheckValueOrNull(feature);
-            Contracts.CheckValueOrNull(custom);
-
-            var list = new List<KeyValuePair<ColumnRole, string>>();
-            if (!string.IsNullOrWhiteSpace(feature))
-                list.Add(ColumnRole.Feature.Bind(feature));
-            if (!string.IsNullOrWhiteSpace(group))
-                list.Add(ColumnRole.Group.Bind(group));
-            if (custom != null)
-                list.AddRange(custom);
-
-            return new RoleMappedSchema(schema, list, opt: true);
-        }
-
-        /// <summary>
         /// Given a view and a bunch of column names, create the RoleMappedData object. Any or all of the column
         /// names may be null or whitespace, in which case they are ignored. Any columns that are specified must
         /// be valid columns of the schema.
         /// </summary>
+        [Obsolete("Please use the constructor on " + nameof(RoleMappedData) + " directly")]
         public static RoleMappedData CreateExamples(IDataView view, string label, string feature,
             string group = null, string weight = null, string name = null,
             IEnumerable<KeyValuePair<ColumnRole, string>> custom = null)
@@ -609,21 +589,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValueOrNull(name);
             Contracts.CheckValueOrNull(custom);
 
-            var list = new List<KeyValuePair<ColumnRole, string>>();
-            if (!string.IsNullOrWhiteSpace(label))
-                list.Add(ColumnRole.Label.Bind(label));
-            if (!string.IsNullOrWhiteSpace(feature))
-                list.Add(ColumnRole.Feature.Bind(feature));
-            if (!string.IsNullOrWhiteSpace(group))
-                list.Add(ColumnRole.Group.Bind(group));
-            if (!string.IsNullOrWhiteSpace(weight))
-                list.Add(ColumnRole.Weight.Bind(weight));
-            if (!string.IsNullOrWhiteSpace(name))
-                list.Add(ColumnRole.Name.Bind(name));
-            if (custom != null)
-                list.AddRange(custom);
-
-            return new RoleMappedData(view, list);
+            return new RoleMappedData(view, label, feature, group, weight, name, custom);
         }
 
         /// <summary>
@@ -631,6 +597,7 @@ namespace Microsoft.ML.Runtime.Data
         /// names may be null or whitespace, in which case they are ignored. Any columns that are specified but not
         /// valid columns of the schema are also ignored.
         /// </summary>
+        [Obsolete("Please use the constructor on " + nameof(RoleMappedData) + " directly with opt: true")]
         public static RoleMappedData CreateExamplesOpt(IDataView view, string label, string feature,
             string group = null, string weight = null, string name = null,
             IEnumerable<KeyValuePair<ColumnRole, string>> custom = null)
@@ -642,26 +609,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValueOrNull(name);
             Contracts.CheckValueOrNull(custom);
 
-            var list = new List<KeyValuePair<ColumnRole, string>>();
-            if (!string.IsNullOrWhiteSpace(label))
-                list.Add(ColumnRole.Label.Bind(label));
-            if (!string.IsNullOrWhiteSpace(feature))
-                list.Add(ColumnRole.Feature.Bind(feature));
-            if (!string.IsNullOrWhiteSpace(group))
-                list.Add(ColumnRole.Group.Bind(group));
-            if (!string.IsNullOrWhiteSpace(weight))
-                list.Add(ColumnRole.Weight.Bind(weight));
-            if (!string.IsNullOrWhiteSpace(name))
-                list.Add(ColumnRole.Name.Bind(name));
-            if (custom != null)
-                list.AddRange(custom);
-
-            return new RoleMappedData(view, list, opt: true);
-        }
-
-        private static KeyValuePair<ColumnRole, T> Pair<T>(ColumnRole kind, T value)
-        {
-            return new KeyValuePair<ColumnRole, T>(kind, value);
+            return new RoleMappedData(view, label, feature, group, weight, name, custom, opt: true);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Runtime.Data
                     ch.Trace("Constructing the validation pipeline");
                     IDataView validPipe = CreateRawLoader(dataFile: Args.ValidationFile);
                     validPipe = ApplyTransformUtils.ApplyAllTransformsToData(Host, trainPipe, validPipe);
-                    validData = RoleMappedData.Create(validPipe, data.Schema.GetColumnRoleNames());
+                    validData = new RoleMappedData(validPipe, data.Schema.GetColumnRoleNames());
                 }
             }
 

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Runtime.Data
 
             ch.Trace("Binding columns");
             var customCols = TrainUtils.CheckAndGenerateCustomColumns(ch, Args.CustomColumn);
-            var data = TrainUtils.CreateExamples(trainPipe, label, features, group, weight, name, customCols);
+            var data = new RoleMappedData(trainPipe, label, features, group, weight, name, customCols);
 
             RoleMappedData validData = null;
             if (!string.IsNullOrWhiteSpace(Args.ValidationFile))
@@ -189,8 +189,8 @@ namespace Microsoft.ML.Runtime.Data
             if (!evalComp.IsGood())
                 evalComp = EvaluateUtils.GetEvaluatorType(ch, scorePipe.Schema);
             var evaluator = evalComp.CreateInstance(Host);
-            var dataEval = TrainUtils.CreateExamplesOpt(scorePipe, label, features,
-                group, weight, name, customCols);
+            var dataEval = new RoleMappedData(scorePipe, label, features,
+                group, weight, name, customCols, opt: true);
             var metrics = evaluator.Evaluate(dataEval);
             MetricWriter.PrintWarnings(ch, metrics);
             evaluator.PrintFoldResults(ch, metrics);
@@ -204,7 +204,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!string.IsNullOrWhiteSpace(Args.OutputDataFile))
             {
                 var perInst = evaluator.GetPerInstanceMetrics(dataEval);
-                var perInstData = TrainUtils.CreateExamples(perInst, label, null, group, weight, name, customCols);
+                var perInstData = new RoleMappedData(perInst, label, null, group, weight, name, customCols);
                 var idv = evaluator.GetPerInstanceDataViewToSave(perInstData);
                 MetricWriter.SavePerInstance(Host, ch, Args.OutputDataFile, idv);
             }

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -379,8 +379,9 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                 if (size > 0)
                     Array.Copy(names, _names, size);
 
-                _schema = RoleMappedSchema.Create(new FeatureNameCollectionSchema(this),
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Feature, RoleMappedSchema.ColumnRole.Feature.Value));
+                // REVIEW: This seems wrong. The default feature column name is "Features" yet the role is named "Feature".
+                _schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this), opt: false,
+                    RoleMappedSchema.ColumnRole.Feature.Bind(RoleMappedSchema.ColumnRole.Feature.Value));
             }
 
             public override int Count => _count;
@@ -470,8 +471,9 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                 }
                 Contracts.Assert(cv == cnn);
 
-                _schema = RoleMappedSchema.Create(new FeatureNameCollectionSchema(this),
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Feature, RoleMappedSchema.ColumnRole.Feature.Value));
+                // REVIEW: This seems wrong. The default feature column name is "Features" yet the role is named "Feature".
+                _schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this), opt: false,
+                    RoleMappedSchema.ColumnRole.Feature.Bind(RoleMappedSchema.ColumnRole.Feature.Value));
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -364,9 +364,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
             private readonly int _count;
             private readonly string[] _names;
 
-            private readonly RoleMappedSchema _schema;
-
-            public override RoleMappedSchema Schema => _schema;
+            public override RoleMappedSchema Schema { get; }
 
             public Dense(int count, string[] names)
             {
@@ -380,7 +378,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                     Array.Copy(names, _names, size);
 
                 // REVIEW: This seems wrong. The default feature column name is "Features" yet the role is named "Feature".
-                _schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this), opt: false,
+                Schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this), opt: false,
                     RoleMappedSchema.ColumnRole.Feature.Bind(RoleMappedSchema.ColumnRole.Feature.Value));
             }
 

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -378,8 +378,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                     Array.Copy(names, _names, size);
 
                 // REVIEW: This seems wrong. The default feature column name is "Features" yet the role is named "Feature".
-                Schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this), opt: false,
-                    RoleMappedSchema.ColumnRole.Feature.Bind(RoleMappedSchema.ColumnRole.Feature.Value));
+                Schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this),
+                    roles: RoleMappedSchema.ColumnRole.Feature.Bind(RoleMappedSchema.ColumnRole.Feature.Value));
             }
 
             public override int Count => _count;
@@ -470,8 +470,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                 Contracts.Assert(cv == cnn);
 
                 // REVIEW: This seems wrong. The default feature column name is "Features" yet the role is named "Feature".
-                _schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this), opt: false,
-                    RoleMappedSchema.ColumnRole.Feature.Bind(RoleMappedSchema.ColumnRole.Feature.Value));
+                _schema = new RoleMappedSchema(new FeatureNameCollectionSchema(this),
+                    roles: RoleMappedSchema.ColumnRole.Feature.Bind(RoleMappedSchema.ColumnRole.Feature.Value));
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
@@ -146,7 +146,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 TrainUtils.AddNormalizerIfNeeded(host, ch, trainer, ref view, feature, input.NormalizeFeatures);
 
                 ch.Trace("Binding columns");
-                var roleMappedData = TrainUtils.CreateExamples(view, label, feature, group, weight, name, custom);
+                var roleMappedData = new RoleMappedData(view, label, feature, group, weight, name, custom);
 
                 RoleMappedData cachedRoleMappedData = roleMappedData;
                 Cache.CachingType? cachingType = null;

--- a/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         Data = roleMappedData.Data,
                         Caching = cachingType.Value
                     }).OutputData;
-                    cachedRoleMappedData = RoleMappedData.Create(cacheView, roleMappedData.Schema.GetColumnRoleNames());
+                    cachedRoleMappedData = new RoleMappedData(cacheView, roleMappedData.Schema.GetColumnRoleNames());
                 }
 
                 var predictor = TrainUtils.Train(host, ch, cachedRoleMappedData, trainer, "Train", calibrator, maxCalibrationExamples);

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModel.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModel.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 // Create the chain of transforms for saving.
                 IDataView data = new EmptyDataView(env, _transformModel.InputSchema);
                 data = _transformModel.Apply(env, data);
-                var roleMappedData = RoleMappedData.CreateOpt(data, _roleMappings);
+                var roleMappedData = new RoleMappedData(data, _roleMappings, opt: true);
 
                 TrainUtils.SaveModel(env, ch, stream, _predictor, roleMappedData);
                 ch.Done();
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             env.CheckValue(input, nameof(input));
 
             input = _transformModel.Apply(env, input);
-            roleMappedData = RoleMappedData.CreateOpt(input, _roleMappings);
+            roleMappedData = new RoleMappedData(input, _roleMappings, opt: true);
             predictor = _predictor;
         }
 
@@ -141,7 +141,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
         {
             Contracts.CheckValue(env, nameof(env));
             var predInput = _transformModel.Apply(env, new EmptyDataView(env, _transformModel.InputSchema));
-            var trainRms = RoleMappedSchema.CreateOpt(predInput.Schema, _roleMappings);
+            var trainRms = new RoleMappedSchema(predInput.Schema, _roleMappings, opt: true);
             return trainRms;
         }
     }

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -796,7 +796,7 @@ namespace Microsoft.ML.Runtime.Data
             string name;
             MatchColumns(host, input, out label, out weight, out name);
             var evaluator = new AnomalyDetectionMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, null, null, weight, name);
+            var data = new RoleMappedData(input.Data, label, null, null, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -1455,7 +1455,7 @@ namespace Microsoft.ML.Runtime.Data
             string name;
             MatchColumns(host, input, out label, out weight, out name);
             var evaluator = new BinaryClassifierMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, null, null, weight, name);
+            var data = new RoleMappedData(input.Data, label, null, null, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -867,7 +867,7 @@ namespace Microsoft.ML.Runtime.Data
                 nameof(ClusteringMamlEvaluator.Arguments.FeatureColumn),
                 input.FeatureColumn, DefaultColumnNames.Features);
             var evaluator = new ClusteringMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, features, null, weight, name);
+            var data = new RoleMappedData(input.Data, label, features, null, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -776,7 +776,7 @@ namespace Microsoft.ML.Runtime.Data
                 string feat = EvaluateUtils.GetColName(_featureCol, schema.Feature, DefaultColumnNames.Features);
                 if (!schema.Schema.TryGetColumnIndex(feat, out int featCol))
                     throw Host.ExceptUserArg(nameof(Arguments.FeatureColumn), "Features column '{0}' not found", feat);
-                yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Feature, feat);
+                yield return RoleMappedSchema.ColumnRole.Feature.Bind(feat);
             }
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -108,7 +108,7 @@ namespace Microsoft.ML.Runtime.Data
                 : StratCols.Select(col => RoleMappedSchema.CreatePair(Strat, col));
 
             if (needName && schema.Name != null)
-                roles = roles.Prepend(RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Name, schema.Name.Name));
+                roles = roles.Prepend(RoleMappedSchema.ColumnRole.Name.Bind(schema.Name.Name));
 
             return roles.Concat(GetInputColumnRolesCore(schema));
         }
@@ -127,11 +127,11 @@ namespace Microsoft.ML.Runtime.Data
 
             // Get the label column information.
             string lab = EvaluateUtils.GetColName(LabelCol, schema.Label, DefaultColumnNames.Label);
-            yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, lab);
+            yield return RoleMappedSchema.ColumnRole.Label.Bind(lab);
 
             var weight = EvaluateUtils.GetColName(WeightCol, schema.Weight, null);
             if (!string.IsNullOrEmpty(weight))
-                yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Weight, weight);
+                yield return RoleMappedSchema.ColumnRole.Weight.Bind(weight);
         }
 
         public virtual IEnumerable<MetricColumn> GetOverallMetricColumns()

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Runtime.Data
 
         public Dictionary<string, IDataView> Evaluate(RoleMappedData data)
         {
-            data = RoleMappedData.Create(data.Data, GetInputColumnRoles(data.Schema, needStrat: true));
+            data = new RoleMappedData(data.Data, GetInputColumnRoles(data.Schema, needStrat: true));
             return Evaluator.Evaluate(data);
         }
 
@@ -203,7 +203,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertValue(scoredData);
 
             var schema = scoredData.Schema;
-            var dataEval = RoleMappedData.Create(scoredData.Data, GetInputColumnRoles(schema));
+            var dataEval = new RoleMappedData(scoredData.Data, GetInputColumnRoles(schema));
             return Evaluator.GetPerInstanceMetrics(dataEval);
         }
 
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Runtime.Data
         public IDataView GetPerInstanceDataViewToSave(RoleMappedData perInstance)
         {
             Host.CheckValue(perInstance, nameof(perInstance));
-            var data = RoleMappedData.Create(perInstance.Data, GetInputColumnRoles(perInstance.Schema, needName: true));
+            var data = new RoleMappedData(perInstance.Data, GetInputColumnRoles(perInstance.Schema, needName: true));
             return WrapPerInstance(data);
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -126,8 +126,8 @@ namespace Microsoft.ML.Runtime.Data
             yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);
 
             // Get the label column information.
-            string lab = EvaluateUtils.GetColName(LabelCol, schema.Label, DefaultColumnNames.Label);
-            yield return RoleMappedSchema.ColumnRole.Label.Bind(lab);
+            string label = EvaluateUtils.GetColName(LabelCol, schema.Label, DefaultColumnNames.Label);
+            yield return RoleMappedSchema.ColumnRole.Label.Bind(label);
 
             string weight = EvaluateUtils.GetColName(WeightCol, schema.Weight, null);
             if (!string.IsNullOrEmpty(weight))

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -129,7 +129,7 @@ namespace Microsoft.ML.Runtime.Data
             string lab = EvaluateUtils.GetColName(LabelCol, schema.Label, DefaultColumnNames.Label);
             yield return RoleMappedSchema.ColumnRole.Label.Bind(lab);
 
-            var weight = EvaluateUtils.GetColName(WeightCol, schema.Weight, null);
+            string weight = EvaluateUtils.GetColName(WeightCol, schema.Weight, null);
             if (!string.IsNullOrEmpty(weight))
                 yield return RoleMappedSchema.ColumnRole.Weight.Bind(weight);
         }

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -784,7 +784,7 @@ namespace Microsoft.ML.Runtime.Data
             string name;
             MatchColumns(host, input, out label, out weight, out name);
             var evaluator = new MultiOutputRegressionMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, null, null, weight, name);
+            var data = new RoleMappedData(input.Data, label, null, null, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
@@ -1070,7 +1070,7 @@ namespace Microsoft.ML.Runtime.Data
 
             MatchColumns(host, input, out string label, out string weight, out string name);
             var evaluator = new MultiClassMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, null, null, weight, name);
+            var data = new RoleMappedData(input.Data, label, null, null, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -556,7 +556,7 @@ namespace Microsoft.ML.Runtime.Data
             string name;
             MatchColumns(host, input, out label, out weight, out name);
             var evaluator = new QuantileRegressionMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, null, null, weight, name);
+            var data = new RoleMappedData(input.Data, label, null, null, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -1039,7 +1039,7 @@ namespace Microsoft.ML.Runtime.Data
                 nameof(RankerMamlEvaluator.Arguments.GroupIdColumn),
                 input.GroupIdColumn, DefaultColumnNames.GroupId);
             var evaluator = new RankerMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, null, groupId, weight, name);
+            var data = new RoleMappedData(input.Data, label, null, groupId, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -851,7 +851,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             var cols = base.GetInputColumnRolesCore(schema);
             var groupIdCol = EvaluateUtils.GetColName(_groupIdCol, schema.Group, DefaultColumnNames.GroupId);
-            return cols.Prepend(RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Group, groupIdCol));
+            return cols.Prepend(RoleMappedSchema.ColumnRole.Group.Bind(groupIdCol));
         }
 
         protected override void PrintAdditionalMetricsCore(IChannel ch, Dictionary<string, IDataView>[] metrics)

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -354,7 +354,7 @@ namespace Microsoft.ML.Runtime.Data
             string name;
             MatchColumns(host, input, out label, out weight, out name);
             var evaluator = new RegressionMamlEvaluator(host, input);
-            var data = TrainUtils.CreateExamples(input.Data, label, null, null, weight, name);
+            var data = new RoleMappedData(input.Data, label, null, null, weight, name);
             var metrics = evaluator.Evaluate(data);
 
             var warnings = ExtractWarnings(host, metrics);

--- a/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
@@ -152,8 +152,8 @@ namespace Microsoft.ML.Runtime.Model.Pfa
                 {
                     // We had a predictor, but no roles stored in the model. Just suppose
                     // default column names are OK, if present.
-                    data = TrainUtils.CreateExamplesOpt(end, DefaultColumnNames.Label,
-                        DefaultColumnNames.Features, DefaultColumnNames.GroupId, DefaultColumnNames.Weight, DefaultColumnNames.Name);
+                    data = new RoleMappedData(end, DefaultColumnNames.Label,
+                        DefaultColumnNames.Features, DefaultColumnNames.GroupId, DefaultColumnNames.Weight, DefaultColumnNames.Name, opt: true);
                 }
 
                 var scorePipe = ScoreUtils.GetScorer(rawPred, data, Host, trainSchema);

--- a/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             {
                 RoleMappedData data;
                 if (trainSchema != null)
-                    data = RoleMappedData.Create(end, trainSchema.GetColumnRoleNames());
+                    data = new RoleMappedData(end, trainSchema.GetColumnRoleNames());
                 else
                 {
                     // We had a predictor, but no roles stored in the model. Just suppose

--- a/src/Microsoft.ML.Data/Scorers/GenericScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/GenericScorer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.AssertValue(roles);
                 Contracts.AssertValueOrNull(suffix);
 
-                var mapper = bindable.Bind(env, RoleMappedSchema.Create(input, roles));
+                var mapper = bindable.Bind(env, new RoleMappedSchema(input, roles));
                 // We don't actually depend on this invariant, but if this assert fires it means the bindable
                 // did the wrong thing.
                 Contracts.Assert(mapper.InputSchema.Schema == input);

--- a/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ML.Runtime.Data
                 env.AssertValue(bindable);
 
                 string scoreCol = RowMapper.OutputSchema.GetColumnName(ScoreColumnIndex);
-                var schema = RoleMappedSchema.Create(input, RowMapper.GetInputColumnRoles());
+                var schema = new RoleMappedSchema(input, RowMapper.GetInputColumnRoles());
 
                 // Checks compatibility of the predictor input types.
                 var mapper = bindable.Bind(env, schema);
@@ -148,7 +148,7 @@ namespace Microsoft.ML.Runtime.Data
                 string scoreKind = ctx.LoadNonEmptyString();
                 string scoreCol = ctx.LoadNonEmptyString();
 
-                var mapper = bindable.Bind(env, RoleMappedSchema.Create(input, roles));
+                var mapper = bindable.Bind(env, new RoleMappedSchema(input, roles));
                 var rowMapper = mapper as ISchemaBoundRowMapper;
                 env.CheckParam(rowMapper != null, nameof(bindable), "Bindable expected to be an " + nameof(ISchemaBindableMapper) + "!");
 

--- a/src/Microsoft.ML.Data/Transforms/NormalizeTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeTransform.cs
@@ -225,7 +225,7 @@ namespace Microsoft.ML.Runtime.Data
             env.AssertValue(featInfo); // Should be defined, if FEaturesAreNormalized returned a definite value.
 
             var view = CreateMinMaxNormalizer(env, data.Data, name: featInfo.Name);
-            data = RoleMappedData.Create(view, data.Schema.GetColumnRoleNames());
+            data = new RoleMappedData(view, data.Schema.GetColumnRoleNames());
             return true;
         }
 

--- a/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
@@ -181,7 +181,7 @@ namespace Microsoft.ML.Runtime.Data
             var name = TrainUtils.MatchNameOrDefaultOrNull(ectx, schema, nameof(args.NameColumn), args.NameColumn,
                 DefaultColumnNames.Name);
             var customCols = TrainUtils.CheckAndGenerateCustomColumns(ectx, args.CustomColumn);
-            return TrainUtils.CreateExamples(input, label, feat, group, weight, name, customCols);
+            return new RoleMappedData(input, label, feat, group, weight, name, customCols);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -338,7 +338,7 @@ namespace Microsoft.ML.Runtime.Model
             if (roleMappings == null)
                 return null;
             var pipe = ModelFileUtils.LoadLoader(h, rep, new MultiFileSource(null), loadTransforms: true);
-            return RoleMappedSchema.Create(pipe.Schema, roleMappings);
+            return new RoleMappedSchema(pipe.Schema, roleMappings);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 host, "FeatureSelector", data.Data, name, name, type, type,
                 (ref VBuffer<Single> src, ref VBuffer<Single> dst) => SelectFeatures(ref src, features, card, ref dst));
 
-            var res = RoleMappedData.Create(view, data.Schema.GetColumnRoleNames());
+            var res = new RoleMappedData(view, data.Schema.GetColumnRoleNames());
             return res;
         }
 

--- a/src/Microsoft.ML.Ensemble/EntryPoints/CreateEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/CreateEnsemble.cs
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var dv = new EmptyDataView(env, inputSchema);
 
             // The role mappings are specific to the individual predictors.
-            var rmd = new RoleMappedData(dv);
+            var rmd = new RoleMappedData(dv, opt: true);
             var predictorModel = new PredictorModel(env, rmd, dv, ensemble);
 
             var output = new TOut { PredictorModel = predictorModel };

--- a/src/Microsoft.ML.Ensemble/EntryPoints/CreateEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/CreateEnsemble.cs
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var dv = new EmptyDataView(env, inputSchema);
 
             // The role mappings are specific to the individual predictors.
-            var rmd = RoleMappedData.Create(dv);
+            var rmd = new RoleMappedData(dv);
             var predictorModel = new PredictorModel(env, rmd, dv, ensemble);
 
             var output = new TOut { PredictorModel = predictorModel };

--- a/src/Microsoft.ML.Ensemble/EntryPoints/CreateEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/CreateEnsemble.cs
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var dv = new EmptyDataView(env, inputSchema);
 
             // The role mappings are specific to the individual predictors.
-            var rmd = new RoleMappedData(dv, opt: true);
+            var rmd = new RoleMappedData(dv);
             var predictorModel = new PredictorModel(env, rmd, dv, ensemble);
 
             var output = new TOut { PredictorModel = predictorModel };

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
@@ -185,7 +185,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 bldr.AddColumn("Features", NumberType.Float, features);
 
                 var view = bldr.GetDataView();
-                var rmd = RoleMappedData.Create(view, ColumnRole.Label.Bind("Label"), ColumnRole.Feature.Bind("Features"));
+                var rmd = new RoleMappedData(view, opt: false, ColumnRole.Label.Bind("Label"), ColumnRole.Feature.Bind("Features"));
 
                 var trainer = BasePredictorType.CreateInstance(host);
                 if (trainer is ITrainerEx ex && ex.NeedNormalization)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
@@ -185,7 +185,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 bldr.AddColumn("Features", NumberType.Float, features);
 
                 var view = bldr.GetDataView();
-                var rmd = new RoleMappedData(view, opt: false, ColumnRole.Label.Bind("Label"), ColumnRole.Feature.Bind("Features"));
+                var rmd = new RoleMappedData(view, "Label", "Features");
 
                 var trainer = BasePredictorType.CreateInstance(host);
                 if (trainer is ITrainerEx ex && ex.NeedNormalization)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
@@ -181,11 +181,11 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 var bldr = new ArrayDataViewBuilder(host);
                 Array.Resize(ref labels, count);
                 Array.Resize(ref features, count);
-                bldr.AddColumn("Label", NumberType.Float, labels);
-                bldr.AddColumn("Features", NumberType.Float, features);
+                bldr.AddColumn(DefaultColumnNames.Label, NumberType.Float, labels);
+                bldr.AddColumn(DefaultColumnNames.Features, NumberType.Float, features);
 
                 var view = bldr.GetDataView();
-                var rmd = new RoleMappedData(view, "Label", "Features");
+                var rmd = new RoleMappedData(view, DefaultColumnNames.Label, DefaultColumnNames.Features);
 
                 var trainer = BasePredictorType.CreateInstance(host);
                 if (trainer is ITrainerEx ex && ex.NeedNormalization)

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
                 if (caliTrainer.NeedsTraining)
                 {
-                    var bound = new Bound(this, RoleMappedSchema.Create(data.Schema));
+                    var bound = new Bound(this, new RoleMappedSchema(data.Schema));
                     using (var curs = data.GetRowCursor(col => true))
                     {
                         var scoreGetter = (ValueGetter<Single>)bound.CreateScoreGetter(curs, col => true, out Action disposer);

--- a/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseSubModelSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseSubModelSelector.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubModelSelector
                 // REVIEW: Should we somehow allow the user to customize the evaluator?
                 // By what mechanism should we allow that?
                 var evalComp = GetEvaluatorSubComponent();
-                RoleMappedData scoredTestData = RoleMappedData.Create(scorePipe,
+                RoleMappedData scoredTestData = new RoleMappedData(scorePipe,
                     GetColumnRoles(testData.Schema, scorePipe.Schema));
                 IEvaluator evaluator = evalComp.CreateInstance(Host);
                 // REVIEW: with the new evaluators, metrics of individual models are no longer

--- a/src/Microsoft.ML.Ensemble/Selector/SubsetSelector/BaseSubsetSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubsetSelector/BaseSubsetSelector.cs
@@ -76,8 +76,8 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubsetSelector
                     var view = new GenerateNumberTransform(Host, args, Data.Data);
                     var viewTest = new RangeFilter(Host, new RangeFilter.Arguments() { Column = name, Max = ValidationDatasetProportion }, view);
                     var viewTrain = new RangeFilter(Host, new RangeFilter.Arguments() { Column = name, Max = ValidationDatasetProportion, Complement = true }, view);
-                    dataTest = RoleMappedData.Create(viewTest, Data.Schema.GetColumnRoleNames());
-                    dataTrain = RoleMappedData.Create(viewTrain, Data.Schema.GetColumnRoleNames());
+                    dataTest = new RoleMappedData(viewTest, Data.Schema.GetColumnRoleNames());
+                    dataTrain = new RoleMappedData(viewTrain, Data.Schema.GetColumnRoleNames());
                 }
 
                 if (BatchSize > 0)

--- a/src/Microsoft.ML.Ensemble/Selector/SubsetSelector/BootstrapSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubsetSelector/BootstrapSelector.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubsetSelector
             {
                 // REVIEW: Consider ways to reintroduce "balanced" samples.
                 var viewTrain = new BootstrapSampleTransform(Host, new BootstrapSampleTransform.Arguments(), Data.Data);
-                var dataTrain = RoleMappedData.Create(viewTrain, Data.Schema.GetColumnRoleNames());
+                var dataTrain = new RoleMappedData(viewTrain, Data.Schema.GetColumnRoleNames());
                 yield return FeatureSelector.SelectFeatures(dataTrain, rand);
             }
         }

--- a/src/Microsoft.ML.Ensemble/Selector/SubsetSelector/RandomPartitionSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubsetSelector/RandomPartitionSelector.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubsetSelector
             for (int i = 0; i < Size; i++)
             {
                 var viewTrain = new RangeFilter(Host, new RangeFilter.Arguments() { Column = name, Min = (Double)i / Size, Max = (Double)(i + 1) / Size }, view);
-                var dataTrain = RoleMappedData.Create(viewTrain, Data.Schema.GetColumnRoleNames());
+                var dataTrain = new RoleMappedData(viewTrain, Data.Schema.GetColumnRoleNames());
                 yield return FeatureSelector.SelectFeatures(dataTrain, rand);
             }
         }

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1386,7 +1386,7 @@ The output of the ensemble produced by MART on a given instance is the sum of th
 
                     // Since we've passed it through a few transforms, reconstitute the mapping on the
                     // newly transformed data.
-                    examples = RoleMappedData.Create(data, examples.Schema.GetColumnRoleNames());
+                    examples = new RoleMappedData(data, examples.Schema.GetColumnRoleNames());
 
                     // Get the index of the columns in the transposed view, while we're at it composing
                     // the list of the columns we want to transpose.

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -990,10 +990,11 @@ namespace Microsoft.ML.Runtime.FastTree
                     {
                         _eval = eval;
                         var builder = new ArrayDataViewBuilder(pred.Host);
-                        builder.AddColumn("Label", NumberType.Float, _labels);
-                        builder.AddColumn("Score", NumberType.Float, _scores);
-                        _dataForEvaluator = new RoleMappedData(builder.GetDataView(), opt: false, RoleMappedSchema.ColumnRole.Label.Bind("Label"),
-                            new RoleMappedSchema.ColumnRole(MetadataUtils.Const.ScoreValueKind.Score).Bind("Score"));
+                        builder.AddColumn(DefaultColumnNames.Label, NumberType.Float, _labels);
+                        builder.AddColumn(DefaultColumnNames.Score, NumberType.Float, _scores);
+                        _dataForEvaluator = new RoleMappedData(builder.GetDataView(), opt: false,
+                            RoleMappedSchema.ColumnRole.Label.Bind(DefaultColumnNames.Label),
+                            new RoleMappedSchema.ColumnRole(MetadataUtils.Const.ScoreValueKind.Score).Bind(DefaultColumnNames.Score));
                     }
 
                     _data.Schema.Schema.TryGetColumnIndex(DefaultColumnNames.Features, out int featureIndex);

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -992,8 +992,8 @@ namespace Microsoft.ML.Runtime.FastTree
                         var builder = new ArrayDataViewBuilder(pred.Host);
                         builder.AddColumn("Label", NumberType.Float, _labels);
                         builder.AddColumn("Score", NumberType.Float, _scores);
-                        _dataForEvaluator = RoleMappedData.Create(builder.GetDataView(), RoleMappedSchema.ColumnRole.Label.Bind("Label"),
-                            RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, "Score"));
+                        _dataForEvaluator = new RoleMappedData(builder.GetDataView(), opt: false, RoleMappedSchema.ColumnRole.Label.Bind("Label"),
+                            new RoleMappedSchema.ColumnRole(MetadataUtils.Const.ScoreValueKind.Score).Bind("Score"));
                     }
 
                     _data.Schema.Schema.TryGetColumnIndex(DefaultColumnNames.Features, out int featureIndex);
@@ -1196,7 +1196,7 @@ namespace Microsoft.ML.Runtime.FastTree
                 }
                 var pred = rawPred as GamPredictorBase;
                 ch.CheckUserArg(pred != null, nameof(Args.InputModelFile), "Predictor was not a " + nameof(GamPredictorBase));
-                var data = RoleMappedData.CreateOpt(loader, schema.GetColumnRoleNames());
+                var data = new RoleMappedData(loader, schema.GetColumnRoleNames(), opt: true);
                 if (hadCalibrator && !string.IsNullOrWhiteSpace(Args.OutputModelFile))
                     ch.Warning("If you save the GAM model, only the GAM model, not the wrapping calibrator, will be saved.");
 

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -393,8 +393,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {
-                yield return new KeyValuePair<RoleMappedSchema.ColumnRole, string>(
-                    RoleMappedSchema.ColumnRole.Feature, _inputSchema.Feature.Name);
+                yield return RoleMappedSchema.ColumnRole.Feature.Bind(_inputSchema.Feature.Name);
             }
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -122,23 +122,19 @@ It uses various bounding techniques to identify this redundancy and eliminate ma
             _numThreads = ComputeNumThreads(Host, args.NumThreads);
         }
 
-        public override bool NeedNormalization
-        {
+        public override bool NeedNormalization {
             get { return true; }
         }
 
-        public override bool NeedCalibration
-        {
+        public override bool NeedCalibration {
             get { return false; }
         }
 
-        public override bool WantCaching
-        {
+        public override bool WantCaching {
             get { return true; }
         }
 
-        public override PredictionKind PredictionKind
-        {
+        public override PredictionKind PredictionKind {
             get { return PredictionKind.Clustering; }
         }
 
@@ -902,7 +898,7 @@ It uses various bounding techniques to identify this redundancy and eliminate ma
                     arrDv.AddColumn(DefaultColumnNames.Features, PrimitiveType.FromKind(DataKind.R4), clusters);
                     arrDv.AddColumn(DefaultColumnNames.Weight, PrimitiveType.FromKind(DataKind.R4), totalWeights);
                     var subDataViewCursorFactory = new FeatureFloatVectorCursor.Factory(
-                        new RoleMappedData(arrDv.GetDataView(), null, DefaultColumnNames.Features,weight: DefaultColumnNames.Weight), CursOpt.Weight | CursOpt.Features);
+                        new RoleMappedData(arrDv.GetDataView(), null, DefaultColumnNames.Features, weight: DefaultColumnNames.Weight), CursOpt.Weight | CursOpt.Features);
                     long discard1;
                     long discard2;
                     KMeansPlusPlusInit.Initialize(host, numThreads, ch, subDataViewCursorFactory, k, dimensionality, centroids, out discard1, out discard2, false);

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -899,10 +899,10 @@ It uses various bounding techniques to identify this redundancy and eliminate ma
                 else
                 {
                     ArrayDataViewBuilder arrDv = new ArrayDataViewBuilder(host);
-                    arrDv.AddColumn("Features", PrimitiveType.FromKind(DataKind.R4), clusters);
-                    arrDv.AddColumn("Weights", PrimitiveType.FromKind(DataKind.R4), totalWeights);
+                    arrDv.AddColumn(DefaultColumnNames.Features, PrimitiveType.FromKind(DataKind.R4), clusters);
+                    arrDv.AddColumn(DefaultColumnNames.Weight, PrimitiveType.FromKind(DataKind.R4), totalWeights);
                     var subDataViewCursorFactory = new FeatureFloatVectorCursor.Factory(
-                        new RoleMappedData(arrDv.GetDataView(), null, "Features", weight: "Weights"), CursOpt.Weight | CursOpt.Features);
+                        new RoleMappedData(arrDv.GetDataView(), null, DefaultColumnNames.Features,weight: DefaultColumnNames.Weight), CursOpt.Weight | CursOpt.Features);
                     long discard1;
                     long discard2;
                     KMeansPlusPlusInit.Initialize(host, numThreads, ch, subDataViewCursorFactory, k, dimensionality, centroids, out discard1, out discard2, false);

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -902,7 +902,7 @@ It uses various bounding techniques to identify this redundancy and eliminate ma
                     arrDv.AddColumn("Features", PrimitiveType.FromKind(DataKind.R4), clusters);
                     arrDv.AddColumn("Weights", PrimitiveType.FromKind(DataKind.R4), totalWeights);
                     var subDataViewCursorFactory = new FeatureFloatVectorCursor.Factory(
-                        TrainUtils.CreateExamples(arrDv.GetDataView(), null, "Features", weight: "Weights"), CursOpt.Weight | CursOpt.Features);
+                        new RoleMappedData(arrDv.GetDataView(), null, "Features", weight: "Weights"), CursOpt.Weight | CursOpt.Features);
                     long discard1;
                     long discard2;
                     KMeansPlusPlusInit.Initialize(host, numThreads, ch, subDataViewCursorFactory, k, dimensionality, centroids, out discard1, out discard2, false);

--- a/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
+++ b/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
@@ -177,8 +177,8 @@ namespace Microsoft.ML.Runtime.Model.Onnx
                 {
                     // We had a predictor, but no roles stored in the model. Just suppose
                     // default column names are OK, if present.
-                    data = TrainUtils.CreateExamplesOpt(end, DefaultColumnNames.Label,
-                        DefaultColumnNames.Features, DefaultColumnNames.GroupId, DefaultColumnNames.Weight, DefaultColumnNames.Name);
+                    data = new RoleMappedData(end, DefaultColumnNames.Label,
+                        DefaultColumnNames.Features, DefaultColumnNames.GroupId, DefaultColumnNames.Weight, DefaultColumnNames.Name, opt: true);
                 }
 
                 var scorePipe = ScoreUtils.GetScorer(rawPred, data, Host, trainSchema);

--- a/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
+++ b/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Runtime.Model.Onnx
             {
                 RoleMappedData data;
                 if (trainSchema != null)
-                    data = RoleMappedData.Create(end, trainSchema.GetColumnRoleNames());
+                    data = new RoleMappedData(end, trainSchema.GetColumnRoleNames());
                 else
                 {
                     // We had a predictor, but no roles stored in the model. Just suppose

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             _pred = pred;
 
             var inputFeatureColumns = _columns.Select(c => new KeyValuePair<RoleMappedSchema.ColumnRole, string>(RoleMappedSchema.ColumnRole.Feature, c.Name)).ToList();
-            InputSchema = RoleMappedSchema.Create(schema.Schema, inputFeatureColumns);
+            InputSchema = new RoleMappedSchema(schema.Schema, inputFeatureColumns);
             OutputSchema = outputSchema;
 
             _inputColumnIndexes = new List<int>();

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Runtime.Learners
             ch.Assert(idvToFeedTrain.CanShuffle);
 
             var roles = examples.Schema.GetColumnRoleNames();
-            var examplesToFeedTrain = RoleMappedData.Create(idvToFeedTrain, roles);
+            var examplesToFeedTrain = new RoleMappedData(idvToFeedTrain, roles);
 
             ch.Assert(examplesToFeedTrain.Schema.Label != null);
             ch.Assert(examplesToFeedTrain.Schema.Feature != null);

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Runtime.Learners
             var roles = data.Schema.GetColumnRoleNames()
                 .Where(kvp => kvp.Key.Value != CR.Label.Value)
                 .Prepend(CR.Label.Bind(dstName));
-            var td = RoleMappedData.Create(view, roles);
+            var td = new RoleMappedData(view, roles);
 
             trainer.Train(td);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -214,7 +214,7 @@ namespace Microsoft.ML.Runtime.Learners
                     input.FeatureColumn, DefaultColumnNames.Features);
                 var weight = TrainUtils.MatchNameOrDefaultOrNull(ch, schema, nameof(input.WeightColumn),
                     input.WeightColumn, DefaultColumnNames.Weight);
-                var data = TrainUtils.CreateExamples(normalizedView, label, feature, null, weight);
+                var data = new RoleMappedData(normalizedView, label, feature, null, weight);
 
                 return new ModelOperations.PredictorModelOutput
                 {

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ML.Runtime.Learners
             var roles = data.Schema.GetColumnRoleNames()
                 .Where(kvp => kvp.Key.Value != CR.Label.Value)
                 .Prepend(CR.Label.Bind(dstName));
-            var td = RoleMappedData.Create(view, roles);
+            var td = new RoleMappedData(view, roles);
 
             trainer.Train(td);
 

--- a/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Runtime.Sweeper
 
             IDataView view = dvBuilder.GetDataView();
             _host.Assert(view.GetRowCount() == targets.Length, "This data view will have as many rows as there have been evaluations");
-            RoleMappedData data = TrainUtils.CreateExamples(view, "Label", "Features");
+            RoleMappedData data = new RoleMappedData(view, "Label", "Features");
 
             using (IChannel ch = _host.Start("Single training"))
             {

--- a/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
@@ -126,12 +126,12 @@ namespace Microsoft.ML.Runtime.Sweeper
             }
 
             ArrayDataViewBuilder dvBuilder = new ArrayDataViewBuilder(_host);
-            dvBuilder.AddColumn("Label", NumberType.Float, targets);
-            dvBuilder.AddColumn("Features", NumberType.Float, features);
+            dvBuilder.AddColumn(DefaultColumnNames.Label, NumberType.Float, targets);
+            dvBuilder.AddColumn(DefaultColumnNames.Features, NumberType.Float, features);
 
             IDataView view = dvBuilder.GetDataView();
             _host.Assert(view.GetRowCount() == targets.Length, "This data view will have as many rows as there have been evaluations");
-            RoleMappedData data = new RoleMappedData(view, "Label", "Features");
+            RoleMappedData data = new RoleMappedData(view, DefaultColumnNames.Label, DefaultColumnNames.Features);
 
             using (IChannel ch = _host.Start("Single training"))
             {

--- a/src/Microsoft.ML.Transforms/LearnerFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/LearnerFeatureSelection.cs
@@ -299,7 +299,7 @@ namespace Microsoft.ML.Runtime.Data
                 ch.Trace("Binding columns");
 
                 var customCols = TrainUtils.CheckAndGenerateCustomColumns(ch, args.CustomColumn);
-                var data = TrainUtils.CreateExamples(view, label, feature, group, weight, name, customCols);
+                var data = new RoleMappedData(view, label, feature, group, weight, name, customCols);
 
                 var predictor = TrainUtils.Train(host, ch, data, trainer, args.Filter.Kind, null,
                     null, 0, args.CacheData);

--- a/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/CrossValidationMacro.cs
@@ -433,13 +433,11 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var eval = GetEvaluator(env, input.Kind);
 
             var perInst = EvaluateUtils.ConcatenatePerInstanceDataViews(env, eval, true, true, input.PerInstanceMetrics.Select(
-                idv => RoleMappedData.CreateOpt(idv, new[]
-                {
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, input.LabelColumn),
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Weight, input.WeightColumn.Value),
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Group, input.GroupColumn.Value),
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Name, input.NameColumn.Value)
-                })).ToArray(),
+                idv => new RoleMappedData(idv, opt: true,
+                    RoleMappedSchema.ColumnRole.Label.Bind(input.LabelColumn),
+                    RoleMappedSchema.ColumnRole.Weight.Bind(input.WeightColumn.Value),
+                    RoleMappedSchema.ColumnRole.Group.Bind(input.GroupColumn),
+                    RoleMappedSchema.ColumnRole.Name.Bind(input.NameColumn.Value))).ToArray(),
                 out var variableSizeVectorColumnNames);
 
             var warnings = input.Warnings != null ? new List<IDataView>(input.Warnings) : new List<IDataView>();

--- a/src/Microsoft.ML/Runtime/EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/FeatureCombiner.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             using (var ch = host.Start(featureCombiner))
             {
                 var viewTrain = input.Data;
-                var rms = RoleMappedSchema.Create(viewTrain.Schema, input.GetRoles());
+                var rms = new RoleMappedSchema(viewTrain.Schema, input.GetRoles());
                 var feats = rms.GetColumns(RoleMappedSchema.ColumnRole.Feature);
                 if (Utils.Size(feats) == 0)
                     throw ch.Except("No feature columns specified");

--- a/src/Microsoft.ML/Runtime/EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/FeatureCombiner.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             [Argument(ArgumentType.Multiple, HelpText = "Features", SortOrder = 2)]
             public string[] Features;
 
-            public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetRoles()
+            internal IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetRoles()
             {
                 if (Utils.Size(Features) > 0)
                 {

--- a/src/Microsoft.ML/Runtime/EntryPoints/OneVersusAllMacro.cs
+++ b/src/Microsoft.ML/Runtime/EntryPoints/OneVersusAllMacro.cs
@@ -128,7 +128,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     input.WeightColumn, DefaultColumnNames.Weight);
 
                 // Get number of classes
-                var data = TrainUtils.CreateExamples(input.TrainingData, label, feature, null, weight);
+                var data = new RoleMappedData(input.TrainingData, label, feature, null, weight);
                 data.CheckMultiClassLabel(out var numClasses);
                 return numClasses;
             }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -684,9 +684,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             // This tests that the SchemaBindableCalibratedPredictor doesn't get confused if its sub-predictor is already calibrated.
             var fastForest = new FastForestClassification(Env, new FastForestClassification.Arguments());
-            var rmd = new RoleMappedData(splitOutput.TrainData[0], opt: false,
-                RoleMappedSchema.ColumnRole.Feature.Bind("Features"),
-                RoleMappedSchema.ColumnRole.Label.Bind("Label"));
+            var rmd = new RoleMappedData(splitOutput.TrainData[0], "Label", "Features");
             fastForest.Train(rmd);
             var ffModel = new PredictorModel(Env, rmd, splitOutput.TrainData[0], fastForest.CreatePredictor());
             var calibratedFfModel = Calibrate.Platt(Env,
@@ -1220,9 +1218,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }, data);
 
                 var mlr = new MulticlassLogisticRegression(Env, new MulticlassLogisticRegression.Arguments());
-                RoleMappedData rmd = new RoleMappedData(data, opt: false,
-                    RoleMappedSchema.ColumnRole.Feature.Bind("Features"),
-                    RoleMappedSchema.ColumnRole.Label.Bind("Label"));
+                var rmd = new RoleMappedData(data, "Label", "Features");
                 mlr.Train(rmd);
 
                 predictorModels[i] = new PredictorModel(Env, rmd, data, mlr.CreatePredictor());

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -684,9 +684,9 @@ namespace Microsoft.ML.Runtime.RunTests
 
             // This tests that the SchemaBindableCalibratedPredictor doesn't get confused if its sub-predictor is already calibrated.
             var fastForest = new FastForestClassification(Env, new FastForestClassification.Arguments());
-            var rmd = RoleMappedData.Create(splitOutput.TrainData[0],
-                RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Feature, "Features"),
-                RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, "Label"));
+            var rmd = new RoleMappedData(splitOutput.TrainData[0], opt: false,
+                RoleMappedSchema.ColumnRole.Feature.Bind("Features"),
+                RoleMappedSchema.ColumnRole.Label.Bind("Label"));
             fastForest.Train(rmd);
             var ffModel = new PredictorModel(Env, rmd, splitOutput.TrainData[0], fastForest.CreatePredictor());
             var calibratedFfModel = Calibrate.Platt(Env,
@@ -1220,9 +1220,9 @@ namespace Microsoft.ML.Runtime.RunTests
                 }, data);
 
                 var mlr = new MulticlassLogisticRegression(Env, new MulticlassLogisticRegression.Arguments());
-                RoleMappedData rmd = RoleMappedData.Create(data,
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Feature, "Features"),
-                    RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, "Label"));
+                RoleMappedData rmd = new RoleMappedData(data, opt: false,
+                    RoleMappedSchema.ColumnRole.Feature.Bind("Features"),
+                    RoleMappedSchema.ColumnRole.Label.Bind("Label"));
                 mlr.Train(rmd);
 
                 predictorModels[i] = new PredictorModel(Env, rmd, data, mlr.CreatePredictor());

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -599,7 +599,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             var fastTree = combiner.CombineModels(fastTrees.Select(pm => pm.Predictor as IPredictorProducing<float>));
 
-            var data = RoleMappedData.Create(idv, RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Feature, "Features"));
+            var data = new RoleMappedData(idv, opt: false, RoleMappedSchema.ColumnRole.Feature.Bind("Features"));
             var scored = ScoreModel.Score(Env, new ScoreModel.Input() { Data = idv, PredictorModel = new PredictorModel(Env, data, idv, fastTree) }).ScoredData;
             Assert.True(scored.Schema.TryGetColumnIndex("Score", out int scoreCol));
             Assert.True(scored.Schema.TryGetColumnIndex("Probability", out int probCol));

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -599,7 +599,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             var fastTree = combiner.CombineModels(fastTrees.Select(pm => pm.Predictor as IPredictorProducing<float>));
 
-            var data = new RoleMappedData(idv, opt: false, RoleMappedSchema.ColumnRole.Feature.Bind("Features"));
+            var data = new RoleMappedData(idv, label: null, feature: "Features");
             var scored = ScoreModel.Score(Env, new ScoreModel.Input() { Data = idv, PredictorModel = new PredictorModel(Env, data, idv, fastTree) }).ScoredData;
             Assert.True(scored.Schema.TryGetColumnIndex("Score", out int scoreCol));
             Assert.True(scored.Schema.TryGetColumnIndex("Probability", out int probCol));

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -1537,10 +1537,10 @@ output Out [3] from H all;
                             Column = new[] { new NormalizeTransform.AffineColumn() { Name = "Features", Source = "Features" } }
                         },
                      trainView);
-                var trainData = TrainUtils.CreateExamples(trainView, "Label", "Features");
+                var trainData = new RoleMappedData(trainView, "Label", "Features");
                 IDataView testView = new TextLoader(env, new TextLoader.Arguments(), new MultiFileSource(GetDataPath(TestDatasets.mnistOneClass.testFilename)));
                 ApplyTransformUtils.ApplyAllTransformsToData(env, trainView, testView);
-                var testData = TrainUtils.CreateExamples(testView, "Label", "Features");
+                var testData = new RoleMappedData(testView, "Label", "Features");
 
                 CompareSvmToLibSvmCore("linear kernel", "LinearKernel", env, trainData, testData);
                 CompareSvmToLibSvmCore("polynomial kernel", "PolynomialKernel{d=2}", env, trainData, testData);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Scenarios
 
                 // Explicity adding CacheDataView since caching is not working though trainer has 'Caching' On/Auto
                 var cached = new CacheDataView(env, trans, prefetch: null);
-                var trainRoles = TrainUtils.CreateExamples(cached, label: "Label", feature: "Features");
+                var trainRoles = new RoleMappedData(cached, label: "Label", feature: "Features");
                 trainer.Train(trainRoles);
 
                 // Get scorer and evaluate the predictions from test data
@@ -176,7 +176,7 @@ namespace Microsoft.ML.Scenarios
 
         private ClassificationMetrics Evaluate(IHostEnvironment env, IDataView scoredData)
         {
-            var dataEval = TrainUtils.CreateExamplesOpt(scoredData, label: "Label", feature: "Features");
+            var dataEval = new RoleMappedData(scoredData, label: "Label", feature: "Features", opt: true);
             
             // Evaluate.
             // It does not work. It throws error "Failed to find 'Score' column" when Evaluate is called
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Scenarios
             using (var ch = env.Start("Saving model"))
             using (var memoryStream = new MemoryStream())
             {
-                var trainRoles = TrainUtils.CreateExamples(transforms, label: "Label", feature: "Features");
+                var trainRoles = new RoleMappedData(transforms, label: "Label", feature: "Features");
 
                 // Model cannot be saved with CacheDataView
                 TrainUtils.SaveModel(env, ch, memoryStream, pred, trainRoles);
@@ -201,7 +201,7 @@ namespace Microsoft.ML.Scenarios
                 using (var rep = RepositoryReader.Open(memoryStream, ch))
                 {
                     IDataLoader testPipe = ModelFileUtils.LoadLoader(env, rep, new MultiFileSource(testDataPath), true);
-                    RoleMappedData testRoles = TrainUtils.CreateExamples(testPipe, label: "Label", feature: "Features");
+                    RoleMappedData testRoles = new RoleMappedData(testPipe, label: "Label", feature: "Features");
                     return ScoreUtils.GetScorer(pred, testRoles, env, testRoles.Schema);
                 }
             }

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Scenarios
                     MinDocumentsInLeafs = 2
                 });
 
-                var trainRoles = TrainUtils.CreateExamples(trans, label: "Label", feature: "Features");
+                var trainRoles = new RoleMappedData(trans, label: "Label", feature: "Features");
                 trainer.Train(trainRoles);
 
                 // Get scorer and evaluate the predictions from test data
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Scenarios
 
         private BinaryClassificationMetrics EvaluateBinary(IHostEnvironment env, IDataView scoredData)
         {
-            var dataEval = TrainUtils.CreateExamplesOpt(scoredData, label: "Label", feature: "Features");
+            var dataEval = new RoleMappedData(scoredData, label: "Label", feature: "Features", opt: true);
 
             // Evaluate.
             // It does not work. It throws error "Failed to find 'Score' column" when Evaluate is called


### PR DESCRIPTION
Fixes #445.

* Generally, favors creating `RoleMappedSchema`/`RoleMappedData` by actual constructors, since that's how objects are generally created.
* Concentrated the actual globally useful "conveniences" inside the classes themselves, rather than in completely undiscoverable `Utils` classes.
* Got rid of the `Create` and `CreateOpt` idiom that required that we declare every creation method *twice* in favor of a simpler `bool` parameter on the constructors.
* Added documentation.