### PR TITLE
 Move Scorers and Calibrators to use IComponentFactory.

### DIFF
--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -1297,6 +1297,41 @@ namespace Microsoft.ML.Runtime.CommandLine
                 typeBase.IsEnum;
         }
 
+        /// <summary>
+        /// Creates an ICommandLineComponentFactory given the factory type, signature type,
+        /// and a command line string.
+        /// </summary>
+        public static ICommandLineComponentFactory CreateComponentFactory(
+            Type factoryType,
+            Type signatureType,
+            string settings)
+        {
+            ParseComponentStrings(settings, out string name, out string args);
+
+            string[] argsArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : new string[] { args };
+
+            return ComponentFactoryFactory.CreateComponentFactory(factoryType, signatureType, name, argsArray);
+        }
+
+        private static void ParseComponentStrings(string str, out string kind, out string args)
+        {
+            kind = args = null;
+            if (string.IsNullOrWhiteSpace(str))
+                return;
+            str = str.Trim();
+            int ich = str.IndexOf('{');
+            if (ich < 0)
+            {
+                kind = str;
+                return;
+            }
+            if (ich == 0 || str[str.Length - 1] != '}')
+                throw Contracts.Except("Invalid Component string: mismatched braces, or empty component name.");
+
+            kind = str.Substring(0, ich);
+            args = CmdLexer.UnquoteValue(str.Substring(ich));
+        }
+
         private sealed class ArgValue
         {
             public readonly string FirstValue;
@@ -1838,155 +1873,6 @@ namespace Microsoft.ML.Runtime.CommandLine
                 }
 
                 return error;
-            }
-
-            /// <summary>
-            /// A factory class for creating IComponentFactory instances.
-            /// </summary>
-            private static class ComponentFactoryFactory
-            {
-                public static IComponentFactory CreateComponentFactory(
-                    Type factoryType,
-                    Type signatureType,
-                    string name,
-                    string[] settings)
-                {
-                    Contracts.Check(factoryType != null &&
-                        typeof(IComponentFactory).IsAssignableFrom(factoryType) &&
-                        factoryType.IsGenericType);
-
-                    Type componentFactoryType;
-                    switch (factoryType.GenericTypeArguments.Length)
-                    {
-                        case 1: componentFactoryType = typeof(ComponentFactory<>); break;
-                        case 2: componentFactoryType = typeof(ComponentFactory<,>); break;
-                        case 3: componentFactoryType = typeof(ComponentFactory<,,>); break;
-                        case 4: componentFactoryType = typeof(ComponentFactory<,,,>); break;
-                        default: throw Contracts.ExceptNotImpl("ComponentFactoryFactory can only create component factories with 4 or less type args.");
-                    }
-
-                    return (IComponentFactory)Activator.CreateInstance(
-                        componentFactoryType.MakeGenericType(factoryType.GenericTypeArguments),
-                        signatureType,
-                        name,
-                        settings);
-                }
-
-                private abstract class ComponentFactory : ICommandLineComponentFactory
-                {
-                    public Type SignatureType { get; }
-                    public string Name { get; }
-                    private string[] Settings { get; }
-
-                    protected ComponentFactory(Type signatureType, string name, string[] settings)
-                    {
-                        SignatureType = signatureType;
-                        Name = name;
-
-                        if (settings == null || (settings.Length == 1 && string.IsNullOrEmpty(settings[0])))
-                        {
-                            settings = Array.Empty<string>();
-                        }
-                        Settings = settings;
-                    }
-
-                    public string GetSettingsString()
-                    {
-                        return CombineSettings(Settings);
-                    }
-
-                    public override string ToString()
-                    {
-                        if (string.IsNullOrEmpty(Name) && Settings.Length == 0)
-                            return "{}";
-
-                        if (Settings.Length == 0)
-                            return Name;
-
-                        string str = CombineSettings(Settings);
-                        StringBuilder sb = new StringBuilder();
-                        CmdQuoter.QuoteValue(str, sb, true);
-                        return Name + sb.ToString();
-                    }
-                }
-
-                private class ComponentFactory<TComponent> : ComponentFactory, IComponentFactory<TComponent>
-                    where TComponent : class
-                {
-                    public ComponentFactory(Type signatureType, string name, string[] settings)
-                        : base(signatureType, name, settings)
-                    {
-                    }
-
-                    public TComponent CreateComponent(IHostEnvironment env)
-                    {
-                        return ComponentCatalog.CreateInstance<TComponent>(
-                            env,
-                            SignatureType,
-                            Name,
-                            GetSettingsString());
-                    }
-                }
-
-                private class ComponentFactory<TArg1, TComponent> : ComponentFactory, IComponentFactory<TArg1, TComponent>
-                    where TComponent : class
-                {
-                    public ComponentFactory(Type signatureType, string name, string[] settings)
-                        : base(signatureType, name, settings)
-                    {
-                    }
-
-                    public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1)
-                    {
-                        return ComponentCatalog.CreateInstance<TComponent>(
-                            env,
-                            SignatureType,
-                            Name,
-                            GetSettingsString(),
-                            argument1);
-                    }
-                }
-
-                private class ComponentFactory<TArg1, TArg2, TComponent> : ComponentFactory, IComponentFactory<TArg1, TArg2, TComponent>
-                    where TComponent : class
-                {
-                    public ComponentFactory(Type signatureType, string name, string[] settings)
-                        : base(signatureType, name, settings)
-                    {
-                    }
-
-                    public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2)
-                    {
-                        return ComponentCatalog.CreateInstance<TComponent>(
-                            env,
-                            SignatureType,
-                            Name,
-                            GetSettingsString(),
-                            argument1,
-                            argument2);
-                    }
-                }
-
-                private class ComponentFactory<TArg1, TArg2, TArg3, TComponent> : ComponentFactory, IComponentFactory<TArg1, TArg2, TArg3, TComponent>
-                    where TComponent : class
-                {
-                    public ComponentFactory(Type signatureType, string name, string[] settings)
-                        : base(signatureType, name, settings)
-                    {
-                    }
-
-                    public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2, TArg3 argument3)
-                    {
-                        return ComponentCatalog.CreateInstance<TComponent>(
-                            env,
-                            SignatureType,
-                            Name,
-                            GetSettingsString(),
-                            argument1,
-                            argument2,
-                            argument3);
-                    }
-                }
             }
 
             private bool ReportMissingRequiredArgument(CmdParser owner, ArgValue val)
@@ -2622,6 +2508,155 @@ namespace Microsoft.ML.Runtime.CommandLine
 
             public bool IsCustomItemType {
                 get { return _infoCustom != null; }
+            }
+        }
+
+        /// <summary>
+        /// A factory class for creating IComponentFactory instances.
+        /// </summary>
+        private static class ComponentFactoryFactory
+        {
+            public static ICommandLineComponentFactory CreateComponentFactory(
+                Type factoryType,
+                Type signatureType,
+                string name,
+                string[] settings)
+            {
+                Contracts.Check(factoryType != null &&
+                    typeof(IComponentFactory).IsAssignableFrom(factoryType) &&
+                    factoryType.IsGenericType);
+
+                Type componentFactoryType;
+                switch (factoryType.GenericTypeArguments.Length)
+                {
+                    case 1: componentFactoryType = typeof(ComponentFactory<>); break;
+                    case 2: componentFactoryType = typeof(ComponentFactory<,>); break;
+                    case 3: componentFactoryType = typeof(ComponentFactory<,,>); break;
+                    case 4: componentFactoryType = typeof(ComponentFactory<,,,>); break;
+                    default: throw Contracts.ExceptNotImpl("ComponentFactoryFactory can only create component factories with 4 or less type args.");
+                }
+
+                return (ICommandLineComponentFactory)Activator.CreateInstance(
+                    componentFactoryType.MakeGenericType(factoryType.GenericTypeArguments),
+                    signatureType,
+                    name,
+                    settings);
+            }
+
+            private abstract class ComponentFactory : ICommandLineComponentFactory
+            {
+                public Type SignatureType { get; }
+                public string Name { get; }
+                private string[] Settings { get; }
+
+                protected ComponentFactory(Type signatureType, string name, string[] settings)
+                {
+                    SignatureType = signatureType;
+                    Name = name;
+
+                    if (settings == null || (settings.Length == 1 && string.IsNullOrEmpty(settings[0])))
+                    {
+                        settings = Array.Empty<string>();
+                    }
+                    Settings = settings;
+                }
+
+                public string GetSettingsString()
+                {
+                    return CombineSettings(Settings);
+                }
+
+                public override string ToString()
+                {
+                    if (string.IsNullOrEmpty(Name) && Settings.Length == 0)
+                        return "{}";
+
+                    if (Settings.Length == 0)
+                        return Name;
+
+                    string str = CombineSettings(Settings);
+                    StringBuilder sb = new StringBuilder();
+                    CmdQuoter.QuoteValue(str, sb, true);
+                    return Name + sb.ToString();
+                }
+            }
+
+            private class ComponentFactory<TComponent> : ComponentFactory, IComponentFactory<TComponent>
+                where TComponent : class
+            {
+                public ComponentFactory(Type signatureType, string name, string[] settings)
+                    : base(signatureType, name, settings)
+                {
+                }
+
+                public TComponent CreateComponent(IHostEnvironment env)
+                {
+                    return ComponentCatalog.CreateInstance<TComponent>(
+                        env,
+                        SignatureType,
+                        Name,
+                        GetSettingsString());
+                }
+            }
+
+            private class ComponentFactory<TArg1, TComponent> : ComponentFactory, IComponentFactory<TArg1, TComponent>
+                where TComponent : class
+            {
+                public ComponentFactory(Type signatureType, string name, string[] settings)
+                    : base(signatureType, name, settings)
+                {
+                }
+
+                public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1)
+                {
+                    return ComponentCatalog.CreateInstance<TComponent>(
+                        env,
+                        SignatureType,
+                        Name,
+                        GetSettingsString(),
+                        argument1);
+                }
+            }
+
+            private class ComponentFactory<TArg1, TArg2, TComponent> : ComponentFactory, IComponentFactory<TArg1, TArg2, TComponent>
+                where TComponent : class
+            {
+                public ComponentFactory(Type signatureType, string name, string[] settings)
+                    : base(signatureType, name, settings)
+                {
+                }
+
+                public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2)
+                {
+                    return ComponentCatalog.CreateInstance<TComponent>(
+                        env,
+                        SignatureType,
+                        Name,
+                        GetSettingsString(),
+                        argument1,
+                        argument2);
+                }
+            }
+
+            private class ComponentFactory<TArg1, TArg2, TArg3, TComponent> : ComponentFactory, IComponentFactory<TArg1, TArg2, TArg3, TComponent>
+                where TComponent : class
+            {
+                public ComponentFactory(Type signatureType, string name, string[] settings)
+                    : base(signatureType, name, settings)
+                {
+                }
+
+                public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2, TArg3 argument3)
+                {
+                    return ComponentCatalog.CreateInstance<TComponent>(
+                        env,
+                        SignatureType,
+                        Name,
+                        GetSettingsString(),
+                        argument1,
+                        argument2,
+                        argument3);
+                }
             }
         }
     }

--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -1856,17 +1856,13 @@ namespace Microsoft.ML.Runtime.CommandLine
                         factoryType.IsGenericType);
 
                     Type componentFactoryType;
-                    if (factoryType.GenericTypeArguments.Length == 1)
+                    switch (factoryType.GenericTypeArguments.Length)
                     {
-                        componentFactoryType = typeof(ComponentFactory<>);
-                    }
-                    else if (factoryType.GenericTypeArguments.Length == 2)
-                    {
-                        componentFactoryType = typeof(ComponentFactory<,>);
-                    }
-                    else
-                    {
-                        throw Contracts.ExceptNotImpl("ComponentFactoryFactory can only create components with 1 or 2 type args.");
+                        case 1: componentFactoryType = typeof(ComponentFactory<>); break;
+                        case 2: componentFactoryType = typeof(ComponentFactory<,>); break;
+                        case 3: componentFactoryType = typeof(ComponentFactory<,,>); break;
+                        case 4: componentFactoryType = typeof(ComponentFactory<,,,>); break;
+                        default: throw Contracts.ExceptNotImpl("ComponentFactoryFactory can only create component factories with 4 or less type args.");
                     }
 
                     return (IComponentFactory)Activator.CreateInstance(
@@ -1948,6 +1944,47 @@ namespace Microsoft.ML.Runtime.CommandLine
                             Name,
                             GetSettingsString(),
                             argument1);
+                    }
+                }
+
+                private class ComponentFactory<TArg1, TArg2, TComponent> : ComponentFactory, IComponentFactory<TArg1, TArg2, TComponent>
+                    where TComponent : class
+                {
+                    public ComponentFactory(Type signatureType, string name, string[] settings)
+                        : base(signatureType, name, settings)
+                    {
+                    }
+
+                    public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2)
+                    {
+                        return ComponentCatalog.CreateInstance<TComponent>(
+                            env,
+                            SignatureType,
+                            Name,
+                            GetSettingsString(),
+                            argument1,
+                            argument2);
+                    }
+                }
+
+                private class ComponentFactory<TArg1, TArg2, TArg3, TComponent> : ComponentFactory, IComponentFactory<TArg1, TArg2, TArg3, TComponent>
+                    where TComponent : class
+                {
+                    public ComponentFactory(Type signatureType, string name, string[] settings)
+                        : base(signatureType, name, settings)
+                    {
+                    }
+
+                    public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2, TArg3 argument3)
+                    {
+                        return ComponentCatalog.CreateInstance<TComponent>(
+                            env,
+                            SignatureType,
+                            Name,
+                            GetSettingsString(),
+                            argument1,
+                            argument2,
+                            argument3);
                     }
                 }
             }

--- a/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
+++ b/src/Microsoft.ML.Core/EntryPoints/ComponentFactory.cs
@@ -64,4 +64,32 @@ namespace Microsoft.ML.Runtime.EntryPoints
     {
         TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2);
     }
+
+    /// <summary>
+    /// An interface for creating a component when we take three extra parameters (and an <see cref="IHostEnvironment"/>).
+    /// </summary>
+    public interface IComponentFactory<in TArg1, in TArg2, in TArg3, out TComponent> : IComponentFactory
+    {
+        TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2, TArg3 argument3);
+    }
+
+    /// <summary>
+    /// A class for creating a component when we take three extra parameters
+    /// (and an <see cref="IHostEnvironment"/>) that simply wraps a delegate which
+    /// creates the component.
+    /// </summary>
+    public class SimpleComponentFactory<TArg1, TArg2, TArg3, TComponent> : IComponentFactory<TArg1, TArg2, TArg3, TComponent>
+    {
+        private Func<IHostEnvironment, TArg1, TArg2, TArg3, TComponent> _factory;
+
+        public SimpleComponentFactory(Func<IHostEnvironment, TArg1, TArg2, TArg3, TComponent> factory)
+        {
+            _factory = factory;
+        }
+
+        public TComponent CreateComponent(IHostEnvironment env, TArg1 argument1, TArg2 argument2, TArg3 argument3)
+        {
+            return _factory(env, argument1, argument2, argument3);
+        }
+    }
 }

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -559,7 +559,8 @@ namespace Microsoft.ML.Runtime.Data
 
                     // Score.
                     ch.Trace("Scoring and evaluating");
-                    var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, _scorer as ICommandLineComponentFactory);
+                    ch.Assert(_scorer == null || _scorer is ICommandLineComponentFactory, "CrossValidationCommand should only be used from the command line.");
+                    var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, scorerFactorySettings: _scorer as ICommandLineComponentFactory);
                     ch.AssertValue(bindable);
                     var mapper = bindable.Bind(host, testData.Schema);
                     var scorerComp = _scorer ?? ScoreUtils.GetScorerComponent(mapper);

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -28,8 +28,8 @@ namespace Microsoft.ML.Runtime.Data
             [Argument(ArgumentType.Multiple, HelpText = "Trainer to use", ShortName = "tr")]
             public SubComponent<ITrainer, SignatureTrainer> Trainer = new SubComponent<ITrainer, SignatureTrainer>("AveragedPerceptron");
 
-            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SortOrder = 101)]
-            public SubComponent<IDataScorerTransform, SignatureDataScorer> Scorer;
+            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SortOrder = 101, SignatureType = typeof(SignatureDataScorer))]
+            public IComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform> Scorer;
 
             [Argument(ArgumentType.Multiple, HelpText = "Evaluator to use", ShortName = "eval", NullName = "<Auto>", SortOrder = 102)]
             public SubComponent<IMamlEvaluator, SignatureMamlEvaluator> Evaluator;
@@ -76,8 +76,8 @@ namespace Microsoft.ML.Runtime.Data
             [Argument(ArgumentType.AtMostOnce, IsInputFileName = true, HelpText = "The validation data file", ShortName = "valid")]
             public string ValidationFile;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>")]
-            public SubComponent<ICalibratorTrainer, SignatureCalibrator> Calibrator = new SubComponent<ICalibratorTrainer, SignatureCalibrator>("PlattCalibration");
+            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>", SignatureType = typeof(SignatureCalibrator))]
+            public IComponentFactory<ICalibratorTrainer> Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of instances to train the calibrator", ShortName = "numcali")]
             public int MaxCalibrationExamples = 1000000000;
@@ -383,9 +383,9 @@ namespace Microsoft.ML.Runtime.Data
             private readonly string _splitColumn;
             private readonly int _numFolds;
             private readonly SubComponent<ITrainer, SignatureTrainer> _trainer;
-            private readonly SubComponent<IDataScorerTransform, SignatureDataScorer> _scorer;
+            private readonly IComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform> _scorer;
             private readonly SubComponent<IMamlEvaluator, SignatureMamlEvaluator> _evaluator;
-            private readonly SubComponent<ICalibratorTrainer, SignatureCalibrator> _calibrator;
+            private readonly IComponentFactory<ICalibratorTrainer> _calibrator;
             private readonly int _maxCalibrationExamples;
             private readonly bool _useThreads;
             private readonly bool? _cacheData;
@@ -423,7 +423,7 @@ namespace Microsoft.ML.Runtime.Data
             Arguments args,
             Func<IHostEnvironment, IChannel, IDataView, ITrainer, RoleMappedData> createExamples,
             Func<IHostEnvironment, IChannel, IDataView, RoleMappedData, IDataView, RoleMappedData> applyTransformsToTestData,
-            SubComponent<IDataScorerTransform, SignatureDataScorer> scorer,
+            IComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform> scorer,
             SubComponent<IMamlEvaluator, SignatureMamlEvaluator> evaluator,
             Func<IDataView> getValidationDataView = null,
             Func<IHostEnvironment, IChannel, IDataView, RoleMappedData, IDataView, RoleMappedData> applyTransformsToValidationData = null,
@@ -559,11 +559,11 @@ namespace Microsoft.ML.Runtime.Data
 
                     // Score.
                     ch.Trace("Scoring and evaluating");
-                    var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, _scorer);
+                    var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, _scorer as ICommandLineComponentFactory);
                     ch.AssertValue(bindable);
                     var mapper = bindable.Bind(host, testData.Schema);
-                    var scorerComp = _scorer.IsGood() ? _scorer : ScoreUtils.GetScorerComponent(mapper);
-                    IDataScorerTransform scorePipe = scorerComp.CreateInstance(host, testData.Data, mapper, trainData.Schema);
+                    var scorerComp = _scorer ?? ScoreUtils.GetScorerComponent(mapper);
+                    IDataScorerTransform scorePipe = scorerComp.CreateComponent(host, testData.Data, mapper, trainData.Schema);
 
                     // Save per-fold model.
                     string modelFileName = ConstructPerFoldName(_outputModelFile, fold);

--- a/src/Microsoft.ML.Data/Commands/TestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TestCommand.cs
@@ -108,6 +108,7 @@ namespace Microsoft.ML.Runtime.Data
 
             // Score.
             ch.Trace("Scoring and evaluating");
+            ch.Assert(Args.Scorer == null || Args.Scorer is ICommandLineComponentFactory, "TestCommand should only be used from the command line.");
             IDataScorerTransform scorePipe = ScoreUtils.GetScorer(Args.Scorer, predictor, loader, features, group, customCols, Host, trainSchema);
 
             // Evaluate.

--- a/src/Microsoft.ML.Data/Commands/TestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TestCommand.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Command;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Utilities;
 
 [assembly: LoadableClass(TestCommand.Summary, typeof(TestCommand), typeof(TestCommand.Arguments), typeof(SignatureCommand),
@@ -37,8 +38,8 @@ namespace Microsoft.ML.Runtime.Data
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Columns with custom kinds declared through key assignments, e.g., col[Kind]=Name to assign column named 'Name' kind 'Kind'", ShortName = "col", SortOrder = 10)]
             public KeyValuePair<string, string>[] CustomColumn;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SortOrder = 101)]
-            public SubComponent<IDataScorerTransform, SignatureDataScorer> Scorer;
+            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SortOrder = 101, SignatureType = typeof(SignatureDataScorer))]
+            public IComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform> Scorer;
 
             [Argument(ArgumentType.Multiple, HelpText = "Evaluator to use", ShortName = "eval", NullName = "<Auto>", SortOrder = 102)]
             public SubComponent<IMamlEvaluator, SignatureMamlEvaluator> Evaluator;

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Command;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Calibration;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Model;
@@ -26,8 +27,8 @@ namespace Microsoft.ML.Runtime.Data
             [Argument(ArgumentType.Multiple, HelpText = "Trainer to use", ShortName = "tr")]
             public SubComponent<ITrainer, SignatureTrainer> Trainer = new SubComponent<ITrainer, SignatureTrainer>("AveragedPerceptron");
 
-            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SortOrder = 101)]
-            public SubComponent<IDataScorerTransform, SignatureDataScorer> Scorer;
+            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SortOrder = 101, SignatureType = typeof(SignatureDataScorer))]
+            public IComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform> Scorer;
 
             [Argument(ArgumentType.Multiple, HelpText = "Evaluator to use", ShortName = "eval", NullName = "<Auto>", SortOrder = 102)]
             public SubComponent<IMamlEvaluator, SignatureMamlEvaluator> Evaluator;
@@ -62,8 +63,8 @@ namespace Microsoft.ML.Runtime.Data
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Whether we should cache input training data", ShortName = "cache")]
             public bool? CacheData;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>")]
-            public SubComponent<ICalibratorTrainer, SignatureCalibrator> Calibrator = new SubComponent<ICalibratorTrainer, SignatureCalibrator>("PlattCalibration");
+            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>", SignatureType = typeof(SignatureCalibrator))]
+            public IComponentFactory<ICalibratorTrainer> Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of instances to train the calibrator", ShortName = "numcali")]
             public int MaxCalibrationExamples = 1000000000;

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -183,6 +183,7 @@ namespace Microsoft.ML.Runtime.Data
 
             // Score.
             ch.Trace("Scoring and evaluating");
+            ch.Assert(Args.Scorer == null || Args.Scorer is ICommandLineComponentFactory, "TrainTestCommand should only be used from the command line.");
             IDataScorerTransform scorePipe = ScoreUtils.GetScorer(Args.Scorer, predictor, testPipe, features, group, customCols, Host, data.Schema);
 
             // Evaluate.

--- a/src/Microsoft.ML.Data/EntryPoints/ScoreModel.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/ScoreModel.cs
@@ -79,14 +79,12 @@ namespace Microsoft.ML.Runtime.EntryPoints
             using (var ch = host.Start("Creating scoring pipeline"))
             {
                 ch.Trace("Creating pipeline");
-                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, scorerSettings: null);
+                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, scorerFactorySettings: null);
                 ch.AssertValue(bindable);
 
                 var mapper = bindable.Bind(host, data.Schema);
-                var scorer = ScoreUtils.GetScorerComponent(mapper);
-                Contracts.Assert(string.IsNullOrEmpty(scorer.SubComponentSettings));
-                scorer.SubComponentSettings = string.Format("suffix={{{0}}}", input.Suffix);
-                scoredPipe = scorer.CreateInstance(host, data.Data, mapper, input.PredictorModel.GetTrainingSchema(host));
+                var scorer = ScoreUtils.GetScorerComponent(mapper, input.Suffix);
+                scoredPipe = scorer.CreateComponent(host, data.Data, mapper, input.PredictorModel.GetTrainingSchema(host));
                 ch.Done();
             }
 
@@ -132,12 +130,12 @@ namespace Microsoft.ML.Runtime.EntryPoints
             using (var ch = host.Start("Creating scoring pipeline"))
             {
                 ch.Trace("Creating pipeline");
-                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, scorerSettings: null);
+                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, scorerFactorySettings: null);
                 ch.AssertValue(bindable);
 
                 var mapper = bindable.Bind(host, data.Schema);
                 var scorer = ScoreUtils.GetScorerComponent(mapper);
-                scoredPipe = scorer.CreateInstance(host, data.Data, mapper, input.PredictorModel.GetTrainingSchema(host));
+                scoredPipe = scorer.CreateComponent(host, data.Data, mapper, input.PredictorModel.GetTrainingSchema(host));
                 ch.Done();
             }
 

--- a/src/Microsoft.ML.Data/EntryPoints/ScoreModel.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/ScoreModel.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             using (var ch = host.Start("Creating scoring pipeline"))
             {
                 ch.Trace("Creating pipeline");
-                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, scorerFactorySettings: null);
+                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor);
                 ch.AssertValue(bindable);
 
                 var mapper = bindable.Bind(host, data.Schema);
@@ -130,7 +130,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             using (var ch = host.Start("Creating scoring pipeline"))
             {
                 ch.Trace("Creating pipeline");
-                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor, scorerFactorySettings: null);
+                var bindable = ScoreUtils.GetSchemaBindableMapper(host, predictor);
                 ch.AssertValue(bindable);
 
                 var mapper = bindable.Bind(host, data.Schema);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -622,14 +622,14 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
         public SchemaBindableCalibratedPredictor(IHostEnvironment env, IPredictorProducing<Single> predictor, ICalibrator calibrator)
             : base(env, LoaderSignature, predictor, calibrator)
         {
-            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor, null);
+            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor, scorerFactorySettings: null);
             _whatTheFeature = SubPredictor as IWhatTheFeatureValueMapper;
         }
 
         private SchemaBindableCalibratedPredictor(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, LoaderSignature, GetPredictor(env, ctx), GetCalibrator(env, ctx))
         {
-            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor, null);
+            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor, scorerFactorySettings: null);
             _whatTheFeature = SubPredictor as IWhatTheFeatureValueMapper;
         }
 
@@ -717,7 +717,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 return false;
             }
 
-            var bindable = ScoreUtils.GetSchemaBindableMapper(env, predictor, null);
+            var bindable = ScoreUtils.GetSchemaBindableMapper(env, predictor, scorerFactorySettings: null);
             var bound = bindable.Bind(env, schema);
             var outputSchema = bound.OutputSchema;
             int scoreCol;

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -622,14 +622,14 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
         public SchemaBindableCalibratedPredictor(IHostEnvironment env, IPredictorProducing<Single> predictor, ICalibrator calibrator)
             : base(env, LoaderSignature, predictor, calibrator)
         {
-            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor, scorerFactorySettings: null);
+            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor);
             _whatTheFeature = SubPredictor as IWhatTheFeatureValueMapper;
         }
 
         private SchemaBindableCalibratedPredictor(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, LoaderSignature, GetPredictor(env, ctx), GetCalibrator(env, ctx))
         {
-            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor, scorerFactorySettings: null);
+            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubPredictor);
             _whatTheFeature = SubPredictor as IWhatTheFeatureValueMapper;
         }
 
@@ -717,7 +717,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 return false;
             }
 
-            var bindable = ScoreUtils.GetSchemaBindableMapper(env, predictor, scorerFactorySettings: null);
+            var bindable = ScoreUtils.GetSchemaBindableMapper(env, predictor);
             var bound = bindable.Bind(env, schema);
             var outputSchema = bound.OutputSchema;
             int scoreCol;

--- a/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
@@ -194,13 +194,25 @@ namespace Microsoft.ML.Runtime.Data
             return Create(env, args, trainer, input, null);
         }
 
-        public static IDataTransform Create(IHostEnvironment env, Arguments args, IDataView input, IComponentFactory<IPredictor, ISchemaBindableMapper> mapperFactory = null)
+        public static IDataTransform Create(IHostEnvironment env, Arguments args, IDataView input)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(args, nameof(args));
             env.CheckUserArg(args.Trainer.IsGood(), nameof(args.Trainer),
                 "Trainer cannot be null. If your model is already trained, please use ScoreTransform instead.");
             env.CheckValue(input, nameof(input));
+
+            return Create(env, args, args.Trainer.CreateInstance(env), input, null);
+        }
+
+        public static IDataTransform Create(IHostEnvironment env, Arguments args, IDataView input, IComponentFactory<IPredictor, ISchemaBindableMapper> mapperFactory)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            env.CheckValue(args, nameof(args));
+            env.CheckUserArg(args.Trainer.IsGood(), nameof(args.Trainer),
+                "Trainer cannot be null. If your model is already trained, please use ScoreTransform instead.");
+            env.CheckValue(input, nameof(input));
+            env.CheckValueOrNull(mapperFactory);
 
             return Create(env, args, args.Trainer.CreateInstance(env), input, mapperFactory);
         }

--- a/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
@@ -191,10 +191,10 @@ namespace Microsoft.ML.Runtime.Data
                 GroupColumn = groupColumn
             };
 
-            return Create(env, args, trainer, input);
+            return Create(env, args, trainer, input, null);
         }
 
-        public static IDataTransform Create(IHostEnvironment env, Arguments args, IDataView input)
+        public static IDataTransform Create(IHostEnvironment env, Arguments args, IDataView input, IComponentFactory<IPredictor, ISchemaBindableMapper> mapperFactory = null)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(args, nameof(args));
@@ -202,10 +202,10 @@ namespace Microsoft.ML.Runtime.Data
                 "Trainer cannot be null. If your model is already trained, please use ScoreTransform instead.");
             env.CheckValue(input, nameof(input));
 
-            return Create(env, args, args.Trainer.CreateInstance(env), input);
+            return Create(env, args, args.Trainer.CreateInstance(env), input, mapperFactory);
         }
 
-        private static IDataTransform Create(IHostEnvironment env, Arguments args, ITrainer trainer, IDataView input)
+        private static IDataTransform Create(IHostEnvironment env, Arguments args, ITrainer trainer, IDataView input, IComponentFactory<IPredictor, ISchemaBindableMapper> mapperFactory)
         {
             Contracts.AssertValue(env, nameof(env));
             env.AssertValue(args, nameof(args));
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 ch.Done();
 
-                return ScoreUtils.GetScorer(args.Scorer, predictor, input, feat, group, customCols, env, data.Schema);
+                return ScoreUtils.GetScorer(args.Scorer, predictor, input, feat, group, customCols, env, data.Schema, mapperFactory);
             }
         }
 

--- a/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TrainAndScoreTransform.cs
@@ -36,8 +36,8 @@ namespace Microsoft.ML.Runtime.Data
                 ShortName = "col", SortOrder = 101, Purpose = SpecialPurpose.ColumnSelector)]
             public KeyValuePair<string, string>[] CustomColumn;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>")]
-            public SubComponent<IDataScorerTransform, SignatureDataScorer> Scorer;
+            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SignatureType = typeof(SignatureDataScorer))]
+            public IComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform> Scorer;
 
             [Argument(ArgumentType.AtMostOnce, IsInputFileName = true, HelpText = "Predictor model file used in scoring",
                 ShortName = "in", SortOrder = 2)]
@@ -145,14 +145,14 @@ namespace Microsoft.ML.Runtime.Data
 
         public sealed class Arguments : ArgumentsBase<SignatureTrainer>
         {
-            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>")]
-            public SubComponent<ICalibratorTrainer, SignatureCalibrator> Calibrator = new SubComponent<ICalibratorTrainer, SignatureCalibrator>("PlattCalibration");
+            [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", NullName = "<None>", SignatureType = typeof(SignatureCalibrator))]
+            public IComponentFactory<ICalibratorTrainer> Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of instances to train the calibrator", ShortName = "numcali")]
             public int MaxCalibrationExamples = 1000000000;
 
-            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>")]
-            public SubComponent<IDataScorerTransform, SignatureDataScorer> Scorer;
+            [Argument(ArgumentType.Multiple, HelpText = "Scorer to use", NullName = "<Auto>", SignatureType = typeof(SignatureDataScorer))]
+            public IComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform> Scorer;
         }
 
         internal const string Summary = "Trains a predictor, or loads it from a file, and runs it on the data.";

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     Parent.PredictorModels[i].PrepareData(Parent.Host, emptyDv, out RoleMappedData rmd, out IPredictor predictor);
 
                     // Get the predictor as a bindable mapper, and bind it to the RoleMappedSchema found above.
-                    var bindable = ScoreUtils.GetSchemaBindableMapper(Parent.Host, Parent.PredictorModels[i].Predictor, null);
+                    var bindable = ScoreUtils.GetSchemaBindableMapper(Parent.Host, Parent.PredictorModels[i].Predictor, scorerFactorySettings: null);
                     Mappers[i] = bindable.Bind(Parent.Host, rmd.Schema) as ISchemaBoundRowMapper;
                     if (Mappers[i] == null)
                         throw Parent.Host.Except("Predictor {0} is not a row to row mapper", i);

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     Parent.PredictorModels[i].PrepareData(Parent.Host, emptyDv, out RoleMappedData rmd, out IPredictor predictor);
 
                     // Get the predictor as a bindable mapper, and bind it to the RoleMappedSchema found above.
-                    var bindable = ScoreUtils.GetSchemaBindableMapper(Parent.Host, Parent.PredictorModels[i].Predictor, scorerFactorySettings: null);
+                    var bindable = ScoreUtils.GetSchemaBindableMapper(Parent.Host, Parent.PredictorModels[i].Predictor);
                     Mappers[i] = bindable.Bind(Parent.Host, rmd.Schema) as ISchemaBoundRowMapper;
                     if (Mappers[i] == null)
                         throw Parent.Host.Except("Predictor {0} is not a row to row mapper", i);

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -666,11 +666,6 @@ namespace Microsoft.ML.Runtime.Data
                     ch.Assert(args.Trainer.IsGood());
 
                     ch.Trace("Creating TrainAndScoreTransform");
-                    string scorerSettings = CmdParser.GetSettings(ch, scorerArgs,
-                        new TreeEnsembleFeaturizerBindableMapper.Arguments());
-                    var scorer =
-                        new SubComponent<IDataScorerTransform, SignatureDataScorer>(
-                            TreeEnsembleFeaturizerBindableMapper.LoadNameShort, scorerSettings);
 
                     var trainScoreArgs = new TrainAndScoreTransform.Arguments();
                     args.CopyTo(trainScoreArgs);
@@ -678,7 +673,8 @@ namespace Microsoft.ML.Runtime.Data
                         args.Trainer.Settings);
 
                     var labelInput = AppendLabelTransform(host, ch, input, trainScoreArgs.LabelColumn, args.LabelPermutationSeed);
-                    trainScoreArgs.Scorer = scorer;
+                    trainScoreArgs.Scorer = new SimpleComponentFactory<IDataView, ISchemaBoundMapper, RoleMappedSchema, IDataScorerTransform>(
+                        (e, data, mapper, trainSchema) => Create(e, scorerArgs, data, mapper, trainSchema));
                     var scoreXf = TrainAndScoreTransform.Create(host, trainScoreArgs, labelInput);
                     if (input == labelInput)
                         return scoreXf;

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -7,10 +7,10 @@ using Float = System.Single;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Data.Conversion;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Calibration;
 using Microsoft.ML.Runtime.Internal.Internallearn;
 using Microsoft.ML.Runtime.Training;
-using Microsoft.ML.Runtime.EntryPoints;
 
 namespace Microsoft.ML.Runtime.Learners
 {


### PR DESCRIPTION
Also, PartitionedFileLoader is now SubComponent-free.

This is the next round of SubComponent removal from our public API.  I've removed all `Scorer` and `Calibrator` usages of SubComponent.

@Ivanidzo4ka - I still need to update this so CmdParser doesn't throw an exception.  I'll do that when I'm back in the office. I wanted to send this out now to get eyes on it while I'm out.