### PR TITLE
Updated version number of MlNetMklDeps package to 0.0.0.6

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -8,7 +8,7 @@
     <SystemReflectionEmitLightweightPackageVersion>4.3.0</SystemReflectionEmitLightweightPackageVersion>
     <PublishSymbolsPackageVersion>1.0.0-beta-62824-02</PublishSymbolsPackageVersion>
     <LightGBMPackageVersion>2.1.2.2</LightGBMPackageVersion>
-    <MlNetMklDepsPackageVersion>0.0.0.5</MlNetMklDepsPackageVersion>
+    <MlNetMklDepsPackageVersion>0.0.0.6</MlNetMklDepsPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>
     <BenchmarkDotNetVersion>0.11.1</BenchmarkDotNetVersion>
     <TensorFlowVersion>1.10.0</TensorFlowVersion>


### PR DESCRIPTION
Fixes #859.

I updated the version number of the package MlNetMklDeps in build/Dependencies.props. 

Although ML.NET does not officially support x86 at this moment, the new MlNetMklDeps nuget package contains the x86 binaries.
