### PR TITLE
Update Onnx Convert documentation, limited to ONNX-ML target platforms

### DIFF
--- a/src/Microsoft.ML/Models/OnnxConverter.cs
+++ b/src/Microsoft.ML/Models/OnnxConverter.cs
@@ -13,11 +13,10 @@ namespace Microsoft.ML.Models
         /// <see href="https://onnx.ai/">ONNX</see> is an intermediate representation format 
         /// for machine learning models. It is used to make models portable such that you can 
         /// train a model using a toolkit and run it in another tookit's runtime, for example,
-        /// you can create a model using ML.NET (or any ONNX compatible toolkit), convert it to ONNX and 
-        /// then the ONNX model can be converted into say, CoreML, TensorFlow or WinML model 
-        /// to run on the respective runtime.
+        /// you can create a model using ML.NET, export it to an ONNX-ML model file, 
+        /// then load and run that ONNX-ML model in Windows ML, on an UWP Windows 10 app. 
         /// 
-        /// This API converts an ML.NET model to ONNX format by inspecting the transform pipeline 
+        /// This API converts an ML.NET model to ONNX-ML format by inspecting the transform pipeline 
         /// from the end, checking for components that know how to save themselves as ONNX. 
         /// The first item in the transform pipeline that does not know how to save itself 
         /// as ONNX, is considered the "input" to the ONNX pipeline. (Ideally this would be the 


### PR DESCRIPTION
This PR is just updating the documentation/comments for the ML.NET Convert/export to ONNX.
The ML.NET export/convert feature uses ONNX-ML (not the regular ONNX specification). 
Currently, the only target platform supported by ONNX-ML is Windows ML.
The current comments in the documentation have examples mentioning Apple CoreML and TensorFlow, which are currently not supported by ONNX-ML. 
This PR is simply fixing the comments/documentation.

Further details on ONNX and ONNX-ML:
ONNX is not a single specification but two different variations of the standard. The neural-network-only (DNN) ONNX variant recognizes only tensors as input and output types, while ONNX-ML is a classical Machine Learning variant. 
ONNX-ML is part of the ONNX standard that provides functionality for classic ML and pipelines. It is a superset of core ONNX.
Frameworks like Caffe2 and CNTK will not support ONNX-ML since they are focused on DNN. 

Apple CoreML and other ONNX backends might support ONNX-ML in the future, but they currently don't, so our example should not mention Apple CoreML and TensorFlow as sample target platforms to use after exporting the ONNX file. At least, not yet.


