### PR TITLE
Few benchmark fixes

### DIFF
--- a/test/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
+++ b/test/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -11,7 +11,7 @@
     <None Remove="BenchmarkDotNet.Artifacts\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ML.StandardLearners\Microsoft.ML.StandardLearners.csproj" />

--- a/test/Microsoft.ML.Benchmarks/Program.cs
+++ b/test/Microsoft.ML.Benchmarks/Program.cs
@@ -26,8 +26,9 @@ namespace Microsoft.ML.Benchmarks
                 .Run(args, CreateCustomConfig());
 
         private static IConfig CreateCustomConfig() 
-            => DefaultConfig.Instance.With(
-                Job.ShortRun
+            => DefaultConfig.Instance
+                .With(Job.Default
+                    .WithMaxIterationCount(20)
                     .With(InProcessToolchain.Instance))
                 .With(new ClassificationMetricsColumn("AccuracyMacro", "Macro-average accuracy of the model"))
                 .With(MemoryDiagnoser.Default);

--- a/test/Microsoft.ML.Benchmarks/Program.cs
+++ b/test/Microsoft.ML.Benchmarks/Program.cs
@@ -8,15 +8,9 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Reports;
-using BenchmarkDotNet.Toolchains.CsProj;
 using BenchmarkDotNet.Toolchains.InProcess;
-using System;
 using System.IO;
 using Microsoft.ML.Models;
-using Microsoft.ML.Runtime.Api;
-using Microsoft.ML.Trainers;
-using Microsoft.ML.Transforms;
-using Microsoft.ML.Benchmarks;
 
 namespace Microsoft.ML.Benchmarks
 {
@@ -70,19 +64,19 @@ namespace Microsoft.ML.Benchmarks
         public string Id => _metricName;
         public string Legend => _legend;
         public bool IsNumeric => true;
-        public bool IsDefault(Summary summary, Benchmark benchmark) => true;
+        public bool IsDefault(Summary summary, BenchmarkCase benchmark) => true;
         public bool IsAvailable(Summary summary) => true;
         public bool AlwaysShow => true;
         public ColumnCategory Category => ColumnCategory.Custom;
         public int PriorityInCategory => 1;
         public UnitType UnitType => UnitType.Dimensionless;
 
-        public string GetValue(Summary summary, Benchmark benchmark, ISummaryStyle style)
+        public string GetValue(Summary summary, BenchmarkCase benchmark, ISummaryStyle style)
         {
             var property = typeof(ClassificationMetrics).GetProperty(_metricName);
             return property.GetValue(StochasticDualCoordinateAscentClassifierBench.s_metrics).ToString();
         }
-        public string GetValue(Summary summary, Benchmark benchmark) => GetValue(summary, benchmark, null);
+        public string GetValue(Summary summary, BenchmarkCase benchmark) => GetValue(summary, benchmark, null);
 
         public override string ToString() => ColumnName;
     }

--- a/test/Microsoft.ML.Benchmarks/Program.cs
+++ b/test/Microsoft.ML.Benchmarks/Program.cs
@@ -20,22 +20,17 @@ namespace Microsoft.ML.Benchmarks
         /// execute dotnet run -c Release and choose the benchmarks you want to run
         /// </summary>
         /// <param name="args"></param>
-        static void Main(string[] args)
-        {
-            BenchmarkSwitcher
+        static void Main(string[] args) 
+            => BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(null, CreateClrVsCoreConfig());
-        }
+                .Run(args, CreateCustomConfig());
 
-        private static IConfig CreateClrVsCoreConfig()
-        {
-            var config = DefaultConfig.Instance.With(
-                Job.ShortRun.
-                With(InProcessToolchain.Instance)).
-                With(new ClassificationMetricsColumn("AccuracyMacro", "Macro-average accuracy of the model")).
-                With(MemoryDiagnoser.Default);
-            return config;
-        }
+        private static IConfig CreateCustomConfig() 
+            => DefaultConfig.Instance.With(
+                Job.ShortRun
+                    .With(InProcessToolchain.Instance))
+                .With(new ClassificationMetricsColumn("AccuracyMacro", "Macro-average accuracy of the model"))
+                .With(MemoryDiagnoser.Default);
 
         internal static string GetDataPath(string name)
             => Path.GetFullPath(Path.Combine(_dataRoot, name));
@@ -51,8 +46,8 @@ namespace Microsoft.ML.Benchmarks
 
     public class ClassificationMetricsColumn : IColumn
     {
-        string _metricName;
-        string _legend;
+        private readonly string _metricName;
+        private readonly string _legend;
 
         public ClassificationMetricsColumn(string metricName, string legend)
         {

--- a/test/Microsoft.ML.Benchmarks/README.md
+++ b/test/Microsoft.ML.Benchmarks/README.md
@@ -1,0 +1,36 @@
+# ML.NET Benchmarks
+
+This project contains performance benchmarks.
+
+## Run the Performance Tests
+
+**Pre-requisite:** On a clean repo, `build.cmd` at the root installs the right version of dotnet.exe and builds the solution. You need to build the solution in `Release` with native dependencies. 
+
+    build.cmd -release -buildNative
+
+**Pre-requisite:** To use dotnet cli from the `Tools\dotnetcli` directory remember to set `DOTNET_MULTILEVEL_LOOKUP` environment variable to `0`!
+
+    $env:DOTNET_MULTILEVEL_LOOKUP=0
+
+1. Navigate to the benchmarks directory (machinelearning\test\Microsoft.ML.Benchmarks)
+
+2. Run the benchmarks in Release, choose one of the benchmarks when prompted
+
+```log
+    ..\..\Tools\dotnetcli\dotnet.exe run -c Release
+```
+   
+3. To run specific tests only, pass in the filter to the harness:
+
+```log
+    ..\..\Tools\dotnetcli\dotnet.exe run -c Release -- --filter namespace*
+    ..\..\Tools\dotnetcli\dotnet.exe run -c Release -- --filter *typeName*
+    ..\..\Tools\dotnetcli\dotnet.exe run -c Release -- --filter *.methodName
+    ..\..\Tools\dotnetcli\dotnet.exe run -c Release -- --filter namespace.typeName.methodName
+```
+
+4. To find out more about supported command line arguments run
+
+```log
+    ..\..\Tools\dotnetcli\dotnet.exe run -c Release -- --help
+```

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
 using Microsoft.ML.Data;
 using Microsoft.ML.Models;
 using Microsoft.ML.Runtime.Api;
@@ -11,7 +10,6 @@ using Microsoft.ML.Trainers;
 using Microsoft.ML.Transforms;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.ML.Benchmarks
 {

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/Microsoft.ML.CpuMath.PerformanceTests.csproj
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/Microsoft.ML.CpuMath.PerformanceTests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/Program.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/Program.cs
@@ -12,8 +12,8 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
                 .Run(args, CreateCustomConfig());
 
         private static IConfig CreateCustomConfig()
-            => DefaultConfig.Instance.With(
-                Job.ShortRun
+            => DefaultConfig.Instance
+                .With(Job.ShortRun
                     .With(InProcessToolchain.Instance));
     }
 }

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/Program.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/Program.cs
@@ -2,28 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.InProcess;
-
 namespace Microsoft.ML.CpuMath.PerformanceTests
 {
     class Program
     {
-        public static void Main(string[] args)
-        {
-            BenchmarkSwitcher
+        public static void Main(string[] args) 
+            => BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(null, CreateClrVsCoreConfig());
-        }
+                .Run(args, CreateCustomConfig());
 
-        private static IConfig CreateClrVsCoreConfig()
-        {
-            var config = DefaultConfig.Instance.With(
-                Job.ShortRun.
-                With(InProcessToolchain.Instance));
-            return config;
-        }
+        private static IConfig CreateCustomConfig()
+            => DefaultConfig.Instance.With(
+                Job.ShortRun
+                    .With(InProcessToolchain.Instance));
     }
 }


### PR DESCRIPTION
1. I added README.md so everyone can find out how to run the benchmarks
2. I fixed a bug in the benchmarks where it was returning a lazy-executed `IEnumerable<T>` without the actual execution. So instead of 16 nanoseconds we now have 2.3 milisecond ;)
3. I updated BenchmarkDotNet to latest version to get advantage of performance improvements and new features.
4. I have changed the configuration to run not 3 (`Job.Short`) but up to 20 iterations (BenchmarkDotNet implements a heuristic based on standard error and runs the benchmarks until they are not stable). 3 iterations is simply not enough to get trustworthy results.

/cc @danmosemsft @KrzysztofCwalina 