### PR TITLE
Extended contexts to regression and multiclass, added FFM pigstension

### DIFF
--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorStaticExtensions.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorStaticExtensions.cs
@@ -51,13 +51,13 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Evaluates scored binary classification data.
+        /// Evaluates scored binary classification data, if the predictions are not calibrated.
         /// </summary>
         /// <typeparam name="T">The shape type for the input data.</typeparam>
         /// <param name="ctx">The binary classification context.</param>
         /// <param name="data">The data to evaluate.</param>
         /// <param name="label">The index delegate for the label column.</param>
-        /// <param name="pred">The index delegate for columns from calibrated prediction of a binary classifier.
+        /// <param name="pred">The index delegate for columns from uncalibrated prediction of a binary classifier.
         /// Under typical scenarios, this will just be the same tuple of results returned from the trainer.</param>
         /// <returns>The evaluation results for these uncalibrated outputs.</returns>
         public static BinaryClassifierEvaluator.Result Evaluate<T>(
@@ -82,6 +82,90 @@ namespace Microsoft.ML.Runtime.Data
 
             var eval = new BinaryClassifierEvaluator(env, new BinaryClassifierEvaluator.Arguments() { });
             return eval.Evaluate(data.AsDynamic, labelName, scoreName, predName);
+        }
+
+        /// <summary>
+        /// Evaluates scored multiclass classification data.
+        /// </summary>
+        /// <typeparam name="T">The shape type for the input data.</typeparam>
+        /// <typeparam name="TKey">The value type for the key label.</typeparam>
+        /// <param name="ctx">The multiclass classification context.</param>
+        /// <param name="data">The data to evaluate.</param>
+        /// <param name="label">The index delegate for the label column.</param>
+        /// <param name="pred">The index delegate for columns from the prediction of a multiclass classifier.
+        /// Under typical scenarios, this will just be the same tuple of results returned from the trainer.</param>
+        /// <param name="topK">If given a positive value, the <see cref="MultiClassClassifierEvaluator.Result.TopKAccuracy"/> will be filled with
+        /// the top-K accuracy, that is, the accuracy assuming we consider an example with the correct class within
+        /// the top-K values as being stored "correctly."</param>
+        /// <returns>The evaluation metrics.</returns>
+        public static MultiClassClassifierEvaluator.Result Evaluate<T, TKey>(
+            this MulticlassClassificationContext ctx,
+            DataView<T> data,
+            Func<T, Key<uint, TKey>> label,
+            Func<T, (Vector<float> score, Key<uint, TKey> predictedLabel)> pred,
+            int topK = 0)
+        {
+            Contracts.CheckValue(data, nameof(data));
+            var env = StaticPipeUtils.GetEnvironment(data);
+            Contracts.AssertValue(env);
+            env.CheckValue(label, nameof(label));
+            env.CheckValue(pred, nameof(pred));
+            env.CheckParam(topK >= 0, nameof(topK), "Must not be negative.");
+
+            var indexer = StaticPipeUtils.GetIndexer(data);
+            string labelName = indexer.Get(label(indexer.Indices));
+            (var scoreCol, var predCol) = pred(indexer.Indices);
+            Contracts.CheckParam(scoreCol != null, nameof(pred), "Indexing delegate resulted in null score column.");
+            Contracts.CheckParam(predCol != null, nameof(pred), "Indexing delegate resulted in null predicted label column.");
+            string scoreName = indexer.Get(scoreCol);
+            string predName = indexer.Get(predCol);
+
+            var args = new MultiClassClassifierEvaluator.Arguments() { };
+            if (topK > 0)
+                args.OutputTopKAcc = topK;
+
+            var eval = new MultiClassClassifierEvaluator(env, args);
+            return eval.Evaluate(data.AsDynamic, labelName, scoreName, predName);
+        }
+
+        private sealed class TrivialRegressionLossFactory : ISupportRegressionLossFactory
+        {
+            private readonly IRegressionLoss _loss;
+            public TrivialRegressionLossFactory(IRegressionLoss loss) => _loss = loss;
+            public IRegressionLoss CreateComponent(IHostEnvironment env) => _loss;
+        }
+
+        /// <summary>
+        /// Evaluates scored multiclass classification data.
+        /// </summary>
+        /// <typeparam name="T">The shape type for the input data.</typeparam>
+        /// <param name="ctx">The regression context.</param>
+        /// <param name="data">The data to evaluate.</param>
+        /// <param name="label">The index delegate for the label column.</param>
+        /// <param name="score">The index delegate for predicted score column.</param>
+        /// <param name="loss">Potentially custom loss function. If left unspecified defaults to <see cref="SquaredLoss"/>.</param>
+        /// <returns>The evaluation metrics.</returns>
+        public static RegressionEvaluator.Result Evaluate<T>(
+            this RegressionContext ctx,
+            DataView<T> data,
+            Func<T, Scalar<float>> label,
+            Func<T, Scalar<float>> score,
+            IRegressionLoss loss = null)
+        {
+            Contracts.CheckValue(data, nameof(data));
+            var env = StaticPipeUtils.GetEnvironment(data);
+            Contracts.AssertValue(env);
+            env.CheckValue(label, nameof(label));
+            env.CheckValue(score, nameof(score));
+
+            var indexer = StaticPipeUtils.GetIndexer(data);
+            string labelName = indexer.Get(label(indexer.Indices));
+            string scoreName = indexer.Get(score(indexer.Indices));
+
+            var args = new RegressionEvaluator.Arguments() { };
+            if (loss != null)
+                args.LossFunction = new TrivialRegressionLossFactory(loss);
+            return new RegressionEvaluator(env, args).Evaluate(data.AsDynamic, labelName, scoreName);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
@@ -604,7 +604,6 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
         /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
         /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
-        /// <returns>The evaluation results for these uncalibrated outputs.</returns>
         /// <returns>The evaluation results for these outputs.</returns>
         public Result Evaluate(IDataView data, string label, string score, string predictedLabel)
         {

--- a/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
@@ -598,62 +598,38 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Evaluates scored regression data.
+        /// Evaluates scored multiclass classification data.
         /// </summary>
-        /// <typeparam name="T">The shape type for the input data.</typeparam>
-        /// <typeparam name="TKey">The value type for the key label.</typeparam>
-        /// <param name="data">The data to evaluate.</param>
-        /// <param name="label">The index delegate for the label column.</param>
-        /// <param name="pred">The index delegate for columns from prediction of a multi-class classifier.
-        /// Under typical scenarios, this will just be the same tuple of results returned from the trainer.</param>
-        /// <param name="topK">If given a positive value, the <see cref="Result.TopKAccuracy"/> will be filled with
-        /// the top-K accuracy, that is, the accuracy assuming we consider an example with the correct class within
-        /// the top-K values as being stored "correctly."</param>
+        /// <param name="data">The scored data.</param>
+        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <returns>The evaluation results for these uncalibrated outputs.</returns>
         /// <returns>The evaluation results for these outputs.</returns>
-        public static Result Evaluate<T, TKey>(
-            DataView<T> data,
-            Func<T, Key<uint, TKey>> label,
-            Func<T, (Vector<float> score, Key<uint, TKey> predictedLabel)> pred,
-            int topK = 0)
+        public Result Evaluate(IDataView data, string label, string score, string predictedLabel)
         {
-            Contracts.CheckValue(data, nameof(data));
-            var env = StaticPipeUtils.GetEnvironment(data);
-            Contracts.AssertValue(env);
-            env.CheckValue(label, nameof(label));
-            env.CheckValue(pred, nameof(pred));
-            env.CheckParam(topK >= 0, nameof(topK), "Must not be negative.");
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+            Host.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
 
-            var indexer = StaticPipeUtils.GetIndexer(data);
-            string labelName = indexer.Get(label(indexer.Indices));
-            (var scoreCol, var predCol) = pred(indexer.Indices);
-            Contracts.CheckParam(scoreCol != null, nameof(pred), "Indexing delegate resulted in null score column.");
-            Contracts.CheckParam(predCol != null, nameof(pred), "Indexing delegate resulted in null predicted label column.");
-            string scoreName = indexer.Get(scoreCol);
-            string predName = indexer.Get(predCol);
+            var roles = new RoleMappedData(data, opt: false,
+                RoleMappedSchema.ColumnRole.Label.Bind(label),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, score),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.PredictedLabel, predictedLabel));
 
-            var args = new Arguments() { };
-            if (topK > 0)
-                args.OutputTopKAcc = topK;
-
-            var eval = new MultiClassClassifierEvaluator(env, args);
-
-            var roles = new RoleMappedData(data.AsDynamic, opt: false,
-                RoleMappedSchema.ColumnRole.Label.Bind(labelName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.PredictedLabel, predName));
-
-            var resultDict = eval.Evaluate(roles);
-            env.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
+            var resultDict = Evaluate(roles);
+            Host.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             Result result;
             using (var cursor = overall.GetRowCursor(i => true))
             {
                 var moved = cursor.MoveNext();
-                env.Assert(moved);
-                result = new Result(env, cursor, topK);
+                Host.Assert(moved);
+                result = new Result(Host, cursor, _outputTopKAcc ?? 0);
                 moved = cursor.MoveNext();
-                env.Assert(!moved);
+                Host.Assert(!moved);
             }
             return result;
         }

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -219,65 +219,42 @@ namespace Microsoft.ML.Runtime.Data
                 double Fetch(string name) => Fetch<double>(ectx, overallResult, name);
                 L1 = Fetch(RegressionEvaluator.L1);
                 L2 = Fetch(RegressionEvaluator.L2);
-                Rms= Fetch(RegressionEvaluator.Rms);
+                Rms = Fetch(RegressionEvaluator.Rms);
                 LossFn = Fetch(RegressionEvaluator.Loss);
                 RSquared = Fetch(RegressionEvaluator.RSquared);
             }
         }
 
-        private sealed class TrivialLossFactory : ISupportRegressionLossFactory
-        {
-            private readonly IRegressionLoss _loss;
-            public TrivialLossFactory(IRegressionLoss loss) => _loss = loss;
-            public IRegressionLoss CreateComponent(IHostEnvironment env) => _loss;
-        }
-
         /// <summary>
         /// Evaluates scored regression data.
         /// </summary>
-        /// <typeparam name="T">The shape type for the input data.</typeparam>
         /// <param name="data">The data to evaluate.</param>
-        /// <param name="label">The index delegate for the label column.</param>
-        /// <param name="score">The index delegate for the predicted score column.</param>
-        /// <param name="loss">Potentially custom loss function. If left unspecified defaults to <see cref="SquaredLoss"/>.</param>
-        /// <returns>The evaluation results for these outputs.</returns>
-        public static Result Evaluate<T>(
-            DataView<T> data,
-            Func<T, Scalar<float>> label,
-            Func<T, Scalar<float>> score,
-            IRegressionLoss loss = null)
+        /// <param name="label">The name of the label column.</param>
+        /// <param name="score">The name of the predicted score column.</param>
+        public Result Evaluate(
+            IDataView data,
+            string label,
+            string score)
         {
-            Contracts.CheckValue(data, nameof(data));
-            var env = StaticPipeUtils.GetEnvironment(data);
-            Contracts.AssertValue(env);
-            env.CheckValue(label, nameof(label));
-            env.CheckValue(score, nameof(score));
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+            var roles = new RoleMappedData(data, opt: false,
+                RoleMappedSchema.ColumnRole.Label.Bind(label),
+                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, score));
 
-            var indexer = StaticPipeUtils.GetIndexer(data);
-            string labelName = indexer.Get(label(indexer.Indices));
-            string scoreName = indexer.Get(score(indexer.Indices));
-
-            var args = new Arguments() { };
-            if (loss != null)
-                args.LossFunction = new TrivialLossFactory(loss);
-            var eval = new RegressionEvaluator(env, args);
-
-            var roles = new RoleMappedData(data.AsDynamic, opt: false,
-                RoleMappedSchema.ColumnRole.Label.Bind(labelName),
-                RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreName));
-
-            var resultDict = eval.Evaluate(roles);
-            env.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
+            var resultDict = Evaluate(roles);
+            Host.Assert(resultDict.ContainsKey(MetricKinds.OverallMetrics));
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             Result result;
             using (var cursor = overall.GetRowCursor(i => true))
             {
                 var moved = cursor.MoveNext();
-                env.Assert(moved);
-                result = new Result(env, cursor);
+                Host.Assert(moved);
+                result = new Result(Host, cursor);
                 moved = cursor.MoveNext();
-                env.Assert(!moved);
+                Host.Assert(!moved);
             }
             return result;
         }

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -231,6 +231,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="data">The data to evaluate.</param>
         /// <param name="label">The name of the label column.</param>
         /// <param name="score">The name of the predicted score column.</param>
+        /// <returns>The evaluation metrics for these outputs.</returns>
         public Result Evaluate(
             IDataView data,
             string label,

--- a/src/Microsoft.ML.Data/StaticPipe/TrainerEstimatorReconciler.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/TrainerEstimatorReconciler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
     /// </summary>
     public abstract class TrainerEstimatorReconciler : EstimatorReconciler
     {
-        private readonly PipelineColumn[] _inputs;
+        protected readonly PipelineColumn[] Inputs;
         private readonly string[] _outputNames;
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             Contracts.CheckValue(inputs, nameof(inputs));
             Contracts.CheckValue(outputNames, nameof(outputNames));
 
-            _inputs = inputs;
+            Inputs = inputs;
             _outputNames = outputNames;
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             env.AssertValue(usedNames);
 
             // The reconciler should have been called with all the input columns having names.
-            env.Assert(inputNames.Keys.All(_inputs.Contains) && _inputs.All(inputNames.Keys.Contains));
+            env.Assert(inputNames.Keys.All(Inputs.Contains) && Inputs.All(inputNames.Keys.Contains));
             // The output name map should contain only outputs as their keys. Yet, it is possible not all
             // outputs will be required in which case these will both be subsets of those outputs indicated
             // at construction.
@@ -105,7 +105,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             }
 
             // Map the inputs to the names.
-            string[] mappedInputNames = _inputs.Select(c => inputNames[c]).ToArray();
+            string[] mappedInputNames = Inputs.Select(c => inputNames[c]).ToArray();
             // Finally produce the trainer.
             var trainerEst = ReconcileCore(env, mappedInputNames);
             if (result == null)
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             {
                 Contracts.CheckValue(estimatorFactory, nameof(estimatorFactory));
                 _estFact = estimatorFactory;
-                Contracts.Assert(_inputs.Length == 2 || _inputs.Length == 3);
+                Contracts.Assert(Inputs.Length == 2 || Inputs.Length == 3);
                 Score = new Impl(this);
             }
 
@@ -182,13 +182,13 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
             {
                 Contracts.AssertValue(env);
-                env.Assert(Utils.Size(inputNames) == _inputs.Length);
+                env.Assert(Utils.Size(inputNames) == Inputs.Length);
                 return _estFact(env, inputNames[0], inputNames[1], inputNames.Length > 2 ? inputNames[2] : null);
             }
 
             private sealed class Impl : Scalar<float>
             {
-                public Impl(Regression rec) : base(rec, rec._inputs) { }
+                public Impl(Regression rec) : base(rec, rec.Inputs) { }
             }
         }
 
@@ -231,7 +231,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             {
                 Contracts.CheckValue(estimatorFactory, nameof(estimatorFactory));
                 _estFact = estimatorFactory;
-                Contracts.Assert(_inputs.Length == 2 || _inputs.Length == 3);
+                Contracts.Assert(Inputs.Length == 2 || Inputs.Length == 3);
 
                 Output = (new Impl(this), new Impl(this), new ImplBool(this));
             }
@@ -242,18 +242,18 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
             {
                 Contracts.AssertValue(env);
-                env.Assert(Utils.Size(inputNames) == _inputs.Length);
+                env.Assert(Utils.Size(inputNames) == Inputs.Length);
                 return _estFact(env, inputNames[0], inputNames[1], inputNames.Length > 2 ? inputNames[2] : null);
             }
 
             private sealed class Impl : Scalar<float>
             {
-                public Impl(BinaryClassifier rec) : base(rec, rec._inputs) { }
+                public Impl(BinaryClassifier rec) : base(rec, rec.Inputs) { }
             }
 
             private sealed class ImplBool : Scalar<bool>
             {
-                public ImplBool(BinaryClassifier rec) : base(rec, rec._inputs) { }
+                public ImplBool(BinaryClassifier rec) : base(rec, rec.Inputs) { }
             }
         }
 
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             {
                 Contracts.CheckValue(estimatorFactory, nameof(estimatorFactory));
                 _estFact = estimatorFactory;
-                Contracts.Assert(_inputs.Length == 2 || _inputs.Length == 3);
+                Contracts.Assert(Inputs.Length == 2 || Inputs.Length == 3);
 
                 Output = (new Impl(this), new ImplBool(this));
 
@@ -322,18 +322,18 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
             {
                 Contracts.AssertValue(env);
-                env.Assert(Utils.Size(inputNames) == _inputs.Length);
+                env.Assert(Utils.Size(inputNames) == Inputs.Length);
                 return _estFact(env, inputNames[0], inputNames[1], inputNames.Length > 2 ? inputNames[2] : null);
             }
 
             private sealed class Impl : Scalar<float>
             {
-                public Impl(BinaryClassifierNoCalibration rec) : base(rec, rec._inputs) { }
+                public Impl(BinaryClassifierNoCalibration rec) : base(rec, rec.Inputs) { }
             }
 
             private sealed class ImplBool : Scalar<bool>
             {
-                public ImplBool(BinaryClassifierNoCalibration rec) : base(rec, rec._inputs) { }
+                public ImplBool(BinaryClassifierNoCalibration rec) : base(rec, rec.Inputs) { }
             }
         }
 
@@ -378,7 +378,7 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             {
                 Contracts.CheckValue(estimatorFactory, nameof(estimatorFactory));
                 _estFact = estimatorFactory;
-                Contracts.Assert(_inputs.Length == 2 || _inputs.Length == 3);
+                Contracts.Assert(Inputs.Length == 2 || Inputs.Length == 3);
                 Output = (new ImplScore(this), new ImplLabel(this));
             }
 
@@ -388,18 +388,18 @@ namespace Microsoft.ML.Data.StaticPipe.Runtime
             protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
             {
                 Contracts.AssertValue(env);
-                env.Assert(Utils.Size(inputNames) == _inputs.Length);
+                env.Assert(Utils.Size(inputNames) == Inputs.Length);
                 return _estFact(env, inputNames[0], inputNames[1], inputNames.Length > 2 ? inputNames[2] : null);
             }
 
             private sealed class ImplLabel : Key<uint, TVal>
             {
-                public ImplLabel(MulticlassClassifier<TVal> rec) : base(rec, rec._inputs) { }
+                public ImplLabel(MulticlassClassifier<TVal> rec) : base(rec, rec.Inputs) { }
             }
 
             private sealed class ImplScore : Vector<float>
             {
-                public ImplScore(MulticlassClassifier<TVal> rec) : base(rec, rec._inputs) { }
+                public ImplScore(MulticlassClassifier<TVal> rec) : base(rec, rec.Inputs) { }
             }
         }
 

--- a/src/Microsoft.ML.Data/Training/TrainContext.cs
+++ b/src/Microsoft.ML.Data/Training/TrainContext.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Runtime.Training
         /// For trainers for performing binary classification.
         /// </summary>
         /// <remarks>
-        /// Component authors that have written binary classification.
+        /// Component authors that have written binary classification. They are great people.
         /// </remarks>
         public BinaryClassificationTrainers Trainers { get; }
 
@@ -139,6 +139,99 @@ namespace Microsoft.ML.Runtime.Training
 
             var eval = new BinaryClassifierEvaluator(Host, new BinaryClassifierEvaluator.Arguments() { });
             return eval.Evaluate(data, label, score, predictedLabel);
+        }
+    }
+
+    /// <summary>
+    /// The central context for multiclass classification trainers.
+    /// </summary>
+    public sealed class MulticlassClassificationContext : TrainContextBase
+    {
+        /// <summary>
+        /// For trainers for performing multiclass classification.
+        /// </summary>
+        public MulticlassClassificationTrainers Trainers { get; }
+
+        public MulticlassClassificationContext(IHostEnvironment env)
+            : base(env, nameof(MulticlassClassificationContext))
+        {
+            Trainers = new MulticlassClassificationTrainers(this);
+        }
+
+        public sealed class MulticlassClassificationTrainers : ContextInstantiatorBase
+        {
+            internal MulticlassClassificationTrainers(MulticlassClassificationContext ctx)
+                : base(ctx)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Evaluates scored multiclass classification data.
+        /// </summary>
+        /// <param name="data">The scored data.</param>
+        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <param name="topK">If given a positive value, the <see cref="MultiClassClassifierEvaluator.Result.TopKAccuracy"/> will be filled with
+        /// the top-K accuracy, that is, the accuracy assuming we consider an example with the correct class within
+        /// the top-K values as being stored "correctly."</param>
+        /// <returns>The evaluation results for these calibrated outputs.</returns>
+        public MultiClassClassifierEvaluator.Result Evaluate(IDataView data, string label, string score = DefaultColumnNames.Score,
+            string predictedLabel = DefaultColumnNames.PredictedLabel, int topK = 0)
+        {
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+            Host.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
+
+            var args = new MultiClassClassifierEvaluator.Arguments() { };
+            if (topK > 0)
+                args.OutputTopKAcc = topK;
+            var eval = new MultiClassClassifierEvaluator(Host, args);
+            return eval.Evaluate(data, label, score, predictedLabel);
+        }
+    }
+
+    /// <summary>
+    /// The central context for regression trainers.
+    /// </summary>
+    public sealed class RegressionContext : TrainContextBase
+    {
+        /// <summary>
+        /// For trainers for performing regression.
+        /// </summary>
+        public RegressionTrainers Trainers { get; }
+
+        public RegressionContext(IHostEnvironment env)
+            : base(env, nameof(RegressionContext))
+        {
+            Trainers = new RegressionTrainers(this);
+        }
+
+        public sealed class RegressionTrainers : ContextInstantiatorBase
+        {
+            internal RegressionTrainers(RegressionContext ctx)
+                : base(ctx)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Evaluates scored regression data.
+        /// </summary>
+        /// <param name="data">The scored data.</param>
+        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <returns>The evaluation results for these calibrated outputs.</returns>
+        public RegressionEvaluator.Result Evaluate(IDataView data, string label, string score = DefaultColumnNames.Score)
+        {
+            Host.CheckValue(data, nameof(data));
+            Host.CheckNonEmpty(label, nameof(label));
+            Host.CheckNonEmpty(score, nameof(score));
+
+            var eval = new RegressionEvaluator(Host, new RegressionEvaluator.Arguments() { });
+            return eval.Evaluate(data, label, score);
         }
     }
 }

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineStatic.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data.StaticPipe;
+using Microsoft.ML.Data.StaticPipe.Runtime;
+using Microsoft.ML.Runtime;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.FactorizationMachine;
+using Microsoft.ML.Runtime.Internal.Utilities;
+using Microsoft.ML.Runtime.Training;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.ML.Trainers
+{
+    /// <summary>
+    /// Extension methods and utilities for instantiating FFM trainer estimators inside statically typed pipelines.
+    /// </summary>
+    public static class FactorizationMachineStatic
+    {
+        /// <summary>
+        /// Predict a target using a field-aware factorization machine.
+        /// </summary>
+        /// <param name="ctx">The binary classifier context trainer object.</param>
+        /// <param name="label">The label, or dependent variable.</param>
+        /// <param name="features">The features, or independent variables.</param>
+        /// <param name="learningRate">Initial learning rate.</param>
+        /// <param name="numIterations">Number of training iterations.</param>
+        /// <param name="numLatentDimensions">Latent space dimensions.</param>
+        /// <param name="advancedSettings">A delegate to set more settings.</param>
+        /// <param name="onFit">A delegate that is called every time the
+        /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}.Fit(DataView{TTupleInShape})"/> method is called on the
+        /// <see cref="Estimator{TTupleInShape, TTupleOutShape, TTransformer}"/> instance created out of this. This delegate will receive
+        /// the model that was trained.  Note that this action cannot change the result in any way; it is only a way for the caller to
+        /// be informed about what was learnt.</param>
+        /// <returns>The predicted output.</returns>
+        public static (Scalar<float> score, Scalar<bool> predictedLabel) FieldAwareFactorizationMachine(this BinaryClassificationContext.BinaryClassificationTrainers ctx,
+            Scalar<bool> label, Vector<float>[] features,
+            float learningRate = 0.1f,
+            int numIterations = 5,
+            int numLatentDimensions = 20,
+            Action<FieldAwareFactorizationMachineTrainer.Arguments> advancedSettings = null,
+            Action<FieldAwareFactorizationMachinePredictor> onFit = null)
+        {
+            Contracts.CheckValue(label, nameof(label));
+            Contracts.CheckNonEmpty(features, nameof(features));
+
+            Contracts.CheckParam(learningRate > 0, nameof(learningRate), "Must be positive");
+            Contracts.CheckParam(numIterations > 0, nameof(numIterations), "Must be positive");
+            Contracts.CheckParam(numLatentDimensions > 0, nameof(numLatentDimensions), "Must be positive");
+            Contracts.CheckValueOrNull(advancedSettings);
+            Contracts.CheckValueOrNull(onFit);
+
+            var rec = new CustomReconciler((env, labelCol, featureCols) =>
+            {
+                var trainer = new FieldAwareFactorizationMachineTrainer(env, labelCol, featureCols, advancedSettings:
+                    args =>
+                    {
+                        args.LearningRate = learningRate;
+                        args.Iters = numIterations;
+                        args.LatentDim = numLatentDimensions;
+                        advancedSettings?.Invoke(args);
+                    });
+                if (onFit != null)
+                    return trainer.WithOnFitDelegate(trans => onFit(trans.Model));
+                else
+                    return trainer;
+            }, label, features);
+            return rec.Output;
+        }
+
+        private sealed class CustomReconciler : TrainerEstimatorReconciler
+        {
+            private static readonly string[] _fixedOutputNames = new[] { DefaultColumnNames.Score, DefaultColumnNames.PredictedLabel };
+            private readonly Func<IHostEnvironment, string, string[], IEstimator<ITransformer>> _factory;
+
+            /// <summary>
+            /// The general output for binary classifiers.
+            /// </summary>
+            public (Scalar<float> score, Scalar<bool> predictedLabel) Output { get; }
+
+            /// <summary>
+            /// The output columns.
+            /// </summary>
+            protected override IEnumerable<PipelineColumn> Outputs { get; }
+
+            public CustomReconciler(Func<IHostEnvironment, string, string[], IEstimator<ITransformer>> factory, Scalar<bool> label, Vector<float>[] features)
+                : base(MakeInputs(Contracts.CheckRef(label, nameof(label)), Contracts.CheckRef(features, nameof(features))), _fixedOutputNames)
+            {
+                Contracts.AssertValue(factory);
+                _factory = factory;
+
+                Output = (new Impl(this), new ImplBool(this));
+                Outputs = new PipelineColumn[] { Output.score, Output.predictedLabel };
+            }
+
+            private static PipelineColumn[] MakeInputs(Scalar<bool> label, Vector<float>[] features)
+                => new PipelineColumn[] { label }.Concat(features).ToArray();
+
+            protected override IEstimator<ITransformer> ReconcileCore(IHostEnvironment env, string[] inputNames)
+            {
+                Contracts.AssertValue(env);
+                env.Assert(Utils.Size(inputNames) == Inputs.Length);
+
+                // First input is label, rest are features.
+                return _factory(env, inputNames[0], inputNames.Skip(1).ToArray());
+            }
+
+            private sealed class Impl : Scalar<float>
+            {
+                public Impl(CustomReconciler rec) : base(rec, rec.Inputs) { }
+            }
+
+            private sealed class ImplBool : Scalar<bool>
+            {
+                public ImplBool(CustomReconciler rec) : base(rec, rec.Inputs) { }
+            }
+        }
+    }
+}

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
@@ -5,11 +5,13 @@
 using System;
 using Microsoft.ML.Data.StaticPipe;
 using Microsoft.ML.Data.StaticPipe.Runtime;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Calibration;
+using Microsoft.ML.Runtime.Learners;
 using Microsoft.ML.Runtime.Training;
 
-namespace Microsoft.ML.Runtime.Learners
+namespace Microsoft.ML.Trainers
 {
     /// <summary>
     /// Extension methods and utilities for instantiating SDCA trainer estimators inside statically typed pipelines.
@@ -19,6 +21,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Predict a target using a linear regression model trained with the SDCA trainer.
         /// </summary>
+        /// <param name="ctx">The regression context trainer object.</param>
         /// <param name="label">The label, or dependent variable.</param>
         /// <param name="features">The features, or independent variables.</param>
         /// <param name="weights">The optional example weights.</param>
@@ -32,7 +35,8 @@ namespace Microsoft.ML.Runtime.Learners
         /// the linear model that was trained.  Note that this action cannot change the result in any way; it is only a way for the caller to
         /// be informed about what was learnt.</param>
         /// <returns>The predicted output.</returns>
-        public static Scalar<float> PredictSdcaRegression(this Scalar<float> label, Vector<float> features, Scalar<float> weights = null,
+        public static Scalar<float> Sdca(this RegressionContext.RegressionTrainers ctx,
+            Scalar<float> label, Vector<float> features, Scalar<float> weights = null,
             float? l2Const = null,
             float? l1Threshold = null,
             int? maxIterations = null,
@@ -205,6 +209,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Predict a target using a linear multiclass classification model trained with the SDCA trainer.
         /// </summary>
+        /// <param name="ctx">The multiclass classification context trainer object.</param>
         /// <param name="label">The label, or dependent variable.</param>
         /// <param name="features">The features, or independent variables.</param>
         /// /// <param name="loss">The custom loss.</param>
@@ -219,7 +224,9 @@ namespace Microsoft.ML.Runtime.Learners
         /// result in any way; it is only a way for the caller to be informed about what was learnt.</param>
         /// <returns>The set of output columns including in order the predicted per-class likelihoods (between 0 and 1, and summing up to 1), and the predicted label.</returns>
         public static (Vector<float> score, Key<uint, TVal> predictedLabel)
-            PredictSdcaClassification<TVal>(this Key<uint, TVal> label, Vector<float> features,
+            Sdca<TVal>(this MulticlassClassificationContext.MulticlassClassificationTrainers ctx,
+                Key<uint, TVal> label,
+                Vector<float> features,
                 ISupportSdcaClassificationLoss loss = null,
                 Scalar<float> weights = null,
                 float? l2Const = null,

--- a/test/Microsoft.ML.StaticPipelineTesting/Microsoft.ML.StaticPipelineTesting.csproj
+++ b/test/Microsoft.ML.StaticPipelineTesting/Microsoft.ML.StaticPipelineTesting.csproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="..\..\src\Microsoft.ML.ImageAnalytics\Microsoft.ML.ImageAnalytics.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.StandardLearners\Microsoft.ML.StandardLearners.csproj" />
     <ProjectReference Include="..\Microsoft.ML.TestFramework\Microsoft.ML.TestFramework.csproj" />
+    <NativeAssemblyReference Include="FactorizationMachineNative" />
 
     <ProjectReference Include="..\..\src\Microsoft.ML.Analyzer\Microsoft.ML.Analyzer.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.ML.Trainers;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.FactorizationMachine;
 using Microsoft.ML.Runtime.Internal.Calibration;
 using Microsoft.ML.Runtime.Learners;
 using Microsoft.ML.Runtime.RunTests;
 using Microsoft.ML.Runtime.Training;
+using Microsoft.ML.Trainers;
 using System;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.ML.Runtime.FactorizationMachine;
 
 namespace Microsoft.ML.StaticPipelineTesting
 {

--- a/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
+++ b/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <Compile Remove="Scenarios\Api\AspirationalExamples.cs" />
@@ -21,18 +21,18 @@
     <ProjectReference Include="..\Microsoft.ML.Predictor.Tests\Microsoft.ML.Predictor.Tests.csproj" />
     <ProjectReference Include="..\Microsoft.ML.TestFramework\Microsoft.ML.TestFramework.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <NativeAssemblyReference Include="CpuMathNative" />
     <NativeAssemblyReference Include="FastTreeNative" />
-     <NativeAssemblyReference Include="FactorizationMachineNative" />
+    <NativeAssemblyReference Include="FactorizationMachineNative" />
     <NativeAssemblyReference Include="LdaNative" />
     <NativeAssemblyReference Include="SymSgdNative" />
     <NativeAssemblyReference Include="MklImports" />
     <NativeAssemblyReference Include="tensorflow" />
     <NativeAssemblyReference Condition="'$(OS)' != 'Windows_NT'" Include="tensorflow_framework" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="Scenarios\Api\AspirationalExamples.cs" />
   </ItemGroup>


### PR DESCRIPTION
Part of #754, extends #949.
Added MulticlassClassification context and RegressionContext, with corresponding Evaluate methods. Also added FFM binary trainer to the context extensions.
