### PR TITLE
Fix TrainAndPredictIrisModelUsingDirectInstantiationTest

### DIFF
--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Scenarios
 
                 // Get feature importance i.e. weight vector
                 var summary = ((MulticlassLogisticRegressionPredictor)pred).GetSummaryInKeyValuePairs(trainRoles.Schema);
-                Assert.Equal(7.757867, Convert.ToDouble(summary[0].Value), 5);
+                Assert.Equal(7.757864, Convert.ToDouble(summary[0].Value), 5);
             }
         }
 
@@ -97,10 +97,10 @@ namespace Microsoft.ML.Scenarios
         {
             IrisPrediction prediction = model.Predict(new IrisData()
             {
-                SepalLength = 3.3f,
-                SepalWidth = 1.6f,
-                PetalLength = 0.2f,
-                PetalWidth = 5.1f,
+                SepalLength = 5.1f,
+                SepalWidth = 3.3f,
+                PetalLength = 1.6f,
+                PetalWidth = 0.2f,
             });
 
             Assert.Equal(1, prediction.PredictedLabels[0], 2);
@@ -109,10 +109,10 @@ namespace Microsoft.ML.Scenarios
 
             prediction = model.Predict(new IrisData()
             {
-                SepalLength = 3.1f,
-                SepalWidth = 5.5f,
-                PetalLength = 2.2f,
-                PetalWidth = 6.4f,
+                SepalLength = 6.4f,
+                SepalWidth = 3.1f,
+                PetalLength = 5.5f,
+                PetalWidth = 2.2f,
             });
 
             Assert.Equal(0, prediction.PredictedLabels[0], 2);
@@ -121,10 +121,10 @@ namespace Microsoft.ML.Scenarios
 
             prediction = model.Predict(new IrisData()
             {
-                SepalLength = 3.1f,
-                SepalWidth = 2.5f,
-                PetalLength = 1.2f,
-                PetalWidth = 4.4f,
+                SepalLength = 4.4f,
+                SepalWidth = 3.1f,
+                PetalLength = 2.5f,
+                PetalWidth = 1.2f,
             });
 
             Assert.Equal(.2, prediction.PredictedLabels[0], 1);


### PR DESCRIPTION
Fixes #526 .

The test `TrainAndPredictIrisModelUsingDirectInstantiationTest` now has analogous changes to the `TrainAndPredictIrisModelTest` test.