### PR TITLE
Validate XML comments in test sources during builds

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,6 +2,19 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!--
+      Don't warn about missing documentation in test projects.
+
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      CS1712: Type parameter 'parameter' has no matching typeparam tag in the XML comment on 'Type_or_Member' (but other type parameters do)
+    -->
+    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <VSTestLogger>trx</VSTestLogger>
     <VSTestResultsDirectory>$(OutputPath)</VSTestResultsDirectory>
     <AssemblyOriginatorKeyFile>$(ToolsDir)Test.snk</AssemblyOriginatorKeyFile>

--- a/test/Microsoft.ML.TestFramework/CopyAction.cs
+++ b/test/Microsoft.ML.TestFramework/CopyAction.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Runtime.RunTests
         /// <summary>
         /// Since test folder doesn't have libraries from AutoLoad folder and Win libraries, 
         /// we copy them for each test (only newest one).
-        //  This allow execute tests locally.
+        /// This allow execute tests locally.
         /// </summary>
         public static void Execute()
         {

--- a/test/Microsoft.ML.TestFramework/TestCategory.cs
+++ b/test/Microsoft.ML.TestFramework/TestCategory.cs
@@ -8,19 +8,18 @@ using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-/// <summary>
-/// This is a replacement for the MSTest [TestCategoryAttribute] on xunit
-/// xunit does not have the concept of Category for tests and instead, the have [TraitAttribute(string key, string value)]
-/// If we replace the MSTest [TestCategoryAttribute] for the [Trait("Category", "BVT")], we will surely fall at some time in cases
-/// where people will typo on the "Category" key part of the Trait. 
-/// On order to achieve the same behaviour as on MSTest, a custom [TestCategory] was created 
-/// to mimic the MSTest one and avoid replace it on every existent test. 
-/// The tests can be filtered by xunit runners by usage of "-trait" on the command line with the expresion like
-/// <code>-trait "Category=BVT"</code> for example that will only run the tests with [TestCategory("BVT")] on it.
-/// </summary>
-
 namespace Xunit
 {
+    /// <summary>
+    /// This is a replacement for the MSTest [TestCategoryAttribute] on xunit
+    /// xunit does not have the concept of Category for tests and instead, the have [TraitAttribute(string key, string value)]
+    /// If we replace the MSTest [TestCategoryAttribute] for the [Trait("Category", "BVT")], we will surely fall at some time in cases
+    /// where people will typo on the "Category" key part of the Trait. 
+    /// On order to achieve the same behaviour as on MSTest, a custom [TestCategory] was created 
+    /// to mimic the MSTest one and avoid replace it on every existent test. 
+    /// The tests can be filtered by xunit runners by usage of "-trait" on the command line with the expresion like
+    /// <code>-trait "Category=BVT"</code> for example that will only run the tests with [TestCategory("BVT")] on it.
+    /// </summary>
     [TraitDiscoverer("CategoryDiscoverer", "TestExtensions")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
     public class TestCategoryAttribute : Attribute, ITraitAttribute

--- a/test/Microsoft.ML.TestFramework/TestCommandBase.cs
+++ b/test/Microsoft.ML.TestFramework/TestCommandBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.ML.Runtime;
+using Microsoft.ML.Runtime.Command;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Utilities;
@@ -308,7 +309,7 @@ namespace Microsoft.ML.Runtime.RunTests
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="writer">
-        /// The writer to print the <see cref="ProgressLogLine"/>. Usually this should be the same writer that is used in <paramref name="env"/>.
+        /// The writer to print the <see cref="BaseTestBaseline.ProgressLogLine"/>. Usually this should be the same writer that is used in <paramref name="env"/>.
         /// </param>
         /// <param name="args">The arguments for MAML.</param>
         /// <param name="printProgress">Whether to print the progress summary. If true, progress summary will appear in the end of baseline output file.</param>
@@ -591,7 +592,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
         /// <summary>
         /// Creates an output path with a suffix based on the test name. For new tests please
-        /// do not use this, but instead utilize the <see cref="RunContextBase.InitPath"/>
+        /// do not use this, but instead utilize the <see cref="TestCommandBase.RunContextBase.InitPath"/>
         /// method.
         /// </summary>
         protected OutputPath CreateOutputPath(string suffix)


### PR DESCRIPTION
* CS1573, CS1591, and CS1712 are disabled in test code (documentation is not required)
* Other documentation warnings are enabled (documentation, when included, must be syntactically and semantically correct)
* Fixes cases where comments were incorrect in the current code

Related to #434

⚠️ ~~Please do not rewrite/rebase/squash this pull request during the merge.~~ Edit: relaxing this request for this pull request. ⚠️ 