### PR TITLE
PredictionEngine uses IRowToRowMapper, ITransformer can create IRowToRowMapper

### DIFF
--- a/src/Microsoft.ML.Api/ComponentCreation.cs
+++ b/src/Microsoft.ML.Api/ComponentCreation.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.ML.Core.Data;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Model;
@@ -187,6 +188,26 @@ namespace Microsoft.ML.Runtime.Api
             env.CheckValueOrNull(inputSchemaDefinition);
             env.CheckValueOrNull(outputSchemaDefinition);
             return new PredictionEngine<TSrc, TDst>(env, dataPipe, ignoreMissingColumns, inputSchemaDefinition, outputSchemaDefinition);
+        }
+
+        /// <summary>
+        /// Create an on-demand prediction engine.
+        /// </summary>
+        /// <param name="env">The host environment to use.</param>
+        /// <param name="transformer">The transformer.</param>
+        /// <param name="ignoreMissingColumns">Whether to ignore missing columns in the data view.</param>
+        /// <param name="inputSchemaDefinition">The optional input schema. If <c>null</c>, the schema is inferred from the <typeparamref name="TSrc"/> type.</param>
+        /// <param name="outputSchemaDefinition">The optional output schema. If <c>null</c>, the schema is inferred from the <typeparamref name="TDst"/> type.</param>
+        public static PredictionEngine<TSrc, TDst> CreatePredictionEngine<TSrc, TDst>(this IHostEnvironment env, ITransformer transformer,
+            bool ignoreMissingColumns = false, SchemaDefinition inputSchemaDefinition = null, SchemaDefinition outputSchemaDefinition = null)
+            where TSrc : class
+            where TDst : class, new()
+        {
+            Contracts.CheckValue(env, nameof(env));
+            env.CheckValue(transformer, nameof(transformer));
+            env.CheckValueOrNull(inputSchemaDefinition);
+            env.CheckValueOrNull(outputSchemaDefinition);
+            return new PredictionEngine<TSrc, TDst>(env, transformer, ignoreMissingColumns, inputSchemaDefinition, outputSchemaDefinition);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
+using Microsoft.ML.Runtime.Model;
 
 namespace Microsoft.ML.Runtime.Api
 {
@@ -42,6 +44,275 @@ namespace Microsoft.ML.Runtime.Api
             return new StreamingDataView<TRow>(env, data, internalSchemaDefn);
         }
 
+        public static InputRow<TRow> CreateInputRow<TRow>(IHostEnvironment env, SchemaDefinition schemaDefinition = null)
+            where TRow : class
+        {
+            Contracts.AssertValue(env);
+            env.AssertValueOrNull(schemaDefinition);
+            var internalSchemaDefn = schemaDefinition == null
+                ? InternalSchemaDefinition.Create(typeof(TRow), SchemaDefinition.Direction.Read)
+                : InternalSchemaDefinition.Create(typeof(TRow), schemaDefinition);
+
+            return new InputRow<TRow>(env, internalSchemaDefn);
+        }
+
+        public static IDataView LoadPipeWithPredictor(IHostEnvironment env, Stream modelStream, IDataView view)
+        {
+            // Load transforms.
+            var pipe = env.LoadTransforms(modelStream, view);
+
+            // Load predictor (if present) and apply default scorer.
+            // REVIEW: distinguish the case of predictor / no predictor?
+            var predictor = env.LoadPredictorOrNull(modelStream);
+            if (predictor != null)
+            {
+                var roles = ModelFileUtils.LoadRoleMappingsOrNull(env, modelStream);
+                pipe = roles != null
+                    ? env.CreateDefaultScorer(new RoleMappedData(pipe, roles, opt: true), predictor)
+                    : env.CreateDefaultScorer(new RoleMappedData(pipe, label: null, "Features"), predictor);
+            }
+            return pipe;
+        }
+
+        public sealed class InputRow<TRow> : InputRowBase<TRow>, IInputRow<TRow>
+            where TRow : class
+        {
+            private TRow _value;
+
+            private long _position;
+            public override long Position => _position;
+
+            public InputRow(IHostEnvironment env, InternalSchemaDefinition schemaDef)
+                : base(env, new SchemaProxy(schemaDef), schemaDef, MakePeeks(schemaDef), c => true)
+            {
+                _position = -1;
+            }
+
+            private static Delegate[] MakePeeks(InternalSchemaDefinition schemaDef)
+            {
+                var peeks = new Delegate[schemaDef.Columns.Length];
+                for (var i = 0; i < peeks.Length; i++)
+                {
+                    var currentColumn = schemaDef.Columns[i];
+                    peeks[i] = currentColumn.IsComputed
+                        ? currentColumn.Generator
+                        : ApiUtils.GeneratePeek<InputRow<TRow>, TRow>(currentColumn);
+                }
+                return peeks;
+            }
+
+            public void AcceptValues(TRow row)
+            {
+                Host.CheckValue(row, nameof(row));
+                _value = row;
+                _position++;
+            }
+
+            public override ValueGetter<UInt128> GetIdGetter()
+            {
+                return IdGetter;
+            }
+
+            private void IdGetter(ref UInt128 val) => val = new UInt128((ulong)Position, 0);
+
+            protected override TRow GetCurrentRowObject() => _value;
+        }
+
+        /// <summary>
+        /// A row that consumes items of type <typeparamref name="TRow"/>, and provides an <see cref="IRow"/>. This
+        /// is in contrast to <see cref="IRow{TRow}"/> which consumes a data view row and publishes them as the output type.
+        /// </summary>
+        /// <typeparam name="TRow">The input data type.</typeparam>
+        public abstract class InputRowBase<TRow> : IRow
+            where TRow : class
+        {
+            private readonly int _colCount;
+            private readonly Delegate[] _getters;
+            protected readonly IHost Host;
+
+            public long Batch => 0;
+
+            public ISchema Schema { get; }
+
+            public abstract long Position { get; }
+
+            public InputRowBase(IHostEnvironment env, ISchema schema, InternalSchemaDefinition schemaDef, Delegate[] peeks, Func<int, bool> predicate)
+            {
+                Contracts.AssertValue(env);
+                Host = env.Register("Row");
+                Host.AssertValue(schema);
+                Host.AssertValue(schemaDef);
+                Host.AssertValue(peeks);
+                Host.AssertValue(predicate);
+                Host.Assert(schema.ColumnCount == schemaDef.Columns.Length);
+                Host.Assert(schema.ColumnCount == peeks.Length);
+
+                _colCount = schema.ColumnCount;
+                Schema = schema;
+                _getters = new Delegate[_colCount];
+                for (int c = 0; c < _colCount; c++)
+                    _getters[c] = predicate(c) ? CreateGetter(schema.GetColumnType(c), schemaDef.Columns[c], peeks[c]) : null;
+            }
+
+            //private Delegate CreateGetter(SchemaProxy schema, int index, Delegate peek)
+            private Delegate CreateGetter(ColumnType colType, InternalSchemaDefinition.Column column, Delegate peek)
+            {
+                var outputType = column.OutputType;
+                var genericType = outputType;
+                Func<Delegate, Delegate> del;
+
+                if (outputType.IsArray)
+                {
+                    Host.Assert(colType.IsVector);
+                    // String[] -> ReadOnlyMemory<char>
+                    if (outputType.GetElementType() == typeof(string))
+                    {
+                        Host.Assert(colType.ItemType.IsText);
+                        return CreateConvertingArrayGetterDelegate<string, ReadOnlyMemory<char>>(peek, x => x != null ? x.AsMemory() : ReadOnlyMemory<char>.Empty);
+                    }
+
+                    // T[] -> VBuffer<T>
+                    if (outputType.GetElementType().IsGenericType && outputType.GetElementType().GetGenericTypeDefinition() == typeof(Nullable<>))
+                        Host.Assert(Nullable.GetUnderlyingType(outputType.GetElementType()) == colType.ItemType.RawType);
+                    else
+                        Host.Assert(outputType.GetElementType() == colType.ItemType.RawType);
+                    del = CreateDirectArrayGetterDelegate<int>;
+                    genericType = outputType.GetElementType();
+                }
+                else if (colType.IsVector)
+                {
+                    // VBuffer<T> -> VBuffer<T>
+                    // REVIEW: Do we care about accomodating VBuffer<string> -> ReadOnlyMemory<char>?
+                    Host.Assert(outputType.IsGenericType);
+                    Host.Assert(outputType.GetGenericTypeDefinition() == typeof(VBuffer<>));
+                    Host.Assert(outputType.GetGenericArguments()[0] == colType.ItemType.RawType);
+                    del = CreateDirectVBufferGetterDelegate<int>;
+                    genericType = colType.ItemType.RawType;
+                }
+                else if (colType.IsPrimitive)
+                {
+                    if (outputType == typeof(string))
+                    {
+                        // String -> ReadOnlyMemory<char>
+                        Host.Assert(colType.IsText);
+                        return CreateConvertingGetterDelegate<String, ReadOnlyMemory<char>>(peek, x => x != null ? x.AsMemory() : ReadOnlyMemory<char>.Empty);
+                    }
+
+                    // T -> T
+                    if (outputType.IsGenericType && outputType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                        Host.Assert(colType.RawType == Nullable.GetUnderlyingType(outputType));
+                    else
+                        Host.Assert(colType.RawType == outputType);
+                    del = CreateDirectGetterDelegate<int>;
+                }
+                else
+                {
+                    // REVIEW: Is this even possible?
+                    throw Host.ExceptNotSupp("Type '{0}' is not yet supported.", outputType.FullName);
+                }
+                return Utils.MarshalInvoke(del, genericType, peek);
+            }
+
+            // REVIEW: The converting getter invokes a type conversion delegate on every call, so it's inherently slower
+            // than the 'direct' getter. We don't have good indication of this to the user, and the selection
+            // of affected types is pretty arbitrary (signed integers and bools, but not uints and floats).
+            private Delegate CreateConvertingArrayGetterDelegate<TSrc, TDst>(Delegate peekDel, Func<TSrc, TDst> convert)
+            {
+                var peek = peekDel as Peek<TRow, TSrc[]>;
+                Host.AssertValue(peek);
+                TSrc[] buf = default;
+                return (ValueGetter<VBuffer<TDst>>)((ref VBuffer<TDst> dst) =>
+                {
+                    peek(GetCurrentRowObject(), Position, ref buf);
+                    var n = Utils.Size(buf);
+                    dst = new VBuffer<TDst>(n, Utils.Size(dst.Values) < n
+                        ? new TDst[n]
+                        : dst.Values, dst.Indices);
+                    for (int i = 0; i < n; i++)
+                        dst.Values[i] = convert(buf[i]);
+                });
+            }
+
+            private Delegate CreateConvertingGetterDelegate<TSrc, TDst>(Delegate peekDel, Func<TSrc, TDst> convert)
+            {
+                var peek = peekDel as Peek<TRow, TSrc>;
+                Host.AssertValue(peek);
+                TSrc buf = default;
+                return (ValueGetter<TDst>)((ref TDst dst) =>
+                {
+                    peek(GetCurrentRowObject(), Position, ref buf);
+                    dst = convert(buf);
+                });
+            }
+
+            private Delegate CreateDirectArrayGetterDelegate<TDst>(Delegate peekDel)
+            {
+                var peek = peekDel as Peek<TRow, TDst[]>;
+                Host.AssertValue(peek);
+                TDst[] buf = null;
+                return (ValueGetter<VBuffer<TDst>>)((ref VBuffer<TDst> dst) =>
+                {
+                    peek(GetCurrentRowObject(), Position, ref buf);
+                    var n = Utils.Size(buf);
+                    dst = new VBuffer<TDst>(n, Utils.Size(dst.Values) < n ? new TDst[n] : dst.Values,
+                        dst.Indices);
+                    if (buf != null)
+                        Array.Copy(buf, dst.Values, n);
+                });
+            }
+
+            private Delegate CreateDirectVBufferGetterDelegate<TDst>(Delegate peekDel)
+            {
+                var peek = peekDel as Peek<TRow, VBuffer<TDst>>;
+                Host.AssertValue(peek);
+                VBuffer<TDst> buf = default(VBuffer<TDst>);
+                return (ValueGetter<VBuffer<TDst>>)((ref VBuffer<TDst> dst) =>
+                {
+                    // The peek for a VBuffer is just a simple assignment, so there is
+                    // no copy going on in the peek, so we must do that as a second
+                    // step to the destination.
+                    peek(GetCurrentRowObject(), Position, ref buf);
+                    buf.CopyTo(ref dst);
+                });
+            }
+
+            private Delegate CreateDirectGetterDelegate<TDst>(Delegate peekDel)
+            {
+                var peek = peekDel as Peek<TRow, TDst>;
+                Host.AssertValue(peek);
+                return (ValueGetter<TDst>)((ref TDst dst) =>
+                    peek(GetCurrentRowObject(), Position, ref dst));
+            }
+
+            protected abstract TRow GetCurrentRowObject();
+
+            public bool IsColumnActive(int col)
+            {
+                CheckColumnInRange(col);
+                return _getters[col] != null;
+            }
+
+            private void CheckColumnInRange(int columnIndex)
+            {
+                if (columnIndex < 0 || columnIndex >= _colCount)
+                    throw Host.Except("Column index must be between 0 and {0}", _colCount);
+            }
+
+            public ValueGetter<TValue> GetGetter<TValue>(int col)
+            {
+                if (!IsColumnActive(col))
+                    throw Host.Except("Column {0} is not active in the cursor", col);
+                var getter = _getters[col];
+                Contracts.AssertValue(getter);
+                var fn = getter as ValueGetter<TValue>;
+                if (fn == null)
+                    throw Host.Except("Invalid TValue in GetGetter for column #{0}: '{1}'", col, typeof(TValue));
+                return fn;
+            }
+
+            public abstract ValueGetter<UInt128> GetIdGetter();
+        }
+
         /// <summary>
         /// The base class for the data view over items of user-defined type.
         /// </summary>
@@ -58,10 +329,7 @@ namespace Microsoft.ML.Runtime.Api
 
             public abstract bool CanShuffle { get; }
 
-            public ISchema Schema
-            {
-                get { return _schema; }
-            }
+            public ISchema Schema => _schema;
 
             protected DataViewBase(IHostEnvironment env, string name, InternalSchemaDefinition schemaDefn)
             {
@@ -92,198 +360,126 @@ namespace Microsoft.ML.Runtime.Api
                 return new[] { GetRowCursor(predicate, rand) };
             }
 
-            public abstract class DataViewCursorBase : RootCursorBase, IRowCursor
+            public abstract class DataViewCursorBase : InputRowBase<TRow>, IRowCursor
             {
                 protected readonly DataViewBase<TRow> DataView;
-                private readonly int _colCount;
-                private readonly Delegate[] _getters;
+                protected readonly IChannel Ch;
 
-                protected DataViewCursorBase(IChannelProvider provider, DataViewBase<TRow> dataView,
+                private long _position;
+                /// <summary>
+                /// Zero-based position of the cursor.
+                /// </summary>
+                public override long Position => _position;
+
+                protected DataViewCursorBase(IHostEnvironment env, DataViewBase<TRow> dataView,
                     Func<int, bool> predicate)
-                    : base(provider)
+                    : base(env, dataView.Schema, dataView._schema.SchemaDefn, dataView._peeks, predicate)
                 {
+                    Contracts.AssertValue(env);
+                    Ch = env.Start("Cursor");
                     Ch.AssertValue(dataView);
                     Ch.AssertValue(predicate);
 
                     DataView = dataView;
-                    _colCount = DataView._schema.SchemaDefn.Columns.Length;
-
-                    _getters = new Delegate[_colCount];
-                    for (int i = 0; i < _colCount; i++)
-                        _getters[i] = predicate(i) ? CreateGetter(i) : null;
+                    _position = -1;
+                    State = CursorState.NotStarted;
                 }
 
-                private Delegate CreateGetter(int index)
+                public CursorState State { get; private set; }
+
+                /// <summary>
+                /// Convenience property for checking whether the current state of the cursor is <see cref="CursorState.Good"/>.
+                /// </summary>
+                protected bool IsGood => State == CursorState.Good;
+
+                public virtual void Dispose()
                 {
-                    var colType = DataView.Schema.GetColumnType(index);
-
-                    var column = DataView._schema.SchemaDefn.Columns[index];
-                    var outputType = column.OutputType;
-                    var genericType = outputType;
-                    Func<int, Delegate> del;
-
-                    if (outputType.IsArray)
+                    if (State != CursorState.Done)
                     {
-                        Ch.Assert(colType.IsVector);
-                        // String[] -> ReadOnlyMemory<char>
-                        if (outputType.GetElementType() == typeof(string))
-                        {
-                            Ch.Assert(colType.ItemType.IsText);
-                            return CreateConvertingArrayGetterDelegate<string, ReadOnlyMemory<char>>(index, x =>  x != null ? x.AsMemory() : ReadOnlyMemory<char>.Empty);
-                        }
-
-                        // T[] -> VBuffer<T>
-                        if (outputType.GetElementType().IsGenericType && outputType.GetElementType().GetGenericTypeDefinition() == typeof(Nullable<>))
-                            Ch.Assert(Nullable.GetUnderlyingType(outputType.GetElementType()) == colType.ItemType.RawType);
-                        else
-                            Ch.Assert(outputType.GetElementType() == colType.ItemType.RawType);
-                        del = CreateDirectArrayGetterDelegate<int>;
-                        genericType = outputType.GetElementType();
+                        Ch.Done();
+                        Ch.Dispose();
+                        _position = -1;
+                        State = CursorState.Done;
                     }
-                    else if (colType.IsVector)
+                }
+
+                public bool MoveNext()
+                {
+                    if (State == CursorState.Done)
+                        return false;
+
+                    Ch.Assert(State == CursorState.NotStarted || State == CursorState.Good);
+                    if (MoveNextCore())
                     {
-                        // VBuffer<T> -> VBuffer<T>
-                        // REVIEW: Do we care about accomodating VBuffer<string> -> ReadOnlyMemory<char>?
-                        Ch.Assert(outputType.IsGenericType);
-                        Ch.Assert(outputType.GetGenericTypeDefinition() == typeof(VBuffer<>));
-                        Ch.Assert(outputType.GetGenericArguments()[0] == colType.ItemType.RawType);
-                        del = CreateDirectVBufferGetterDelegate<int>;
-                        genericType = colType.ItemType.RawType;
+                        Ch.Assert(State == CursorState.NotStarted || State == CursorState.Good);
+
+                        _position++;
+                        State = CursorState.Good;
+                        return true;
                     }
-                    else if (colType.IsPrimitive)
-                    {
-                        if (outputType == typeof(string))
-                        {
-                            // String -> ReadOnlyMemory<char>
-                            Ch.Assert(colType.IsText);
-                            return CreateConvertingGetterDelegate<String, ReadOnlyMemory<char>>(index, x => x != null ? x.AsMemory() : ReadOnlyMemory<char>.Empty);
-                        }
 
-                        // T -> T
-                        if (outputType.IsGenericType && outputType.GetGenericTypeDefinition() == typeof(Nullable<>))
-                            Ch.Assert(colType.RawType == Nullable.GetUnderlyingType(outputType));
-                        else
-                            Ch.Assert(colType.RawType == outputType);
-                        del = CreateDirectGetterDelegate<int>;
+                    Dispose();
+                    return false;
+                }
+
+                public bool MoveMany(long count)
+                {
+                    // Note: If we decide to allow count == 0, then we need to special case
+                    // that MoveNext() has never been called. It's not entirely clear what the return
+                    // result would be in that case.
+                    Ch.CheckParam(count > 0, nameof(count));
+
+                    if (State == CursorState.Done)
+                        return false;
+
+                    Ch.Assert(State == CursorState.NotStarted || State == CursorState.Good);
+                    if (MoveManyCore(count))
+                    {
+                        Ch.Assert(State == CursorState.NotStarted || State == CursorState.Good);
+
+                        _position += count;
+                        State = CursorState.Good;
+                        return true;
                     }
-                    else
+
+                    Dispose();
+                    return false;
+                }
+
+                /// <summary>
+                /// Default implementation is to simply call MoveNextCore repeatedly. Derived classes should
+                /// override if they can do better.
+                /// </summary>
+                /// <param name="count">The number of rows to move forward.</param>
+                /// <returns>Whether the move forward is on a valid row</returns>
+                protected virtual bool MoveManyCore(long count)
+                {
+                    Ch.Assert(State == CursorState.NotStarted || State == CursorState.Good);
+                    Ch.Assert(count > 0);
+
+                    while (MoveNextCore())
                     {
-                        // REVIEW: Is this even possible?
-                        throw Ch.ExceptNotImpl("Type '{0}' is not yet supported.", outputType.FullName);
+                        Ch.Assert(State == CursorState.NotStarted || State == CursorState.Good);
+                        if (--count <= 0)
+                            return true;
                     }
-                    MethodInfo meth =
-                        del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(genericType);
-                    return (Delegate)meth.Invoke(this, new object[] { index });
+
+                    return false;
                 }
 
-                // REVIEW: The converting getter invokes a type conversion delegate on every call, so it's inherently slower
-                // than the 'direct' getter. We don't have good indication of this to the user, and the selection
-                // of affected types is pretty arbitrary (signed integers and bools, but not uints and floats).
-                private Delegate CreateConvertingArrayGetterDelegate<TSrc, TDst>(int index, Func<TSrc, TDst> convert)
-                {
-                    var peek = DataView._peeks[index] as Peek<TRow, TSrc[]>;
-                    Ch.AssertValue(peek);
-                    TSrc[] buf = default;
-                    return (ValueGetter<VBuffer<TDst>>)((ref VBuffer<TDst> dst) =>
-                    {
-                        peek(GetCurrentRowObject(), Position, ref buf);
-                        var n = Utils.Size(buf);
-                        dst = new VBuffer<TDst>(n, Utils.Size(dst.Values) < n
-                            ? new TDst[n]
-                            : dst.Values, dst.Indices);
-                        for (int i = 0; i < n; i++)
-                            dst.Values[i] = convert(buf[i]);
-                    });
-                }
+                /// <summary>
+                /// Core implementation of <see cref="MoveNext"/>, called if the cursor state is not
+                /// <see cref="CursorState.Done"/>.
+                /// </summary>
+                protected abstract bool MoveNextCore();
 
-                private Delegate CreateConvertingGetterDelegate<TSrc, TDst>(int index, Func<TSrc, TDst> convert)
-                {
-                    var peek = DataView._peeks[index] as Peek<TRow, TSrc>;
-                    Ch.AssertValue(peek);
-                    TSrc buf = default;
-                    return (ValueGetter<TDst>)((ref TDst dst) =>
-                    {
-                        peek(GetCurrentRowObject(), Position, ref buf);
-                        dst = convert(buf);
-                    });
-                }
-
-                private Delegate CreateDirectArrayGetterDelegate<TDst>(int index)
-                {
-                    var peek = DataView._peeks[index] as Peek<TRow, TDst[]>;
-                    Ch.AssertValue(peek);
-                    TDst[] buf = null;
-                    return (ValueGetter<VBuffer<TDst>>)((ref VBuffer<TDst> dst) =>
-                    {
-                        peek(GetCurrentRowObject(), Position, ref buf);
-                        var n = Utils.Size(buf);
-                        dst = new VBuffer<TDst>(n, Utils.Size(dst.Values) < n ? new TDst[n] : dst.Values,
-                            dst.Indices);
-                        if (buf != null)
-                            Array.Copy(buf, dst.Values, n);
-                    });
-                }
-
-                private Delegate CreateDirectVBufferGetterDelegate<TDst>(int index)
-                {
-                    var peek = DataView._peeks[index] as Peek<TRow, VBuffer<TDst>>;
-                    Ch.AssertValue(peek);
-                    VBuffer<TDst> buf = default(VBuffer<TDst>);
-                    return (ValueGetter<VBuffer<TDst>>)((ref VBuffer<TDst> dst) =>
-                    {
-                        // The peek for a VBuffer is just a simple assignment, so there is
-                        // no copy going on in the peek, so we must do that as a second
-                        // step to the destination.
-                        peek(GetCurrentRowObject(), Position, ref buf);
-                        buf.CopyTo(ref dst);
-                    });
-                }
-
-                private Delegate CreateDirectGetterDelegate<TDst>(int index)
-                {
-                    var peek = DataView._peeks[index] as Peek<TRow, TDst>;
-                    Ch.AssertValue(peek);
-                    return (ValueGetter<TDst>)((ref TDst dst) =>
-                    {
-                        peek(GetCurrentRowObject(), Position, ref dst);
-                    });
-                }
-
-                protected abstract TRow GetCurrentRowObject();
-
-                public override long Batch
-                {
-                    get { return 0; }
-                }
-
-                public ISchema Schema
-                {
-                    get { return DataView._schema; }
-                }
-
-                public bool IsColumnActive(int col)
-                {
-                    CheckColumnInRange(col);
-                    return _getters[col] != null;
-                }
-
-                public ValueGetter<TValue> GetGetter<TValue>(int col)
-                {
-                    if (!IsColumnActive(col))
-                        throw Ch.Except("Column {0} is not active in the cursor", col);
-                    var getter = _getters[col];
-                    Contracts.AssertValue(getter);
-                    var fn = getter as ValueGetter<TValue>;
-                    if (fn == null)
-                        throw Ch.Except("Invalid TValue in GetGetter for column #{0}: '{1}'", col, typeof(TValue));
-                    return fn;
-                }
-
-                private void CheckColumnInRange(int columnIndex)
-                {
-                    if (columnIndex < 0 || columnIndex >= _colCount)
-                        throw Ch.Except("Column index must be between 0 and {0}", _colCount);
-                }
+                /// <summary>
+                /// Returns a cursor that can be used for invoking <see cref="Position"/>, <see cref="State"/>,
+                /// <see cref="MoveNext"/>, and <see cref="MoveMany(long)"/>, with results identical to calling
+                /// those on this cursor. Generally, if the root cursor is not the same as this cursor, using
+                /// the root cursor will be faster.
+                /// </summary>
+                public ICursor GetRootCursor() => this;
             }
         }
 
@@ -329,9 +525,9 @@ namespace Microsoft.ML.Runtime.Api
                     get { return _permutation == null ? (int)Position : _permutation[(int)Position]; }
                 }
 
-                public Cursor(IChannelProvider provider, string name, ListDataView<TRow> dataView,
+                public Cursor(IHostEnvironment env, string name, ListDataView<TRow> dataView,
                     Func<int, bool> predicate, IRandom rand)
-                    : base(provider, dataView, predicate)
+                    : base(env, dataView, predicate)
                 {
                     Ch.AssertValueOrNull(rand);
                     _data = dataView._data;
@@ -434,8 +630,8 @@ namespace Microsoft.ML.Runtime.Api
                 private readonly IEnumerator<TRow> _enumerator;
                 private TRow _currentRow;
 
-                public Cursor(IChannelProvider provider, StreamingDataView<TRow> dataView, Func<int, bool> predicate)
-                    : base(provider, dataView, predicate)
+                public Cursor(IHostEnvironment env, StreamingDataView<TRow> dataView, Func<int, bool> predicate)
+                    : base(env, dataView, predicate)
                 {
                     _enumerator = dataView._data.GetEnumerator();
                     _currentRow = null;
@@ -509,8 +705,8 @@ namespace Microsoft.ML.Runtime.Api
             {
                 private readonly TRow _currentRow;
 
-                public Cursor(IChannelProvider provider, SingleRowLoopDataView<TRow> dataView, Func<int, bool> predicate)
-                    : base(provider, dataView, predicate)
+                public Cursor(IHostEnvironment env, SingleRowLoopDataView<TRow> dataView, Func<int, bool> predicate)
+                    : base(env, dataView, predicate)
                 {
                     _currentRow = dataView._current;
                 }

--- a/src/Microsoft.ML.Api/MapTransform.cs
+++ b/src/Microsoft.ML.Api/MapTransform.cs
@@ -24,8 +24,6 @@ namespace Microsoft.ML.Runtime.Api
         where TDst : class, new()
     {
         private const string RegistrationNameTemplate = "MapTransform<{0}, {1}>";
-
-        private readonly IDataView _source;
         private readonly Action<TSrc, TDst> _mapAction;
         private readonly MergedSchema _schema;
 
@@ -56,12 +54,12 @@ namespace Microsoft.ML.Runtime.Api
             SchemaDefinition inputSchemaDefinition = null, SchemaDefinition outputSchemaDefinition = null)
             : base(env, RegistrationName, saveAction, loadFunc)
         {
-            Host.AssertValue(source, "source");
-            Host.AssertValue(mapAction, "mapAction");
+            Host.AssertValue(source);
+            Host.AssertValue(mapAction);
             Host.AssertValueOrNull(inputSchemaDefinition);
             Host.AssertValueOrNull(outputSchemaDefinition);
 
-            _source = source;
+            Source = source;
             _mapAction = mapAction;
             _inputSchemaDefinition = inputSchemaDefinition;
             _typedSource = TypedCursorable<TSrc>.Create(Host, Source, false, inputSchemaDefinition);
@@ -69,7 +67,7 @@ namespace Microsoft.ML.Runtime.Api
                ? InternalSchemaDefinition.Create(typeof(TDst), SchemaDefinition.Direction.Write)
                : InternalSchemaDefinition.Create(typeof(TDst), outputSchemaDefinition);
 
-            _schema = MergedSchema.Create(_source.Schema, outSchema);
+            _schema = MergedSchema.Create(Source.Schema, outSchema);
         }
 
         /// <summary>
@@ -81,26 +79,20 @@ namespace Microsoft.ML.Runtime.Api
             Host.AssertValue(transform);
             Host.AssertValue(newSource);
 
-            _source = newSource;
+            Source = newSource;
             _mapAction = transform._mapAction;
             _typedSource = TypedCursorable<TSrc>.Create(Host, newSource, false, transform._inputSchemaDefinition);
 
             _schema = MergedSchema.Create(newSource.Schema, transform._schema.AddedSchema);
         }
 
-        public bool CanShuffle
-        {
-            get { return _source.CanShuffle; }
-        }
+        public bool CanShuffle => Source.CanShuffle;
 
-        public ISchema Schema
-        {
-            get { return _schema; }
-        }
+        public ISchema Schema => _schema;
 
         public long? GetRowCount(bool lazy = true)
         {
-            return _source.GetRowCount(lazy);
+            return Source.GetRowCount(lazy);
         }
 
         public IRowCursor GetRowCursor(Func<int, bool> predicate, IRandom rand = null)
@@ -136,10 +128,7 @@ namespace Microsoft.ML.Runtime.Api
             return cursors;
         }
 
-        public IDataView Source
-        {
-            get { return _source; }
-        }
+        public IDataView Source { get; }
 
         public IDataTransform ApplyToData(IHostEnvironment env, IDataView newSource)
         {
@@ -161,13 +150,13 @@ namespace Microsoft.ML.Runtime.Api
             return _typedSource.GetDependencies(srcPredicate);
         }
 
-        ISchema IRowToRowMapper.InputSchema => _source.Schema;
+        ISchema IRowToRowMapper.InputSchema => Source.Schema;
 
         public IRow GetRow(IRow input, Func<int, bool> active, out Action disposer)
         {
             Host.CheckValue(input, nameof(input));
             Host.CheckValue(active, nameof(active));
-            Host.CheckParam(input.Schema == _source.Schema, nameof(input), "Schema of input row must be the same as the schema the mapper is bound to");
+            Host.CheckParam(input.Schema == Source.Schema, nameof(input), "Schema of input row must be the same as the schema the mapper is bound to");
 
             var src = new TSrc();
             var dst = new TDst();
@@ -234,7 +223,7 @@ namespace Microsoft.ML.Runtime.Api
                     () =>
                     {
                         if (!IsGood)
-                            throw Contracts.Except("Getter is called when the cursor is {0}, which is not allowed.", Input.State);
+                            throw Ch.Except("Getter is called when the cursor is {0}, which is not allowed.", Input.State);
                     };
                 return _row.GetGetterCore<TValue>(col, isGood);
             }
@@ -253,7 +242,6 @@ namespace Microsoft.ML.Runtime.Api
 
         private sealed class Row : IRow
         {
-            private readonly ISchema _schema;
             private readonly IRow<TSrc> _input;
             private readonly IRow _appendedRow;
             private readonly bool[] _active;
@@ -269,15 +257,15 @@ namespace Microsoft.ML.Runtime.Api
 
             public long Position => _input.Position;
 
-            public ISchema Schema => _schema;
+            public ISchema Schema { get; }
 
             public Row(IRow<TSrc> input, MapTransform<TSrc, TDst> parent, Func<int, bool> active, TSrc src, TDst dst)
             {
                 _input = input;
                 _parent = parent;
-                _schema = parent.Schema;
+                Schema = parent.Schema;
 
-                _active = Utils.BuildArray(_schema.ColumnCount, active);
+                _active = Utils.BuildArray(Schema.ColumnCount, active);
                 _src = src;
                 _dst = dst;
 
@@ -321,7 +309,7 @@ namespace Microsoft.ML.Runtime.Api
 
             public bool IsColumnActive(int col)
             {
-                _parent.Host.Check(0 <= col && col < _schema.ColumnCount);
+                _parent.Host.Check(0 <= col && col < Schema.ColumnCount);
                 return _active[col];
             }
         }

--- a/src/Microsoft.ML.Api/MapTransform.cs
+++ b/src/Microsoft.ML.Api/MapTransform.cs
@@ -242,7 +242,7 @@ namespace Microsoft.ML.Runtime.Api
 
         private sealed class Row : IRow
         {
-            private readonly IRow<TSrc> _input;
+            private readonly IRowReadableAs<TSrc> _input;
             private readonly IRow _appendedRow;
             private readonly bool[] _active;
 
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Runtime.Api
 
             public ISchema Schema { get; }
 
-            public Row(IRow<TSrc> input, MapTransform<TSrc, TDst> parent, Func<int, bool> active, TSrc src, TDst dst)
+            public Row(IRowReadableAs<TSrc> input, MapTransform<TSrc, TDst> parent, Func<int, bool> active, TSrc src, TDst dst)
             {
                 _input = input;
                 _parent = parent;

--- a/src/Microsoft.ML.Api/MapTransform.cs
+++ b/src/Microsoft.ML.Api/MapTransform.cs
@@ -161,6 +161,8 @@ namespace Microsoft.ML.Runtime.Api
             return _typedSource.GetDependencies(srcPredicate);
         }
 
+        ISchema IRowToRowMapper.InputSchema => _source.Schema;
+
         public IRow GetRow(IRow input, Func<int, bool> active, out Action disposer)
         {
             Host.CheckValue(input, nameof(input));

--- a/src/Microsoft.ML.Api/PredictionEngine.cs
+++ b/src/Microsoft.ML.Api/PredictionEngine.cs
@@ -139,7 +139,7 @@ namespace Microsoft.ML.Runtime.Api
         where TDst : class, new()
     {
         private readonly DataViewConstructionUtils.InputRow<TSrc> _inputRow;
-        private readonly IRow<TDst> _outputRow;
+        private readonly IRowReadableAs<TDst> _outputRow;
         private readonly Action _disposer;
         private TDst _result;
 
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Runtime.Api
         public TDst Predict(TSrc example)
         {
             Contracts.CheckValue(example, nameof(example));
-            _inputRow.AcceptValues(example);
+            _inputRow.ExtractValues(example);
             if (_result == null)
                 _result = new TDst();
             _outputRow.FillValues(_result);

--- a/src/Microsoft.ML.Api/PredictionFunction.cs
+++ b/src/Microsoft.ML.Api/PredictionFunction.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Runtime.Data
             env.CheckValue(transformer, nameof(transformer));
 
             IDataView dv = env.CreateDataView(new TSrc[0]);
-            _engine = env.CreatePredictionEngine<TSrc, TDst>(transformer.Transform(dv));
+            _engine = env.CreatePredictionEngine<TSrc, TDst>(transformer);
         }
 
         public TDst Predict(TSrc example) => _engine.Predict(example);

--- a/src/Microsoft.ML.Api/TypedCursor.cs
+++ b/src/Microsoft.ML.Api/TypedCursor.cs
@@ -27,6 +27,21 @@ namespace Microsoft.ML.Runtime.Api
     }
 
     /// <summary>
+    /// This interface is an <see cref="IRow"/> with 'stringly typed' binding.
+    /// It can accept values of type <typeparamref name="TRow"/> and present the value as a row.
+    /// </summary>
+    /// <typeparam name="TRow"></typeparam>
+    public interface IInputRow<TRow> : IRow
+        where TRow : class
+    {
+        /// <summary>
+        /// Accepts the fields of the user-supplied <paramref name="row"/> object and publishes the instance as a row.
+        /// </summary>
+        /// <param name="row">The row object. Cannot be null.</param>
+        void AcceptValues(TRow row);
+    }
+
+    /// <summary>
     /// This interface provides cursoring through a <see cref="IDataView"/> via a 'strongly typed' binding.
     /// It can populate the user-supplied object's fields with the values of the current row.
     /// </summary>
@@ -239,11 +254,11 @@ namespace Microsoft.ML.Runtime.Api
             private readonly IRow _input;
             private readonly Action<TRow>[] _setters;
 
-            public long Batch { get { return _input.Batch; } }
+            public long Batch => _input.Batch;
 
-            public long Position { get { return _input.Position; } }
+            public long Position => _input.Position;
 
-            public ISchema Schema { get { return _input.Schema; } }
+            public ISchema Schema => _input.Schema;
 
             public TypedRowBase(TypedCursorable<TRow> parent, IRow input, string channelMessage)
             {

--- a/src/Microsoft.ML.Api/TypedCursor.cs
+++ b/src/Microsoft.ML.Api/TypedCursor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Runtime.Api
     /// It can populate the user-supplied object's fields with the values of the current row.
     /// </summary>
     /// <typeparam name="TRow">The user-defined type that is being populated while cursoring.</typeparam>
-    public interface IRow<TRow> : IRow
+    public interface IRowReadableAs<TRow> : IRow
         where TRow : class
     {
         /// <summary>
@@ -27,18 +27,19 @@ namespace Microsoft.ML.Runtime.Api
     }
 
     /// <summary>
-    /// This interface is an <see cref="IRow"/> with 'stringly typed' binding.
+    /// This interface is an <see cref="IRow"/> with 'strongly typed' binding.
     /// It can accept values of type <typeparamref name="TRow"/> and present the value as a row.
     /// </summary>
-    /// <typeparam name="TRow"></typeparam>
-    public interface IInputRow<TRow> : IRow
+    /// <typeparam name="TRow">The user-defined type that provides the values while cursoring.</typeparam>
+    public interface IRowBackedBy<TRow> : IRow
         where TRow : class
     {
         /// <summary>
         /// Accepts the fields of the user-supplied <paramref name="row"/> object and publishes the instance as a row.
+        /// If the row is accessed prior to any object being set, then the data accessors on the row should throw.
         /// </summary>
-        /// <param name="row">The row object. Cannot be null.</param>
-        void AcceptValues(TRow row);
+        /// <param name="row">The row object. Cannot be <c>null</c>.</param>
+        void ExtractValues(TRow row);
     }
 
     /// <summary>
@@ -46,7 +47,7 @@ namespace Microsoft.ML.Runtime.Api
     /// It can populate the user-supplied object's fields with the values of the current row.
     /// </summary>
     /// <typeparam name="TRow">The user-defined type that is being populated while cursoring.</typeparam>
-    public interface IRowCursor<TRow> : IRow<TRow>, ICursor
+    public interface IRowCursor<TRow> : IRowReadableAs<TRow>, ICursor
         where TRow : class
     {
     }
@@ -174,7 +175,7 @@ namespace Microsoft.ML.Runtime.Api
             return GetCursor(x => false, randomSeed);
         }
 
-        public IRow<TRow> GetRow(IRow input)
+        public IRowReadableAs<TRow> GetRow(IRow input)
         {
             return new TypedRow(this, input);
         }
@@ -248,7 +249,7 @@ namespace Microsoft.ML.Runtime.Api
             return new TypedCursorable<TRow>(env, data, ignoreMissingColumns, outSchema);
         }
 
-        private abstract class TypedRowBase : IRow<TRow>
+        private abstract class TypedRowBase : IRowReadableAs<TRow>
         {
             protected readonly IChannel Ch;
             private readonly IRow _input;

--- a/src/Microsoft.ML.Core/Data/IEstimator.cs
+++ b/src/Microsoft.ML.Core/Data/IEstimator.cs
@@ -245,6 +245,21 @@ namespace Microsoft.ML.Core.Data
         /// Note that <see cref="IDataView"/>'s are lazy, so no actual transformations happen here, just schema validation.
         /// </summary>
         IDataView Transform(IDataView input);
+
+        /// <summary>
+        /// Whether a call to <see cref="GetRowToRowMapper(ISchema)"/> should succeed, on an
+        /// appropriate schema.
+        /// </summary>
+        bool IsRowToRowMapper { get; }
+
+        /// <summary>
+        /// Constructs a row-to-row mapper based on an input schema. If <see cref="IsRowToRowMapper"/>
+        /// is <c>false</c>, then an exception should be thrown. If the input schema is in any way
+        /// unsuitable for constructing the mapper, an exception should likewise be thrown.
+        /// </summary>
+        /// <param name="inputSchema">The input schema for which we should get the mapper.</param>
+        /// <returns>The row to row mapper.</returns>
+        IRowToRowMapper GetRowToRowMapper(ISchema inputSchema);
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
+++ b/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <summary>
         /// The <see cref="RoleMappedSchema"/> that was passed to the <see cref="ISchemaBoundMapper"/> in the binding process.
         /// </summary>
-        RoleMappedSchema InputSchema { get; }
+        RoleMappedSchema InputRoleMappedSchema { get; }
 
         /// <summary>
         /// A property to get back the <see cref="ISchemaBindableMapper"/> that produced this <see cref="ISchemaBoundMapper"/>.
@@ -65,8 +65,14 @@ namespace Microsoft.ML.Runtime.Data
     public interface IRowToRowMapper : ISchematized
     {
         /// <summary>
+        /// Mappers are defined as accepting inputs with this very specific schema.
+        /// </summary>
+        ISchema InputSchema { get; }
+
+        /// <summary>
         /// Given a predicate specifying which columns are needed, return a predicate indicating which input columns are
-        /// needed.
+        /// needed. The domain of the function is defined over the indices of the columns of <see cref="ISchema.ColumnCount"/>
+        /// for <see cref="InputSchema"/>.
         /// </summary>
         Func<int, bool> GetDependencies(Func<int, bool> predicate);
 
@@ -75,9 +81,9 @@ namespace Microsoft.ML.Runtime.Data
         /// The active columns are those for which <paramref name="active"/> returns true. Getting values on inactive
         /// columns of the returned row will throw. Null predicates are disallowed.
         ///
-        /// The <see cref="ISchematized.Schema"/> of <paramref name="input"/> should be exactly the same <see
-        /// cref="ISchema"/>
-        /// that was used to create this object. This method should throw if that is not the case.
+        /// The <see cref="ISchematized.Schema"/> of <paramref name="input"/> should be the same object as
+        /// <see cref="InputSchema"/>. Implementors of this method should throw if that is not the case. Conversely,
+        /// the returned value must have the same schema as <see cref="ISchematized.Schema"/>.
         ///
         /// This method creates a live connection between the input <see cref="IRow"/> and the output <see
         /// cref="IRow"/>. In particular, when the getters of the output <see cref="IRow"/> are invoked, they invoke the

--- a/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
@@ -302,8 +302,8 @@ namespace Microsoft.ML.Runtime.Data
 
             ComponentCatalog.LoadableClassInfo info = null;
             ReadOnlyMemory<char> scoreKind = default;
-            if (mapper.OutputSchema.ColumnCount > 0 &&
-                mapper.OutputSchema.TryGetMetadata(TextType.Instance, MetadataUtils.Kinds.ScoreColumnKind, 0, ref scoreKind) &&
+            if (mapper.Schema.ColumnCount > 0 &&
+                mapper.Schema.TryGetMetadata(TextType.Instance, MetadataUtils.Kinds.ScoreColumnKind, 0, ref scoreKind) &&
                 !scoreKind.IsEmpty)
             {
                 var loadName = scoreKind.ToString();

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Runtime.Data
             // The walkback should have ended at the input.
             Contracts.Assert(chain == input);
             revMaps.Reverse();
-            return new ChainedRowToRowMapper(inputSchema, revMaps.ToArray());
+            return new CompositeRowToRowMapper(inputSchema, revMaps.ToArray());
         }
     }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
@@ -48,6 +48,8 @@ namespace Microsoft.ML.Runtime.Data
 
         private const string TransformDirTemplate = "Transform_{0:000}";
 
+        public bool IsRowToRowMapper => _transformers.All(t => t.IsRowToRowMapper);
+
         private static VersionInfo GetVersionInfo()
         {
             return new VersionInfo(
@@ -197,6 +199,21 @@ namespace Microsoft.ML.Runtime.Data
         public IEnumerator<ITransformer> GetEnumerator() => ((IEnumerable<ITransformer>)_transformers).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Contracts.CheckValue(inputSchema, nameof(inputSchema));
+            Contracts.Check(IsRowToRowMapper, nameof(GetRowToRowMapper) + " method called despite " + nameof(IsRowToRowMapper) + " being false.");
+
+            IRowToRowMapper[] mappers = new IRowToRowMapper[_transformers.Length];
+            ISchema schema = inputSchema;
+            for (int i = 0; i < mappers.Length; ++i)
+            {
+                mappers[i] = _transformers[i].GetRowToRowMapper(schema);
+                schema = mappers[i].Schema;
+            }
+            return new ChainedRowToRowMapper(inputSchema, mappers);
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Runtime.Data
                 mappers[i] = _transformers[i].GetRowToRowMapper(schema);
                 schema = mappers[i].Schema;
             }
-            return new ChainedRowToRowMapper(inputSchema, mappers);
+            return new CompositeRowToRowMapper(inputSchema, mappers);
         }
     }
 

--- a/src/Microsoft.ML.Data/DataView/ChainedRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/ChainedRowToRowMapper.cs
@@ -30,6 +30,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValueOrNull(mappers);
             _innerMappers = Utils.Size(mappers) > 0 ? mappers : _empty;
             InputSchema = inputSchema;
+            Schema = Utils.Size(mappers) > 0 ? mappers[mappers.Length - 1].Schema : inputSchema;
         }
 
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
@@ -67,7 +68,7 @@ namespace Microsoft.ML.Runtime.Data
             // computed based on the dependencies of the next one in the chain.
             var deps = new Func<int, bool>[_innerMappers.Length];
             deps[deps.Length - 1] = active;
-            for (int i = deps.Length - 1; i <= 1; --i)
+            for (int i = deps.Length - 1; i >= 1; --i)
                 deps[i - 1] = _innerMappers[i].GetDependencies(deps[i]);
 
             IRow result = input;

--- a/src/Microsoft.ML.Data/DataView/ChainedRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/ChainedRowToRowMapper.cs
@@ -15,8 +15,8 @@ namespace Microsoft.ML.Runtime.Data
         private readonly IRowToRowMapper[] _innerMappers;
         private static readonly IRowToRowMapper[] _empty = new IRowToRowMapper[0];
 
+        public ISchema InputSchema { get; }
         public ISchema Schema { get; }
-        private readonly ISchema _inputSchema;
 
         /// <summary>
         /// Out of a series of mappers, construct a seemingly unitary mapper that is able to apply them in sequence.
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(inputSchema, nameof(inputSchema));
             Contracts.CheckValueOrNull(mappers);
             _innerMappers = Utils.Size(mappers) > 0 ? mappers : _empty;
-            _inputSchema = inputSchema;
+            InputSchema = inputSchema;
         }
 
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.CheckValue(input, nameof(input));
             Contracts.CheckValue(active, nameof(active));
-            Contracts.CheckParam(input.Schema == _inputSchema, nameof(input), "Schema did not match original schema");
+            Contracts.CheckParam(input.Schema == InputSchema, nameof(input), "Schema did not match original schema");
 
             disposer = null;
             if (_innerMappers.Length == 0)

--- a/src/Microsoft.ML.Data/DataView/ChainedRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/ChainedRowToRowMapper.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.ML.Runtime.Internal.Utilities;
+
+namespace Microsoft.ML.Runtime.Data
+{
+    /// <summary>
+    /// A row-to-row mapper that is the result of a chained application of multiple mappers.
+    /// </summary>
+    public sealed class ChainedRowToRowMapper : IRowToRowMapper
+    {
+        private readonly IRowToRowMapper[] _innerMappers;
+        private static readonly IRowToRowMapper[] _empty = new IRowToRowMapper[0];
+
+        public ISchema Schema { get; }
+        private readonly ISchema _inputSchema;
+
+        /// <summary>
+        /// Out of a series of mappers, construct a seemingly unitary mapper that is able to apply them in sequence.
+        /// </summary>
+        /// <param name="inputSchema">The input schema.</param>
+        /// <param name="mappers">The sequence of mappers to wrap. An empty or <c>null</c> argument
+        /// is legal, and counts as being a no-op application.</param>
+        public ChainedRowToRowMapper(ISchema inputSchema, IRowToRowMapper[] mappers)
+        {
+            Contracts.CheckValue(inputSchema, nameof(inputSchema));
+            Contracts.CheckValueOrNull(mappers);
+            _innerMappers = Utils.Size(mappers) > 0 ? mappers : _empty;
+            _inputSchema = inputSchema;
+        }
+
+        public Func<int, bool> GetDependencies(Func<int, bool> predicate)
+        {
+            Func<int, bool> toReturn = predicate;
+            for (int i = _innerMappers.Length - 1; i <= 0; --i)
+                toReturn = _innerMappers[i].GetDependencies(toReturn);
+            return toReturn;
+        }
+
+        public IRow GetRow(IRow input, Func<int, bool> active, out Action disposer)
+        {
+            Contracts.CheckValue(input, nameof(input));
+            Contracts.CheckValue(active, nameof(active));
+            Contracts.CheckParam(input.Schema == _inputSchema, nameof(input), "Schema did not match original schema");
+
+            disposer = null;
+            if (_innerMappers.Length == 0)
+            {
+                bool differentActive = false;
+                for (int c = 0; c < input.Schema.ColumnCount; ++c)
+                {
+                    bool wantsActive = active(c);
+                    bool isActive = input.IsColumnActive(c);
+                    differentActive |= wantsActive != isActive;
+
+                    if (wantsActive && !isActive)
+                        throw Contracts.ExceptParam(nameof(input), $"Mapper required column '{input.Schema.GetColumnName(c)}' active but it was not.");
+                }
+                return input;
+            }
+
+            // For each of the inner mappers, we will be calling their GetRow method, but to do so we need to know
+            // what we need from them. The last one will just have the input, but the rest will need to be
+            // computed based on the dependencies of the next one in the chain.
+            var deps = new Func<int, bool>[_innerMappers.Length];
+            deps[deps.Length - 1] = active;
+            for (int i = deps.Length - 1; i <= 1; --i)
+                deps[i - 1] = _innerMappers[i].GetDependencies(deps[i]);
+
+            IRow result = input;
+            for (int i = 0; i < _innerMappers.Length; ++i)
+            {
+                result = _innerMappers[i].GetRow(result, deps[i], out var localDisp);
+                if (localDisp != null)
+                {
+                    if (disposer == null)
+                        disposer = localDisp;
+                    else
+                        disposer = localDisp + disposer;
+                    // We want the last disposer to be called first, so the order of the addition here is important.
+                }
+            }
+            return result;
+        }
+
+        private sealed class SubsetActive : IRow
+        {
+            private readonly IRow _row;
+            private Func<int, bool> _pred;
+
+            public SubsetActive(IRow row, Func<int, bool> pred)
+            {
+                Contracts.AssertValue(row);
+                Contracts.AssertValue(pred);
+                _row = row;
+                _pred = pred;
+            }
+
+            public ISchema Schema => _row.Schema;
+            public long Position => _row.Position;
+            public long Batch => _row.Batch;
+            public ValueGetter<TValue> GetGetter<TValue>(int col) => _row.GetGetter<TValue>(col);
+            public ValueGetter<UInt128> GetIdGetter() => _row.GetIdGetter();
+            public bool IsColumnActive(int col) => _pred(col);
+        }
+    }
+}

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ML.Runtime.Data
     /// <summary>
     /// A row-to-row mapper that is the result of a chained application of multiple mappers.
     /// </summary>
-    public sealed class ChainedRowToRowMapper : IRowToRowMapper
+    public sealed class CompositeRowToRowMapper : IRowToRowMapper
     {
         private readonly IRowToRowMapper[] _innerMappers;
         private static readonly IRowToRowMapper[] _empty = new IRowToRowMapper[0];
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="inputSchema">The input schema.</param>
         /// <param name="mappers">The sequence of mappers to wrap. An empty or <c>null</c> argument
         /// is legal, and counts as being a no-op application.</param>
-        public ChainedRowToRowMapper(ISchema inputSchema, IRowToRowMapper[] mappers)
+        public CompositeRowToRowMapper(ISchema inputSchema, IRowToRowMapper[] mappers)
         {
             Contracts.CheckValue(inputSchema, nameof(inputSchema));
             Contracts.CheckValueOrNull(mappers);

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -360,6 +360,8 @@ namespace Microsoft.ML.Runtime.Data
             return predicateInput;
         }
 
+        ISchema IRowToRowMapper.InputSchema => Source.Schema;
+
         public IRow GetRow(IRow input, Func<int, bool> active, out Action disposer)
         {
             Host.CheckValue(input, nameof(input));

--- a/src/Microsoft.ML.Data/EntryPoints/TransformModel.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/TransformModel.cs
@@ -192,6 +192,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
             private readonly ISchema _rootSchema;
             private readonly IExceptionContext _ectx;
 
+            public ISchema Schema => _chain.Schema;
+
             public CompositeRowToRowMapper(IExceptionContext ectx, IDataView chain, ISchema rootSchema)
             {
                 Contracts.CheckValue(ectx, nameof(ectx));

--- a/src/Microsoft.ML.Data/EntryPoints/TransformModel.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/TransformModel.cs
@@ -233,13 +233,15 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 return pred;
             }
 
+            public ISchema InputSchema => _rootSchema;
+
             public IRow GetRow(IRow input, Func<int, bool> active, out Action disposer)
             {
                 _ectx.Assert(IsCompositeRowToRowMapper(_chain));
                 _ectx.AssertValue(input);
                 _ectx.AssertValue(active);
 
-                _ectx.Check(input.Schema == _rootSchema, "Schema of input row must be the same as the schema the mapper is bound to");
+                _ectx.Check(input.Schema == InputSchema, "Schema of input row must be the same as the schema the mapper is bound to");
 
                 disposer = null;
                 var mappers = new List<IRowToRowMapper>();

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime.Data
             if (rowMapper == null)
                 return false; // We could cover this case, but it is of no practical worth as far as I see, so I decline to do so.
 
-            ISchema outSchema = mapper.OutputSchema;
+            ISchema outSchema = mapper.Schema;
             int scoreIdx;
             if (!outSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIdx))
                 return false; // The mapper doesn't even publish a score column to attach the metadata to.
@@ -223,7 +223,7 @@ namespace Microsoft.ML.Runtime.Data
         protected override Delegate GetPredictedLabelGetter(IRow output, out Delegate scoreGetter)
         {
             Host.AssertValue(output);
-            Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
+            Host.Assert(output.Schema == Bindings.RowMapper.Schema);
             Host.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
 
             ValueGetter<Float> mapperScoreGetter = output.GetGetter<Float>(Bindings.ScoreColumnIndex);

--- a/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime.Data
         protected override Delegate GetPredictedLabelGetter(IRow output, out Delegate scoreGetter)
         {
             Contracts.AssertValue(output);
-            Contracts.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
+            Contracts.Assert(output.Schema == Bindings.RowMapper.Schema);
             Contracts.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
 
             ValueGetter<VBuffer<Float>> mapperScoreGetter = output.GetGetter<VBuffer<Float>>(Bindings.ScoreColumnIndex);

--- a/src/Microsoft.ML.Data/Scorers/GenericScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/GenericScorer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.AssertValueOrNull(suffix);
                 // We don't actually depend on this invariant, but if this assert fires it means the bindable
                 // did the wrong thing.
-                Contracts.Assert(mapper.InputSchema.Schema == input);
+                Contracts.Assert(mapper.InputSchema == input);
 
                 return new Bindings(input, mapper, suffix, user);
             }
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Runtime.Data
                 var mapper = bindable.Bind(env, new RoleMappedSchema(input, roles));
                 // We don't actually depend on this invariant, but if this assert fires it means the bindable
                 // did the wrong thing.
-                Contracts.Assert(mapper.InputSchema.Schema == input);
+                Contracts.Assert(mapper.InputRoleMappedSchema.Schema == input);
 
                 var rowMapper = mapper as ISchemaBoundRowMapper;
                 Contracts.Check(rowMapper != null, "Predictor expected to be a RowMapper!");
@@ -205,7 +205,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.Assert(Bindable is IBindableCanSavePfa);
             var pfaBindable = (IBindableCanSavePfa)Bindable;
 
-            var schema = _bindings.RowMapper.InputSchema;
+            var schema = _bindings.RowMapper.InputRoleMappedSchema;
             Host.Assert(_bindings.DerivedColumnCount == 0);
             string[] outColNames = new string[_bindings.InfoCount];
             for (int iinfo = 0; iinfo < _bindings.InfoCount; ++iinfo)
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.Assert(Bindable is IBindableCanSaveOnnx);
             var onnxBindable = (IBindableCanSaveOnnx)Bindable;
 
-            var schema = _bindings.RowMapper.InputSchema;
+            var schema = _bindings.RowMapper.InputRoleMappedSchema;
             Host.Assert(_bindings.DerivedColumnCount == 0);
             string[] outVariableNames = new string[_bindings.InfoCount];
             for (int iinfo = 0; iinfo < _bindings.InfoCount; ++iinfo)

--- a/src/Microsoft.ML.Data/Scorers/GenericScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/GenericScorer.cs
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.Assert(_bindings.DerivedColumnCount == 0);
             Host.AssertValue(output);
             Host.AssertValue(predicate);
-            Host.Assert(output.Schema == _bindings.RowMapper.OutputSchema);
+            Host.Assert(output.Schema == _bindings.RowMapper.Schema);
 
             return GetGettersFromRow(output, predicate);
         }

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -248,9 +248,10 @@ namespace Microsoft.ML.Runtime.Data
                 private LabelNameBindableMapper _bindable;
                 private readonly Func<ISchemaBoundMapper, ColumnType, bool> _canWrap;
 
-                public ISchema Schema { get { return _outSchema; } }
+                public ISchema Schema => _outSchema;
 
-                public RoleMappedSchema InputSchema { get { return _mapper.InputSchema; } }
+                public RoleMappedSchema InputRoleMappedSchema => _mapper.InputRoleMappedSchema;
+                public ISchema InputSchema => _mapper.InputSchema;
 
                 public ISchemaBindableMapper Bindable
                 {

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -248,7 +248,7 @@ namespace Microsoft.ML.Runtime.Data
                 private LabelNameBindableMapper _bindable;
                 private readonly Func<ISchemaBoundMapper, ColumnType, bool> _canWrap;
 
-                public ISchema OutputSchema { get { return _outSchema; } }
+                public ISchema Schema { get { return _outSchema; } }
 
                 public RoleMappedSchema InputSchema { get { return _mapper.InputSchema; } }
 
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Runtime.Data
                     _mapper = mapper;
 
                     int scoreIdx;
-                    bool result = mapper.OutputSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIdx);
+                    bool result = mapper.Schema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIdx);
                     if (!result)
                         throw env.ExceptParam(nameof(mapper), "Mapper did not have a '{0}' column", MetadataUtils.Const.ScoreValueKind.Score);
 
@@ -291,7 +291,7 @@ namespace Microsoft.ML.Runtime.Data
                     _labelNameGetter = getter;
                     _metadataKind = metadataKind;
 
-                    _outSchema = new SchemaImpl(mapper.OutputSchema, scoreIdx, _labelNameType, _labelNameGetter, _metadataKind);
+                    _outSchema = new SchemaImpl(mapper.Schema, scoreIdx, _labelNameType, _labelNameGetter, _metadataKind);
                     _canWrap = canWrap;
                 }
 
@@ -305,10 +305,10 @@ namespace Microsoft.ML.Runtime.Data
                     return _mapper.GetInputColumnRoles();
                 }
 
-                public IRow GetOutputRow(IRow input, Func<int, bool> predicate, out Action disposer)
+                public IRow GetRow(IRow input, Func<int, bool> predicate, out Action disposer)
                 {
-                    var innerRow = _mapper.GetOutputRow(input, predicate, out disposer);
-                    return new RowImpl(innerRow, OutputSchema);
+                    var innerRow = _mapper.GetRow(input, predicate, out disposer);
+                    return new RowImpl(innerRow, Schema);
                 }
 
                 private sealed class SchemaImpl : ISchema
@@ -463,7 +463,7 @@ namespace Microsoft.ML.Runtime.Data
             if (rowMapper == null)
                 return false; // We could cover this case, but it is of no practical worth as far as I see, so I decline to do so.
 
-            ISchema outSchema = mapper.OutputSchema;
+            ISchema outSchema = mapper.Schema;
             int scoreIdx;
             if (!outSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIdx))
                 return false; // The mapper doesn't even publish a score column to attach the metadata to.
@@ -548,7 +548,7 @@ namespace Microsoft.ML.Runtime.Data
         protected override Delegate GetPredictedLabelGetter(IRow output, out Delegate scoreGetter)
         {
             Host.AssertValue(output);
-            Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
+            Host.Assert(output.Schema == Bindings.RowMapper.Schema);
             Host.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
 
             ValueGetter<VBuffer<Float>> mapperScoreGetter = output.GetGetter<VBuffer<Float>>(Bindings.ScoreColumnIndex);

--- a/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
@@ -62,24 +62,24 @@ namespace Microsoft.ML.Runtime.Data
                 // bearing object makes pushing the logic into the multiclass scorer almost impossible.
                 if (predColType.IsKey)
                 {
-                    ColumnType scoreSlotsType = mapper.OutputSchema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, scoreColIndex);
+                    ColumnType scoreSlotsType = mapper.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, scoreColIndex);
                     if (scoreSlotsType != null && scoreSlotsType.IsKnownSizeVector &&
                         scoreSlotsType.VectorSize == predColType.KeyCount)
                     {
                         Contracts.Assert(scoreSlotsType.VectorSize > 0);
                         IColumn col = Utils.MarshalInvoke(KeyValueMetadataFromMetadata<int>,
-                            scoreSlotsType.RawType, mapper.OutputSchema, scoreColIndex, MetadataUtils.Kinds.SlotNames);
+                            scoreSlotsType.RawType, mapper.Schema, scoreColIndex, MetadataUtils.Kinds.SlotNames);
                         _predColMetadata = RowColumnUtils.GetRow(null, col);
                     }
                     else
                     {
-                        scoreSlotsType = mapper.OutputSchema.GetMetadataTypeOrNull(MetadataUtils.Kinds.TrainingLabelValues, scoreColIndex);
+                        scoreSlotsType = mapper.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.TrainingLabelValues, scoreColIndex);
                         if (scoreSlotsType != null && scoreSlotsType.IsKnownSizeVector &&
                             scoreSlotsType.VectorSize == predColType.KeyCount)
                         {
                             Contracts.Assert(scoreSlotsType.VectorSize > 0);
                             IColumn col = Utils.MarshalInvoke(KeyValueMetadataFromMetadata<int>,
-                                scoreSlotsType.RawType, mapper.OutputSchema, scoreColIndex, MetadataUtils.Kinds.TrainingLabelValues);
+                                scoreSlotsType.RawType, mapper.Schema, scoreColIndex, MetadataUtils.Kinds.TrainingLabelValues);
                             _predColMetadata = RowColumnUtils.GetRow(null, col);
                         }
                     }
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Runtime.Data
                 env.AssertValue(input);
                 env.AssertValue(bindable);
 
-                string scoreCol = RowMapper.OutputSchema.GetColumnName(ScoreColumnIndex);
+                string scoreCol = RowMapper.Schema.GetColumnName(ScoreColumnIndex);
                 var schema = new RoleMappedSchema(input, RowMapper.GetInputColumnRoles());
 
                 // Checks compatibility of the predictor input types.
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Runtime.Data
                 var rowMapper = mapper as ISchemaBoundRowMapper;
                 env.CheckParam(rowMapper != null, nameof(bindable), "Mapper must implement ISchemaBoundRowMapper");
                 int mapperScoreColumn;
-                bool tmp = rowMapper.OutputSchema.TryGetColumnIndex(scoreCol, out mapperScoreColumn);
+                bool tmp = rowMapper.Schema.TryGetColumnIndex(scoreCol, out mapperScoreColumn);
                 env.Check(tmp, "Mapper doesn't have expected score column");
 
                 return new BindingsImpl(input, rowMapper, Suffix, ScoreColumnKind, true, mapperScoreColumn, PredColType);
@@ -154,9 +154,9 @@ namespace Microsoft.ML.Runtime.Data
 
                 // Find the score column of the mapper.
                 int scoreColIndex;
-                env.CheckDecode(mapper.OutputSchema.TryGetColumnIndex(scoreCol, out scoreColIndex));
+                env.CheckDecode(mapper.Schema.TryGetColumnIndex(scoreCol, out scoreColIndex));
 
-                var scoreType = mapper.OutputSchema.GetColumnType(scoreColIndex);
+                var scoreType = mapper.Schema.GetColumnType(scoreColIndex);
                 env.CheckDecode(outputTypeMatches(scoreType));
                 var predColType = getPredColType(scoreType, rowMapper);
 
@@ -173,7 +173,7 @@ namespace Microsoft.ML.Runtime.Data
                 // int: id of the column used for deriving the predicted label column
                 SaveBase(ctx);
                 ctx.SaveNonEmptyString(ScoreColumnKind);
-                ctx.SaveNonEmptyString(RowMapper.OutputSchema.GetColumnName(ScoreColumnIndex));
+                ctx.SaveNonEmptyString(RowMapper.Schema.GetColumnName(ScoreColumnIndex));
             }
 
             protected override ColumnType GetColumnTypeCore(int iinfo)
@@ -301,10 +301,10 @@ namespace Microsoft.ML.Runtime.Data
             Host.CheckParam(rowMapper != null, nameof(mapper), "mapper should implement " + nameof(ISchemaBoundRowMapper));
 
             int scoreColIndex;
-            if (!mapper.OutputSchema.TryGetColumnIndex(scoreColName, out scoreColIndex))
+            if (!mapper.Schema.TryGetColumnIndex(scoreColName, out scoreColIndex))
                 throw Host.ExceptParam(nameof(scoreColName), "mapper does not contain a column '{0}'", scoreColName);
 
-            var scoreType = mapper.OutputSchema.GetColumnType(scoreColIndex);
+            var scoreType = mapper.Schema.GetColumnType(scoreColIndex);
             Host.Check(outputTypeMatches(scoreType), "Unexpected predictor output type");
             var predColType = getPredColType(scoreType, rowMapper);
 
@@ -405,7 +405,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.Assert(Bindings.DerivedColumnCount == 1);
             Host.AssertValue(output);
             Host.AssertValue(predicate);
-            Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
+            Host.Assert(output.Schema == Bindings.RowMapper.Schema);
             Host.Assert(Bindings.InfoCount == output.Schema.ColumnCount + 1);
 
             var getters = new Delegate[Bindings.InfoCount];

--- a/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
@@ -342,7 +342,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.Assert(Bindable is IBindableCanSavePfa);
             var pfaBindable = (IBindableCanSavePfa)Bindable as IBindableCanSavePfa;
 
-            var schema = Bindings.RowMapper.InputSchema;
+            var schema = Bindings.RowMapper.InputRoleMappedSchema;
             int delta = Bindings.DerivedColumnCount;
             Host.Assert(delta == 1);
             string[] outColNames = new string[Bindings.InfoCount - delta];
@@ -371,7 +371,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.Assert(Bindable is IBindableCanSaveOnnx);
             var onnxBindable = (IBindableCanSaveOnnx)Bindable;
 
-            var schema = Bindings.RowMapper.InputSchema;
+            var schema = Bindings.RowMapper.InputRoleMappedSchema;
             int delta = Bindings.DerivedColumnCount;
 
             Host.Assert(delta == 1);

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -93,6 +93,8 @@ namespace Microsoft.ML.Runtime.Data
         /// <returns>The transformed <see cref="IDataView"/></returns>
         public abstract IDataView Transform(IDataView input);
 
+        public abstract IRowToRowMapper GetRowToRowMapper(ISchema inputSchema);
+
         protected void SaveModel(ModelSaveContext ctx)
         {
             // *** Binary format ***
@@ -187,8 +189,6 @@ namespace Microsoft.ML.Runtime.Data
             SaveModel(ctx);
             ctx.SaveStringOrNull(FeatureColumn);
         }
-
-        public abstract IRowToRowMapper GetRowToRowMapper(ISchema inputSchema);
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -428,6 +428,14 @@ namespace Microsoft.ML.Runtime.Data
             return _scorer.ApplyToData(Host, input);
         }
 
+        public override bool IsRowToRowMapper => true;
+
+        public override IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Host.CheckValue(inputSchema, nameof(inputSchema));
+            return (IRowToRowMapper)_scorer.ApplyToData(Host, new EmptyDataView(Host, inputSchema));
+        }
+
         protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -41,6 +41,8 @@ namespace Microsoft.ML.Runtime.Data
         protected ISchemaBindableMapper BindableMapper;
         protected ISchema TrainSchema;
 
+        public abstract bool IsRowToRowMapper { get; }
+
         protected PredictionTransformerBase(IHost host, TModel model, ISchema trainSchema)
         {
             Contracts.CheckValue(host, nameof(host));
@@ -185,6 +187,8 @@ namespace Microsoft.ML.Runtime.Data
             SaveModel(ctx);
             ctx.SaveStringOrNull(FeatureColumn);
         }
+
+        public abstract IRowToRowMapper GetRowToRowMapper(ISchema inputSchema);
     }
 
     /// <summary>
@@ -232,6 +236,14 @@ namespace Microsoft.ML.Runtime.Data
         {
             Host.CheckValue(input, nameof(input));
             return _scorer.ApplyToData(Host, input);
+        }
+
+        public override bool IsRowToRowMapper => true;
+
+        public override IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Host.CheckValue(inputSchema, nameof(inputSchema));
+            return (IRowToRowMapper)_scorer.ApplyToData(Host, new EmptyDataView(Host, inputSchema));
         }
 
         protected override void SaveCore(ModelSaveContext ctx)
@@ -301,6 +313,14 @@ namespace Microsoft.ML.Runtime.Data
             return _scorer.ApplyToData(Host, input);
         }
 
+        public override bool IsRowToRowMapper => true;
+
+        public override IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Host.CheckValue(inputSchema, nameof(inputSchema));
+            return (IRowToRowMapper)_scorer.ApplyToData(Host, new EmptyDataView(Host, inputSchema));
+        }
+
         protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);
@@ -352,6 +372,14 @@ namespace Microsoft.ML.Runtime.Data
         {
             Host.CheckValue(input, nameof(input));
             return _scorer.ApplyToData(Host, input);
+        }
+
+        public override bool IsRowToRowMapper => true;
+
+        public override IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Host.CheckValue(inputSchema, nameof(inputSchema));
+            return (IRowToRowMapper)_scorer.ApplyToData(Host, new EmptyDataView(Host, inputSchema));
         }
 
         protected override void SaveCore(ModelSaveContext ctx)

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -194,7 +194,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public RoleMappedSchema InputSchema { get { return _inputSchema; } }
 
-            public ISchema OutputSchema { get { return _outputSchema; } }
+            public ISchema Schema { get { return _outputSchema; } }
 
             public ISchemaBindableMapper Bindable { get { return _parent; } }
 
@@ -213,7 +213,7 @@ namespace Microsoft.ML.Runtime.Data
                 yield return RoleMappedSchema.ColumnRole.Feature.Bind(_inputSchema.Feature.Name);
             }
 
-            public IRow GetOutputRow(IRow input, Func<int, bool> predicate, out Action disposer)
+            public IRow GetRow(IRow input, Func<int, bool> predicate, out Action disposer)
             {
                 Contracts.AssertValue(input);
                 Contracts.AssertValue(predicate);
@@ -480,13 +480,13 @@ namespace Microsoft.ML.Runtime.Data
 
             public RoleMappedSchema InputSchema { get { return _inputSchema; } }
 
-            public ISchema OutputSchema { get { return _outputSchema; } }
+            public ISchema Schema { get { return _outputSchema; } }
 
             public ISchemaBindableMapper Bindable { get { return _parent; } }
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < Schema.ColumnCount; i++)
                 {
                     if (predicate(i) && _inputSchema.Feature != null)
                         return col => col == _inputSchema.Feature.Index;
@@ -555,13 +555,13 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            public IRow GetOutputRow(IRow input, Func<int, bool> predicate, out Action disposer)
+            public IRow GetRow(IRow input, Func<int, bool> predicate, out Action disposer)
             {
                 Contracts.AssertValue(input);
-                var active = Utils.BuildArray(OutputSchema.ColumnCount, predicate);
+                var active = Utils.BuildArray(Schema.ColumnCount, predicate);
                 var getters = CreateGetters(input, active);
                 disposer = null;
-                return new SimpleRow(OutputSchema, input, getters);
+                return new SimpleRow(Schema, input, getters);
             }
         }
     }

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -485,7 +485,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 for (int i = 0; i < Schema.ColumnCount; i++)
                 {
-                    if (predicate(i) && _inputSchema.Feature != null)
+                    if (predicate(i) && InputRoleMappedSchema.Feature != null)
                         return col => col == InputRoleMappedSchema.Feature.Index;
                 }
                 return col => false;

--- a/src/Microsoft.ML.Data/Transforms/ConcatTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConcatTransform.cs
@@ -415,6 +415,14 @@ namespace Microsoft.ML.Runtime.Data
             return RowToRowMapperTransform.GetOutputSchema(inputSchema, MakeRowMapper(inputSchema));
         }
 
+        public bool IsRowToRowMapper => true;
+
+        public IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            _host.CheckValue(inputSchema, nameof(inputSchema));
+            return new RowToRowMapperTransform(_host, new EmptyDataView(_host, inputSchema), MakeRowMapper(inputSchema));
+        }
+
         private sealed class Mapper : IRowMapper, ISaveAsOnnx, ISaveAsPfa
         {
             private readonly IHost _host;

--- a/src/Microsoft.ML.Data/Transforms/CopyColumnsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/CopyColumnsTransform.cs
@@ -207,6 +207,14 @@ namespace Microsoft.ML.Runtime.Data
         {
             return CreateRowToRowMapper(input);
         }
+
+        public bool IsRowToRowMapper => true;
+
+        public IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            _host.CheckValue(inputSchema, nameof(inputSchema));
+            return CreateRowToRowMapper(new EmptyDataView(_host, inputSchema));
+        }
     }
 
     internal sealed class CopyColumnsRowMapper : IRowMapper

--- a/src/Microsoft.ML.Data/Transforms/NopTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/NopTransform.cs
@@ -20,8 +20,11 @@ namespace Microsoft.ML.Runtime.Data
     /// </summary>
     public sealed class NopTransform : IDataTransform, IRowToRowMapper
     {
-        private readonly IDataView _input;
         private readonly IHost _host;
+
+        public IDataView Source { get; }
+
+        ISchema IRowToRowMapper.InputSchema => Source.Schema;
 
         /// <summary>
         /// Creates a NopTransform if the input is not an IDataTransform.
@@ -40,7 +43,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(input, nameof(input));
 
-            _input = input;
+            Source = input;
             _host = env.Register(RegistrationName);
         }
 
@@ -75,7 +78,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.AssertValue(host, "host");
             host.CheckValue(input, nameof(input));
 
-            _input = input;
+            Source = input;
             _host = host;
 
             // *** Binary format ***
@@ -94,32 +97,27 @@ namespace Microsoft.ML.Runtime.Data
 
         public bool CanShuffle
         {
-            get { return _input.CanShuffle; }
+            get { return Source.CanShuffle; }
         }
 
         public ISchema Schema
         {
-            get { return _input.Schema; }
+            get { return Source.Schema; }
         }
 
         public long? GetRowCount(bool lazy = true)
         {
-            return _input.GetRowCount(lazy);
+            return Source.GetRowCount(lazy);
         }
 
         public IRowCursor GetRowCursor(Func<int, bool> predicate, IRandom rand = null)
         {
-            return _input.GetRowCursor(predicate, rand);
+            return Source.GetRowCursor(predicate, rand);
         }
 
         public IRowCursor[] GetRowCursorSet(out IRowCursorConsolidator consolidator, Func<int, bool> predicate, int n, IRandom rand = null)
         {
-            return _input.GetRowCursorSet(out consolidator, predicate, n, rand);
-        }
-
-        public IDataView Source
-        {
-            get { return _input; }
+            return Source.GetRowCursorSet(out consolidator, predicate, n, rand);
         }
 
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
@@ -129,6 +127,10 @@ namespace Microsoft.ML.Runtime.Data
 
         public IRow GetRow(IRow input, Func<int, bool> active, out Action disposer)
         {
+            Contracts.CheckValue(input, nameof(input));
+            Contracts.CheckValue(active, nameof(active));
+            Contracts.CheckParam(input.Schema == Source.Schema, nameof(input), "Schema of input row must be the same as the schema the mapper is bound to");
+
             disposer = null;
             return input;
         }

--- a/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
@@ -88,6 +88,15 @@ namespace Microsoft.ML.Runtime.Data
             // By default, there are no extra checks.
         }
 
+        public bool IsRowToRowMapper => true;
+
+        public IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Host.CheckValue(inputSchema, nameof(inputSchema));
+            var simplerMapper = MakeRowMapper(inputSchema);
+            return new RowToRowMapperTransform(Host, new EmptyDataView(Host, inputSchema), simplerMapper);
+        }
+
         protected abstract IRowMapper MakeRowMapper(ISchema schema);
 
         public ISchema GetOutputSchema(ISchema inputSchema)

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -154,6 +154,8 @@ namespace Microsoft.ML.Runtime.Data
 
         protected abstract Func<int, bool> GetDependenciesCore(Func<int, bool> predicate);
 
+        ISchema IRowToRowMapper.InputSchema => Source.Schema;
+
         public IRow GetRow(IRow input, Func<int, bool> active, out Action disposer)
         {
             Host.CheckValue(input, nameof(input));

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private sealed class BoundMapper : ISchemaBoundRowMapper
         {
-            private sealed class Schema : ISchema
+            private sealed class SchemaImpl : ISchema
             {
                 private readonly IExceptionContext _ectx;
                 private readonly string[] _names;
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 public int ColumnCount { get { return _types.Length; } }
 
-                public Schema(IExceptionContext ectx, TreeEnsembleFeaturizerBindableMapper parent,
+                public SchemaImpl(IExceptionContext ectx, TreeEnsembleFeaturizerBindableMapper parent,
                     ColumnType treeValueColType, ColumnType leafIdColType, ColumnType pathIdColType)
                 {
                     Contracts.CheckValueOrNull(ectx);
@@ -167,13 +167,11 @@ namespace Microsoft.ML.Runtime.Data
             private const int PathIdx = 2;
 
             private readonly TreeEnsembleFeaturizerBindableMapper _owner;
-            private readonly RoleMappedSchema _inputSchema;
-            private readonly ISchema _outputSchema;
             private readonly IExceptionContext _ectx;
 
-            public RoleMappedSchema InputSchema { get { return _inputSchema; } }
+            public RoleMappedSchema InputSchema { get; }
 
-            public ISchema OutputSchema { get { return _outputSchema; } }
+            public ISchema Schema { get; }
 
             public ISchemaBindableMapper Bindable { get { return _owner; } }
 
@@ -188,7 +186,7 @@ namespace Microsoft.ML.Runtime.Data
                 _ectx = ectx;
 
                 _owner = owner;
-                _inputSchema = schema;
+                InputSchema = schema;
 
                 // A vector containing the output of each tree on a given example.
                 var treeValueType = new VectorType(NumberType.Float, _owner._ensemble.NumTrees);
@@ -203,15 +201,15 @@ namespace Microsoft.ML.Runtime.Data
                 // which means that #internal = #leaf - 1.
                 // Therefore, the number of internal nodes in the ensemble is #leaf - #trees.
                 var pathIdType = new VectorType(NumberType.Float, _owner._totalLeafCount - _owner._ensemble.NumTrees);
-                _outputSchema = new Schema(ectx, owner, treeValueType, leafIdType, pathIdType);
+                Schema = new SchemaImpl(ectx, owner, treeValueType, leafIdType, pathIdType);
             }
 
-            public IRow GetOutputRow(IRow input, Func<int, bool> predicate, out Action disposer)
+            public IRow GetRow(IRow input, Func<int, bool> predicate, out Action disposer)
             {
                 _ectx.CheckValue(input, nameof(input));
                 _ectx.CheckValue(predicate, nameof(predicate));
                 disposer = null;
-                return new SimpleRow(_outputSchema, input, CreateGetters(input, predicate));
+                return new SimpleRow(Schema, input, CreateGetters(input, predicate));
             }
 
             private Delegate[] CreateGetters(IRow input, Func<int, bool> predicate)
@@ -228,7 +226,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (!treeValueActive && !leafIdActive && !pathIdActive)
                     return delegates;
 
-                var state = new State(_ectx, input, _owner._ensemble, _owner._totalLeafCount, _inputSchema.Feature.Index);
+                var state = new State(_ectx, input, _owner._ensemble, _owner._totalLeafCount, InputSchema.Feature.Index);
 
                 // Get the tree value getter.
                 if (treeValueActive)
@@ -393,15 +391,15 @@ namespace Microsoft.ML.Runtime.Data
 
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {
-                yield return RoleMappedSchema.ColumnRole.Feature.Bind(_inputSchema.Feature.Name);
+                yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputSchema.Feature.Name);
             }
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < Schema.ColumnCount; i++)
                 {
                     if (predicate(i))
-                        return col => col == _inputSchema.Feature.Index;
+                        return col => col == InputSchema.Feature.Index;
                 }
                 return col => false;
             }

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -169,11 +169,12 @@ namespace Microsoft.ML.Runtime.Data
             private readonly TreeEnsembleFeaturizerBindableMapper _owner;
             private readonly IExceptionContext _ectx;
 
-            public RoleMappedSchema InputSchema { get; }
+            public RoleMappedSchema InputRoleMappedSchema { get; }
 
             public ISchema Schema { get; }
+            public ISchema InputSchema => InputRoleMappedSchema.Schema;
 
-            public ISchemaBindableMapper Bindable { get { return _owner; } }
+            public ISchemaBindableMapper Bindable => _owner;
 
             public BoundMapper(IExceptionContext ectx, TreeEnsembleFeaturizerBindableMapper owner,
                 RoleMappedSchema schema)
@@ -186,7 +187,7 @@ namespace Microsoft.ML.Runtime.Data
                 _ectx = ectx;
 
                 _owner = owner;
-                InputSchema = schema;
+                InputRoleMappedSchema = schema;
 
                 // A vector containing the output of each tree on a given example.
                 var treeValueType = new VectorType(NumberType.Float, _owner._ensemble.NumTrees);
@@ -226,7 +227,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (!treeValueActive && !leafIdActive && !pathIdActive)
                     return delegates;
 
-                var state = new State(_ectx, input, _owner._ensemble, _owner._totalLeafCount, InputSchema.Feature.Index);
+                var state = new State(_ectx, input, _owner._ensemble, _owner._totalLeafCount, InputRoleMappedSchema.Feature.Index);
 
                 // Get the tree value getter.
                 if (treeValueActive)
@@ -391,7 +392,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {
-                yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputSchema.Feature.Name);
+                yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputRoleMappedSchema.Feature.Name);
             }
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
@@ -399,7 +400,7 @@ namespace Microsoft.ML.Runtime.Data
                 for (int i = 0; i < Schema.ColumnCount; i++)
                 {
                     if (predicate(i))
-                        return col => col == InputSchema.Feature.Index;
+                        return col => col == InputRoleMappedSchema.Feature.Index;
                 }
                 return col => false;
             }

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachinePredictor.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachinePredictor.cs
@@ -302,6 +302,14 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             return _scorer.ApplyToData(Host, input);
         }
 
+        public override bool IsRowToRowMapper => true;
+
+        public override IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Host.CheckValue(inputSchema, nameof(inputSchema));
+            return (IRowToRowMapper)_scorer.ApplyToData(Host, new EmptyDataView(Host, inputSchema));
+        }
+
         /// <summary>
         /// Saves the transformer to file.
         /// </summary>

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -57,9 +57,10 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
     {
         private readonly FieldAwareFactorizationMachinePredictor _pred;
 
-        public RoleMappedSchema InputSchema { get; }
+        public RoleMappedSchema InputRoleMappedSchema { get; }
 
         public ISchema Schema { get; }
+        public ISchema InputSchema => InputRoleMappedSchema.Schema;
 
         public ISchemaBindableMapper Bindable => _pred;
 
@@ -82,7 +83,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             _pred = pred;
 
             var inputFeatureColumns = _columns.Select(c => new KeyValuePair<RoleMappedSchema.ColumnRole, string>(RoleMappedSchema.ColumnRole.Feature, c.Name)).ToList();
-            InputSchema = new RoleMappedSchema(schema.Schema, inputFeatureColumns);
+            InputRoleMappedSchema = new RoleMappedSchema(schema.Schema, inputFeatureColumns);
             Schema = outputSchema;
 
             _inputColumnIndexes = new List<int>();
@@ -141,7 +142,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
 
         public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
         {
-            return InputSchema.GetColumnRoles().Select(kvp => new KeyValuePair<RoleMappedSchema.ColumnRole, string>(kvp.Key, kvp.Value.Name));
+            return InputRoleMappedSchema.GetColumnRoles().Select(kvp => new KeyValuePair<RoleMappedSchema.ColumnRole, string>(kvp.Key, kvp.Value.Name));
         }
     }
 }

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
 
         public RoleMappedSchema InputSchema { get; }
 
-        public ISchema OutputSchema { get; }
+        public ISchema Schema { get; }
 
         public ISchemaBindableMapper Bindable => _pred;
 
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
 
             var inputFeatureColumns = _columns.Select(c => new KeyValuePair<RoleMappedSchema.ColumnRole, string>(RoleMappedSchema.ColumnRole.Feature, c.Name)).ToList();
             InputSchema = new RoleMappedSchema(schema.Schema, inputFeatureColumns);
-            OutputSchema = outputSchema;
+            Schema = outputSchema;
 
             _inputColumnIndexes = new List<int>();
             foreach (var kvp in inputFeatureColumns)
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             }
         }
 
-        public IRow GetOutputRow(IRow input, Func<int, bool> predicate, out Action action)
+        public IRow GetRow(IRow input, Func<int, bool> predicate, out Action action)
         {
             var latentSum = new AlignedArray(_pred.FieldCount * _pred.FieldCount * _pred.LatentDimAligned, 16);
             var featureBuffer = new VBuffer<float>();
@@ -128,12 +128,12 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
                 getters[1] = probGetter;
             }
 
-            return new SimpleRow(OutputSchema, input, getters);
+            return new SimpleRow(Schema, input, getters);
         }
 
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
         {
-            if (Enumerable.Range(0, OutputSchema.ColumnCount).Any(predicate))
+            if (Enumerable.Range(0, Schema.ColumnCount).Any(predicate))
                 return index => _inputColumnIndexes.Any(c => c == index);
             else
                 return index => false;

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -288,6 +288,14 @@ namespace Microsoft.ML.Transforms
                 ctx.SaveNonEmptyString(colName);
         }
 
+        public bool IsRowToRowMapper => true;
+
+        public IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            _host.CheckValue(inputSchema, nameof(inputSchema));
+            return MakeDataTransform(new EmptyDataView(_host, inputSchema));
+        }
+
         private sealed class Mapper : IRowMapper
         {
             private readonly IHost _host;

--- a/src/Microsoft.ML.Transforms/CategoricalTransform.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalTransform.cs
@@ -167,6 +167,14 @@ namespace Microsoft.ML.Runtime.Data
         public IDataView Transform(IDataView input) => _transformer.Transform(input);
 
         public void Save(ModelSaveContext ctx) => _transformer.Save(ctx);
+
+        public bool IsRowToRowMapper => _transformer.IsRowToRowMapper;
+
+        public IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+        {
+            Contracts.CheckValue(inputSchema, nameof(inputSchema));
+            return _transformer.GetRowToRowMapper(inputSchema);
+        }
     }
 
     public sealed class CategoricalEstimator : IEstimator<CategoricalTransform>

--- a/src/Microsoft.ML.Transforms/Text/TextTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextTransform.cs
@@ -601,7 +601,7 @@ namespace Microsoft.ML.Runtime.Data
                 // The walkback should have ended at the input.
                 Contracts.Assert(chain == input);
                 revMaps.Reverse();
-                return new ChainedRowToRowMapper(inputSchema, revMaps.ToArray());
+                return new CompositeRowToRowMapper(inputSchema, revMaps.ToArray());
             }
 
             public void Save(ModelSaveContext ctx)

--- a/src/Microsoft.ML.Transforms/Text/TextTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextTransform.cs
@@ -584,6 +584,26 @@ namespace Microsoft.ML.Runtime.Data
                 return ApplyTransformUtils.ApplyAllTransformsToData(_host, _xf, input);
             }
 
+            public bool IsRowToRowMapper => true;
+
+            public IRowToRowMapper GetRowToRowMapper(ISchema inputSchema)
+            {
+                _host.CheckValue(inputSchema, nameof(inputSchema));
+                var input = new EmptyDataView(_host, inputSchema);
+                var revMaps = new List<IRowToRowMapper>();
+                IDataView chain;
+                for (chain = ApplyTransformUtils.ApplyAllTransformsToData(_host, _xf, input); chain is IDataTransform xf; chain = xf.Source)
+                {
+                    // Everything in the chain ought to be a row mapper.
+                    _host.Assert(xf is IRowToRowMapper);
+                    revMaps.Add((IRowToRowMapper)xf);
+                }
+                // The walkback should have ended at the input.
+                Contracts.Assert(chain == input);
+                revMaps.Reverse();
+                return new ChainedRowToRowMapper(inputSchema, revMaps.ToArray());
+            }
+
             public void Save(ModelSaveContext ctx)
             {
                 _host.CheckValue(ctx, nameof(ctx));

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -96,6 +96,7 @@ namespace Microsoft.ML.Runtime.RunTests
             }
 
             var transformer = estimator.Fit(validFitInput);
+            // Check whether it's a mapper.
             // Save and reload.
             string modelPath = GetOutputPath(TestName + "-model.zip");
             using (var fs = File.Create(modelPath))
@@ -110,6 +111,14 @@ namespace Microsoft.ML.Runtime.RunTests
             Action<IDataView> checkOnData = (IDataView data) =>
             {
                 var schema = transformer.GetOutputSchema(data.Schema);
+
+                // If it's a row to row mapper, then the output name.
+                if (transformer.IsRowToRowMapper)
+                {
+                    var mapper = transformer.GetRowToRowMapper(data.Schema);
+                    Check(mapper.InputSchema == data.Schema, "InputSchemas were not identical to actual input schema");
+                    CheckSameSchemas(schema, mapper.Schema);
+                }
 
                 // Loaded transformer needs to have the same schema propagation.
                 CheckSameSchemas(schema, loadedTransformer.GetOutputSchema(data.Schema));

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -96,7 +96,6 @@ namespace Microsoft.ML.Runtime.RunTests
             }
 
             var transformer = estimator.Fit(validFitInput);
-            // Check whether it's a mapper.
             // Save and reload.
             string modelPath = GetOutputPath(TestName + "-model.zip");
             using (var fs = File.Create(modelPath))
@@ -112,12 +111,16 @@ namespace Microsoft.ML.Runtime.RunTests
             {
                 var schema = transformer.GetOutputSchema(data.Schema);
 
-                // If it's a row to row mapper, then the output name.
+                // If it's a row to row mapper, then the output schema should be the same.
                 if (transformer.IsRowToRowMapper)
                 {
                     var mapper = transformer.GetRowToRowMapper(data.Schema);
                     Check(mapper.InputSchema == data.Schema, "InputSchemas were not identical to actual input schema");
                     CheckSameSchemas(schema, mapper.Schema);
+                }
+                else
+                {
+                    mustFail(() => transformer.GetRowToRowMapper(data.Schema));
                 }
 
                 // Loaded transformer needs to have the same schema propagation.


### PR DESCRIPTION
In which we reduce the overhead of calls to `Predict` by avoiding the creation of cursors.

`PredictionEngine` used to create a "fake" data view under the hood, by wrapping a `BatchPredictionEngine`, but only feeding in one item. This was a fairly heavy operation involving spooling up of cursors, including heavy reflection based processing on each row, etc. Now we are able to avoid this by using an existing interface `IRowToRowMapper`.

The other major part of the change is, of course, changing transformers so they *can* produce `IRowToRowMapper`, which they previously did not. In most cases this is relatively straightforward since nearly all transformers of interest are using these `IRowToRowMapper` under the hood to support their computation.

* `IRowToRowMapper` enhancements, unification of some interfaces.
* `ITransformer` has `IRowToRowMapper` accessor.
* `PredictionEngine` now uses `IRowToRowMapper`

The effects of this are most dramatic using prediction engines *outside* of the ML.NET v0.1 pipeline API (e.g., using `IEstimator` based pipelines, pre-ML.NET v0.1 API, and so forth). The effect of this is that when predicting, now actual computation dominates the cost, as opposed to reflection based stuff. 😄 Due to architectural limitations of pipeline API models, these do not see benefit.

Will perhaps update with timings later.

Fix #986.