### PR TITLE
Fix official build failure

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -53,7 +53,7 @@
   </Target>
 
   <Target Name="BuildPackages"
-          DependsOnTargets="CreateOrUpdateCurrentVersionFile">
+          DependsOnTargets="CreateOrUpdateCurrentVersionFile;RestoreProjects">
     <Message Importance="High" Text="Building packages ..." />
 
     <ItemGroup>


### PR DESCRIPTION
Now that the HalLearners nuget package doesn't have a PackageReference to MlNetMklDeps, the MlNetMklDeps package is no longer getting restored during the official build. Since HalLearners needs the license file from MlNetMklDeps, it is failing to build the nuget package.

The fix is to restore all project before building the packages.