### PR TITLE
Add TensorFlow documentation to the main class, and include examples on it. 

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -296,9 +296,9 @@ namespace Microsoft.ML.Transforms
             public string OutputColumn;
         }
 
-        public const string Summary = "Transforms the data using the TensorFlow model.";
-        public const string UserName = "TensorFlowTransform";
-        public const string ShortName = "TFTransform";
+        internal const string Summary = "Transforms the data using the TensorFlow model.";
+        internal const string UserName = "TensorFlowTransform";
+        internal const string ShortName = "TFTransform";
         private const string RegistrationName = "TensorFlowTransform";
 
         /// <summary>
@@ -373,12 +373,7 @@ namespace Microsoft.ML.Transforms
             }
         }
 
-        [TlcModule.EntryPoint(Name = "Transforms.TensorFlowScorer",
-            Desc = Summary,
-            UserName = UserName,
-            ShortName = ShortName,
-            XmlInclude = new[] { @"<include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/member[@name=""TensorflowTransform""]/*' />",
-                                 @"<include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/example[@name=""TensorflowTransform""]/*' />" })]
+        [TlcModule.EntryPoint(Name = "Transforms.TensorFlowScorer", Desc = Summary, UserName = UserName, ShortName = ShortName)]
         public static CommonOutputs.TransformOutput TensorFlowScorer(IHostEnvironment env, Arguments input)
         {
             Contracts.CheckValue(env, nameof(env));

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -25,6 +25,7 @@ using Microsoft.ML.Transforms.TensorFlow;
 
 namespace Microsoft.ML.Transforms
 {
+    /// <include file='doc.xml' path='doc/members/member[@name="TensorflowTransform"]/*' />
     public static class TensorFlowTransform
     {
         internal sealed class TensorFlowMapper : IRowMapper
@@ -372,7 +373,12 @@ namespace Microsoft.ML.Transforms
             }
         }
 
-        [TlcModule.EntryPoint(Name = "Transforms.TensorFlowScorer", Desc = Summary, UserName = UserName, ShortName = ShortName)]
+        [TlcModule.EntryPoint(Name = "Transforms.TensorFlowScorer",
+            Desc = Summary,
+            UserName = UserName,
+            ShortName = ShortName,
+            XmlInclude = new[] { @"<include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/member[@name=""TensorflowTransform""]/*' />",
+                                 @"<include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/example[@name=""TensorflowTransform""]/*' />" })]
         public static CommonOutputs.TransformOutput TensorFlowScorer(IHostEnvironment env, Arguments input)
         {
             Contracts.CheckValue(env, nameof(env));

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -373,7 +373,12 @@ namespace Microsoft.ML.Transforms
             }
         }
 
-        [TlcModule.EntryPoint(Name = "Transforms.TensorFlowScorer", Desc = Summary, UserName = UserName, ShortName = ShortName)]
+        [TlcModule.EntryPoint(Name = "Transforms.TensorFlowScorer",
+            Desc = Summary,
+            UserName = UserName,
+            ShortName = ShortName,
+            XmlInclude = new[] { @"<include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/member[@name=""TensorflowTransform""]/*' />",
+                                 @"<include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/example[@name=""TensorflowTransform""]/*' />" })]
         public static CommonOutputs.TransformOutput TensorFlowScorer(IHostEnvironment env, Arguments input)
         {
             Contracts.CheckValue(env, nameof(env));

--- a/src/Microsoft.ML.TensorFlow/doc.xml
+++ b/src/Microsoft.ML.TensorFlow/doc.xml
@@ -30,7 +30,6 @@
 		
       </remarks>
     </member>
-    <example name="TensorflowTransform">
       <example>
         <code language="csharp">
           pipeline.Add(new TextLoader(dataFile).CreateFrom&lt;MNISTData&gt;(useHeader: false));
@@ -72,7 +71,6 @@
                 OutputColumn = &quot;Output&quot;
             });
         </code>
-      </example>
     </example>
     
   </members>

--- a/src/Microsoft.ML/CSharpApi.cs
+++ b/src/Microsoft.ML/CSharpApi.cs
@@ -15777,9 +15777,8 @@ namespace Microsoft.ML
     namespace Transforms
     {
 
-        /// <summary>
-        /// Transforms the data using the TensorFlow model.
-        /// </summary>
+        /// <include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/member[@name="TensorflowTransform"]/*' />
+        /// <include file='../Microsoft.ML.TensorFlow/doc.xml' path='doc/members/example[@name="TensorflowTransform"]/*' />
         public sealed partial class TensorFlowScorer : Microsoft.ML.Runtime.EntryPoints.CommonInputs.ITransformInput, Microsoft.ML.ILearningPipelineItem
         {
 


### PR DESCRIPTION
Fixes #866 
Adds the documentation to the class, and not just the Create method, and changes the visibility of some of the properties that don't need to be user-facing. 

Includes the examples in the doc.  



