### PR TITLE
[Part 1] Added comments/description to convenience constructors for a set of transform

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/ConcatTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConcatTransform.cs
@@ -536,10 +536,11 @@ namespace Microsoft.ML.Runtime.Data
         public override ISchema Schema => _bindings;
 
         /// <summary>
-        /// Convenience constructor for public facing API.
+        /// Convenience constructor for creating <see cref="ConcatTransform"/>.
+        /// The <see cref="ConcatTransform"/> concatenates two or more columns (either scalar or vector) of same type into a single vector column.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Input columns to concatenate.</param>
         public ConcatTransform(IHostEnvironment env, IDataView input, string name, params string[] source)

--- a/src/Microsoft.ML.Data/Transforms/CopyColumnsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/CopyColumnsTransform.cs
@@ -65,10 +65,11 @@ namespace Microsoft.ML.Runtime.Data
         private const string RegistrationName = "CopyColumns";
 
         /// <summary>
-        /// Convenience constructor for public facing API.
+        /// Convenience constructor for creating <see cref="CopyColumnsTransform"/>.
+        /// The <see cref="CopyColumnsTransform"/> copies a column in <see cref="IDataView"/>.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be copied.</param>
         public CopyColumnsTransform(IHostEnvironment env, IDataView input, string name, string source)

--- a/src/Microsoft.ML.Data/Transforms/DropColumnsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropColumnsTransform.cs
@@ -238,10 +238,12 @@ namespace Microsoft.ML.Runtime.Data
         private const string KeepRegistrationName = "KeepColumns";
 
         /// <summary>
-        /// Convenience constructor for public facing API.
+        /// Convenience constructor for creating <see cref="DropColumnsTransform"/>.
+        /// The <see cref="DropColumnsTransform"/> drops columns with the given names. Note that if there are names that
+        /// are not in the input schema, that is not an error.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="columnsToDrop">Name of the columns to be dropped.</param>
         public DropColumnsTransform(IHostEnvironment env, IDataView input, params string[] columnsToDrop)
          :this(env, new Arguments() { Column = columnsToDrop }, input)

--- a/src/Microsoft.ML.Data/Transforms/DropColumnsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropColumnsTransform.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Runtime.Data
 {
     /// <summary>
     /// Transform to drop columns with the given names. Note that if there are names that
-    /// are not in the input schema, that is not an error.
+    /// are not in the input schema, the operation will not result in an error and data will not be affected.
     /// </summary>
     public sealed class DropColumnsTransform : RowToRowMapperTransformBase
     {
@@ -240,7 +240,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <summary>
         /// Convenience constructor for creating <see cref="DropColumnsTransform"/>.
         /// The <see cref="DropColumnsTransform"/> drops columns with the given names. Note that if there are names that
-        /// are not in the input schema, that is not an error.
+        /// are not in the input schema, the operation will not result in an error and data will not be affected.
         /// </summary>
         /// <param name="env">Host Environment.</param>
         /// <param name="input">Input <see cref="IDataView"/>.</param>

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -79,10 +79,11 @@ namespace Microsoft.ML.Runtime.Data
         private const string RegistrationName = "MissingValueFilter";
 
         /// <summary>
-        /// Convenience constructor for public facing API.
+        /// Convenience constructor for creating <see cref="NAFilter"/>.
+        /// <include file='doc.xml' path='doc/members/member[@name="NAFilter"]/summary'/>
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="complement">If true, keep only rows that contain NA values, and filter the rest.</param>
         /// <param name="columns">Name of the columns. Only these columns will be used to filter rows having 'NA' values.</param>
         public NAFilter(IHostEnvironment env, IDataView input, bool complement = Defaults.Complement, params string[] columns)

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
@@ -231,6 +231,8 @@ namespace Microsoft.ML.Runtime.Data
         /// Convenience method for instantiating <see cref="NormalizeTransform"/> for Min-Max normalization.
         /// Min-Max normalization is a normalization strategy which linearly transforms values in a column X to y = (x - min) / (max - min),
         /// where min and max are the minimum and maximum values in X.
+        ///
+        /// For vector columns, Min-Max normalization is applied on each individual column (slot).
         /// </summary>
         /// <param name="env">Host Environment.</param>
         /// <param name="input">Input <see cref="IDataView"/>.</param>
@@ -403,7 +405,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <summary>
         /// Convenience method for instantiating <see cref="NormalizeTransform"/> for Supervised Binning normalization.
         /// It is similar to BinNormalizer <see cref="NormalizeTransform.CreateBinningNormalizer(IHostEnvironment, IDataView, string, string, int)"/>,
-        /// but calculates bins based on correlation with the label column, not equi-density. The value is mapped to bin_number / number_of_bins.
+        /// but calculates bins based on correlation with the label column, not equidensity. The value is mapped to bin_number / number_of_bins.
         /// </summary>
         /// <param name="env">Host Environment.</param>
         /// <param name="input">Input <see cref="IDataView"/>.</param>

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
@@ -228,10 +228,12 @@ namespace Microsoft.ML.Runtime.Data
         public const string SupervisedBinNormalizerShortName = "SupBin";
 
         /// <summary>
-        /// A helper method to create MinMaxNormalizer transform for public facing API.
+        /// Convenience method for instantiating <see cref="NormalizeTransform"/> for Min-Max normalization.
+        /// Min-Max normalization is a normalization strategy which linearly transforms values in a column X to y = (x - min) / (max - min),
+        /// where min and max are the minimum and maximum values in X.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
         public static NormalizeTransform CreateMinMaxNormalizer(IHostEnvironment env, IDataView input, string name, string source = null)
@@ -264,7 +266,10 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// A helper method to create MeanVarNormalizer transform for public facing API.
+        /// Convenience method for instantiating <see cref="NormalizeTransform"/> for Mean-Variance normalization.
+        /// Mean-Variance normalization normalizes values in a column (X) such that resulting column values have zero mean and unit variance
+        /// i.e. it converts x to y = (x - m) / v,
+        /// where m is the mean of X and v is the variance.
         /// </summary>
         /// <param name="env">Host Environment.</param>
         /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
@@ -306,10 +311,14 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// A helper method to create LogMeanVarNormalizer transform for public facing API.
+        /// Convenience method for instantiating <see cref="NormalizeTransform"/> for Log-Mean-Variance normalization.
+        /// Log-Mean-Variance normalization is similar to Mean-Variance normalization
+        /// <see cref="NormalizeTransform.CreateMeanVarNormalizer(IHostEnvironment, IDataView, string, string, bool)"/>
+        /// except that it apply log on the resulting value i.e. it converts x to y = log((x - m) / v),
+        /// where m is the mean of X and v is the variance.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
         /// /// <param name="useCdf">Whether to use CDF as the output.</param>
@@ -347,6 +356,16 @@ namespace Microsoft.ML.Runtime.Data
             return func;
         }
 
+        /// <summary>
+        /// Convenience method for instantiating <see cref="NormalizeTransform"/> for Binning normalization.
+        /// BinNormalizer assigs column values into equidensity bins and a value is mapped to its bin_number/number_of_bins.
+        /// </summary>
+        /// <param name="env">Host Environment.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
+        /// <param name="name">Name of the output column.</param>
+        /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
+        /// <param name="numBins">Max number of bins, power of 2 recommended</param>
+        /// <returns></returns>
         public static NormalizeTransform CreateBinningNormalizer(IHostEnvironment env,
             IDataView input,
             string name,
@@ -381,6 +400,19 @@ namespace Microsoft.ML.Runtime.Data
             return func;
         }
 
+        /// <summary>
+        /// Convenience method for instantiating <see cref="NormalizeTransform"/> for Supervised Binning normalization.
+        /// It is similar to BinNormalizer <see cref="NormalizeTransform.CreateBinningNormalizer(IHostEnvironment, IDataView, string, string, int)"/>,
+        /// but calculates bins based on correlation with the label column, not equi-density. The value is mapped to bin_number / number_of_bins.
+        /// </summary>
+        /// <param name="env">Host Environment.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
+        /// <param name="labelColumn">Label column for supervised binning</param>
+        /// <param name="name">Name of the output column.</param>
+        /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
+        /// <param name="numBins">Max number of bins, power of 2 recommended</param>
+        /// <param name="minBinSize">Minimum number of examples per bin</param>
+        /// <returns></returns>
         public static NormalizeTransform CreateSupervisedBinningNormalizer(IHostEnvironment env,
             IDataView input,
             string labelColumn,

--- a/src/Microsoft.ML.Transforms/BootstrapSampleTransform.cs
+++ b/src/Microsoft.ML.Transforms/BootstrapSampleTransform.cs
@@ -84,10 +84,11 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Convenience constructor for public facing API.
+        /// Convenience constructor for creating <see cref="BootstrapSampleTransform"/>.
+        /// The <see cref="BootstrapSampleTransform"/> performs bootstrap sampling (random sampling with replacement) over <see cref="IDataView"/>.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/></param>
         /// <param name="complement">Whether this is the out-of-bag sample, that is, all those rows that are not selected by the transform.</param>
         /// <param name="seed">The random seed. If unspecified random state will be instead derived from the environment.</param>
         /// <param name="shuffleInput">Whether we should attempt to shuffle the source data. By default on, but can be turned off for efficiency.</param>

--- a/src/Microsoft.ML.Transforms/CategoricalHashTransform.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalHashTransform.cs
@@ -131,10 +131,11 @@ namespace Microsoft.ML.Runtime.Data
         public const string UserName = "Categorical Hash Transform";
 
         /// <summary>
-        /// A helper method to create <see cref="CategoricalHashTransform"/> for public facing API.
+        /// Convenience method for creating <see cref="CategoricalHashTransform"/>.
+        /// <include file='doc.xml' path='doc/members/member[@name="CategoricalHashOneHotVectorizer"]/summary' />
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
         /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>

--- a/src/Microsoft.ML.Transforms/CategoricalTransform.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalTransform.cs
@@ -124,10 +124,11 @@ namespace Microsoft.ML.Runtime.Data
         public const string UserName = "Categorical Transform";
 
         /// <summary>
-        /// A helper method to create <see cref="CategoricalTransform"/> for public facing API.
+        /// Convenience method for creating <see cref="CategoricalTransform"/>.
+        /// <include file = 'doc.xml' path='doc/members/member[@name="CategoricalOneHotVectorizer"]/summary' />
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
         /// <param name="outputKind">The type of output expected.</param>

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -41,7 +41,8 @@ namespace Microsoft.ML.Runtime.Data
         internal static string RegistrationName = "CountFeatureSelectionTransform";
 
         /// <summary>
-        /// A helper method to create CountFeatureSelection transform for public facing API.
+        /// Convenience method for creating <see cref="CountFeatureSelectionTransform"/>.
+        /// <include file='doc.xml' path='doc/members/member[@name="CountFeatureSelection"]/summary' />
         /// </summary>
         /// <param name="env">Host Environment.</param>
         /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -308,12 +308,12 @@ namespace Microsoft.ML.Runtime.Data
 
         /// <summary>
         /// Convenience method for creating <see cref="LpNormNormalizerTransform"/> for Lp-Norm normalization.
-        /// The Lp-Norm normalizer normalizes rows individually by rescaling them to unit norm (L2, L1 or LInf).
+        /// The Lp-Norm normalizes rows individually by rescaling them to unit norm (L2, L1 or LInf).
         /// It performs the following operation on a vector X:
         ///         Y = (X - M) / D, where M is mean and D is either L2 norm, L1 norm or LInf norm.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
         ///         /// <param name="normKind">The norm to use to normalize each sample.</param>

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -247,10 +247,12 @@ namespace Microsoft.ML.Runtime.Data
         private readonly ColInfoEx[] _exes;
 
         /// <summary>
-        /// A helper method to create GlobalContrastNormalizer transform for public facing API.
+        /// Convenience method for creating <see cref="LpNormNormalizerTransform"/> for Global contrast normalization (GCN).
+        /// The GCN performs the following operation on a vector X:
+        ///         Y = (s * X - M) / D, where s is a scale, M is mean and D is either L2 norm or standard deviation.
         /// </summary>
         /// <param name="env">Host Environment.</param>
-        /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>
+        /// <param name="input">Input <see cref="IDataView"/>.</param>
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
         /// <param name="subMean">Subtract mean from each value before normalizing.</param>
@@ -305,7 +307,10 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// A helper method to create LpNormNormalizer transform for public facing API.
+        /// Convenience method for creating <see cref="LpNormNormalizerTransform"/> for Lp-Norm normalization.
+        /// The Lp-Norm normalizer normalizes rows individually by rescaling them to unit norm (L2, L1 or LInf).
+        /// It performs the following operation on a vector X:
+        ///         Y = (X - M) / D, where M is mean and D is either L2 norm, L1 norm or LInf norm.
         /// </summary>
         /// <param name="env">Host Environment.</param>
         /// <param name="input">Input <see cref="IDataView"/>. This is the output from previous transform or loader.</param>


### PR DESCRIPTION
This PR partially addresses #524.

Informative comments/description is added to convenience constructors of transforms so that comments/description appear in the intellisense for users.

Description/Comments are obtained from relevant `doc.xml` file and added to C# summary comments section using `<include>` tag. If  `doc.xml` does not contain the required information it is directly added to C# summary comments.

Following is list of transforms covered in this PR.

- BootstrapSampleTransform
- CategoricalHashTransform
- CategoricalTransform
- ConcatTransform
- CopyColumnsTransform
- CountFeatureSelection
- DropColumnsTransform
- LpNormNormalizerTransform
- NAFilter
- NormalizeTransform
