### PR TITLE
Remove ComponentCatalog from EntryPointGraph's and GraphRunner's constructors

### DIFF
--- a/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
@@ -1007,13 +1007,11 @@ namespace Microsoft.ML.Runtime.EntryPoints
         public EntryPointGraph(IHostEnvironment env, JArray nodes)
         {
             Contracts.CheckValue(env, nameof(env));
-            var catalog = env.ComponentCatalog;
             _host = env.Register(RegistrationName);
-            _host.CheckValue(catalog, nameof(catalog));
             _host.CheckValue(nodes, nameof(nodes));
 
             _context = new RunContext(_host);
-            _nodes = EntryPointNode.ValidateNodes(_host, _context, nodes, catalog);
+            _nodes = EntryPointNode.ValidateNodes(_host, _context, nodes, env.ComponentCatalog);
         }
 
         public bool HasRunnableNodes => _nodes.FirstOrDefault(x => x.CanStart()) != null;

--- a/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
@@ -1004,9 +1004,10 @@ namespace Microsoft.ML.Runtime.EntryPoints
         private readonly RunContext _context;
         private readonly List<EntryPointNode> _nodes;
 
-        public EntryPointGraph(IHostEnvironment env, ComponentCatalog catalog, JArray nodes)
+        public EntryPointGraph(IHostEnvironment env, JArray nodes)
         {
             Contracts.CheckValue(env, nameof(env));
+            var catalog = env.ComponentCatalog;
             _host = env.Register(RegistrationName);
             _host.CheckValue(catalog, nameof(catalog));
             _host.CheckValue(nodes, nameof(nodes));

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/ExecuteGraphCommand.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/ExecuteGraphCommand.cs
@@ -59,8 +59,7 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
                 throw _host.Except(ex, "Failed to parse experiment graph: {0}", ex.Message);
             }
 
-            var catalog = _host.ComponentCatalog;
-            var runner = new GraphRunner(_host, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(_host, graph[FieldNames.Nodes] as JArray);
 
             // Setting inputs.
             var jInputs = graph[FieldNames.Inputs] as JObject;

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/GraphRunner.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/GraphRunner.cs
@@ -26,9 +26,7 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
         public GraphRunner(IHostEnvironment env, JArray nodes)
         {
             Contracts.CheckValue(env, nameof(env));
-            var catalog = env.ComponentCatalog;
             _host = env.Register(RegistrationName);
-            _host.CheckValue(catalog, nameof(catalog));
             _host.CheckValue(nodes, nameof(nodes));
 
             _graph = new EntryPointGraph(_host, nodes);

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/GraphRunner.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/GraphRunner.cs
@@ -23,14 +23,15 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
         private readonly IHost _host;
         private readonly EntryPointGraph _graph;
 
-        public GraphRunner(IHostEnvironment env, ComponentCatalog catalog, JArray nodes)
+        public GraphRunner(IHostEnvironment env, JArray nodes)
         {
             Contracts.CheckValue(env, nameof(env));
+            var catalog = env.ComponentCatalog;
             _host = env.Register(RegistrationName);
             _host.CheckValue(catalog, nameof(catalog));
             _host.CheckValue(nodes, nameof(nodes));
 
-            _graph = new EntryPointGraph(_host, catalog, nodes);
+            _graph = new EntryPointGraph(_host, nodes);
         }
 
         public GraphRunner(IHostEnvironment env, EntryPointGraph graph)

--- a/src/Microsoft.ML.Legacy/Runtime/Experiment/Experiment.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/Experiment/Experiment.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Runtime
         {
             _env.Check(_graph == null, "Multiple calls to " + nameof(Compile) + "() detected.");
             var nodes = GetNodes();
-            _graph = new EntryPointGraph(_env, _catalog, nodes);
+            _graph = new EntryPointGraph(_env, nodes);
         }
 
         public JArray GetNodes()

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -561,8 +561,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -2483,8 +2482,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -2579,8 +2577,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -2687,8 +2684,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -2792,8 +2788,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -2953,8 +2948,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -3148,8 +3142,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -3271,8 +3264,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graphJson = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var graph = new EntryPointGraph(Env, catalog, graphJson[FieldNames.Nodes] as JArray);
+            var graph = new EntryPointGraph(Env, graphJson[FieldNames.Nodes] as JArray);
             Assert.True(graph.Macros.All(x => x.CanStart()));
         }
 
@@ -3326,11 +3318,10 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graphJson = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var graph = new EntryPointGraph(Env, catalog, graphJson[FieldNames.Nodes] as JArray);
+            var graph = new EntryPointGraph(Env, graphJson[FieldNames.Nodes] as JArray);
             // Serialize the nodes with ToJson() and then executing them to ensure serialization working correctly.
             var nodes = new JArray(graph.AllNodes.Select(node => node.ToJson()));
-            var runner = new GraphRunner(Env, catalog, nodes);
+            var runner = new GraphRunner(Env, nodes);
 
             var dataPath = GetDataPath("breast-cancer.txt");
             var inputFile = new SimpleFileHandle(Env, dataPath, false, false);
@@ -3386,8 +3377,7 @@ namespace Microsoft.ML.Runtime.RunTests
                   ]
                 }";
             JObject graphJson = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var graph = new EntryPointGraph(Env, catalog, graphJson[FieldNames.Nodes] as JArray);
+            var graph = new EntryPointGraph(Env, graphJson[FieldNames.Nodes] as JArray);
             for (int i = 0; i < 2; i++)
             {
                 var nodes = graph.AllNodes.ToArray();
@@ -3405,7 +3395,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
                 // Serialize the graph and verify again.
                 var serNodes = new JArray(graph.AllNodes.Select(node => node.ToJson()));
-                graph = new EntryPointGraph(Env, catalog, serNodes);
+                graph = new EntryPointGraph(Env, serNodes);
             }
         }
 

--- a/test/Microsoft.ML.Predictor.Tests/TestPipelineSweeper.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPipelineSweeper.cs
@@ -81,9 +81,8 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
 
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
             runner.SetInput("TrainingData", datasetTrain);
             runner.SetInput("TestingData", datasetTest);
             runner.RunAll();
@@ -219,11 +218,10 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graphJson = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var graph = new EntryPointGraph(Env, catalog, graphJson[FieldNames.Nodes] as JArray);
+            var graph = new EntryPointGraph(Env, graphJson[FieldNames.Nodes] as JArray);
             // Test if ToJson() works properly.
             var nodes = new JArray(graph.AllNodes.Select(node => node.ToJson()));
-            var runner = new GraphRunner(Env, catalog, nodes);
+            var runner = new GraphRunner(Env, nodes);
             runner.SetInput("TrainingData", datasetTrain);
             runner.SetInput("TestingData", datasetTest);
             runner.RunAll();
@@ -300,8 +298,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graphJson = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graphJson[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graphJson[FieldNames.Nodes] as JArray);
             runner.SetInput("TrainingData", datasetTrain);
             runner.SetInput("TestingData", datasetTest);
             runner.RunAll();
@@ -384,8 +381,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graphJson = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
-            var runner = new GraphRunner(Env, catalog, graphJson[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graphJson[FieldNames.Nodes] as JArray);
             runner.SetInput("TrainingData", datasetTrain);
             runner.SetInput("TestingData", datasetTest);
             runner.RunAll();
@@ -468,9 +464,8 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
 
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
             runner.SetInput("TrainingData", datasetTrain);
             runner.SetInput("TestingData", datasetTest);
             runner.RunAll();
@@ -552,9 +547,8 @@ namespace Microsoft.ML.Runtime.RunTests
                 }";
 
             JObject graph = JObject.Parse(inputGraph);
-            var catalog = Env.ComponentCatalog;
 
-            var runner = new GraphRunner(Env, catalog, graph[FieldNames.Nodes] as JArray);
+            var runner = new GraphRunner(Env, graph[FieldNames.Nodes] as JArray);
             runner.SetInput("TrainingData", datasetTrain);
             runner.SetInput("TestingData", datasetTest);
             runner.RunAll();


### PR DESCRIPTION
Fixes #1113 .

The constructors now use env.ComponentCatalog as their catalog, instead of a catalog being passed as an argument. All call sites were changed accordingly.