### PR TITLE
Remove the error tracing when assembly loading fails for Maml.

### DIFF
--- a/src/Common/AssemblyLoadingUtils.cs
+++ b/src/Common/AssemblyLoadingUtils.cs
@@ -157,6 +157,7 @@ namespace Microsoft.ML.Runtime
                 case "parallelcommunicator.dll":
                 case "microsoft.ml.runtime.runtests.dll":
                 case "scopecompiler.dll":
+                case "symsgdnative.dll":
                 case "tbb.dll":
                 case "internallearnscope.dll":
                 case "unmanagedlib.dll":

--- a/src/Common/AssemblyLoadingUtils.cs
+++ b/src/Common/AssemblyLoadingUtils.cs
@@ -140,9 +140,12 @@ namespace Microsoft.ML.Runtime
             string name = Path.GetFileName(path).ToLowerInvariant();
             switch (name)
             {
+                case "cpumathnative.dll":
                 case "cqo.dll":
                 case "fasttreenative.dll":
+                case "factorizationmachinenative.dll":
                 case "libiomp5md.dll":
+                case "ldanative.dll":
                 case "libvw.dll":
                 case "matrixinterf.dll":
                 case "microsoft.ml.neuralnetworks.gpucuda.dll":
@@ -179,20 +182,16 @@ namespace Microsoft.ML.Runtime
             if (!Directory.Exists(dir))
                 return;
 
-            using (var ch = env.Start("LoadAssembliesInDir"))
+            // Load all dlls in the given directory.
+            var paths = Directory.EnumerateFiles(dir, "*.dll");
+            foreach (string path in paths)
             {
-                // Load all dlls in the given directory.
-                var paths = Directory.EnumerateFiles(dir, "*.dll");
-                foreach (string path in paths)
+                if (filter && ShouldSkipPath(path))
                 {
-                    if (filter && ShouldSkipPath(path))
-                    {
-                        ch.Info($"Skipping assembly '{path}' because its name was filtered.");
-                        continue;
-                    }
-
-                    LoadAssembly(env, path);
+                    continue;
                 }
+
+                LoadAssembly(env, path);
             }
         }
 
@@ -206,12 +205,8 @@ namespace Microsoft.ML.Runtime
             {
                 assembly = Assembly.LoadFrom(path);
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                using (var ch = env.Start("LoadAssembly"))
-                {
-                    ch.Error("Could not load assembly {0}:\n{1}", path, e.ToString());
-                }
                 return null;
             }
 


### PR DESCRIPTION
Also adding our native assemblies to the list to skip, so they aren't attempted to be loaded.

Fix #1034

