### PR TITLE
Add convenience constructors for TextLoader.

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -40,6 +40,19 @@ namespace Microsoft.ML.Runtime.Data
         /// </example>
         public sealed class Column
         {
+            public Column() { }
+
+            public Column(string name, DataKind? type, int index)
+               : this(name, type, new[] { new Range(index) }) { }
+
+            public Column(string name, DataKind? type = null, Range[] source = null, KeyRange keyRange = null)
+            {
+                Name = name;
+                Type = type;
+                Source = source;
+                KeyRange = keyRange;
+            }
+
             [Argument(ArgumentType.AtMostOnce, HelpText = "Name of the column")]
             public string Name;
 
@@ -179,6 +192,14 @@ namespace Microsoft.ML.Runtime.Data
 
         public sealed class Range
         {
+            public Range() { }
+
+            public Range(int index)
+            {
+                Min = index;
+                Max = index;
+            }
+
             [Argument(ArgumentType.Required, HelpText = "First index in the range")]
             public int Min;
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -491,13 +491,13 @@ namespace Microsoft.ML.Runtime.Data.IO
             {
                 var key = type.ItemType.AsKey;
                 if (!key.Contiguous)
-                    keyRange = new KeyRange() { Min = key.Min, Contiguous = false };
+                    keyRange = new KeyRange(key.Min, contiguous: false);
                 else if (key.Count == 0)
-                    keyRange = new KeyRange() { Min = key.Min };
+                    keyRange = new KeyRange(key.Min);
                 else
                 {
                     Contracts.Assert(key.Count >= 1);
-                    keyRange = new KeyRange() { Min = key.Min, Max = key.Min + (ulong)(key.Count - 1) };
+                    keyRange = new KeyRange(key.Min, key.Min + (ulong)(key.Count - 1));
                 }
                 kind = key.RawKind;
             }

--- a/src/Microsoft.ML.Data/Transforms/TermTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TermTransform.cs
@@ -352,15 +352,7 @@ namespace Microsoft.ML.Runtime.Data
                         new TextLoader.Arguments()
                         {
                             Separator = "tab",
-                            Column = new[]
-                            {
-                                new TextLoader.Column()
-                                {
-                                    Name ="Term",
-                                    Type = DataKind.TX,
-                                    Source = new[] { new TextLoader.Range() { Min = 0 } }
-                                }
-                            }
+                            Column = new[] { new TextLoader.Column("Term", DataKind.TX, 0) }
                         },
                         fileSource);
                     src = "Term";

--- a/src/Microsoft.ML.Data/Utilities/TypeParsingUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/TypeParsingUtils.cs
@@ -85,6 +85,15 @@ namespace Microsoft.ML.Runtime.Data
     /// </summary>
     public sealed class KeyRange
     {
+        public KeyRange() { }
+
+        public KeyRange(ulong min, ulong? max = null, bool contiguous = true)
+        {
+            Min = min;
+            Max = max;
+            Contiguous = contiguous;
+        }
+
         [Argument(ArgumentType.AtMostOnce, HelpText = "First index in the range")]
         public ulong Min;
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -43,19 +43,9 @@ namespace Microsoft.ML.Runtime.RunTests
                 {
                     Column = new[]
                     {
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min = 0, Max = 0} },
-                            Type = Runtime.Data.DataKind.R4
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "Features",
-                            Source = new [] { new TextLoader.Range() { Min = 1, Max = 9} },
-                            Type = Runtime.Data.DataKind.R4
-                        }
+                        new TextLoader.Column("Label", DataKind.R4, 0),
+                        new TextLoader.Column("Features", DataKind.R4, 
+                            new [] { new TextLoader.Range() { Min = 1, Max = 9} })
                     }
                 },
 
@@ -74,31 +64,10 @@ namespace Microsoft.ML.Runtime.RunTests
                     HasHeader = true,
                     Column = new[]
                     {
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min = 0, Max = 0} }
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "F1",
-                            Source = new [] { new TextLoader.Range() { Min = 1, Max = 1} },
-                            Type = Runtime.Data.DataKind.Text
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "F2",
-                            Source = new [] { new TextLoader.Range() { Min = 2, Max = 2} },
-                            Type = Runtime.Data.DataKind.I4
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "Rest",
-                            Source = new [] { new TextLoader.Range() { Min = 3, Max = 9} }
-                        }
+                        new TextLoader.Column("Label", type: null, 0),
+                        new TextLoader.Column("F1", DataKind.Text, 1),
+                        new TextLoader.Column("F2", DataKind.I4, 2),
+                        new TextLoader.Column("Rest", source: new [] { new TextLoader.Range() { Min = 3, Max = 9} })
                     }
                 },
 
@@ -998,19 +967,8 @@ namespace Microsoft.ML.Runtime.RunTests
                     HasHeader = true,
                     Column = new[]
                     {
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min = 0, Max = 0} },
-                            Type = Runtime.Data.DataKind.TX
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "Text",
-                            Source = new [] { new TextLoader.Range() { Min = 3, Max = 3} },
-                            Type = Runtime.Data.DataKind.TX
-                        }
+                        new TextLoader.Column("Label", DataKind.TX, 0),
+                        new TextLoader.Column("Text", DataKind.TX, 3)
                     }
                 },
 
@@ -1222,19 +1180,9 @@ namespace Microsoft.ML.Runtime.RunTests
                 {
                     Column = new[]
                     {
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min = 0, Max = 0} },
-                            Type = Runtime.Data.DataKind.R4
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "Features",
-                            Source = new [] { new TextLoader.Range() { Min = 1, Max = 4} },
-                            Type = Runtime.Data.DataKind.R4
-                        }
+                        new TextLoader.Column("Label", DataKind.R4, 0),
+                        new TextLoader.Column("Features", DataKind.R4, 
+                            new [] { new TextLoader.Range() { Min = 1, Max = 4} })
                     }
                 },
 
@@ -3474,18 +3422,9 @@ namespace Microsoft.ML.Runtime.RunTests
                     HasHeader = true,
                     Column = new[]
                     {
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min = 0, Max = 0} },
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "Features",
-                            Source = new [] { new TextLoader.Range() { Min = 1, Max = 9} },
-                            Type = Runtime.Data.DataKind.Num
-                        }
+                        new TextLoader.Column("Label", type: null, 0),
+                        new TextLoader.Column("Features", DataKind.Num,
+                            new [] { new TextLoader.Range() { Min = 1, Max = 9} })
                     }
                 },
 
@@ -3774,12 +3713,8 @@ namespace Microsoft.ML.Runtime.RunTests
                     SeparatorChars = new []{' '},
                     Column = new[]
                     {
-                        new TextLoader.Column()
-                        {
-                            Name = "Text",
-                            Source = new [] { new TextLoader.Range() { Min = 0, VariableEnd=true, ForceVector=true} },
-                            Type = DataKind.Text
-                        }
+                        new TextLoader.Column("Text", DataKind.Text,
+                            new [] { new TextLoader.Range() { Min = 0, VariableEnd=true, ForceVector=true} })
                     }
                 },
                 InputFile = inputFile,

--- a/test/Microsoft.ML.Tests/Scenarios/Api/SimpleTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/SimpleTrainAndPredict.cs
@@ -82,44 +82,18 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
         private static TextLoader.Arguments MakeIrisTextLoaderArgs()
         {
-
             return new TextLoader.Arguments()
             {
                 Separator = "comma",
                 HasHeader = true,
                 Column = new[]
-                    {
-                        new TextLoader.Column()
-                        {
-                            Name = "SepalLength",
-                            Source = new [] { new TextLoader.Range() { Min=0, Max=0} },
-                            Type = DataKind.R4
-                        },
-                        new TextLoader.Column()
-                        {
-                            Name = "SepalWidth",
-                            Source = new [] { new TextLoader.Range() { Min=1, Max=1} },
-                            Type = DataKind.R4
-                        },
-                        new TextLoader.Column()
-                        {
-                            Name = "PetalLength",
-                            Source = new [] { new TextLoader.Range() { Min=2, Max=2} },
-                            Type = DataKind.R4
-                        },
-                        new TextLoader.Column()
-                        {
-                            Name = "PetalWidth",
-                            Source = new [] { new TextLoader.Range() { Min=3, Max=3} },
-                            Type = DataKind.R4
-                        },
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min=4, Max=4} },
-                            Type = DataKind.Text
-                        }
-                    }
+                {
+                    new TextLoader.Column("SepalLength", DataKind.R4, 0),
+                    new TextLoader.Column("SepalWidth", DataKind.R4, 1),
+                    new TextLoader.Column("PetalLength", DataKind.R4, 2),
+                    new TextLoader.Column("PetalWidth",DataKind.R4, 3),
+                    new TextLoader.Column("Label", DataKind.Text, 4)
+                }
             };
         }
         private static TextLoader.Arguments MakeSentimentTextLoaderArgs()
@@ -129,21 +103,10 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 Separator = "tab",
                 HasHeader = true,
                 Column = new[]
-                    {
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min=0, Max=0} },
-                            Type = DataKind.BL
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "SentimentText",
-                            Source = new [] { new TextLoader.Range() { Min=1, Max=1} },
-                            Type = DataKind.Text
-                        }
-                    }
+                {
+                    new TextLoader.Column("Label", DataKind.BL, 0),
+                    new TextLoader.Column("SentimentText", DataKind.Text, 1)
+                }
             };
         }
     }

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -29,37 +29,13 @@ namespace Microsoft.ML.Scenarios
                     new TextLoader.Arguments()
                     {
                         HasHeader = false,
-                        Column = new[] {
-                            new TextLoader.Column()
-                            {
-                                Name = "Label",
-                                Source = new [] { new TextLoader.Range() { Min = 0, Max = 0} },
-                                Type = DataKind.R4
-                            },
-                            new TextLoader.Column()
-                            {
-                                Name = "SepalLength",
-                                Source = new [] { new TextLoader.Range() { Min = 1, Max = 1} },
-                                Type = DataKind.R4
-                            },
-                            new TextLoader.Column()
-                            {
-                                Name = "SepalWidth",
-                                Source = new [] { new TextLoader.Range() { Min = 2, Max = 2} },
-                                Type = DataKind.R4
-                            },
-                            new TextLoader.Column()
-                            {
-                                Name = "PetalLength",
-                                Source = new [] { new TextLoader.Range() { Min = 3, Max = 3} },
-                                Type = DataKind.R4
-                            },
-                            new TextLoader.Column()
-                            {
-                                Name = "PetalWidth",
-                                Source = new [] { new TextLoader.Range() { Min = 4, Max = 4} },
-                                Type = DataKind.R4
-                            }
+                        Column = new[]
+                        {
+                            new TextLoader.Column("Label", DataKind.R4, 0),
+                            new TextLoader.Column("SepalLength", DataKind.R4, 1),
+                            new TextLoader.Column("SepalWidth", DataKind.R4, 2),
+                            new TextLoader.Column("PetalLength", DataKind.R4, 3),
+                            new TextLoader.Column("PetalWidth", DataKind.R4, 4)
                         }
                     }, new MultiFileSource(dataPath));
 

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
@@ -36,19 +36,8 @@ namespace Microsoft.ML.Scenarios
                     HasHeader = true,
                     Column = new[]
                     {
-                        new TextLoader.Column()
-                        {
-                            Name = "Label",
-                            Source = new [] { new TextLoader.Range() { Min=0, Max=0} },
-                            Type = DataKind.Num
-                        },
-
-                        new TextLoader.Column()
-                        {
-                            Name = "SentimentText",
-                            Source = new [] { new TextLoader.Range() { Min=1, Max=1} },
-                            Type = DataKind.Text
-                        }
+                        new TextLoader.Column("Label", DataKind.Num, 0),
+                        new TextLoader.Column("SentimentText", DataKind.Text, 1)
                     }
                 }, new MultiFileSource(dataPath));
 


### PR DESCRIPTION
Creating a TextLoader and specifying its arguments manually is too verbose. We should add a few constructor overloads to make it easier.
