### PR TITLE
Conversion of ITrainer.Train returns predictor, accepts +TrainContext

### DIFF
--- a/src/Microsoft.ML.Core/Prediction/ITrainer.cs
+++ b/src/Microsoft.ML.Core/Prediction/ITrainer.cs
@@ -101,12 +101,4 @@ namespace Microsoft.ML.Runtime
     {
         TPredictor CombineModels(IEnumerable<TModel> models);
     }
-
-    /// <summary>
-    /// Interface implemented by the MetalinearLearners base class.
-    /// Used to distinguish the MetaLinear Learners from the other learners
-    /// </summary>
-    public interface IMetaLinearTrainer
-    {
-    }
 }

--- a/src/Microsoft.ML.Core/Prediction/ITrainer.cs
+++ b/src/Microsoft.ML.Core/Prediction/ITrainer.cs
@@ -26,47 +26,6 @@ namespace Microsoft.ML.Runtime
     public delegate void SignatureSequenceTrainer();
     public delegate void SignatureMatrixRecommendingTrainer();
 
-    /// <summary>
-    /// Interface to provide extra information about a trainer.
-    /// </summary>
-    public interface ITrainerEx : ITrainer
-    {
-        // REVIEW: Ideally trainers should be able to communicate
-        // something about the type of data they are capable of being trained
-        // on, e.g., what ColumnKinds they want, how many of each, of what type,
-        // etc. This interface seems like the most natural conduit for that sort
-        // of extra information.
-
-        // REVIEW: Can we please have consistent naming here?
-        // 'Need' vs. 'Want' looks arbitrary to me, and it's grammatically more correct to
-        // be 'Needs' / 'Wants' anyway.
-
-        /// <summary>
-        /// Whether the trainer needs to see data in normalized form.
-        /// </summary>
-        bool NeedNormalization { get; }
-
-        /// <summary>
-        /// Whether the trainer needs calibration to produce probabilities.
-        /// </summary>
-        bool NeedCalibration { get; }
-
-        /// <summary>
-        /// Whether this trainer could benefit from a cached view of the data.
-        /// </summary>
-        bool WantCaching { get; }
-
-        bool SupportsValidation { get; }
-        bool SupportsIncrementalTraining { get; }
-    }
-
-    // The Trainer (of Factory) can optionally implement this.
-    public interface IModelCombiner<TModel, TPredictor>
-        where TPredictor : IPredictor
-    {
-        TPredictor CombineModels(IEnumerable<TModel> models);
-    }
-
     public delegate void SignatureModelCombiner(PredictionKind kind);
 
     /// <summary>
@@ -128,6 +87,58 @@ namespace Microsoft.ML.Runtime
         /// <returns>The trained predictor</returns>
         public static TPredictor Train<TPredictor>(this ITrainer<TPredictor> trainer, RoleMappedData trainData) where TPredictor : IPredictor
             => trainer.Train(new TrainContext(trainData));
+    }
+
+    /// <summary>
+    /// Interface to provide extra information about a trainer.
+    /// </summary>
+    public interface ITrainerEx : ITrainer
+    {
+        // REVIEW: Ideally trainers should be able to communicate
+        // something about the type of data they are capable of being trained
+        // on, e.g., what ColumnKinds they want, how many of each, of what type,
+        // etc. This interface seems like the most natural conduit for that sort
+        // of extra information.
+
+        // REVIEW: Can we please have consistent naming here?
+        // 'Need' vs. 'Want' looks arbitrary to me, and it's grammatically more correct to
+        // be 'Needs' / 'Wants' anyway.
+
+        /// <summary>
+        /// Whether the trainer needs to see data in normalized form.
+        /// </summary>
+        bool NeedNormalization { get; }
+
+        /// <summary>
+        /// Whether the trainer needs calibration to produce probabilities.
+        /// </summary>
+        bool NeedCalibration { get; }
+
+        /// <summary>
+        /// Whether this trainer could benefit from a cached view of the data.
+        /// </summary>
+        bool WantCaching { get; }
+
+        /// <summary>
+        /// Whether the trainer supports validation sets via <see cref="TrainContext.ValidationSet"/>.
+        /// Not implementing this interface and returning <c>true</c> from this property is an indication
+        /// the trainer does not support that.
+        /// </summary>
+        bool SupportsValidation { get; }
+
+        /// <summary>
+        /// Whether the trainer can support incremental trainers via <see cref="TrainContext.InitialPredictor"/>.
+        /// Not implementing this interface and returning <c>true</c> from this property is an indication
+        /// the trainer does not support that.
+        /// </summary>
+        bool SupportsIncrementalTraining { get; }
+    }
+
+    // A trainer can optionally implement this to indicate it can combine multiple models into a single predictor.
+    public interface IModelCombiner<TModel, TPredictor>
+        where TPredictor : IPredictor
+    {
+        TPredictor CombineModels(IEnumerable<TModel> models);
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Core/Prediction/ITrainer.cs
+++ b/src/Microsoft.ML.Core/Prediction/ITrainer.cs
@@ -35,6 +35,12 @@ namespace Microsoft.ML.Runtime
     public interface ITrainer
     {
         /// <summary>
+        /// Auxiliary information about the trainer in terms of its capabilities
+        /// and requirements.
+        /// </summary>
+        TrainerInfo Info { get; }
+
+        /// <summary>
         /// Return the type of prediction task for the produced predictor.
         /// </summary>
         PredictionKind PredictionKind { get; }
@@ -87,51 +93,6 @@ namespace Microsoft.ML.Runtime
         /// <returns>The trained predictor</returns>
         public static TPredictor Train<TPredictor>(this ITrainer<TPredictor> trainer, RoleMappedData trainData) where TPredictor : IPredictor
             => trainer.Train(new TrainContext(trainData));
-    }
-
-    /// <summary>
-    /// Interface to provide extra information about a trainer.
-    /// </summary>
-    public interface ITrainerEx : ITrainer
-    {
-        // REVIEW: Ideally trainers should be able to communicate
-        // something about the type of data they are capable of being trained
-        // on, e.g., what ColumnKinds they want, how many of each, of what type,
-        // etc. This interface seems like the most natural conduit for that sort
-        // of extra information.
-
-        // REVIEW: Can we please have consistent naming here?
-        // 'Need' vs. 'Want' looks arbitrary to me, and it's grammatically more correct to
-        // be 'Needs' / 'Wants' anyway.
-
-        /// <summary>
-        /// Whether the trainer needs to see data in normalized form.
-        /// </summary>
-        bool NeedNormalization { get; }
-
-        /// <summary>
-        /// Whether the trainer needs calibration to produce probabilities.
-        /// </summary>
-        bool NeedCalibration { get; }
-
-        /// <summary>
-        /// Whether this trainer could benefit from a cached view of the data.
-        /// </summary>
-        bool WantCaching { get; }
-
-        /// <summary>
-        /// Whether the trainer supports validation sets via <see cref="TrainContext.ValidationSet"/>.
-        /// Not implementing this interface and returning <c>true</c> from this property is an indication
-        /// the trainer does not support that.
-        /// </summary>
-        bool SupportsValidation { get; }
-
-        /// <summary>
-        /// Whether the trainer can support incremental trainers via <see cref="TrainContext.InitialPredictor"/>.
-        /// Not implementing this interface and returning <c>true</c> from this property is an indication
-        /// the trainer does not support that.
-        /// </summary>
-        bool SupportsIncrementalTraining { get; }
     }
 
     // A trainer can optionally implement this to indicate it can combine multiple models into a single predictor.

--- a/src/Microsoft.ML.Core/Prediction/TrainContext.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainContext.cs
@@ -37,21 +37,21 @@ namespace Microsoft.ML.Runtime
         /// <summary>
         /// Constructor, given a training set and optional other arguments.
         /// </summary>
-        /// <param name="train">Will set <see cref="TrainingSet"/> to this value. This must be specified</param>
-        /// <param name="valid">Will set <see cref="ValidationSet"/> to this value if specified</param>
-        /// <param name="initPredictor">Will set <see cref="InitialPredictor"/> to this value if specified</param>
-        public TrainContext(RoleMappedData train, RoleMappedData valid = null, IPredictor initPredictor = null)
+        /// <param name="trainingSet">Will set <see cref="TrainingSet"/> to this value. This must be specified</param>
+        /// <param name="validationSet">Will set <see cref="ValidationSet"/> to this value if specified</param>
+        /// <param name="initialPredictor">Will set <see cref="InitialPredictor"/> to this value if specified</param>
+        public TrainContext(RoleMappedData trainingSet, RoleMappedData validationSet = null, IPredictor initialPredictor = null)
         {
-            Contracts.CheckValue(train, nameof(train));
-            Contracts.CheckValueOrNull(valid);
-            Contracts.CheckValueOrNull(initPredictor);
+            Contracts.CheckValue(trainingSet, nameof(trainingSet));
+            Contracts.CheckValueOrNull(validationSet);
+            Contracts.CheckValueOrNull(initialPredictor);
 
             // REVIEW: Should there be code here to ensure that the role mappings between the two are compatible?
             // That is, all the role mappings are the same and the columns between them have identical types?
 
-            TrainingSet = train;
-            ValidationSet = valid;
-            InitialPredictor = initPredictor;
+            TrainingSet = trainingSet;
+            ValidationSet = validationSet;
+            InitialPredictor = initialPredictor;
         }
     }
 }

--- a/src/Microsoft.ML.Core/Prediction/TrainContext.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainContext.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Runtime.Data;
+
+namespace Microsoft.ML.Runtime
+{
+    /// <summary>
+    /// Instances of this class are meant to be constructed and passed to trainers.
+    /// </summary>
+    public sealed class TrainContext
+    {
+        /// <summary>
+        /// The training set. Cannot be <c>null</c>.
+        /// </summary>
+        public RoleMappedData Train { get; }
+
+        /// <summary>
+        /// The validation set. Can be <c>null</c>.
+        /// </summary>
+        public RoleMappedData Validation { get; }
+
+        /// <summary>
+        /// The initial 
+        /// </summary>
+        public IPredictor InitialPredictor { get; }
+
+
+        /// <summary>
+        /// Constructor, given a training set and optional other arguments.
+        /// </summary>
+        /// <param name="train">Will be set to <see cref="Train"/>, must be specified</param>
+        /// <param name="valid">Will be set to <see cref="Validation"/> if specified</param>
+        /// <param name="initPredictor">Will be set to <see cref="InitialPredictor"/> if specified</param>
+        public TrainContext(RoleMappedData train, RoleMappedData valid = null, IPredictor initPredictor = null)
+        {
+            Contracts.CheckValue(train, nameof(train));
+            Contracts.CheckValueOrNull(valid);
+            Contracts.CheckValueOrNull(initPredictor);
+
+            // REVIEW: Should there be code here to ensure that the role mappings between the two are compatible?
+            // That is, all the role mappings are the same and the columns between them have identical types?
+
+            Train = train;
+            Validation = valid;
+            InitialPredictor = initPredictor;
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Prediction/TrainContext.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainContext.cs
@@ -7,22 +7,29 @@ using Microsoft.ML.Runtime.Data;
 namespace Microsoft.ML.Runtime
 {
     /// <summary>
-    /// Instances of this class are meant to be constructed and passed to trainers.
+    /// Holds information relevant to trainers. Instances of this class are meant to be constructed and passed
+    /// into <see cref="ITrainer{TPredictor}.Train(TrainContext)"/> or <see cref="ITrainer.Train(TrainContext)"/>.
+    /// This holds at least a training set, as well as optioonally a predictor.
     /// </summary>
     public sealed class TrainContext
     {
         /// <summary>
         /// The training set. Cannot be <c>null</c>.
         /// </summary>
-        public RoleMappedData Train { get; }
+        public RoleMappedData TrainingSet { get; }
 
         /// <summary>
-        /// The validation set. Can be <c>null</c>.
+        /// The validation set. Can be <c>null</c>. Note that passing a non-<c>null</c> validation set into
+        /// a trainer that does not support validation sets should not be considered an error condition. It
+        /// should simply be ignored in that case.
         /// </summary>
-        public RoleMappedData Validation { get; }
+        public RoleMappedData ValidationSet { get; }
 
         /// <summary>
-        /// The initial 
+        /// The initial predictor, for incremental training. Note that if a <see cref="ITrainer"/> implementor
+        /// does not support incremental training, then it can ignore it similarly to how one would ignore
+        /// <see cref="ValidationSet"/>. However, if the trainer does support incremental training and there
+        /// is something wrong with a non-<c>null</c> value of this, then the trainer ought to throw an exception.
         /// </summary>
         public IPredictor InitialPredictor { get; }
 
@@ -30,9 +37,9 @@ namespace Microsoft.ML.Runtime
         /// <summary>
         /// Constructor, given a training set and optional other arguments.
         /// </summary>
-        /// <param name="train">Will be set to <see cref="Train"/>, must be specified</param>
-        /// <param name="valid">Will be set to <see cref="Validation"/> if specified</param>
-        /// <param name="initPredictor">Will be set to <see cref="InitialPredictor"/> if specified</param>
+        /// <param name="train">Will set <see cref="TrainingSet"/> to this value. This must be specified</param>
+        /// <param name="valid">Will set <see cref="ValidationSet"/> to this value if specified</param>
+        /// <param name="initPredictor">Will set <see cref="InitialPredictor"/> to this value if specified</param>
         public TrainContext(RoleMappedData train, RoleMappedData valid = null, IPredictor initPredictor = null)
         {
             Contracts.CheckValue(train, nameof(train));
@@ -42,8 +49,8 @@ namespace Microsoft.ML.Runtime
             // REVIEW: Should there be code here to ensure that the role mappings between the two are compatible?
             // That is, all the role mappings are the same and the columns between them have identical types?
 
-            Train = train;
-            Validation = valid;
+            TrainingSet = train;
+            ValidationSet = valid;
             InitialPredictor = initPredictor;
         }
     }

--- a/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Runtime
+{
+    /// <summary>
+    /// Instances of this class posses information about trainers, in terms of their requirements and capabilities.
+    /// The intended usage is as the value for <see cref="ITrainer.Info"/>.
+    /// </summary>
+    public sealed class TrainerInfo
+    {
+        // REVIEW: Ideally trainers should be able to communicate
+        // something about the type of data they are capable of being trained
+        // on, e.g., what ColumnKinds they want, how many of each, of what type,
+        // etc. This interface seems like the most natural conduit for that sort
+        // of extra information.
+
+        // REVIEW: Can we please have consistent naming here?
+        // 'Need' vs. 'Want' looks arbitrary to me, and it's grammatically more correct to
+        // be 'Needs' / 'Wants' anyway.
+
+        /// <summary>
+        /// Whether the trainer needs to see data in normalized form. Only non-parametric learners will tend to produce
+        /// normalization here.
+        /// </summary>
+        public bool NeedNormalization { get; }
+
+        /// <summary>
+        /// Whether the trainer needs calibration to produce probabilities. As a general rule only trainers that produce
+        /// binary classifier predictors that also do not have a natural probabilistic interpretation should have a
+        /// <c>true</c> value here.
+        /// </summary>
+        public bool NeedCalibration { get; }
+
+        /// <summary>
+        /// Whether this trainer could benefit from a cached view of the data. Trainers that have few passes over the
+        /// data, or that need to build their own custom data structure over the data, will have a <c>false</c> here.
+        /// </summary>
+        public bool WantCaching { get; }
+
+        /// <summary>
+        /// Whether the trainer supports validation sets via <see cref="TrainContext.ValidationSet"/>. Not implementing
+        /// this interface and returning <c>true</c> from this property is an indication the trainer does not support
+        /// that.
+        /// </summary>
+        public bool SupportsValidation { get; }
+
+        /// <summary>
+        /// Whether the trainer can support incremental trainers via <see cref="TrainContext.InitialPredictor"/>. Not
+        /// implementing this interface and returning <c>true</c> from this property is an indication the trainer does
+        /// not support that.
+        /// </summary>
+        public bool SupportsIncrementalTraining { get; }
+
+        /// <summary>
+        /// Initializes with the given parameters. The parameters have default values for the most typical values
+        /// for most classical trainers.
+        /// </summary>
+        /// <param name="normalization">The value for the property <see cref="NeedNormalization"/></param>
+        /// <param name="calibration">The value for the property <see cref="NeedCalibration"/></param>
+        /// <param name="caching">The value for the property <see cref="WantCaching"/></param>
+        /// <param name="supportValid">The value for the property <see cref="SupportsValidation"/></param>
+        /// <param name="supportIncrementalTrain">The value for the property <see cref="SupportsIncrementalTraining"/></param>
+        public TrainerInfo(bool normalization = true, bool calibration = false, bool caching = true,
+            bool supportValid = false, bool supportIncrementalTrain = false)
+        {
+            NeedNormalization = normalization;
+            NeedCalibration = calibration;
+            WantCaching = caching;
+            SupportsValidation = supportValid;
+            SupportsIncrementalTraining = supportIncrementalTrain;
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
@@ -16,10 +16,6 @@ namespace Microsoft.ML.Runtime
         // etc. This interface seems like the most natural conduit for that sort
         // of extra information.
 
-        // REVIEW: Can we please have consistent naming here?
-        // 'Need' vs. 'Want' looks arbitrary to me, and it's grammatically more correct to
-        // be 'Needs' / 'Wants' anyway.
-
         /// <summary>
         /// Whether the trainer needs to see data in normalized form. Only non-parametric learners will tend to produce
         /// normalization here.

--- a/src/Microsoft.ML.Core/Utilities/ObjectPool.cs
+++ b/src/Microsoft.ML.Core/Utilities/ObjectPool.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         public int Count => _pool.Count;
         public int NumCreated { get { return _numCreated; } }
 
-        protected internal ObjectPoolBase()
+        private protected ObjectPoolBase()
         {
             _pool = new ConcurrentBag<T>();
         }

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -538,7 +538,7 @@ namespace Microsoft.ML.Runtime.Data
                     if (_getValidationDataView != null)
                     {
                         ch.Assert(_applyTransformsToValidationData != null);
-                        if (!TrainUtils.CanUseValidationData(trainer))
+                        if (!trainer.Info.SupportsValidation)
                             ch.Warning("Trainer does not accept validation dataset.");
                         else
                         {

--- a/src/Microsoft.ML.Data/Commands/TrainCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainCommand.cs
@@ -235,10 +235,10 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         public static IPredictor Train(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, string name, RoleMappedData validData,
-            SubComponent<ICalibratorTrainer, SignatureCalibrator> calibrator, int maxCalibrationExamples, bool? cacheData, IPredictor inpPredictor = null)
+            SubComponent<ICalibratorTrainer, SignatureCalibrator> calibrator, int maxCalibrationExamples, bool? cacheData, IPredictor inputPredictor = null)
         {
             ICalibratorTrainer caliTrainer = !calibrator.IsGood() ? null : calibrator.CreateInstance(env);
-            return TrainCore(env, ch, data, trainer, name, validData, caliTrainer, maxCalibrationExamples, cacheData, inpPredictor);
+            return TrainCore(env, ch, data, trainer, name, validData, caliTrainer, maxCalibrationExamples, cacheData, inputPredictor);
         }
 
         private static IPredictor TrainCore(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, string name, RoleMappedData validData,

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Runtime.Data
             RoleMappedData validData = null;
             if (!string.IsNullOrWhiteSpace(Args.ValidationFile))
             {
-                if (!TrainUtils.CanUseValidationData(trainer))
+                if (!trainer.Info.SupportsValidation)
                 {
                     ch.Warning("Ignoring validationFile: Trainer does not accept validation dataset.");
                 }

--- a/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
@@ -164,9 +164,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         }
                     case CachingOptions.Auto:
                         {
-                            ITrainerEx trainerEx = trainer as ITrainerEx;
                             // REVIEW: we should switch to hybrid caching in future.
-                            if (!(input.TrainingData is BinaryLoader) && (trainerEx == null || trainerEx.WantCaching))
+                            if (!(input.TrainingData is BinaryLoader) && trainer.Info.WantCaching)
                                 // default to Memory so mml is on par with maml
                                 cachingType = Cache.CachingType.Memory;
                             break;

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -687,8 +687,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
         private static bool NeedCalibration(IHostEnvironment env, IChannel ch, ICalibratorTrainer calibrator,
             ITrainer trainer, IPredictor predictor, RoleMappedSchema schema)
         {
-            var trainerEx = trainer as ITrainerEx;
-            if (trainerEx == null || !trainerEx.NeedCalibration)
+            if (!trainer.Info.NeedCalibration)
             {
                 ch.Info("Not training a calibrator because it is not needed.");
                 return false;

--- a/src/Microsoft.ML.Data/Training/EarlyStoppingCriteria.cs
+++ b/src/Microsoft.ML.Data/Training/EarlyStoppingCriteria.cs
@@ -139,9 +139,9 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
             public int WindowSize = 5;
         }
 
-        protected internal Queue<Float> PastScores;
+        protected Queue<Float> PastScores;
 
-        internal MovingWindowEarlyStoppingCriterion(Arguments args, bool lowerIsBetter)
+        private protected MovingWindowEarlyStoppingCriterion(Arguments args, bool lowerIsBetter)
             : base(args, lowerIsBetter)
         {
             Contracts.CheckUserArg(0 <= Args.Threshold && args.Threshold <= 1, nameof(args.Threshold), "Must be in range [0,1].");

--- a/src/Microsoft.ML.Data/Training/TrainerBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerBase.cs
@@ -7,7 +7,11 @@ namespace Microsoft.ML.Runtime.Training
     public abstract class TrainerBase<TPredictor> : ITrainer<TPredictor>, ITrainerEx
         where TPredictor : IPredictor
     {
-        public const string NoTrainingInstancesMessage = "No valid training instances found, all instances have missing features.";
+        /// <summary>
+        /// A standard string to use in errors or warnings by subclasses, to communicate the idea that no valid
+        /// instances were able to be found.
+        /// </summary>
+        protected const string NoTrainingInstancesMessage = "No valid training instances found, all instances have missing features.";
 
         protected IHost Host { get; }
 

--- a/src/Microsoft.ML.Data/Training/TrainerBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerBase.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.ML.Runtime.Training
 {
-    public abstract class TrainerBase<TPredictor> : ITrainer<TPredictor>, ITrainerEx
+    public abstract class TrainerBase<TPredictor> : ITrainer<TPredictor>
         where TPredictor : IPredictor
     {
         /// <summary>
@@ -17,12 +17,7 @@ namespace Microsoft.ML.Runtime.Training
 
         public string Name { get; }
         public abstract PredictionKind PredictionKind { get; }
-        public abstract bool NeedNormalization { get; }
-        public abstract bool NeedCalibration { get; }
-        public abstract bool WantCaching { get; }
-
-        public virtual bool SupportsValidation => false;
-        public virtual bool SupportsIncrementalTraining => false;
+        public abstract TrainerInfo Info { get; }
 
         protected TrainerBase(IHostEnvironment env, string name)
         {

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
@@ -27,10 +27,10 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             [Argument(ArgumentType.Multiple, HelpText = "Base predictor for meta learning", ShortName = "bp", SortOrder = 50,
                 Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
             [TGUI(Label = "Base predictor")]
-            public SubComponent<ITrainer<RoleMappedData, IPredictorProducing<TOutput>>, TSigBase> BasePredictorType;
+            public SubComponent<ITrainer<IPredictorProducing<TOutput>>, TSigBase> BasePredictorType;
         }
 
-        protected readonly SubComponent<ITrainer<RoleMappedData, IPredictorProducing<TOutput>>, TSigBase> BasePredictorType;
+        protected readonly SubComponent<ITrainer<IPredictorProducing<TOutput>>, TSigBase> BasePredictorType;
         protected readonly IHost Host;
         protected IPredictorProducing<TOutput> Meta;
 
@@ -190,8 +190,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 var trainer = BasePredictorType.CreateInstance(host);
                 if (trainer is ITrainerEx ex && ex.NeedNormalization)
                     ch.Warning("The trainer specified for stacking wants normalization, but we do not currently allow this.");
-                trainer.Train(rmd);
-                Meta = trainer.CreatePredictor();
+                Meta = trainer.Train(rmd);
                 CheckMeta();
 
                 ch.Done();

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 var rmd = new RoleMappedData(view, DefaultColumnNames.Label, DefaultColumnNames.Features);
 
                 var trainer = BasePredictorType.CreateInstance(host);
-                if (trainer is ITrainerEx ex && ex.NeedNormalization)
+                if (trainer.Info.NeedNormalization)
                     ch.Warning("The trainer specified for stacking wants normalization, but we do not currently allow this.");
                 Meta = trainer.Train(rmd);
                 CheckMeta();

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             public Arguments()
             {
                 // REVIEW: Perhaps we can have a better non-parametetric learner.
-                BasePredictorType = new SubComponent<ITrainer<RoleMappedData, TVectorPredictor>, SignatureMultiClassClassifierTrainer>(
+                BasePredictorType = new SubComponent<ITrainer<TVectorPredictor>, SignatureMultiClassClassifierTrainer>(
                     "OVA", "p=FastTreeBinaryClassification");
             }
         }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/RegressionStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/RegressionStacking.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         {
             public Arguments()
             {
-                BasePredictorType = new SubComponent<ITrainer<RoleMappedData, TScalarPredictor>, SignatureRegressorTrainer>("FastTreeRegression");
+                BasePredictorType = new SubComponent<ITrainer<TScalarPredictor>, SignatureRegressorTrainer>("FastTreeRegression");
             }
 
             public IRegressionOutputCombiner CreateComponent(IHostEnvironment env) => new RegressionStacking(env, this);

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/Stacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/Stacking.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         {
             public Arguments()
             {
-                BasePredictorType = new SubComponent<ITrainer<RoleMappedData, TScalarPredictor>, SignatureBinaryClassifierTrainer>("FastTreeBinaryClassification");
+                BasePredictorType = new SubComponent<ITrainer<TScalarPredictor>, SignatureBinaryClassifierTrainer>("FastTreeBinaryClassification");
             }
 
             public IBinaryOutputCombiner CreateComponent(IHostEnvironment env) => new Stacking(env, this);

--- a/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseDiverseSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseDiverseSelector.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubModelSelector
         private readonly IComponentFactory<IDiversityMeasure<TOutput>> _diversityMetricType;
         private ConcurrentDictionary<FeatureSubsetModel<IPredictorProducing<TOutput>>, TOutput[]> _predictions;
 
-        protected internal BaseDiverseSelector(IHostEnvironment env, DiverseSelectorArguments args, string name,
+        private protected BaseDiverseSelector(IHostEnvironment env, DiverseSelectorArguments args, string name,
             IComponentFactory<IDiversityMeasure<TOutput>> diversityMetricType)
             : base(args, env, name)
         {

--- a/src/Microsoft.ML.Ensemble/Trainer/Binary/EnsembleTrainer.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/Binary/EnsembleTrainer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        protected internal override TScalarPredictor CreatePredictor(List<FeatureSubsetModel<TScalarPredictor>> models)
+        private protected override TScalarPredictor CreatePredictor(List<FeatureSubsetModel<TScalarPredictor>> models)
         {
             if (models.All(m => m.Predictor is TDistPredictor))
                 return new EnsembleDistributionPredictor(Host, PredictionKind, CreateModels<TDistPredictor>(models), Combiner);

--- a/src/Microsoft.ML.Ensemble/Trainer/EnsembleTrainerBase.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/EnsembleTrainerBase.cs
@@ -59,17 +59,17 @@ namespace Microsoft.ML.Runtime.Ensemble
 
         private const int DefaultNumModels = 50;
         /// <summary> Command-line arguments </summary>
-        protected internal readonly ArgumentsBase Args;
-        protected internal readonly int NumModels;
+        private protected readonly ArgumentsBase Args;
+        private protected readonly int NumModels;
 
         /// <summary> Ensemble members </summary>
-        protected internal readonly ITrainer<IPredictorProducing<TOutput>>[] Trainers;
+        private protected readonly ITrainer<IPredictorProducing<TOutput>>[] Trainers;
 
         private readonly ISubsetSelector _subsetSelector;
-        protected internal ISubModelSelector<TOutput> SubModelSelector;
-        protected internal IOutputCombiner<TOutput> Combiner;
+        private protected ISubModelSelector<TOutput> SubModelSelector;
+        private protected IOutputCombiner<TOutput> Combiner;
 
-        protected internal EnsembleTrainerBase(ArgumentsBase args, IHostEnvironment env, string name)
+        private protected EnsembleTrainerBase(ArgumentsBase args, IHostEnvironment env, string name)
             : base(env, name)
         {
             Args = args;
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 validationDataSetProportion = Math.Max(validationDataSetProportion, stackingTrainer.ValidationDatasetProportion);
 
             var needMetrics = Args.ShowMetrics || Combiner is IWeightedAverager;
-            var Models = new List<FeatureSubsetModel<IPredictorProducing<TOutput>>>();
+            var models = new List<FeatureSubsetModel<IPredictorProducing<TOutput>>>();
 
             _subsetSelector.Initialize(data, NumModels, Args.BatchSize, validationDataSetProportion);
             int batchNumber = 1;
@@ -179,16 +179,16 @@ namespace Microsoft.ML.Runtime.Ensemble
                 if (stackingTrainer != null)
                     stackingTrainer.Train(modelsList, _subsetSelector.GetTestData(null, batch), Host);
 
-                Models.AddRange(modelsList);
-                int modelSize = Utils.Size(Models);
+                models.AddRange(modelsList);
+                int modelSize = Utils.Size(models);
                 if (modelSize < Utils.Size(Trainers))
                     ch.Warning("{0} of {1} trainings failed.", Utils.Size(Trainers) - modelSize, Utils.Size(Trainers));
                 ch.Check(modelSize > 0, "Ensemble training resulted in no valid models.");
             }
-            return CreatePredictor(Models);
+            return CreatePredictor(models);
         }
 
-        protected internal abstract TPredictor CreatePredictor(List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models);
+        private protected abstract TPredictor CreatePredictor(List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models);
 
         private bool EnsureMinimumFeaturesSelected(Subset subset)
         {
@@ -203,7 +203,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             return false;
         }
 
-        protected internal virtual void PrintMetrics(IChannel ch, List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models)
+        private protected virtual void PrintMetrics(IChannel ch, List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models)
         {
             // REVIEW: The formatting of this method is bizarre and seemingly not even self-consistent
             // w.r.t. its usage of |. Is this intentional?
@@ -216,7 +216,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 ch.Info("{0}{1}", string.Join("", model.Metrics.Select(m => string.Format("| {0} |", m.Value))), model.Predictor.GetType().Name);
         }
 
-        protected internal static FeatureSubsetModel<T>[] CreateModels<T>(List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models) where T : IPredictor
+        private protected static FeatureSubsetModel<T>[] CreateModels<T>(List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models) where T : IPredictor
         {
             var subsetModels = new FeatureSubsetModel<T>[models.Count];
             for (int i = 0; i < models.Count; i++)

--- a/src/Microsoft.ML.Ensemble/Trainer/EnsembleTrainerBase.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/EnsembleTrainerBase.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
             using (var ch = Host.Start("Training"))
             {
-                var pred = TrainCore(ch, context.Train);
+                var pred = TrainCore(ch, context.TrainingSet);
                 ch.Done();
                 return pred;
             }

--- a/src/Microsoft.ML.Ensemble/Trainer/EnsembleTrainerBase.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/EnsembleTrainerBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 {
     using Stopwatch = System.Diagnostics.Stopwatch;
 
-    public abstract class EnsembleTrainerBase<TOutput, TPredictor, TSelector, TCombiner, TSig> : TrainerBase<RoleMappedData, TPredictor>
+    public abstract class EnsembleTrainerBase<TOutput, TPredictor, TSelector, TCombiner, TSig> : TrainerBase<TPredictor>
          where TPredictor : class, IPredictorProducing<TOutput>
          where TSelector : class, ISubModelSelector<TOutput>
          where TCombiner : class, IOutputCombiner<TOutput>
@@ -54,27 +54,22 @@ namespace Microsoft.ML.Runtime.Ensemble
             public bool ShowMetrics;
 
             [Argument(ArgumentType.Multiple, HelpText = "Base predictor type", ShortName = "bp,basePredictorTypes", SortOrder = 1, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
-            public SubComponent<ITrainer<RoleMappedData, IPredictorProducing<TOutput>>, TSig>[] BasePredictors;
+            public SubComponent<ITrainer<IPredictorProducing<TOutput>>, TSig>[] BasePredictors;
         }
 
         private const int DefaultNumModels = 50;
         /// <summary> Command-line arguments </summary>
-        protected readonly ArgumentsBase Args;
-        protected readonly int NumModels;
+        protected internal readonly ArgumentsBase Args;
+        protected internal readonly int NumModels;
 
         /// <summary> Ensemble members </summary>
-        protected readonly ITrainer<RoleMappedData, IPredictorProducing<TOutput>>[] Trainers;
+        protected internal readonly ITrainer<IPredictorProducing<TOutput>>[] Trainers;
 
         private readonly ISubsetSelector _subsetSelector;
-        protected ISubModelSelector<TOutput> SubModelSelector;
-        protected IOutputCombiner<TOutput> Combiner;
+        protected internal ISubModelSelector<TOutput> SubModelSelector;
+        protected internal IOutputCombiner<TOutput> Combiner;
 
-        protected List<FeatureSubsetModel<IPredictorProducing<TOutput>>> Models;
-
-        private readonly bool _needNorm;
-        private readonly bool _needCalibration;
-
-        internal EnsembleTrainerBase(ArgumentsBase args, IHostEnvironment env, string name)
+        protected internal EnsembleTrainerBase(ArgumentsBase args, IHostEnvironment env, string name)
             : base(env, name)
         {
             Args = args;
@@ -93,41 +88,36 @@ namespace Microsoft.ML.Runtime.Ensemble
 
                 _subsetSelector = Args.SamplingType.CreateComponent(Host);
 
-                Trainers = new ITrainer<RoleMappedData, IPredictorProducing<TOutput>>[NumModels];
+                Trainers = new ITrainer<IPredictorProducing<TOutput>>[NumModels];
                 for (int i = 0; i < Trainers.Length; i++)
                     Trainers[i] = Args.BasePredictors[i % Args.BasePredictors.Length].CreateInstance(Host);
-                _needNorm = Trainers.Any(
-                    t =>
-                    {
-                        return t is ITrainerEx nn && nn.NeedNormalization;
-                    });
-                _needCalibration = Trainers.Any(
-                    t =>
-                    {
-                        return t is ITrainerEx nn && nn.NeedCalibration;
-                    });
+                NeedNormalization = Trainers.Any(t => t is ITrainerEx nn && nn.NeedNormalization);
+                NeedCalibration = Trainers.Any(t => t is ITrainerEx nn && nn.NeedCalibration);
                 ch.Done();
             }
         }
 
-        public override bool NeedNormalization => _needNorm;
+        public override bool NeedNormalization { get; }
 
-        public override bool NeedCalibration => _needCalibration;
+        public override bool NeedCalibration { get; }
 
         // No matter the internal predictors, we are performing multiple passes over the data
         // so it is probably appropriate to always cache.
         public override bool WantCaching => true;
 
-        public override void Train(RoleMappedData data)
+        public sealed override TPredictor Train(TrainContext context)
         {
+            Host.CheckValue(context, nameof(context));
+
             using (var ch = Host.Start("Training"))
             {
-                TrainCore(ch, data);
+                var pred = TrainCore(ch, context.Train);
                 ch.Done();
+                return pred;
             }
         }
 
-        private void TrainCore(IChannel ch, RoleMappedData data)
+        private TPredictor TrainCore(IChannel ch, RoleMappedData data)
         {
             Host.AssertValue(ch);
             ch.AssertValue(data);
@@ -143,6 +133,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 validationDataSetProportion = Math.Max(validationDataSetProportion, stackingTrainer.ValidationDatasetProportion);
 
             var needMetrics = Args.ShowMetrics || Combiner is IWeightedAverager;
+            var Models = new List<FeatureSubsetModel<IPredictorProducing<TOutput>>>();
 
             _subsetSelector.Initialize(data, NumModels, Args.BatchSize, validationDataSetProportion);
             int batchNumber = 1;
@@ -150,7 +141,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             {
                 // 2. Core train
                 ch.Info("Training {0} learners for the batch {1}", Trainers.Length, batchNumber++);
-                var models = new FeatureSubsetModel<IPredictorProducing<TOutput>>[Trainers.Length];
+                var batchModels = new FeatureSubsetModel<IPredictorProducing<TOutput>>[Trainers.Length];
 
                 Parallel.ForEach(_subsetSelector.GetSubsets(batch, Host.Rand),
                     new ParallelOptions() { MaxDegreeOfParallelism = Args.TrainParallel ? -1 : 1 },
@@ -162,26 +153,24 @@ namespace Microsoft.ML.Runtime.Ensemble
                         {
                             if (EnsureMinimumFeaturesSelected(subset))
                             {
-                                Trainers[(int)index].Train(subset.Data);
-
                                 var model = new FeatureSubsetModel<IPredictorProducing<TOutput>>(
-                                    Trainers[(int)index].CreatePredictor(),
+                                    Trainers[(int)index].Train(subset.Data),
                                     subset.SelectedFeatures,
                                     null);
                                 SubModelSelector.CalculateMetrics(model, _subsetSelector, subset, batch, needMetrics);
-                                models[(int)index] = model;
+                                batchModels[(int)index] = model;
                             }
                         }
                         catch (Exception ex)
                         {
-                            ch.Assert(models[(int)index] == null);
+                            ch.Assert(batchModels[(int)index] == null);
                             ch.Warning(ex.Sensitivity(), "Trainer {0} of {1} was not learned properly due to the exception '{2}' and will not be added to models.",
                                 index + 1, Trainers.Length, ex.Message);
                         }
                         ch.Info("Trainer {0} of {1} finished in {2}", index + 1, Trainers.Length, sw.Elapsed);
                     });
 
-                var modelsList = models.Where(m => m != null).ToList();
+                var modelsList = batchModels.Where(m => m != null).ToList();
                 if (Args.ShowMetrics)
                     PrintMetrics(ch, modelsList);
 
@@ -190,14 +179,16 @@ namespace Microsoft.ML.Runtime.Ensemble
                 if (stackingTrainer != null)
                     stackingTrainer.Train(modelsList, _subsetSelector.GetTestData(null, batch), Host);
 
-                foreach (var model in modelsList)
-                    Utils.Add(ref Models, model);
+                Models.AddRange(modelsList);
                 int modelSize = Utils.Size(Models);
                 if (modelSize < Utils.Size(Trainers))
                     ch.Warning("{0} of {1} trainings failed.", Utils.Size(Trainers) - modelSize, Utils.Size(Trainers));
                 ch.Check(modelSize > 0, "Ensemble training resulted in no valid models.");
             }
+            return CreatePredictor(Models);
         }
+
+        protected internal abstract TPredictor CreatePredictor(List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models);
 
         private bool EnsureMinimumFeaturesSelected(Subset subset)
         {
@@ -212,7 +203,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             return false;
         }
 
-        protected virtual void PrintMetrics(IChannel ch, List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models)
+        protected internal virtual void PrintMetrics(IChannel ch, List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models)
         {
             // REVIEW: The formatting of this method is bizarre and seemingly not even self-consistent
             // w.r.t. its usage of |. Is this intentional?
@@ -225,17 +216,17 @@ namespace Microsoft.ML.Runtime.Ensemble
                 ch.Info("{0}{1}", string.Join("", model.Metrics.Select(m => string.Format("| {0} |", m.Value))), model.Predictor.GetType().Name);
         }
 
-        protected FeatureSubsetModel<T>[] CreateModels<T>() where T : IPredictor
+        protected internal static FeatureSubsetModel<T>[] CreateModels<T>(List<FeatureSubsetModel<IPredictorProducing<TOutput>>> models) where T : IPredictor
         {
-            var models = new FeatureSubsetModel<T>[Models.Count];
-            for (int i = 0; i < Models.Count; i++)
+            var subsetModels = new FeatureSubsetModel<T>[models.Count];
+            for (int i = 0; i < models.Count; i++)
             {
-                models[i] = new FeatureSubsetModel<T>(
-                    (T)Models[i].Predictor,
-                    Models[i].SelectedFeatures,
-                    Models[i].Metrics);
+                subsetModels[i] = new FeatureSubsetModel<T>(
+                    (T)models[i].Predictor,
+                    models[i].SelectedFeatures,
+                    models[i].Metrics);
             }
-            return models;
+            return subsetModels;
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/Trainer/Multiclass/MulticlassDataPartitionEnsembleTrainer.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/Multiclass/MulticlassDataPartitionEnsembleTrainer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
             public Arguments()
             {
-                BasePredictors = new[] { new SubComponent<ITrainer<RoleMappedData, TVectorPredictor>, SignatureMultiClassClassifierTrainer>("MultiClassLogisticRegression") };
+                BasePredictors = new[] { new SubComponent<ITrainer<TVectorPredictor>, SignatureMultiClassClassifierTrainer>("MultiClassLogisticRegression") };
             }
         }
 
@@ -61,12 +61,11 @@ namespace Microsoft.ML.Runtime.Ensemble
             Combiner = args.OutputCombiner.CreateComponent(Host);
         }
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.MultiClassClassification; } }
+        public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
-        public override EnsembleMultiClassPredictor CreatePredictor()
+        protected internal override EnsembleMultiClassPredictor CreatePredictor(List<FeatureSubsetModel<TVectorPredictor>> models)
         {
-            var combiner = Combiner;
-            return new EnsembleMultiClassPredictor(Host, CreateModels<TVectorPredictor>(), combiner as IMultiClassOutputCombiner);
+            return new EnsembleMultiClassPredictor(Host, CreateModels<TVectorPredictor>(models), Combiner as IMultiClassOutputCombiner);
         }
 
         public TVectorPredictor CombineModels(IEnumerable<TVectorPredictor> models)

--- a/src/Microsoft.ML.Ensemble/Trainer/Multiclass/MulticlassDataPartitionEnsembleTrainer.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/Multiclass/MulticlassDataPartitionEnsembleTrainer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
         public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
-        protected internal override EnsembleMultiClassPredictor CreatePredictor(List<FeatureSubsetModel<TVectorPredictor>> models)
+        private protected override EnsembleMultiClassPredictor CreatePredictor(List<FeatureSubsetModel<TVectorPredictor>> models)
         {
             return new EnsembleMultiClassPredictor(Host, CreateModels<TVectorPredictor>(models), Combiner as IMultiClassOutputCombiner);
         }

--- a/src/Microsoft.ML.Ensemble/Trainer/Regression/RegressionEnsembleTrainer.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/Regression/RegressionEnsembleTrainer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
             public Arguments()
             {
-                BasePredictors = new[] { new SubComponent<ITrainer<RoleMappedData, TScalarPredictor>, SignatureRegressorTrainer>("OnlineGradientDescent") };
+                BasePredictors = new[] { new SubComponent<ITrainer<TScalarPredictor>, SignatureRegressorTrainer>("OnlineGradientDescent") };
             }
         }
 
@@ -55,14 +55,11 @@ namespace Microsoft.ML.Runtime.Ensemble
             Combiner = args.OutputCombiner.CreateComponent(Host);
         }
 
-        public override PredictionKind PredictionKind
-        {
-            get { return PredictionKind.Regression; }
-        }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        public override TScalarPredictor CreatePredictor()
+        protected internal override TScalarPredictor CreatePredictor(List<FeatureSubsetModel<TScalarPredictor>> models)
         {
-            return new EnsemblePredictor(Host, PredictionKind, CreateModels<TScalarPredictor>(), Combiner);
+            return new EnsemblePredictor(Host, PredictionKind, CreateModels<TScalarPredictor>(models), Combiner);
         }
 
         public TScalarPredictor CombineModels(IEnumerable<TScalarPredictor> models)

--- a/src/Microsoft.ML.Ensemble/Trainer/Regression/RegressionEnsembleTrainer.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/Regression/RegressionEnsembleTrainer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        protected internal override TScalarPredictor CreatePredictor(List<FeatureSubsetModel<TScalarPredictor>> models)
+        private protected override TScalarPredictor CreatePredictor(List<FeatureSubsetModel<TScalarPredictor>> models)
         {
             return new EnsemblePredictor(Host, PredictionKind, CreateModels<TScalarPredictor>(models), Combiner);
         }

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -85,6 +85,8 @@ namespace Microsoft.ML.Runtime.FastTree
 
         public bool HasCategoricalFeatures => Utils.Size(CategoricalFeatures) > 0;
 
+        private protected virtual bool NeedCalibration => false;
+
         private protected FastTreeTrainerBase(IHostEnvironment env, TArgs args)
             : base(env, RegisterName)
         {
@@ -93,7 +95,7 @@ namespace Microsoft.ML.Runtime.FastTree
             // The discretization step renders this trainer non-parametric, and therefore it does not need normalization.
             // Also since it builds its own internal discretized columnar structures, it cannot benefit from caching.
             // Finally, even the binary classifiers, being logitboost, tend to not benefit from external calibration.
-            Info = new TrainerInfo(normalization: false, caching: false, calibration: this is FastForestClassification);
+            Info = new TrainerInfo(normalization: false, caching: false, calibration: NeedCalibration);
             int numThreads = Args.NumThreads ?? Environment.ProcessorCount;
             if (Host.ConcurrencyFactor > 0 && numThreads > Host.ConcurrencyFactor)
             {

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Runtime.FastTree
 
         public override bool SupportsValidation => true;
 
-        protected internal FastTreeTrainerBase(IHostEnvironment env, TArgs args)
+        private protected FastTreeTrainerBase(IHostEnvironment env, TArgs args)
             : base(env, RegisterName)
         {
             Host.CheckValue(args, nameof(args));
@@ -1880,7 +1880,7 @@ namespace Microsoft.ML.Runtime.FastTree
                         missingInstances = cursor.BadFeaturesRowCount;
                     }
 
-                    ch.Check(totalInstances > 0, TrainerBase<IPredictor>.NoTrainingInstancesMessage);
+                    ch.Check(totalInstances > 0, "All instances skipped due to missing features.");
 
                     if (missingInstances > 0)
                         ch.Warning("Skipped {0} instances with missing features during training", missingInstances);
@@ -2806,7 +2806,7 @@ namespace Microsoft.ML.Runtime.FastTree
         public bool CanSavePfa => true;
         public bool CanSaveOnnx => true;
 
-        protected internal FastTreePredictionWrapper(IHostEnvironment env, string name, Ensemble trainedEnsemble, int numFeatures, string innerArgs)
+        protected FastTreePredictionWrapper(IHostEnvironment env, string name, Ensemble trainedEnsemble, int numFeatures, string innerArgs)
             : base(env, name)
         {
             Host.CheckValue(trainedEnsemble, nameof(trainedEnsemble));

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -116,8 +116,6 @@ namespace Microsoft.ML.Runtime.FastTree
         {
         }
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
         public override IPredictorWithFeatureWeights<Float> Train(TrainContext context)

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -118,10 +118,14 @@ namespace Microsoft.ML.Runtime.FastTree
 
         public override bool NeedCalibration => false;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        public override void Train(RoleMappedData trainData)
+        public override IPredictorWithFeatureWeights<Float> Train(TrainContext context)
         {
+            Host.CheckValue(context, nameof(context));
+            var trainData = context.Train;
+            ValidData = context.Validation;
+
             using (var ch = Host.Start("Training"))
             {
                 ch.CheckValue(trainData, nameof(trainData));
@@ -133,12 +137,6 @@ namespace Microsoft.ML.Runtime.FastTree
                 TrainCore(ch);
                 ch.Done();
             }
-        }
-
-        public override IPredictorWithFeatureWeights<Float> CreatePredictor()
-        {
-            Host.Check(TrainedEnsemble != null,
-                "The predictor cannot be created before training is complete");
 
             // The FastTree binary classification boosting is naturally calibrated to
             // output probabilities when transformed using a scaled logistic function,

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -62,11 +62,11 @@ namespace Microsoft.ML.Runtime.FastTree
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010002; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010002;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010004; } }
+        protected override uint VerDefaultValueSerialized => 0x00010004;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010005; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
         internal FastTreeBinaryPredictor(IHostEnvironment env, Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Runtime.FastTree
             return new SchemaBindableCalibratedPredictor(env, predictor, calibrator);
         }
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
     }
 
     /// <include file = './doc.xml' path='docs/members/member[@name="FastTree"]/*' />
@@ -123,8 +123,8 @@ namespace Microsoft.ML.Runtime.FastTree
         public override IPredictorWithFeatureWeights<Float> Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var trainData = context.Train;
-            ValidData = context.Validation;
+            var trainData = context.TrainingSet;
+            ValidData = context.ValidationSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -51,8 +51,6 @@ namespace Microsoft.ML.Runtime.FastTree
         private Test _specialTrainSetTest;
         private TestHistory _firstTestSetHistory;
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.Ranking;
 
         public FastTreeRankingTrainer(IHostEnvironment env, Arguments args)

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -65,8 +65,12 @@ namespace Microsoft.ML.Runtime.FastTree
             return GetLabelGains().Length - 1;
         }
 
-        public override void Train(RoleMappedData trainData)
+        public override FastTreeRankingPredictor Train(TrainContext context)
         {
+            Host.CheckValue(context, nameof(context));
+            var trainData = context.Train;
+            ValidData = context.Validation;
+
             using (var ch = Host.Start("Training"))
             {
                 var maxLabel = GetLabelGains().Length - 1;
@@ -75,11 +79,6 @@ namespace Microsoft.ML.Runtime.FastTree
                 FeatureCount = trainData.Schema.Feature.Type.ValueCount;
                 ch.Done();
             }
-        }
-
-        public override FastTreeRankingPredictor CreatePredictor()
-        {
-            Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             return new FastTreeRankingPredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -68,8 +68,8 @@ namespace Microsoft.ML.Runtime.FastTree
         public override FastTreeRankingPredictor Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var trainData = context.Train;
-            ValidData = context.Validation;
+            var trainData = context.TrainingSet;
+            ValidData = context.ValidationSet;
 
             using (var ch = Host.Start("Training"))
             {
@@ -1062,11 +1062,11 @@ namespace Microsoft.ML.Runtime.FastTree
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010002; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010002;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010004; } }
+        protected override uint VerDefaultValueSerialized => 0x00010004;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010005; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
         internal FastTreeRankingPredictor(IHostEnvironment env, Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -1089,7 +1089,7 @@ namespace Microsoft.ML.Runtime.FastTree
             return new FastTreeRankingPredictor(env, ctx);
         }
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Ranking; } }
+        public override PredictionKind PredictionKind => PredictionKind.Ranking;
     }
 
     public static partial class FastTree

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -43,8 +43,6 @@ namespace Microsoft.ML.Runtime.FastTree
         private Test _trainRegressionTest;
         private Test _testRegressionTest;
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         public FastTreeRegressionTrainer(IHostEnvironment env, Arguments args)

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -43,23 +43,23 @@ namespace Microsoft.ML.Runtime.FastTree
         private Test _trainRegressionTest;
         private Test _testRegressionTest;
 
+        public override bool NeedCalibration => false;
+
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
+
         public FastTreeRegressionTrainer(IHostEnvironment env, Arguments args)
             : base(env, args)
         {
         }
 
-        public override bool NeedCalibration
+        public override FastTreeRegressionPredictor Train(TrainContext context)
         {
-            get { return false; }
-        }
+            Host.CheckValue(context, nameof(context));
+            var trainData = context.Train;
+            ValidData = context.Validation;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
-
-        public override void Train(RoleMappedData trainData)
-        {
             using (var ch = Host.Start("Training"))
             {
-                ch.CheckValue(trainData, nameof(trainData));
                 trainData.CheckRegressionLabel();
                 trainData.CheckFeatureFloatVector();
                 trainData.CheckOptFloatWeight();
@@ -68,12 +68,6 @@ namespace Microsoft.ML.Runtime.FastTree
                 TrainCore(ch);
                 ch.Done();
             }
-        }
-
-        public override FastTreeRegressionPredictor CreatePredictor()
-        {
-            Host.Check(TrainedEnsemble != null,
-                "The predictor cannot be created before training is complete");
             return new FastTreeRegressionPredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -55,8 +55,8 @@ namespace Microsoft.ML.Runtime.FastTree
         public override FastTreeRegressionPredictor Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var trainData = context.Train;
-            ValidData = context.Validation;
+            var trainData = context.TrainingSet;
+            ValidData = context.ValidationSet;
 
             using (var ch = Host.Start("Training"))
             {
@@ -408,11 +408,11 @@ namespace Microsoft.ML.Runtime.FastTree
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010002; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010002;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010004; } }
+        protected override uint VerDefaultValueSerialized => 0x00010004;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010005; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
         internal FastTreeRegressionPredictor(IHostEnvironment env, Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Runtime.FastTree
             return new FastTreeRegressionPredictor(env, ctx);
         }
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
     }
 
     public static partial class FastTree

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -55,8 +55,12 @@ namespace Microsoft.ML.Runtime.FastTree
             Host.CheckUserArg(1 <= Args.Index && Args.Index <= 2, nameof(Args.Index), "Must be in the range [1, 2]");
         }
 
-        public override void Train(RoleMappedData trainData)
+        public override FastTreeTweediePredictor Train(TrainContext context)
         {
+            Host.CheckValue(context, nameof(context));
+            var trainData = context.Train;
+            ValidData = context.Validation;
+
             using (var ch = Host.Start("Training"))
             {
                 ch.CheckValue(trainData, nameof(trainData));
@@ -68,12 +72,6 @@ namespace Microsoft.ML.Runtime.FastTree
                 TrainCore(ch);
                 ch.Done();
             }
-        }
-
-        public override FastTreeTweediePredictor CreatePredictor()
-        {
-            Host.Check(TrainedEnsemble != null,
-                "The predictor cannot be created before training is complete");
             return new FastTreeTweediePredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -42,8 +42,6 @@ namespace Microsoft.ML.Runtime.FastTree
         private Test _trainRegressionTest;
         private Test _testRegressionTest;
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         public FastTreeTweedieTrainer(IHostEnvironment env, Arguments args)

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -42,12 +42,9 @@ namespace Microsoft.ML.Runtime.FastTree
         private Test _trainRegressionTest;
         private Test _testRegressionTest;
 
-        public override bool NeedCalibration
-        {
-            get { return false; }
-        }
+        public override bool NeedCalibration => false;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         public FastTreeTweedieTrainer(IHostEnvironment env, Arguments args)
             : base(env, args)
@@ -58,8 +55,8 @@ namespace Microsoft.ML.Runtime.FastTree
         public override FastTreeTweediePredictor Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var trainData = context.Train;
-            ValidData = context.Validation;
+            var trainData = context.TrainingSet;
+            ValidData = context.ValidationSet;
 
             using (var ch = Host.Start("Training"))
             {
@@ -407,11 +404,11 @@ namespace Microsoft.ML.Runtime.FastTree
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010001; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010001;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010002; } }
+        protected override uint VerDefaultValueSerialized => 0x00010002;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010003; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010003;
 
         internal FastTreeTweediePredictor(IHostEnvironment env, Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -450,7 +447,7 @@ namespace Microsoft.ML.Runtime.FastTree
             dst = MathUtils.ExpSlow(dst);
         }
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
     }
 
     public static partial class FastTree

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.ML.Runtime.FastTree
             data.CheckRegressionLabel();
         }
 
-        protected internal override RegressionGamPredictor CreatePredictor()
+        private protected override RegressionGamPredictor CreatePredictor()
         {
             return new RegressionGamPredictor(Host, InputLength, TrainSet, BinEffects, FeatureMap);
         }
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Runtime.FastTree
             return boolArray;
         }
 
-        protected internal override BinaryClassGamPredictor CreatePredictor()
+        private protected override BinaryClassGamPredictor CreatePredictor()
         {
             return new BinaryClassGamPredictor(Host, InputLength, TrainSet, BinEffects, FeatureMap);
         }
@@ -231,7 +231,7 @@ namespace Microsoft.ML.Runtime.FastTree
 
         public override bool WantCaching => false;
 
-        protected internal GamTrainerBase(IHostEnvironment env, TArgs args)
+        private protected GamTrainerBase(IHostEnvironment env, TArgs args)
             : base(env, RegisterName)
         {
             Contracts.CheckValue(env, nameof(env));
@@ -276,7 +276,7 @@ namespace Microsoft.ML.Runtime.FastTree
             }
         }
 
-        protected internal abstract TPredictor CreatePredictor();
+        private protected abstract TPredictor CreatePredictor();
 
         internal abstract void CheckLabel(RoleMappedData data);
 
@@ -571,7 +571,7 @@ namespace Microsoft.ML.Runtime.FastTree
 
         public ColumnType OutputType => NumberType.Float;
 
-        protected internal GamPredictorBase(IHostEnvironment env, string name, int inputLength, Dataset trainSet, double[][] binEffects, int[] featureMap)
+        private protected GamPredictorBase(IHostEnvironment env, string name, int inputLength, Dataset trainSet, double[][] binEffects, int[] featureMap)
             : base(env, name)
         {
             Host.CheckValue(trainSet, nameof(trainSet));

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -107,7 +107,6 @@ namespace Microsoft.ML.Runtime.FastTree
         internal const string ShortName = "gam";
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
-        public override bool NeedCalibration => true;
 
         public BinaryClassificationGamTrainer(IHostEnvironment env, Arguments args)
             : base(env, args) { }
@@ -225,11 +224,7 @@ namespace Microsoft.ML.Runtime.FastTree
         protected double[][] BinEffects;
         protected int[] FeatureMap;
 
-        public override bool NeedCalibration => false;
-
-        public override bool NeedNormalization => false;
-
-        public override bool WantCaching => false;
+        public override TrainerInfo Info { get; }
 
         private protected GamTrainerBase(IHostEnvironment env, TArgs args)
             : base(env, RegisterName)
@@ -245,6 +240,7 @@ namespace Microsoft.ML.Runtime.FastTree
             Host.CheckParam(0 < args.NumIterations, nameof(args.NumIterations), "Must be positive.");
 
             Args = args;
+            Info = new TrainerInfo(normalization: false, calibration: this is BinaryClassificationGamTrainer, caching: false);
             _gainConfidenceInSquaredStandardDeviations = Math.Pow(ProbabilityFunctions.Probit(1 - (1 - Args.GainConfidenceLevel) * 0.5), 2);
             _entropyCoefficient = Args.EntropyCoefficient * 1e-6;
             int numThreads = args.NumThreads ?? Environment.ProcessorCount;

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -107,6 +107,7 @@ namespace Microsoft.ML.Runtime.FastTree
         internal const string ShortName = "gam";
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
+        private protected override bool NeedCalibration => true;
 
         public BinaryClassificationGamTrainer(IHostEnvironment env, Arguments args)
             : base(env, args) { }
@@ -225,6 +226,7 @@ namespace Microsoft.ML.Runtime.FastTree
         protected int[] FeatureMap;
 
         public override TrainerInfo Info { get; }
+        private protected virtual bool NeedCalibration => false;
 
         private protected GamTrainerBase(IHostEnvironment env, TArgs args)
             : base(env, RegisterName)
@@ -240,7 +242,7 @@ namespace Microsoft.ML.Runtime.FastTree
             Host.CheckParam(0 < args.NumIterations, nameof(args.NumIterations), "Must be positive.");
 
             Args = args;
-            Info = new TrainerInfo(normalization: false, calibration: this is BinaryClassificationGamTrainer, caching: false);
+            Info = new TrainerInfo(normalization: false, calibration: NeedCalibration, caching: false);
             _gainConfidenceInSquaredStandardDeviations = Math.Pow(ProbabilityFunctions.Probit(1 - (1 - Args.GainConfidenceLevel) * 0.5), 2);
             _entropyCoefficient = Args.EntropyCoefficient * 1e-6;
             int numThreads = args.NumThreads ?? Environment.ProcessorCount;

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -267,8 +267,8 @@ namespace Microsoft.ML.Runtime.FastTree
             using (var ch = Host.Start("Training"))
             {
                 ch.CheckValue(context, nameof(context));
-                ConvertData(context.Train);
-                InputLength = context.Train.Schema.Feature.Type.ValueCount;
+                ConvertData(context.TrainingSet);
+                InputLength = context.TrainingSet.Schema.Feature.Type.ValueCount;
                 TrainCore(ch);
                 var pred = CreatePredictor();
                 ch.Done();

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -129,13 +129,13 @@ namespace Microsoft.ML.Runtime.FastTree
 
         private bool[] _trainSetLabels;
 
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
+
         public FastForestClassification(IHostEnvironment env, Arguments args)
             : base(env, args)
         {
+            
         }
-
-        public override bool NeedCalibration => true;
-        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
         public override IPredictorWithFeatureWeights<Float> Train(TrainContext context)
         {

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -134,15 +134,15 @@ namespace Microsoft.ML.Runtime.FastTree
         {
         }
 
-        public override bool NeedCalibration
-        {
-            get { return true; }
-        }
+        public override bool NeedCalibration => true;
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }
-
-        public override void Train(RoleMappedData trainData)
+        public override IPredictorWithFeatureWeights<Float> Train(TrainContext context)
         {
+            Host.CheckValue(context, nameof(context));
+            var trainData = context.Train;
+            ValidData = context.Validation;
+
             using (var ch = Host.Start("Training"))
             {
                 ch.CheckValue(trainData, nameof(trainData));
@@ -154,13 +154,6 @@ namespace Microsoft.ML.Runtime.FastTree
                 TrainCore(ch);
                 ch.Done();
             }
-        }
-
-        public override IPredictorWithFeatureWeights<Float> CreatePredictor()
-        {
-            Host.Check(TrainedEnsemble != null,
-                "The predictor cannot be created before training is complete");
-
             // LogitBoost is naturally calibrated to
             // output probabilities when transformed using
             // the logistic function, so if we have trained no 

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -130,11 +130,11 @@ namespace Microsoft.ML.Runtime.FastTree
         private bool[] _trainSetLabels;
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
+        private protected override bool NeedCalibration => true;
 
         public FastForestClassification(IHostEnvironment env, Arguments args)
             : base(env, args)
         {
-            
         }
 
         public override IPredictorWithFeatureWeights<Float> Train(TrainContext context)

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -67,13 +67,13 @@ namespace Microsoft.ML.Runtime.FastTree
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010003; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010003;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010005; } }
+        protected override uint VerDefaultValueSerialized => 0x00010005;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010006; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010006;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
         internal FastForestClassificationPredictor(IHostEnvironment env, Ensemble trainedEnsemble, int featureCount,
             string innerArgs)
@@ -140,8 +140,8 @@ namespace Microsoft.ML.Runtime.FastTree
         public override IPredictorWithFeatureWeights<Float> Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var trainData = context.Train;
-            ValidData = context.Validation;
+            var trainData = context.TrainingSet;
+            ValidData = context.ValidationSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -158,15 +158,16 @@ namespace Microsoft.ML.Runtime.FastTree
         {
         }
 
-        public override bool NeedCalibration
-        {
-            get { return false; }
-        }
+        public override bool NeedCalibration => false;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        public override void Train(RoleMappedData trainData)
+        public override FastForestRegressionPredictor Train(TrainContext context)
         {
+            Host.CheckValue(context, nameof(context));
+            var trainData = context.Train;
+            ValidData = context.Validation;
+
             using (var ch = Host.Start("Training"))
             {
                 ch.CheckValue(trainData, nameof(trainData));
@@ -178,13 +179,6 @@ namespace Microsoft.ML.Runtime.FastTree
                 TrainCore(ch);
                 ch.Done();
             }
-        }
-
-        public override FastForestRegressionPredictor CreatePredictor()
-        {
-            Host.Check(TrainedEnsemble != null,
-                "The predictor cannot be created before training is complete");
-
             return new FastForestRegressionPredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs, Args.QuantileSampleCount);
         }
 

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -158,8 +158,6 @@ namespace Microsoft.ML.Runtime.FastTree
         {
         }
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         public override FastForestRegressionPredictor Train(TrainContext context)

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -53,11 +53,11 @@ namespace Microsoft.ML.Runtime.FastTree
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010003; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010003;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010005; } }
+        protected override uint VerDefaultValueSerialized => 0x00010005;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010006; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010006;
 
         internal FastForestRegressionPredictor(IHostEnvironment env, Ensemble trainedEnsemble, int featureCount,
             string innerArgs, int samplesCount)
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Runtime.FastTree
             return new FastForestRegressionPredictor(env, ctx);
         }
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         protected override void Map(ref VBuffer<Float> src, ref Float dst)
         {
@@ -165,8 +165,8 @@ namespace Microsoft.ML.Runtime.FastTree
         public override FastForestRegressionPredictor Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var trainData = context.Train;
-            ValidData = context.Validation;
+            var trainData = context.TrainingSet;
+            ValidData = context.ValidationSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/Training/Test.cs
+++ b/src/Microsoft.ML.FastTree/Training/Test.cs
@@ -207,8 +207,8 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
         protected IList<TestResult[]> History;
         protected int Iteration { get; private set; }
 
-        public TestResult BestResult { get; protected internal set; }
-        public int BestIteration { get; protected internal set; }
+        public TestResult BestResult { get; private protected set; }
+        public int BestIteration { get; private protected set; }
 
         // scenarioWithoutHistory - simple test scenario we want to track the history and look for best iteration
         // lossIndex - index of lossFunction in case Test returns more than one loss (default should be 0)

--- a/src/Microsoft.ML.FastTree/Training/Test.cs
+++ b/src/Microsoft.ML.FastTree/Training/Test.cs
@@ -10,10 +10,8 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ML.Runtime.FastTree.Internal
 {
-    public class TestResult : IComparable<TestResult>
+    public sealed class TestResult : IComparable<TestResult>
     {
-        private double _finalValue;
-
         public enum ValueOperator : int
         {
             None = 0, // the final value will be the raw value,
@@ -36,33 +34,31 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
             // the raw value should be the same constant for all test results.
         }
 
-        public string LossFunctionName { get; private set; }
+        public string LossFunctionName { get; }
 
         /// <summary>
         /// Raw value used for calculating final test result value.
         /// </summary>
-        public double RawValue { get; private set; }
+        public double RawValue { get; }
 
         /// <summary>
         /// The factor used for calculating final test result value.
         /// </summary>
-        public double Factor { get; private set; }
+        public double Factor { get; }
 
         /// <summary>
         /// The operator used for calculating final test result value.
         /// Final value = Operator(RawValue, Factor)
         /// </summary>
-        public ValueOperator Operator { get; private set; }
+        public ValueOperator Operator { get; }
 
         /// <summary>
         /// Indicates that the lower value of this metric is better
         /// This is used for early stopping (with TestHistory and TestWindowWithTolerance)
         /// </summary>
-        public bool LowerIsBetter { get; private set; }
+        public bool LowerIsBetter { get; }
 
-        public double FinalValue {
-            get { return _finalValue; }
-        }
+        public double FinalValue { get; }
 
         public TestResult(string lossFunctionName, double rawValue, double factor, bool lowerIsBetter, ValueOperator valueOperator)
         {
@@ -72,7 +68,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
             Operator = valueOperator;
             LowerIsBetter = lowerIsBetter;
 
-            CalculateFinalValue();
+            FinalValue = CalculateFinalValue();
         }
 
         public int CompareTo(TestResult o)
@@ -124,7 +120,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
                 (ValueOperator)valueOperator);
         }
 
-        private void CalculateFinalValue()
+        private double CalculateFinalValue()
         {
             switch (Operator)
             {
@@ -133,14 +129,11 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
                 case ValueOperator.Min:
                 case ValueOperator.None:
                 case ValueOperator.Sum:
-                    _finalValue = RawValue;
-                    break;
+                    return RawValue;
                 case ValueOperator.Average:
-                    _finalValue = RawValue / Factor;
-                    break;
+                    return RawValue / Factor;
                 case ValueOperator.SqrtAverage:
-                    _finalValue = Math.Sqrt(RawValue / Factor);
-                    break;
+                    return Math.Sqrt(RawValue / Factor);
                 default:
                     throw Contracts.Except("Unsupported value operator: {0}", Operator);
             }
@@ -157,7 +150,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
 
         //The method returns one or more losses on a given Dataset
         public abstract IEnumerable<TestResult> ComputeTests(double[] scores);
-        public Test(ScoreTracker scoreTracker)
+        private protected Test(ScoreTracker scoreTracker)
         {
             ScoreTracker = scoreTracker;
             if (ScoreTracker != null)
@@ -213,7 +206,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
         // scenarioWithoutHistory - simple test scenario we want to track the history and look for best iteration
         // lossIndex - index of lossFunction in case Test returns more than one loss (default should be 0)
         // lower is better: are we looking for minimum or maximum of loss function?
-        public TestHistory(Test scenarioWithoutHistory, int lossIndex)
+        private protected TestHistory(Test scenarioWithoutHistory, int lossIndex)
             : base(null)
         {
             History = new List<TestResult[]>();

--- a/src/Microsoft.ML.FastTree/Training/Test.cs
+++ b/src/Microsoft.ML.FastTree/Training/Test.cs
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Runtime.FastTree.Internal
         // scenarioWithoutHistory - simple test scenario we want to track the history and look for best iteration
         // lossIndex - index of lossFunction in case Test returns more than one loss (default should be 0)
         // lower is better: are we looking for minimum or maximum of loss function?
-        private protected TestHistory(Test scenarioWithoutHistory, int lossIndex)
+        internal TestHistory(Test scenarioWithoutHistory, int lossIndex)
             : base(null)
         {
             History = new List<TestResult[]>();

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -29,7 +29,7 @@ using Microsoft.ML.Runtime.EntryPoints;
 namespace Microsoft.ML.Runtime.KMeans
 {
     /// <include file='./doc.xml' path='docs/members/member[@name="KMeans++"]/*' />
-    public class KMeansPlusPlusTrainer : TrainerBase<RoleMappedData, KMeansPredictor>
+    public class KMeansPlusPlusTrainer : TrainerBase<KMeansPredictor>
     {
         public const string LoadNameValue = "KMeansPlusPlus";
         internal const string UserNameValue = "KMeans++ Clustering";
@@ -74,11 +74,6 @@ namespace Microsoft.ML.Runtime.KMeans
         }
 
         private readonly int _k;
-        private int _dimensionality;
-
-        // The coordinates of the final centroids at the end of the training. During training
-        // it holds the centroids of the previous iteration.
-        private readonly VBuffer<Float>[] _centroids;
 
         private readonly int _maxIterations; // max number of iterations to train
         private readonly Float _convergenceThreshold; // convergence thresholds
@@ -101,8 +96,6 @@ namespace Microsoft.ML.Runtime.KMeans
             Host.CheckUserArg(args.OptTol > 0, nameof(args.OptTol), "Tolerance must be positive");
             _convergenceThreshold = args.OptTol;
 
-            _centroids = new VBuffer<Float>[_k];
-
             Host.CheckUserArg(args.AccelMemBudgetMb > 0, nameof(args.AccelMemBudgetMb), "Must be positive");
             _accelMemBudgetMb = args.AccelMemBudgetMb;
 
@@ -118,29 +111,35 @@ namespace Microsoft.ML.Runtime.KMeans
         public override bool WantCaching => true;
         public override PredictionKind PredictionKind => PredictionKind.Clustering;
 
-        public override void Train(RoleMappedData data)
+        public override KMeansPredictor Train(TrainContext context)
         {
-            Host.CheckValue(data, nameof(data));
+            Host.CheckValue(context, nameof(context));
+            var data = context.Train;
 
-            data.CheckFeatureFloatVector(out _dimensionality);
-            Contracts.Assert(_dimensionality > 0);
+            data.CheckFeatureFloatVector(out int dimensionality);
+            Contracts.Assert(dimensionality > 0);
 
             using (var ch = Host.Start("Training"))
             {
-                TrainCore(ch, data);
+                var pred = TrainCore(ch, data, dimensionality);
                 ch.Done();
+                return pred;
             }
         }
 
-        private void TrainCore(IChannel ch, RoleMappedData data)
+        private KMeansPredictor TrainCore(IChannel ch, RoleMappedData data, int dimensionality)
         {
             Host.AssertValue(ch);
             ch.AssertValue(data);
 
-            // REVIEW: In high-dimensionality cases this is less than ideal
-            // and we should consider using sparse buffers.
+            // REVIEW: In high-dimensionality cases this is less than ideal and we should consider
+            // using sparse buffers for the centroids.
+
+            // The coordinates of the final centroids at the end of the training. During training
+            // it holds the centroids of the previous iteration.
+            var centroids = new VBuffer<Float>[_k];
             for (int i = 0; i < _k; i++)
-                _centroids[i] = VBufferUtils.CreateDense<Float>(_dimensionality);
+                centroids[i] = VBufferUtils.CreateDense<Float>(dimensionality);
 
             ch.Info("Initializing centroids");
             long missingFeatureCount;
@@ -154,29 +153,29 @@ namespace Microsoft.ML.Runtime.KMeans
             // pay attention to their incoming set of centroids and incrementally train.
             if (_initAlgorithm == InitAlgorithm.KMeansPlusPlus)
             {
-                KMeansPlusPlusInit.Initialize(Host, _numThreads, ch, cursorFactory, _k, _dimensionality,
-                    _centroids, out missingFeatureCount, out totalTrainingInstances);
+                KMeansPlusPlusInit.Initialize(Host, _numThreads, ch, cursorFactory, _k, dimensionality,
+                    centroids, out missingFeatureCount, out totalTrainingInstances);
             }
             else if (_initAlgorithm == InitAlgorithm.Random)
             {
                 KMeansRandomInit.Initialize(Host, _numThreads, ch, cursorFactory, _k,
-                    _centroids, out missingFeatureCount, out totalTrainingInstances);
+                    centroids, out missingFeatureCount, out totalTrainingInstances);
             }
             else
             {
                 // Defaulting to KMeans|| initialization.
-                KMeansBarBarInitialization.Initialize(Host, _numThreads, ch, cursorFactory, _k, _dimensionality,
-                    _centroids, _accelMemBudgetMb, out missingFeatureCount, out totalTrainingInstances);
+                KMeansBarBarInitialization.Initialize(Host, _numThreads, ch, cursorFactory, _k, dimensionality,
+                    centroids, _accelMemBudgetMb, out missingFeatureCount, out totalTrainingInstances);
             }
 
-            KMeansUtils.VerifyModelConsistency(_centroids);
+            KMeansUtils.VerifyModelConsistency(centroids);
             ch.Info("Centroids initialized, starting main trainer");
 
             KMeansLloydsYinYangTrain.Train(
-                Host, _numThreads, ch, cursorFactory, totalTrainingInstances, _k, _dimensionality, _maxIterations,
-                _accelMemBudgetMb, _convergenceThreshold, _centroids);
+                Host, _numThreads, ch, cursorFactory, totalTrainingInstances, _k, dimensionality, _maxIterations,
+                _accelMemBudgetMb, _convergenceThreshold, centroids);
 
-            KMeansUtils.VerifyModelConsistency(_centroids);
+            KMeansUtils.VerifyModelConsistency(centroids);
             ch.Info("Model trained successfully on {0} instances", totalTrainingInstances);
             if (missingFeatureCount > 0)
             {
@@ -184,11 +183,7 @@ namespace Microsoft.ML.Runtime.KMeans
                     "{0} instances with missing features detected and ignored. Consider using MissingHandler.",
                     missingFeatureCount);
             }
-        }
-
-        public override KMeansPredictor CreatePredictor()
-        {
-            return new KMeansPredictor(Host, _k, _centroids, copyIn: true);
+            return new KMeansPredictor(Host, _k, centroids, copyIn: true);
         }
 
         private static int ComputeNumThreads(IHost host, int? argNumThreads)

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -82,6 +82,9 @@ namespace Microsoft.ML.Runtime.KMeans
         private readonly InitAlgorithm _initAlgorithm;
         private readonly int _numThreads;
 
+        public override TrainerInfo Info { get; }
+        public override PredictionKind PredictionKind => PredictionKind.Clustering;
+
         public KMeansPlusPlusTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
@@ -104,12 +107,8 @@ namespace Microsoft.ML.Runtime.KMeans
             Host.CheckUserArg(!args.NumThreads.HasValue || args.NumThreads > 0, nameof(args.NumThreads),
                 "Must be either null or a positive integer.");
             _numThreads = ComputeNumThreads(Host, args.NumThreads);
+            Info = new TrainerInfo();
         }
-
-        public override bool NeedNormalization => true;
-        public override bool NeedCalibration => false;
-        public override bool WantCaching => true;
-        public override PredictionKind PredictionKind => PredictionKind.Clustering;
 
         public override KMeansPredictor Train(TrainContext context)
         {

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Runtime.KMeans
         public override KMeansPredictor Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var data = context.Train;
+            var data = context.TrainingSet;
 
             data.CheckFeatureFloatVector(out int dimensionality);
             Contracts.Assert(dimensionality > 0);

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -44,10 +44,9 @@ namespace Microsoft.ML.Runtime.LightGBM
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
-
         protected override uint VerDefaultValueSerialized => 0x00010004;
-
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
         internal LightGbmBinaryPredictor(IHostEnvironment env, FastTree.Internal.Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -77,8 +76,6 @@ namespace Microsoft.ML.Runtime.LightGBM
                 return predictor;
             return new CalibratedPredictor(env, predictor, calibrator);
         }
-
-        public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }
     }
 
     /// <include file='./doc.xml' path='docs/members/member[@name="LightGBM"]/*' />
@@ -89,8 +86,10 @@ namespace Microsoft.ML.Runtime.LightGBM
         internal const string ShortName = "LightGBM";
         internal const string Summary = "Train a LightGBM binary classification model.";
 
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
+
         public LightGbmBinaryTrainer(IHostEnvironment env, LightGbmArguments args)
-            : base(env, args, PredictionKind.BinaryClassification, "LGBBINCL")
+            : base(env, args, LoadNameValue)
         {
         }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -43,11 +43,11 @@ namespace Microsoft.ML.Runtime.LightGBM
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010002; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010002;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010004; } }
+        protected override uint VerDefaultValueSerialized => 0x00010004;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010005; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
         internal LightGbmBinaryPredictor(IHostEnvironment env, FastTree.Internal.Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
         }
 
-        public override IPredictorWithFeatureWeights<float> CreatePredictor()
+        protected internal override IPredictorWithFeatureWeights<float> CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
         }
 
-        protected internal override IPredictorWithFeatureWeights<float> CreatePredictor()
+        private protected override IPredictorWithFeatureWeights<float> CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Runtime.LightGBM
             return new LightGbmBinaryPredictor(Host, GetBinaryEnsemble(classID), FeatureCount, innerArgs);
         }
 
-        public override OvaPredictor CreatePredictor()
+        protected internal override OvaPredictor CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete.");
 

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Runtime.LightGBM
             return new LightGbmBinaryPredictor(Host, GetBinaryEnsemble(classID), FeatureCount, innerArgs);
         }
 
-        protected internal override OvaPredictor CreatePredictor()
+        private protected override OvaPredictor CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete.");
 

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -29,9 +29,10 @@ namespace Microsoft.ML.Runtime.LightGBM
         private const double _maxNumClass = 1e6;
         private int _numClass;
         private int _tlcNumClass;
+        public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
         public LightGbmMulticlassTrainer(IHostEnvironment env, LightGbmArguments args)
-            : base(env, args, PredictionKind.MultiClassClassification, "LightGBMMulticlass")
+            : base(env, args, LoadNameValue)
         {
             _numClass = -1;
         }

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -42,10 +42,9 @@ namespace Microsoft.ML.Runtime.LightGBM
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
-
         protected override uint VerDefaultValueSerialized => 0x00010004;
-
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
+        public override PredictionKind PredictionKind => PredictionKind.Ranking;
 
         internal LightGbmRankingPredictor(IHostEnvironment env, FastTree.Internal.Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -67,8 +66,6 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
             return new LightGbmRankingPredictor(env, ctx);
         }
-
-        public override PredictionKind PredictionKind => PredictionKind.Ranking;
     }
 
     /// <include file='./doc.xml' path='docs/members/member[@name="LightGBM"]/*' />
@@ -78,8 +75,10 @@ namespace Microsoft.ML.Runtime.LightGBM
         public const string LoadNameValue = "LightGBMRanking";
         public const string ShortName = "LightGBMRank";
 
+        public override PredictionKind PredictionKind => PredictionKind.Ranking;
+
         public LightGbmRankingTrainer(IHostEnvironment env, LightGbmArguments args)
-            : base(env, args, PredictionKind.Ranking, "LightGBMRanking")
+            : base(env, args, LoadNameValue)
         {
         }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -41,11 +41,11 @@ namespace Microsoft.ML.Runtime.LightGBM
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010002; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010002;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010004; } }
+        protected override uint VerDefaultValueSerialized => 0x00010004;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010005; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
         internal LightGbmRankingPredictor(IHostEnvironment env, FastTree.Internal.Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Runtime.LightGBM
             return new LightGbmRankingPredictor(env, ctx);
         }
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Ranking; } }
+        public override PredictionKind PredictionKind => PredictionKind.Ranking;
     }
 
     /// <include file='./doc.xml' path='docs/members/member[@name="LightGBM"]/*' />
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Runtime.LightGBM
             }
         }
 
-        public override LightGbmRankingPredictor CreatePredictor()
+        protected internal override LightGbmRankingPredictor CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Runtime.LightGBM
             }
         }
 
-        protected internal override LightGbmRankingPredictor CreatePredictor()
+        private protected override LightGbmRankingPredictor CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -42,10 +42,9 @@ namespace Microsoft.ML.Runtime.LightGBM
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
-
         protected override uint VerDefaultValueSerialized => 0x00010004;
-
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         internal LightGbmRegressionPredictor(IHostEnvironment env, FastTree.Internal.Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -70,8 +69,6 @@ namespace Microsoft.ML.Runtime.LightGBM
             ctx.CheckAtModel(GetVersionInfo());
             return new LightGbmRegressionPredictor(env, ctx);
         }
-
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
     }
 
     public sealed class LightGbmRegressorTrainer : LightGbmTrainerBase<float, LightGbmRegressionPredictor>
@@ -81,8 +78,10 @@ namespace Microsoft.ML.Runtime.LightGBM
         public const string ShortName = "LightGBMR";
         public const string UserNameValue = "LightGBM Regressor";
 
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
+
         public LightGbmRegressorTrainer(IHostEnvironment env, LightGbmArguments args)
-            : base(env, args, PredictionKind.Regression, "LightGBMRegressor")
+            : base(env, args, LoadNameValue)
         {
         }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -41,11 +41,11 @@ namespace Microsoft.ML.Runtime.LightGBM
                 loaderSignature: LoaderSignature);
         }
 
-        protected override uint VerNumFeaturesSerialized { get { return 0x00010002; } }
+        protected override uint VerNumFeaturesSerialized => 0x00010002;
 
-        protected override uint VerDefaultValueSerialized { get { return 0x00010004; } }
+        protected override uint VerDefaultValueSerialized => 0x00010004;
 
-        protected override uint VerCategoricalSplitSerialized { get { return 0x00010005; } }
+        protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
         internal LightGbmRegressionPredictor(IHostEnvironment env, FastTree.Internal.Ensemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
         }
 
-        public override LightGbmRegressionPredictor CreatePredictor()
+        protected internal override LightGbmRegressionPredictor CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null,
                 "The predictor cannot be created before training is complete");

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -85,7 +85,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
         }
 
-        protected internal override LightGbmRegressionPredictor CreatePredictor()
+        private protected override LightGbmRegressionPredictor CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null,
                 "The predictor cannot be created before training is complete");

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         private protected int FeatureCount;
         private protected FastTree.Internal.Ensemble TrainedEnsemble;
 
-        private static TrainerInfo _info = new TrainerInfo(normalization: false, caching: false, supportValid: true);
+        private static readonly TrainerInfo _info = new TrainerInfo(normalization: false, caching: false, supportValid: true);
         public override TrainerInfo Info => _info;
 
         private protected LightGbmTrainerBase(IHostEnvironment env, LightGbmArguments args, string name)

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -37,26 +37,26 @@ namespace Microsoft.ML.Runtime.LightGBM
             public bool[] IsCategoricalFeature;
         }
 
-        protected internal readonly LightGbmArguments Args;
+        private protected readonly LightGbmArguments Args;
 
         /// <summary>
         /// Stores argumments as objects to convert them to invariant string type in the end so that 
         /// the code is culture agnostic. When retrieving key value from this dictionary as string 
         /// please convert to string invariant by string.Format(CultureInfo.InvariantCulture, "{0}", Option[key]). 
         /// </summary>
-        protected internal readonly Dictionary<string, object> Options;
-        protected internal readonly IParallel ParallelTraining;
+        private protected readonly Dictionary<string, object> Options;
+        private protected readonly IParallel ParallelTraining;
 
         // Store _featureCount and _trainedEnsemble to construct predictor.
-        protected internal int FeatureCount;
-        protected internal FastTree.Internal.Ensemble TrainedEnsemble;
+        private protected int FeatureCount;
+        private protected FastTree.Internal.Ensemble TrainedEnsemble;
 
         public override bool NeedNormalization => false;
         public override bool NeedCalibration => false;
         public override bool WantCaching => false;
         public override bool SupportsValidation => true;
 
-        protected internal LightGbmTrainerBase(IHostEnvironment env, LightGbmArguments args, string name)
+        private protected LightGbmTrainerBase(IHostEnvironment env, LightGbmArguments args, string name)
             : base(env, name)
         {
             Host.CheckValue(args, nameof(args));
@@ -851,7 +851,7 @@ namespace Microsoft.ML.Runtime.LightGBM
             return ret;
         }
 
-        protected internal abstract TPredictor CreatePredictor();
+        private protected abstract TPredictor CreatePredictor();
 
         /// <summary>
         /// This function will be called before training. It will check the label/group and add parameters for specific applications.

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -51,10 +51,8 @@ namespace Microsoft.ML.Runtime.LightGBM
         private protected int FeatureCount;
         private protected FastTree.Internal.Ensemble TrainedEnsemble;
 
-        public override bool NeedNormalization => false;
-        public override bool NeedCalibration => false;
-        public override bool WantCaching => false;
-        public override bool SupportsValidation => true;
+        private static TrainerInfo _info = new TrainerInfo(normalization: false, caching: false, supportValid: true);
+        public override TrainerInfo Info => _info;
 
         private protected LightGbmTrainerBase(IHostEnvironment env, LightGbmArguments args, string name)
             : base(env, name)

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -56,14 +56,13 @@ namespace Microsoft.ML.Runtime.LightGBM
         public override bool WantCaching => false;
         public override bool SupportsValidation => true;
 
-        protected internal LightGbmTrainerBase(IHostEnvironment env, LightGbmArguments args, PredictionKind predictionKind, string name)
+        protected internal LightGbmTrainerBase(IHostEnvironment env, LightGbmArguments args, string name)
             : base(env, name)
         {
             Host.CheckValue(args, nameof(args));
 
             Args = args;
             Options = Args.ToDictionary(Host);
-            PredictionKind = predictionKind;
             ParallelTraining = Args.ParallelTrainer != null ? Args.ParallelTrainer.CreateComponent(env) : new SingleTrainer();
             InitParallelTraining();
         }
@@ -851,8 +850,6 @@ namespace Microsoft.ML.Runtime.LightGBM
             ret = Math.Min(ret, numRow);
             return ret;
         }
-
-        public override PredictionKind PredictionKind { get; }
 
         protected internal abstract TPredictor CreatePredictor();
 

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -81,9 +81,9 @@ namespace Microsoft.ML.Runtime.LightGBM
                 {
                     using (var pch = Host.StartProgressChannel("Loading data for LightGBM"))
                     {
-                        dtrain = LoadTrainingData(ch, context.Train, out catMetaData);
-                        if (context.Validation != null)
-                            dvalid = LoadValidationData(ch, dtrain, context.Validation, catMetaData);
+                        dtrain = LoadTrainingData(ch, context.TrainingSet, out catMetaData);
+                        if (context.ValidationSet != null)
+                            dvalid = LoadValidationData(ch, dtrain, context.ValidationSet, catMetaData);
                     }
                     ch.Done();
                 }

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -75,7 +75,10 @@ namespace Microsoft.ML.Runtime.PCA
         private readonly int _seed;
 
         public override PredictionKind PredictionKind => PredictionKind.AnomalyDetection;
-        public override TrainerInfo Info { get; }
+
+        // The training performs two passes, only. Probably not worth caching.
+        private static readonly TrainerInfo _info = new TrainerInfo(caching: false);
+        public override TrainerInfo Info => _info;
 
         public RandomizedPcaTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
@@ -84,8 +87,6 @@ namespace Microsoft.ML.Runtime.PCA
             Host.CheckUserArg(args.Rank > 0, nameof(args.Rank), "Rank must be positive");
             Host.CheckUserArg(args.Oversampling >= 0, nameof(args.Oversampling), "Oversampling must be non-negative");
 
-            // Two passes, only. Probably not worth caching.
-            Info = new TrainerInfo(caching: false);
             _rank = args.Rank;
             _center = args.Center;
             _oversampling = args.Oversampling;

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -101,11 +101,11 @@ namespace Microsoft.ML.Runtime.PCA
         {
             Host.CheckValue(context, nameof(context));
 
-            context.Train.CheckFeatureFloatVector(out int dimension);
+            context.TrainingSet.CheckFeatureFloatVector(out int dimension);
 
             using (var ch = Host.Start("Training"))
             {
-                var pred = TrainCore(ch, context.Train, dimension);
+                var pred = TrainCore(ch, context.TrainingSet, dimension);
                 ch.Done();
                 return pred;
             }

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -74,6 +74,9 @@ namespace Microsoft.ML.Runtime.PCA
         private readonly bool _center;
         private readonly int _seed;
 
+        public override PredictionKind PredictionKind => PredictionKind.AnomalyDetection;
+        public override TrainerInfo Info { get; }
+
         public RandomizedPcaTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
@@ -81,20 +84,13 @@ namespace Microsoft.ML.Runtime.PCA
             Host.CheckUserArg(args.Rank > 0, nameof(args.Rank), "Rank must be positive");
             Host.CheckUserArg(args.Oversampling >= 0, nameof(args.Oversampling), "Oversampling must be non-negative");
 
+            // Two passes, only. Probably not worth caching.
+            Info = new TrainerInfo(caching: false);
             _rank = args.Rank;
             _center = args.Center;
             _oversampling = args.Oversampling;
             _seed = args.Seed ?? Host.Rand.Next();
         }
-
-        public override bool NeedNormalization => true;
-
-        public override bool NeedCalibration => false;
-
-        // Two passes, only. Probably not worth caching.
-        public override bool WantCaching => false;
-
-        public override PredictionKind PredictionKind => PredictionKind.AnomalyDetection;
 
         //Note: the notations used here are the same as in http://web.stanford.edu/group/mmds/slides2010/Martinsson.pdf (pg. 9)
         public override PcaPredictor Train(TrainContext context)

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Runtime.PCA
     /// <remarks>
     /// This PCA can be made into Kernel PCA by using Random Fourier Features transform
     /// </remarks>
-    public sealed class RandomizedPcaTrainer : TrainerBase<RoleMappedData, PcaPredictor>
+    public sealed class RandomizedPcaTrainer : TrainerBase<PcaPredictor>
     {
         public const string LoadNameValue = "pcaAnomaly";
         internal const string UserNameValue = "PCA Anomaly Detector";
@@ -69,13 +69,10 @@ namespace Microsoft.ML.Runtime.PCA
             public int? Seed;
         }
 
-        private int _dimension;
         private readonly int _rank;
         private readonly int _oversampling;
         private readonly bool _center;
         private readonly int _seed;
-        private VBuffer<Float>[] _eigenvectors; // top eigenvectors of the covariance matrix
-        private VBuffer<Float> _mean;
 
         public RandomizedPcaTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
@@ -90,65 +87,52 @@ namespace Microsoft.ML.Runtime.PCA
             _seed = args.Seed ?? Host.Rand.Next();
         }
 
-        public override bool NeedNormalization
-        {
-            get { return true; }
-        }
+        public override bool NeedNormalization => true;
 
-        public override bool NeedCalibration
-        {
-            get { return false; }
-        }
+        public override bool NeedCalibration => false;
 
-        public override bool WantCaching
-        {
-            // Two passes, only. Probably not worth caching.
-            get { return false; }
-        }
+        // Two passes, only. Probably not worth caching.
+        public override bool WantCaching => false;
 
-        public override PcaPredictor CreatePredictor()
-        {
-            return new PcaPredictor(Host, _rank, _eigenvectors, ref _mean);
-        }
-
-        public override PredictionKind PredictionKind { get { return PredictionKind.AnomalyDetection; } }
+        public override PredictionKind PredictionKind => PredictionKind.AnomalyDetection;
 
         //Note: the notations used here are the same as in http://web.stanford.edu/group/mmds/slides2010/Martinsson.pdf (pg. 9)
-        public override void Train(RoleMappedData data)
+        public override PcaPredictor Train(TrainContext context)
         {
-            Host.CheckValue(data, nameof(data));
+            Host.CheckValue(context, nameof(context));
 
-            data.CheckFeatureFloatVector(out _dimension);
+            context.Train.CheckFeatureFloatVector(out int dimension);
 
             using (var ch = Host.Start("Training"))
             {
-                TrainCore(ch, data);
+                var pred = TrainCore(ch, context.Train, dimension);
                 ch.Done();
+                return pred;
             }
         }
 
-        private void TrainCore(IChannel ch, RoleMappedData data)
+        private PcaPredictor TrainCore(IChannel ch, RoleMappedData data, int dimension)
         {
             Host.AssertValue(ch);
             ch.AssertValue(data);
 
-            if (_rank > _dimension)
-                throw ch.Except("Rank ({0}) cannot be larger than the original dimension ({1})", _rank, _dimension);
-            int oversampledRank = Math.Min(_rank + _oversampling, _dimension);
+            if (_rank > dimension)
+                throw ch.Except("Rank ({0}) cannot be larger than the original dimension ({1})", _rank, dimension);
+            int oversampledRank = Math.Min(_rank + _oversampling, dimension);
 
             //exact: (size of the 2 big matrices + other minor allocations) / (2^30)
-            Double memoryUsageEstimate = 2.0 * _dimension * oversampledRank * sizeof(Float) / 1e9;
+            Double memoryUsageEstimate = 2.0 * dimension * oversampledRank * sizeof(Float) / 1e9;
             if (memoryUsageEstimate > 2)
                 ch.Info("Estimate memory usage: {0:G2} GB. If running out of memory, reduce rank and oversampling factor.", memoryUsageEstimate);
 
-            var y = Zeros(oversampledRank, _dimension);
-            _mean = _center ? VBufferUtils.CreateDense<Float>(_dimension) : VBufferUtils.CreateEmpty<Float>(_dimension);
+            var y = Zeros(oversampledRank, dimension);
+            var mean = _center ? VBufferUtils.CreateDense<Float>(dimension) : VBufferUtils.CreateEmpty<Float>(dimension);
 
-            var omega = GaussianMatrix(oversampledRank, _dimension, _seed);
+            var omega = GaussianMatrix(oversampledRank, dimension, _seed);
 
             var cursorFactory = new FeatureFloatVectorCursor.Factory(data, CursOpt.Features | CursOpt.Weight);
             long numBad;
-            Project(Host, cursorFactory, ref _mean, omega, y, out numBad);
+            Project(Host, cursorFactory, ref mean, omega, y, out numBad);
             if (numBad > 0)
                 ch.Warning("Skipped {0} instances with missing features/weights during training", numBad);
 
@@ -166,7 +150,7 @@ namespace Microsoft.ML.Runtime.PCA
             var q = y; // q in QR decomposition.
 
             var b = omega; // reuse the memory allocated by Omega.
-            Project(Host, cursorFactory, ref _mean, q, b, out numBad);
+            Project(Host, cursorFactory, ref mean, q, b, out numBad);
 
             //Compute B2 = B' * B
             var b2 = new Float[oversampledRank * oversampledRank];
@@ -179,8 +163,9 @@ namespace Microsoft.ML.Runtime.PCA
             Float[] smallEigenvalues;// eigenvectors and eigenvalues of the small matrix B2.
             Float[] smallEigenvectors;
             EigenUtils.EigenDecomposition(b2, out smallEigenvalues, out smallEigenvectors);
-            PostProcess(b, smallEigenvalues, smallEigenvectors, _dimension, oversampledRank);
-            _eigenvectors = b;
+            PostProcess(b, smallEigenvalues, smallEigenvectors, dimension, oversampledRank);
+
+            return new PcaPredictor(Host, _rank, b, ref mean);
         }
 
         private static VBuffer<Float>[] Zeros(int k, int d)

--- a/src/Microsoft.ML.PipelineInference/ExperimentsGenerator.cs
+++ b/src/Microsoft.ML.PipelineInference/ExperimentsGenerator.cs
@@ -110,8 +110,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
 
             //get all the trainers for this task, and generate the initial set of candidates.
             // Exclude the hidden learners, and the metalinear learners. 
-            var trainers = ComponentCatalog.GetAllDerivedClasses(typeof(ITrainer), predictorType)
-                .Where(cls => !cls.IsHidden && !typeof(IMetaLinearTrainer).IsAssignableFrom(cls.Type));
+            var trainers = ComponentCatalog.GetAllDerivedClasses(typeof(ITrainer), predictorType).Where(cls => !cls.IsHidden);
 
             var loaderSubComponent = new SubComponent("TextLoader", loaderSettings);
             string loader = $" loader={loaderSubComponent}";

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -74,9 +74,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
         }
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
-        public override bool NeedNormalization => true;
-        public override bool NeedCalibration => false;
-        public override bool WantCaching => true;
+        public override TrainerInfo Info { get; }
         private readonly int _latentDim;
         private readonly int _latentDimAligned;
         private readonly float _lambdaLinear;
@@ -105,6 +103,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             _shuffle = args.Shuffle;
             _verbose = args.Verbose;
             _radius = args.Radius;
+            Info = new TrainerInfo();
         }
 
         private void InitializeTrainingState(int fieldCount, int featureCount, FieldAwareFactorizationMachinePredictor predictor, out float[] linearWeights,

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -356,7 +356,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             using (var ch = Host.Start("Training"))
             using (var pch = Host.StartProgressChannel("Training"))
             {
-                var pred = TrainCore(ch, pch, context.Train, context.Validation, initPredictor);
+                var pred = TrainCore(ch, pch, context.TrainingSet, context.ValidationSet, initPredictor);
                 ch.Done();
                 return pred;
             }

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -985,9 +985,10 @@ namespace Microsoft.ML.Runtime.Learners
                 _duals = new Float[length];
             }
 
-            public override Float this[long index] {
-                get { return _duals[(int)index]; }
-                set { _duals[(int)index] = value; }
+            public override Float this[long index]
+            {
+                get => _duals[(int)index];
+                set => _duals[(int)index] = value;
             }
 
             public override void ApplyAt(long index, Visitor manip)
@@ -1003,7 +1004,7 @@ namespace Microsoft.ML.Runtime.Learners
         {
             private BigArray<Float> _duals;
 
-            public override long Length { get { return _duals.Length; } }
+            public override long Length => _duals.Length;
 
             public BigArrayDualsTable(long length)
             {
@@ -1011,13 +1012,10 @@ namespace Microsoft.ML.Runtime.Learners
                 _duals = new BigArray<Float>(length);
             }
 
-            public override Float this[long index] {
-                get {
-                    return _duals[index];
-                }
-                set {
-                    _duals[index] = value;
-                }
+            public override Float this[long index]
+            {
+                get => _duals[index];
+                set => _duals[index] = value;
             }
 
             public override void ApplyAt(long index, Visitor manip)
@@ -1104,7 +1102,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// the table growing operation initializes a new larger bucket and rehash the existing entries to
         /// the new bucket. Such operation has an expected complexity proportional to the size.
         /// </summary>
-        protected internal sealed class IdToIdxLookup
+        protected sealed class IdToIdxLookup
         {
             // Utilizing this struct gives better cache behavior than using parallel arrays.
             private struct Entry
@@ -1131,7 +1129,7 @@ namespace Microsoft.ML.Runtime.Learners
             /// <summary>
             /// Gets the count of id entries.
             /// </summary>
-            public long Count { get { return _count; } }
+            public long Count => _count;
 
             /// <summary>
             /// Initializes an instance of the <see cref="IdToIdxLookup"/> class with the specified size.

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Runtime.Learners
             TPredictor pred;
             using (var ch = Host.Start("Training"))
             {
-                var preparedData = PrepareDataFromTrainingExamples(ch, context.Train, out int weightSetCount);
+                var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
                 var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearPredictor;
                 linInitPred = linInitPred ?? initPred as LinearPredictor;

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -44,12 +44,9 @@ namespace Microsoft.ML.Runtime.Learners
     using Stopwatch = System.Diagnostics.Stopwatch;
     using TScalarPredictor = IPredictorWithFeatureWeights<Float>;
 
-    public abstract class LinearTrainerBase<TPredictor> : TrainerBase<RoleMappedData, TPredictor>
+    public abstract class LinearTrainerBase<TPredictor> : TrainerBase<TPredictor>
         where TPredictor : IPredictor
     {
-        protected int NumFeatures;
-        protected VBuffer<Float>[] Weights;
-        protected Float[] Bias;
         protected bool NeedShuffle;
 
         public override bool NeedNormalization => true;
@@ -66,40 +63,39 @@ namespace Microsoft.ML.Runtime.Learners
         {
         }
 
-        protected void TrainEx(RoleMappedData data, LinearPredictor predictor)
+        public override TPredictor Train(TrainContext context)
         {
+            Host.CheckValue(context, nameof(context));
+            TPredictor pred;
             using (var ch = Host.Start("Training"))
             {
-                ch.AssertValue(data, nameof(data));
-                ch.AssertValueOrNull(predictor);
-                var preparedData = PrepareDataFromTrainingExamples(ch, data);
-                TrainCore(ch, preparedData, predictor);
+                var preparedData = PrepareDataFromTrainingExamples(ch, context.Train, out int weightSetCount);
+                var initPred = context.InitialPredictor;
+                var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearPredictor;
+                linInitPred = linInitPred ?? initPred as LinearPredictor;
+                Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
+                    "Initial predictor was not a linear predictor.");
+                pred = TrainCore(ch, preparedData, linInitPred, weightSetCount);
                 ch.Done();
             }
+            return pred;
         }
 
-        public override void Train(RoleMappedData examples)
-        {
-            Host.CheckValue(examples, nameof(examples));
-            TrainEx(examples, null);
-        }
-
-        protected abstract void TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor);
-
-        /// <summary>
-        /// Gets the size of weights and bias array. For binary classification and regression, this is 1. 
-        /// For multi-class classification, this equals the number of classes.
-        /// </summary>
-        protected abstract int WeightArraySize { get; }
+        protected abstract TPredictor TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor, int weightSetCount);
 
         /// <summary>
         /// This method ensures that the data meets the requirements of this trainer and its
         /// subclasses, injects necessary transforms, and throws if it couldn't meet them.
         /// </summary>
-        protected RoleMappedData PrepareDataFromTrainingExamples(IChannel ch, RoleMappedData examples)
+        /// <param name="ch">The channel</param>
+        /// <param name="examples">The training examples</param>
+        /// <param name="weightSetCount">Gets the length of weights and bias array. For binary classification and regression,
+        /// this is 1. For multi-class classification, this equals the number of classes on the label.</param>
+        /// <returns>A potentially modified version of <paramref name="examples"/></returns>
+        protected RoleMappedData PrepareDataFromTrainingExamples(IChannel ch, RoleMappedData examples, out int weightSetCount)
         {
             ch.AssertValue(examples);
-            CheckLabel(examples);
+            CheckLabel(examples, out weightSetCount);
             examples.CheckFeatureFloatVector();
             var idvToShuffle = examples.Data;
             IDataView idvToFeedTrain;
@@ -120,17 +116,17 @@ namespace Microsoft.ML.Runtime.Learners
             var roles = examples.Schema.GetColumnRoleNames();
             var examplesToFeedTrain = new RoleMappedData(idvToFeedTrain, roles);
 
-            ch.Assert(examplesToFeedTrain.Schema.Label != null);
-            ch.Assert(examplesToFeedTrain.Schema.Feature != null);
+            ch.AssertValue(examplesToFeedTrain.Schema.Label);
+            ch.AssertValue(examplesToFeedTrain.Schema.Feature);
             if (examples.Schema.Weight != null)
-                ch.Assert(examplesToFeedTrain.Schema.Weight != null);
+                ch.AssertValue(examplesToFeedTrain.Schema.Weight);
 
-            NumFeatures = examplesToFeedTrain.Schema.Feature.Type.VectorSize;
-            ch.Check(NumFeatures > 0, "Training set has 0 instances, aborting training.");
+            int numFeatures = examplesToFeedTrain.Schema.Feature.Type.VectorSize;
+            ch.Check(numFeatures > 0, "Training set has no features, aborting training.");
             return examplesToFeedTrain;
         }
 
-        protected abstract void CheckLabel(RoleMappedData examples);
+        protected abstract void CheckLabel(RoleMappedData examples, out int weightSetCount);
 
         protected Float WDot(ref VBuffer<Float> features, ref VBuffer<Float> weights, Float bias)
         {
@@ -165,13 +161,13 @@ namespace Microsoft.ML.Runtime.Learners
         {
             [Argument(ArgumentType.AtMostOnce, HelpText = "L2 regularizer constant. By default the l2 constant is automatically inferred based on data set.", NullName = "<Auto>", ShortName = "l2", SortOrder = 1)]
             [TGUI(Label = "L2 Regularizer Constant", SuggestedSweeps = "<Auto>,1e-7,1e-6,1e-5,1e-4,1e-3,1e-2")]
-            [TlcModule.SweepableDiscreteParamAttribute("L2Const", new object[] { "<Auto>", 1e-7f, 1e-6f, 1e-5f, 1e-4f, 1e-3f, 1e-2f })]
+            [TlcModule.SweepableDiscreteParam("L2Const", new object[] { "<Auto>", 1e-7f, 1e-6f, 1e-5f, 1e-4f, 1e-3f, 1e-2f })]
             public Float? L2Const;
 
             // REVIEW: make the default positive when we know how to consume a sparse model
             [Argument(ArgumentType.AtMostOnce, HelpText = "L1 soft threshold (L1/L2). Note that it is easier to control and sweep using the threshold parameter than the raw L1-regularizer constant. By default the l1 threshold is automatically inferred based on data set.", NullName = "<Auto>", ShortName = "l1", SortOrder = 2)]
             [TGUI(Label = "L1 Soft Threshold", SuggestedSweeps = "<Auto>,0,0.25,0.5,0.75,1")]
-            [TlcModule.SweepableDiscreteParamAttribute("L1Threshold", new object[] { "<Auto>", 0f, 0.25f, 0.5f, 0.75f, 1f })]
+            [TlcModule.SweepableDiscreteParam("L1Threshold", new object[] { "<Auto>", 0f, 0.25f, 0.5f, 0.75f, 1f })]
             public Float? L1Threshold;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Degree of lock-free parallelism. Defaults to automatic. Determinism not guaranteed.", NullName = "<Auto>", ShortName = "nt,t,threads", SortOrder = 50)]
@@ -180,16 +176,16 @@ namespace Microsoft.ML.Runtime.Learners
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The tolerance for the ratio between duality gap and primal loss for convergence checking.", ShortName = "tol")]
             [TGUI(SuggestedSweeps = "0.001, 0.01, 0.1, 0.2")]
-            [TlcModule.SweepableDiscreteParamAttribute("ConvergenceTolerance", new object[] { 0.001f, 0.01f, 0.1f, 0.2f })]
+            [TlcModule.SweepableDiscreteParam("ConvergenceTolerance", new object[] { 0.001f, 0.01f, 0.1f, 0.2f })]
             public Float ConvergenceTolerance = 0.1f;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of iterations; set to 1 to simulate online learning. Defaults to automatic.", NullName = "<Auto>", ShortName = "iter")]
             [TGUI(Label = "Max number of iterations", SuggestedSweeps = "<Auto>,10,20,100")]
-            [TlcModule.SweepableDiscreteParamAttribute("MaxIterations", new object[] { "<Auto>", 10, 20, 100 })]
+            [TlcModule.SweepableDiscreteParam("MaxIterations", new object[] { "<Auto>", 10, 20, 100 })]
             public int? MaxIterations;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Shuffle data every epoch?", ShortName = "shuf")]
-            [TlcModule.SweepableDiscreteParamAttribute("Shuffle", null, isBool: true)]
+            [TlcModule.SweepableDiscreteParam("Shuffle", null, isBool: true)]
             public bool Shuffle = true;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Convergence check frequency (in terms of number of iterations). Set as negative or zero for not checking at all. If left blank, it defaults to check after every 'numThreads' iterations.", NullName = "<Auto>", ShortName = "checkFreq")]
@@ -197,7 +193,7 @@ namespace Microsoft.ML.Runtime.Learners
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The learning rate for adjusting bias from being regularized.", ShortName = "blr")]
             [TGUI(SuggestedSweeps = "0, 0.01, 0.1, 1")]
-            [TlcModule.SweepableDiscreteParamAttribute("BiasLearningRate", new object[] { 0.0f, 0.01f, 0.1f, 1f })]
+            [TlcModule.SweepableDiscreteParam("BiasLearningRate", new object[] { 0.0f, 0.01f, 0.1f, 1f })]
             public Float BiasLearningRate = 0;
 
             internal virtual void Check(IHostEnvironment env)
@@ -217,6 +213,7 @@ namespace Microsoft.ML.Runtime.Learners
                             "could drastically slow down the convergence. So using l2Const = {1} instead.", L2Const);
 
                         L2Const = L2LowerBound;
+                        ch.Done();
                     }
                 }
             }
@@ -243,12 +240,9 @@ namespace Microsoft.ML.Runtime.Learners
         private readonly ArgumentsBase _args;
         protected ISupportSdcaLoss Loss;
 
-        public override bool NeedNormalization
-        {
-            get { return true; }
-        }
+        public override bool NeedNormalization => true;
 
-        protected override bool ShuffleData { get { return _args.Shuffle; } }
+        protected override bool ShuffleData => _args.Shuffle;
 
         protected SdcaTrainerBase(ArgumentsBase args, IHostEnvironment env, string name)
             : base(env, name)
@@ -257,13 +251,13 @@ namespace Microsoft.ML.Runtime.Learners
             _args.Check(env);
         }
 
-        protected override void TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor)
+        protected sealed override TPredictor TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor, int weightSetCount)
         {
             Contracts.Assert(predictor == null, "SDCA based trainers don't support continuous training.");
-            Contracts.Assert(NumFeatures > 0, "Number of features must be assigned prior to passing into TrainCore.");
-            int weightArraySize = WeightArraySize;
-            Contracts.Assert(weightArraySize >= 1);
-            long maxTrainingExamples = MaxDualTableSize / weightArraySize;
+            Contracts.Assert(weightSetCount >= 1);
+
+            int numFeatures = data.Schema.Feature.Type.VectorSize;
+            long maxTrainingExamples = MaxDualTableSize / weightSetCount;
             var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight | CursOpt.Id);
             int numThreads;
             if (_args.NumThreads.HasValue)
@@ -301,8 +295,7 @@ namespace Microsoft.ML.Runtime.Learners
             ch.Assert(checkFrequency > 0);
 
             var pOptions = new ParallelOptions { MaxDegreeOfParallelism = numThreads };
-            var converged = false;
-            var watch = new Stopwatch();
+            bool converged = false;
 
             // Getting the total count of rows in data. Ignore rows with bad label and feature values.
             long count = 0;
@@ -398,24 +391,24 @@ namespace Microsoft.ML.Runtime.Learners
 
             Contracts.Assert(_args.L2Const.HasValue);
             if (_args.L1Threshold == null)
-                _args.L1Threshold = TuneDefaultL1(ch, NumFeatures);
+                _args.L1Threshold = TuneDefaultL1(ch, numFeatures);
 
             ch.Assert(_args.L1Threshold.HasValue);
             var l1Threshold = _args.L1Threshold.Value;
             var l1ThresholdZero = l1Threshold == 0;
-            VBuffer<Float>[] weights = new VBuffer<Float>[weightArraySize];
-            VBuffer<Float>[] bestWeights = new VBuffer<Float>[weightArraySize];
-            VBuffer<Float>[] l1IntermediateWeights = l1ThresholdZero ? null : new VBuffer<Float>[weightArraySize];
-            Float[] biasReg = new Float[weightArraySize];
-            Float[] bestBiasReg = new Float[weightArraySize];
-            Float[] biasUnreg = new Float[weightArraySize];
-            Float[] bestBiasUnreg = new Float[weightArraySize];
-            Float[] l1IntermediateBias = l1ThresholdZero ? null : new Float[weightArraySize];
+            var weights = new VBuffer<Float>[weightSetCount];
+            var bestWeights = new VBuffer<Float>[weightSetCount];
+            var l1IntermediateWeights = l1ThresholdZero ? null : new VBuffer<Float>[weightSetCount];
+            var biasReg = new Float[weightSetCount];
+            var bestBiasReg = new Float[weightSetCount];
+            var biasUnreg = new Float[weightSetCount];
+            var bestBiasUnreg = new Float[weightSetCount];
+            var l1IntermediateBias = l1ThresholdZero ? null : new Float[weightSetCount];
 
-            for (int i = 0; i < weightArraySize; i++)
+            for (int i = 0; i < weightSetCount; i++)
             {
-                weights[i] = VBufferUtils.CreateDense<Float>(NumFeatures);
-                bestWeights[i] = VBufferUtils.CreateDense<Float>(NumFeatures);
+                weights[i] = VBufferUtils.CreateDense<Float>(numFeatures);
+                bestWeights[i] = VBufferUtils.CreateDense<Float>(numFeatures);
                 biasReg[i] = 0;
                 bestBiasReg[i] = 0;
                 biasUnreg[i] = 0;
@@ -423,7 +416,7 @@ namespace Microsoft.ML.Runtime.Learners
 
                 if (!l1ThresholdZero)
                 {
-                    l1IntermediateWeights[i] = VBufferUtils.CreateDense<Float>(NumFeatures);
+                    l1IntermediateWeights[i] = VBufferUtils.CreateDense<Float>(numFeatures);
                     l1IntermediateBias[i] = 0;
                 }
             }
@@ -441,7 +434,7 @@ namespace Microsoft.ML.Runtime.Learners
             if (idToIdx == null)
             {
                 Contracts.Assert(!needLookup);
-                long dualsLength = ((long)idLoMax + 1) * WeightArraySize;
+                long dualsLength = ((long)idLoMax + 1) * weightSetCount;
                 if (dualsLength <= Utils.ArrayMaxSize)
                 {
                     // The dual variables fit into a standard float[].
@@ -465,7 +458,7 @@ namespace Microsoft.ML.Runtime.Learners
             {
                 // Similar logic as above when using the id-to-index lookup.
                 Contracts.Assert(needLookup);
-                long dualsLength = count * WeightArraySize;
+                long dualsLength = count * weightSetCount;
                 if (dualsLength <= Utils.ArrayMaxSize)
                 {
                     duals = new StandardArrayDualsTable((int)dualsLength);
@@ -497,8 +490,6 @@ namespace Microsoft.ML.Runtime.Learners
             ch.Assert(_args.MaxIterations.HasValue);
             var maxIterations = _args.MaxIterations.Value;
 
-            watch.Start();
-
             var rands = new IRandom[maxIterations];
             for (int i = 0; i < maxIterations; i++)
                 rands[i] = RandomUtils.Create(Host.Rand.Next());
@@ -506,9 +497,9 @@ namespace Microsoft.ML.Runtime.Learners
             // If we favor storing the invariants, precompute the invariants now.
             if (invariants != null)
             {
-                Contracts.Assert((idToIdx == null & ((long)idLoMax + 1) * WeightArraySize <= Utils.ArrayMaxSize) | (idToIdx != null & count * WeightArraySize <= Utils.ArrayMaxSize));
-                Func<UInt128, long, long> getIndexFromIdAndRow = GetIndexFromIdAndRowGetter(idToIdx);
-                int invariantCoeff = WeightArraySize == 1 ? 1 : 2;
+                Contracts.Assert((idToIdx == null & ((long)idLoMax + 1) * weightSetCount <= Utils.ArrayMaxSize) | (idToIdx != null & count * weightSetCount <= Utils.ArrayMaxSize));
+                Func<UInt128, long, long> getIndexFromIdAndRow = GetIndexFromIdAndRowGetter(idToIdx, biasReg.Length);
+                int invariantCoeff = weightSetCount == 1 ? 1 : 2;
                 using (var cursor = cursorFactory.Create())
                 using (var pch = Host.StartProgressChannel("SDCA invariants initialization"))
                 {
@@ -599,22 +590,24 @@ namespace Microsoft.ML.Runtime.Learners
                 }
             }
 
-            Bias = new Float[weightArraySize];
+            var bias = new Float[weightSetCount];
             if (bestIter > 0)
             {
                 ch.Info("Using best model from iteration {0}.", bestIter);
-                Weights = bestWeights;
-                for (int i = 0; i < weightArraySize; i++)
-                    Bias[i] = bestBiasReg[i] + bestBiasUnreg[i];
+                weights = bestWeights;
+                for (int i = 0; i < weightSetCount; i++)
+                    bias[i] = bestBiasReg[i] + bestBiasUnreg[i];
             }
             else
             {
                 ch.Info("Using model from last iteration.");
-                Weights = weights;
-                for (int i = 0; i < weightArraySize; i++)
-                    Bias[i] = biasReg[i] + biasUnreg[i];
+                for (int i = 0; i < weightSetCount; i++)
+                    bias[i] = biasReg[i] + biasUnreg[i];
             }
+            return CreatePredictor(weights, bias);
         }
+
+        protected abstract TPredictor CreatePredictor(VBuffer<Float>[] weights, Float[] bias);
 
         // Assign an upper bound for number of iterations based on data set size first.
         // This ensures SDCA will not run forever...
@@ -746,7 +739,7 @@ namespace Microsoft.ML.Runtime.Learners
                 if (pch != null)
                     pch.SetHeader(new ProgressHeader("examples"), e => e.SetProgress(0, rowCount));
 
-                Func<UInt128, long> getIndexFromId = GetIndexFromIdGetter(idToIdx);
+                Func<UInt128, long> getIndexFromId = GetIndexFromIdGetter(idToIdx, biasReg.Length);
                 while (cursor.MoveNext())
                 {
                     long idx = getIndexFromId(cursor.Id);
@@ -901,7 +894,7 @@ namespace Microsoft.ML.Runtime.Learners
             using (var cursor = cursorFactory.Create())
             {
                 long row = 0;
-                Func<UInt128, long, long> getIndexFromIdAndRow = GetIndexFromIdAndRowGetter(idToIdx);
+                Func<UInt128, long, long> getIndexFromIdAndRow = GetIndexFromIdAndRowGetter(idToIdx, biasReg.Length);
                 // Iterates through data to compute loss function.
                 while (cursor.MoveNext())
                 {
@@ -992,8 +985,7 @@ namespace Microsoft.ML.Runtime.Learners
                 _duals = new Float[length];
             }
 
-            public override Float this[long index]
-            {
+            public override Float this[long index] {
                 get { return _duals[(int)index]; }
                 set { _duals[(int)index] = value; }
             }
@@ -1019,14 +1011,11 @@ namespace Microsoft.ML.Runtime.Learners
                 _duals = new BigArray<Float>(length);
             }
 
-            public override Float this[long index]
-            {
-                get
-                {
+            public override Float this[long index] {
+                get {
                     return _duals[index];
                 }
-                set
-                {
+                set {
                     _duals[index] = value;
                 }
             }
@@ -1042,10 +1031,10 @@ namespace Microsoft.ML.Runtime.Learners
         /// Returns a function delegate to retrieve index from id.
         /// This is to avoid redundant conditional branches in the tight loop of training.
         /// </summary>
-        protected Func<UInt128, long> GetIndexFromIdGetter(IdToIdxLookup idToIdx)
+        protected Func<UInt128, long> GetIndexFromIdGetter(IdToIdxLookup idToIdx, int biasLength)
         {
             Contracts.AssertValueOrNull(idToIdx);
-            long maxTrainingExamples = MaxDualTableSize / WeightArraySize;
+            long maxTrainingExamples = MaxDualTableSize / biasLength;
             if (idToIdx == null)
             {
                 return (UInt128 id) =>
@@ -1073,10 +1062,10 @@ namespace Microsoft.ML.Runtime.Learners
         /// Only works if the cursor is not shuffled.
         /// This is to avoid redundant conditional branches in the tight loop of training.
         /// </summary>
-        protected Func<UInt128, long, long> GetIndexFromIdAndRowGetter(IdToIdxLookup idToIdx)
+        protected Func<UInt128, long, long> GetIndexFromIdAndRowGetter(IdToIdxLookup idToIdx, int biasLength)
         {
             Contracts.AssertValueOrNull(idToIdx);
-            long maxTrainingExamples = MaxDualTableSize / WeightArraySize;
+            long maxTrainingExamples = MaxDualTableSize / biasLength;
             if (idToIdx == null)
             {
                 return (UInt128 id, long row) =>
@@ -1368,7 +1357,7 @@ namespace Microsoft.ML.Runtime.Learners
         }
     }
 
-    public sealed class LinearClassificationTrainer : SdcaTrainerBase<IPredictor>, ITrainer<RoleMappedData, TScalarPredictor>, ITrainerEx
+    public sealed class LinearClassificationTrainer : SdcaTrainerBase<TScalarPredictor>, ITrainerEx
     {
         public const string LoadNameValue = "SDCA";
         public const string UserNameValue = "Fast Linear (SA-SDCA)";
@@ -1404,8 +1393,6 @@ namespace Microsoft.ML.Runtime.Learners
 
         public override bool NeedCalibration => !(_loss is LogLoss);
 
-        protected override int WeightArraySize => 1;
-
         public LinearClassificationTrainer(IHostEnvironment env, Arguments args)
             : base(args, env, LoadNameValue)
         {
@@ -1416,25 +1403,19 @@ namespace Microsoft.ML.Runtime.Learners
             _positiveInstanceWeight = _args.PositiveInstanceWeight;
         }
 
-        public override IPredictor CreatePredictor()
+        protected override TScalarPredictor CreatePredictor(VBuffer<Float>[] weights, Float[] bias)
         {
-            Contracts.Assert(WeightArraySize == 1);
-            Contracts.Assert(Utils.Size(Weights) == 1);
-            Contracts.Assert(Utils.Size(Bias) == 1);
-            Host.Check(Weights[0].Length > 0);
-            VBuffer<Float> maybeSparseWeights = VBufferUtils.CreateEmpty<Float>(Weights[0].Length);
-            VBufferUtils.CreateMaybeSparseCopy(ref Weights[0], ref maybeSparseWeights, Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
-            var predictor = new LinearBinaryPredictor(Host, ref maybeSparseWeights, Bias[0]);
+            Host.CheckParam(Utils.Size(weights) == 1, nameof(weights));
+            Host.CheckParam(Utils.Size(bias) == 1, nameof(bias));
+            Host.CheckParam(weights[0].Length > 0, nameof(weights));
+
+            VBuffer<Float> maybeSparseWeights = default;
+            VBufferUtils.CreateMaybeSparseCopy(ref weights[0], ref maybeSparseWeights,
+                Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
+            var predictor = new LinearBinaryPredictor(Host, ref maybeSparseWeights, bias[0]);
             if (!(_loss is LogLoss))
                 return predictor;
             return new ParameterMixingCalibratedPredictor(Host, predictor, new PlattCalibrator(Host, -1, 0));
-        }
-
-        TScalarPredictor ITrainer<RoleMappedData, TScalarPredictor>.CreatePredictor()
-        {
-            var predictor = CreatePredictor() as TScalarPredictor;
-            Contracts.AssertValue(predictor);
-            return predictor;
         }
 
         protected override Float GetInstanceWeight(FloatLabelCursor cursor)
@@ -1442,21 +1423,21 @@ namespace Microsoft.ML.Runtime.Learners
             return cursor.Label > 0 ? cursor.Weight * _positiveInstanceWeight : cursor.Weight;
         }
 
-        protected override void CheckLabel(RoleMappedData examples)
+        protected override void CheckLabel(RoleMappedData examples, out int weightSetCount)
         {
             examples.CheckBinaryLabel();
+            weightSetCount = 1;
         }
     }
 
     public sealed class StochasticGradientDescentClassificationTrainer :
-        LinearTrainerBase<IPredictor>,
-        IIncrementalTrainer<RoleMappedData, IPredictor>,
-        ITrainer<RoleMappedData, TScalarPredictor>,
-        ITrainerEx
+        LinearTrainerBase<TScalarPredictor>
     {
         public const string LoadNameValue = "BinarySGD";
         public const string UserNameValue = "Hogwild SGD (binary)";
         public const string ShortName = "HogwildSGD";
+
+        public override bool SupportsIncrementalTraining => true;
 
         public sealed class Arguments : LearnerInputBaseWithWeight
         {
@@ -1465,7 +1446,7 @@ namespace Microsoft.ML.Runtime.Learners
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "L2 regularizer constant", ShortName = "l2", SortOrder = 50)]
             [TGUI(Label = "L2 Regularizer Constant", SuggestedSweeps = "1e-7,5e-7,1e-6,5e-6,1e-5")]
-            [TlcModule.SweepableDiscreteParamAttribute("L2Const", new object[] { 1e-7f, 5e-7f, 1e-6f, 5e-6f, 1e-5f })]
+            [TlcModule.SweepableDiscreteParam("L2Const", new object[] { 1e-7f, 5e-7f, 1e-6f, 5e-6f, 1e-5f })]
             public Float L2Const = (Float)1e-6;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Degree of lock-free parallelism. Defaults to automatic depending on data sparseness. Determinism not guaranteed.", ShortName = "nt,t,threads", SortOrder = 50)]
@@ -1474,12 +1455,12 @@ namespace Microsoft.ML.Runtime.Learners
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Exponential moving averaged improvement tolerance for convergence", ShortName = "tol")]
             [TGUI(SuggestedSweeps = "1e-2,1e-3,1e-4,1e-5")]
-            [TlcModule.SweepableDiscreteParamAttribute("ConvergenceTolerance", new object[] { 1e-2f, 1e-3f, 1e-4f, 1e-5f })]
+            [TlcModule.SweepableDiscreteParam("ConvergenceTolerance", new object[] { 1e-2f, 1e-3f, 1e-4f, 1e-5f })]
             public Double ConvergenceTolerance = 1e-4;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of iterations; set to 1 to simulate online learning.", ShortName = "iter")]
             [TGUI(Label = "Max number of iterations", SuggestedSweeps = "1,5,10,20")]
-            [TlcModule.SweepableDiscreteParamAttribute("MaxIterations", new object[] { 1, 5, 10, 20 })]
+            [TlcModule.SweepableDiscreteParam("MaxIterations", new object[] { 1, 5, 10, 20 })]
             public int MaxIterations = 20;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Initial learning rate (only used by SGD)", ShortName = "ilr,lr")]
@@ -1487,7 +1468,7 @@ namespace Microsoft.ML.Runtime.Learners
             public Double InitLearningRate = 0.01;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Shuffle data every epoch?", ShortName = "shuf")]
-            [TlcModule.SweepableDiscreteParamAttribute("Shuffle", null, isBool: true)]
+            [TlcModule.SweepableDiscreteParam("Shuffle", null, isBool: true)]
             public bool Shuffle = true;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Apply weight to the positive class, for imbalanced data", ShortName = "piw")]
@@ -1502,15 +1483,23 @@ namespace Microsoft.ML.Runtime.Learners
             [Argument(ArgumentType.AtMostOnce, HelpText = "The maximum number of examples to use when training the calibrator", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
             public int MaxCalibrationExamples = 1000000;
 
-            public void Check(ITrainerHost host)
+            internal void Check(IHostEnvironment env)
             {
-                Contracts.CheckUserArg(L2Const >= 0, nameof(L2Const), "L2 constant must be non-negative.");
-                Contracts.CheckUserArg(InitLearningRate > 0, nameof(InitLearningRate), "Initial learning rate must be positive.");
-                Contracts.CheckUserArg(MaxIterations > 0, nameof(MaxIterations), "Max number of iterations must be positive.");
-                Contracts.CheckUserArg(PositiveInstanceWeight > 0, nameof(PositiveInstanceWeight), "Weight for positive instances must be positive");
+                Contracts.CheckValue(env, nameof(env));
+                env.CheckUserArg(L2Const >= 0, nameof(L2Const), "Must be non-negative.");
+                env.CheckUserArg(InitLearningRate > 0, nameof(InitLearningRate), "Must be positive.");
+                env.CheckUserArg(MaxIterations > 0, nameof(MaxIterations), "Must be positive.");
+                env.CheckUserArg(PositiveInstanceWeight > 0, nameof(PositiveInstanceWeight), "Must be positive");
 
                 if (InitLearningRate * L2Const >= 1)
-                    host.StdOut.WriteLine("Learning rate {0} set too high; reducing to {1}", InitLearningRate, InitLearningRate = (Float)0.5 / L2Const);
+                {
+                    using (var ch = env.Start("Argument Adjustment"))
+                    {
+                        ch.Warning("{0} {1} set too high; reducing to {1}", nameof(InitLearningRate),
+                            InitLearningRate, InitLearningRate = (Float)0.5 / L2Const);
+                        ch.Done();
+                    }
+                }
 
                 if (ConvergenceTolerance <= 0)
                     ConvergenceTolerance = Float.Epsilon;
@@ -1520,63 +1509,33 @@ namespace Microsoft.ML.Runtime.Learners
         private readonly IClassificationLoss _loss;
         private readonly Arguments _args;
 
-        protected override bool ShuffleData { get { return _args.Shuffle; } }
+        protected override bool ShuffleData => _args.Shuffle;
 
-        protected override int WeightArraySize { get { return 1; } }
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }
-
-        public override bool NeedCalibration
-        {
-            get { return !(_loss is LogLoss); }
-        }
+        public override bool NeedCalibration => !(_loss is LogLoss);
 
         public StochasticGradientDescentClassificationTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
+            args.Check(env);
             _loss = args.LossFunction.CreateComponent(env);
             NeedShuffle = args.Shuffle;
             _args = args;
         }
 
-        public override IPredictor CreatePredictor()
-        {
-            Contracts.Assert(WeightArraySize == 1);
-            Contracts.Assert(Utils.Size(Weights) == 1);
-            Contracts.Assert(Utils.Size(Bias) == 1);
-            Host.Check(Weights[0].Length > 0);
-            VBuffer<Float> maybeSparseWeights = VBufferUtils.CreateEmpty<Float>(Weights[0].Length);
-            VBufferUtils.CreateMaybeSparseCopy(ref Weights[0], ref maybeSparseWeights, Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
-            var predictor = new LinearBinaryPredictor(Host, ref maybeSparseWeights, Bias[0]);
-            if (!(_loss is LogLoss))
-                return predictor;
-            return new ParameterMixingCalibratedPredictor(Host, predictor, new PlattCalibrator(Host, -1, 0));
-        }
-
-        TScalarPredictor ITrainer<RoleMappedData, TScalarPredictor>.CreatePredictor()
-        {
-            var predictor = CreatePredictor() as TScalarPredictor;
-            Contracts.AssertValue(predictor);
-            return predictor;
-        }
-
-        public void Train(RoleMappedData data, IPredictor predictor)
-        {
-            Host.CheckValue(data, nameof(data));
-            Host.CheckValue(predictor, nameof(predictor));
-            LinearPredictor pred = (predictor as CalibratedPredictorBase)?.SubPredictor as LinearPredictor;
-            pred = pred ?? predictor as LinearPredictor;
-            Host.CheckParam(pred != null, nameof(predictor), "Not a linear predictor.");
-            TrainEx(data, pred);
-        }
-
         //For complexity analysis, we assume that
         // - The number of features is N
         // - Average number of non-zero per instance is k
-        protected override void TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor)
+        protected override TScalarPredictor TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor, int weightSetCount)
         {
-            ch.Assert(NumFeatures > 0, "Number of features must be assigned prior to passing into TrainCore.");
+            Contracts.AssertValue(data);
+            Contracts.Assert(weightSetCount == 1);
+            Contracts.AssertValueOrNull(predictor);
+
+            int numFeatures = data.Schema.Feature.Type.VectorSize;
             var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight);
+
             int numThreads;
             if (_args.NumThreads.HasValue)
             {
@@ -1603,7 +1562,7 @@ namespace Microsoft.ML.Runtime.Learners
                 bias = predictor.Bias;
             }
             else
-                weights = VBufferUtils.CreateDense<float>(NumFeatures);
+                weights = VBufferUtils.CreateDense<float>(numFeatures);
 
             var weightsSync = new object();
             double weightScaling = 1;
@@ -1742,15 +1701,18 @@ namespace Microsoft.ML.Runtime.Learners
 
             VectorUtils.ScaleBy(ref weights, (Float)weightScaling); // restore the true weights
 
-            Weights = new VBuffer<Float>[1];
-            Bias = new Float[1];
-            Weights[0] = weights;
-            Bias[0] = bias;
+            VBuffer<Float> maybeSparseWeights = default;
+            VBufferUtils.CreateMaybeSparseCopy(ref weights, ref maybeSparseWeights, Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
+            var pred = new LinearBinaryPredictor(Host, ref maybeSparseWeights, bias);
+            if (!(_loss is LogLoss))
+                return pred;
+            return new ParameterMixingCalibratedPredictor(Host, pred, new PlattCalibrator(Host, -1, 0));
         }
 
-        protected override void CheckLabel(RoleMappedData examples)
+        protected override void CheckLabel(RoleMappedData examples, out int weightSetCount)
         {
             examples.CheckBinaryLabel();
+            weightSetCount = 1;
         }
 
         [TlcModule.EntryPoint(Name = "Trainers.StochasticGradientDescentBinaryClassifier", Desc = "Train an Hogwild SGD binary model.", UserName = UserNameValue, ShortName = ShortName)]

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -49,7 +49,8 @@ namespace Microsoft.ML.Runtime.Learners
     {
         protected bool NeedShuffle;
 
-        public override TrainerInfo Info { get; }
+        private static readonly TrainerInfo _info = new TrainerInfo();
+        public override TrainerInfo Info => _info;
 
         /// <summary>
         /// Whether data is to be shuffled every epoch.
@@ -59,7 +60,6 @@ namespace Microsoft.ML.Runtime.Learners
         private protected LinearTrainerBase(IHostEnvironment env, string name)
             : base(env, name)
         {
-            Info = new TrainerInfo();
         }
 
         public override TPredictor Train(TrainContext context)

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -132,7 +132,10 @@ namespace Microsoft.ML.Runtime.Learners
         private VBuffer<Float>[] _localGradients;
         private Float[] _localLosses;
 
-        public override TrainerInfo Info { get; }
+        // REVIEW: It's pointless to request caching when we're going to load everything into
+        // memory, that is, when using multiple threads. So should caching not be requested?
+        private static readonly TrainerInfo _info = new TrainerInfo(caching: true, supportIncrementalTrain: true);
+        public override TrainerInfo Info => _info;
 
         internal LbfgsTrainerBase(ArgumentsBase args, IHostEnvironment env, string name, bool showTrainingStats = false)
             : base(env, name)
@@ -160,9 +163,6 @@ namespace Microsoft.ML.Runtime.Learners
             DenseOptimizer = args.DenseOptimizer;
             ShowTrainingStats = showTrainingStats;
             EnforceNonNegativity = args.EnforceNonNegativity;
-            // REVIEW: It's pointless to request caching when we're going to load everything into
-            // memory, that is, when using multiple threads. So should caching not be requested?
-            Info = new TrainerInfo(caching: true, supportIncrementalTrain: true);
 
             if (EnforceNonNegativity && ShowTrainingStats)
             {

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -303,8 +303,8 @@ namespace Microsoft.ML.Runtime.Learners
         {
             Contracts.CheckValue(context, nameof(context));
 
-            var data = context.Train;
-            _srcPredictor = context.Train as TPredictor;
+            var data = context.TrainingSet;
+            _srcPredictor = context.TrainingSet as TPredictor;
             data.CheckFeatureFloatVector(out NumFeatures);
             CheckLabel(data);
             data.CheckOptFloatWeight();

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -55,9 +55,9 @@ namespace Microsoft.ML.Runtime.Learners
             _posWeight = 0;
         }
 
-        public override bool NeedCalibration { get { return false; } }
+        public override bool NeedCalibration => false;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
         protected override void CheckLabel(RoleMappedData data)
         {
@@ -373,7 +373,7 @@ namespace Microsoft.ML.Runtime.Learners
             return InitializeWeights(pred.Weights2, new[] { pred.Bias });
         }
 
-        public override ParameterMixingCalibratedPredictor CreatePredictor()
+        protected override ParameterMixingCalibratedPredictor CreatePredictor()
         {
             // Logistic regression is naturally calibrated to
             // output probabilities when transformed using

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -55,8 +55,6 @@ namespace Microsoft.ML.Runtime.Learners
             _posWeight = 0;
         }
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
         protected override void CheckLabel(RoleMappedData data)

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -67,16 +67,16 @@ namespace Microsoft.ML.Runtime.Learners
 
         private LinearModelStatistics _stats;
 
-        protected override int ClassCount { get { return _numClasses; } }
+        protected override int ClassCount => _numClasses;
 
         public MulticlassLogisticRegression(IHostEnvironment env, Arguments args)
             : base(args, env, LoadNameValue, Contracts.CheckRef(args, nameof(args)).ShowTrainingStats)
         {
         }
 
-        public override bool NeedCalibration { get { return false; } }
+        public override bool NeedCalibration => false;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.MultiClassClassification; } }
+        public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
         protected override void CheckLabel(RoleMappedData data)
         {
@@ -203,7 +203,7 @@ namespace Microsoft.ML.Runtime.Learners
             return InitializeWeights(srcPredictor.DenseWeightsEnumerable(), srcPredictor.BiasesEnumerable());
         }
 
-        public override MulticlassLogisticRegressionPredictor CreatePredictor()
+        protected override MulticlassLogisticRegressionPredictor CreatePredictor()
         {
             if (_numClasses < 1)
                 throw Contracts.Except("Cannot create a multiclass predictor with {0} classes", _numClasses);

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -74,8 +74,6 @@ namespace Microsoft.ML.Runtime.Learners
         {
         }
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
         protected override void CheckLabel(RoleMappedData data)

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Runtime.Learners
         public override TPred Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var data = context.Train;
+            var data = context.TrainingSet;
 
             data.CheckFeatureFloatVector();
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -45,15 +45,13 @@ It also assumes that the features are strictly independent.
 
         public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
-        public override bool NeedNormalization => false;
-
-        public override bool NeedCalibration => false;
-
-        public override bool WantCaching => false;
+        public override TrainerInfo Info { get; }
 
         public MultiClassNaiveBayesTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadName)
         {
+            Host.CheckValue(args, nameof(args));
+            Info = new TrainerInfo(normalization: false, caching: false);
         }
 
         public override MultiClassNaiveBayesPredictor Train(TrainContext context)

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -45,13 +45,13 @@ It also assumes that the features are strictly independent.
 
         public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
-        public override TrainerInfo Info { get; }
+        private static readonly TrainerInfo _info = new TrainerInfo(normalization: false, caching: false);
+        public override TrainerInfo Info => _info;
 
         public MultiClassNaiveBayesTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadName)
         {
             Host.CheckValue(args, nameof(args));
-            Info = new TrainerInfo(normalization: false, caching: false);
         }
 
         public override MultiClassNaiveBayesPredictor Train(TrainContext context)

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -59,7 +59,7 @@ It also assumes that the features are strictly independent.
         public override MultiClassNaiveBayesPredictor Train(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
-            var data = context.Train;
+            var data = context.TrainingSet;
             Host.Check(data.Schema.Label != null, "Missing Label column");
             Host.Check(data.Schema.Label.Type == NumberType.Float || data.Schema.Label.Type is KeyType,
                 "Invalid type for Label column, only floats and known-size keys are supported");

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Runtime.Learners
 {
     using CR = RoleMappedSchema.ColumnRole;
     using TScalarPredictor = IPredictorProducing<Float>;
-    using TScalarTrainer = ITrainer<RoleMappedData, IPredictorProducing<Float>>;
+    using TScalarTrainer = ITrainer<IPredictorProducing<Float>>;
 
     public sealed class Ova : MetaMulticlassTrainer<OvaPredictor, Ova.Arguments>
     {
@@ -81,9 +81,10 @@ namespace Microsoft.ML.Runtime.Learners
                 .Prepend(CR.Label.Bind(dstName));
             var td = new RoleMappedData(view, roles);
 
-            trainer.Train(td);
+            // REVIEW: In principle we could support validation sets and the like via the train context, but
+            // this is currently unsupported.
+            var predictor = trainer.Train(td);
 
-            var predictor = trainer.CreatePredictor();
             if (Args.UseProbabilities)
             {
                 ICalibratorTrainer calibrator;

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -26,7 +26,7 @@ using Microsoft.ML.Runtime.Model;
 
 namespace Microsoft.ML.Runtime.Learners
 {
-    using TScalarTrainer = ITrainer<RoleMappedData, IPredictorProducing<Float>>;
+    using TScalarTrainer = ITrainer<IPredictorProducing<Float>>;
     using TScalarPredictor = IPredictorProducing<Float>;
     using TDistPredictor = IDistPredictorProducing<Float, Float>;
     using CR = RoleMappedSchema.ColumnRole;
@@ -78,14 +78,13 @@ namespace Microsoft.ML.Runtime.Learners
                 .Prepend(CR.Label.Bind(dstName));
             var td = new RoleMappedData(view, roles);
 
-            trainer.Train(td);
+            var predictor = trainer.Train(td);
 
             ICalibratorTrainer calibrator;
             if (!Args.Calibrator.IsGood())
                 calibrator = null;
             else
                 calibrator = Args.Calibrator.CreateInstance(Host);
-            TScalarPredictor predictor = trainer.CreatePredictor();
             var res = CalibratorUtils.TrainCalibratorIfNeeded(Host, ch, calibrator, Args.MaxCalibrationExamples,
                 trainer, predictor, td);
             var dist = res as TDistPredictor;

--- a/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.Runtime.Learners
 {
-    public sealed class OlsLinearRegressionTrainer : TrainerBase<RoleMappedData, OlsLinearRegressionPredictor>
+    public sealed class OlsLinearRegressionTrainer : TrainerBase<OlsLinearRegressionPredictor>
     {
         public sealed class Arguments : LearnerInputBaseWithWeight
         {
@@ -57,17 +57,6 @@ It assumes that the conditional mean of the dependent variable follows a linear 
 By minimizing the squares of the difference between observed values and the predictions, the parameters of the regressor can be estimated.
 </remarks>";
 
-        private VBuffer<Float> _weights;
-        private Float _bias;
-
-        // These have length equal to the number of model parameters, i.e., one for bias plus length of weights.
-        private Double[] _standardErrors;
-        private Double[] _tValues;
-        private Double[] _pValues;
-
-        private Double _rSquared;
-        private Double _rSquaredAdjusted;
-
         private readonly Float _l2Weight;
         private readonly bool _perParameterSignificance;
 
@@ -80,24 +69,11 @@ By minimizing the squares of the difference between observed values and the pred
             _perParameterSignificance = args.PerParameterSignificance;
         }
 
-        public override bool NeedNormalization
-        {
-            get { return true; }
-        }
-
-        public override bool NeedCalibration
-        {
-            get { return false; }
-        }
-
-        public override bool WantCaching
-        {
-            // Two passes, only. Probably not worth caching.
-            get { return false; }
-        }
-
-        public override PredictionKind PredictionKind
-        { get { return PredictionKind.Regression; } }
+        public override bool NeedNormalization => true;
+        public override bool NeedCalibration => false;
+        // Two passes, only. Probably not worth caching.
+        public override bool WantCaching => false;
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         /// <summary>
         /// In several calculations, we calculate probabilities or other quantities that should range
@@ -107,15 +83,14 @@ By minimizing the squares of the difference between observed values and the pred
         /// <param name="p">The quantity that should be clamped from 0 to 1</param>
         /// <returns>Either p, or 0 or 1 if it was outside the range 0 to 1</returns>
         private static Double ProbClamp(Double p)
-        {
-            return Math.Max(0, Math.Min(p, 1));
-        }
+            => Math.Max(0, Math.Min(p, 1));
 
-        public override void Train(RoleMappedData examples)
+        public override OlsLinearRegressionPredictor Train(TrainContext context)
         {
             using (var ch = Host.Start("Training"))
             {
-                ch.CheckValue(examples, nameof(examples));
+                ch.CheckValue(context, nameof(context));
+                var examples = context.Train;
                 ch.CheckParam(examples.Schema.Feature != null, nameof(examples), "Need a feature column");
                 ch.CheckParam(examples.Schema.Label != null, nameof(examples), "Need a label column");
 
@@ -133,12 +108,13 @@ By minimizing the squares of the difference between observed values and the pred
 
                 var cursorFactory = new FloatLabelCursor.Factory(examples, CursOpt.Label | CursOpt.Features);
 
-                TrainCore(ch, cursorFactory, typeFeat.VectorSize);
+                var pred = TrainCore(ch, cursorFactory, typeFeat.VectorSize);
                 ch.Done();
+                return pred;
             }
         }
 
-        private void TrainCore(IChannel ch, FloatLabelCursor.Factory cursorFactory, int featureCount)
+        private OlsLinearRegressionPredictor TrainCore(IChannel ch, FloatLabelCursor.Factory cursorFactory, int featureCount)
         {
             Host.AssertValue(ch);
             ch.AssertValue(cursorFactory);
@@ -262,26 +238,21 @@ By minimizing the squares of the difference between observed values and the pred
             var weights = VBufferUtils.CreateDense<Float>(beta.Length - 1);
             for (int i = 1; i < beta.Length; ++i)
                 weights.Values[i - 1] = (Float)beta[i];
-            _weights = weights;
-            _bias = (Float)beta[0];
-            _standardErrors = _tValues = _pValues = null;
+            var bias = (Float)beta[0];
             if (!(_l2Weight > 0) && m == n)
             {
                 // We would expect the solution to the problem to be exact in this case.
-                _rSquared = 1;
-                _rSquaredAdjusted = Float.NaN;
                 ch.Info("Number of examples equals number of parameters, solution is exact but no statistics can be derived");
-                ch.Done();
-                return;
+                return new OlsLinearRegressionPredictor(Host, ref weights, bias, null, null, null, 1, Float.NaN);
             }
 
             Double rss = 0; // residual sum of squares
             Double tss = 0; // total sum of squares
             using (var cursor = cursorFactory.Create())
             {
-                var lrPredictor = new LinearRegressionPredictor(Host, ref _weights, _bias);
+                var lrPredictor = new LinearRegressionPredictor(Host, ref weights, bias);
                 var lrMap = lrPredictor.GetMapper<VBuffer<Float>, Float>();
-                Float yh = default(Float);
+                Float yh = default;
                 while (cursor.MoveNext())
                 {
                     var features = cursor.Features;
@@ -292,27 +263,28 @@ By minimizing the squares of the difference between observed values and the pred
                     tss += ydm * ydm;
                 }
             }
-            _rSquared = ProbClamp(1 - (rss / tss));
+            var rSquared = ProbClamp(1 - (rss / tss));
             // R^2 adjusted differs from the normal formula on account of the bias term, by Said's reckoning.
+            double rSquaredAdjusted;
             if (n > m)
             {
-                _rSquaredAdjusted = ProbClamp(1 - (1 - _rSquared) * (n - 1) / (n - m));
+                rSquaredAdjusted = ProbClamp(1 - (1 - rSquared) * (n - 1) / (n - m));
                 ch.Info("Coefficient of determination R2 = {0:g}, or {1:g} (adjusted)",
-                    _rSquared, _rSquaredAdjusted);
+                    rSquared, rSquaredAdjusted);
             }
             else
-                _rSquaredAdjusted = Double.NaN;
+                rSquaredAdjusted = Double.NaN;
 
             // The per parameter significance is compute intensive and may not be required for all practitioners.
             // Also we can't estimate it, unless we can estimate the variance, which requires more examples than
             // parameters.
             if (!_perParameterSignificance || m >= n)
-                return;
+                return new OlsLinearRegressionPredictor(Host, ref weights, bias, null, null, null, rSquared, rSquaredAdjusted);
 
-            ch.Assert(!Double.IsNaN(_rSquaredAdjusted));
-            _standardErrors = new Double[m];
-            _tValues = new Double[m];
-            _pValues = new Double[m];
+            ch.Assert(!Double.IsNaN(rSquaredAdjusted));
+            var standardErrors = new Double[m];
+            var tValues = new Double[m];
+            var pValues = new Double[m];
             // Invert X'X:
             Mkl.Pptri(Mkl.Layout.RowMajor, Mkl.UpLo.Lo, m, xtx);
             var s2 = rss / (n - m); // estimate of variance of y
@@ -320,7 +292,7 @@ By minimizing the squares of the difference between observed values and the pred
             for (int i = 0; i < m; i++)
             {
                 // Initialize with inverse Hessian.
-                _standardErrors[i] = (Single)xtx[i * (i + 1) / 2 + i];
+                standardErrors[i] = (Single)xtx[i * (i + 1) / 2 + i];
             }
 
             if (_l2Weight > 0)
@@ -334,9 +306,9 @@ By minimizing the squares of the difference between observed values and the pred
                     {
                         var entry = (Single)xtx[ioffset];
                         var adjustment = -reg * entry * entry;
-                        _standardErrors[iRow] -= adjustment;
+                        standardErrors[iRow] -= adjustment;
                         if (0 < iCol && iCol < iRow)
-                            _standardErrors[iCol] -= adjustment;
+                            standardErrors[iCol] -= adjustment;
                         ioffset++;
                     }
                 }
@@ -347,17 +319,14 @@ By minimizing the squares of the difference between observed values and the pred
             for (int i = 0; i < m; i++)
             {
                 // sqrt of diagonal entries of s2 * inverse(X'X + reg * I) * X'X * inverse(X'X + reg * I).
-                _standardErrors[i] = Math.Sqrt(s2 * _standardErrors[i]);
-                ch.Check(FloatUtils.IsFinite(_standardErrors[i]), "Non-finite standard error detected from OLS solution");
-                _tValues[i] = beta[i] / _standardErrors[i];
-                _pValues[i] = (Float)MathUtils.TStatisticToPValue(_tValues[i], n - m);
-                ch.Check(0 <= _pValues[i] && _pValues[i] <= 1, "p-Value calculated outside expected [0,1] range");
+                standardErrors[i] = Math.Sqrt(s2 * standardErrors[i]);
+                ch.Check(FloatUtils.IsFinite(standardErrors[i]), "Non-finite standard error detected from OLS solution");
+                tValues[i] = beta[i] / standardErrors[i];
+                pValues[i] = (Float)MathUtils.TStatisticToPValue(tValues[i], n - m);
+                ch.Check(0 <= pValues[i] && pValues[i] <= 1, "p-Value calculated outside expected [0,1] range");
             }
-        }
 
-        public override OlsLinearRegressionPredictor CreatePredictor()
-        {
-            return new OlsLinearRegressionPredictor(Host, ref _weights, _bias, _standardErrors, _tValues, _pValues, _rSquared, _rSquaredAdjusted);
+            return new OlsLinearRegressionPredictor(Host, ref weights, bias, standardErrors, tValues, pValues, rSquared, rSquaredAdjusted);
         }
 
         internal static class Mkl

--- a/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
@@ -90,7 +90,7 @@ By minimizing the squares of the difference between observed values and the pred
             using (var ch = Host.Start("Training"))
             {
                 ch.CheckValue(context, nameof(context));
-                var examples = context.Train;
+                var examples = context.TrainingSet;
                 ch.CheckParam(examples.Schema.Feature != null, nameof(examples), "Need a feature column");
                 ch.CheckParam(examples.Schema.Label != null, nameof(examples), "Need a label column");
 

--- a/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
@@ -61,7 +61,10 @@ By minimizing the squares of the difference between observed values and the pred
         private readonly bool _perParameterSignificance;
 
         public override PredictionKind PredictionKind => PredictionKind.Regression;
-        public override TrainerInfo Info { get; }
+
+        // The training performs two passes, only. Probably not worth caching.
+        private static readonly TrainerInfo _info = new TrainerInfo(caching: false);
+        public override TrainerInfo Info => _info;
 
         public OlsLinearRegressionTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
@@ -70,8 +73,6 @@ By minimizing the squares of the difference between observed values and the pred
             Host.CheckUserArg(args.L2Weight >= 0, nameof(args.L2Weight), "L2 regularization term cannot be negative");
             _l2Weight = args.L2Weight;
             _perParameterSignificance = args.PerParameterSignificance;
-            // Two passes, only. Probably not worth caching.
-            Info = new TrainerInfo(caching: false);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/OlsLinearRegression.cs
@@ -60,6 +60,9 @@ By minimizing the squares of the difference between observed values and the pred
         private readonly Float _l2Weight;
         private readonly bool _perParameterSignificance;
 
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
+        public override TrainerInfo Info { get; }
+
         public OlsLinearRegressionTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
@@ -67,13 +70,9 @@ By minimizing the squares of the difference between observed values and the pred
             Host.CheckUserArg(args.L2Weight >= 0, nameof(args.L2Weight), "L2 regularization term cannot be negative");
             _l2Weight = args.L2Weight;
             _perParameterSignificance = args.PerParameterSignificance;
+            // Two passes, only. Probably not worth caching.
+            Info = new TrainerInfo(caching: false);
         }
-
-        public override bool NeedNormalization => true;
-        public override bool NeedCalibration => false;
-        // Two passes, only. Probably not worth caching.
-        public override bool WantCaching => false;
-        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         /// <summary>
         /// In several calculations, we calculate probabilities or other quantities that should range

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
@@ -49,15 +49,12 @@ namespace Microsoft.ML.Runtime.Learners
             public int MaxCalibrationExamples = 1000000;
         }
 
+        protected override bool NeedCalibration => true;
+
         public AveragedPerceptronTrainer(IHostEnvironment env, Arguments args)
             : base(args, env, UserNameValue)
         {
             LossFunction = Args.LossFunction.CreateComponent(env);
-        }
-
-        public override bool NeedCalibration
-        {
-            get { return true; }
         }
 
         public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Runtime.Learners
             data.CheckBinaryLabel();
         }
 
-        public override LinearBinaryPredictor CreatePredictor()
+        protected override LinearBinaryPredictor CreatePredictor()
         {
             Contracts.Assert(WeightsScale == 1);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -80,16 +80,13 @@ namespace Microsoft.ML.Runtime.Learners
         private Float _weightsUpdateScale;
         private Float _biasUpdate;
 
+        protected override bool NeedCalibration => true;
+
         public LinearSvm(IHostEnvironment env, Arguments args)
             : base(args, env, UserNameValue)
         {
             Contracts.CheckUserArg(args.Lambda > 0, nameof(args.Lambda), UserErrorPositive);
             Contracts.CheckUserArg(args.BatchSize > 0, nameof(args.BatchSize), UserErrorPositive);
-        }
-
-        public override bool NeedCalibration
-        {
-            get { return true; }
         }
 
         public override PredictionKind PredictionKind { get { return PredictionKind.BinaryClassification; } }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Runtime.Learners
             }
         }
 
-        public override TPredictor CreatePredictor()
+        protected override TPredictor CreatePredictor()
         {
             Contracts.Assert(WeightsScale == 1);
             return new LinearBinaryPredictor(Host, ref Weights, Bias);

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
@@ -58,11 +58,6 @@ namespace Microsoft.ML.Runtime.Learners
             LossFunction = args.LossFunction.CreateComponent(env);
         }
 
-        public override bool NeedCalibration
-        {
-            get { return false; }
-        }
-
         public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
 
         protected override void CheckLabel(RoleMappedData data)

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Runtime.Learners
             data.CheckRegressionLabel();
         }
 
-        public override TPredictor CreatePredictor()
+        protected override TPredictor CreatePredictor()
         {
             Contracts.Assert(WeightsScale == 1);
             VBuffer<Float> weights = default(VBuffer<Float>);

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -70,6 +70,10 @@ namespace Microsoft.ML.Runtime.Learners
         protected const string UserErrorPositive = "must be positive";
         protected const string UserErrorNonNegative = "must be non-negative";
 
+        public override TrainerInfo Info { get; }
+
+        protected virtual bool NeedCalibration => false;
+
         protected OnlineLinearTrainer(TArguments args, IHostEnvironment env, string name)
             : base(env, name)
         {
@@ -79,16 +83,12 @@ namespace Microsoft.ML.Runtime.Learners
             Contracts.CheckUserArg(args.StreamingCacheSize > 0, nameof(args.StreamingCacheSize), UserErrorPositive);
 
             Args = args;
+            // REVIEW: Caching could be false for one iteration, if we got around the whole shuffling issue.
+            Info = new TrainerInfo(calibration: NeedCalibration);
         }
 
-        public override bool NeedNormalization => true;
-
-        // REVIEW: This could return true if there are more than 0 iterations,
-        // if we got around the whole shuffling issue.
-        public override bool WantCaching => true;
-
         /// <summary>
-        /// Propagates the <c>_weightsScale </c> to the weights vector.
+        /// Propagates the <see cref="WeightsScale"/> to the <see cref="Weights"/> vector.
         /// </summary>
         protected void ScaleWeights()
         {
@@ -100,9 +100,9 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         /// <summary>
-        /// Conditionally propagates the <c>_weightsScale</c> to the weights vector when
-        /// it reaches a scale where additions to weights would start dropping too much
-        /// precision. ("Too much" is mostly empirically defined.)
+        /// Conditionally propagates the <see cref="WeightsScale"/> to the <see cref="Weights"/> vector
+        /// when it reaches a scale where additions to weights would start dropping too much precision.
+        /// ("Too much" is mostly empirically defined.)
         /// </summary>
         protected void ScaleWeightsIfNeeded()
         {

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ML.Runtime.Learners
             var initPredictor = context.InitialPredictor;
             var initLinearPred = initPredictor as LinearPredictor ?? (initPredictor as CalibratedPredictorBase)?.SubPredictor as LinearPredictor;
             Host.CheckParam(initPredictor == null || initLinearPred != null, nameof(context), "Not a linear predictor.");
-            var data = context.Train;
+            var data = context.TrainingSet;
 
             data.CheckFeatureFloatVector(out int numFeatures);
             CheckLabel(data);

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -45,8 +45,6 @@ namespace Microsoft.ML.Runtime.Learners
         {
         }
 
-        public override bool NeedCalibration => false;
-
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         protected override void CheckLabel(RoleMappedData data)

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -45,9 +45,9 @@ namespace Microsoft.ML.Runtime.Learners
         {
         }
 
-        public override bool NeedCalibration { get { return false; } }
+        public override bool NeedCalibration => false;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
         protected override void CheckLabel(RoleMappedData data)
         {
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Runtime.Learners
             return -(y * dot - lambda) * weight;
         }
 
-        public override PoissonRegressionPredictor CreatePredictor()
+        protected override PoissonRegressionPredictor CreatePredictor()
         {
             VBuffer<Float> weights = default(VBuffer<Float>);
             CurrentWeights.CopyTo(ref weights, 1, CurrentWeights.Length - 1);

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -45,21 +45,10 @@ namespace Microsoft.ML.Runtime.Learners
 
         private readonly ISupportSdcaClassificationLoss _loss;
         private readonly Arguments _args;
-        private int _numClasses;
 
-        public override PredictionKind PredictionKind
-        {
-            get { return PredictionKind.MultiClassClassification; }
-        }
+        public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
 
-        protected override int WeightArraySize
-        {
-            get
-            {
-                Contracts.Assert(_numClasses > 0, "_numClasses should already have been initialized when this property is called.");
-                return _numClasses;
-            }
-        }
+        public override bool NeedCalibration => false;
 
         public SdcaMultiClassTrainer(IHostEnvironment env, Arguments args)
             : base(args, env, LoadNameValue)
@@ -69,8 +58,6 @@ namespace Microsoft.ML.Runtime.Learners
             NeedShuffle = args.Shuffle;
             _args = args;
         }
-
-        public override bool NeedCalibration { get { return false; } }
 
         /// <inheritdoc/>
         protected override void TrainWithoutLock(IProgressChannelProvider progress, FloatLabelCursor.Factory cursorFactory, IRandom rand,
@@ -82,11 +69,9 @@ namespace Microsoft.ML.Runtime.Learners
             Contracts.AssertValueOrNull(idToIdx);
             Contracts.AssertValueOrNull(invariants);
             Contracts.AssertValueOrNull(featureNormSquared);
-            int weightArraySize = WeightArraySize;
-            Contracts.Assert(weightArraySize == _numClasses);
-            Contracts.Assert(Utils.Size(weights) == weightArraySize);
-            Contracts.Assert(Utils.Size(biasReg) == weightArraySize);
-            Contracts.Assert(Utils.Size(biasUnreg) == weightArraySize);
+            int numClasses = Utils.Size(weights);
+            Contracts.Assert(Utils.Size(biasReg) == numClasses);
+            Contracts.Assert(Utils.Size(biasUnreg) == numClasses);
 
             int maxUpdateTrials = 2 * numThreads;
             var l1Threshold = _args.L1Threshold.Value;
@@ -101,11 +86,11 @@ namespace Microsoft.ML.Runtime.Learners
                 if (pch != null)
                     pch.SetHeader(new ProgressHeader("examples"), e => e.SetProgress(0, rowCount));
 
-                Func<UInt128, long> getIndexFromId = GetIndexFromIdGetter(idToIdx);
+                Func<UInt128, long> getIndexFromId = GetIndexFromIdGetter(idToIdx, biasReg.Length);
                 while (cursor.MoveNext())
                 {
                     long idx = getIndexFromId(cursor.Id);
-                    long dualIndexInitPos = idx * weightArraySize;
+                    long dualIndexInitPos = idx * numClasses;
                     var features = cursor.Features;
                     var label = (int)cursor.Label;
                     Float invariant;
@@ -139,7 +124,7 @@ namespace Microsoft.ML.Runtime.Learners
                     Float labelAdjustment = 0;
 
                     // Iterates through all classes.
-                    for (int iClass = 0; iClass < _numClasses; iClass++)
+                    for (int iClass = 0; iClass < numClasses; iClass++)
                     {
                         // Skip the dual/weights/bias update for label class. Will be taken care of at the end.
                         if (iClass == label)
@@ -161,9 +146,7 @@ namespace Microsoft.ML.Runtime.Learners
                             dualUpdate -= adjustment;
                             bool success = false;
                             duals.ApplyAt(dualIndex, (long index, ref Float value) =>
-                            {
-                                success = Interlocked.CompareExchange(ref value, dual + dualUpdate, dual) == dual;
-                            });
+                                success = Interlocked.CompareExchange(ref value, dual + dualUpdate, dual) == dual);
 
                             if (success)
                             {
@@ -251,24 +234,23 @@ namespace Microsoft.ML.Runtime.Learners
         {
             Contracts.AssertValue(weights);
             Contracts.AssertValue(duals);
-            Contracts.Assert(weights.Length == _numClasses);
-            Contracts.Assert(duals.Length >= _numClasses * count);
+            int numClasses = weights.Length;
+            Contracts.Assert(duals.Length >= numClasses * count);
             Contracts.AssertValueOrNull(idToIdx);
-            int weightArraySize = WeightArraySize;
-            Contracts.Assert(weightArraySize == _numClasses);
-            Contracts.Assert(Utils.Size(weights) == weightArraySize);
-            Contracts.Assert(Utils.Size(biasReg) == weightArraySize);
-            Contracts.Assert(Utils.Size(biasUnreg) == weightArraySize);
+            Contracts.Assert(Utils.Size(weights) == numClasses);
+            Contracts.Assert(Utils.Size(biasReg) == numClasses);
+            Contracts.Assert(Utils.Size(biasUnreg) == numClasses);
             Contracts.Assert(Utils.Size(metrics) == 6);
             var reportedValues = new Double?[metrics.Length + 1];
             reportedValues[metrics.Length] = iter;
             var lossSum = new CompensatedSum();
             var dualLossSum = new CompensatedSum();
+            int numFeatures = weights[0].Length;
 
             using (var cursor = cursorFactory.Create())
             {
                 long row = 0;
-                Func<UInt128, long, long> getIndexFromIdAndRow = GetIndexFromIdAndRowGetter(idToIdx);
+                Func<UInt128, long, long> getIndexFromIdAndRow = GetIndexFromIdAndRowGetter(idToIdx, biasReg.Length);
                 // Iterates through data to compute loss function.
                 while (cursor.MoveNext())
                 {
@@ -279,8 +261,8 @@ namespace Microsoft.ML.Runtime.Learners
                     Double subLoss = 0;
                     Double subDualLoss = 0;
                     long idx = getIndexFromIdAndRow(cursor.Id, row);
-                    long dualIndex = idx * _numClasses;
-                    for (int iClass = 0; iClass < _numClasses; iClass++)
+                    long dualIndex = idx * numClasses;
+                    for (int iClass = 0; iClass < numClasses; iClass++)
                     {
                         if (iClass == label)
                         {
@@ -290,7 +272,7 @@ namespace Microsoft.ML.Runtime.Learners
 
                         var currentClassOutput = WDot(ref features, ref weights[iClass], biasReg[iClass] + biasUnreg[iClass]);
                         subLoss += _loss.Loss(labelOutput - currentClassOutput, 1);
-                        Contracts.Assert(dualIndex == iClass + idx * _numClasses);
+                        Contracts.Assert(dualIndex == iClass + idx * numClasses);
                         var dual = duals[dualIndex++];
                         subDualLoss += _loss.DualLoss(1, dual);
                     }
@@ -300,7 +282,7 @@ namespace Microsoft.ML.Runtime.Learners
 
                     row++;
                 }
-                Host.Assert(idToIdx == null || row * WeightArraySize == duals.Length);
+                Host.Assert(idToIdx == null || row * numClasses == duals.Length);
             }
 
             Contracts.Assert(_args.L2Const.HasValue);
@@ -311,7 +293,7 @@ namespace Microsoft.ML.Runtime.Learners
             Double weightsL1Norm = 0;
             Double weightsL2NormSquared = 0;
             Double biasRegularizationAdjustment = 0;
-            for (int iClass = 0; iClass < _numClasses; iClass++)
+            for (int iClass = 0; iClass < numClasses; iClass++)
             {
                 weightsL1Norm += VectorUtils.L1Norm(ref weights[iClass]) + Math.Abs(biasReg[iClass]);
                 weightsL2NormSquared += VectorUtils.NormSquared(weights[iClass]) + biasReg[iClass] * biasReg[iClass];
@@ -330,13 +312,14 @@ namespace Microsoft.ML.Runtime.Learners
             metrics[(int)MetricKind.DualityGap] = dualityGap;
             metrics[(int)MetricKind.BiasUnreg] = biasUnreg[0];
             metrics[(int)MetricKind.BiasReg] = biasReg[0];
-            metrics[(int)MetricKind.L1Sparsity] = _args.L1Threshold == 0 ? 1 : (Double)weights.Sum(weight => weight.Values.Count(w => w != 0)) / (_numClasses * NumFeatures);
+            metrics[(int)MetricKind.L1Sparsity] = _args.L1Threshold == 0 ? 1 : weights.Sum(
+                weight => weight.Values.Count(w => w != 0)) / (numClasses * numFeatures);
 
             bool converged = dualityGap / newLoss < _args.ConvergenceTolerance;
 
             if (metrics[(int)MetricKind.Loss] < bestPrimalLoss)
             {
-                for (int iClass = 0; iClass < _numClasses; iClass++)
+                for (int iClass = 0; iClass < numClasses; iClass++)
                 {
                     // Maintain a copy of weights and bias with best primal loss thus far. 
                     // This is some extra work and uses extra memory, but it seems worth doing it.
@@ -358,14 +341,19 @@ namespace Microsoft.ML.Runtime.Learners
             return converged;
         }
 
-        public override TVectorPredictor CreatePredictor()
+        protected override TVectorPredictor CreatePredictor(VBuffer<Float>[] weights, Float[] bias)
         {
-            return new MulticlassLogisticRegressionPredictor(Host, Weights, Bias, _numClasses, NumFeatures, null, stats: null);
+            Host.CheckValue(weights, nameof(weights));
+            Host.CheckValue(bias, nameof(bias));
+            Host.CheckParam(weights.Length > 0, nameof(weights));
+            Host.CheckParam(weights.Length == bias.Length, nameof(weights));
+
+            return new MulticlassLogisticRegressionPredictor(Host, weights, bias, bias.Length, weights[0].Length, null, stats: null);
         }
 
-        protected override void CheckLabel(RoleMappedData examples)
+        protected override void CheckLabel(RoleMappedData examples, out int weightSetCount)
         {
-            examples.CheckMultiClassLabel(out _numClasses);
+            examples.CheckMultiClassLabel(out weightSetCount);
         }
 
         protected override Float[] InitializeFeatureNormSquared(int length)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Runtime.Learners
 
     // SDCA linear multiclass trainer.
     /// <include file='./doc.xml' path='docs/members/member[@name="SDCA"]/*' />
-    public class SdcaMultiClassTrainer : SdcaTrainerBase<TVectorPredictor>, ITrainerEx
+    public class SdcaMultiClassTrainer : SdcaTrainerBase<TVectorPredictor>
     {
         public const string LoadNameValue = "SDCAMC";
         public const string UserNameValue = "Fast Linear Multi-class Classification (SA-SDCA)";
@@ -47,8 +47,6 @@ namespace Microsoft.ML.Runtime.Learners
         private readonly Arguments _args;
 
         public override PredictionKind PredictionKind => PredictionKind.MultiClassClassification;
-
-        public override bool NeedCalibration => false;
 
         public SdcaMultiClassTrainer(IHostEnvironment env, Arguments args)
             : base(args, env, LoadNameValue)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Runtime.Learners
     using TScalarPredictor = IPredictorWithFeatureWeights<Float>;
 
     /// <include file='./doc.xml' path='docs/members/member[@name="SDCA"]/*' />
-    public sealed class SdcaRegressionTrainer : SdcaTrainerBase<IPredictor>, ITrainer<RoleMappedData, TScalarPredictor>, ITrainerEx
+    public sealed class SdcaRegressionTrainer : SdcaTrainerBase<TScalarPredictor>
     {
         public const string LoadNameValue = "SDCAR";
         public const string UserNameValue = "Fast Linear Regression (SA-SDCA)";
@@ -51,11 +51,9 @@ namespace Microsoft.ML.Runtime.Learners
         private readonly ISupportSdcaRegressionLoss _loss;
         private readonly Arguments _args;
 
-        public override PredictionKind PredictionKind { get { return PredictionKind.Regression; } }
+        public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        public override bool NeedCalibration { get { return false; } }
-
-        protected override int WeightArraySize { get { return 1; } }
+        public override bool NeedCalibration => false;
 
         public SdcaRegressionTrainer(IHostEnvironment env, Arguments args)
             : base(args, env, LoadNameValue)
@@ -66,22 +64,16 @@ namespace Microsoft.ML.Runtime.Learners
             _args = args;
         }
 
-        public override IPredictor CreatePredictor()
+        protected override TScalarPredictor CreatePredictor(VBuffer<Float>[] weights, Float[] bias)
         {
-            Contracts.Assert(WeightArraySize == 1);
-            Contracts.Assert(Utils.Size(Weights) == 1);
-            Contracts.Assert(Utils.Size(Bias) == 1);
-            Host.Check(Weights[0].Length > 0);
-            VBuffer<Float> maybeSparseWeights = VBufferUtils.CreateEmpty<Float>(Weights[0].Length);
-            VBufferUtils.CreateMaybeSparseCopy(ref Weights[0], ref maybeSparseWeights, Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
-            return new LinearRegressionPredictor(Host, ref maybeSparseWeights, Bias[0]);
-        }
+            Host.CheckParam(Utils.Size(weights) == 1, nameof(weights));
+            Host.CheckParam(Utils.Size(bias) == 1, nameof(bias));
+            Host.CheckParam(weights[0].Length > 0, nameof(weights));
 
-        TScalarPredictor ITrainer<RoleMappedData, TScalarPredictor>.CreatePredictor()
-        {
-            var predictor = CreatePredictor() as TScalarPredictor;
-            Contracts.AssertValue(predictor);
-            return predictor;
+            VBuffer<Float> maybeSparseWeights = default;
+            VBufferUtils.CreateMaybeSparseCopy(ref weights[0], ref maybeSparseWeights,
+                Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
+            return new LinearRegressionPredictor(Host, ref maybeSparseWeights, bias[0]);
         }
 
         protected override Float GetInstanceWeight(FloatLabelCursor cursor)
@@ -89,9 +81,10 @@ namespace Microsoft.ML.Runtime.Learners
             return cursor.Weight;
         }
 
-        protected override void CheckLabel(RoleMappedData examples)
+        protected override void CheckLabel(RoleMappedData examples, out int weightSetCount)
         {
             examples.CheckRegressionLabel();
+            weightSetCount = 1;
         }
 
         // REVIEW: No extra benefits from using more threads in training.

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
@@ -53,8 +53,6 @@ namespace Microsoft.ML.Runtime.Learners
 
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        public override bool NeedCalibration => false;
-
         public SdcaRegressionTrainer(IHostEnvironment env, Arguments args)
             : base(args, env, LoadNameValue)
         {

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -54,15 +54,15 @@ namespace Microsoft.ML.Runtime.Learners
             public bool BooleanArg = false;
         }
 
+        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
+        public override TrainerInfo Info { get; }
+
         public RandomTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
+            Host.CheckValue(args, nameof(args));
+            Info = new TrainerInfo(normalization: false, caching: false);
         }
-
-        public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
-        public override bool NeedNormalization => false;
-        public override bool NeedCalibration => false;
-        public override bool WantCaching => false;
 
         public override RandomPredictor Train(TrainContext context)
         {
@@ -205,13 +205,13 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
-        public override bool NeedNormalization => false;
-        public override bool NeedCalibration => false;
-        public override bool WantCaching => false;
+        public override TrainerInfo Info { get; }
 
         public PriorTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
+            Host.CheckValue(args, nameof(args));
+            Info = new TrainerInfo(normalization: false, caching: false);
         }
 
         public override PriorPredictor Train(TrainContext context)

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -217,7 +217,7 @@ namespace Microsoft.ML.Runtime.Learners
         public override PriorPredictor Train(TrainContext context)
         {
             Contracts.CheckValue(context, nameof(context));
-            var data = context.Train;
+            var data = context.TrainingSet;
             data.CheckBinaryLabel();
             Contracts.CheckParam(data.Schema.Label != null, nameof(data), "Missing Label column");
             Contracts.CheckParam(data.Schema.Label.Type == NumberType.Float, nameof(data), "Invalid type for Label column");

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -55,13 +55,14 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
-        public override TrainerInfo Info { get; }
+
+        private static readonly TrainerInfo _info = new TrainerInfo(normalization: false, caching: false);
+        public override TrainerInfo Info => _info;
 
         public RandomTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
             Host.CheckValue(args, nameof(args));
-            Info = new TrainerInfo(normalization: false, caching: false);
         }
 
         public override RandomPredictor Train(TrainContext context)
@@ -205,13 +206,14 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
-        public override TrainerInfo Info { get; }
+
+        private static readonly TrainerInfo _info = new TrainerInfo(normalization: false, caching: false);
+        public override TrainerInfo Info => _info;
 
         public PriorTrainer(IHostEnvironment env, Arguments args)
             : base(env, LoadNameValue)
         {
             Host.CheckValue(args, nameof(args));
-            Info = new TrainerInfo(normalization: false, caching: false);
         }
 
         public override PriorPredictor Train(TrainContext context)

--- a/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
@@ -142,9 +142,8 @@ namespace Microsoft.ML.Runtime.Sweeper
                 args.MinDocumentsInLeafs = _args.NMinForSplit;
 
                 // Train random forest.
-                FastForestRegression trainer = new FastForestRegression(_host, args);
-                trainer.Train(data);
-                FastForestRegressionPredictor predictor = trainer.CreatePredictor();
+                var trainer = new FastForestRegression(_host, args);
+                var predictor = trainer.Train(data);
 
                 // Return random forest predictor.
                 ch.Done();

--- a/src/Microsoft.ML.Transforms/LearnerFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/LearnerFeatureSelection.cs
@@ -33,8 +33,8 @@ namespace Microsoft.ML.Runtime.Data
             public int? NumSlotsToKeep;
 
             [Argument(ArgumentType.Multiple, HelpText = "Filter", ShortName = "f", SortOrder = 1)]
-            public SubComponent<ITrainer<RoleMappedData, IPredictorWithFeatureWeights<Single>>, SignatureFeatureScorerTrainer> Filter =
-                new SubComponent<ITrainer<RoleMappedData, IPredictorWithFeatureWeights<Single>>, SignatureFeatureScorerTrainer>("SDCA");
+            public SubComponent<ITrainer<IPredictorWithFeatureWeights<Single>>, SignatureFeatureScorerTrainer> Filter =
+                new SubComponent<ITrainer<IPredictorWithFeatureWeights<Single>>, SignatureFeatureScorerTrainer>("SDCA");
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Column to use for features", ShortName = "feat,col", SortOrder = 3, Purpose = SpecialPurpose.ColumnName)]
             public string FeatureColumn = DefaultColumnNames.Features;

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -685,8 +685,7 @@ namespace Microsoft.ML.Runtime.RunTests
             // This tests that the SchemaBindableCalibratedPredictor doesn't get confused if its sub-predictor is already calibrated.
             var fastForest = new FastForestClassification(Env, new FastForestClassification.Arguments());
             var rmd = new RoleMappedData(splitOutput.TrainData[0], "Label", "Features");
-            fastForest.Train(rmd);
-            var ffModel = new PredictorModel(Env, rmd, splitOutput.TrainData[0], fastForest.CreatePredictor());
+            var ffModel = new PredictorModel(Env, rmd, splitOutput.TrainData[0], fastForest.Train(rmd));
             var calibratedFfModel = Calibrate.Platt(Env,
                 new Calibrate.NoArgumentsInput() { Data = splitOutput.TestData[0], UncalibratedPredictorModel = ffModel }).PredictorModel;
             var twiceCalibratedFfModel = Calibrate.Platt(Env,
@@ -1219,9 +1218,8 @@ namespace Microsoft.ML.Runtime.RunTests
 
                 var mlr = new MulticlassLogisticRegression(Env, new MulticlassLogisticRegression.Arguments());
                 var rmd = new RoleMappedData(data, "Label", "Features");
-                mlr.Train(rmd);
 
-                predictorModels[i] = new PredictorModel(Env, rmd, data, mlr.CreatePredictor());
+                predictorModels[i] = new PredictorModel(Env, rmd, data, mlr.Train(rmd));
                 var transformModel = new TransformModel(Env, data, splitOutput.TrainData[i]);
 
                 predictorModels[i] = ModelOperations.CombineTwoModels(Env,

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -75,10 +75,9 @@ namespace Microsoft.ML.Scenarios
                 // Explicity adding CacheDataView since caching is not working though trainer has 'Caching' On/Auto
                 var cached = new CacheDataView(env, trans, prefetch: null);
                 var trainRoles = new RoleMappedData(cached, label: "Label", feature: "Features");
-                trainer.Train(trainRoles);
+                var pred = trainer.Train(trainRoles);
 
                 // Get scorer and evaluate the predictions from test data
-                var pred = trainer.CreatePredictor();
                 IDataScorerTransform testDataScorer = GetScorer(env, trans, pred, testDataPath);
                 var metrics = Evaluate(env, testDataScorer);
                 CompareMatrics(metrics);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Scenarios
                 trans = NormalizeTransform.CreateMinMaxNormalizer(env, trans, "Features");
 
                 // Train
-                var trainer = new SdcaMultiClassTrainer(env, new SdcaMultiClassTrainer.Arguments());
+                var trainer = new SdcaMultiClassTrainer(env, new SdcaMultiClassTrainer.Arguments() { NumThreads = 1 } );
 
                 // Explicity adding CacheDataView since caching is not working though trainer has 'Caching' On/Auto
                 var cached = new CacheDataView(env, trans, prefetch: null);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
@@ -79,10 +79,9 @@ namespace Microsoft.ML.Scenarios
                 });
 
                 var trainRoles = new RoleMappedData(trans, label: "Label", feature: "Features");
-                trainer.Train(trainRoles);
+                var pred = trainer.Train(trainRoles);
 
                 // Get scorer and evaluate the predictions from test data
-                var pred = trainer.CreatePredictor();
                 IDataScorerTransform testDataScorer = GetScorer(env, trans, pred, testDataPath);
                 var metrics = EvaluateBinary(env, testDataScorer);
                 ValidateBinaryMetrics(metrics);


### PR DESCRIPTION
Fixes #509.

* `ITrainer.Train` returns a predictor. There is no `CreatePredictor` method on the interface.

* `ITrainer.Train` always accepts a `TrainContext`. Dataset type is no longer a generic parameter. This context object replaces the functionality previously offered by the combination of `ITrainer`, `IValidatingTrainer`, `IIncrementalTrainer`, and `IIncrementalValidatingTrainer`, which is now captured in one `ITrainer.Train` method with differently configured contexts.

* All trainers updated to these two new idioms. Many trainers correspondingly improved to no longer be stateful objects. (The exceptions are those that are just too far gone to be done with less than herculean effort at refactoring them to no longer use instance fields for their computation, most notably, LBFGS and FastTree based trainers.)

* Utility code meant to deal with the complexity of the aforementioned `IT/IVT/IIT/IIVT` idiom reduced considerably.

* Opportunistic improvements to `ITrainer` implementors where observed.