### PR TITLE
Remove agent.os demands on windows ci

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -11,5 +11,3 @@ phases:
     buildScript: build.cmd
     queue:
       name: Hosted VS2017
-      demands:
-        - agent.os -equals Windows_NT

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -13,7 +13,7 @@ phases:
       ${{ if ne(parameters.dockerImage, '') }}:
         _PREVIEW_VSTS_DOCKER_IMAGE: ${{ parameters.dockerImage }}
     queue:
-      parallel: 4
+      parallel: 99
       matrix:
         Build_Debug:
           _configuration: Debug

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -13,12 +13,12 @@ phases:
       ${{ if ne(parameters.dockerImage, '') }}:
         _PREVIEW_VSTS_DOCKER_IMAGE: ${{ parameters.dockerImage }}
     queue:
-      parallel: 2
+      parallel: 4
       matrix:
         Build_Debug:
           _configuration: Debug
         Build_Release:
-          _configuration: Release 
+          _configuration: Release
       ${{ insert }}: ${{ parameters.queue }}
     steps:
     - script: $(_buildScript) -$(_configuration) -runtests


### PR DESCRIPTION
All the machines in this pool are guaranteed to be Windows_NT and now that the pool was made big enough not all of them define an agent.os property, so if they don't have one it will only use the machines that define that only. So in order to have more machines available and make CI faster, let's remove that statement and bump parallel to 4.

This was causing Windows builds to be slow and not ran in parallel.

cc: @chcosta @eerhardt 

