### PR TITLE
Ensure all Microsoft.ML assemblies are loaded by the LearningPipeline API.

### DIFF
--- a/src/Microsoft.ML.Legacy/AssemblyRegistration.cs
+++ b/src/Microsoft.ML.Legacy/AssemblyRegistration.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Runtime.Api;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.FastTree;
+using Microsoft.ML.Runtime.KMeans;
+using Microsoft.ML.Runtime.PCA;
+using Microsoft.ML.Runtime.Sweeper;
+using Microsoft.ML.Runtime.Tools;
+using System;
+using System.Reflection;
+
+namespace Microsoft.ML.Runtime
+{
+    internal static class AssemblyRegistration
+    {
+        private static readonly Lazy<bool> _assemblyInitializer = new Lazy<bool>(LoadStandardAssemblies);
+
+        public static void RegisterAssemblies(IHostEnvironment environment)
+        {
+            // ensure all the assemblies in the Microsoft.ML package have been loaded
+            if (!_assemblyInitializer.IsValueCreated)
+            {
+                _ = _assemblyInitializer.Value;
+                Contracts.Assert(_assemblyInitializer.Value);
+            }
+
+            AssemblyLoadingUtils.RegisterCurrentLoadedAssemblies(environment);
+        }
+
+        /// <summary>
+        /// Loads all the assemblies in the Microsoft.ML package that contain components.
+        /// </summary>
+        private static bool LoadStandardAssemblies()
+        {
+            Assembly apiAssembly = typeof(LambdaTransform).Assembly; // ML.Api
+            AssemblyName apiAssemblyName = apiAssembly.GetName();
+
+            _ = typeof(TextLoader).Assembly; // ML.Data
+            //_ = typeof(EnsemblePredictor).Assembly); // ML.Ensemble BUG https://github.com/dotnet/machinelearning/issues/1078 Ensemble isn't in a NuGet package
+            _ = typeof(FastTreeBinaryPredictor).Assembly; // ML.FastTree
+            _ = typeof(KMeansPredictor).Assembly; // ML.KMeansClustering
+            _ = typeof(Maml).Assembly; // ML.Maml
+            _ = typeof(PcaPredictor).Assembly; // ML.PCA
+            _ = typeof(SweepCommand).Assembly; // ML.Sweeper
+            _ = typeof(CategoricalTransform).Assembly; // ML.Transforms
+
+            // The following assemblies reference this assembly, so we can't directly reference them
+
+            //_ = typeof(Microsoft.ML.Runtime.PipelineInference.AutoInference).Assembly); // ML.PipelineInference
+            _ = Assembly.Load(new AssemblyName()
+            {
+                Name = "Microsoft.ML.PipelineInference",
+                Version = apiAssemblyName.Version, //assume the same version as ML.Api
+            });
+
+            //_ = typeof(Microsoft.ML.Runtime.Data.LinearPredictor).Assembly); // ML.StandardLearners
+            _ = Assembly.Load(new AssemblyName()
+            {
+                Name = "Microsoft.ML.StandardLearners",
+                Version = apiAssemblyName.Version, //assume the same version as ML.Api
+            });
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.ML.Legacy/Microsoft.ML.Legacy.csproj
+++ b/src/Microsoft.ML.Legacy/Microsoft.ML.Legacy.csproj
@@ -19,7 +19,11 @@
     <ProjectReference Include="..\Microsoft.ML.Api\Microsoft.ML.Api.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.FastTree\Microsoft.ML.FastTree.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.KMeansClustering\Microsoft.ML.KMeansClustering.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Maml\Microsoft.ML.Maml.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.PCA\Microsoft.ML.PCA.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.Sweeper\Microsoft.ML.Sweeper.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Transforms\Microsoft.ML.Transforms.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.ML.Legacy/PredictionModel.cs
+++ b/src/Microsoft.ML.Legacy/PredictionModel.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Legacy
 
             using (var environment = new ConsoleEnvironment())
             {
-                AssemblyLoadingUtils.RegisterCurrentLoadedAssemblies(environment);
+                AssemblyRegistration.RegisterAssemblies(environment);
 
                 BatchPredictionEngine<TInput, TOutput> predictor =
                     environment.CreateBatchPredictionEngine<TInput, TOutput>(stream);

--- a/src/Microsoft.ML.Legacy/Runtime/Experiment/Experiment.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/Experiment/Experiment.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Runtime
         public Experiment(Runtime.IHostEnvironment env)
         {
             _env = env;
-            AssemblyLoadingUtils.RegisterCurrentLoadedAssemblies(_env);
+            AssemblyRegistration.RegisterAssemblies(_env);
 
             _catalog = _env.ComponentCatalog;
             _jsonNodes = new List<string>();


### PR DESCRIPTION
This way, all components are registered before the Experiment tries to instantiate them.

Fix #1042
