### PR TITLE
Binary train context with evaluation and SDCA

### DIFF
--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -920,104 +920,75 @@ namespace Microsoft.ML.Runtime.Data
         /// <summary>
         /// Evaluates scored binary classification data.
         /// </summary>
-        /// <typeparam name="T">The shape type for the input data.</typeparam>
-        /// <param name="data">The data to evaluate.</param>
-        /// <param name="label">The index delegate for the label column.</param>
-        /// <param name="pred">The index delegate for columns from calibrated prediction of a binary classifier.
-        /// Under typical scenarios, this will just be the same tuple of results returned from the trainer.</param>
+        /// <param name="data">The scored data.</param>
+        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="probability">The name of the probability column in <paramref name="data"/>, the calibrated version of <paramref name="score"/>.</param>
+        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these calibrated outputs.</returns>
-        public static CalibratedResult Evaluate<T>(
-            DataView<T> data,
-            Func<T, Scalar<bool>> label,
-            Func<T, (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel)> pred)
+        public CalibratedResult Evaluate(IDataView data, string label, string score, string probability, string predictedLabel)
         {
-            Contracts.CheckValue(data, nameof(data));
-            var env = StaticPipeUtils.GetEnvironment(data);
-            Contracts.AssertValue(env);
-            env.CheckValue(label, nameof(label));
-            env.CheckValue(pred, nameof(pred));
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+            Host.CheckNonEmpty(probability, nameof(probability));
+            Host.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
 
-            var indexer = StaticPipeUtils.GetIndexer(data);
-            string labelName = indexer.Get(label(indexer.Indices));
-            (var scoreCol, var probCol, var predCol) = pred(indexer.Indices);
-            Contracts.CheckParam(scoreCol != null, nameof(pred), "Indexing delegate resulted in null score column.");
-            Contracts.CheckParam(probCol != null, nameof(pred), "Indexing delegate resulted in null probability column.");
-            Contracts.CheckParam(predCol != null, nameof(pred), "Indexing delegate resulted in null predicted label column.");
-            string scoreName = indexer.Get(scoreCol);
-            string probName = indexer.Get(probCol);
-            string predName = indexer.Get(predCol);
+            var roles = new RoleMappedData(data, opt: false,
+                RoleMappedSchema.ColumnRole.Label.Bind(label),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, score),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probability),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.PredictedLabel, predictedLabel));
 
-            var eval = new BinaryClassifierEvaluator(env, new Arguments() { });
-
-            var roles = new RoleMappedData(data.AsDynamic, opt: false,
-                RoleMappedSchema.ColumnRole.Label.Bind(labelName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.PredictedLabel, predName));
-
-            var resultDict = eval.Evaluate(roles);
-            env.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
+            var resultDict = Evaluate(roles);
+            Host.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             CalibratedResult result;
             using (var cursor = overall.GetRowCursor(i => true))
             {
                 var moved = cursor.MoveNext();
-                env.Assert(moved);
-                result = new CalibratedResult(env, cursor);
+                Host.Assert(moved);
+                result = new CalibratedResult(Host, cursor);
                 moved = cursor.MoveNext();
-                env.Assert(!moved);
+                Host.Assert(!moved);
             }
             return result;
         }
 
         /// <summary>
-        /// Evaluates scored binary classification data.
+        /// Evaluates scored binary classification data, without probability-based metrics.
         /// </summary>
-        /// <typeparam name="T">The shape type for the input data.</typeparam>
-        /// <param name="data">The data to evaluate.</param>
-        /// <param name="label">The index delegate for the label column.</param>
-        /// <param name="pred">The index delegate for columns from calibrated prediction of a binary classifier.
-        /// Under typical scenarios, this will just be the same tuple of results returned from the trainer.</param>
+        /// <param name="data">The scored data.</param>
+        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these uncalibrated outputs.</returns>
-        public static Result Evaluate<T>(
-            DataView<T> data,
-            Func<T, Scalar<bool>> label,
-            Func<T, (Scalar<float> score, Scalar<bool> predictedLabel)> pred)
+        /// <seealso cref="Evaluate(IDataView, string, string, string)"/>
+        public Result Evaluate(IDataView data, string label, string score, string predictedLabel)
         {
-            Contracts.CheckValue(data, nameof(data));
-            var env = StaticPipeUtils.GetEnvironment(data);
-            Contracts.AssertValue(env);
-            env.CheckValue(label, nameof(label));
-            env.CheckValue(pred, nameof(pred));
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+            Host.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
 
-            var indexer = StaticPipeUtils.GetIndexer(data);
-            string labelName = indexer.Get(label(indexer.Indices));
-            (var scoreCol, var predCol) = pred(indexer.Indices);
-            Contracts.CheckParam(scoreCol != null, nameof(pred), "Indexing delegate resulted in null score column.");
-            Contracts.CheckParam(predCol != null, nameof(pred), "Indexing delegate resulted in null predicted label column.");
-            string scoreName = indexer.Get(scoreCol);
-            string predName = indexer.Get(predCol);
+            var roles = new RoleMappedData(data, opt: false,
+                RoleMappedSchema.ColumnRole.Label.Bind(label),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, score),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.PredictedLabel, predictedLabel));
 
-            var eval = new BinaryClassifierEvaluator(env, new Arguments() { });
-
-            var roles = new RoleMappedData(data.AsDynamic, opt: false,
-                RoleMappedSchema.ColumnRole.Label.Bind(labelName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.PredictedLabel, predName));
-
-            var resultDict = eval.Evaluate(roles);
-            env.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
+            var resultDict = Evaluate(roles);
+            Host.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             Result result;
             using (var cursor = overall.GetRowCursor(i => true))
             {
                 var moved = cursor.MoveNext();
-                env.Assert(moved);
-                result = new Result(env, cursor);
+                Host.Assert(moved);
+                result = new Result(Host, cursor);
                 moved = cursor.MoveNext();
-                env.Assert(!moved);
+                Host.Assert(!moved);
             }
             return result;
         }

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorStaticExtensions.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorStaticExtensions.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.ML.Data.StaticPipe;
+using Microsoft.ML.Data.StaticPipe.Runtime;
+using Microsoft.ML.Runtime.Training;
+
+namespace Microsoft.ML.Runtime.Data
+{
+    /// <summary>
+    /// Extension methods for evaluation.
+    /// </summary>
+    public static class EvaluatorStaticExtensions
+    {
+        /// <summary>
+        /// Evaluates scored binary classification data.
+        /// </summary>
+        /// <typeparam name="T">The shape type for the input data.</typeparam>
+        /// <param name="ctx">The binary classification context.</param>
+        /// <param name="data">The data to evaluate.</param>
+        /// <param name="label">The index delegate for the label column.</param>
+        /// <param name="pred">The index delegate for columns from calibrated prediction of a binary classifier.
+        /// Under typical scenarios, this will just be the same tuple of results returned from the trainer.</param>
+        /// <returns>The evaluation results for these calibrated outputs.</returns>
+        public static BinaryClassifierEvaluator.CalibratedResult Evaluate<T>(
+            this BinaryClassificationContext ctx,
+            DataView<T> data,
+            Func<T, Scalar<bool>> label,
+            Func<T, (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel)> pred)
+        {
+            Contracts.CheckValue(data, nameof(data));
+            var env = StaticPipeUtils.GetEnvironment(data);
+            Contracts.AssertValue(env);
+            env.CheckValue(label, nameof(label));
+            env.CheckValue(pred, nameof(pred));
+
+            var indexer = StaticPipeUtils.GetIndexer(data);
+            string labelName = indexer.Get(label(indexer.Indices));
+            (var scoreCol, var probCol, var predCol) = pred(indexer.Indices);
+            env.CheckParam(scoreCol != null, nameof(pred), "Indexing delegate resulted in null score column.");
+            env.CheckParam(probCol != null, nameof(pred), "Indexing delegate resulted in null probability column.");
+            env.CheckParam(predCol != null, nameof(pred), "Indexing delegate resulted in null predicted label column.");
+            string scoreName = indexer.Get(scoreCol);
+            string probName = indexer.Get(probCol);
+            string predName = indexer.Get(predCol);
+
+            var eval = new BinaryClassifierEvaluator(env, new BinaryClassifierEvaluator.Arguments() { });
+            return eval.Evaluate(data.AsDynamic, labelName, scoreName, probName, predName);
+        }
+
+        /// <summary>
+        /// Evaluates scored binary classification data.
+        /// </summary>
+        /// <typeparam name="T">The shape type for the input data.</typeparam>
+        /// <param name="ctx">The binary classification context.</param>
+        /// <param name="data">The data to evaluate.</param>
+        /// <param name="label">The index delegate for the label column.</param>
+        /// <param name="pred">The index delegate for columns from calibrated prediction of a binary classifier.
+        /// Under typical scenarios, this will just be the same tuple of results returned from the trainer.</param>
+        /// <returns>The evaluation results for these uncalibrated outputs.</returns>
+        public static BinaryClassifierEvaluator.Result Evaluate<T>(
+            this BinaryClassificationContext ctx,
+            DataView<T> data,
+            Func<T, Scalar<bool>> label,
+            Func<T, (Scalar<float> score, Scalar<bool> predictedLabel)> pred)
+        {
+            Contracts.CheckValue(data, nameof(data));
+            var env = StaticPipeUtils.GetEnvironment(data);
+            Contracts.AssertValue(env);
+            env.CheckValue(label, nameof(label));
+            env.CheckValue(pred, nameof(pred));
+
+            var indexer = StaticPipeUtils.GetIndexer(data);
+            string labelName = indexer.Get(label(indexer.Indices));
+            (var scoreCol, var predCol) = pred(indexer.Indices);
+            Contracts.CheckParam(scoreCol != null, nameof(pred), "Indexing delegate resulted in null score column.");
+            Contracts.CheckParam(predCol != null, nameof(pred), "Indexing delegate resulted in null predicted label column.");
+            string scoreName = indexer.Get(scoreCol);
+            string predName = indexer.Get(predCol);
+
+            var eval = new BinaryClassifierEvaluator(env, new BinaryClassifierEvaluator.Arguments() { });
+            return eval.Evaluate(data.AsDynamic, labelName, scoreName, predName);
+        }
+    }
+}

--- a/src/Microsoft.ML.Data/Training/TrainContext.cs
+++ b/src/Microsoft.ML.Data/Training/TrainContext.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Runtime.Data;
+
+namespace Microsoft.ML.Runtime.Training
+{
+    /// <summary>
+    /// A training context is an object instantiable by a user to do various tasks relating to a particular
+    /// "area" of machine learning. A subclass would represent a particular task in machine learning. The idea
+    /// is that a user can instantiate that particular area, and get trainers and evaluators.
+    /// </summary>
+    public abstract class TrainContextBase
+    {
+        protected readonly IHost Host;
+        internal IHostEnvironment Environment => Host;
+
+        protected TrainContextBase(IHostEnvironment env, string registrationName)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            env.CheckNonEmpty(registrationName, nameof(registrationName));
+            Host = env.Register(registrationName);
+        }
+
+        /// <summary>
+        /// Subclasses of <see cref="TrainContext"/> will provide little "extension method" hookable objects
+        /// (e.g., something like <see cref="BinaryClassificationContext.Trainers"/>). User code will only
+        /// interact with these objects by invoking the extension methods. The actual component code can work
+        /// through <see cref="TrainContextComponentUtils"/> to get more "hidden" information from this object,
+        /// e.g., the environment.
+        /// </summary>
+        public abstract class ContextInstantiatorBase
+        {
+            internal TrainContextBase Owner { get; }
+
+            protected ContextInstantiatorBase(TrainContextBase ctx)
+            {
+                Owner = ctx;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Utilities for component authors that want to be able to instantiate components using these context
+    /// objects. These utilities are not hidden from non-component authoring users per see, but are at least
+    /// registered somewhat less obvious so that they are not confused by the presence.
+    /// </summary>
+    /// <seealso cref="TrainContextBase"/>
+    public static class TrainContextComponentUtils
+    {
+        /// <summary>
+        /// Gets the environment hidden within the instantiator's context.
+        /// </summary>
+        /// <param name="obj">The extension method hook object for a context.</param>
+        /// <returns>An environment that can be used when instantiating components.</returns>
+        public static IHostEnvironment GetEnvironment(TrainContextBase.ContextInstantiatorBase obj)
+        {
+            Contracts.CheckValue(obj, nameof(obj));
+            return obj.Owner.Environment;
+        }
+
+        /// <summary>
+        /// Gets the environment hidden within the context.
+        /// </summary>
+        /// <param name="ctx">The context.</param>
+        /// <returns>An environment that can be used when instantiating components.</returns>
+        public static IHostEnvironment GetEnvironment(TrainContextBase ctx)
+        {
+            Contracts.CheckValue(ctx, nameof(ctx));
+            return ctx.Environment;
+        }
+    }
+
+    /// <summary>
+    /// The central context for binary classification trainers.
+    /// </summary>
+    public sealed class BinaryClassificationContext : TrainContextBase
+    {
+        /// <summary>
+        /// For trainers for performing binary classification.
+        /// </summary>
+        /// <remarks>
+        /// Component authors that have written binary classification.
+        /// </remarks>
+        public BinaryClassificationTrainers Trainers { get; }
+
+        public BinaryClassificationContext(IHostEnvironment env)
+            : base(env, nameof(BinaryClassificationContext))
+        {
+            Trainers = new BinaryClassificationTrainers(this);
+        }
+
+        public sealed class BinaryClassificationTrainers : ContextInstantiatorBase
+        {
+            internal BinaryClassificationTrainers(BinaryClassificationContext ctx)
+                : base(ctx)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Evaluates scored binary classification data.
+        /// </summary>
+        /// <param name="data">The scored data.</param>
+        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="probability">The name of the probability column in <paramref name="data"/>, the calibrated version of <paramref name="score"/>.</param>
+        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <returns>The evaluation results for these calibrated outputs.</returns>
+        public BinaryClassifierEvaluator.CalibratedResult Evaluate(IDataView data, string label, string score = DefaultColumnNames.Score,
+            string probability = DefaultColumnNames.Probability, string predictedLabel = DefaultColumnNames.PredictedLabel)
+        {
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+            Host.CheckNonEmpty(probability, nameof(probability));
+            Host.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
+
+            var eval = new BinaryClassifierEvaluator(Host, new BinaryClassifierEvaluator.Arguments() { });
+            return eval.Evaluate(data, label, score, probability, predictedLabel);
+        }
+
+        /// <summary>
+        /// Evaluates scored binary classification data, without probability-based metrics.
+        /// </summary>
+        /// <param name="data">The scored data.</param>
+        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <returns>The evaluation results for these uncalibrated outputs.</returns>
+        public BinaryClassifierEvaluator.Result EvaluateNonCalibrated(IDataView data, string label, string score = DefaultColumnNames.Score,
+            string predictedLabel = DefaultColumnNames.PredictedLabel)
+        {
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+            Host.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
+
+            var eval = new BinaryClassifierEvaluator(Host, new BinaryClassifierEvaluator.Arguments() { });
+            return eval.Evaluate(data, label, score, predictedLabel);
+        }
+    }
+}

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Data.StaticPipe;
 using Microsoft.ML.Data.StaticPipe.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Calibration;
+using Microsoft.ML.Runtime.Training;
 
 namespace Microsoft.ML.Runtime.Learners
 {
@@ -71,6 +72,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Predict a target using a linear binary classification model trained with the SDCA trainer, and log-loss.
         /// </summary>
+        /// <param name="ctx">The binary classification context trainer object.</param>
         /// <param name="label">The label, or dependent variable.</param>
         /// <param name="features">The features, or independent variables.</param>
         /// <param name="weights">The optional example weights.</param>
@@ -84,8 +86,9 @@ namespace Microsoft.ML.Runtime.Learners
         /// result in any way; it is only a way for the caller to be informed about what was learnt.</param>
         /// <returns>The set of output columns including in order the predicted binary classification score (which will range
         /// from negative to positive infinity), the calibrated prediction (from 0 to 1), and the predicted label.</returns>
-        public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel)
-            PredictSdcaBinaryClassification(this Scalar<bool> label, Vector<float> features, Scalar<float> weights = null,
+        public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel) Sdca(
+                this BinaryClassificationContext.BinaryClassificationTrainers ctx,
+                Scalar<bool> label, Vector<float> features, Scalar<float> weights = null,
                 float? l2Const = null,
                 float? l1Threshold = null,
                 int? maxIterations = null,
@@ -132,6 +135,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// Note that because we cannot be sure that all loss functions will produce naturally calibrated outputs, setting
         /// a custom loss function will not produce a calibrated probability column.
         /// </summary>
+        /// <param name="ctx">The binary classification context trainer object.</param>
         /// <param name="label">The label, or dependent variable.</param>
         /// <param name="features">The features, or independent variables.</param>
         /// /// <param name="loss">The custom loss.</param>
@@ -146,9 +150,10 @@ namespace Microsoft.ML.Runtime.Learners
         /// result in any way; it is only a way for the caller to be informed about what was learnt.</param>
         /// <returns>The set of output columns including in order the predicted binary classification score (which will range
         /// from negative to positive infinity), and the predicted label.</returns>
-        /// <seealso cref="PredictSdcaBinaryClassification(Scalar{bool}, Vector{float}, Scalar{float}, float?, float?, int?, Action{LinearBinaryPredictor, ParameterMixingCalibratedPredictor})"/>
-        public static (Scalar<float> score, Scalar<bool> predictedLabel)
-            PredictSdcaBinaryClassification(this Scalar<bool> label, Vector<float> features,
+        /// <seealso cref="Sdca(BinaryClassificationContext.BinaryClassificationTrainers, Scalar{bool}, Vector{float}, Scalar{float}, float?, float?, int?, Action{LinearBinaryPredictor, ParameterMixingCalibratedPredictor})"/>
+        public static (Scalar<float> score, Scalar<bool> predictedLabel) Sdca(
+                this BinaryClassificationContext.BinaryClassificationTrainers ctx,
+                Scalar<bool> label, Vector<float> features,
                 ISupportSdcaClassificationLoss loss,
                 Scalar<float> weights = null,
                 float? l2Const = null,


### PR DESCRIPTION
Fixes #949. In which I provide a working sketch of the context object, for evaluation (both dynamic and otherwise). If we think this is a good idea then we can add more capabilities to it. (Either in this PR or future ones.)