### PR TITLE
Change the linux official build queue from test to production.

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -10,7 +10,7 @@ phases:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
   queue:
-    name: DotNetCore-Test
+    name: DotNet-Build
     demands:
     - agent.os -equals linux
   steps:


### PR DESCRIPTION
We were using a "test" build queue because of some limitations with the build lab.  Those limitations are now fixed, so we can start using the "production" build queue again.
