### PR TITLE
Update our Windows CI leg to use the non-Hosted Windows queue

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -10,7 +10,7 @@ phases:
     name: Windows_NT
     buildScript: build.cmd
     queue:
-      name: Hosted VS2017
+      name: DotNetCore-Windows 
 
 - template: /build/ci/phase-template.yml
   parameters:

--- a/test/Microsoft.ML.Predictor.Tests/TestAutoInference.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestAutoInference.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [TestCategory("EntryPoints")]
         public void TestLearn()
         {
-            using (var env = new LocalEnvironment()
+            using (var env = new ConsoleEnvironment()
                 .AddStandardComponents()) // AutoInference.InferPipelines uses ComponentCatalog to read text data
             {
                 string pathData = GetDataPath("adult.train");
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [Fact(Skip = "Need CoreTLC specific baseline update")]
         public void TestTextDatasetLearn()
         {
-            using (var env = new LocalEnvironment()
+            using (var env = new ConsoleEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 string pathData = GetDataPath(@"../UnitTest/tweets_labeled_10k_test_validation.tsv");
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [Fact]
         public void TestPipelineNodeCloning()
         {
-            using (var env = new LocalEnvironment()
+            using (var env = new ConsoleEnvironment()
                 .AddStandardComponents()) // RecipeInference.AllowedLearners uses ComponentCatalog to find all learners
             {
                 var lr1 = RecipeInference
@@ -142,7 +142,7 @@ namespace Microsoft.ML.Runtime.RunTests
             int batchSize = 1;
             int numIterations = 10;
             int numTransformLevels = 3;
-            using (var env = new LocalEnvironment()
+            using (var env = new ConsoleEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 SupportedMetric metric = PipelineSweeperSupportedMetrics.GetSupportedMetric(PipelineSweeperSupportedMetrics.Metrics.Auc);
@@ -191,7 +191,7 @@ namespace Microsoft.ML.Runtime.RunTests
             int batchSize = 5;
             int numIterations = 10;
             int numTransformLevels = 1;
-            using (var env = new LocalEnvironment()
+            using (var env = new ConsoleEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 SupportedMetric metric = PipelineSweeperSupportedMetrics.GetSupportedMetric(PipelineSweeperSupportedMetrics.Metrics.AccuracyMicro);
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Runtime.RunTests
             int numIterations = 1;
             int numTransformLevels = 2;
             var retainedLearnerNames = new[] { $"LogisticRegressionBinaryClassifier", $"FastTreeBinaryClassifier" };
-            using (var env = new LocalEnvironment()
+            using (var env = new ConsoleEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 SupportedMetric metric = PipelineSweeperSupportedMetrics.GetSupportedMetric(PipelineSweeperSupportedMetrics.Metrics.Auc);

--- a/test/Microsoft.ML.Predictor.Tests/TestAutoInference.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestAutoInference.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [TestCategory("EntryPoints")]
         public void TestLearn()
         {
-            using (var env = new ConsoleEnvironment()
+            using (var env = new LocalEnvironment()
                 .AddStandardComponents()) // AutoInference.InferPipelines uses ComponentCatalog to read text data
             {
                 string pathData = GetDataPath("adult.train");
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [Fact(Skip = "Need CoreTLC specific baseline update")]
         public void TestTextDatasetLearn()
         {
-            using (var env = new ConsoleEnvironment()
+            using (var env = new LocalEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 string pathData = GetDataPath(@"../UnitTest/tweets_labeled_10k_test_validation.tsv");
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [Fact]
         public void TestPipelineNodeCloning()
         {
-            using (var env = new ConsoleEnvironment()
+            using (var env = new LocalEnvironment()
                 .AddStandardComponents()) // RecipeInference.AllowedLearners uses ComponentCatalog to find all learners
             {
                 var lr1 = RecipeInference
@@ -142,7 +142,7 @@ namespace Microsoft.ML.Runtime.RunTests
             int batchSize = 1;
             int numIterations = 10;
             int numTransformLevels = 3;
-            using (var env = new ConsoleEnvironment()
+            using (var env = new LocalEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 SupportedMetric metric = PipelineSweeperSupportedMetrics.GetSupportedMetric(PipelineSweeperSupportedMetrics.Metrics.Auc);
@@ -191,7 +191,7 @@ namespace Microsoft.ML.Runtime.RunTests
             int batchSize = 5;
             int numIterations = 10;
             int numTransformLevels = 1;
-            using (var env = new ConsoleEnvironment()
+            using (var env = new LocalEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 SupportedMetric metric = PipelineSweeperSupportedMetrics.GetSupportedMetric(PipelineSweeperSupportedMetrics.Metrics.AccuracyMicro);
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Runtime.RunTests
             int numIterations = 1;
             int numTransformLevels = 2;
             var retainedLearnerNames = new[] { $"LogisticRegressionBinaryClassifier", $"FastTreeBinaryClassifier" };
-            using (var env = new ConsoleEnvironment()
+            using (var env = new LocalEnvironment()
                 .AddStandardComponents()) // AutoInference uses ComponentCatalog to find all learners
             {
                 SupportedMetric metric = PipelineSweeperSupportedMetrics.GetSupportedMetric(PipelineSweeperSupportedMetrics.Metrics.Auc);


### PR DESCRIPTION
We are getting a random test hang using the hosted Windows queue. Changing to a non-hosted queue so we will be able to debug it if it happens again.

/cc @shauheen 