### PR TITLE
different config files for train and predict benchmarks

### DIFF
--- a/test/Microsoft.ML.Benchmarks/PredictConfig.cs
+++ b/test/Microsoft.ML.Benchmarks/PredictConfig.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Benchmarks
         {
             Add(DefaultConfig.Instance
                 .With(Job.Default
-                    .WithWarmupCount(1) // for our time consuming benchmarks 1 warmup iteration is enough
+                    .WithWarmupCount(1)
                     .WithMaxIterationCount(20)
                     .With(Program.CreateToolchain()))
                 .With(new ExtraMetricColumn())

--- a/test/Microsoft.ML.Benchmarks/PredictConfig.cs
+++ b/test/Microsoft.ML.Benchmarks/PredictConfig.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace Microsoft.ML.Benchmarks
+{
+    internal class PredictConfig : ManualConfig
+    {
+        public PredictConfig()
+        {
+            Add(DefaultConfig.Instance
+                .With(Job.Default
+                    .WithWarmupCount(1) // for our time consuming benchmarks 1 warmup iteration is enough
+                    .WithMaxIterationCount(20)
+                    .With(Program.CreateToolchain()))
+                .With(new ExtraMetricColumn())
+                .With(MemoryDiagnoser.Default));
+        }
+    }
+}

--- a/test/Microsoft.ML.Benchmarks/Program.cs
+++ b/test/Microsoft.ML.Benchmarks/Program.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains;
 using BenchmarkDotNet.Toolchains.CsProj;
@@ -25,21 +22,12 @@ namespace Microsoft.ML.Benchmarks
         static void Main(string[] args) 
             => BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(args, CreateCustomConfig());
-
-        private static IConfig CreateCustomConfig() 
-            => DefaultConfig.Instance
-                .With(Job.Default
-                    .WithWarmupCount(1) // for our time consuming benchmarks 1 warmup iteration is enough
-                    .WithMaxIterationCount(20)
-                    .With(CreateToolchain()))
-                .With(new ExtraMetricColumn())
-                .With(MemoryDiagnoser.Default);
+                .Run(args);
 
         /// <summary>
         /// we need our own toolchain because MSBuild by default does not copy recursive native dependencies to the output
         /// </summary>
-        private static IToolchain CreateToolchain()
+        internal static IToolchain CreateToolchain()
         {
             var csProj = CsProjCoreToolchain.Current.Value;
             var tfm = NetCoreAppSettings.Current.Value.TargetFrameworkMoniker;

--- a/test/Microsoft.ML.Benchmarks/Text/MultiClassClassification.cs
+++ b/test/Microsoft.ML.Benchmarks/Text/MultiClassClassification.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Benchmarks
                     " xf=CategoricalTransform{col=ns}" +
                     " xf=TextTransform{col=FeaturesText:comment wordExtractor=NGramExtractorTransform{ngram=2}}" +
                     " xf=Concat{col=Features:FeaturesText,logged_in,ns}" +
-                    "tr=LightGBMMulticlass{iter=10}";
+                    " tr=LightGBMMulticlass{iter=10}";
 
             using (var environment = new ConsoleEnvironment(verbose: false, sensitivity: MessageSensitivity.None, outWriter: EmptyWriter.Instance))
             {

--- a/test/Microsoft.ML.Benchmarks/Text/MultiClassClassification.cs
+++ b/test/Microsoft.ML.Benchmarks/Text/MultiClassClassification.cs
@@ -11,42 +11,18 @@ using System.IO;
 
 namespace Microsoft.ML.Benchmarks
 {
-    public class MultiClassClassification
+    [Config(typeof(TrainConfig))]
+    public class MultiClassClassificationTrain
     {
         private string _dataPath_Wiki;
-        private string _modelPath_Wiki;
 
-        [GlobalSetup(Targets = new string[] {
-            nameof(CV_Multiclass_WikiDetox_BigramsAndTrichar_OVAAveragedPerceptron),
-            nameof(CV_Multiclass_WikiDetox_BigramsAndTrichar_LightGBMMulticlass),
-            nameof(CV_Multiclass_WikiDetox_WordEmbeddings_OVAAveragedPerceptron),
-            nameof(CV_Multiclass_WikiDetox_WordEmbeddings_SDCAMC)})]
+        [GlobalSetup]
         public void SetupTrainingSpeedTests()
         {
             _dataPath_Wiki = Path.GetFullPath(TestDatasets.WikiDetox.trainFilename);
 
             if (!File.Exists(_dataPath_Wiki))
                 throw new FileNotFoundException(string.Format(Helpers.DatasetNotFound, _dataPath_Wiki));           
-        }
-
-        [GlobalSetup(Target = nameof(Test_Multiclass_WikiDetox_BigramsAndTrichar_OVAAveragedPerceptron))]
-        public void SetupScoringSpeedTests()
-        {
-            SetupTrainingSpeedTests();
-            _modelPath_Wiki = Path.Combine(Directory.GetCurrentDirectory(), @"WikiModel.zip");
-
-            string cmd = @"CV k=5 data=" + _dataPath_Wiki +
-                " loader=TextLoader{quote=- sparse=- col=Label:R4:0 col=rev_id:TX:1 col=comment:TX:2 col=logged_in:BL:4 col=ns:TX:5 col=sample:TX:6 col=split:TX:7 col=year:R4:3 header=+} xf=Convert{col=logged_in type=R4}" +
-                " xf=CategoricalTransform{col=ns}" +
-                " xf=TextTransform{col=FeaturesText:comment wordExtractor=NGramExtractorTransform{ngram=2}}" +
-                " xf=Concat{col=Features:FeaturesText,logged_in,ns}" +
-                " tr=OVA{p=AveragedPerceptron{iter=10}}" +
-                " out={" + _modelPath_Wiki + "}";
-
-            using (var environment = new ConsoleEnvironment(verbose: false, sensitivity: MessageSensitivity.None, outWriter: EmptyWriter.Instance))
-            {
-                Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
-            }
         }
 
         [Benchmark]
@@ -74,20 +50,9 @@ namespace Microsoft.ML.Benchmarks
                     " xf=Convert{col=logged_in type=R4}" +
                     " xf=CategoricalTransform{col=ns}" +
                     " xf=TextTransform{col=FeaturesText:comment wordExtractor=NGramExtractorTransform{ngram=2}}" +
-                    " xf=Concat{col=Features:FeaturesText,logged_in,ns} tr=LightGBMMulticlass{}";
+                    " xf=Concat{col=Features:FeaturesText,logged_in,ns}" +
+                    "tr=LightGBMMulticlass{iter=10}";
 
-            using (var environment = new ConsoleEnvironment(verbose: false, sensitivity: MessageSensitivity.None, outWriter: EmptyWriter.Instance))
-            {
-                Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
-            }
-        }
-
-        [Benchmark]
-        public void Test_Multiclass_WikiDetox_BigramsAndTrichar_OVAAveragedPerceptron()
-        {
-            // This benchmark is profiling bulk scoring speed and not training speed. 
-            string modelpath = Path.Combine(Directory.GetCurrentDirectory(), @"WikiModel.fold000.zip");
-            string cmd = @"Test data=" + _dataPath_Wiki + " in=" + modelpath;
             using (var environment = new ConsoleEnvironment(verbose: false, sensitivity: MessageSensitivity.None, outWriter: EmptyWriter.Instance))
             {
                 Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
@@ -124,6 +89,49 @@ namespace Microsoft.ML.Benchmarks
                 " xf=WordEmbeddingsTransform{col=FeaturesWordEmbedding:FeaturesText_TransformedText model=FastTextWikipedia300D}" +
                 " xf=Concat{col=Features:FeaturesWordEmbedding,logged_in,ns}";
 
+            using (var environment = new ConsoleEnvironment(verbose: false, sensitivity: MessageSensitivity.None, outWriter: EmptyWriter.Instance))
+            {
+                Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            }
+        }
+    }
+
+    [Config(typeof(PredictConfig))]
+    public class MultiClassClassificationTest
+    {
+        private string _dataPath_Wiki;
+        private string _modelPath_Wiki;
+
+        [GlobalSetup]
+        public void SetupScoringSpeedTests()
+        {
+            _dataPath_Wiki = Path.GetFullPath(TestDatasets.WikiDetox.trainFilename);
+
+            if (!File.Exists(_dataPath_Wiki))
+                throw new FileNotFoundException(string.Format(Helpers.DatasetNotFound, _dataPath_Wiki));
+
+            _modelPath_Wiki = Path.Combine(Directory.GetCurrentDirectory(), @"WikiModel.zip");
+
+            string cmd = @"CV k=5 data=" + _dataPath_Wiki +
+                " loader=TextLoader{quote=- sparse=- col=Label:R4:0 col=rev_id:TX:1 col=comment:TX:2 col=logged_in:BL:4 col=ns:TX:5 col=sample:TX:6 col=split:TX:7 col=year:R4:3 header=+} xf=Convert{col=logged_in type=R4}" +
+                " xf=CategoricalTransform{col=ns}" +
+                " xf=TextTransform{col=FeaturesText:comment wordExtractor=NGramExtractorTransform{ngram=2}}" +
+                " xf=Concat{col=Features:FeaturesText,logged_in,ns}" +
+                " tr=OVA{p=AveragedPerceptron{iter=10}}" +
+                " out={" + _modelPath_Wiki + "}";
+
+            using (var environment = new ConsoleEnvironment(verbose: false, sensitivity: MessageSensitivity.None, outWriter: EmptyWriter.Instance))
+            {
+                Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            }
+        }
+
+        [Benchmark]
+        public void Test_Multiclass_WikiDetox_BigramsAndTrichar_OVAAveragedPerceptron()
+        {
+            // This benchmark is profiling bulk scoring speed and not training speed. 
+            string modelpath = Path.Combine(Directory.GetCurrentDirectory(), @"WikiModel.fold000.zip");
+            string cmd = @"Test data=" + _dataPath_Wiki + " in=" + modelpath;
             using (var environment = new ConsoleEnvironment(verbose: false, sensitivity: MessageSensitivity.None, outWriter: EmptyWriter.Instance))
             {
                 Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);

--- a/test/Microsoft.ML.Benchmarks/TrainConfig.cs
+++ b/test/Microsoft.ML.Benchmarks/TrainConfig.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace Microsoft.ML.Benchmarks
+{
+    public class TrainConfig : ManualConfig
+    {
+        public TrainConfig()
+        {
+            Add(DefaultConfig.Instance
+                .With(Job.Default
+                    .WithWarmupCount(0)
+                    .WithIterationCount(1)
+                    .WithLaunchCount(3)
+                    .With(Program.CreateToolchain()))
+                .With(new ExtraMetricColumn())
+                .With(MemoryDiagnoser.Default));
+        }
+    }
+}

--- a/test/Microsoft.ML.Benchmarks/TrainConfig.cs
+++ b/test/Microsoft.ML.Benchmarks/TrainConfig.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Benchmarks
                 .With(Job.Default
                     .WithWarmupCount(0)
                     .WithIterationCount(1)
-                    .WithLaunchCount(3)
+                    .WithLaunchCount(3)  // BDN will start 3 dedicated processes, each of them will just run given benchmark once, without any warm up to mimic the real world.
                     .With(Program.CreateToolchain()))
                 .With(new ExtraMetricColumn())
                 .With(MemoryDiagnoser.Default));


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/982
- different Config files for train and test
- solves problem of long running time
- train benchmarks contain only one iteration as it gives more idea on how the users will use. (with no warmup iteration)
- predict config is the original version

cc @danmosemsft @eerhardt @adamsitnik @justinormont 
