### PR TITLE
Improvements to the "Sum" SIMD algorithm

### DIFF
--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -388,11 +388,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
             if (Avx.IsSupported)
             {
-                return AvxIntrinsics.SumU(src);
+                return AvxIntrinsics.Sum(src);
             }
             else if (Sse.IsSupported)
             {
-                return SseIntrinsics.SumU(src);
+                return SseIntrinsics.Sum(src);
             }
             else
             {

--- a/src/Microsoft.ML.CpuMath/Sse.cs
+++ b/src/Microsoft.ML.CpuMath/Sse.cs
@@ -246,7 +246,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             unsafe
             {
                 fixed (float* psrc = &MemoryMarshal.GetReference(src))
-                    return Thunk.SumU(psrc, src.Length);
+                    return Thunk.Sum(psrc, src.Length);
             }
         }
 

--- a/src/Microsoft.ML.CpuMath/Thunk.cs
+++ b/src/Microsoft.ML.CpuMath/Thunk.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static extern void AddSU(/*const*/ float* ps, /*const*/ int* pi, float* pd, int c);
 
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
-        public static extern float SumU(/*const*/ float* ps, int c);
+        public static extern float Sum(/*const*/ float* pValues, int length);
 
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
         public static extern float SumSqU(/*const*/ float* ps, int c);

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/AvxPerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/AvxPerformanceTests.cs
@@ -55,8 +55,8 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
             => AvxIntrinsics.MulElementWiseU(src1, src2, dst, Length);
 
         [Benchmark]
-        public float SumU()
-            => AvxIntrinsics.SumU(new Span<float>(src, 0, Length));
+        public float Sum()
+            => AvxIntrinsics.Sum(new Span<float>(src, 0, Length));
 
         [Benchmark]
         [BenchmarkCategory("Fma")]

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
@@ -50,8 +50,8 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
         [DllImport("CpuMathNative", EntryPoint = "MulElementWiseU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void MulElementWiseU(/*_In_ const*/ float* ps1, /*_In_ const*/ float* ps2, /*_Inout_*/ float* pd, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "SumU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe float SumU(/*const*/ float* ps, int c);
+        [DllImport("CpuMathNative", EntryPoint = "Sum"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe float Sum(/*const*/ float* pValues, int length);
 
         [DllImport("CpuMathNative", EntryPoint = "SumSqU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe float SumSqU(/*const*/ float* ps, int c);

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/NativePerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/NativePerformanceTests.cs
@@ -113,11 +113,11 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
         }
         
         [Benchmark]
-        public unsafe float SumU()
+        public unsafe float Sum()
         {
             fixed (float* psrc = src)
             {
-                return CpuMathNativeUtils.SumU(psrc, Length);
+                return CpuMathNativeUtils.Sum(psrc, Length);
             }
         }
         

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/SsePerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/SsePerformanceTests.cs
@@ -52,8 +52,8 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
             => SseIntrinsics.MulElementWiseU(src1, src2, dst, Length);
 
         [Benchmark]
-        public float SumU()
-            => SseIntrinsics.SumU(new Span<float>(src, 0, Length));
+        public float Sum()
+            => SseIntrinsics.Sum(new Span<float>(src, 0, Length));
 
         [Benchmark]
         public float SumSqU()

--- a/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
@@ -346,7 +346,7 @@ namespace Microsoft.ML.CpuMath.UnitTests
         [Theory]
         [InlineData(0, -187.8f)]
         [InlineData(1, -191.09f)]
-        public void SumUTest(int test, float expected)
+        public void SumTest(int test, float expected)
         {
             float[] src = (float[])_testArrays[test].Clone();
             var actual = CpuMathUtils.Sum(src);

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 // This in turn means that the schema of loaded transformer matches for 
                 // Transform and GetOutputSchema calls.
                 CheckSameSchemas(scoredTrain.Schema, scoredTrain2.Schema);
-                CheckSameValues(scoredTrain, scoredTrain2);
+                CheckSameValues(scoredTrain, scoredTrain2, exactDoubles: false);
             };
 
             checkOnData(validFitInput);
@@ -1092,7 +1092,7 @@ namespace Microsoft.ML.Runtime.RunTests
                         if (exactDoubles)
                             return GetComparerOne<Double>(r1, r2, col, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
                         else
-                            return GetComparerOne<Double>(r1, r2, col, EqualWithEps);
+                            return GetComparerOne<Double>(r1, r2, col, EqualWithEpsDouble);
                     case DataKind.Text:
                         return GetComparerOne<ReadOnlyMemory<char>>(r1, r2, col, (a ,b) => a.Span.SequenceEqual(b.Span));
                     case DataKind.Bool:
@@ -1133,12 +1133,15 @@ namespace Microsoft.ML.Runtime.RunTests
                     case DataKind.U8:
                         return GetComparerVec<ulong>(r1, r2, col, size, (x, y) => x == y);
                     case DataKind.R4:
-                        return GetComparerVec<Single>(r1, r2, col, size, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
+                        if (exactDoubles)
+                            return GetComparerVec<Single>(r1, r2, col, size, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
+                        else
+                            return GetComparerVec<Single>(r1, r2, col, size, EqualWithEpsSingle);
                     case DataKind.R8:
                         if (exactDoubles)
                             return GetComparerVec<Double>(r1, r2, col, size, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
                         else
-                            return GetComparerVec<Double>(r1, r2, col, size, EqualWithEps);
+                            return GetComparerVec<Double>(r1, r2, col, size, EqualWithEpsDouble);
                     case DataKind.Text:
                         return GetComparerVec<ReadOnlyMemory<char>>(r1, r2, col, size, (a, b) => a.Span.SequenceEqual(b.Span));
                     case DataKind.Bool:
@@ -1176,10 +1179,18 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private const Double DoubleEps = 1e-9;
 
-        private static bool EqualWithEps(Double x, Double y)
+        private static bool EqualWithEpsDouble(Double x, Double y)
         {
             // bitwise comparison is needed because Abs(Inf-Inf) and Abs(NaN-NaN) are not 0s.
             return FloatUtils.GetBits(x) == FloatUtils.GetBits(y) || Math.Abs(x - y) < DoubleEps;
+        }
+
+        private const float SingleEps = 1e-6f;
+
+        private static bool EqualWithEpsSingle(float x, float y)
+        {
+            // bitwise comparison is needed because Abs(Inf-Inf) and Abs(NaN-NaN) are not 0s.
+            return FloatUtils.GetBits(x) == FloatUtils.GetBits(y) || Math.Abs(x - y) < SingleEps;
         }
 
         protected Func<bool> GetComparerOne<T>(IRow r1, IRow r2, int col, Func<T, T, bool> fn)


### PR DESCRIPTION
Does some cleanup so that we have a single "Sum" algorithm (rather than one for aligned and one for unaligned inputs).

For inputs with fewer elements than can fit in the `Vector` type, it falls back to scalar code.
For inputs that are not naturally aligned (the alignment is not a multiple of 4), it does exclusively unaligned loads
For all other inputs, it will do at most two unaligned loads (one each for any leading/trailing unaligned elements) and all other loads will be aligned.