### PR TITLE
Initial replacement of SubComponent with IComponentFactory

### DIFF
--- a/src/Microsoft.ML.Core/CommandLine/ArgumentAttribute.cs
+++ b/src/Microsoft.ML.Core/CommandLine/ArgumentAttribute.cs
@@ -34,6 +34,7 @@ namespace Microsoft.ML.Runtime.CommandLine
         private string _specialPurpose;
         private VisibilityType _visibility;
         private string _name;
+        private Type _signatureType;
 
         /// <summary>
         /// Allows control of command line parsing.
@@ -138,6 +139,12 @@ namespace Microsoft.ML.Runtime.CommandLine
         public bool IsRequired
         {
             get { return ArgumentType.Required == (_type & ArgumentType.Required); }
+        }
+
+        public Type SignatureType
+        {
+            get { return _signatureType; }
+            set { _signatureType = value; }
         }
     }
 }

--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -249,8 +249,9 @@ namespace Microsoft.ML.Runtime.CommandLine
         Default = ShortNames | NoSlashes
     }
 
-    public interface IComponentWithSettings
+    public interface ICommandLineComponentFactory
     {
+        Type SignatureType { get; }
         string Name { get; }
         string GetSettingsString();
     }
@@ -1851,9 +1852,9 @@ namespace Microsoft.ML.Runtime.CommandLine
                         settings);
                 }
 
-                private abstract class ComponentFactory: IComponentWithSettings
+                private abstract class ComponentFactory : ICommandLineComponentFactory
                 {
-                    protected Type SignatureType { get; }
+                    public Type SignatureType { get; }
                     public string Name { get; }
                     protected string[] Settings { get; }
 
@@ -2394,13 +2395,13 @@ namespace Microsoft.ML.Runtime.CommandLine
                         }
                         return buffer.ToString();
                     }
-                    else if (value is IComponentWithSettings valueWithSettings)
+                    else if (value is ICommandLineComponentFactory)
                     {
                         return value.ToString();
                     }
                     else
                     {
-                        throw ectx.Except($"IComponentFactory instances either need to be EntryPointComponents or implement {nameof(IComponentWithSettings)}.");
+                        throw ectx.Except($"IComponentFactory instances either need to be EntryPointComponents or implement {nameof(ICommandLineComponentFactory)}.");
                     }
                 }
 

--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -1899,7 +1899,7 @@ namespace Microsoft.ML.Runtime.CommandLine
                         if (string.IsNullOrEmpty(Name) && Settings?.Length == 0)
                             return "{}";
 
-                        if (Settings.Length == 0)
+                        if (Settings?.Length == 0)
                             return Name;
 
                         string str = CombineSettings(Settings);

--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -1886,6 +1886,11 @@ namespace Microsoft.ML.Runtime.CommandLine
                     {
                         SignatureType = signatureType;
                         Name = name;
+
+                        if (settings == null || (settings.Length == 1 && string.IsNullOrEmpty(settings[0])))
+                        {
+                            settings = Array.Empty<string>();
+                        }
                         Settings = settings;
                     }
 
@@ -1896,10 +1901,10 @@ namespace Microsoft.ML.Runtime.CommandLine
 
                     public override string ToString()
                     {
-                        if (string.IsNullOrEmpty(Name) && Settings?.Length == 0)
+                        if (string.IsNullOrEmpty(Name) && Settings.Length == 0)
                             return "{}";
 
-                        if (Settings?.Length == 0)
+                        if (Settings.Length == 0)
                             return Name;
 
                         string str = CombineSettings(Settings);

--- a/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
@@ -832,10 +832,15 @@ namespace Microsoft.ML.Runtime
 
         public static LoadableClassInfo GetLoadableClassInfo<TSig>(string loadName)
         {
-            Contracts.CheckParam(typeof(TSig).BaseType == typeof(MulticastDelegate), nameof(TSig), "TSig must be a delegate type");
+            return GetLoadableClassInfo(loadName, typeof(TSig));
+        }
+
+        public static LoadableClassInfo GetLoadableClassInfo(string loadName, Type signatureType)
+        {
+            Contracts.CheckParam(signatureType.BaseType == typeof(MulticastDelegate), nameof(signatureType), "signatureType must be a delegate type");
             Contracts.CheckValueOrNull(loadName);
             loadName = (loadName ?? "").ToLowerInvariant().Trim();
-            return FindClassCore(new LoadableClassInfo.Key(loadName, typeof(TSig)));
+            return FindClassCore(new LoadableClassInfo.Key(loadName, signatureType));
         }
 
         public static LoadableClassInfo GetLoadableClassInfo<TRes, TSig>(SubComponent<TRes, TSig> sub)

--- a/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
@@ -914,12 +914,18 @@ namespace Microsoft.ML.Runtime
         public static bool TryCreateInstance<TRes, TSig>(IHostEnvironment env, out TRes result, string name, string options, params object[] extra)
             where TRes : class
         {
+            return TryCreateInstance<TRes>(env, typeof(TSig), out result, name, options, extra);
+        }
+
+        public static bool TryCreateInstance<TRes>(IHostEnvironment env, Type signatureType, out TRes result, string name, string options, params object[] extra)
+            where TRes : class
+        {
             Contracts.CheckValue(env, nameof(env));
-            env.Check(typeof(TSig).BaseType == typeof(MulticastDelegate));
+            env.Check(signatureType.BaseType == typeof(MulticastDelegate));
             env.CheckValueOrNull(name);
 
             string nameLower = (name ?? "").ToLowerInvariant().Trim();
-            LoadableClassInfo info = FindClassCore(new LoadableClassInfo.Key(nameLower, typeof(TSig)));
+            LoadableClassInfo info = FindClassCore(new LoadableClassInfo.Key(nameLower, signatureType));
             if (info == null)
             {
                 result = null;

--- a/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
@@ -892,6 +892,18 @@ namespace Microsoft.ML.Runtime
         }
 
         /// <summary>
+        /// Create an instance of the indicated component with the given extra parameters.
+        /// </summary>
+        public static TRes CreateInstance<TRes>(IHostEnvironment env, Type signatureType, string name, string options, params object[] extra)
+            where TRes : class
+        {
+            TRes result;
+            if (TryCreateInstance(env, signatureType, out result, name, options, extra))
+                return result;
+            throw Contracts.Except("Unknown loadable class: {0}", name).MarkSensitive(MessageSensitivity.None);
+        }
+
+        /// <summary>
         /// Try to create an instance of the indicated component with the given extra parameters. If there is no
         /// such component in the catalog, returns false. Any other error results in an exception.
         /// </summary>
@@ -922,7 +934,7 @@ namespace Microsoft.ML.Runtime
             return TryCreateInstance<TRes>(env, typeof(TSig), out result, name, options, extra);
         }
 
-        public static bool TryCreateInstance<TRes>(IHostEnvironment env, Type signatureType, out TRes result, string name, string options, params object[] extra)
+        private static bool TryCreateInstance<TRes>(IHostEnvironment env, Type signatureType, out TRes result, string name, string options, params object[] extra)
             where TRes : class
         {
             Contracts.CheckValue(env, nameof(env));

--- a/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
+++ b/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
@@ -52,6 +52,21 @@ namespace Microsoft.ML.Runtime.EntryPoints
         TComponent CreateComponent(IHostEnvironment env, TArg1 argument1);
     }
 
+    public class SimpleComponentFactory<TArg1, TComponent> : IComponentFactory<TArg1, TComponent>
+    {
+        private Func<IHostEnvironment, TArg1, TComponent> _factory;
+
+        public SimpleComponentFactory(Func<IHostEnvironment, TArg1, TComponent> factory)
+        {
+            _factory = factory;
+        }
+
+        public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1)
+        {
+            return _factory(env, argument1);
+        }
+    }
+
     /// <summary>
     /// An interface for creating a component when we take two extra parameters (and an <see cref="IHostEnvironment"/>).
     /// </summary>

--- a/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
+++ b/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
@@ -29,21 +29,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
         TComponent CreateComponent(IHostEnvironment env);
     }
 
-    public class SimpleComponentFactory<TComponent> : IComponentFactory<TComponent>
-    {
-        private Func<IHostEnvironment, TComponent> _factory;
-
-        public SimpleComponentFactory(Func<IHostEnvironment, TComponent> factory)
-        {
-            _factory = factory;
-        }
-
-        public TComponent CreateComponent(IHostEnvironment env)
-        {
-            return _factory(env);
-        }
-    }
-
     /// <summary>
     /// An interface for creating a component when we take one extra parameter (and an <see cref="IHostEnvironment"/>).
     /// </summary>

--- a/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
+++ b/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
@@ -37,6 +37,11 @@ namespace Microsoft.ML.Runtime.EntryPoints
         TComponent CreateComponent(IHostEnvironment env, TArg1 argument1);
     }
 
+    /// <summary>
+    /// A class for creating a component when we take one extra parameter
+    /// (and an <see cref="IHostEnvironment"/>) that simply wraps a delegate which
+    /// creates the component.
+    /// </summary>
     public class SimpleComponentFactory<TArg1, TComponent> : IComponentFactory<TArg1, TComponent>
     {
         private Func<IHostEnvironment, TArg1, TComponent> _factory;

--- a/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
+++ b/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
@@ -29,6 +29,21 @@ namespace Microsoft.ML.Runtime.EntryPoints
         TComponent CreateComponent(IHostEnvironment env);
     }
 
+    public class SimpleComponentFactory<TComponent> : IComponentFactory<TComponent>
+    {
+        private Func<IHostEnvironment, TComponent> _factory;
+
+        public SimpleComponentFactory(Func<IHostEnvironment, TComponent> factory)
+        {
+            _factory = factory;
+        }
+
+        public TComponent CreateComponent(IHostEnvironment env)
+        {
+            return _factory(env);
+        }
+    }
+
     /// <summary>
     /// An interface for creating a component when we take one extra parameter (and an <see cref="IHostEnvironment"/>).
     /// </summary>

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -263,7 +263,7 @@ namespace Microsoft.ML.Runtime.Data
         private RoleMappedData CreateRoleMappedData(IHostEnvironment env, IChannel ch, IDataView data, ITrainer trainer)
         {
             foreach (var kvp in Args.Transform)
-                data = kvp.Value.CreateInstance(env, data);
+                data = kvp.Value.CreateComponent(env, data);
 
             var schema = data.Schema;
             string label = TrainUtils.MatchNameOrDefaultOrNull(ch, schema, nameof(Args.LabelColumn), Args.LabelColumn, DefaultColumnNames.Label);

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -132,10 +132,10 @@ namespace Microsoft.ML.Runtime.Data
                 Host.AssertValue(pipe);
                 Host.AssertValueOrNull(factory);
 
-                if (factory is IComponentWithSettings factoryWithSettings)
-                    pipe.Send(TelemetryMessage.CreateTrainer(factoryWithSettings.Name, factoryWithSettings.GetSettingsString()));
+                if (factory is ICommandLineComponentFactory commandLineFactory)
+                    pipe.Send(TelemetryMessage.CreateTrainer(commandLineFactory.Name, commandLineFactory.GetSettingsString()));
                 else
-                    pipe.Send(TelemetryMessage.CreateTrainer("Unknown", "Non-IComponentWithSettings object"));
+                    pipe.Send(TelemetryMessage.CreateTrainer("Unknown", "Non-ICommandLineComponentFactory object"));
             }
 
             protected virtual void SendTelemetryCore(IPipe<TelemetryMessage> pipe)

--- a/src/Microsoft.ML.Data/Commands/EvaluateCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/EvaluateCommand.cs
@@ -217,7 +217,8 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertValue(ch);
 
             ch.Trace("Creating loader");
-            IDataView view = CreateAndSaveLoader(IO.BinaryLoader.LoadName);
+            IDataView view = CreateAndSaveLoader(
+                (env, source) => new IO.BinaryLoader(env, new IO.BinaryLoader.Arguments(), source));
 
             ch.Trace("Binding columns");
             ISchema schema = view.Schema;

--- a/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Command;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Model;
 
@@ -62,8 +63,8 @@ namespace Microsoft.ML.Runtime.Data
             [Argument(ArgumentType.AtMostOnce, HelpText = "Whether to include hidden columns", ShortName = "keep")]
             public bool KeepHidden;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Post processing transform", ShortName = "pxf")]
-            public KeyValuePair<string, SubComponent<IDataTransform, SignatureDataTransform>>[] PostTransform;
+            [Argument(ArgumentType.Multiple, HelpText = "Post processing transform", ShortName = "pxf", SignatureType = typeof(SignatureDataTransform))]
+            public KeyValuePair<string, IComponentFactory<IDataView, IDataTransform>>[] PostTransform;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Whether to output all columns or just scores", ShortName = "all")]
             public bool? OutputAllColumns;

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -35,11 +35,11 @@ namespace Microsoft.ML.Runtime.Data
     {
         public sealed class Arguments
         {
-            [Argument(ArgumentType.Multiple, HelpText = "The data loader", ShortName = "loader")]
-            public SubComponent<IDataLoader, SignatureDataLoader> Loader;
+            [Argument(ArgumentType.Multiple, HelpText = "The data loader", ShortName = "loader", SignatureType = typeof(SignatureDataLoader))]
+            public IComponentFactory<IMultiStreamSource, IDataLoader> Loader;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Transform", ShortName = "xf")]
-            public KeyValuePair<string, SubComponent<IDataTransform, SignatureDataTransform>>[] Transform;
+            [Argument(ArgumentType.Multiple, HelpText = "Transform", ShortName = "xf", SignatureType = typeof(SignatureDataTransform))]
+            public KeyValuePair<string, IComponentFactory<IDataView, IDataTransform>>[] Transform;
         }
 
         private struct TransformEx
@@ -99,10 +99,10 @@ namespace Microsoft.ML.Runtime.Data
             var h = env.Register(RegistrationName);
 
             h.CheckValue(args, nameof(args));
-            h.CheckUserArg(args.Loader.IsGood(), nameof(args.Loader));
+            h.CheckValue(args.Loader, nameof(args.Loader));
             h.CheckValue(files, nameof(files));
 
-            var loader = args.Loader.CreateInstance(h, files);
+            var loader = args.Loader.CreateComponent(h, files);
             return CreateCore(h, loader, args.Transform);
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -112,56 +112,6 @@ namespace Microsoft.ML.Runtime.Data
         /// If there are no transforms, the <paramref name="srcLoader"/> is returned.
         /// </summary>
         public static IDataLoader Create(IHostEnvironment env, IDataLoader srcLoader,
-            params KeyValuePair<string, SubComponent<IDataTransform, SignatureDataTransform>>[] transformArgs)
-        {
-            Contracts.CheckValue(env, nameof(env));
-            var h = env.Register(RegistrationName);
-
-            h.CheckValue(srcLoader, nameof(srcLoader));
-            h.CheckValueOrNull(transformArgs);
-            return CreateCore(h, srcLoader, transformArgs);
-        }
-
-        private static IDataLoader CreateCore(IHost host, IDataLoader srcLoader,
-            KeyValuePair<string, SubComponent<IDataTransform, SignatureDataTransform>>[] transformArgs)
-        {
-            Contracts.AssertValue(host, "host");
-            host.AssertValue(srcLoader, "srcLoader");
-            host.AssertValueOrNull(transformArgs);
-
-            if (Utils.Size(transformArgs) == 0)
-                return srcLoader;
-
-            var tagData = transformArgs
-                .Select(x => new KeyValuePair<string, string>(x.Key, x.Value.ToString()))
-                .ToArray();
-
-            // Warn if tags coincide with ones already present in the loader.
-            var composite = srcLoader as CompositeDataLoader;
-            if (composite != null)
-            {
-                using (var ch = host.Start("TagValidation"))
-                {
-                    foreach (var pair in tagData)
-                    {
-                        if (!string.IsNullOrEmpty(pair.Key) && composite._transforms.Any(x => x.Tag == pair.Key))
-                            ch.Warning("The transform with tag '{0}' already exists in the chain", pair.Key);
-                    }
-
-                    ch.Done();
-                }
-            }
-
-            return ApplyTransformsCore(host, srcLoader, tagData,
-                (prov, index, data) => transformArgs[index].Value.CreateInstance(prov, data));
-        }
-
-        /// <summary>
-        /// Creates a <see cref="CompositeDataLoader"/> that starts with the <paramref name="srcLoader"/>,
-        /// and follows with transforms created from the <paramref name="transformArgs"/> array.
-        /// If there are no transforms, the <paramref name="srcLoader"/> is returned.
-        /// </summary>
-        public static IDataLoader Create(IHostEnvironment env, IDataLoader srcLoader,
             params KeyValuePair<string, IComponentFactory<IDataView, IDataTransform>>[] transformArgs)
         {
             Contracts.CheckValue(env, nameof(env));

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -132,8 +132,15 @@ namespace Microsoft.ML.Runtime.Data
             if (Utils.Size(transformArgs) == 0)
                 return srcLoader;
 
+            string GetTagData(IComponentFactory<IDataView, IDataTransform> factory)
+            {
+                // When coming from the command line, preserve the string arguments.
+                // For other factories, we aren't able to get the string.
+                return (factory as ICommandLineComponentFactory)?.ToString();
+            }
+
             var tagData = transformArgs
-                .Select(x => new KeyValuePair<string, string>(x.Key, x.Value.ToString()))
+                .Select(x => new KeyValuePair<string, string>(x.Key, GetTagData(x.Value)))
                 .ToArray();
 
             // Warn if tags coincide with ones already present in the loader.

--- a/src/Microsoft.ML.Data/Transforms/TermTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TermTransform.cs
@@ -358,7 +358,7 @@ namespace Microsoft.ML.Runtime.Data
                                 {
                                     Name ="Term",
                                     Type = DataKind.TX,
-                                    KeyRange = new KeyRange() { Min = 0 }
+                                    Source = new TextLoader.Range() { Min = 0 }
                                 }
                             }
                         },

--- a/src/Microsoft.ML.Data/Transforms/TermTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TermTransform.cs
@@ -358,7 +358,7 @@ namespace Microsoft.ML.Runtime.Data
                                 {
                                     Name ="Term",
                                     Type = DataKind.TX,
-                                    Source = new TextLoader.Range() { Min = 0 }
+                                    Source = new[] { new TextLoader.Range() { Min = 0 } }
                                 }
                             }
                         },

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Runtime.Data.Conversion;
 using Microsoft.ML.Runtime.Internal.Calibration;
 using Microsoft.ML.Runtime.Internal.Internallearn;
 using Microsoft.ML.Runtime.Training;
+using Microsoft.ML.Runtime.EntryPoints;
 
 namespace Microsoft.ML.Runtime.Learners
 {
@@ -21,13 +22,13 @@ namespace Microsoft.ML.Runtime.Learners
     {
         public abstract class ArgumentsBase
         {
-            [Argument(ArgumentType.Multiple, HelpText = "Base predictor", ShortName = "p", SortOrder = 1)]
+            [Argument(ArgumentType.Multiple, HelpText = "Base predictor", ShortName = "p", SortOrder = 1, SignatureType = typeof(SignatureBinaryClassifierTrainer))]
             [TGUI(Label = "Predictor Type", Description = "Type of underlying binary predictor")]
-            public SubComponent<TScalarTrainer, SignatureBinaryClassifierTrainer> PredictorType =
-                new SubComponent<TScalarTrainer, SignatureBinaryClassifierTrainer>(LinearSvm.LoadNameValue);
+            public IComponentFactory<TScalarTrainer> PredictorType;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>")]
-            public SubComponent<ICalibratorTrainer, SignatureCalibrator> Calibrator = new SubComponent<ICalibratorTrainer, SignatureCalibrator>("PlattCalibration");
+            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>", SignatureType = typeof(SignatureCalibrator))]
+            public IComponentFactory<ICalibratorTrainer> Calibrator =
+                new SimpleComponentFactory<ICalibratorTrainer>(env => new PlattCalibratorTrainer(env));
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of instances to train the calibrator", ShortName = "numcali")]
             public int MaxCalibrationExamples = 1000000000;
@@ -47,12 +48,18 @@ namespace Microsoft.ML.Runtime.Learners
         {
             Host.CheckValue(args, nameof(args));
             Args = args;
-            Host.CheckUserArg(Args.PredictorType.IsGood(), nameof(Args.PredictorType));
             // Create the first trainer so errors in the args surface early.
-            _trainer = Args.PredictorType.CreateInstance(Host);
+            _trainer = CreateTrainer();
             // Regarding caching, no matter what the internal predictor, we're performing many passes
             // simply by virtue of this being a meta-trainer, so we will still cache.
             Info = new TrainerInfo(normalization: _trainer.Info.NeedNormalization);
+        }
+
+        private TScalarTrainer CreateTrainer()
+        {
+            return Args.PredictorType != null ?
+                Args.PredictorType.CreateComponent(Host) :
+                new LinearSvm(Host, new LinearSvm.Arguments());
         }
 
         protected IDataView MapLabelsCore<T>(ColumnType type, RefPredicate<T> equalsTarget, RoleMappedData data, string dstName)
@@ -84,7 +91,7 @@ namespace Microsoft.ML.Runtime.Learners
         {
             // We may have instantiated the first trainer to use already, from the constructor.
             // If so capture it and set the retained trainer to null; otherwise create a new one.
-            var train = _trainer ?? Args.PredictorType.CreateInstance(Host);
+            var train = _trainer ?? CreateTrainer();
             _trainer = null;
             return train;
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -27,8 +27,7 @@ namespace Microsoft.ML.Runtime.Learners
             public IComponentFactory<TScalarTrainer> PredictorType;
 
             [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>", SignatureType = typeof(SignatureCalibrator))]
-            public IComponentFactory<ICalibratorTrainer> Calibrator =
-                new SimpleComponentFactory<ICalibratorTrainer>(env => new PlattCalibratorTrainer(env));
+            public IComponentFactory<ICalibratorTrainer> Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of instances to train the calibrator", ShortName = "numcali")]
             public int MaxCalibrationExamples = 1000000000;

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -89,10 +89,10 @@ namespace Microsoft.ML.Runtime.Learners
             if (Args.UseProbabilities)
             {
                 ICalibratorTrainer calibrator;
-                if (!Args.Calibrator.IsGood())
+                if (Args.Calibrator == null)
                     calibrator = null;
                 else
-                    calibrator = Args.Calibrator.CreateInstance(Host);
+                    calibrator = Args.Calibrator.CreateComponent(Host);
                 var res = CalibratorUtils.TrainCalibratorIfNeeded(Host, ch, calibrator, Args.MaxCalibrationExamples,
                     trainer, predictor, td);
                 predictor = res as TScalarPredictor;

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -104,10 +104,10 @@ namespace Microsoft.ML.Runtime.Learners
             var predictor = trainer.Train(td);
 
             ICalibratorTrainer calibrator;
-            if (!Args.Calibrator.IsGood())
+            if (Args.Calibrator == null)
                 calibrator = null;
             else
-                calibrator = Args.Calibrator.CreateInstance(Host);
+                calibrator = Args.Calibrator.CreateComponent(Host);
             var res = CalibratorUtils.TrainCalibratorIfNeeded(Host, ch, calibrator, Args.MaxCalibrationExamples,
                 trainer, predictor, td);
             var dist = res as TDistPredictor;

--- a/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
@@ -451,8 +451,8 @@ namespace Microsoft.ML.Runtime.Data
         [Argument(ArgumentType.AtMostOnce, IsInputFileName = true, HelpText = "Data file containing the terms", ShortName = "data", SortOrder = 2, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
         public string DataFile;
 
-        [Argument(ArgumentType.Multiple, HelpText = "Data loader", NullName = "<Auto>", SortOrder = 3, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
-        public SubComponent<IDataLoader, SignatureDataLoader> Loader;
+        [Argument(ArgumentType.Multiple, HelpText = "Data loader", NullName = "<Auto>", SortOrder = 3, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly, SignatureType = typeof(SignatureDataLoader))]
+        public IComponentFactory<IMultiStreamSource, IDataLoader> Loader;
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "Name of the text column containing the terms", ShortName = "termCol", SortOrder = 4, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
         public string TermsColumn;

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Data.IO;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Model;
 using Xunit;
@@ -215,28 +216,35 @@ namespace Microsoft.ML.Runtime.RunTests
                 VerifyCustArgs(kvp.Value);
         }
 
-        protected void VerifyCustArgs<TRes, TSig>(SubComponent<TRes, TSig> sub)
+        protected void VerifyCustArgs<TArg, TRes>(IComponentFactory<TArg, TRes> factory)
             where TRes : class
         {
-            var str = CmdParser.CombineSettings(sub.Settings);
-            var info = ComponentCatalog.GetLoadableClassInfo<TSig>(sub.Kind);
-            Assert.NotNull(info);
-            var def = info.CreateArguments();
+            if (factory is ICommandLineComponentFactory commandLineFactory)
+            {
+                var str = commandLineFactory.GetSettingsString();
+                var info = ComponentCatalog.GetLoadableClassInfo(commandLineFactory.Name, commandLineFactory.SignatureType);
+                Assert.NotNull(info);
+                var def = info.CreateArguments();
 
-            var a1 = info.CreateArguments();
-            CmdParser.ParseArguments(Env, str, a1);
+                var a1 = info.CreateArguments();
+                CmdParser.ParseArguments(Env, str, a1);
 
-            // Get both the expanded and custom forms.
-            string exp1 = CmdParser.GetSettings(Env, a1, def, SettingsFlags.Default | SettingsFlags.NoUnparse);
-            string cust = CmdParser.GetSettings(Env, a1, def);
+                // Get both the expanded and custom forms.
+                string exp1 = CmdParser.GetSettings(Env, a1, def, SettingsFlags.Default | SettingsFlags.NoUnparse);
+                string cust = CmdParser.GetSettings(Env, a1, def);
 
-            // Map cust back to an object, then get its full form.
-            var a2 = info.CreateArguments();
-            CmdParser.ParseArguments(Env, cust, a2);
-            string exp2 = CmdParser.GetSettings(Env, a2, def, SettingsFlags.Default | SettingsFlags.NoUnparse);
+                // Map cust back to an object, then get its full form.
+                var a2 = info.CreateArguments();
+                CmdParser.ParseArguments(Env, cust, a2);
+                string exp2 = CmdParser.GetSettings(Env, a2, def, SettingsFlags.Default | SettingsFlags.NoUnparse);
 
-            if (exp1 != exp2)
-                Fail("Custom unparse failed on '{0}' starting with '{1}': '{2}' vs '{3}'", sub.Kind, str, exp1, exp2);
+                if (exp1 != exp2)
+                    Fail("Custom unparse failed on '{0}' starting with '{1}': '{2}' vs '{3}'", commandLineFactory.Name, str, exp1, exp2);
+            }
+            else
+            {
+                Fail($"TestDataPipeBase was called with a non command line loader or transform '{factory}'");
+            }
         }
 
         protected bool SaveLoadText(IDataView view, IHostEnvironment env,


### PR DESCRIPTION
This is the first round of code changes necessary in order to remove SubComponent and instead use IComponentFactory.

This change removes SubComponent from the following public APIs:

* `CompositeDataLoader`
    * In order to completely remove it here, I needed to also remove it in some of the DataCommand classes as well - since they were calling methods on CompositeDataLoader that used SubComponent.
* `Ova` and `Pkpd`
* `TermTransform`

Working towards #585 
