### PR TITLE
Temporary fix for warning issue in KeyToValueTransform

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/KeyToValueTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValueTransform.cs
@@ -318,21 +318,12 @@ namespace Microsoft.ML.Runtime.Data
                     _values = values;
 
                     // REVIEW: May want to include more specific information about what the specific value is for the default.
-                    using (var ch = Parent.Host.Start("Getting NA Predicate and Value"))
-                    {
-                        _na = Conversions.Instance.GetNAOrDefault<TValue>(TypeOutput.ItemType, out _naMapsToDefault);
+                    _na = Conversions.Instance.GetNAOrDefault<TValue>(TypeOutput.ItemType, out _naMapsToDefault);
 
-                        if (_naMapsToDefault)
-                        {
-                            // Only initialize _isDefault if _defaultIsNA is true as this is the only case in which it is used.
-                            _isDefault = Conversions.Instance.GetIsDefaultPredicate<TValue>(TypeOutput.ItemType);
-                            RefPredicate<TValue> del;
-                            if (!Conversions.Instance.TryGetIsNAPredicate<TValue>(TypeOutput.ItemType, out del))
-                            {
-                                ch.Warning("There is no NA value for type '{0}'. The missing key value " +
-                                    "will be mapped to the default value of '{0}'", TypeOutput.ItemType);
-                            }
-                        }
+                    if (_naMapsToDefault)
+                    {
+                        // Only initialize _isDefault if _defaultIsNA is true as this is the only case in which it is used.
+                        _isDefault = Conversions.Instance.GetIsDefaultPredicate<TValue>(TypeOutput.ItemType);
                     }
 
                     bool identity;

--- a/test/BaselineOutput/SingleDebug/Command/CommandCrossValidationKeyLabelWithFloatKeyValues-out.txt
+++ b/test/BaselineOutput/SingleDebug/Command/CommandCrossValidationKeyLabelWithFloatKeyValues-out.txt
@@ -38,8 +38,6 @@ DCG@2:              0.000000 (0.0000)
 DCG@3:              0.000000 (0.0000)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleDebug/LightGBMMC/LightGBMMC-CV-iris.key-out.txt
+++ b/test/BaselineOutput/SingleDebug/LightGBMMC/LightGBMMC-CV-iris.key-out.txt
@@ -46,12 +46,6 @@ Log-loss:           0.253074 (0.0597)
 Log-loss reduction: 76.713844 (5.4729)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleDebug/LightGBMMC/LightGBMMC-CV-iris.keyU404-out.txt
+++ b/test/BaselineOutput/SingleDebug/LightGBMMC/LightGBMMC-CV-iris.keyU404-out.txt
@@ -50,10 +50,6 @@ Log-loss:           0.253074 (0.0597)
 Log-loss reduction: 76.713839 (5.4729)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/LogisticRegression-Non-Negative-CV-iris-out.txt
+++ b/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/LogisticRegression-Non-Negative-CV-iris-out.txt
@@ -48,10 +48,6 @@ Log-loss:           0.127710 (0.0021)
 Log-loss reduction: 88.246783 (0.1875)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-out.txt
+++ b/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-out.txt
@@ -48,10 +48,6 @@ Log-loss:           0.088839 (0.0130)
 Log-loss reduction: 91.825026 (1.1919)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-out.txt
+++ b/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-out.txt
@@ -62,10 +62,6 @@ Log-loss:           0.244241 (0.0864)
 Log-loss reduction: 77.528944 (7.9330)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-permuted-out.txt
+++ b/test/BaselineOutput/SingleDebug/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-permuted-out.txt
@@ -62,10 +62,6 @@ Log-loss:           0.151753 (0.0498)
 Log-loss reduction: 86.037885 (4.5746)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleRelease/Command/CommandCrossValidationKeyLabelWithFloatKeyValues-out.txt
+++ b/test/BaselineOutput/SingleRelease/Command/CommandCrossValidationKeyLabelWithFloatKeyValues-out.txt
@@ -38,8 +38,6 @@ DCG@2:              0.000000 (0.0000)
 DCG@3:              0.000000 (0.0000)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleRelease/LightGBMMC/LightGBMMC-CV-iris.key-out.txt
+++ b/test/BaselineOutput/SingleRelease/LightGBMMC/LightGBMMC-CV-iris.key-out.txt
@@ -46,12 +46,6 @@ Log-loss:           0.253074 (0.0597)
 Log-loss reduction: 76.713844 (5.4729)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleRelease/LightGBMMC/LightGBMMC-CV-iris.keyU404-out.txt
+++ b/test/BaselineOutput/SingleRelease/LightGBMMC/LightGBMMC-CV-iris.keyU404-out.txt
@@ -50,10 +50,6 @@ Log-loss:           0.253074 (0.0597)
 Log-loss reduction: 76.713839 (5.4729)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/LogisticRegression-Non-Negative-CV-iris-out.txt
+++ b/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/LogisticRegression-Non-Negative-CV-iris-out.txt
@@ -48,10 +48,6 @@ Log-loss:           0.127710 (0.0021)
 Log-loss reduction: 88.246783 (0.1875)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-out.txt
+++ b/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-out.txt
@@ -48,10 +48,6 @@ Log-loss:           0.088839 (0.0130)
 Log-loss reduction: 91.825026 (1.1919)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-out.txt
+++ b/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-out.txt
@@ -62,10 +62,6 @@ Log-loss:           0.244241 (0.0864)
 Log-loss reduction: 77.528944 (7.9330)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%

--- a/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-permuted-out.txt
+++ b/test/BaselineOutput/SingleRelease/MulticlassLogisticRegression/MulticlassLogisticRegression-CV-iris-tree-featurized-permuted-out.txt
@@ -62,10 +62,6 @@ Log-loss:           0.151753 (0.0498)
 Log-loss reduction: 86.037885 (4.5746)
 
 ---------------------------------------
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
-Warning: There is no NA value for type 'Text'. The missing key value will be mapped to the default value of 'Text'
 Physical memory usage(MB): %Number%
 Virtual memory usage(MB): %Number%
 %DateTime%	 Time elapsed(s): %Number%


### PR DESCRIPTION
This is a temporary fix for the issue #1059.

As outlined by Tom, we suppress the warning temporarily. There will thus be no warning when a the KeyToValueTransform is used with types that don't support missing values (e.g. strings, int, bool).

The next steps are also outlined by Tom's comment, and will involve providing a default value to the KeyToValueTranform for missing values, as well as throwing when a missing value is encountered if a default value was not provided. 