### PR TITLE
Update build yaml to use official container functionality

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -9,7 +9,7 @@ phases:
     name: Linux
     buildScript: ./build.sh
     queue:
-      name: dnceng-linux-external-temp
+      name: DotNetCore-Linux
       container: LinuxContainer
 
 - template: /build/ci/phase-template.yml

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -1,9 +1,16 @@
+resources:
+  containers:
+  - container: LinuxContainer
+    image: microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424
+
 phases:
 - template: /build/ci/phase-template.yml
   parameters:
     name: Linux
     buildScript: ./build.sh
-    dockerImage: microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
+    queue:
+      name: Hosted Ubuntu 1604
+      container: LinuxContainer
 
 - template: /build/ci/phase-template.yml
   parameters:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -1,7 +1,11 @@
+################################################################################
+# ML.NET's PR validation build
+################################################################################
+
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424
+    image: microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
 
 phases:
 - template: /build/ci/phase-template.yml
@@ -9,7 +13,7 @@ phases:
     name: Linux
     buildScript: ./build.sh
     queue:
-      name: DotNetCore-Linux
+      name: Hosted Ubuntu 1604
       container: LinuxContainer
 
 - template: /build/ci/phase-template.yml

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -9,7 +9,7 @@ phases:
     name: Linux
     buildScript: ./build.sh
     queue:
-      name: Hosted Ubuntu 1604
+      name: dnceng-linux-external-temp
       container: LinuxContainer
 
 - template: /build/ci/phase-template.yml

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -1,7 +1,6 @@
 parameters:
   name: ''
   buildScript: ''
-  dockerImage: ''
   queue: {}
 
 phases:
@@ -9,9 +8,6 @@ phases:
     variables:
       _buildScript: ${{ parameters.buildScript }}
       _phaseName: ${{ parameters.name }}
-      # if dockerImage is not equal to '' then run under docker container
-      ${{ if ne(parameters.dockerImage, '') }}:
-        _PREVIEW_VSTS_DOCKER_IMAGE: ${{ parameters.dockerImage }}
     queue:
       parallel: 99
       matrix:

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -1,9 +1,13 @@
+resources:
+  containers:
+  - container: LinuxContainer
+    image: microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424
+
 phases:
 ################################################################################
 - phase: Linux
 ################################################################################
   variables:
-    _PREVIEW_VSTS_DOCKER_IMAGE: microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424
     BuildConfig: Release
     OfficialBuildId: $(BUILD.BUILDNUMBER)
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -13,6 +17,7 @@ phases:
     name: DotNet-Build
     demands:
     - agent.os -equals linux
+    container: LinuxContainer
   steps:
   - script: ./build.sh -buildNative -$(BuildConfig)
     displayName: Build

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -1,7 +1,11 @@
+################################################################################
+# ML.NET's official, signed build 
+################################################################################
+
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424
+    image: microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
 
 phases:
 ################################################################################


### PR DESCRIPTION
We were using a pre-release Azure DevOps feature to do our Linux builds: `_PREVIEW_VSTS_DOCKER_IMAGE`. This feature is now an official feature, so we should switch to the officially supported functionality.

I also moved the PR validation Linux queue to use the Azure DevOps hosted Linux machines.