### PR TITLE
Added training method that accepts initial predictor for Symboli SGD estimator

### DIFF
--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -200,6 +200,9 @@ namespace Microsoft.ML.Runtime.SymSgd
         protected override BinaryPredictionTransformer<TPredictor> MakeTransformer(TPredictor model, ISchema trainSchema)
              => new BinaryPredictionTransformer<TPredictor>(Host, model, trainSchema, FeatureColumn.Name);
 
+        public BinaryPredictionTransformer<TPredictor> Train(IDataView trainData, IDataView validationData = null, TPredictor initialPredictor = null)
+            => TrainTransformer(trainData, validationData, initialPredictor);
+
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
         {
             return new[]

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -2,10 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Data.IO;
+using Microsoft.ML.Runtime.Learners;
 using Microsoft.ML.Runtime.RunTests;
 using Microsoft.ML.Runtime.SymSgd;
+using System;
+using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.ML.Tests.TrainerEstimators
@@ -18,6 +24,43 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             (var pipe, var dataView) = GetBinaryClassificationPipeline();
             pipe.Append(new SymSgdClassificationTrainer(Env, "Features", "Label"));
             TestEstimatorCore(pipe, dataView);
+            Done();
+        }
+
+        [Fact]
+        public void TestEstimatorSymSgdInitPredictor()
+        {
+            (var pipe, var dataView) = GetBinaryClassificationPipeline();
+            var transformedData = pipe.Fit(dataView).Transform(dataView);
+
+            // No actual training happens. 
+            var args = new LinearClassificationTrainer.Arguments();
+            var initPredictor = new LinearClassificationTrainer(Env, args, "Features", "Label").Fit(transformedData);
+            var data = initPredictor.Transform(transformedData);
+
+            var withInitPredictor = new SymSgdClassificationTrainer(Env, "Features", "Label").Train(transformedData, initialPredictor: initPredictor.Model);
+            var outInitData = withInitPredictor.Transform(transformedData);
+
+            var notInitPredictor = new SymSgdClassificationTrainer(Env, "Features", "Label").Train(transformedData);
+            var outNoInitData = notInitPredictor.Transform(transformedData);
+
+            int numExamples = 10;
+            var col1 = data.GetColumn<float>(Env, "Score").Take(numExamples).ToArray();
+            var col2 = outInitData.GetColumn<float>(Env, "Score").Take(numExamples).ToArray();
+            var col3 = outNoInitData.GetColumn<float>(Env, "Score").Take(numExamples).ToArray();
+
+            bool col12Diff = default;
+            bool col23Diff = default;
+            bool col13Diff = default;
+
+            for (int i = 0; i < numExamples; i++)
+            {
+                Console.WriteLine(col1[i].ToString() + " " + col2[i].ToString() + " " + col3[i].ToString());
+                col12Diff = col12Diff || (col1[i] != col2[i]);
+                col23Diff = col23Diff || (col2[i] != col3[i]);
+                col13Diff = col13Diff || (col1[i] != col3[i]);
+            }
+            Contracts.Assert(col12Diff && col23Diff && col13Diff);
             Done();
         }
     }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -33,7 +33,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             (var pipe, var dataView) = GetBinaryClassificationPipeline();
             var transformedData = pipe.Fit(dataView).Transform(dataView);
 
-            // No actual training happens. 
             var args = new LinearClassificationTrainer.Arguments();
             var initPredictor = new LinearClassificationTrainer(Env, args, "Features", "Label").Fit(transformedData);
             var data = initPredictor.Transform(transformedData);
@@ -55,7 +54,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             for (int i = 0; i < numExamples; i++)
             {
-                Console.WriteLine(col1[i].ToString() + " " + col2[i].ToString() + " " + col3[i].ToString());
                 col12Diff = col12Diff || (col1[i] != col2[i]);
                 col23Diff = col23Diff || (col2[i] != col3[i]);
                 col13Diff = col13Diff || (col1[i] != col3[i]);


### PR DESCRIPTION
Fixes #1087.

This PR restores the ability to train SymbolicSGD estimator starting from the weights of a previously trained predictor.

I added a  test to demonstrate that it works. 