### PR TITLE
Add package tags

### DIFF
--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -25,7 +25,8 @@
     <PackageProjectUrl>https://dot.net/ml</PackageProjectUrl>
     <PackageIconUrl>https://aka.ms/mlnetlogo</PackageIconUrl>
     <PackageReleaseNotes>https://aka.ms/mlnetreleasenotes</PackageReleaseNotes>
-    <PackageTags>ML.NET, ML, Machine Learning</PackageTags>
+    <!-- space separated -->
+    <PackageTags>ML.NET ML Machine Learning</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -26,7 +26,6 @@
     <PackageIconUrl>https://aka.ms/mlnetlogo</PackageIconUrl>
     <PackageReleaseNotes>https://aka.ms/mlnetreleasenotes</PackageReleaseNotes>
     <PackageTags>ML.NET, ML, Machine Learning</PackageTags>
-    <Title>ML.NET</Title>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -25,6 +25,8 @@
     <PackageProjectUrl>https://dot.net/ml</PackageProjectUrl>
     <PackageIconUrl>https://aka.ms/mlnetlogo</PackageIconUrl>
     <PackageReleaseNotes>https://aka.ms/mlnetreleasenotes</PackageReleaseNotes>
+    <PackageTags>ML.NET, ML, Machine Learning</PackageTags>
+    <Title>ML.NET</Title>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix https://github.com/dotnet/machinelearning/issues/484

Add some tags to the nuget package to help us appear more prominently when searching for "ML.NET"

We can also add a custom title (see first commit) which apparently helps, but it is probably not a good idea, since as @eerhardt pointed out, one might expect to be able to add `<PackageReference Include="ML.NET" />` if the title is `ML.NET`, but not the package ID.
