### PR TITLE
add .NET Core 3.0 support for the benchmarks

### DIFF
--- a/test/Microsoft.ML.Benchmarks/Harness/Configs.cs
+++ b/test/Microsoft.ML.Benchmarks/Harness/Configs.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ML.Benchmarks
             Add(DefaultConfig.Instance); // this config contains all of the basic settings (exporters, columns etc)
 
             Add(GetJobDefinition() // job defines how many times given benchmark should be executed
+                .WithCustomBuildConfiguration(GetBuildConfigurationName())
                 .With(CreateToolchain())); // toolchain is responsible for generating, building and running dedicated executable per benchmark
 
             Add(new ExtraMetricColumn()); // an extra colum that can display additional metric reported by the benchmarks
@@ -31,14 +32,32 @@ namespace Microsoft.ML.Benchmarks
         /// </summary>
         private IToolchain CreateToolchain()
         {
-            var csProj = CsProjCoreToolchain.Current.Value;
-            var tfm = NetCoreAppSettings.Current.Value.TargetFrameworkMoniker;
+            var tfm = GetTargetFrameworkMoniker();
+            var csProj = CsProjCoreToolchain.From(new NetCoreAppSettings(targetFrameworkMoniker: tfm, runtimeFrameworkVersion: null, name: tfm));
 
             return new Toolchain(
                 tfm,
                 new ProjectGenerator(tfm), // custom generator that copies native dependencies
                 csProj.Builder,
                 csProj.Executor);
+        }
+
+        private static string GetTargetFrameworkMoniker()
+        {
+#if NETCOREAPP3_0 // todo: remove the #IF DEFINES when BDN 0.11.2 gets released (BDN gains the 3.0 support)
+            return "netcoreapp3.0";
+#else
+            return NetCoreAppSettings.Current.Value.TargetFrameworkMoniker;
+#endif
+        }
+
+        private static string GetBuildConfigurationName()
+        {
+#if NETCOREAPP3_0
+            return "Release-Intrinsics";
+#else
+            return "Release";
+#endif
         }
     }
 

--- a/test/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
+++ b/test/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <LangVersion>7.2</LangVersion>
     <StartupObject>Microsoft.ML.Benchmarks.Program</StartupObject>
+    <TargetFramework Condition="'$(UseIntrinsics)' != 'true'">netcoreapp2.1</TargetFramework>
+    <TargetFramework Condition="'$(UseIntrinsics)' == 'true'">netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="BenchmarkDotNet.Artifacts\**" />

--- a/test/Microsoft.ML.Benchmarks/README.md
+++ b/test/Microsoft.ML.Benchmarks/README.md
@@ -43,6 +43,21 @@ To get the total number of allocated managed memory please pass additional conso
     dotnet run -c Release -- --help
 ```
 
+## .NET Core 3.0
+
+**Pre-requisite:** Follow the [netcoreapp3.0 instructions](../../docs/building/netcoreapp3.0-instructions.md).
+
+**Pre-requisite:** To use dotnet cli from the root directory remember to set `DOTNET_MULTILEVEL_LOOKUP` environment variable to `0`!
+
+    $env:DOTNET_MULTILEVEL_LOOKUP=0
+
+1. Navigate to the benchmarks directory (machinelearning\test\Microsoft.ML.Benchmarks)
+
+2. Run the benchmarks in `Release-Intrinsics` configuration, choose one of the benchmarks when prompted
+
+```log
+    ..\..\Tools\dotnetcli\dotnet.exe run -c Release-Intrinsics -f netcoreapp3.0
+```
 ## Authoring new benchmarks
 
 1. The type which contains benchmark(s) has to be a public, non-sealed, non-static class.


### PR DESCRIPTION
@Anipik works on making the 3.0 test pass, the Benchmark test was failing so here is the fix for it