### PR TITLE
Fix bounding checking error of SSE SumU intrinsic

### DIFF
--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -764,7 +764,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
                 Vector128<float> result = Sse.SetZeroVector128();
 
-                while (pSrcCurrent + 4 < pSrcEnd)
+                while (pSrcCurrent + 4 <= pSrcEnd)
                 {
                     result = Sse.Add(result, Sse.LoadVector128(pSrcCurrent));
                     pSrcCurrent += 4;


### PR DESCRIPTION
Added an "=" sign to a bound check inside the SSE SumU intrinsic to fix a previous typo and make it consistent with all other intrinsics' implementations - look forward to green light!

cc: @eerhardt @tannergooding @safern 