### PR TITLE
Change SseUtils call sites to call CpuMathUtils instead

### DIFF
--- a/src/Microsoft.ML.CpuMath/AlignedMatrix.cs
+++ b/src/Microsoft.ML.CpuMath/AlignedMatrix.cs
@@ -550,7 +550,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
             // REVIEW: Ideally, we'd adjust the indices once so we wouldn't need to
             // repeatedly deal with padding adjustments.
-            SseUtils.ZeroMatrixItems(Items, ColCount, ColCountPhy, indices);
+            CpuMathUtils.ZeroMatrixItems(Items, ColCount, ColCountPhy, indices);
         }
     }
 

--- a/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
+++ b/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 #if DEBUG
             var mat = values as TMatrix;
             Contracts.AssertValue(mat);
-            Contracts.Assert(mat.Items.CbAlign == CpuMathUtils.CbAlign);
+            Contracts.Assert(mat.Items.CbAlign == CpuMathUtils.SseCbAlign);
 #endif
         }
 
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 #if DEBUG
             CpuAlignedVector vec = values as CpuAlignedVector;
             Contracts.AssertValue(vec);
-            Contracts.Assert(vec.Items.CbAlign == CpuMathUtils.CbAlign);
+            Contracts.Assert(vec.Items.CbAlign == CpuMathUtils.SseCbAlign);
 #endif
         }
 

--- a/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
+++ b/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 #if DEBUG
             var mat = values as TMatrix;
             Contracts.AssertValue(mat);
-            Contracts.Assert(mat.Items.CbAlign == SseUtils.CbAlign);
+            Contracts.Assert(mat.Items.CbAlign == CpuMathUtils.CbAlign);
 #endif
         }
 
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 #if DEBUG
             CpuAlignedVector vec = values as CpuAlignedVector;
             Contracts.AssertValue(vec);
-            Contracts.Assert(vec.Items.CbAlign == SseUtils.CbAlign);
+            Contracts.Assert(vec.Items.CbAlign == CpuMathUtils.CbAlign);
 #endif
         }
 

--- a/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
+++ b/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 #if DEBUG
             var mat = values as TMatrix;
             Contracts.AssertValue(mat);
-            Contracts.Assert(mat.Items.CbAlign == CpuMathUtils.SseCbAlign);
+            Contracts.Assert(mat.Items.CbAlign == CpuMathUtils.Vector128Alignment);
 #endif
         }
 
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 #if DEBUG
             CpuAlignedVector vec = values as CpuAlignedVector;
             Contracts.AssertValue(vec);
-            Contracts.Assert(vec.Items.CbAlign == CpuMathUtils.SseCbAlign);
+            Contracts.Assert(vec.Items.CbAlign == CpuMathUtils.Vector128Alignment);
 #endif
         }
 

--- a/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
+++ b/src/Microsoft.ML.CpuMath/CpuAligenedMathUtils.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             bool colMajor = typeof(TMatrix) == typeof(CpuAlignedMatrixCol);
             AssertCompatible(mat, src, dst);
             var m = A(mat);
-            SseUtils.MatTimesSrc(colMajor, add, m.Items, A(src).Items, A(dst).Items, m.RunCnt);
+            CpuMathUtils.MatTimesSrc(colMajor, add, m.Items, A(src).Items, A(dst).Items, m.RunCnt);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             bool colMajor = typeof(TMatrix) == typeof(CpuAlignedMatrixCol);
             AssertCompatible(mat, dst, src);
             var m = A(mat);
-            SseUtils.MatTimesSrc(!colMajor, add, m.Items, A(src).Items, A(dst).Items, m.RunCnt);
+            CpuMathUtils.MatTimesSrc(!colMajor, add, m.Items, A(src).Items, A(dst).Items, m.RunCnt);
         }
     }
 

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -9,6 +9,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
+        public const int CbAlign = 16;
+
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun)
         {
             Contracts.Assert(mat.Size == dst.Size * src.Size);

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -9,7 +9,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
-        public const int SseCbAlign = 16;
+        // The count of bytes in Vector128<T>, corresponding to _cbAlign in AlignedArray
+        public const int Vector128Alignment = 16;
 
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun)
         {

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
-        public const int CbAlign = 16;
+        public const int SseCbAlign = 16;
 
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun)
         {

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
@@ -6,6 +6,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
+        public const int CbAlign = 16;
+
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun) => SseUtils.MatTimesSrc(tran, add, mat, src, dst, crun);
 
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, int[] rgposSrc, AlignedArray srcValues,

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
-        public const int CbAlign = 16;
+        public const int SseCbAlign = 16;
 
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun) => SseUtils.MatTimesSrc(tran, add, mat, src, dst, crun);
 

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
@@ -6,7 +6,8 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     public static partial class CpuMathUtils
     {
-        public const int SseCbAlign = 16;
+        // The count of bytes in Vector128<T>, corresponding to _cbAlign in AlignedArray
+        public const int Vector128Alignment = 16;
 
         public static void MatTimesSrc(bool tran, bool add, AlignedArray mat, AlignedArray src, AlignedArray dst, int crun) => SseUtils.MatTimesSrc(tran, add, mat, src, dst, crun);
 

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -22,20 +22,21 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     internal static class SseIntrinsics
     {
-        private const int CbAlign = 16;
+        // The count of bytes in Vector128<T>, corresponding to _cbAlign in AlignedArray
+        private const int Vector128Alignment = 16;
 
         private static bool Compat(AlignedArray a)
         {
             Contracts.AssertValue(a);
             Contracts.Assert(a.Size > 0);
-            return a.CbAlign == CbAlign;
+            return a.CbAlign == Vector128Alignment;
         }
 
         private static unsafe float* Ptr(AlignedArray a, float* p)
         {
             Contracts.AssertValue(a);
             float* q = p + a.GetBase((long)p);
-            Contracts.Assert(((long)q & (CbAlign - 1)) == 0);
+            Contracts.Assert(((long)q & (Vector128Alignment - 1)) == 0);
             return q;
         }
 

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             if (a.Count == 0)
                 return 0;
-            return SseUtils.SumSq(a.Values, 0, a.Count);
+            return CpuMathUtils.SumSq(a.Values, 0, a.Count);
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Runtime.Numeric
         /// </summary>
         public static Float NormSquared(Float[] a, int offset, int count)
         {
-            return SseUtils.SumSq(a, offset, count);
+            return CpuMathUtils.SumSq(a, offset, count);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             if (a.Count == 0)
                 return 0;
-            return SseUtils.SumAbs(a.Values, 0, a.Count);
+            return CpuMathUtils.SumAbs(a.Values, 0, a.Count);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             if (a.Count == 0)
                 return 0;
-            return SseUtils.MaxAbs(a.Values, 0, a.Count);
+            return CpuMathUtils.MaxAbs(a.Values, 0, a.Count);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             if (a.Count == 0)
                 return 0;
-            return SseUtils.Sum(a.Values, 0, a.Count);
+            return CpuMathUtils.Sum(a.Values, 0, a.Count);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Runtime.Numeric
             if (c == 1 || dst.Count == 0)
                 return;
             if (c != 0)
-                SseUtils.Scale(c, dst.Values, dst.Count);
+                CpuMathUtils.Scale(c, dst.Values, dst.Count);
             else // Maintain density of dst.
                 Array.Clear(dst.Values, 0, dst.Count);
             // REVIEW: Any benefit in sparsifying?
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 if (c == 0)
                     Array.Clear(dstValues, 0, length);
                 else
-                    SseUtils.Scale(c, src.Values, dstValues, length);
+                    CpuMathUtils.Scale(c, src.Values, dstValues, length);
                 dst = new VBuffer<Float>(length, dstValues, dst.Indices);
             }
             else
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 if (c == 0)
                     Array.Clear(dstValues, 0, count);
                 else
-                    SseUtils.Scale(c, src.Values, dstValues, count);
+                    CpuMathUtils.Scale(c, src.Values, dstValues, count);
                 dst = new VBuffer<Float>(length, count, dstValues, dstIndices);
             }
         }
@@ -142,9 +142,9 @@ namespace Microsoft.ML.Runtime.Numeric
             if (dst.IsDense)
             {
                 if (src.IsDense)
-                    SseUtils.Add(src.Values, dst.Values, src.Length);
+                    CpuMathUtils.Add(src.Values, dst.Values, src.Length);
                 else
-                    SseUtils.Add(src.Values, src.Indices, dst.Values, src.Count);
+                    CpuMathUtils.Add(src.Values, src.Indices, dst.Values, src.Count);
                 return;
             }
             // REVIEW: Should we use SSE for any of these possibilities?
@@ -168,9 +168,9 @@ namespace Microsoft.ML.Runtime.Numeric
             if (dst.IsDense)
             {
                 if (src.IsDense)
-                    SseUtils.AddScale(c, src.Values, dst.Values, src.Length);
+                    CpuMathUtils.AddScale(c, src.Values, dst.Values, src.Length);
                 else
-                    SseUtils.AddScale(c, src.Values, src.Indices, dst.Values, src.Count);
+                    CpuMathUtils.AddScale(c, src.Values, src.Indices, dst.Values, src.Count);
                 return;
             }
             // REVIEW: Should we use SSE for any of these possibilities?
@@ -197,7 +197,7 @@ namespace Microsoft.ML.Runtime.Numeric
             if (dst.IsDense && src.IsDense)
             {
                 Float[] resValues = Utils.Size(res.Values) >= length ? res.Values : new Float[length];
-                SseUtils.AddScaleCopy(c, src.Values, dst.Values, resValues, length);
+                CpuMathUtils.AddScaleCopy(c, src.Values, dst.Values, resValues, length);
                 res = new VBuffer<Float>(length, resValues, res.Indices);
                 return;
             }
@@ -239,9 +239,9 @@ namespace Microsoft.ML.Runtime.Numeric
             {
                 // This is by far the most common case.
                 if (src.IsDense)
-                    SseUtils.AddScale(c, src.Values, dst.Values, offset, src.Count);
+                    CpuMathUtils.AddScale(c, src.Values, dst.Values, offset, src.Count);
                 else
-                    SseUtils.AddScale(c, src.Values, src.Indices, dst.Values, offset, src.Count);
+                    CpuMathUtils.AddScale(c, src.Values, src.Indices, dst.Values, offset, src.Count);
                 return;
             }
             // REVIEW: Perhaps implementing an ApplyInto with an offset would be more

--- a/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             Contracts.Check(Utils.Size(a) == Utils.Size(b), "Arrays must have the same length");
             Contracts.Check(Utils.Size(a) > 0);
-            return SseUtils.DotProductDense(a, b, a.Length);
+            return CpuMathUtils.DotProductDense(a, b, a.Length);
         }
 
         public static Float DotProduct(Float[] a, ref VBuffer<Float> b)
@@ -33,8 +33,8 @@ namespace Microsoft.ML.Runtime.Numeric
             if (b.Count == 0)
                 return 0;
             if (b.IsDense)
-                return SseUtils.DotProductDense(a, b.Values, b.Length);
-            return SseUtils.DotProductSparse(a, b.Values, b.Indices, b.Count);
+                return CpuMathUtils.DotProductDense(a, b.Values, b.Length);
+            return CpuMathUtils.DotProductSparse(a, b.Values, b.Indices, b.Count);
         }
 
         public static Float DotProduct(ref VBuffer<Float> a, ref VBuffer<Float> b)
@@ -47,12 +47,12 @@ namespace Microsoft.ML.Runtime.Numeric
             if (a.IsDense)
             {
                 if (b.IsDense)
-                    return SseUtils.DotProductDense(a.Values, b.Values, a.Length);
-                return SseUtils.DotProductSparse(a.Values, b.Values, b.Indices, b.Count);
+                    return CpuMathUtils.DotProductDense(a.Values, b.Values, a.Length);
+                return CpuMathUtils.DotProductSparse(a.Values, b.Values, b.Indices, b.Count);
             }
 
             if (b.IsDense)
-                return SseUtils.DotProductSparse(b.Values, a.Values, a.Indices, a.Count);
+                return CpuMathUtils.DotProductSparse(b.Values, a.Values, a.Indices, a.Count);
             return DotProductSparse(a.Values, a.Indices, 0, a.Count, b.Values, b.Indices, 0, b.Count, 0);
         }
 
@@ -159,7 +159,7 @@ namespace Microsoft.ML.Runtime.Numeric
             Contracts.Check(a.Length == dst.Length, "Vectors must have the same dimensionality.");
 
             if (a.IsDense && dst.IsDense)
-                SseUtils.MulElementWise(a.Values, dst.Values, dst.Values, a.Length);
+                CpuMathUtils.MulElementWise(a.Values, dst.Values, dst.Values, a.Length);
             else
                 VBufferUtils.ApplyWithEitherDefined(ref a, ref dst, (int ind, Float v1, ref Float v2) => { v2 *= v1; });
         }
@@ -228,11 +228,11 @@ namespace Microsoft.ML.Runtime.Numeric
             Contracts.Assert(0 <= countB && countB <= Utils.Size(indicesB));
             Contracts.Assert(countB <= Utils.Size(valuesB));
 
-            var normA = SseUtils.SumSq(valuesA, 0, lengthA);
+            var normA = CpuMathUtils.SumSq(valuesA, 0, lengthA);
             if (countB == 0)
                 return normA;
-            var normB = SseUtils.SumSq(valuesB, 0, countB);
-            var dotP = SseUtils.DotProductSparse(valuesA, valuesB, indicesB, countB);
+            var normB = CpuMathUtils.SumSq(valuesB, 0, countB);
+            var dotP = CpuMathUtils.DotProductSparse(valuesA, valuesB, indicesB, countB);
             var res = normA + normB - 2 * dotP;
             return res < 0 ? 0 : res;
         }
@@ -246,7 +246,7 @@ namespace Microsoft.ML.Runtime.Numeric
 
             if (length == 0)
                 return 0;
-            return SseUtils.L2DistSquared(valuesA, valuesB, length);
+            return CpuMathUtils.L2DistSquared(valuesA, valuesB, length);
         }
 
         /// <summary>
@@ -267,8 +267,8 @@ namespace Microsoft.ML.Runtime.Numeric
             if (a.IsDense)
             {
                 if (b.IsDense)
-                    return SseUtils.DotProductDense(a.Values, offset, b.Values, b.Length);
-                return SseUtils.DotProductSparse(a.Values, offset, b.Values, b.Indices, b.Count);
+                    return CpuMathUtils.DotProductDense(a.Values, offset, b.Values, b.Length);
+                return CpuMathUtils.DotProductSparse(a.Values, offset, b.Values, b.Indices, b.Count);
             }
             else
             {
@@ -314,8 +314,8 @@ namespace Microsoft.ML.Runtime.Numeric
                 return 0;
 
             if (b.IsDense)
-                return SseUtils.DotProductDense(a, offset, b.Values, b.Length);
-            return SseUtils.DotProductSparse(a, offset, b.Values, b.Indices, b.Count);
+                return CpuMathUtils.DotProductDense(a, offset, b.Values, b.Length);
+            return CpuMathUtils.DotProductSparse(a, offset, b.Values, b.Indices, b.Count);
         }
 
         private static Float DotProductSparse(Float[] aValues, int[] aIndices, int ia, int iaLim, Float[] bValues, int[] bIndices, int ib, int ibLim, int offset)
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Runtime.Numeric
             Contracts.CheckParam(src.Length == dst.Length, nameof(dst), "Arrays must have the same dimensionality.");
             if (src.Length == 0)
                 return;
-            SseUtils.Add(src, dst, src.Length);
+            CpuMathUtils.Add(src, dst, src.Length);
         }
 
         /// <summary>
@@ -452,7 +452,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 return;
 
             if (src.IsDense)
-                SseUtils.AddScale(c, src.Values, dst, src.Count);
+                CpuMathUtils.AddScale(c, src.Values, dst, src.Count);
             else
             {
                 for (int i = 0; i < src.Count; i++)
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Runtime.Numeric
             if (c == 0)
                 return;
 
-            SseUtils.AddScale(c, src, dst, src.Length);
+            CpuMathUtils.AddScale(c, src, dst, src.Length);
         }
 
         /// <summary>
@@ -510,7 +510,7 @@ namespace Microsoft.ML.Runtime.Numeric
         /// </summary>
         public static Float Norm(Float[] a)
         {
-            return MathUtils.Sqrt(SseUtils.SumSq(a, a.Length));
+            return MathUtils.Sqrt(CpuMathUtils.SumSq(a, a.Length));
         }
 
         /// <summary>
@@ -520,7 +520,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             if (a == null || a.Length == 0)
                 return 0;
-            return SseUtils.Sum(a, a.Length);
+            return CpuMathUtils.Sum(a, a.Length);
         }
 
         /// <summary>
@@ -534,7 +534,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 return;
 
             if (c != 0)
-                SseUtils.Scale(c, dst, dst.Length);
+                CpuMathUtils.Scale(c, dst, dst.Length);
             else
                 Array.Clear(dst, 0, dst.Length);
         }

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -830,7 +830,7 @@ namespace Microsoft.ML.Runtime.KMeans
                     {
                         weights = new Float[totalSamples];
                         for (int i = 0; i < workStateWeights.Length; i++)
-                            SseUtils.Add(workStateWeights[i], weights, totalSamples);
+                            CpuMathUtils.Add(workStateWeights[i], weights, totalSamples);
                     },
                     ref weightBuffer, ref totalWeights);
 #if DEBUG

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -797,9 +797,9 @@ namespace Microsoft.ML.Runtime.Learners
                                 }
 
                                 if (features.IsDense)
-                                    SseUtils.SdcaL1UpdateDense(primalUpdate, features.Length, features.Values, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                    CpuMathUtils.SdcaL1UpdateDense(primalUpdate, features.Length, features.Values, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
                                 else if (features.Count > 0)
-                                    SseUtils.SdcaL1UpdateSparse(primalUpdate, features.Length, features.Values, features.Indices, features.Count, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                    CpuMathUtils.SdcaL1UpdateSparse(primalUpdate, features.Length, features.Values, features.Indices, features.Count, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
                             }
 
                             break;

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -175,9 +175,9 @@ namespace Microsoft.ML.Runtime.Learners
                                     }
 
                                     if (features.IsDense)
-                                        SseUtils.SdcaL1UpdateDense(-primalUpdate, features.Length, features.Values, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                        CpuMathUtils.SdcaL1UpdateDense(-primalUpdate, features.Length, features.Values, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
                                     else if (features.Count > 0)
-                                        SseUtils.SdcaL1UpdateSparse(-primalUpdate, features.Length, features.Values, features.Indices, features.Count, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                        CpuMathUtils.SdcaL1UpdateSparse(-primalUpdate, features.Length, features.Values, features.Indices, features.Count, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
                                 }
 
                                 break;
@@ -202,9 +202,9 @@ namespace Microsoft.ML.Runtime.Learners
                             : 0;
 
                         if (features.IsDense)
-                            SseUtils.SdcaL1UpdateDense(labelPrimalUpdate, features.Length, features.Values, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                            CpuMathUtils.SdcaL1UpdateDense(labelPrimalUpdate, features.Length, features.Values, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
                         else if (features.Count > 0)
-                            SseUtils.SdcaL1UpdateSparse(labelPrimalUpdate, features.Length, features.Values, features.Indices, features.Count, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                            CpuMathUtils.SdcaL1UpdateSparse(labelPrimalUpdate, features.Length, features.Values, features.Indices, features.Count, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
                     }
 
                     rowCount++;

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -565,7 +565,7 @@ namespace Microsoft.ML.Runtime.Data
                     Array.Copy(src.Indices, dstIndices, count);
                 }
 
-                SseUtils.Scale(normScale, src.Values, dstValues, count);
+                CpuMathUtils.Scale(normScale, src.Values, dstValues, count);
                 dst = new VBuffer<Float>(length, count, dstValues, dstIndices);
 
                 return;
@@ -575,9 +575,9 @@ namespace Microsoft.ML.Runtime.Data
             src.CopyToDense(ref dst);
 
             if (normScale != 1)
-                SseUtils.ScaleAdd(normScale, -offset, dst.Values, length);
+                CpuMathUtils.ScaleAdd(normScale, -offset, dst.Values, length);
             else
-                SseUtils.Add(-offset, dst.Values, length);
+                CpuMathUtils.Add(-offset, dst.Values, length);
         }
 
         /// <summary>
@@ -591,7 +591,7 @@ namespace Microsoft.ML.Runtime.Data
             if (count == 0)
                 return 0;
             // We need a mean to compute variance.
-            Float tmpMean = SseUtils.Sum(values, 0, count) / length;
+            Float tmpMean = CpuMathUtils.Sum(values, 0, count) / length;
             Float sumSq = 0;
             if (count != length && tmpMean != 0)
             {
@@ -599,7 +599,7 @@ namespace Microsoft.ML.Runtime.Data
                 Float meanSq = tmpMean * tmpMean;
                 sumSq = (length - count) * meanSq;
             }
-            sumSq += SseUtils.SumSq(tmpMean, values, 0, count);
+            sumSq += CpuMathUtils.SumSq(tmpMean, values, 0, count);
             return MathUtils.Sqrt(sumSq / length);
         }
 
@@ -619,7 +619,7 @@ namespace Microsoft.ML.Runtime.Data
                 Float meanSq = mean * mean;
                 sumSq = (length - count) * meanSq;
             }
-            sumSq += SseUtils.SumSq(mean, values, 0, count);
+            sumSq += CpuMathUtils.SumSq(mean, values, 0, count);
             return MathUtils.Sqrt(sumSq / length);
         }
 
@@ -631,7 +631,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             if (count == 0)
                 return 0;
-            return MathUtils.Sqrt(SseUtils.SumSq(mean, values, 0, count));
+            return MathUtils.Sqrt(CpuMathUtils.SumSq(mean, values, 0, count));
         }
 
         /// <summary>
@@ -642,7 +642,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             if (count == 0)
                 return 0;
-            return SseUtils.SumAbs(mean, values, 0, count);
+            return CpuMathUtils.SumAbs(mean, values, 0, count);
         }
 
         /// <summary>
@@ -653,14 +653,14 @@ namespace Microsoft.ML.Runtime.Data
         {
             if (count == 0)
                 return 0;
-            return SseUtils.MaxAbsDiff(mean, values, count);
+            return CpuMathUtils.MaxAbsDiff(mean, values, count);
         }
 
         private static Float Mean(Float[] src, int count, int length)
         {
             if (length == 0 || count == 0)
                 return 0;
-            return SseUtils.Sum(src, 0, count) / length;
+            return CpuMathUtils.Sum(src, 0, count) / length;
         }
     }
 

--- a/src/Microsoft.ML.Transforms/RffTransform.cs
+++ b/src/Microsoft.ML.Transforms/RffTransform.cs
@@ -23,8 +23,6 @@ using Microsoft.ML.Runtime.Numeric;
 
 namespace Microsoft.ML.Runtime.Data
 {
-    using CpuUtils = CpuMathUtils;
-
     public sealed class RffTransform : OneToOneTransformBase
     {
         private static class Defaults
@@ -124,8 +122,8 @@ namespace Microsoft.ML.Runtime.Data
 
                 int roundedUpD = RoundUp(NewDim, CfltAlign);
                 int roundedUpNumFeatures = RoundUp(SrcDim, CfltAlign);
-                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuUtils.CbAlign);
-                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuUtils.CbAlign);
+                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuMathUtils.SseCbAlign);
+                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuMathUtils.SseCbAlign);
 
                 InitializeFourierCoefficients(roundedUpNumFeatures, roundedUpD);
             }
@@ -160,8 +158,8 @@ namespace Microsoft.ML.Runtime.Data
                 // initialize the transform matrix
                 int roundedUpD = RoundUp(NewDim, CfltAlign);
                 int roundedUpNumFeatures = RoundUp(SrcDim, CfltAlign);
-                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuUtils.CbAlign);
-                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuUtils.CbAlign);
+                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuMathUtils.SseCbAlign);
+                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuMathUtils.SseCbAlign);
                 InitializeFourierCoefficients(roundedUpNumFeatures, roundedUpD);
             }
 
@@ -229,7 +227,7 @@ namespace Microsoft.ML.Runtime.Data
         private readonly TransformInfo[] _transformInfos;
 
         private const string RegistrationName = "Rff";
-        private const int CfltAlign = CpuUtils.CbAlign / sizeof(float);
+        private const int CfltAlign = CpuMathUtils.SseCbAlign / sizeof(float);
 
         private static string TestColumnType(ColumnType type)
         {
@@ -498,8 +496,8 @@ namespace Microsoft.ML.Runtime.Data
             var getSrc = GetSrcGetter<VBuffer<Float>>(input, iinfo);
             var src = default(VBuffer<Float>);
 
-            var featuresAligned = new AlignedArray(RoundUp(Infos[iinfo].TypeSrc.ValueCount, CfltAlign), CpuUtils.CbAlign);
-            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuUtils.CbAlign);
+            var featuresAligned = new AlignedArray(RoundUp(Infos[iinfo].TypeSrc.ValueCount, CfltAlign), CpuMathUtils.SseCbAlign);
+            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuMathUtils.SseCbAlign);
 
             return
                 (ref VBuffer<Float> dst) =>
@@ -514,8 +512,8 @@ namespace Microsoft.ML.Runtime.Data
             var getSrc = GetSrcGetter<Float>(input, iinfo);
             var src = default(Float);
 
-            var featuresAligned = new AlignedArray(RoundUp(1, CfltAlign), CpuUtils.CbAlign);
-            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuUtils.CbAlign);
+            var featuresAligned = new AlignedArray(RoundUp(1, CfltAlign), CpuMathUtils.SseCbAlign);
+            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuMathUtils.SseCbAlign);
 
             var oneDimensionalVector = new VBuffer<Float>(1, new Float[] { 0 });
 
@@ -552,7 +550,7 @@ namespace Microsoft.ML.Runtime.Data
             if (src.IsDense)
             {
                 featuresAligned.CopyFrom(src.Values, 0, src.Length);
-                CpuUtils.MatTimesSrc(false, false, transformInfo.RndFourierVectors, featuresAligned, productAligned,
+                CpuMathUtils.MatTimesSrc(false, false, transformInfo.RndFourierVectors, featuresAligned, productAligned,
                     transformInfo.NewDim);
             }
             else
@@ -560,7 +558,7 @@ namespace Microsoft.ML.Runtime.Data
                 // This overload of MatTimesSrc ignores the values in slots that are not in src.Indices, so there is
                 // no need to zero them out.
                 featuresAligned.CopyFrom(src.Indices, src.Values, 0, 0, src.Count, zeroItems: false);
-                CpuUtils.MatTimesSrc(false, false, transformInfo.RndFourierVectors, src.Indices, featuresAligned, 0, 0,
+                CpuMathUtils.MatTimesSrc(false, false, transformInfo.RndFourierVectors, src.Indices, featuresAligned, 0, 0,
                     src.Count, productAligned, transformInfo.NewDim);
             }
 

--- a/src/Microsoft.ML.Transforms/RffTransform.cs
+++ b/src/Microsoft.ML.Transforms/RffTransform.cs
@@ -23,7 +23,7 @@ using Microsoft.ML.Runtime.Numeric;
 
 namespace Microsoft.ML.Runtime.Data
 {
-    using CpuUtils = SseUtils;
+    using CpuUtils = CpuMathUtils;
 
     public sealed class RffTransform : OneToOneTransformBase
     {

--- a/src/Microsoft.ML.Transforms/RffTransform.cs
+++ b/src/Microsoft.ML.Transforms/RffTransform.cs
@@ -122,8 +122,8 @@ namespace Microsoft.ML.Runtime.Data
 
                 int roundedUpD = RoundUp(NewDim, CfltAlign);
                 int roundedUpNumFeatures = RoundUp(SrcDim, CfltAlign);
-                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuMathUtils.SseCbAlign);
-                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuMathUtils.SseCbAlign);
+                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuMathUtils.Vector128Alignment);
+                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuMathUtils.Vector128Alignment);
 
                 InitializeFourierCoefficients(roundedUpNumFeatures, roundedUpD);
             }
@@ -158,8 +158,8 @@ namespace Microsoft.ML.Runtime.Data
                 // initialize the transform matrix
                 int roundedUpD = RoundUp(NewDim, CfltAlign);
                 int roundedUpNumFeatures = RoundUp(SrcDim, CfltAlign);
-                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuMathUtils.SseCbAlign);
-                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuMathUtils.SseCbAlign);
+                RndFourierVectors = new AlignedArray(roundedUpD * roundedUpNumFeatures, CpuMathUtils.Vector128Alignment);
+                RotationTerms = _useSin ? null : new AlignedArray(roundedUpD, CpuMathUtils.Vector128Alignment);
                 InitializeFourierCoefficients(roundedUpNumFeatures, roundedUpD);
             }
 
@@ -227,7 +227,7 @@ namespace Microsoft.ML.Runtime.Data
         private readonly TransformInfo[] _transformInfos;
 
         private const string RegistrationName = "Rff";
-        private const int CfltAlign = CpuMathUtils.SseCbAlign / sizeof(float);
+        private const int CfltAlign = CpuMathUtils.Vector128Alignment / sizeof(float);
 
         private static string TestColumnType(ColumnType type)
         {
@@ -496,8 +496,8 @@ namespace Microsoft.ML.Runtime.Data
             var getSrc = GetSrcGetter<VBuffer<Float>>(input, iinfo);
             var src = default(VBuffer<Float>);
 
-            var featuresAligned = new AlignedArray(RoundUp(Infos[iinfo].TypeSrc.ValueCount, CfltAlign), CpuMathUtils.SseCbAlign);
-            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuMathUtils.SseCbAlign);
+            var featuresAligned = new AlignedArray(RoundUp(Infos[iinfo].TypeSrc.ValueCount, CfltAlign), CpuMathUtils.Vector128Alignment);
+            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuMathUtils.Vector128Alignment);
 
             return
                 (ref VBuffer<Float> dst) =>
@@ -512,8 +512,8 @@ namespace Microsoft.ML.Runtime.Data
             var getSrc = GetSrcGetter<Float>(input, iinfo);
             var src = default(Float);
 
-            var featuresAligned = new AlignedArray(RoundUp(1, CfltAlign), CpuMathUtils.SseCbAlign);
-            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuMathUtils.SseCbAlign);
+            var featuresAligned = new AlignedArray(RoundUp(1, CfltAlign), CpuMathUtils.Vector128Alignment);
+            var productAligned = new AlignedArray(RoundUp(_transformInfos[iinfo].NewDim, CfltAlign), CpuMathUtils.Vector128Alignment);
 
             var oneDimensionalVector = new VBuffer<Float>(1, new Float[] { 0 });
 

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -591,7 +591,7 @@ namespace Microsoft.ML.Runtime.Data
         private static Float DotProduct(Float[] a, int aOffset, Float[] b, int[] indices, int count)
         {
             Contracts.Assert(count <= indices.Length);
-            return SseUtils.DotProductSparse(a, aOffset, b, indices, count);
+            return CpuMathUtils.DotProductSparse(a, aOffset, b, indices, count);
 
         }
 


### PR DESCRIPTION
After all active SSE intrinsics have been implemented and tested for correctness and speed, this PR asks to make all external `SseUtils` call sites call `CpuMathUtils` instead.  This would allow us to obtain a baseline performance of C# hardware intrinsics APIs in a future PR.

cc: @safern @danmosemsft @eerhardt @tannergooding 