### PR TITLE
Port all active C# hardware intrinsics APIs for SSE from SIMD native algorithms

### DIFF
--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -811,7 +811,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             Contracts.Assert(0 < ccol && ccol <= cfltRow);
 
             // REVIEW NEEDED: Since the two methods below do not involve any SSE hardware intrinsics, no software fallback is needed.
-            // REVIEW NEEDED; Keeping the check for SSE support so that we don't miss these two methods in case of any conditional compilation of files
+            // REVIEW NEEDED: Keeping the check for SSE support so that we don't miss these two methods in case of any conditional compilation of files
             if (Sse.IsSupported)
             {
                 if (ccol == cfltRow)

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -9,28 +9,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
-        public const int CbAlign = 16;
-
-        private static bool Compat(AlignedArray a)
-        {
-            Contracts.AssertValue(a);
-            Contracts.Assert(a.Size > 0);
-            return a.CbAlign == CbAlign;
-        }
-
-        internal static unsafe float* Ptr(AlignedArray a, float* p)
-        {
-            Contracts.AssertValue(a);
-            float* q = p + a.GetBase((long)p);
-            Contracts.Assert(((long)q & (CbAlign - 1)) == 0);
-            return q;
-        }
-
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun)
         {
-            Contracts.Assert(Compat(mat));
-            Contracts.Assert(Compat(src));
-            Contracts.Assert(Compat(dst));
             Contracts.Assert(mat.Size == dst.Size * src.Size);
 
             if (Sse.IsSupported)
@@ -55,9 +35,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, int[] rgposSrc, AlignedArray srcValues,
             int posMin, int iposMin, int iposEnd, AlignedArray dst, int crun)
         {
-            Contracts.Assert(Compat(mat));
-            Contracts.Assert(Compat(srcValues));
-            Contracts.Assert(Compat(dst));
             Contracts.AssertValue(rgposSrc);
             Contracts.Assert(0 <= iposMin && iposMin <= iposEnd && iposEnd <= rgposSrc.Length);
             Contracts.Assert(mat.Size == dst.Size * srcValues.Size);
@@ -100,8 +77,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             Contracts.Assert(starts[crow] == indices.Length);
             Contracts.AssertNonEmpty(coefs);
             Contracts.Assert(indices.Length == coefs.Length);
-            Contracts.Assert(Compat(src));
-            Contracts.Assert(Compat(dst));
             Contracts.Assert(0 < crow && crow <= dst.Size);
             Contracts.Assert(crow * src.Size >= coefs.Length);
 
@@ -126,8 +101,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             Contracts.Assert(mprowrun == null || mprowrun.Length == crow);
             Contracts.AssertNonEmpty(runs);
             Contracts.AssertNonEmpty(coefs);
-            Contracts.Assert(Compat(src));
-            Contracts.Assert(Compat(dst));
             Contracts.Assert(0 < crow && crow <= dst.Size);
 
             if (mprowrun == null)

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -12,18 +12,17 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun)
         {
             Contracts.Assert(mat.Size == dst.Size * src.Size);
+            Contracts.Assert(crun >= 0);
 
             if (Sse.IsSupported)
             {
                 if (!tran)
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= dst.Size);
                     SseIntrinsics.MatMulA(add, mat, src, dst, crun, src.Size);
                 }
                 else
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= src.Size);
                     SseIntrinsics.MatMulTranA(add, mat, src, dst, dst.Size, crun);
                 }
@@ -32,7 +31,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             {
                 if (!tran)
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= dst.Size);
                     for (int i = 0; i < crun; i++)
                     {
@@ -54,7 +52,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                 }
                 else
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= src.Size);
                     for (int i = 0; i < dst.Size; i++)
                     {
@@ -94,18 +91,17 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             }
 
             Contracts.AssertNonEmpty(rgposSrc);
+            Contracts.Assert(crun >= 0);
 
             if (Sse.IsSupported)
             {
                 if (!tran)
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= dst.Size);
                     SseIntrinsics.MatMulPA(add, mat, rgposSrc, srcValues, posMin, iposMin, iposLim, dst, crun, srcValues.Size);
                 }
                 else
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= srcValues.Size);
                     SseIntrinsics.MatMulTranPA(add, mat, rgposSrc, srcValues, posMin, iposMin, iposLim, dst, dst.Size);
                 }
@@ -114,7 +110,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             {
                 if (!tran)
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= dst.Size);
                     for (int i = 0; i < crun; i++)
                     {
@@ -137,7 +132,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                 }
                 else
                 {
-                    Contracts.Assert(crun >= 0);
                     Contracts.Assert(crun <= srcValues.Size);
                     for (int i = 0; i < dst.Size; i++)
                     {
@@ -171,7 +165,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             Add(a, new Span<float>(dst, 0, count));
         }
 
-        // dst += a
         private static void Add(float a, Span<float> dst)
         {
             if (Sse.IsSupported)
@@ -856,7 +849,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                 for (int i = 0; i < cindices; ++i)
                 {
                     int index = pidx[i];
-                    Contracts.Assert(0 <= index && index < c);
+                    Contracts.Assert(index >= 0);
+                    Contracts.Assert(index < c);
                     pdst[index] = 0;
                 }
             }
@@ -874,7 +868,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                 for (int i = 0; i < cindices; ++i)
                 {
                     int index = pidx[i];
-                    Contracts.Assert(0 <= index && index < c);
+                    Contracts.Assert(index >= 0);
+                    Contracts.Assert(index < c);
 
                     int col = index - ivLogMin;
                     if ((uint)col >= (uint)ccol)
@@ -886,7 +881,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                         ivLogLim = ivLogMin + ccol;
                         ivPhyMin = row * cfltRow;
 
-                        Contracts.Assert(ivLogMin <= index && index < ivLogLim);
+                        Contracts.Assert(index >= ivLogMin);
+                        Contracts.Assert(index < ivLogLim);
                         col = index - ivLogMin;
                     }
 

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -17,12 +17,14 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             {
                 if (!tran)
                 {
-                    Contracts.Assert(0 <= crun && crun <= dst.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= dst.Size);
                     SseIntrinsics.MatMulA(add, mat, src, dst, crun, src.Size);
                 }
                 else
                 {
-                    Contracts.Assert(0 <= crun && crun <= src.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= src.Size);
                     SseIntrinsics.MatMulTranA(add, mat, src, dst, dst.Size, crun);
                 }
             }
@@ -30,7 +32,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             {
                 if (!tran)
                 {
-                    Contracts.Assert(0 <= crun && crun <= dst.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= dst.Size);
                     for (int i = 0; i < crun; i++)
                     {
                         float dotProduct = 0;
@@ -51,7 +54,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                 }
                 else
                 {
-                    Contracts.Assert(0 <= crun && crun <= src.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= src.Size);
                     for (int i = 0; i < dst.Size; i++)
                     {
                         float dotProduct = 0;
@@ -77,7 +81,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             int posMin, int iposMin, int iposLim, AlignedArray dst, int crun)
         {
             Contracts.AssertValue(rgposSrc);
-            Contracts.Assert(0 <= iposMin && iposMin <= iposLim && iposLim <= rgposSrc.Length);
+            Contracts.Assert(iposMin >= 0);
+            Contracts.Assert(iposMin <= iposLim);
+            Contracts.Assert(iposLim <= rgposSrc.Length);
             Contracts.Assert(mat.Size == dst.Size * srcValues.Size);
 
             if (iposMin >= iposLim)
@@ -93,12 +99,14 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             {
                 if (!tran)
                 {
-                    Contracts.Assert(0 <= crun && crun <= dst.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= dst.Size);
                     SseIntrinsics.MatMulPA(add, mat, rgposSrc, srcValues, posMin, iposMin, iposLim, dst, crun, srcValues.Size);
                 }
                 else
                 {
-                    Contracts.Assert(0 <= crun && crun <= srcValues.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= srcValues.Size);
                     SseIntrinsics.MatMulTranPA(add, mat, rgposSrc, srcValues, posMin, iposMin, iposLim, dst, dst.Size);
                 }
             }
@@ -106,7 +114,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             {
                 if (!tran)
                 {
-                    Contracts.Assert(0 <= crun && crun <= dst.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= dst.Size);
                     for (int i = 0; i < crun; i++)
                     {
                         float dotProduct = 0;
@@ -128,7 +137,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                 }
                 else
                 {
-                    Contracts.Assert(0 <= crun && crun <= srcValues.Size);
+                    Contracts.Assert(crun >= 0);
+                    Contracts.Assert(crun <= srcValues.Size);
                     for (int i = 0; i < dst.Size; i++)
                     {
                         float dotProduct = 0;
@@ -155,8 +165,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void Add(float a, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 < count && count <= dst.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= dst.Length);
 
             Add(a, new Span<float>(dst, 0, count));
         }
@@ -180,7 +190,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void Scale(float a, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 < count && count <= dst.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= dst.Length);
 
             Scale(a, new Span<float>(dst, 0, count));
         }
@@ -188,8 +199,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void Scale(float a, float[] dst, int offset, int count)
         {
             Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset < dst.Length - count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset < (dst.Length - count));
 
             Scale(a, new Span<float>(dst, offset, count));
         }
@@ -213,8 +225,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void Scale(float a, float[] src, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
             Contracts.AssertNonEmpty(dst);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
             Contracts.Assert(count <= dst.Length);
 
             Scale(a, new Span<float>(src, 0, count), new Span<float>(dst, 0, count));
@@ -239,8 +252,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void ScaleAdd(float a, float b, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 < count && count <= dst.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= dst.Length);
 
             ScaleAdd(a, b, new Span<float>(dst, 0, count));
         }
@@ -263,8 +276,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void AddScale(float a, float[] src, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
             Contracts.AssertNonEmpty(dst);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
             Contracts.Assert(count <= dst.Length);
 
             AddScale(a, new Span<float>(src, 0, count), new Span<float>(dst, 0, count));
@@ -273,10 +287,12 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void AddScale(float a, float[] src, float[] dst, int dstOffset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(count <= src.Length);
             Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 <= dstOffset && dstOffset < dst.Length);
-            Contracts.Assert(0 < count && count <= dst.Length - dstOffset);
+            Contracts.Assert(dstOffset >= 0);
+            Contracts.Assert(dstOffset < dst.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
+            Contracts.Assert(count <= (dst.Length - dstOffset));
 
             AddScale(a, new Span<float>(src, 0, count), new Span<float>(dst, dstOffset, count));
         }
@@ -299,10 +315,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void AddScale(float a, float[] src, int[] indices, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
             Contracts.AssertNonEmpty(indices);
-            Contracts.Assert(count <= indices.Length);
             Contracts.AssertNonEmpty(dst);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
+            Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < dst.Length);
 
             AddScale(a, new Span<float>(src), new Span<int>(indices, 0, count), new Span<float>(dst));
@@ -311,12 +328,14 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void AddScale(float a, float[] src, int[] indices, float[] dst, int dstOffset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
             Contracts.AssertNonEmpty(indices);
-            Contracts.Assert(count <= indices.Length);
             Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 <= dstOffset && dstOffset < dst.Length);
-            Contracts.Assert(count < dst.Length - dstOffset);
+            Contracts.Assert(dstOffset >= 0);
+            Contracts.Assert(dstOffset < dst.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
+            Contracts.Assert(count <= indices.Length);
+            Contracts.Assert(count < (dst.Length - dstOffset));
 
             AddScale(a, new Span<float>(src), new Span<int>(indices, 0, count),
                     new Span<float>(dst, dstOffset, dst.Length - dstOffset));
@@ -340,11 +359,12 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
         public static void AddScaleCopy(float a, float[] src, float[] dst, float[] res, int count)
         {
-            Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 < count && count <= dst.Length);
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(count <= src.Length);
+            Contracts.AssertNonEmpty(dst);
             Contracts.AssertNonEmpty(res);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
+            Contracts.Assert(count <= dst.Length);
             Contracts.Assert(count <= res.Length);
 
             AddScaleCopy(a, new Span<float>(src, 0, count), new Span<float>(dst, 0, count), new Span<float>(res, 0, count));
@@ -368,8 +388,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void Add(float[] src, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
             Contracts.AssertNonEmpty(dst);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
             Contracts.Assert(count <= dst.Length);
 
             Add(new Span<float>(src, 0, count), new Span<float>(dst, 0, count));
@@ -393,10 +414,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void Add(float[] src, int[] indices, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
             Contracts.AssertNonEmpty(indices);
-            Contracts.Assert(count <= indices.Length);
             Contracts.AssertNonEmpty(dst);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
+            Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < dst.Length);
 
             Add(new Span<float>(src), new Span<int>(indices, 0, count), new Span<float>(dst));
@@ -405,12 +427,14 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void Add(float[] src, int[] indices, float[] dst, int dstOffset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
             Contracts.AssertNonEmpty(indices);
-            Contracts.Assert(count <= indices.Length);
             Contracts.AssertNonEmpty(dst);
-            Contracts.Assert(0 <= dstOffset && dstOffset < dst.Length);
-            Contracts.Assert(count <= dst.Length - dstOffset);
+            Contracts.Assert(dstOffset >= 0);
+            Contracts.Assert(dstOffset < dst.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
+            Contracts.Assert(count <= indices.Length);
+            Contracts.Assert(count <= (dst.Length - dstOffset));
 
             Add(new Span<float>(src), new Span<int>(indices, 0, count),
                 new Span<float>(dst, dstOffset, dst.Length - dstOffset));
@@ -435,10 +459,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void MulElementWise(float[] src1, float[] src2, float[] dst, int count)
         {
             Contracts.AssertNonEmpty(src1);
-            Contracts.Assert(0 < count && count <= src1.Length);
             Contracts.AssertNonEmpty(src2);
-            Contracts.Assert(0 < count && count <= src2.Length);
             Contracts.AssertNonEmpty(dst);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src1.Length);
+            Contracts.Assert(count <= src2.Length);
 
             MulElementWise(new Span<float>(src1, 0, count), new Span<float>(src2, 0, count),
                             new Span<float>(dst, 0, count));
@@ -462,7 +487,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float Sum(float[] src, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
 
             return Sum(new Span<float>(src, 0, count));
         }
@@ -470,8 +496,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float Sum(float[] src, int offset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset <= src.Length - count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset <= (src.Length - count));
 
             return Sum(new Span<float>(src, offset, count));
         }
@@ -496,7 +523,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float SumSq(float[] src, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
 
             return SumSq(new Span<float>(src, 0, count));
         }
@@ -504,8 +532,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float SumSq(float[] src, int offset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset <= src.Length - count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset <= (src.Length - count));
 
             return SumSq(new Span<float>(src, offset, count));
         }
@@ -530,8 +559,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float SumSq(float mean, float[] src, int offset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset <= src.Length - count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset <= (src.Length - count));
 
             return SumSq(mean, new Span<float>(src, offset, count));
         }
@@ -540,14 +570,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             if (Sse.IsSupported)
             {
-                if (mean == 0)
-                {
-                    return SseIntrinsics.SumSqU(src);
-                }
-                else
-                {
-                    return SseIntrinsics.SumSqDiffU(mean, src);
-                }
+                return (mean == 0) ? SseIntrinsics.SumSqU(src) : SseIntrinsics.SumSqDiffU(mean, src);
             }
             else
             {
@@ -563,7 +586,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float SumAbs(float[] src, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
 
             return SumAbs(new Span<float>(src, 0, count));
         }
@@ -571,8 +595,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float SumAbs(float[] src, int offset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset <= src.Length - count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset <= (src.Length - count));
 
             return SumAbs(new Span<float>(src, offset, count));
         }
@@ -597,8 +622,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float SumAbs(float mean, float[] src, int offset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset <= src.Length - count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset <= (src.Length - count));
 
             return SumAbs(mean, new Span<float>(src, offset, count));
         }
@@ -607,14 +633,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             if (Sse.IsSupported)
             {
-                if (mean == 0)
-                {
-                    return SseIntrinsics.SumAbsU(src);
-                }
-                else
-                {
-                    return SseIntrinsics.SumAbsDiffU(mean, src);
-                }
+                return (mean == 0) ? SseIntrinsics.SumAbsU(src) : SseIntrinsics.SumAbsDiffU(mean, src);
             }
             else
             {
@@ -630,7 +649,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float MaxAbs(float[] src, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
 
             return MaxAbs(new Span<float>(src, 0, count));
         }
@@ -638,8 +658,9 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float MaxAbs(float[] src, int offset, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset <= src.Length - count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset <= (src.Length - count));
 
             return MaxAbs(new Span<float>(src, offset, count));
         }
@@ -668,7 +689,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float MaxAbsDiff(float mean, float[] src, int count)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(0 < count && count <= src.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
 
             return MaxAbsDiff(mean, new Span<float>(src, 0, count));
         }
@@ -698,7 +720,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(a);
             Contracts.AssertNonEmpty(b);
-            Contracts.Assert(0 < count);
+            Contracts.Assert(count > 0);
             Contracts.Assert(a.Length >= count);
             Contracts.Assert(b.Length >= count);
 
@@ -708,10 +730,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float DotProductDense(float[] a, int offset, float[] b, int count)
         {
             Contracts.AssertNonEmpty(a);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset <= a.Length - count);
             Contracts.AssertNonEmpty(b);
-            Contracts.Assert(b.Length >= count);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= b.Length);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset <= (a.Length - count));
 
             return DotProductDense(new Span<float>(a, offset, count), new Span<float>(b, 0, count));
         }
@@ -737,7 +760,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(a);
             Contracts.AssertNonEmpty(b);
-            Contracts.Assert(0 < count);
+            Contracts.AssertNonEmpty(indices);
+            Contracts.Assert(count > 0);
             Contracts.Assert(count < a.Length);
             Contracts.Assert(count <= b.Length);
             Contracts.Assert(count <= indices.Length);
@@ -749,12 +773,14 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float DotProductSparse(float[] a, int offset, float[] b, int[] indices, int count)
         {
             Contracts.AssertNonEmpty(a);
-            Contracts.Assert(0 < count);
-            Contracts.Assert(0 <= offset && offset < a.Length);
-            Contracts.Assert(a.Length - offset > count);
             Contracts.AssertNonEmpty(b);
+            Contracts.AssertNonEmpty(indices);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count < (a.Length - offset));
             Contracts.Assert(count <= b.Length);
             Contracts.Assert(count <= indices.Length);
+            Contracts.Assert(offset >= 0);
+            Contracts.Assert(offset < a.Length);
 
             return DotProductSparse(new Span<float>(a, offset, a.Length - offset),
                                     new Span<float>(b), new Span<int>(indices, 0, count));
@@ -782,7 +808,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(a);
             Contracts.AssertNonEmpty(b);
-            Contracts.Assert(0 < count && count <= a.Length);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= a.Length);
             Contracts.Assert(count <= b.Length);
 
             return L2DistSquared(new Span<float>(a, 0, count), new Span<float>(b, 0, count));
@@ -808,19 +835,62 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
         public static void ZeroMatrixItems(AlignedArray dst, int ccol, int cfltRow, int[] indices)
         {
-            Contracts.Assert(0 < ccol && ccol <= cfltRow);
+            Contracts.Assert(ccol > 0);
+            Contracts.Assert(ccol <= cfltRow);
 
-            // REVIEW NEEDED: Since the two methods below do not involve any SSE hardware intrinsics, no software fallback is needed.
-            // REVIEW NEEDED: Keeping the check for SSE support so that we don't miss these two methods in case of any conditional compilation of files
-            if (Sse.IsSupported)
+            if (ccol == cfltRow)
             {
-                if (ccol == cfltRow)
+                ZeroItemsU(dst, dst.Size, indices, indices.Length);
+            }
+            else
+            {
+                ZeroMatrixItemsCore(dst, dst.Size, ccol, cfltRow, indices, indices.Length);
+            }
+        }
+
+        private static unsafe void ZeroItemsU(AlignedArray dst, int c, int[] indices, int cindices)
+        {
+            fixed (float* pdst = &dst.Items[0])
+            fixed (int* pidx = &indices[0])
+            {
+                for (int i = 0; i < cindices; ++i)
                 {
-                    SseIntrinsics.ZeroItemsU(dst, dst.Size, indices, indices.Length);
+                    int index = pidx[i];
+                    Contracts.Assert(0 <= index && index < c);
+                    pdst[index] = 0;
                 }
-                else
+            }
+        }
+
+        private static unsafe void ZeroMatrixItemsCore(AlignedArray dst, int c, int ccol, int cfltRow, int[] indices, int cindices)
+        {
+            fixed (float* pdst = &dst.Items[0])
+            fixed (int* pidx = &indices[0])
+            {
+                int ivLogMin = 0;
+                int ivLogLim = ccol;
+                int ivPhyMin = 0;
+
+                for (int i = 0; i < cindices; ++i)
                 {
-                    SseIntrinsics.ZeroMatrixItemsCore(dst, dst.Size, ccol, cfltRow, indices, indices.Length);
+                    int index = pidx[i];
+                    Contracts.Assert(0 <= index && index < c);
+
+                    int col = index - ivLogMin;
+                    if ((uint)col >= (uint)ccol)
+                    {
+                        Contracts.Assert(ivLogMin > index || index >= ivLogLim);
+
+                        int row = index / ccol;
+                        ivLogMin = row * ccol;
+                        ivLogLim = ivLogMin + ccol;
+                        ivPhyMin = row * cfltRow;
+
+                        Contracts.Assert(ivLogMin <= index && index < ivLogLim);
+                        col = index - ivLogMin;
+                    }
+
+                    pdst[ivPhyMin + col] = 0;
                 }
             }
         }
@@ -828,12 +898,12 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void SdcaL1UpdateDense(float primalUpdate, int length, float[] src, float threshold, float[] v, float[] w)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(length <= src.Length);
             Contracts.AssertNonEmpty(v);
-            Contracts.Assert(length <= v.Length);
             Contracts.AssertNonEmpty(w);
-            Contracts.Assert(length <= w.Length);
             Contracts.Assert(length > 0);
+            Contracts.Assert(length <= src.Length);
+            Contracts.Assert(length <= v.Length);
+            Contracts.Assert(length <= w.Length);
 
             SdcaL1UpdateDense(primalUpdate, new Span<float>(src, 0, length), threshold, new Span<float>(v, 0, length), new Span<float>(w, 0, length));
         }
@@ -859,15 +929,15 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void SdcaL1UpdateSparse(float primalUpdate, int length, float[] src, int[] indices, int count, float threshold, float[] v, float[] w)
         {
             Contracts.AssertNonEmpty(src);
-            Contracts.Assert(count <= src.Length);
             Contracts.AssertNonEmpty(indices);
-            Contracts.Assert(count <= indices.Length);
-            Contracts.AssertNonEmpty(w);
-            Contracts.Assert(length <= w.Length);
             Contracts.AssertNonEmpty(v);
-            Contracts.Assert(length <= v.Length);
-            Contracts.Assert(0 < count);
+            Contracts.AssertNonEmpty(w);
+            Contracts.Assert(count > 0);
+            Contracts.Assert(count <= src.Length);
+            Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < length);
+            Contracts.Assert(length <= v.Length);
+            Contracts.Assert(length <= w.Length);
 
             SdcaL1UpdateSparse(primalUpdate, new Span<float>(src, 0, count), new Span<int>(indices, 0, count), threshold, new Span<float>(v), new Span<float>(w));
         }

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
@@ -11,15 +11,15 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, int[] rgposSrc, AlignedArray srcValues,
             int posMin, int iposMin, int iposLim, AlignedArray dst, int crun) => SseUtils.MatTimesSrc(tran, add, mat, rgposSrc, srcValues, posMin, iposMin, iposLim, dst, crun);
 
-        public static void MatTimesSrc(bool add, int[] starts, int[] indices, float[] coefs,
-            AlignedArray src, AlignedArray dst, int crow) => SseUtils.MatTimesSrc(add, starts, indices, coefs, src, dst, crow);
-
-        public static void MatTimesSrc(bool add, int[] mprowiv, int[] mprowcol, int[] mprowrun, int[] runs, float[] coefs,
-            AlignedArray src, AlignedArray dst, int crow) => SseUtils.MatTimesSrc(add, mprowiv, mprowcol, mprowrun, runs, coefs, src, dst, crow);
+        public static void Add(float a, float[] dst, int count) => SseUtils.Add(a, dst, count);
 
         public static void Scale(float a, float[] dst, int count) => SseUtils.Scale(a, dst, count);
 
         public static void Scale(float a, float[] dst, int offset, int count) => SseUtils.Scale(a, dst, offset, count);
+
+        public static void Scale(float a, float[] src, float[] dst, int count) => SseUtils.Scale(a, src, dst, count);
+
+        public static void ScaleAdd(float a, float b, float[] dst, int count) => SseUtils.ScaleAdd(a, b, dst, count);
 
         public static void AddScale(float a, float[] src, float[] dst, int count) => SseUtils.AddScale(a, src, dst, count);
 
@@ -29,6 +29,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
         public static void AddScale(float a, float[] src, int[] indices, float[] dst, int dstOffset, int count) => SseUtils.AddScale(a, src, indices, dst, dstOffset, count);
 
+        public static void AddScaleCopy(float a, float[] src, float[] dst, float[] res, int count) => SseUtils.AddScaleCopy(a, src, dst, res, count);
+
         public static void Add(float[] src, float[] dst, int count) => SseUtils.Add(src, dst, count);
 
         public static void Add(float[] src, int[] indices, float[] dst, int count) => SseUtils.Add(src, indices, dst, count);
@@ -37,13 +39,27 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
         public static void MulElementWise(float[] src1, float[] src2, float[] dst, int count) => SseUtils.MulElementWise(src1, src2, dst, count);
 
+        public static float Sum(float[] src, int count) => SseUtils.Sum(src, count);
+
+        public static float Sum(float[] src, int offset, int count) => SseUtils.Sum(src, offset, count);
+
         public static float SumSq(float[] src, int count) => SseUtils.SumSq(src, count);
 
         public static float SumSq(float[] src, int offset, int count) => SseUtils.SumSq(src, offset, count);
 
+        public static float SumSq(float mean, float[] src, int offset, int count) => SseUtils.SumSq(mean, src, offset, count);
+
         public static float SumAbs(float[] src, int count) => SseUtils.SumAbs(src, count);
 
         public static float SumAbs(float[] src, int offset, int count) => SseUtils.SumAbs(src, offset, count);
+
+        public static float SumAbs(float mean, float[] src, int offset, int count) => SseUtils.SumAbs(mean, src, offset, count);
+
+        public static float MaxAbs(float[] src, int count) => SseUtils.MaxAbs(src, count);
+
+        public static float MaxAbs(float[] src, int offset, int count) => SseUtils.MaxAbs(src, offset, count);
+
+        public static float MaxAbsDiff(float mean, float[] src, int count) => SseUtils.MaxAbsDiff(mean, src, count);
 
         public static float DotProductDense(float[] a, float[] b, int count) => SseUtils.DotProductDense(a, b, count);
 
@@ -56,5 +72,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float L2DistSquared(float[] a, float[] b, int count) => SseUtils.L2DistSquared(a, b, count);
 
         public static void ZeroMatrixItems(AlignedArray dst, int ccol, int cfltRow, int[] indices) => SseUtils.ZeroMatrixItems(dst, ccol, cfltRow, indices);
+
+        public static void SdcaL1UpdateDense(float primalUpdate, int length, float[] src, float threshold, float[] v, float[] w)
+            => SseUtils.SdcaL1UpdateDense(primalUpdate, length, src, threshold, v, w);
+
+        public static void SdcaL1UpdateSparse(float primalUpdate, int length, float[] src, int[] indices, int count, float threshold, float[] v, float[] w)
+            => SseUtils.SdcaL1UpdateSparse(primalUpdate, length, src, indices, count, threshold, v, w);
     }
 }

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
@@ -6,6 +6,17 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
+        public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun) => SseUtils.MatTimesSrc(tran, add, mat, src, dst, crun);
+
+        public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, int[] rgposSrc, AlignedArray srcValues,
+            int posMin, int iposMin, int iposLim, AlignedArray dst, int crun) => SseUtils.MatTimesSrc(tran, add, mat, rgposSrc, srcValues, posMin, iposMin, iposLim, dst, crun);
+
+        public static void MatTimesSrc(bool add, int[] starts, int[] indices, float[] coefs,
+            AlignedArray src, AlignedArray dst, int crow) => SseUtils.MatTimesSrc(add, starts, indices, coefs, src, dst, crow);
+
+        public static void MatTimesSrc(bool add, int[] mprowiv, int[] mprowcol, int[] mprowrun, int[] runs, float[] coefs,
+            AlignedArray src, AlignedArray dst, int crow) => SseUtils.MatTimesSrc(add, mprowiv, mprowcol, mprowrun, runs, coefs, src, dst, crow);
+
         public static void Scale(float a, float[] dst, int count) => SseUtils.Scale(a, dst, count);
 
         public static void Scale(float a, float[] dst, int offset, int count) => SseUtils.Scale(a, dst, offset, count);
@@ -43,5 +54,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static float DotProductSparse(float[] a, int offset, float[] b, int[] indices, int count) => SseUtils.DotProductSparse(a, offset, b, indices, count);
 
         public static float L2DistSquared(float[] a, float[] b, int count) => SseUtils.L2DistSquared(a, b, count);
+
+        public static void ZeroMatrixItems(AlignedArray dst, int ccol, int cfltRow, int[] indices) => SseUtils.ZeroMatrixItems(dst, ccol, cfltRow, indices);
     }
 }

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         }
 
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-        private static Vector128<float> VectorSum(Vector128<float> vector)
+        private static Vector128<float> VectorSum(in Vector128<float> vector)
         {
             if (Sse3.IsSupported)
             {

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static Vector128<float> GetAbsMask()
         {
-            return (Sse2.IsSupported) ?
+            return Sse2.IsSupported ?
                 Sse.StaticCast<int, float>(Sse2.SetAllVector128(0x7FFFFFFF)) :
                 Sse.SetAllVector128(BitConverter.Int32BitsToSingle(0x7FFFFFFF));
         }

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
@@ -20,20 +20,6 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
 {
     internal static class CpuMathNativeUtils
     {
-        [DllImport("CpuMathNative", EntryPoint = "MatMulA"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MatMulA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow, int ccol);
-
-        [DllImport("CpuMathNative", EntryPoint = "MatMulPA"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MatMulPA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ int* pposSrc, /*_In_ const*/ float* psrc,
-            int posMin, int iposMin, int iposLim, /*_Inout_*/ float* pdst, int crow, int ccol);
-
-        [DllImport("CpuMathNative", EntryPoint = "MatMulTranA"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MatMulTranA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow, int ccol);
-
-        [DllImport("CpuMathNative", EntryPoint = "MatMulTranPA"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MatMulTranPA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ int* pposSrc, /*_In_ const*/ float* psrc,
-            int posMin, int iposMin, int iposLim, /*_Inout_*/ float* pdst, int crow);
-
         [DllImport("CpuMathNative", EntryPoint = "AddScalarU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe float AddScalarU(float a, /*_Inout_*/ float* pd, int c);
 
@@ -93,12 +79,6 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
 
         [DllImport("CpuMathNative", EntryPoint = "Dist2"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe float Dist2(/*const*/ float* px, /*const*/ float* py, int c);
-
-        [DllImport("CpuMathNative", EntryPoint = "ZeroItemsU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void ZeroItemsU(/*_Inout_*/ float* pd, int c, /*_In_ const*/ int* pindices, int cindices);
-
-        [DllImport("CpuMathNative", EntryPoint = "ZeroMatrixItemsCore"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void ZeroMatrixItemsCore(/*_Inout_*/ float* pd, int c, int ccol, int cfltRow, /*_In_ const*/ int* pindices, int cindices);
 
         [DllImport("CpuMathNative", EntryPoint = "SdcaL1UpdateU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void SdcaL1UpdateU(float primalUpdate, /*_In_ const*/ float* ps, float threshold, /*_Inout_*/ float* pd1, /*_Inout_*/ float* pd2, int c);

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
@@ -9,6 +9,32 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
 {
     internal static class CpuMathNativeUtils
     {
+        [DllImport("CpuMathNative", EntryPoint = "MatMulA"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MatMulA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow, int ccol);
+
+        [DllImport("CpuMathNative", EntryPoint = "MatMulPA"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MatMulPA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ int* pposSrc, /*_In_ const*/ float* psrc,
+            int posMin, int iposMin, int iposLim, /*_Inout_*/ float* pdst, int crow, int ccol);
+
+        [DllImport("CpuMathNative", EntryPoint = "MatMulTranA"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MatMulTranA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow, int ccol);
+
+        [DllImport("CpuMathNative", EntryPoint = "MatMulTranPA"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MatMulTranPA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ int* pposSrc, /*_In_ const*/ float* psrc,
+            int posMin, int iposMin, int iposLim, /*_Inout_*/ float* pdst, int crow);
+
+        [DllImport("CpuMathNative", EntryPoint = "MatMulRU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MatMulRU(bool add, /*_In_ const*/ int* pstarts, /*_In_ const*/ int* pindices, /*_In_ const*/ float* pcoefs,
+            /*_In_ const*/ float* ps, /*_Inout_*/ float* pdst, int crow);
+
+        [DllImport("CpuMathNative", EntryPoint = "MatMulCU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MatMulCU(bool add, /*_In_ const*/ int* pmprowiv, /*_In_ const*/ int* pmprowcol,
+            /*_In_ const*/ int* pruns, /*_In_ const*/ float* pcoefs, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow);
+
+        [DllImport("CpuMathNative", EntryPoint = "MatMulDU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MatMulDU(bool add, /*_In_ const*/ int* pmprowiv, /*_In_ const*/ int* pmprowcol, /*_In_ const*/ int* pmprowrun,
+            /*_In_ const*/ int* pruns, /*_In_ const*/ float* pcoefs, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow);
+
         [DllImport("CpuMathNative", EntryPoint = "DotU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe float DotU(/*const*/ float* pa, /*const*/ float* pb, int c);
 
@@ -41,5 +67,11 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
 
         [DllImport("CpuMathNative", EntryPoint = "MulElementWiseU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void MulElementWiseU(/*_In_ const*/ float* ps1, /*_In_ const*/ float* ps2, /*_Inout_*/ float* pd, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "ZeroItemsU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void ZeroItemsU(/*_Inout_*/ float* pd, int c, /*_In_ const*/ int* pindices, int cindices);
+
+        [DllImport("CpuMathNative", EntryPoint = "ZeroMatrixItemsCore"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void ZeroMatrixItemsCore(/*_Inout_*/ float* pd, int c, int ccol, int cfltRow, /*_In_ const*/ int* pindices, int cindices);
     }
 }

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
@@ -2,6 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// The exported function names need to be unique (can't be disambiguated based on signature), hence
+// we introduce suffix letters to indicate the general patterns used.
+// * A suffix means aligned and padded for SSE operations.
+// * U suffix means unaligned and unpadded.
+// * S suffix means sparse (unaligned) vector.
+// * P suffix means sparse (unaligned) partial vector - the vector is only part of a larger sparse vector.
+// * R suffix means sparse matrix.
+// * C suffix means convolution matrix.
+// * D suffix means convolution matrix, with implicit source padding.
+// * Tran means the matrix is transposed.
+
 using System.Runtime.InteropServices;
 using System.Security;
 
@@ -23,32 +34,17 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
         internal static extern unsafe void MatMulTranPA(bool add, /*_In_ const*/ float* pmat, /*_In_ const*/ int* pposSrc, /*_In_ const*/ float* psrc,
             int posMin, int iposMin, int iposLim, /*_Inout_*/ float* pdst, int crow);
 
-        [DllImport("CpuMathNative", EntryPoint = "MatMulRU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MatMulRU(bool add, /*_In_ const*/ int* pstarts, /*_In_ const*/ int* pindices, /*_In_ const*/ float* pcoefs,
-            /*_In_ const*/ float* ps, /*_Inout_*/ float* pdst, int crow);
+        [DllImport("CpuMathNative", EntryPoint = "AddScalarU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float AddScalarU(float a, /*_Inout_*/ float* pd, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "MatMulCU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MatMulCU(bool add, /*_In_ const*/ int* pmprowiv, /*_In_ const*/ int* pmprowcol,
-            /*_In_ const*/ int* pruns, /*_In_ const*/ float* pcoefs, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow);
+        [DllImport("CpuMathNative", EntryPoint = "ScaleU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void ScaleU(float a, /*_Inout_*/ float* pd, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "MatMulDU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MatMulDU(bool add, /*_In_ const*/ int* pmprowiv, /*_In_ const*/ int* pmprowcol, /*_In_ const*/ int* pmprowrun,
-            /*_In_ const*/ int* pruns, /*_In_ const*/ float* pcoefs, /*_In_ const*/ float* psrc, /*_Inout_*/ float* pdst, int crow);
+        [DllImport("CpuMathNative", EntryPoint = "ScaleSrcU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void ScaleSrcU(float a, /*_In_ const*/ float* ps, /*_Inout_*/ float* pd, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "DotU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe float DotU(/*const*/ float* pa, /*const*/ float* pb, int c);
-
-        [DllImport("CpuMathNative", EntryPoint = "DotSU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe float DotSU(/*const*/ float* pa, /*const*/ float* pb, /*const*/ int* pi, int c);
-
-        [DllImport("CpuMathNative", EntryPoint = "SumSqU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe float SumSqU(/*const*/ float* ps, int c);
-
-        [DllImport("CpuMathNative", EntryPoint = "AddU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void AddU(/*_In_ const*/ float* ps, /*_Inout_*/ float* pd, int c);
-
-        [DllImport("CpuMathNative", EntryPoint = "AddSU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void AddSU(/*_In_ const*/ float* ps, /*_In_ const*/ int* pi, /*_Inout_*/ float* pd, int c);
+        [DllImport("CpuMathNative", EntryPoint = "ScaleAddU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void ScaleAddU(float a, float b, /*_Inout_*/ float* pd, int c);
 
         [DllImport("CpuMathNative", EntryPoint = "AddScaleU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void AddScaleU(float a, /*_In_ const*/ float* ps, /*_Inout_*/ float* pd, int c);
@@ -56,22 +52,58 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
         [DllImport("CpuMathNative", EntryPoint = "AddScaleSU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void AddScaleSU(float a, /*_In_ const*/ float* ps, /*_In_ const*/ int* pi, /*_Inout_*/ float* pd, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "ScaleU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void ScaleU(float a, /*_Inout_*/ float* pd, int c);
+        [DllImport("CpuMathNative", EntryPoint = "AddScaleCopyU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void AddScaleCopyU(float a, /*_In_ const*/ float* ps, /*_In_ const*/ float* pd, /*_Inout_*/ float* pr, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "Dist2"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe float Dist2(/*const*/ float* px, /*const*/ float* py, int c);
+        [DllImport("CpuMathNative", EntryPoint = "AddU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void AddU(/*_In_ const*/ float* ps, /*_Inout_*/ float* pd, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "AddSU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void AddSU(/*_In_ const*/ float* ps, /*_In_ const*/ int* pi, /*_Inout_*/ float* pd, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "MulElementWiseU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void MulElementWiseU(/*_In_ const*/ float* ps1, /*_In_ const*/ float* ps2, /*_Inout_*/ float* pd, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "SumU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float SumU(/*const*/ float* ps, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "SumSqU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float SumSqU(/*const*/ float* ps, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "SumSqDiffU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float SumSqDiffU(float mean, /*const*/ float* ps, int c);
 
         [DllImport("CpuMathNative", EntryPoint = "SumAbsU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe float SumAbsU(/*const*/ float* ps, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "MulElementWiseU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void MulElementWiseU(/*_In_ const*/ float* ps1, /*_In_ const*/ float* ps2, /*_Inout_*/ float* pd, int c);
+        [DllImport("CpuMathNative", EntryPoint = "SumAbsDiffU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float SumAbsDiffU(float mean, /*const*/ float* ps, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "MaxAbsU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float MaxAbsU(/*const*/ float* ps, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "MaxAbsDiffU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float MaxAbsDiffU(float mean, /*const*/ float* ps, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "DotU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float DotU(/*const*/ float* pa, /*const*/ float* pb, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "DotSU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float DotSU(/*const*/ float* pa, /*const*/ float* pb, /*const*/ int* pi, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "Dist2"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float Dist2(/*const*/ float* px, /*const*/ float* py, int c);
 
         [DllImport("CpuMathNative", EntryPoint = "ZeroItemsU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void ZeroItemsU(/*_Inout_*/ float* pd, int c, /*_In_ const*/ int* pindices, int cindices);
 
         [DllImport("CpuMathNative", EntryPoint = "ZeroMatrixItemsCore"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void ZeroMatrixItemsCore(/*_Inout_*/ float* pd, int c, int ccol, int cfltRow, /*_In_ const*/ int* pindices, int cindices);
+
+        [DllImport("CpuMathNative", EntryPoint = "SdcaL1UpdateU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void SdcaL1UpdateU(float primalUpdate, /*_In_ const*/ float* ps, float threshold, /*_Inout_*/ float* pd1, /*_Inout_*/ float* pd2, int c);
+
+        [DllImport("CpuMathNative", EntryPoint = "SdcaL1UpdateSU"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void SdcaL1UpdateSU(float primalUpdate, /*_In_ const*/ float* ps, /*_In_ const*/ int* pi, float threshold, /*_Inout_*/ float* pd1, /*_Inout_*/ float* pd2, int c);
     }
 }

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/SsePerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/SsePerformanceTests.cs
@@ -23,9 +23,6 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
         private const int DEFAULT_CCOL = 2000;
         private const bool ADD = true;
 
-        // Naming follows from SseIntrinsics.
-        private const int CbAlign = 16;
-
         private float[] src, dst, original, src1, src2, result;
         private int[] idx;
         private int seed = DEFAULT_SEED;

--- a/test/Microsoft.ML.CpuMath.UnitTests.netstandard/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netstandard/UnitTests.cs
@@ -13,7 +13,10 @@ namespace Microsoft.ML.CpuMath.UnitTests
     {
         private readonly float[][] testArrays;
         private readonly int[] testIndexArray;
+        private readonly AlignedArray[] testMatrices;
+        private readonly AlignedArray[] testSrcVectors;
         private const float DEFAULT_SCALE = 1.7f;
+        private const int SseCbAlign = 16;
         private FloatEqualityComparer comparer;
 
         public CpuMathUtilsUnitTests()
@@ -25,52 +28,309 @@ namespace Microsoft.ML.CpuMath.UnitTests
             testArrays = new float[][] { testArray1, testArray2 };
             testIndexArray = new int[4] { 0, 2, 5, 6 };
             comparer = new FloatEqualityComparer();
-        }
 
-        [Theory]
-        [InlineData(0, 13306.0376f)]
-        [InlineData(1, 13291.9235f)]
-        public void DotUTest(int test, float expected)
-        {
-            float[] src = (float[]) testArrays[test].Clone();
-            float[] dst = (float[]) src.Clone();
-            
-            for (int i = 0; i < dst.Length; i++)
+            // Padded matrices whose dimensions are multiples of 4
+            float[] testMatrix1 = new float[4 * 4] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f };
+            float[] testMatrix2 = new float[4 * 8];
+
+            for (int i = 0; i < testMatrix2.Length; i++)
             {
-                dst[i] += 1;
+                testMatrix2[i] = i + 1;
             }
 
-            var actual = CpuMathUtils.DotProductDense(src, dst, dst.Length);
-            Assert.Equal(expected, actual, 2);
+            AlignedArray testMatrixAligned1 = new AlignedArray(4 * 4, SseCbAlign);
+            AlignedArray testMatrixAligned2 = new AlignedArray(4 * 8, SseCbAlign);
+            testMatrixAligned1.CopyFrom(testMatrix1, 0, testMatrix1.Length);
+            testMatrixAligned2.CopyFrom(testMatrix2, 0, testMatrix2.Length);
+
+            testMatrices = new AlignedArray[] { testMatrixAligned1, testMatrixAligned2 };
+
+            // Padded source vectors whose dimensions are multiples of 4
+            float[] testSrcVector1 = new float[4] { 1f, 2f, 3f, 4f };
+            float[] testSrcVector2 = new float[8] { 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f };
+
+            AlignedArray testSrcVectorAligned1 = new AlignedArray(4, SseCbAlign);
+            AlignedArray testSrcVectorAligned2 = new AlignedArray(8, SseCbAlign);
+            testSrcVectorAligned1.CopyFrom(testSrcVector1, 0, testSrcVector1.Length);
+            testSrcVectorAligned2.CopyFrom(testSrcVector2, 0, testSrcVector2.Length);
+
+            testSrcVectors = new AlignedArray[] { testSrcVectorAligned1, testSrcVectorAligned2 };
         }
 
         [Theory]
-        [InlineData(0, 736.7352f)]
-        [InlineData(1, 736.7352f)]
-        public void DotSUTest(int test, float expected)
+        [InlineData(0, new float[] { 23.28f, -49.72f, 23.28f, -49.72f })]
+        [InlineData(1, new float[] { 204f, 492f, 780f, 1068f })]
+        public void MatMulATest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[test];
+            AlignedArray dst = new AlignedArray(4, SseCbAlign);
+
+            CpuMathUtils.MatTimesSrc(false, false, mat, src, dst, dst.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new float[] { 23.28f, -48.72f, 25.28f, -46.72f })]
+        [InlineData(1, new float[] { 204f, 493f, 782f, 1071f })]
+        public void MatMulAAddTest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[test];
+            AlignedArray dst = new AlignedArray(4, SseCbAlign);
+
+            for (int i = 0; i < dst.Size; i++)
+            {
+                dst[i] = i;
+            }
+
+            CpuMathUtils.MatTimesSrc(false, true, mat, src, dst, dst.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new float[] { -630.38f, -171.1f, 155.66f, 75.1f })]
+        [InlineData(1, new float[] { 170f, 180f, 190f, 200f, 210f, 220f, 230f, 240f })]
+        public void MatMulTranATest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[0];
+            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
+
+            CpuMathUtils.MatTimesSrc(true, false, mat, src, dst, src.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new float[] { -630.38f, -170.1f, 157.66f, 78.1f })]
+        [InlineData(1, new float[] { 170f, 181f, 192f, 203f, 214f, 225f, 236f, 247f })]
+        public void MatMulTranAAddTest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[0];
+            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
+
+            for (int i = 0; i < dst.Size; i++)
+            {
+                dst[i] = i;
+            }
+
+            CpuMathUtils.MatTimesSrc(true, true, mat, src, dst, src.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new float[] { -27.32f, -9.02f, -27.32f, -9.02f })]
+        [InlineData(1, new float[] { 95f, 231f, 367f, 503f })]
+        public void MatMulPATest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[test];
+            AlignedArray dst = new AlignedArray(4, SseCbAlign);
+            int[] idx = testIndexArray;
+
+            CpuMathUtils.MatTimesSrc(false, false, mat, idx, src, 0, 0, 2 + 2 * test, dst, dst.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new float[] { -27.32f, -8.02f, -25.32f, -6.02f })]
+        [InlineData(1, new float[] { 95f, 232f, 369f, 506f })]
+        public void MatMulPAAddTest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[test];
+            AlignedArray dst = new AlignedArray(4, SseCbAlign);
+            int[] idx = testIndexArray;
+
+            for (int i = 0; i < dst.Size; i++)
+            {
+                dst[i] = i;
+            }
+
+            CpuMathUtils.MatTimesSrc(false, true, mat, idx, src, 0, 0, 2 + 2 * test, dst, dst.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new float[] { 7.84f, -9.52f, -39.04f, 55.36f })]
+        [InlineData(1, new float[] { 52f, 56f, 60f, 64f, 68f, 72f, 76f, 80f })]
+        public void MatMulTranPATest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[0];
+            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
+            int[] idx = testIndexArray;
+
+            CpuMathUtils.MatTimesSrc(true, false, mat, idx, src, 0, 0, 2, dst, src.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new float[] { 7.84f, -8.52f, -37.04f, 58.36f })]
+        [InlineData(1, new float[] { 52f, 57f, 62f, 67f, 72f, 77f, 82f, 87f })]
+        public void MatMulTranPAAddTest(int test, float[] expected)
+        {
+            AlignedArray mat = testMatrices[test];
+            AlignedArray src = testSrcVectors[0];
+            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
+            int[] idx = testIndexArray;
+
+            for (int i = 0; i < dst.Size; i++)
+            {
+                dst[i] = i;
+            }
+
+            CpuMathUtils.MatTimesSrc(true, true, mat, idx, src, 0, 0, 2, dst, src.Size);
+            float[] actual = new float[dst.Size];
+            dst.CopyTo(actual, 0, dst.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void AddScalarUTest(int test)
+        {
+            float[] dst = (float[])testArrays[test].Clone();
+            float[] expected = (float[])dst.Clone();
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] += DEFAULT_SCALE;
+            }
+
+            CpuMathUtils.Add(DEFAULT_SCALE, dst, dst.Length);
+            var actual = dst;
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ScaleUTest(int test)
+        {
+            float[] dst = (float[])testArrays[test].Clone();
+            float[] expected = (float[])dst.Clone();
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] *= DEFAULT_SCALE;
+            }
+
+            CpuMathUtils.Scale(DEFAULT_SCALE, dst, dst.Length);
+            var actual = dst;
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ScaleSrcUTest(int test)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            float[] dst = (float[])src.Clone();
+            float[] expected = (float[])dst.Clone();
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] *= DEFAULT_SCALE;
+            }
+
+            CpuMathUtils.Scale(DEFAULT_SCALE, src, dst, dst.Length);
+            var actual = dst;
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ScaleAddUTest(int test)
+        {
+            float[] dst = (float[])testArrays[test].Clone();
+            float[] expected = (float[])dst.Clone();
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] = DEFAULT_SCALE * (dst[i] + DEFAULT_SCALE);
+            }
+
+            CpuMathUtils.ScaleAdd(DEFAULT_SCALE, DEFAULT_SCALE, dst, dst.Length);
+            var actual = dst;
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void AddScaleUTest(int test)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            float[] dst = (float[])src.Clone();
+            float[] expected = (float[])dst.Clone();
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] *= (1 + DEFAULT_SCALE);
+            }
+
+            CpuMathUtils.AddScale(DEFAULT_SCALE, src, dst, dst.Length);
+            var actual = dst;
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void AddScaleSUTest(int test)
         {
             float[] src = (float[])testArrays[test].Clone();
             float[] dst = (float[])src.Clone();
             int[] idx = testIndexArray;
+            float[] expected = (float[])dst.Clone();
 
-            // Ensures src and dst are different arrays
-            for (int i = 0; i < dst.Length; i++)
-            {
-                dst[i] += 1;
-            }
+            expected[0] = 5.292f;
+            expected[2] = -13.806f;
+            expected[5] = -43.522f;
+            expected[6] = 55.978f;
 
-            var actual = CpuMathUtils.DotProductSparse(src, dst, idx, idx.Length);
-            Assert.Equal(expected, actual, 4);
+            CpuMathUtils.AddScale(DEFAULT_SCALE, src, idx, dst, idx.Length);
+            var actual = dst;
+            Assert.Equal(expected, actual, comparer);
         }
 
         [Theory]
-        [InlineData(0, 13399.9376f)]
-        [InlineData(1, 13389.1135f)]
-        public void SumSqUTest(int test, float expected)
+        [InlineData(0)]
+        [InlineData(1)]
+        public void AddScaleCopyUTest(int test)
         {
             float[] src = (float[])testArrays[test].Clone();
-            var actual = CpuMathUtils.SumSq(src, src.Length);
-            Assert.Equal(expected, actual, 2);
+            float[] dst = (float[])src.Clone();
+            float[] result = (float[])dst.Clone();
+            float[] expected = (float[])dst.Clone();
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] *= (1 + DEFAULT_SCALE);
+            }
+
+            CpuMathUtils.AddScaleCopy(DEFAULT_SCALE, src, dst, result, dst.Length);
+            var actual = result;
+            Assert.Equal(expected, actual, comparer);
         }
 
         [Theory]
@@ -121,91 +381,6 @@ namespace Microsoft.ML.CpuMath.UnitTests
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
-        public void AddScaleUTest(int test)
-        {
-            float[] src = (float[])testArrays[test].Clone();
-            float[] dst = (float[])src.Clone();
-            float[] expected = (float[])dst.Clone();
-
-            for (int i = 0; i < expected.Length; i++)
-            {
-                expected[i] *= (1 + DEFAULT_SCALE);
-            }
-
-            CpuMathUtils.AddScale(DEFAULT_SCALE, src, dst, dst.Length);
-            var actual = dst;
-            Assert.Equal(expected, actual, comparer);
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        public void AddScaleSUTest(int test)
-        {
-            float[] src = (float[])testArrays[test].Clone();
-            float[] dst = (float[])src.Clone();
-            int[] idx = testIndexArray;
-            float[] expected = (float[])dst.Clone();
-
-            expected[0] = 5.292f;
-            expected[2] = -13.806f;
-            expected[5] = -43.522f;
-            expected[6] = 55.978f;
-
-            CpuMathUtils.AddScale(DEFAULT_SCALE, src, idx, dst, idx.Length);
-            var actual = dst;
-            Assert.Equal(expected, actual, comparer);
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        public void ScaleUTest(int test)
-        {
-            float[] dst = (float[])testArrays[test].Clone();
-            float[] expectedOutput = (float[])dst.Clone();
-
-            for (int i = 0; i < expectedOutput.Length; i++)
-            {
-                expectedOutput[i] *= DEFAULT_SCALE;
-            }
-
-            CpuMathUtils.Scale(DEFAULT_SCALE, dst, dst.Length);
-            var managedOutput = dst;
-            Assert.Equal(expectedOutput, managedOutput, comparer);
-        }
-
-        [Theory]
-        [InlineData(0, 8.0f)]
-        [InlineData(1, 7.0f)]
-        public void Dist2Test(int test, float expected)
-        {
-            float[] src = (float[])testArrays[test].Clone();
-            float[] dst = (float[])src.Clone();
-
-            // Ensures src and dst are different arrays
-            for (int i = 0; i < dst.Length; i++)
-            {
-                dst[i] += 1;
-            }
-
-            var actual = CpuMathUtils.L2DistSquared(src, dst, dst.Length);
-            Assert.Equal(expected, actual, 0);
-        }
-
-        [Theory]
-        [InlineData(0, 196.98f)]
-        [InlineData(1, 193.69f)]
-        public void SumAbsUTest(int test, float expected)
-        {
-            float[] src = (float[])testArrays[test].Clone();
-            var actual = CpuMathUtils.SumAbs(src, src.Length);
-            Assert.Equal(expected, actual, 2);
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
         public void MulElementWiseUTest(int test)
         {
             float[] src1 = (float[])testArrays[test].Clone();
@@ -227,6 +402,202 @@ namespace Microsoft.ML.CpuMath.UnitTests
 
             CpuMathUtils.MulElementWise(src1, src2, dst, dst.Length);
             var actual = dst;
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, -93.9f)]
+        [InlineData(1, -97.19f)]
+        public void SumUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            var actual = CpuMathUtils.Sum(src, src.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 13399.9376f)]
+        [InlineData(1, 13389.1135f)]
+        public void SumSqUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            var actual = CpuMathUtils.SumSq(src, src.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 13742.3176f)]
+        [InlineData(1, 13739.7895f)]
+        public void SumSqDiffUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            var actual = CpuMathUtils.SumSq(DEFAULT_SCALE, src, 0, src.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 196.98f)]
+        [InlineData(1, 193.69f)]
+        public void SumAbsUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            var actual = CpuMathUtils.SumAbs(src, src.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 196.98f)]
+        [InlineData(1, 195.39f)]
+        public void SumAbsDiffUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            var actual = CpuMathUtils.SumAbs(DEFAULT_SCALE, src, 0, src.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 106.37f)]
+        [InlineData(1, 106.37f)]
+        public void MaxAbsUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            var actual = CpuMathUtils.MaxAbs(src, src.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 108.07f)]
+        [InlineData(1, 108.07f)]
+        public void MaxAbsDiffUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            var actual = CpuMathUtils.MaxAbsDiff(DEFAULT_SCALE, src, src.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 13306.0376f)]
+        [InlineData(1, 13291.9235f)]
+        public void DotUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            float[] dst = (float[])src.Clone();
+
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] += 1;
+            }
+
+            var actual = CpuMathUtils.DotProductDense(src, dst, dst.Length);
+            Assert.Equal(expected, actual, 2);
+        }
+
+        [Theory]
+        [InlineData(0, 736.7352f)]
+        [InlineData(1, 736.7352f)]
+        public void DotSUTest(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            float[] dst = (float[])src.Clone();
+            int[] idx = testIndexArray;
+
+            // Ensures src and dst are different arrays
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] += 1;
+            }
+
+            var actual = CpuMathUtils.DotProductSparse(src, dst, idx, idx.Length);
+            Assert.Equal(expected, actual, 4);
+        }
+
+        [Theory]
+        [InlineData(0, 8.0f)]
+        [InlineData(1, 7.0f)]
+        public void Dist2Test(int test, float expected)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            float[] dst = (float[])src.Clone();
+
+            // Ensures src and dst are different arrays
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] += 1;
+            }
+
+            var actual = CpuMathUtils.L2DistSquared(src, dst, dst.Length);
+            Assert.Equal(expected, actual, 0);
+        }
+
+        [Theory]
+        [InlineData(0, new int[] { 0, 2 }, new float[] { 0f, 2f, 0f, 4f })]
+        [InlineData(1, new int[] { 0, 2, 5, 6 }, new float[] { 0f, 2f, 0f, 4f, 5f, 0f, 0f, 8f })]
+        public void ZeroItemsUTest(int test, int[] idx, float[] expected)
+        {
+            AlignedArray src = new AlignedArray(4 + 4 * test, SseCbAlign);
+            src.CopyFrom(testSrcVectors[test]);
+
+            CpuMathUtils.ZeroMatrixItems(src, src.Size, src.Size, idx);
+            float[] actual = new float[src.Size];
+            src.CopyTo(actual, 0, src.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0, new int[] { 0, 1 }, new float[] { 0f, 2f, 0f, 4f })]
+        [InlineData(1, new int[] { 0, 2, 4 }, new float[] { 0f, 2f, 0f, 4f, 5f, 0f, 7f, 8f })]
+        public void ZeroMatrixItemsCoreTest(int test, int[] idx, float[] expected)
+        {
+            AlignedArray src = new AlignedArray(4 + 4 * test, SseCbAlign);
+            src.CopyFrom(testSrcVectors[test]);
+
+            CpuMathUtils.ZeroMatrixItems(src, src.Size / 2 - 1, src.Size / 2, idx);
+            float[] actual = new float[src.Size];
+            src.CopyTo(actual, 0, src.Size);
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void SdcaL1UpdateUTest(int test)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            float[] v = (float[])src.Clone();
+            float[] w = (float[])src.Clone();
+            float[] expected = (float[])w.Clone();
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                float value = src[i] * (1 + DEFAULT_SCALE);
+                expected[i] = Math.Abs(value) > DEFAULT_SCALE ? (value > 0 ? value - DEFAULT_SCALE : value + DEFAULT_SCALE) : 0;
+            }
+
+            CpuMathUtils.SdcaL1UpdateDense(DEFAULT_SCALE, src.Length, src, DEFAULT_SCALE, v, w);
+            var actual = w;
+            Assert.Equal(expected, actual, comparer);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void SdcaL1UpdateSUTest(int test)
+        {
+            float[] src = (float[])testArrays[test].Clone();
+            float[] v = (float[])src.Clone();
+            float[] w = (float[])src.Clone();
+            int[] idx = testIndexArray;
+            float[] expected = (float[])w.Clone();
+
+            for (int i = 0; i < idx.Length; i++)
+            {
+                int index = idx[i];
+                float value = v[index] + src[i] * DEFAULT_SCALE;
+                expected[index] = Math.Abs(value) > DEFAULT_SCALE ? (value > 0 ? value - DEFAULT_SCALE : value + DEFAULT_SCALE) : 0;
+            }
+
+            CpuMathUtils.SdcaL1UpdateSparse(DEFAULT_SCALE, src.Length, src, idx, idx.Length, DEFAULT_SCALE, v, w);
+            var actual = w;
             Assert.Equal(expected, actual, comparer);
         }
     }

--- a/test/Microsoft.ML.CpuMath.UnitTests.netstandard/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netstandard/UnitTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ML.CpuMath.UnitTests
         private readonly int[] testIndexArray;
         private readonly AlignedArray[] testMatrices;
         private readonly AlignedArray[] testSrcVectors;
+        private readonly AlignedArray[] testDstVectors;
         private const float DEFAULT_SCALE = 1.7f;
         private const int SseCbAlign = 16;
         private FloatEqualityComparer comparer;
@@ -56,16 +57,28 @@ namespace Microsoft.ML.CpuMath.UnitTests
             testSrcVectorAligned2.CopyFrom(testSrcVector2, 0, testSrcVector2.Length);
 
             testSrcVectors = new AlignedArray[] { testSrcVectorAligned1, testSrcVectorAligned2 };
+
+            // Padded destination vectors whose dimensions are multiples of 4
+            float[] testDstVector1 = new float[4] { 0f, 1f, 2f, 3f };
+            float[] testDstVector2 = new float[8] { 0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f };
+
+            AlignedArray testDstVectorAligned1 = new AlignedArray(4, SseCbAlign);
+            AlignedArray testDstVectorAligned2 = new AlignedArray(8, SseCbAlign);
+            testDstVectorAligned1.CopyFrom(testDstVector1, 0, testDstVector1.Length);
+            testDstVectorAligned2.CopyFrom(testDstVector2, 0, testDstVector2.Length);
+
+            testDstVectors = new AlignedArray[] { testDstVectorAligned1, testDstVectorAligned2 };
         }
 
         [Theory]
-        [InlineData(0, new float[] { 23.28f, -49.72f, 23.28f, -49.72f })]
-        [InlineData(1, new float[] { 204f, 492f, 780f, 1068f })]
-        public void MatMulATest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { 23.28f, -49.72f, 23.28f, -49.72f })]
+        [InlineData(1, 1, 0, new float[] { 204f, 492f, 780f, 1068f })]
+        [InlineData(1, 0, 1, new float[] { 30f, 70f, 110f, 150f, 190f, 230f, 270f, 310f })]
+        public void MatMulATest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[test];
-            AlignedArray dst = new AlignedArray(4, SseCbAlign);
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
 
             CpuMathUtils.MatTimesSrc(false, false, mat, src, dst, dst.Size);
             float[] actual = new float[dst.Size];
@@ -74,18 +87,14 @@ namespace Microsoft.ML.CpuMath.UnitTests
         }
 
         [Theory]
-        [InlineData(0, new float[] { 23.28f, -48.72f, 25.28f, -46.72f })]
-        [InlineData(1, new float[] { 204f, 493f, 782f, 1071f })]
-        public void MatMulAAddTest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { 23.28f, -48.72f, 25.28f, -46.72f })]
+        [InlineData(1, 1, 0, new float[] { 204f, 493f, 782f, 1071f })]
+        [InlineData(1, 0, 1, new float[] { 30f, 71f, 112f, 153f, 194f, 235f, 276f, 317f })]
+        public void MatMulAAddTest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[test];
-            AlignedArray dst = new AlignedArray(4, SseCbAlign);
-
-            for (int i = 0; i < dst.Size; i++)
-            {
-                dst[i] = i;
-            }
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
 
             CpuMathUtils.MatTimesSrc(false, true, mat, src, dst, dst.Size);
             float[] actual = new float[dst.Size];
@@ -94,13 +103,14 @@ namespace Microsoft.ML.CpuMath.UnitTests
         }
 
         [Theory]
-        [InlineData(0, new float[] { -630.38f, -171.1f, 155.66f, 75.1f })]
-        [InlineData(1, new float[] { 170f, 180f, 190f, 200f, 210f, 220f, 230f, 240f })]
-        public void MatMulTranATest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { -630.38f, -171.1f, 155.66f, 75.1f })]
+        [InlineData(1, 0, 1, new float[] { 170f, 180f, 190f, 200f, 210f, 220f, 230f, 240f })]
+        [InlineData(1, 1, 0, new float[] { 708f, 744f, 780f, 816f })]
+        public void MatMulTranATest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[0];
-            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
 
             CpuMathUtils.MatTimesSrc(true, false, mat, src, dst, src.Size);
             float[] actual = new float[dst.Size];
@@ -109,18 +119,14 @@ namespace Microsoft.ML.CpuMath.UnitTests
         }
 
         [Theory]
-        [InlineData(0, new float[] { -630.38f, -170.1f, 157.66f, 78.1f })]
-        [InlineData(1, new float[] { 170f, 181f, 192f, 203f, 214f, 225f, 236f, 247f })]
-        public void MatMulTranAAddTest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { -630.38f, -170.1f, 157.66f, 78.1f })]
+        [InlineData(1, 0, 1, new float[] { 170f, 181f, 192f, 203f, 214f, 225f, 236f, 247f })]
+        [InlineData(1, 1, 0, new float[] { 708f, 745f, 782f, 819f })]
+        public void MatMulTranAAddTest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[0];
-            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
-
-            for (int i = 0; i < dst.Size; i++)
-            {
-                dst[i] = i;
-            }
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
 
             CpuMathUtils.MatTimesSrc(true, true, mat, src, dst, src.Size);
             float[] actual = new float[dst.Size];
@@ -129,74 +135,68 @@ namespace Microsoft.ML.CpuMath.UnitTests
         }
 
         [Theory]
-        [InlineData(0, new float[] { -27.32f, -9.02f, -27.32f, -9.02f })]
-        [InlineData(1, new float[] { 95f, 231f, 367f, 503f })]
-        public void MatMulPATest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { -27.32f, -9.02f, -27.32f, -9.02f })]
+        [InlineData(1, 1, 0, new float[] { 95f, 231f, 367f, 503f })]
+        [InlineData(1, 0, 1, new float[] { 10f, 26f, 42f, 58f, 74f, 90f, 106f, 122f })]
+        public void MatMulPATest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[test];
-            AlignedArray dst = new AlignedArray(4, SseCbAlign);
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
             int[] idx = testIndexArray;
 
-            CpuMathUtils.MatTimesSrc(false, false, mat, idx, src, 0, 0, 2 + 2 * test, dst, dst.Size);
+            CpuMathUtils.MatTimesSrc(false, false, mat, idx, src, 0, 0, 2 + 2 * srcTest, dst, dst.Size);
             float[] actual = new float[dst.Size];
             dst.CopyTo(actual, 0, dst.Size);
             Assert.Equal(expected, actual, comparer);
         }
 
         [Theory]
-        [InlineData(0, new float[] { -27.32f, -8.02f, -25.32f, -6.02f })]
-        [InlineData(1, new float[] { 95f, 232f, 369f, 506f })]
-        public void MatMulPAAddTest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { -27.32f, -8.02f, -25.32f, -6.02f })]
+        [InlineData(1, 1, 0, new float[] { 95f, 232f, 369f, 506f })]
+        [InlineData(1, 0, 1, new float[] { 10f, 27f, 44f, 61f, 78f, 95f, 112f, 129f })]
+        public void MatMulPAAddTest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[test];
-            AlignedArray dst = new AlignedArray(4, SseCbAlign);
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
             int[] idx = testIndexArray;
 
-            for (int i = 0; i < dst.Size; i++)
-            {
-                dst[i] = i;
-            }
-
-            CpuMathUtils.MatTimesSrc(false, true, mat, idx, src, 0, 0, 2 + 2 * test, dst, dst.Size);
+            CpuMathUtils.MatTimesSrc(false, true, mat, idx, src, 0, 0, 2 + 2 * srcTest, dst, dst.Size);
             float[] actual = new float[dst.Size];
             dst.CopyTo(actual, 0, dst.Size);
             Assert.Equal(expected, actual, comparer);
         }
 
         [Theory]
-        [InlineData(0, new float[] { 7.84f, -9.52f, -39.04f, 55.36f })]
-        [InlineData(1, new float[] { 52f, 56f, 60f, 64f, 68f, 72f, 76f, 80f })]
-        public void MatMulTranPATest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { 7.84f, -9.52f, -39.04f, 55.36f })]
+        [InlineData(1, 0, 1, new float[] { 52f, 56f, 60f, 64f, 68f, 72f, 76f, 80f })]
+        [InlineData(1, 1, 0, new float[] { 329f, 346f, 363f, 380f })]
+        public void MatMulTranPATest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[0];
-            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
             int[] idx = testIndexArray;
 
-            CpuMathUtils.MatTimesSrc(true, false, mat, idx, src, 0, 0, 2, dst, src.Size);
+            CpuMathUtils.MatTimesSrc(true, false, mat, idx, src, 0, 0, 2 + 2 * srcTest, dst, src.Size);
             float[] actual = new float[dst.Size];
             dst.CopyTo(actual, 0, dst.Size);
             Assert.Equal(expected, actual, comparer);
         }
 
         [Theory]
-        [InlineData(0, new float[] { 7.84f, -8.52f, -37.04f, 58.36f })]
-        [InlineData(1, new float[] { 52f, 57f, 62f, 67f, 72f, 77f, 82f, 87f })]
-        public void MatMulTranPAAddTest(int test, float[] expected)
+        [InlineData(0, 0, 0, new float[] { 7.84f, -8.52f, -37.04f, 58.36f })]
+        [InlineData(1, 0, 1, new float[] { 52f, 57f, 62f, 67f, 72f, 77f, 82f, 87f })]
+        [InlineData(1, 1, 0, new float[] { 329f, 347f, 365f, 383f })]
+        public void MatMulTranPAAddTest(int matTest, int srcTest, int dstTest, float[] expected)
         {
-            AlignedArray mat = testMatrices[test];
-            AlignedArray src = testSrcVectors[0];
-            AlignedArray dst = new AlignedArray(4 + 4 * test, SseCbAlign);
+            AlignedArray mat = testMatrices[matTest];
+            AlignedArray src = testSrcVectors[srcTest];
+            AlignedArray dst = testDstVectors[dstTest];
             int[] idx = testIndexArray;
 
-            for (int i = 0; i < dst.Size; i++)
-            {
-                dst[i] = i;
-            }
-
-            CpuMathUtils.MatTimesSrc(true, true, mat, idx, src, 0, 0, 2, dst, src.Size);
+            CpuMathUtils.MatTimesSrc(true, true, mat, idx, src, 0, 0, 2 + 2 * srcTest, dst, src.Size);
             float[] actual = new float[dst.Size];
             dst.CopyTo(actual, 0, dst.Size);
             Assert.Equal(expected, actual, comparer);

--- a/test/Microsoft.ML.CpuMath.UnitTests.netstandard/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netstandard/UnitTests.cs
@@ -30,7 +30,8 @@ namespace Microsoft.ML.CpuMath.UnitTests
             comparer = new FloatEqualityComparer();
 
             // Padded matrices whose dimensions are multiples of 4
-            float[] testMatrix1 = new float[4 * 4] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f };
+            float[] testMatrix1 = new float[4 * 4] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f,
+                1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f };
             float[] testMatrix2 = new float[4 * 8];
 
             for (int i = 0; i < testMatrix2.Length; i++)


### PR DESCRIPTION
### What's new:
1. Implemented all remaining active SSE intrinsics, including their software fallbacks and passing unit tests
2. Implemented the performance tests of all remaining active SSE intrinsics, except for those that accept `AlignedArray` as an argument
3. Performance test results for all applicable, active SSE intrinsics are updated in https://github.com/briancylui/machinelearning/issues/1

### Description from https://github.com/dotnet/machinelearning/pull/562:
- with unit tests and performance tests for two target frameworks: .NET Core App 3.0 and .NET Standard 2.0.
- .NET Core App 3.0 gets the new C# hardware intrinsics APIs, while .NET Standard 2.0 gets the original native SIMD algorithms.
- Several things have made this multi-targeting feature possible.
   1. The new CpuMathUtils class that contains the new APIs is implemented as a partial class with method definitions split into two separate files (src\Microsoft.ML.CpuMath\CpuMathUtils.[target].cs), only one of which is compiled based on the target framework.
   2. The Microsoft.ML.CpuMath.csproj file makes the switching decision to compile the right files based on the target framework.

### Structure:
1. All new hardware intrinsics APIs are contained in src\Microsoft.ML.CpuMath.
2. Unit tests for the two target frameworks live in test\Microsoft.ML.CpuMath.UnitTests.[target], and contain the same content except for the target framework in .csproj.
3. Performance tests live in test\Microsoft.ML.CpuMath.PerformanceTests.

### Changes to users:
1. Originally, users call intrinsics APIs via the SseUtils class in src\Microsoft.ML.CpuMath\Sse.cs, but now they call them via the new CpuMathUtils class, which will handle switching between SSE and AVX in the future.
2. CpuMathUtils methods and SseUtils methods share the same signature, but CpuMathUtils methods additionally call a new helper class (SseIntrinsics) for C# implementations of SSE operations.

### Future follow-up for `CpuMath` enhancement
1. Suggestions on `CpuMath` enhancement in this PR scheduled for future follow-ups have been compiled into an issue page (https://github.com/briancylui/machinelearning/issues/2).

### List of new SSE intrinisics implemented
•	MatMulA
•	MatMulTranA
•	MatMulPA
•	MatMulTranPA
•	SdcaL1UpdateU
•	SdcaL1UpdateSU
•	AddScaleCopyU
•	SumU
•	AddScalarU
•	SumSqDiffU
•	SumAbsDiffU
•	MaxAbsDiffU
•	MaxAbsU
•	ScaleSrcU
•	ScaleAddU
•	ZeroItemsU
•	ZeroMatrixItemsCoreU

cc: @eerhardt @tannergooding @safern @danmosemsft 