### PR TITLE
Use  TextLoader.Create in unit test TensorFlowTransformCifarSavedModel

### DIFF
--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -563,7 +563,14 @@ namespace Microsoft.ML.Scenarios
                 var imageWidth = 32;
                 var dataFile = GetDataPath("images/images.tsv");
                 var imageFolder = Path.GetDirectoryName(dataFile);
-                var data = env.CreateLoader("Text{col=ImagePath:TX:0 col=Name:TX:1}", new MultiFileSource(dataFile));
+                var data = TextLoader.Create(env, new TextLoader.Arguments()
+                {
+                    Column = new[]
+                    {
+                        new TextLoader.Column("ImagePath", DataKind.TX, 0),
+                        new TextLoader.Column("Name", DataKind.TX, 1),
+                    }
+                }, new MultiFileSource(dataFile));
                 var images = ImageLoaderTransform.Create(env, new ImageLoaderTransform.Arguments()
                 {
                     Column = new ImageLoaderTransform.Column[1]


### PR DESCRIPTION
Fixes a build break in master cause by  two commits #853 and #970  that went in almost at the same time 

(the two commits work fine by themselves, but there is a dependency between them which caused master to fail)

The fix is to use TextLoader.Create instead of env.CreateLoader("Text...")

