### PR TITLE
Fix official build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -44,7 +44,9 @@
              Targets="Restore" />
   </Target>
 
-  <Target Name="BuildNative" Condition="'$(SkipNativeBuild)' != 'true'">
+  <Target Name="BuildNative"
+          Condition="'$(SkipNativeBuild)' != 'true'"
+          DependsOnTargets="RestoreProjects">
     <Message Importance="High" Text="Building native components..." />
     <MSBuild Projects="src/Native/build.proj"
              Targets="Build" />


### PR DESCRIPTION
Our official build is broken because we introduced a new dependency when building native code.

Previously, when we built native code, we didn't need to restore NuGet packages. But with #624 we now have a dependency from our native C++ code to the MklImports NuGet package. And our build fails if the package hasn't been restored.

The fix is to make `BuildNative` dependent on `RestorePackages`.