### PR TITLE
Add reference to ImageAnalytics nuget so image transforms are packaged.

### DIFF
--- a/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
+++ b/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.ML.Runtime.ImageAnalytics</AssemblyName>
     <RootNamespace>Microsoft.ML.Runtime.ImageAnalytics</RootNamespace>
+    <IncludeInPackage>Microsoft.ML.ImageAnalytics</IncludeInPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add reference to ImageAnalytics nuget so image transforms/learners are packaged.

Fixes #661 


