### PR TITLE
Improvements to the "Scale" SIMD algorithm

### DIFF
--- a/src/Microsoft.ML.CpuMath/Avx.cs
+++ b/src/Microsoft.ML.CpuMath/Avx.cs
@@ -625,7 +625,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             unsafe
             {
                 fixed (float* pd = &dst[0])
-                    Thunk.ScaleU(a, pd, count);
+                    Thunk.Scale(a, pd, count);
             }
         }
 

--- a/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
@@ -482,16 +482,21 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             fixed (uint* pTrailingAlignmentMask = &TrailingAlignmentMask[0])
             fixed (float* pd = dst)
             {
-                float* pdLim = pd + dst.Length;
-
+                float* pDstCurrent = pd;
                 int length = dst.Length;
                 Vector256<float> scaleVector256 = Avx.SetAllVector256(scale);
 
                 if (length < 8)
                 {
-                    for(int i = 0; i < length; i++)
+                    switch(length)
                     {
-                        dst[i] *= scale;
+                        case 7: dst[6] *= scale; goto case 6;
+                        case 6: dst[5] *= scale; goto case 5;
+                        case 5: dst[4] *= scale; goto case 4;
+                        case 4: dst[3] *= scale; goto case 3;
+                        case 3: dst[2] *= scale; goto case 2;
+                        case 2: dst[1] *= scale; goto case 1;
+                        case 1: dst[0] *= scale; break;
                     }
                     return;
                 }
@@ -499,7 +504,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                 nuint address = (nuint)(pd);
                 int misalignment = (int)(address % 32);
                 int remainder = 0;
-                float* pDstCurrent = pd;
 
                 if ((misalignment & 3) != 0)
                 {

--- a/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
@@ -13,11 +13,36 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using nuint = System.UInt64;
 
 namespace Microsoft.ML.Runtime.Internal.CpuMath
 {
     internal static class AvxIntrinsics
     {
+        public static readonly uint[] LeadingAlignmentMask = new uint[64]
+        {
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000,
+            0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000,
+        };
+
+        public static readonly uint[] TrailingAlignmentMask = new uint[64]
+        {
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0xFFFFFFFF,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0xFFFFFFFF, 0xFFFFFFFF,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+            0x00000000, 0x00000000, 0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+            0x00000000, 0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+            0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+        };
+
         private static readonly Vector256<float> _absMask256 = Avx.StaticCast<int, float>(Avx.SetAllVector256(0x7FFFFFFF));
 
         private const int Vector256Alignment = 32;
@@ -451,45 +476,118 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             }
         }
 
-        public static unsafe void ScaleU(float scale, Span<float> dst)
+        public static unsafe void Scale(float scale, Span<float> dst)
         {
-            fixed (float* pdst = dst)
+            fixed (uint* pLeadingAlignmentMask = &LeadingAlignmentMask[0])
+            fixed (uint* pTrailingAlignmentMask = &TrailingAlignmentMask[0])
+            fixed (float* pd = dst)
             {
-                float* pDstCurrent = pdst;
-                float* pEnd = pdst + dst.Length;
+                float* pdLim = pd + dst.Length;
 
+                int length = dst.Length;
                 Vector256<float> scaleVector256 = Avx.SetAllVector256(scale);
 
-                while (pDstCurrent + 8 <= pEnd)
+                if (length < 8)
                 {
-                    Vector256<float> dstVector = Avx.LoadVector256(pDstCurrent);
-
-                    dstVector = Avx.Multiply(scaleVector256, dstVector);
-                    Avx.Store(pDstCurrent, dstVector);
-
-                    pDstCurrent += 8;
+                    for(int i = 0; i < length; i++)
+                    {
+                        dst[i] *= scale;
+                    }
+                    return;
                 }
 
-                Vector128<float> scaleVector128 = Sse.SetAllVector128(scale);
+                nuint address = (nuint)(pd);
+                int misalignment = (int)(address % 32);
+                int remainder = 0;
+                float* pDstCurrent = pd;
 
-                if (pDstCurrent + 4 <= pEnd)
+                if ((misalignment & 3) != 0)
                 {
-                    Vector128<float> dstVector = Sse.LoadVector128(pDstCurrent);
+                    // Handles cases where the data is not 32-bit aligned and we can't ever use aligned operations
+                    remainder = length % 8;
 
-                    dstVector = Sse.Multiply(scaleVector128, dstVector);
-                    Sse.Store(pDstCurrent, dstVector);
-
-                    pDstCurrent += 4;
+                    for (float* pEnd = pd + (length - remainder); pDstCurrent < pEnd; pDstCurrent += 8)
+                    {
+                        Vector256<float> temp = Avx.LoadVector256(pDstCurrent);
+                        temp = Avx.Multiply(scaleVector256, temp);
+                        Avx.Store(pDstCurrent, temp);
+                    }
                 }
-
-                while (pDstCurrent < pEnd)
+                else
                 {
-                    Vector128<float> dstVector = Sse.LoadScalarVector128(pDstCurrent);
+                    if (misalignment != 0)
+                    {
+                        // Handle cases where the data is not 256-bit aligned by doing an unaligned read and then
+                        // masking any elements that will be included in the first aligned read
 
-                    dstVector = Sse.MultiplyScalar(scaleVector128, dstVector);
-                    Sse.StoreScalar(pDstCurrent, dstVector);
+                        misalignment >>= 2;
+                        misalignment = 8 - misalignment;
 
-                    pDstCurrent++;
+                        Vector256<float> result = Avx.LoadVector256(pDstCurrent);
+
+                        Vector256<float> leadingMask = Avx.LoadVector256(((float*)(pLeadingAlignmentMask)) + (misalignment * 8));
+                        Vector256<float> trailingMask = Avx.LoadVector256(((float*)(pTrailingAlignmentMask)) + (( 8 - misalignment) * 8));
+
+                        Vector256<float> temp = Avx.And(result, leadingMask);
+                        result = Avx.And(result, trailingMask);
+
+                        temp = Avx.Multiply(scaleVector256, temp);
+                        result = Avx.Or(temp, result);
+
+                        Avx.Store(pDstCurrent, result);
+
+                        pDstCurrent += misalignment;
+                        length -= misalignment;
+                    }
+
+                    if (length > 7)
+                    {
+                        // Handle all the 256-bit blocks that we can now that we have offset to an aligned address
+
+                        remainder = length % 8;
+
+                        for (float* pEnd = pDstCurrent + (length - remainder); pDstCurrent < pEnd; pDstCurrent += 8)
+                        {
+                            // The JIT will only fold away unaligned loads due to the semantics behind
+                            // the VEX-encoding of the memory operand for `ins xmm, xmm, [mem]`. Since
+                            // modern hardware has unaligned loads that are as fast as aligned loads,
+                            // when it doesn't cross a cache-line/page boundary, we will just assert
+                            // that the alignment is correct and allow for the more-efficient codegen.
+
+                            Contracts.Assert(((nuint)(pDstCurrent) % 32) == 0);
+                            Vector256<float> temp = Avx.LoadVector256(pDstCurrent);
+                            temp = Avx.Multiply(scaleVector256, temp);
+                            Avx.Store(pDstCurrent, temp);
+                        }
+                    }
+                    else
+                    {
+                        // Handle the "worst-case" scenario, which is when we have 8-16 elements and the input is not
+                        // 256-bit aligned. This means we can't do any aligned loads and will just end up doing two
+                        // unaligned loads where we mask the input each time.
+                        remainder = length;
+                    }
+
+                    if (remainder != 0)
+                    {
+                        // Handle any trailing elements that don't fit into a 128-bit block by moving back so that the next
+                        // unaligned load will read to the end of the array and then mask out any elements already processed
+
+                        pDstCurrent -= (8 - remainder);
+
+                        Vector256<float> result = Avx.LoadVector256(pDstCurrent);
+
+                        Vector256<float> trailingMask = Avx.LoadVector256(((float*)(pTrailingAlignmentMask)) + (remainder * 8));
+                        Vector256<float> leadingMask = Avx.LoadVector256(((float*)(pLeadingAlignmentMask)) + (( 8 - remainder) * 8));
+
+                        Vector256<float> temp = Avx.And(result, trailingMask);
+                        result = Avx.And(result, leadingMask);
+
+                        temp = Avx.Multiply(scaleVector256, temp);
+                        temp = Avx.Or(temp, result);
+
+                        Avx.Store(pDstCurrent, temp);
+                    }
                 }
             }
         }

--- a/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
@@ -571,27 +571,27 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                         // unaligned loads where we mask the input each time.
                         remainder = length;
                     }
+                }
 
-                    if (remainder != 0)
-                    {
-                        // Handle any trailing elements that don't fit into a 128-bit block by moving back so that the next
-                        // unaligned load will read to the end of the array and then mask out any elements already processed
+                if (remainder != 0)
+                {
+                    // Handle any trailing elements that don't fit into a 128-bit block by moving back so that the next
+                    // unaligned load will read to the end of the array and then mask out any elements already processed
 
-                        pDstCurrent -= (8 - remainder);
+                    pDstCurrent -= (8 - remainder);
 
-                        Vector256<float> result = Avx.LoadVector256(pDstCurrent);
+                    Vector256<float> result = Avx.LoadVector256(pDstCurrent);
 
-                        Vector256<float> trailingMask = Avx.LoadVector256(((float*)(pTrailingAlignmentMask)) + (remainder * 8));
-                        Vector256<float> leadingMask = Avx.LoadVector256(((float*)(pLeadingAlignmentMask)) + (( 8 - remainder) * 8));
+                    Vector256<float> trailingMask = Avx.LoadVector256(((float*)(pTrailingAlignmentMask)) + (remainder * 8));
+                    Vector256<float> leadingMask = Avx.LoadVector256(((float*)(pLeadingAlignmentMask)) + ((8 - remainder) * 8));
 
-                        Vector256<float> temp = Avx.And(result, trailingMask);
-                        result = Avx.And(result, leadingMask);
+                    Vector256<float> temp = Avx.And(result, trailingMask);
+                    result = Avx.And(result, leadingMask);
 
-                        temp = Avx.Multiply(scaleVector256, temp);
-                        temp = Avx.Or(temp, result);
+                    temp = Avx.Multiply(scaleVector256, temp);
+                    temp = Avx.Or(temp, result);
 
-                        Avx.Store(pDstCurrent, temp);
-                    }
+                    Avx.Store(pDstCurrent, temp);
                 }
             }
         }

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -248,11 +248,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             if (Avx.IsSupported)
             {
-                AvxIntrinsics.ScaleU(a, dst);
+                AvxIntrinsics.Scale(a, dst);
             }
             else if (Sse.IsSupported)
             {
-                SseIntrinsics.ScaleU(a, dst);
+                SseIntrinsics.Scale(a, dst);
             }
             else
             {

--- a/src/Microsoft.ML.CpuMath/Sse.cs
+++ b/src/Microsoft.ML.CpuMath/Sse.cs
@@ -606,7 +606,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             unsafe
             {
                 fixed (float* pdst = &dst.Items[0])
-                    Thunk.ScaleA(a, Ptr(dst, pdst), dst.Size);
+                    Thunk.Scale(a, Ptr(dst, pdst), dst.Size);
             }
         }
 
@@ -618,7 +618,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             unsafe
             {
                 fixed (float* pd = &dst[0])
-                    Thunk.ScaleU(a, pd, count);
+                    Thunk.Scale(a, pd, count);
             }
         }
 
@@ -631,7 +631,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             unsafe
             {
                 fixed (float* pd = &dst[offset])
-                    Thunk.ScaleU(a, pd, count);
+                    Thunk.Scale(a, pd, count);
             }
         }
 

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -558,27 +558,27 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                         // unaligned loads where we mask the input each time.
                         remainder = length;
                     }
+                }
 
-                    if (remainder != 0)
-                    {
-                        // Handle any trailing elements that don't fit into a 128-bit block by moving back so that the next
-                        // unaligned load will read to the end of the array and then mask out any elements already processed
+                if (remainder != 0)
+                {
+                    // Handle any trailing elements that don't fit into a 128-bit block by moving back so that the next
+                    // unaligned load will read to the end of the array and then mask out any elements already processed
 
-                        pDstCurrent -= (4 - remainder);
+                    pDstCurrent -= (4 - remainder);
 
-                        Vector128<float> result = Sse.LoadVector128(pDstCurrent);
+                    Vector128<float> result = Sse.LoadVector128(pDstCurrent);
 
-                        Vector128<float> trailingMask = Sse.LoadVector128(((float*)(pTrailingAlignmentMask)) + (remainder * 4));
-                        Vector128<float> leadingMask = Sse.LoadVector128(((float*)(pLeadingAlignmentMask)) + ((4 - remainder) * 4));
+                    Vector128<float> trailingMask = Sse.LoadVector128(((float*)(pTrailingAlignmentMask)) + (remainder * 4));
+                    Vector128<float> leadingMask = Sse.LoadVector128(((float*)(pLeadingAlignmentMask)) + ((4 - remainder) * 4));
 
-                        Vector128<float> temp = Sse.And(result, trailingMask);
-                        result = Sse.And(result, leadingMask);
+                    Vector128<float> temp = Sse.And(result, trailingMask);
+                    result = Sse.And(result, leadingMask);
 
-                        temp = Sse.Multiply(scaleVector128, temp);
-                        temp = Sse.Or(temp, result);
+                    temp = Sse.Multiply(scaleVector128, temp);
+                    temp = Sse.Or(temp, result);
 
-                        Sse.Store(pDstCurrent, temp);
-                    }
+                    Sse.Store(pDstCurrent, temp);
                 }
             }
         }

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         }
 
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-       internal static Vector128<float> VectorSum128(in Vector128<float> vector)
+        internal static Vector128<float> VectorSum128(in Vector128<float> vector)
         {
             if (Sse3.IsSupported)
             {
@@ -527,28 +527,12 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
                         for (float* pEnd = pDstCurrent + (length - remainder); pDstCurrent < pEnd; pDstCurrent += 4)
                         {
-                            if (Avx.IsSupported)
-                            {
-                                // The JIT will only fold away unaligned loads due to the semantics behind
-                                // the VEX-encoding of the memory operand for `ins xmm, xmm, [mem]`. Since
-                                // modern hardware has unaligned loads that are as fast as aligned loads,
-                                // when it doesn't cross a cache-line/page boundary, we will just assert
-                                // that the alignment is correct and allow for the more-efficient codegen.
-
-                                Contracts.Assert(((nuint)(pDstCurrent) % 16) == 0);
-                                Vector128<float> temp = Sse.LoadVector128(pDstCurrent);
-                                temp = Sse.Multiply(scaleVector128, temp);
-                                Sse.Store(pDstCurrent, temp);
-                            }
-                            else
-                            {
-                                // If we aren't using the VEX-encoding, then the reverse is true and the JIT
-                                // will only fold away aligned loads (due to semantics of the legacy encoding).
-                                // We don't need an assert, since the instruction will throw for unaligned inputs.
-                                Vector128<float> temp = Sse.LoadAlignedVector128(pDstCurrent);
-                                temp = Sse.Multiply(scaleVector128, temp);
-                                Sse.Store(pDstCurrent, temp);
-                            }
+                            // If we aren't using the VEX-encoding, then the reverse is true and the JIT
+                            // will only fold away aligned loads (due to semantics of the legacy encoding).
+                            // We don't need an assert, since the instruction will throw for unaligned inputs.
+                            Vector128<float> temp = Sse.LoadAlignedVector128(pDstCurrent);
+                            temp = Sse.Multiply(scaleVector128, temp);
+                            Sse.Store(pDstCurrent, temp);
                         }
                     }
                     else

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -522,13 +522,12 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
                     if (length > 4)
                     {
                         // Handle all the 128-bit blocks that we can now that we have offset to an aligned address
-
                         remainder = length % 4;
 
                         for (float* pEnd = pDstCurrent + (length - remainder); pDstCurrent < pEnd; pDstCurrent += 4)
                         {
-                            // If we aren't using the VEX-encoding, then the reverse is true and the JIT
-                            // will only fold away aligned loads (due to semantics of the legacy encoding).
+                            // If we aren't using the VEX-encoding, the JIT will only fold away aligned loads 
+                            // (due to semantics of the legacy encoding).
                             // We don't need an assert, since the instruction will throw for unaligned inputs.
                             Vector128<float> temp = Sse.LoadAlignedVector128(pDstCurrent);
                             temp = Sse.Multiply(scaleVector128, temp);

--- a/src/Microsoft.ML.CpuMath/Thunk.cs
+++ b/src/Microsoft.ML.CpuMath/Thunk.cs
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             float decay, float cond, int crow, int ccol);
 
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
-        public static extern void ScaleU(float a, float* pd, int c);
+        public static extern void Scale(float a, float* pd, int c);
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
         public static extern void ScaleA(float a, float* pd, int c);
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]

--- a/src/Microsoft.ML.CpuMath/Thunk.cs
+++ b/src/Microsoft.ML.CpuMath/Thunk.cs
@@ -171,8 +171,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
         public static extern void Scale(float a, float* pd, int c);
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
-        public static extern void ScaleA(float a, float* pd, int c);
-        [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
         public static extern void ScaleX(float a, float* pd, int c);
         [DllImport(NativePath), SuppressUnmanagedCodeSecurity]
         public static extern void ScaleSrcU(float a, /*const*/ float* ps, float* pd, int c);

--- a/src/Native/CpuMathNative/Sse.cpp
+++ b/src/Native/CpuMathNative/Sse.cpp
@@ -1448,16 +1448,15 @@ EXPORT_API(void) AddScalarU(float a, _Inout_ float * pd, int c)
 
 EXPORT_API(void) Scale(float a, _Inout_ float * pd, int c)
 {
-    float * pdLim = pd + c;
     __m128 x1 = _mm_set1_ps(a);
     
     if (c < 4)
     {
-        for (; pd < pdLim; pd++)
+        switch(c)
         {
-            __m128 x2 = _mm_load_ss(pd);
-            x2 = _mm_mul_ss(x1, x2);
-            _mm_store_ss(pd, x2);
+            case 3: pd[2] *= a;
+            case 2: pd[1] *= a;
+            case 1: pd[0] *= a;
         }
         return;           
     }

--- a/src/Native/CpuMathNative/Sse.cpp
+++ b/src/Native/CpuMathNative/Sse.cpp
@@ -1541,7 +1541,6 @@ EXPORT_API(void) Scale(float a, _Inout_ float * pd, int c)
         result = _mm_or_ps(temp, result);            
             
         _mm_storeu_ps(pd, result);
-        return;   
     }
 }
 

--- a/src/Native/CpuMathNative/Sse.cpp
+++ b/src/Native/CpuMathNative/Sse.cpp
@@ -27,6 +27,7 @@
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <nmmintrin.h>
+#include <stdint.h>
 
 #define _load1(ps, pi) \
     _mm_set_ss(ps[pi[0]])

--- a/src/Native/CpuMathNative/Sse.cpp
+++ b/src/Native/CpuMathNative/Sse.cpp
@@ -1449,26 +1449,6 @@ EXPORT_API(void) AddScalarU(float a, _Inout_ float * pd, int c)
 EXPORT_API(void) Scale(float a, _Inout_ float * pd, int c)
 {
     float * pdLim = pd + c;
-
-    __m128 x1 = _mm_set1_ps(a);
-    for (; pd + 4 <= pdLim; pd += 4)
-    {
-        __m128 x2 = _mm_loadu_ps(pd);
-        x2 = _mm_mul_ps(x1, x2);
-        _mm_storeu_ps(pd, x2);
-    }
-
-    for (; pd < pdLim; pd++)
-    {
-        __m128 x2 = _mm_load_ss(pd);
-        x2 = _mm_mul_ss(x1, x2);
-        _mm_store_ss(pd, x2);
-    }
-}
-
-EXPORT_API(void) ScaleU(float a, _Inout_ float * pd, int c)
-{
-    float * pdLim = pd + c;
     __m128 x1 = _mm_set1_ps(a);
     
     if (c < 4)
@@ -1552,8 +1532,8 @@ EXPORT_API(void) ScaleU(float a, _Inout_ float * pd, int c)
         pd -= (4 - remainder);
         __m128 result = _mm_loadu_ps(pd);            
             
-        __m128 trailingMask = _mm_loadu_ps(((float*)(&LeadingAlignmentMask)) + (remainder * 4));
-        __m128 leadingMask = _mm_loadu_ps(((float*)(&TrailingAlignmentMask)) + ((4 - remainder) * 4));
+        __m128 trailingMask = _mm_loadu_ps(((float*)(&TrailingAlignmentMask)) + (remainder * 4));
+        __m128 leadingMask = _mm_loadu_ps(((float*)(&LeadingAlignmentMask)) + ((4 - remainder) * 4));
             
         __m128 temp = _mm_and_ps(result, trailingMask);
         result = _mm_and_ps(result, leadingMask);
@@ -1563,19 +1543,6 @@ EXPORT_API(void) ScaleU(float a, _Inout_ float * pd, int c)
             
         _mm_storeu_ps(pd, result);
         return;   
-    }
-}
-
-EXPORT_API(void) ScaleA(float a, _Inout_ float * pd, int c)
-{
-    float * pdLim = pd + c;
-
-    __m128 x1 = _mm_set1_ps(a);
-    for (; pd < pdLim; pd += 4)
-    {
-        __m128 x2 = _mm_load_ps(pd);
-        x2 = _mm_mul_ps(x1, x2);
-        _mm_store_ps(pd, x2);
     }
 }
 

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/AvxPerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/AvxPerformanceTests.cs
@@ -16,8 +16,8 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
             => AvxIntrinsics.AddScalarU(DefaultScale, new Span<float>(dst, 0, Length));
 
         [Benchmark]
-        public void ScaleU()
-            => AvxIntrinsics.ScaleU(DefaultScale, new Span<float>(dst, 0, Length));
+        public void Scale()
+            => AvxIntrinsics.Scale(DefaultScale, new Span<float>(dst, 0, Length));
 
         [Benchmark]
         public void ScaleSrcU()

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/CpuMathNativeUtils.cs
@@ -23,8 +23,8 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
         [DllImport("CpuMathNative", EntryPoint = "AddScalarU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe float AddScalarU(float a, /*_Inout_*/ float* pd, int c);
 
-        [DllImport("CpuMathNative", EntryPoint = "ScaleU"), SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void ScaleU(float a, /*_Inout_*/ float* pd, int c);
+        [DllImport("CpuMathNative", EntryPoint = "Scale"), SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void Scale(float a, /*_Inout_*/ float* pd, int c);
 
         [DllImport("CpuMathNative", EntryPoint = "ScaleSrcU"), SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void ScaleSrcU(float a, /*_In_ const*/ float* ps, /*_Inout_*/ float* pd, int c);

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/NativePerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/NativePerformanceTests.cs
@@ -21,11 +21,11 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
         }
         
         [Benchmark]
-        public unsafe void ScaleU()
+        public unsafe void Scale()
         {
             fixed (float* pdst = dst)
             {
-                CpuMathNativeUtils.ScaleU(DefaultScale, pdst, Length);
+                CpuMathNativeUtils.Scale(DefaultScale, pdst, Length);
             }
         }
         

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/SsePerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/SsePerformanceTests.cs
@@ -16,8 +16,8 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
             => SseIntrinsics.AddScalarU(DefaultScale, new Span<float>(dst, 0, Length));
         
         [Benchmark]
-        public void ScaleU()
-            => SseIntrinsics.ScaleU(DefaultScale, new Span<float>(dst, 0, Length));
+        public void Scale()
+            => SseIntrinsics.Scale(DefaultScale, new Span<float>(dst, 0, Length));
         
         [Benchmark]
         public void ScaleSrcU()

--- a/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.ML.CpuMath.UnitTests
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
-        public void ScaleUTest(int test)
+        public void ScaleTest(int test)
         {
             float[] dst = (float[])_testArrays[test].Clone();
             float[] expected = (float[])dst.Clone();


### PR DESCRIPTION
For inputs with fewer elements than can fit in the Vector type, it falls back to scalar code.
For inputs that are not naturally aligned (the alignment is not a multiple of 4), it does exclusively unaligned loads
For all other inputs, it will do at most two unaligned loads (one each for any leading/trailing unaligned elements) and all other loads will be aligned.

cc @eerhardt @tannergooding @danmosemsft 