### PR TITLE
Convert ML.Sweeper usages of SubComponent to IComponentFactory.

### DIFF
--- a/src/Microsoft.ML.PipelineInference/AutoMlEngines/RocketEngine.cs
+++ b/src/Microsoft.ML.PipelineInference/AutoMlEngines/RocketEngine.cs
@@ -101,9 +101,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             // If first time optimizing hyperparams, create new hyperparameter sweeper.
             if (!_hyperSweepers.ContainsKey(learner.LearnerName))
             {
-                var paramTups = AutoMlUtils.ConvertToSweepArgumentStrings(learner.PipelineNode.SweepParams);
-                var sps = paramTups.Select(tup =>
-                    new SubComponent<IValueGenerator, SignatureSweeperParameter>(tup.Item1, tup.Item2)).ToArray();
+                var sps = AutoMlUtils.ConvertToComponentFactories(learner.PipelineNode.SweepParams);
                 if (sps.Length > 0)
                 {
                     _hyperSweepers[learner.LearnerName] = new KdoSweeper(Env,

--- a/src/Microsoft.ML.Sweeper/Algorithms/Grid.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/Grid.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Sweeper;
 
@@ -28,8 +29,8 @@ namespace Microsoft.ML.Runtime.Sweeper
     {
         public class ArgumentsBase
         {
-            [Argument(ArgumentType.Multiple, HelpText = "Swept parameters", ShortName = "p")]
-            public SubComponent<IValueGenerator, SignatureSweeperParameter>[] SweptParameters;
+            [Argument(ArgumentType.Multiple, HelpText = "Swept parameters", ShortName = "p", SignatureType = typeof(SignatureSweeperParameter))]
+            public IComponentFactory<IValueGenerator>[] SweptParameters;
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of tries to generate distinct parameter sets.", ShortName = "r")]
             public int Retries = 10;
@@ -49,7 +50,7 @@ namespace Microsoft.ML.Runtime.Sweeper
 
             _args = args;
 
-            SweepParameters = args.SweptParameters.Select(p => p.CreateInstance(Host)).ToArray();
+            SweepParameters = args.SweptParameters.Select(p => p.CreateComponent(Host)).ToArray();
         }
 
         protected SweeperBase(ArgumentsBase args, IHostEnvironment env, IValueGenerator[] sweepParameters, string name)

--- a/src/Microsoft.ML.Sweeper/Algorithms/NelderMead.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/NelderMead.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Numeric;
 using Microsoft.ML.Runtime.Sweeper;
 
@@ -21,11 +22,11 @@ namespace Microsoft.ML.Runtime.Sweeper
     {
         public sealed class Arguments
         {
-            [Argument(ArgumentType.Multiple | ArgumentType.Required, HelpText = "Swept parameters", ShortName = "p")]
-            public SubComponent[] SweptParameters;
+            [Argument(ArgumentType.Multiple | ArgumentType.Required, HelpText = "Swept parameters", ShortName = "p", SignatureType = typeof(SignatureSweeperParameter))]
+            public IComponentFactory<IValueGenerator>[] SweptParameters;
 
-            [Argument(ArgumentType.LastOccurenceWins, HelpText = "The sweeper used to get the initial results.", ShortName = "init")]
-            public SubComponent<ISweeper, SignatureSweeperFromParameterList> FirstBatchSweeper = new SubComponent<ISweeper, SignatureSweeperFromParameterList>("ldrandpl");
+            [Argument(ArgumentType.LastOccurenceWins, HelpText = "The sweeper used to get the initial results.", ShortName = "init", SignatureType = typeof(SignatureSweeperFromParameterList))]
+            public IComponentFactory<IValueGenerator[], ISweeper> FirstBatchSweeper;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Seed for the random number generator for the first batch sweeper", ShortName = "seed")]
             public int RandomSeed;
@@ -100,7 +101,7 @@ namespace Microsoft.ML.Runtime.Sweeper
             _sweepParameters = new List<IValueGenerator>();
             foreach (var sweptParameter in args.SweptParameters)
             {
-                var parameter = ComponentCatalog.CreateInstance<IValueGenerator, SignatureSweeperParameter>(env, sweptParameter);
+                var parameter = sweptParameter.CreateComponent(env);
                 // REVIEW: ideas about how to support discrete values:
                 // 1. assign each discrete value a random number (1-n) to make mirroring possible
                 // 2. each time we need to mirror a discrete value, sample from the remaining value
@@ -112,7 +113,7 @@ namespace Microsoft.ML.Runtime.Sweeper
                 _sweepParameters.Add(parameterNumeric);
             }
 
-            _initSweeper = args.FirstBatchSweeper.CreateInstance(env, new object[] { _sweepParameters.ToArray() });
+            _initSweeper = args.FirstBatchSweeper.CreateComponent(env, _sweepParameters.ToArray());
             _dim = _sweepParameters.Count;
             env.CheckUserArg(_dim > 1, nameof(args.SweptParameters), "Nelder-Mead sweeper needs at least two parameters to sweep over.");
 

--- a/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
@@ -12,6 +12,7 @@ using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Sweeper;
 
 using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.FastTree;
 using Microsoft.ML.Runtime.FastTree.Internal;
 using Microsoft.ML.Runtime.Internal.Utilities;
@@ -28,8 +29,8 @@ namespace Microsoft.ML.Runtime.Sweeper
     {
         public sealed class Arguments
         {
-            [Argument(ArgumentType.Multiple | ArgumentType.Required, HelpText = "Swept parameters", ShortName = "p")]
-            public SubComponent<IValueGenerator, SignatureSweeperParameter>[] SweptParameters;
+            [Argument(ArgumentType.Multiple | ArgumentType.Required, HelpText = "Swept parameters", ShortName = "p", SignatureType = typeof(SignatureSweeperParameter))]
+            public IComponentFactory<IValueGenerator>[] SweptParameters;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Seed for the random number generator for the first batch sweeper", ShortName = "seed")]
             public int RandomSeed;
@@ -83,7 +84,7 @@ namespace Microsoft.ML.Runtime.Sweeper
 
             _args = args;
             _host.CheckUserArg(Utils.Size(args.SweptParameters) > 0, nameof(args.SweptParameters), "SMAC sweeper needs at least one parameter to sweep over");
-            _sweepParameters = args.SweptParameters.Select(p => p.CreateInstance(_host)).ToArray();
+            _sweepParameters = args.SweptParameters.Select(p => p.CreateComponent(_host)).ToArray();
             _randomSweeper = new UniformRandomSweeper(env, new SweeperBase.ArgumentsBase(), _sweepParameters);
         }
 


### PR DESCRIPTION
Moving all the SubComponent usages in the ML.Sweeper assembly to use IComponentFactory.

Note: I logged https://github.com/dotnet/machinelearning/issues/733 for the NelderMeadSweeper, which was using another component that doesn't appear to be in the `dotnet/machinelearning` repo.

Working towards #585