### PR TITLE
Use full test name in estimator routine.

### DIFF
--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             var transformer = estimator.Fit(validFitInput);
             // Save and reload.
-            string modelPath = GetOutputPath(TestName + "-model.zip");
+            string modelPath = GetOutputPath(FullTestName + "-model.zip");
             using (var fs = File.Create(modelPath))
                 transformer.SaveTo(Env, fs);
 


### PR DESCRIPTION
Fixes #1064
We need to use FullTestName variable, otherwise we get name collisions.
https://dnceng.visualstudio.com/public/_build/results?buildId=24407&view=ms.vss-test-web.test-result-details here is example how it fails right now.