### PR TITLE
SDCA Regression and BinaryClassification Pigsty extensions

### DIFF
--- a/src/Microsoft.ML.Data/StaticPipe/Estimator.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/Estimator.cs
@@ -79,20 +79,4 @@ namespace Microsoft.ML.Data.StaticPipe
             }
         }
     }
-
-    public static class Estimator
-    {
-        /// <summary>
-        /// Create an object that can be used as the start of a new pipeline, that assumes it uses
-        /// something with the sahape of <typeparamref name="TTupleShape"/> as its input schema shape.
-        /// The returned object is an empty estimator.
-        /// </summary>
-        /// <param name="fromSchema">Creates a new empty head of a pipeline</param>
-        /// <returns>The empty esitmator, to which new items may be appended to create a pipeline</returns>
-        public static Estimator<TTupleShape, TTupleShape, ITransformer> MakeNew<TTupleShape>(SchemaBearing<TTupleShape> fromSchema)
-        {
-            Contracts.CheckValue(fromSchema, nameof(fromSchema));
-            return fromSchema.MakeNewEstimator();
-        }
-    }
 }

--- a/src/Microsoft.ML.Data/StaticPipe/SchemaBearing.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/SchemaBearing.cs
@@ -37,11 +37,12 @@ namespace Microsoft.ML.Data.StaticPipe
         }
 
         /// <summary>
-        /// Create an object that can be used as the start of a new pipeline, that assumes it uses
-        /// something with the sahape of <typeparamref name="TTupleShape"/> as its input schema shape.
-        /// The returned object is an empty estimator.
+        /// Starts a new pipeline, using the output schema of this object. Note that the returned
+        /// estimator does not contain this object, but it has its schema informed by <typeparamref name="TTupleShape"/>.
+        /// The returned object is an empty estimator, on which a new segment of the pipeline can be created.
         /// </summary>
-        internal Estimator<TTupleShape, TTupleShape, ITransformer> MakeNewEstimator()
+        /// <returns>An empty estimator with the same shape as the object on which it was created</returns>
+        public Estimator<TTupleShape, TTupleShape, ITransformer> MakeNewEstimator()
         {
             var est = new EstimatorChain<ITransformer>();
             return new Estimator<TTupleShape, TTupleShape, ITransformer>(Env, est, Shape, Shape);

--- a/src/Microsoft.ML.Data/StaticPipe/TrainerEstimatorReconciler.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/TrainerEstimatorReconciler.cs
@@ -1,0 +1,335 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.Core.Data;
+using Microsoft.ML.Runtime;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Internal.Utilities;
+
+namespace Microsoft.ML.Data.StaticPipe.Runtime
+{
+    /// <summary>
+    /// General purpose reconciler for a typical case with trainers, where they accept some generally
+    /// fixed number of inputs, and produce some outputs where the names of the outputs are fixed.
+    /// Authors of components that want to produce columns can subclass this directly, or use one of the
+    /// common nested subclasses.
+    /// </summary>
+    public abstract class TrainerEstimatorReconciler : EstimatorReconciler
+    {
+        private readonly PipelineColumn[] _inputs;
+        private readonly string[] _outputNames;
+
+        /// <summary>
+        /// The output columns. Note that subclasses should return exactly the same items each time,
+        /// and the items should correspond to the output names passed into the constructor.
+        /// </summary>
+        protected abstract IEnumerable<PipelineColumn> Outputs { get; }
+
+        /// <summary>
+        /// Constructor for the base class.
+        /// </summary>
+        /// <param name="inputs">The set of inputs</param>
+        /// <param name="outputNames">The names of the outputs, which we assume cannot be changed</param>
+        protected TrainerEstimatorReconciler(PipelineColumn[] inputs, string[] outputNames)
+        {
+            Contracts.CheckValue(inputs, nameof(inputs));
+            Contracts.CheckValue(outputNames, nameof(outputNames));
+
+            _inputs = inputs;
+            _outputNames = outputNames;
+        }
+
+        /// <summary>
+        /// Produce the training estimator.
+        /// </summary>
+        /// <param name="env">The host environment to use to create the estimator</param>
+        /// <param name="inputNames">The names of the inputs, which corresponds exactly to the input columns
+        /// fed into the constructor</param>
+        /// <returns>An estimator, which should produce the additional columns indicated by the output names
+        /// in the constructor</returns>
+        protected abstract IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames);
+
+        /// <summary>
+        /// Produces the estimator. Note that this is made out of <see cref="ReconcileCore(IHostEnvironment, string[])"/>'s
+        /// return value, plus whatever usages of <see cref="CopyColumnsEstimator"/> are necessary to avoid collisions with
+        /// the output names fed to the constructor. This class provides the implementation, and subclassses should instead
+        /// override <see cref="ReconcileCore(IHostEnvironment, string[])"/>.
+        /// </summary>
+        public sealed override IEstimator<ITransformer> Reconcile(IHostEnvironment env,
+            PipelineColumn[] toOutput,
+            IReadOnlyDictionary<PipelineColumn, string> inputNames,
+            IReadOnlyDictionary<PipelineColumn, string> outputNames,
+            IReadOnlyCollection<string> usedNames)
+        {
+            Contracts.AssertValue(env);
+            env.AssertValue(toOutput);
+            env.AssertValue(inputNames);
+            env.AssertValue(outputNames);
+            env.AssertValue(usedNames);
+
+            // The reconciler should have been called with all the input columns having names.
+            env.Assert(inputNames.Keys.All(_inputs.Contains) && _inputs.All(inputNames.Keys.Contains));
+            // The output name map should contain only outputs as their keys. Yet, it is possible not all
+            // outputs will be required in which case these will both be subsets of those outputs indicated
+            // at construction.
+            env.Assert(outputNames.Keys.All(Outputs.Contains));
+            env.Assert(toOutput.All(Outputs.Contains));
+            env.Assert(Outputs.Count() == _outputNames.Length);
+
+            IEstimator<ITransformer> result = null;
+
+            // In the case where we have names used that conflict with the fixed output names, we must have some
+            // renaming logic.
+            var collisions = new HashSet<string>(_outputNames);
+            collisions.IntersectWith(usedNames);
+            var old2New = new Dictionary<string, string>();
+
+            if (collisions.Count > 0)
+            {
+                // First get the old names to some temporary names.
+                int tempNum = 0;
+                foreach (var c in collisions)
+                    old2New[c] = $"#TrainTemp{tempNum++}";
+                // In the case where the input names have anything that is used, we must reconstitute the input mapping.
+                if (inputNames.Values.Any(old2New.ContainsKey))
+                {
+                    var newInputNames = new Dictionary<PipelineColumn, string>();
+                    foreach (var p in inputNames)
+                        newInputNames[p.Key] = old2New.ContainsKey(p.Value) ? old2New[p.Value] : p.Value;
+                    inputNames = newInputNames;
+                }
+                result = new CopyColumnsEstimator(env, old2New.Select(p => (p.Key, p.Value)).ToArray());
+            }
+
+            // Map the inputs to the names.
+            string[] mappedInputNames = _inputs.Select(c => inputNames[c]).ToArray();
+            // Finally produce the trainer.
+            var trainerEst = ReconcileCore(env, mappedInputNames);
+            if (result == null)
+                result = trainerEst;
+            else
+                result = result.Append(trainerEst);
+
+            // OK. Now handle the final renamings from the fixed names, to the desired names, in the case
+            // where the output was desired, and a renaming is even necessary.
+            var toRename = new List<(string source, string name)>();
+            foreach ((PipelineColumn outCol, string fixedName) in Outputs.Zip(_outputNames, (c, n) => (c, n)))
+            {
+                if (outputNames.TryGetValue(outCol, out string desiredName))
+                    toRename.Add((fixedName, desiredName));
+                else
+                    env.Assert(!toOutput.Contains(outCol));
+            }
+            // Finally if applicable handle the renaming back from the temp names to the original names.
+            foreach (var p in old2New)
+                toRename.Add((p.Value, p.Key));
+            if (toRename.Count > 0)
+                result = result.Append(new CopyColumnsEstimator(env, toRename.ToArray()));
+
+            return result;
+        }
+
+        /// <summary>
+        /// A reconciler for regression capable of handling the most common cases for regression.
+        /// </summary>
+        public sealed class Regression : TrainerEstimatorReconciler
+        {
+            /// <summary>
+            /// The delegate to parameterize the <see cref="Regression"/> instance.
+            /// </summary>
+            /// <param name="env">The environment with which to create the estimator</param>
+            /// <param name="label">The label column name</param>
+            /// <param name="features">The features column name</param>
+            /// <param name="weights">The weights column name, or <c>null</c> if the reconciler was constructed with <c>null</c> weights</param>
+            /// <returns>Some sort of estimator producing columns with the fixed name <see cref="DefaultColumnNames.Score"/></returns>
+            public delegate IEstimator<ITransformer> EstimatorMaker(IHostEnvironment env, string label, string features, string weights);
+
+            private readonly EstimatorMaker _estMaker;
+
+            /// <summary>
+            /// The output score column for the regression. This will have this instance as its reconciler.
+            /// </summary>
+            public Scalar<float> Score { get; }
+
+            protected override IEnumerable<PipelineColumn> Outputs => Enumerable.Repeat(Score, 1);
+
+            private static readonly string[] _fixedOutputNames = new[] { DefaultColumnNames.Score };
+
+            /// <summary>
+            /// Constructs a new general regression reconciler.
+            /// </summary>
+            /// <param name="estimatorMaker">The delegate to create the training estimator. It is assumed that this estimator
+            /// will produce a single new scalar <see cref="float"/> column named <see cref="DefaultColumnNames.Score"/>.</param>
+            /// <param name="label">The input label column</param>
+            /// <param name="features">The input features column</param>
+            /// <param name="weights">The input weights column, or <c>null</c> if there are no weights</param>
+            public Regression(EstimatorMaker estimatorMaker, Scalar<float> label, Vector<float> features, Scalar<float> weights)
+                    : base(MakeInputs(Contracts.CheckRef(label, nameof(label)), Contracts.CheckRef(features, nameof(features)), weights),
+                          _fixedOutputNames)
+            {
+                Contracts.CheckValue(estimatorMaker, nameof(estimatorMaker));
+                _estMaker = estimatorMaker;
+                Contracts.Assert(_inputs.Length == 2 || _inputs.Length == 3);
+                Score = new Impl(this);
+            }
+
+            private static PipelineColumn[] MakeInputs(Scalar<float> label, Vector<float> features, Scalar<float> weights)
+                => weights == null ? new PipelineColumn[] { label, features } : new PipelineColumn[] { label, features, weights };
+
+            protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
+            {
+                Contracts.AssertValue(env);
+                env.Assert(Utils.Size(inputNames) == _inputs.Length);
+                return _estMaker(env, inputNames[0], inputNames[1], inputNames.Length > 2 ? inputNames[2] : null);
+            }
+
+            private sealed class Impl : Scalar<float>
+            {
+                public Impl(Regression rec) : base(rec, rec._inputs) { }
+            }
+        }
+
+        /// <summary>
+        /// A reconciler for regression capable of handling the most common cases for binary classifier with calibrated outputs.
+        /// </summary>
+        public sealed class BinaryClassifier : TrainerEstimatorReconciler
+        {
+            /// <summary>
+            /// The delegate to parameterize the <see cref="BinaryClassifier"/> instance.
+            /// </summary>
+            /// <param name="env">The environment with which to create the estimator</param>
+            /// <param name="label">The label column name</param>
+            /// <param name="features">The features column name</param>
+            /// <param name="weights">The weights column name, or <c>null</c> if the reconciler was constructed with <c>null</c> weights</param>
+            /// <returns></returns>
+            public delegate IEstimator<ITransformer> EstimatorMaker(IHostEnvironment env, string label, string features, string weights);
+
+            private readonly EstimatorMaker _estMaker;
+            private static readonly string[] _fixedOutputNames = new[] { DefaultColumnNames.Score, DefaultColumnNames.Probability, DefaultColumnNames.PredictedLabel };
+
+            /// <summary>
+            /// The general output for binary classifiers.
+            /// </summary>
+            public (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel) Output { get; }
+
+            protected override IEnumerable<PipelineColumn> Outputs => new PipelineColumn[] { Output.score, Output.probability, Output.predictedLabel };
+
+            /// <summary>
+            /// Constructs a new general regression reconciler.
+            /// </summary>
+            /// <param name="estimatorMaker">The delegate to create the training estimator. It is assumed that this estimator
+            /// will produce a single new scalar <see cref="float"/> column named <see cref="DefaultColumnNames.Score"/>.</param>
+            /// <param name="label">The input label column</param>
+            /// <param name="features">The input features column</param>
+            /// <param name="weights">The input weights column, or <c>null</c> if there are no weights</param>
+            public BinaryClassifier(EstimatorMaker estimatorMaker, Scalar<bool> label, Vector<float> features, Scalar<float> weights)
+                : base(MakeInputs(Contracts.CheckRef(label, nameof(label)), Contracts.CheckRef(features, nameof(features)), weights),
+                      _fixedOutputNames)
+            {
+                Contracts.CheckValue(estimatorMaker, nameof(estimatorMaker));
+                _estMaker = estimatorMaker;
+                Contracts.Assert(_inputs.Length == 2 || _inputs.Length == 3);
+
+                Output = (new Impl(this), new Impl(this), new ImplBool(this));
+            }
+
+            private static PipelineColumn[] MakeInputs(Scalar<bool> label, Vector<float> features, Scalar<float> weights)
+                => weights == null ? new PipelineColumn[] { label, features } : new PipelineColumn[] { label, features, weights };
+
+            protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
+            {
+                Contracts.AssertValue(env);
+                env.Assert(Utils.Size(inputNames) == _inputs.Length);
+                return _estMaker(env, inputNames[0], inputNames[1], inputNames.Length > 2 ? inputNames[2] : null);
+            }
+
+            private sealed class Impl : Scalar<float>
+            {
+                public Impl(BinaryClassifier rec) : base(rec, rec._inputs) { }
+            }
+
+            private sealed class ImplBool : Scalar<bool>
+            {
+                public ImplBool(BinaryClassifier rec) : base(rec, rec._inputs) { }
+            }
+        }
+
+        /// <summary>
+        /// A reconciler for regression capable of handling the most common cases for binary classification
+        /// that does not necessarily have calibrated outputs.
+        /// </summary>
+        public sealed class BinaryClassifierNoCalibration : TrainerEstimatorReconciler
+        {
+            /// <summary>
+            /// The delegate to parameterize the <see cref="BinaryClassifier"/> instance.
+            /// </summary>
+            /// <param name="env">The environment with which to create the estimator</param>
+            /// <param name="label">The label column name</param>
+            /// <param name="features">The features column name</param>
+            /// <param name="weights">The weights column name, or <c>null</c> if the reconciler was constructed with <c>null</c> weights</param>
+            /// <returns></returns>
+            public delegate IEstimator<ITransformer> EstimatorMaker(IHostEnvironment env, string label, string features, string weights);
+
+            private readonly EstimatorMaker _estMaker;
+            private static readonly string[] _fixedOutputNamesProb = new[] { DefaultColumnNames.Score, DefaultColumnNames.Probability, DefaultColumnNames.PredictedLabel };
+            private static readonly string[] _fixedOutputNames = new[] { DefaultColumnNames.Score, DefaultColumnNames.PredictedLabel };
+
+            /// <summary>
+            /// The general output for binary classifiers.
+            /// </summary>
+            public (Scalar<float> score, Scalar<bool> predictedLabel) Output { get; }
+
+            protected override IEnumerable<PipelineColumn> Outputs { get; }
+
+            /// <summary>
+            /// Constructs a new general binary classifier reconciler.
+            /// </summary>
+            /// <param name="estimatorMaker">The delegate to create the training estimator. It is assumed that this estimator
+            /// will produce a single new scalar <see cref="float"/> column named <see cref="DefaultColumnNames.Score"/>.</param>
+            /// <param name="label">The input label column</param>
+            /// <param name="features">The input features column</param>
+            /// <param name="weights">The input weights column, or <c>null</c> if there are no weights</param>
+            /// <param name="hasProbs">While this type is a compile time construct, it may be that at runtime we have determined that we will have probabilities,
+            /// and so ought to do the renaming of the <see cref="DefaultColumnNames.Probability"/> column anyway if appropriate. If this is so, then this should
+            /// be set to true.</param>
+            public BinaryClassifierNoCalibration(EstimatorMaker estimatorMaker, Scalar<bool> label, Vector<float> features, Scalar<float> weights, bool hasProbs)
+                : base(MakeInputs(Contracts.CheckRef(label, nameof(label)), Contracts.CheckRef(features, nameof(features)), weights),
+                      hasProbs ? _fixedOutputNamesProb : _fixedOutputNames)
+            {
+                Contracts.CheckValue(estimatorMaker, nameof(estimatorMaker));
+                _estMaker = estimatorMaker;
+                Contracts.Assert(_inputs.Length == 2 || _inputs.Length == 3);
+
+                Output = (new Impl(this), new ImplBool(this));
+
+                if (hasProbs)
+                    Outputs = new PipelineColumn[] { Output.score, new Impl(this), Output.predictedLabel };
+                else
+                    Outputs = new PipelineColumn[] { Output.score, Output.predictedLabel };
+            }
+
+            private static PipelineColumn[] MakeInputs(Scalar<bool> label, Vector<float> features, Scalar<float> weights)
+                => weights == null ? new PipelineColumn[] { label, features } : new PipelineColumn[] { label, features, weights };
+
+            protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
+            {
+                Contracts.AssertValue(env);
+                env.Assert(Utils.Size(inputNames) == _inputs.Length);
+                return _estMaker(env, inputNames[0], inputNames[1], inputNames.Length > 2 ? inputNames[2] : null);
+            }
+
+            private sealed class Impl : Scalar<float>
+            {
+                public Impl(BinaryClassifierNoCalibration rec) : base(rec, rec._inputs) { }
+            }
+
+            private sealed class ImplBool : Scalar<bool>
+            {
+                public ImplBool(BinaryClassifierNoCalibration rec) : base(rec, rec._inputs) { }
+            }
+        }
+    }
+}

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -1405,11 +1405,25 @@ namespace Microsoft.ML.Runtime.Learners
             Info = new TrainerInfo(calibration: !(_loss is LogLoss));
             _args = args;
             _positiveInstanceWeight = _args.PositiveInstanceWeight;
-            OutputColumns = new[]
+
+            if (Info.NeedCalibration)
             {
-                new SchemaShape.Column(DefaultColumnNames.Score, SchemaShape.Column.VectorKind.Scalar, NumberType.R4, false),
-                new SchemaShape.Column(DefaultColumnNames.PredictedLabel, SchemaShape.Column.VectorKind.Scalar, BoolType.Instance, false)
-            };
+                OutputColumns = new[]
+                {
+                    new SchemaShape.Column(DefaultColumnNames.Score, SchemaShape.Column.VectorKind.Scalar, NumberType.R4, false),
+                    new SchemaShape.Column(DefaultColumnNames.PredictedLabel, SchemaShape.Column.VectorKind.Scalar, BoolType.Instance, false)
+                };
+            }
+            else
+            {
+                OutputColumns = new[]
+                {
+                    new SchemaShape.Column(DefaultColumnNames.Score, SchemaShape.Column.VectorKind.Scalar, NumberType.R4, false),
+                    new SchemaShape.Column(DefaultColumnNames.Probability, SchemaShape.Column.VectorKind.Scalar, NumberType.R4, false),
+                    new SchemaShape.Column(DefaultColumnNames.PredictedLabel, SchemaShape.Column.VectorKind.Scalar, BoolType.Instance, false)
+                };
+            }
+
         }
 
         public LinearClassificationTrainer(IHostEnvironment env, Arguments args)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
@@ -22,8 +22,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="features">The features, or independent variables.</param>
         /// <param name="weights">The optional example weights.</param>
         /// <param name="l2Const">The L2 regularization hyperparameter.</param>
-        /// <param name="l1Threshold">The L1 regularization hyperparameter. Higher values will tend to lead to
-        /// more sparse model.</param>
+        /// <param name="l1Threshold">The L1 regularization hyperparameter. Higher values will tend to lead to more sparse model.</param>
         /// <param name="maxIterations">The maximum number of passes to perform over the data.</param>
         /// <param name="loss">The custom loss, if unspecified will be <see cref="SquaredLossSDCARegressionLossFunction"/>.</param>
         /// <param name="onFit">A delegate that is called every time the
@@ -76,8 +75,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="features">The features, or independent variables.</param>
         /// <param name="weights">The optional example weights.</param>
         /// <param name="l2Const">The L2 regularization hyperparameter.</param>
-        /// <param name="l1Threshold">The L1 regularization hyperparameter. Higher values will tend to lead to
-        /// more sparse model.</param>
+        /// <param name="l1Threshold">The L1 regularization hyperparameter. Higher values will tend to lead to more sparse model.</param>
         /// <param name="maxIterations">The maximum number of passes to perform over the data.</param>
         /// <param name="onFit">A delegate that is called every time the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}.Fit(DataView{TTupleInShape})"/> method is called on the
@@ -139,8 +137,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// /// <param name="loss">The custom loss.</param>
         /// <param name="weights">The optional example weights.</param>
         /// <param name="l2Const">The L2 regularization hyperparameter.</param>
-        /// <param name="l1Threshold">The L1 regularization hyperparameter. Higher values will tend to lead to
-        /// more sparse model.</param>
+        /// <param name="l1Threshold">The L1 regularization hyperparameter. Higher values will tend to lead to more sparse model.</param>
         /// <param name="maxIterations">The maximum number of passes to perform over the data.</param>
         /// <param name="onFit">A delegate that is called every time the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}.Fit(DataView{TTupleInShape})"/> method is called on the

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="onFit">A delegate that is called every time the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}.Fit(DataView{TTupleInShape})"/> method is called on the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}"/> instance created out of this. This delegate will receive
-        /// the linear model that was learnt.  Note that this action cannot change the result in any way; it is only a way for the caller to
+        /// the linear model that was trained.  Note that this action cannot change the result in any way; it is only a way for the caller to
         /// be informed about what was learnt.</param>
         /// <returns>The predicted output.</returns>
         public static Scalar<float> PredictSdcaRegression(this Scalar<float> label, Vector<float> features, Scalar<float> weights = null,
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="onFit">A delegate that is called every time the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}.Fit(DataView{TTupleInShape})"/> method is called on the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}"/> instance created out of this. This delegate will receive
-        /// the linear model that was learnt, as well as the calibrator on top of that model. Note that this action cannot change the
+        /// the linear model that was trained, as well as the calibrator on top of that model. Note that this action cannot change the
         /// result in any way; it is only a way for the caller to be informed about what was learnt.</param>
         /// <returns>The set of output columns including in order the predicted binary classification score (which will range
         /// from negative to positive infinity), the calibrated prediction (from 0 to 1), and the predicted label.</returns>
@@ -142,7 +142,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="onFit">A delegate that is called every time the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}.Fit(DataView{TTupleInShape})"/> method is called on the
         /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}"/> instance created out of this. This delegate will receive
-        /// the linear model that was learnt, as well as the calibrator on top of that model. Note that this action cannot change the
+        /// the linear model that was trained, as well as the calibrator on top of that model. Note that this action cannot change the
         /// result in any way; it is only a way for the caller to be informed about what was learnt.</param>
         /// <returns>The set of output columns including in order the predicted binary classification score (which will range
         /// from negative to positive infinity), and the predicted label.</returns>

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.ML.Data.StaticPipe.Runtime;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Internal.Calibration;
+
+namespace Microsoft.ML.Runtime.Learners
+{
+    /// <summary>
+    /// Extension methods and utilities.
+    /// </summary>
+    public static class SdcaStatic
+    {
+        public static Scalar<float> PredictSdcaRegression(this Scalar<float> label, Vector<float> features, Scalar<float> weights = null,
+            float? l2Const = null,
+            float? l1Threshold = null,
+            float convergenceTolerance = 0.01f,
+            int? maxIterations = null,
+            bool shuffle = true,
+            float biasLearningRate = 1,
+            ISupportSdcaRegressionLossFactory loss = null,
+            Action<LinearRegressionPredictor> onFit = null)
+        {
+            var args = new SdcaRegressionTrainer.Arguments()
+            {
+                L2Const = l2Const,
+                L1Threshold = l1Threshold,
+                ConvergenceTolerance = convergenceTolerance,
+                MaxIterations = maxIterations,
+                Shuffle = shuffle,
+                BiasLearningRate = biasLearningRate,
+                LossFunction = loss ?? new SquaredLossFactory()
+            };
+
+            var rec = new TrainerEstimatorReconciler.Regression(
+                (env, labelName, featuresName, weightsName) =>
+                {
+                    var trainer = new SdcaRegressionTrainer(env, args, featuresName, labelName, weightsName);
+                    if (onFit != null)
+                        return trainer.WithOnFitDelegate(trans => onFit(trans.Model));
+                    return trainer;
+                }, label, features, weights);
+
+            return rec.Score;
+        }
+
+        public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel)
+            PredictSdcaBinaryClassification(this Scalar<bool> label, Vector<float> features, Scalar<float> weights = null,
+                float? l2Const = null,
+                float? l1Threshold = null,
+                float convergenceTolerance = 0.1f,
+                int? maxIterations = null,
+                bool shuffle = true,
+                float biasLearningRate = 0,
+                Action<LinearBinaryPredictor, ParameterMixingCalibratedPredictor> onFit = null)
+        {
+            var args = new LinearClassificationTrainer.Arguments()
+            {
+                L2Const = l2Const,
+                L1Threshold = l1Threshold,
+                ConvergenceTolerance = convergenceTolerance,
+                MaxIterations = maxIterations,
+                Shuffle = shuffle,
+                BiasLearningRate = biasLearningRate
+            };
+
+            var rec = new TrainerEstimatorReconciler.BinaryClassifier(
+                (env, labelName, featuresName, weightsName) =>
+                {
+                    var trainer = new LinearClassificationTrainer(env, args, featuresName, labelName, weightsName);
+                    if (onFit != null)
+                    {
+                        return trainer.WithOnFitDelegate(trans =>
+                        {
+                            // Under the default log-loss we assume a calibrated predictor.
+                            var model = trans.Model;
+                            var cali = (ParameterMixingCalibratedPredictor)model;
+                            var pred = (LinearBinaryPredictor)cali.SubPredictor;
+                            onFit(pred, cali);
+                        });
+                    }
+                    return trainer;
+                }, label, features, weights);
+
+            return rec.Output;
+        }
+
+        private sealed class TrivialFactory : ISupportSdcaClassificationLossFactory
+        {
+            private readonly ISupportSdcaClassificationLoss _loss;
+
+            public TrivialFactory(ISupportSdcaClassificationLoss loss)
+            {
+                _loss = loss;
+            }
+
+            public ISupportSdcaClassificationLoss CreateComponent(IHostEnvironment env)
+            {
+                // REVIEW: We are ignoring env?
+                return _loss;
+            }
+        }
+
+        public static (Scalar<float> score, Scalar<bool> predictedLabel)
+            PredictSdcaBinaryClassificationCustomLoss(this Scalar<bool> label, Vector<float> features, Scalar<float> weights = null,
+                float? l2Const = null,
+                float? l1Threshold = null,
+                float convergenceTolerance = 0.1f,
+                int? maxIterations = null,
+                bool shuffle = true,
+                float biasLearningRate = 0,
+                ISupportSdcaClassificationLoss loss = null,
+                Action<LinearBinaryPredictor> onFit = null
+            )
+        {
+            ISupportSdcaClassificationLossFactory lossFactory = new LogLossFactory();
+            if (loss != null)
+                lossFactory = new TrivialFactory(loss);
+            bool hasProbs = lossFactory is LogLossFactory || loss is LogLoss;
+
+            var args = new LinearClassificationTrainer.Arguments()
+            {
+                L2Const = l2Const,
+                L1Threshold = l1Threshold,
+                ConvergenceTolerance = convergenceTolerance,
+                MaxIterations = maxIterations,
+                Shuffle = shuffle,
+                LossFunction = lossFactory,
+                BiasLearningRate = biasLearningRate
+            };
+
+            var rec = new TrainerEstimatorReconciler.BinaryClassifierNoCalibration(
+                (env, labelName, featuresName, weightsName) =>
+                {
+                    var trainer = new LinearClassificationTrainer(env, args, featuresName, labelName, weightsName);
+                    if (onFit != null)
+                    {
+                        return trainer.WithOnFitDelegate(trans =>
+                        {
+                            var model = trans.Model;
+                            if (model is ParameterMixingCalibratedPredictor cali)
+                                onFit((LinearBinaryPredictor)cali.SubPredictor);
+                            else
+                                onFit((LinearBinaryPredictor)model);
+                        });
+                    }
+                    return trainer;
+                }, label, features, weights, hasProbs);
+
+            return rec.Output;
+        }
+    }
+}

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/TypeIsSchemaShapeResource.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/TypeIsSchemaShapeResource.cs
@@ -16,7 +16,7 @@ namespace Bubba
                 text: ctx.LoadText(1),
                 numericFeatures: ctx.LoadFloat(2, 5)));
 
-            var est = Estimator.MakeNew(text);
+            var est = text.MakeNewEstimator();
             // This should work.
             est.Append(r => r.text);
             // These should not.

--- a/test/Microsoft.ML.StaticPipelineTesting/ImageAnalyticsTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/ImageAnalyticsTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.ML.StaticPipelineTesting
 {
-    public sealed class ImageAnalyticsTests : MakeConsoleWork
+    public sealed class ImageAnalyticsTests : BaseTestClassWithConsole
     {
         public ImageAnalyticsTests(ITestOutputHelper output)
             : base(output)

--- a/test/Microsoft.ML.StaticPipelineTesting/Microsoft.ML.StaticPipelineTesting.csproj
+++ b/test/Microsoft.ML.StaticPipelineTesting/Microsoft.ML.StaticPipelineTesting.csproj
@@ -5,8 +5,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.ImageAnalytics\Microsoft.ML.ImageAnalytics.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.ML.StandardLearners\Microsoft.ML.StandardLearners.csproj" />
     <ProjectReference Include="..\Microsoft.ML.TestFramework\Microsoft.ML.TestFramework.csproj" />
 
     <ProjectReference Include="..\..\src\Microsoft.ML.Analyzer\Microsoft.ML.Analyzer.csproj" />
+
+    <NativeAssemblyReference Include="CpuMathNative" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Data.StaticPipe;
-using Microsoft.ML.Data.StaticPipe.Runtime;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.TestFramework;
@@ -15,12 +14,12 @@ using Xunit.Abstractions;
 
 namespace Microsoft.ML.StaticPipelineTesting
 {
-    public abstract class MakeConsoleWork : BaseTestClass, IDisposable
+    public abstract class BaseTestClassWithConsole : BaseTestClass, IDisposable
     {
         private readonly TextWriter _originalOut;
         private readonly TextWriter _textWriter;
 
-        public MakeConsoleWork(ITestOutputHelper output)
+        public BaseTestClassWithConsole(ITestOutputHelper output)
             : base(output)
         {
             _originalOut = Console.Out;
@@ -35,7 +34,7 @@ namespace Microsoft.ML.StaticPipelineTesting
         }
     }
 
-    public sealed class StaticPipeTests : MakeConsoleWork
+    public sealed class StaticPipeTests : BaseTestClassWithConsole
     {
         public StaticPipeTests(ITestOutputHelper output)
             : base(output)

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // The next step where we shuffle the names around a little bit is one where we are
             // testing out the implicit usage of copy columns.
 
-            var est = Estimator.MakeNew(text).Append(r => (text: r.label, label: r.numericFeatures));
+            var est = text.MakeNewEstimator().Append(r => (text: r.label, label: r.numericFeatures));
             var newText = text.Append(est);
             var newTextData = newText.Fit(dataSource).Read(dataSource);
 

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -15,15 +15,14 @@ using Xunit.Abstractions;
 
 namespace Microsoft.ML.StaticPipelineTesting
 {
-    public abstract class MakeConsoleWork : IDisposable
+    public abstract class MakeConsoleWork : BaseTestClass, IDisposable
     {
-        private readonly ITestOutputHelper _output;
         private readonly TextWriter _originalOut;
         private readonly TextWriter _textWriter;
 
         public MakeConsoleWork(ITestOutputHelper output)
+            : base(output)
         {
-            _output = output;
             _originalOut = Console.Out;
             _textWriter = new StringWriter();
             Console.SetOut(_textWriter);
@@ -31,7 +30,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
         public void Dispose()
         {
-            _output.WriteLine(_textWriter.ToString());
+            Output.WriteLine(_textWriter.ToString());
             Console.SetOut(_originalOut);
         }
     }

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             LinearRegressionPredictor pred = null;
 
-            var est = Estimator.MakeNew(reader)
+            var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, score: r.label.PredictSdcaRegression(r.features, onFit: p => pred = p)));
 
             var pipe = reader.Append(est);
@@ -64,7 +64,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10), Score: c.LoadText(2)),
                 separator: ';', hasHeader: true);
 
-            var est = Estimator.MakeNew(reader)
+            var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, r.Score, score: r.label.PredictSdcaRegression(r.features)));
 
             var pipe = reader.Append(est);
@@ -94,7 +94,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             LinearBinaryPredictor pred = null;
             ParameterMixingCalibratedPredictor cali = null;
 
-            var est = Estimator.MakeNew(reader)
+            var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: r.label.PredictSdcaBinaryClassification(r.features,
                     onFit: (p, c) => { pred = p; cali = c; })));
 
@@ -132,7 +132,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var loss = new HingeLoss(new HingeLoss.Arguments() { Margin = 1 });
 
             // With a custom loss function we no longer get calibrated predictions.
-            var est = Estimator.MakeNew(reader)
+            var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: r.label.PredictSdcaBinaryClassificationCustomLoss(r.features,
                     loss: loss,  onFit: p => pred = p)));
 

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Data.StaticPipe;
+using Microsoft.ML.Runtime;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Internal.Calibration;
+using Microsoft.ML.Runtime.Learners;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ML.StaticPipelineTesting
+{
+    public sealed class Training : MakeConsoleWork
+    {
+        public Training(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void SdcaRegression()
+        {
+            var env = new TlcEnvironment(seed: 0);
+            var dataPath = GetDataPath("external", "winequality-white.csv");
+            var dataSource = new MultiFileSource(dataPath);
+
+            var reader = TextLoader.CreateReader(env,
+                c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10)),
+                separator: ';', hasHeader: true);
+
+            LinearRegressionPredictor pred = null;
+
+            var est = Estimator.MakeNew(reader)
+                .Append(r => (r.label, score: r.label.PredictSdcaRegression(r.features, onFit: p => pred = p)));
+
+            var pipe = reader.Append(est);
+
+            Assert.Null(pred);
+            var model = pipe.Fit(dataSource);
+            Assert.NotNull(pred);
+            // 11 input features, so we ought to have 11 weights.
+            Assert.Equal(11, pred.Weights2.Count);
+
+            var data = model.Read(dataSource);
+
+            // Just output some data on the schema for fun.
+            var rows = DataViewUtils.ComputeRowCount(data.AsDynamic);
+            var schema = data.AsDynamic.Schema;
+            for (int c = 0; c < schema.ColumnCount; ++c)
+                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+        }
+
+        [Fact]
+        public void SdcaRegressionNameCollision()
+        {
+            var env = new TlcEnvironment(seed: 0);
+            var dataPath = GetDataPath("external", "winequality-white.csv");
+            var dataSource = new MultiFileSource(dataPath);
+
+            // Here we introduce another column called "Score" to collide with the name of the default output. Heh heh heh...
+            var reader = TextLoader.CreateReader(env,
+                c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10), Score: c.LoadText(2)),
+                separator: ';', hasHeader: true);
+
+            var est = Estimator.MakeNew(reader)
+                .Append(r => (r.label, r.Score, score: r.label.PredictSdcaRegression(r.features)));
+
+            var pipe = reader.Append(est);
+
+            var model = pipe.Fit(dataSource);
+            var data = model.Read(dataSource);
+
+            // Now, let's see if that column is still there, and still text!
+            var schema = data.AsDynamic.Schema;
+            Assert.True(schema.TryGetColumnIndex("Score", out int scoreCol), "Score column not present!");
+            Assert.Equal(TextType.Instance, schema.GetColumnType(scoreCol));
+
+            for (int c = 0; c < schema.ColumnCount; ++c)
+                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+        }
+
+        [Fact]
+        public void SdcaBinaryClassification()
+        {
+            var env = new TlcEnvironment(seed: 0);
+            var dataPath = GetDataPath("breast-cancer.txt");
+            var dataSource = new MultiFileSource(dataPath);
+
+            var reader = TextLoader.CreateReader(env,
+                c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
+
+            LinearBinaryPredictor pred = null;
+            ParameterMixingCalibratedPredictor cali = null;
+
+            var est = Estimator.MakeNew(reader)
+                .Append(r => (r.label, preds: r.label.PredictSdcaBinaryClassification(r.features,
+                    onFit: (p, c) => { pred = p; cali = c; })));
+
+            var pipe = reader.Append(est);
+
+            Assert.Null(pred);
+            Assert.Null(cali);
+            var model = pipe.Fit(dataSource);
+            Assert.NotNull(pred);
+            Assert.NotNull(cali);
+            // 9 input features, so we ought to have 9 weights.
+            Assert.Equal(9, pred.Weights2.Count);
+
+            var data = model.Read(dataSource);
+
+            // Just output some data on the schema for fun.
+            var rows = DataViewUtils.ComputeRowCount(data.AsDynamic);
+            var schema = data.AsDynamic.Schema;
+            for (int c = 0; c < schema.ColumnCount; ++c)
+                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+        }
+
+        [Fact]
+        public void SdcaBinaryClassificationNoClaibration()
+        {
+            var env = new TlcEnvironment(seed: 0);
+            var dataPath = GetDataPath("breast-cancer.txt");
+            var dataSource = new MultiFileSource(dataPath);
+
+            var reader = TextLoader.CreateReader(env,
+                c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
+
+            LinearBinaryPredictor pred = null;
+
+            var loss = new HingeLoss(new HingeLoss.Arguments() { Margin = 1 });
+
+            // With a custom loss function we no longer get calibrated predictions.
+            var est = Estimator.MakeNew(reader)
+                .Append(r => (r.label, preds: r.label.PredictSdcaBinaryClassificationCustomLoss(r.features,
+                    loss: loss,  onFit: p => pred = p)));
+
+            var pipe = reader.Append(est);
+
+            Assert.Null(pred);
+            var model = pipe.Fit(dataSource);
+            Assert.NotNull(pred);
+            // 9 input features, so we ought to have 9 weights.
+            Assert.Equal(9, pred.Weights2.Count);
+
+            var data = model.Read(dataSource);
+
+            // Just output some data on the schema for fun.
+            var rows = DataViewUtils.ComputeRowCount(data.AsDynamic);
+            var schema = data.AsDynamic.Schema;
+            for (int c = 0; c < schema.ColumnCount; ++c)
+                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+        }
+    }
+}

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.ML.StaticPipelineTesting
 {
-    public sealed class Training : MakeConsoleWork
+    public sealed class Training : BaseTestClassWithConsole
     {
         public Training(ITestOutputHelper output) : base(output)
         {
@@ -33,7 +33,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             LinearRegressionPredictor pred = null;
 
             var est = reader.MakeNewEstimator()
-                .Append(r => (r.label, score: r.label.PredictSdcaRegression(r.features, onFit: p => pred = p)));
+                .Append(r => (r.label, score: r.label.PredictSdcaRegression(r.features, maxIterations: 2, onFit: p => pred = p)));
 
             var pipe = reader.Append(est);
 
@@ -65,7 +65,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 separator: ';', hasHeader: true);
 
             var est = reader.MakeNewEstimator()
-                .Append(r => (r.label, r.Score, score: r.label.PredictSdcaRegression(r.features)));
+                .Append(r => (r.label, r.Score, score: r.label.PredictSdcaRegression(r.features, maxIterations: 2)));
 
             var pipe = reader.Append(est);
 
@@ -96,6 +96,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: r.label.PredictSdcaBinaryClassification(r.features,
+                    maxIterations: 2,
                     onFit: (p, c) => { pred = p; cali = c; })));
 
             var pipe = reader.Append(est);
@@ -133,8 +134,9 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // With a custom loss function we no longer get calibrated predictions.
             var est = reader.MakeNewEstimator()
-                .Append(r => (r.label, preds: r.label.PredictSdcaBinaryClassificationCustomLoss(r.features,
-                    loss: loss,  onFit: p => pred = p)));
+                .Append(r => (r.label, preds: r.label.PredictSdcaBinaryClassification(r.features,
+                maxIterations: 2,
+                loss: loss, onFit: p => pred = p)));
 
             var pipe = reader.Append(est);
 


### PR DESCRIPTION
Related to the closed #632 and the API overall. In here I introduce extensions for SDCA regression and binary classification. (No multiclass until I also write extensions for term.)

This also includes a sort of general purpose utilities for writing reconcilers for trainers, though, again, only regression, binary classification, and binary classification without probabilities so far.

Also a minor change to the linear classification trainer, as it was not identifying that it was producing probabilities sometimes.