### PR TITLE
Remove explicit ComponentCatalog parameter

### DIFF
--- a/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
@@ -588,7 +588,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             {
                 var entryPointNode = new EntryPointNode(env, ch, context, context.GenerateId(entryPointName), entryPointName,
                     inputBuilder.GetJsonObject(arguments, inputBindingMap, inputMap),
-                    outputHelper.GetJsonObject(outputMap), checkpoint, stageId: stageId, cost: cost);
+                    outputHelper.GetJsonObject(outputMap), checkpoint, stageId, cost);
 
                 ch.Done();
                 return entryPointNode;
@@ -929,7 +929,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         ch.Warning("Node '{0}' has unexpected fields that are ignored: {1}", id, string.Join(", ", unexpectedFields.Select(x => x.Name)));
                     }
 
-                    result.Add(new EntryPointNode(env, ch, context, id, nodeName, inputs, outputs, checkpoint, stageId: stageId, cost: cost, label: label, group: group, weight: weight, name: name));
+                    result.Add(new EntryPointNode(env, ch, context, id, nodeName, inputs, outputs, checkpoint, stageId, cost, label, group, weight, name));
                 }
 
                 ch.Done();

--- a/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
@@ -412,7 +412,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
         public readonly string Id;
 
         private readonly IHost _host;
-        private readonly ComponentCatalog _catalog;
         private readonly ComponentCatalog.EntryPointInfo _entryPoint;
         private readonly InputBuilder _inputBuilder;
         private readonly OutputHelper _outputHelper;
@@ -473,30 +472,29 @@ namespace Microsoft.ML.Runtime.EntryPoints
             }
         }
 
-        private EntryPointNode(IHostEnvironment env, IChannel ch, ComponentCatalog catalog, RunContext context,
-            string id, string entryPointName, JObject inputs, JObject outputs, bool checkpoint = false,
-            string stageId = "", float cost = float.NaN, string label = null, string group = null, string weight = null, string name = null)
+        private EntryPointNode(IHostEnvironment env, IChannel ch, RunContext context,
+          string id, string entryPointName, JObject inputs, JObject outputs, bool checkpoint = false,
+          string stageId = "", float cost = float.NaN, string label = null, string group = null, string weight = null,
+          string name = null)
         {
             Contracts.AssertValue(env);
             env.AssertNonEmpty(id);
             _host = env.Register(id);
             _host.AssertValue(context);
             _host.AssertNonEmpty(entryPointName);
-            _host.AssertValue(catalog);
             _host.AssertValueOrNull(inputs);
             _host.AssertValueOrNull(outputs);
 
             _context = context;
-            _catalog = catalog;
 
-            Id = id;
-            if (!catalog.TryFindEntryPoint(entryPointName, out _entryPoint))
+          Id = id;
+            if (!env.ComponentCatalog.TryFindEntryPoint(entryPointName, out _entryPoint))
                 throw _host.Except($"Entry point '{entryPointName}' not found");
 
             // Validate inputs.
             _inputMap = new Dictionary<ParameterBinding, VariableBinding>();
             _inputBindingMap = new Dictionary<string, List<ParameterBinding>>();
-            _inputBuilder = new InputBuilder(_host, _entryPoint.InputType, catalog);
+            _inputBuilder = new InputBuilder(_host, _entryPoint.InputType, env.ComponentCatalog);
 
             // REVIEW: This logic should move out of Node eventually and be delegated to
             // a class that can nest to handle Components with variables.
@@ -561,39 +559,36 @@ namespace Microsoft.ML.Runtime.EntryPoints
             }
         }
 
-        public static EntryPointNode Create(
-            IHostEnvironment env,
-            string entryPointName,
-            object arguments,
-            ComponentCatalog catalog,
-            RunContext context,
-            Dictionary<string, List<ParameterBinding>> inputBindingMap,
-            Dictionary<ParameterBinding, VariableBinding> inputMap,
-            Dictionary<string, string> outputMap,
-            bool checkpoint = false,
-            string stageId = "",
-            float cost = float.NaN)
+        public static EntryPointNode Create(IHostEnvironment env,
+          string entryPointName,
+          object arguments,
+          RunContext context,
+          Dictionary<string, List<ParameterBinding>> inputBindingMap,
+          Dictionary<ParameterBinding, VariableBinding> inputMap,
+          Dictionary<string, string> outputMap,
+          bool checkpoint = false,
+          string stageId = "",
+          float cost = float.NaN)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckNonEmpty(entryPointName, nameof(entryPointName));
             env.CheckValue(arguments, nameof(arguments));
-            env.CheckValue(catalog, nameof(catalog));
             env.CheckValue(context, nameof(context));
             env.CheckValue(inputBindingMap, nameof(inputBindingMap));
             env.CheckValue(inputMap, nameof(inputMap));
             env.CheckValue(outputMap, nameof(outputMap));
             ComponentCatalog.EntryPointInfo info;
-            bool success = catalog.TryFindEntryPoint(entryPointName, out info);
+            bool success = env.ComponentCatalog.TryFindEntryPoint(entryPointName, out info);
             env.Assert(success);
 
-            var inputBuilder = new InputBuilder(env, info.InputType, catalog);
+            var inputBuilder = new InputBuilder(env, info.InputType, env.ComponentCatalog);
             var outputHelper = new OutputHelper(env, info.OutputType);
 
             using (var ch = env.Start("Create EntryPointNode"))
             {
-                var entryPointNode = new EntryPointNode(env, ch, catalog, context, context.GenerateId(entryPointName), entryPointName,
+                var entryPointNode = new EntryPointNode(env, ch, context, context.GenerateId(entryPointName), entryPointName,
                     inputBuilder.GetJsonObject(arguments, inputBindingMap, inputMap),
-                    outputHelper.GetJsonObject(outputMap), checkpoint, stageId, cost);
+                    outputHelper.GetJsonObject(outputMap), checkpoint, stageId: stageId, cost: cost);
 
                 ch.Done();
                 return entryPointNode;
@@ -625,7 +620,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 inputParamBindingMap.Add(paramBinding, new SimpleVariableBinding(kvp.Value));
             }
 
-            return Create(env, entryPointName, arguments, catalog, context, inputBindingMap, inputParamBindingMap,
+            return Create(env, entryPointName, arguments, context, inputBindingMap, inputParamBindingMap,
                 outputMap, checkpoint, stageId, cost);
         }
 
@@ -855,7 +850,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
         private IEnumerable<EntryPointNode> _macroNodes;
 
         public IEnumerable<EntryPointNode> MacroNodes => _macroNodes;
-        public ComponentCatalog Catalog => _catalog;
+        public ComponentCatalog Catalog => _host.ComponentCatalog;
         public RunContext Context => _context;
         public Dictionary<string, List<ParameterBinding>> InputBindingMap => _inputBindingMap;
         public Dictionary<ParameterBinding, VariableBinding> InputMap => _inputMap;
@@ -895,12 +890,11 @@ namespace Microsoft.ML.Runtime.EntryPoints
         }
 
         public static List<EntryPointNode> ValidateNodes(IHostEnvironment env, RunContext context, JArray nodes,
-            ComponentCatalog catalog, string label = null, string group = null, string weight = null, string name = null)
+          string label = null, string group = null, string weight = null, string name = null)
         {
             Contracts.AssertValue(env);
             env.AssertValue(context);
             env.AssertValue(nodes);
-            env.AssertValue(catalog);
 
             var result = new List<EntryPointNode>(nodes.Count);
             using (var ch = env.Start("Validating graph nodes"))
@@ -935,7 +929,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         ch.Warning("Node '{0}' has unexpected fields that are ignored: {1}", id, string.Join(", ", unexpectedFields.Select(x => x.Name)));
                     }
 
-                    result.Add(new EntryPointNode(env, ch, catalog, context, id, nodeName, inputs, outputs, checkpoint, stageId, cost, label, group, weight, name));
+                    result.Add(new EntryPointNode(env, ch, context, id, nodeName, inputs, outputs, checkpoint, stageId: stageId, cost: cost, label: label, group: group, weight: weight, name: name));
                 }
 
                 ch.Done();
@@ -1011,7 +1005,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             _host.CheckValue(nodes, nameof(nodes));
 
             _context = new RunContext(_host);
-            _nodes = EntryPointNode.ValidateNodes(_host, _context, nodes, env.ComponentCatalog);
+            _nodes = EntryPointNode.ValidateNodes(_host, _context, nodes);
         }
 
         public bool HasRunnableNodes => _nodes.FirstOrDefault(x => x.CanStart()) != null;

--- a/src/Microsoft.ML.Data/Transforms/NormalizeUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeUtils.cs
@@ -158,15 +158,13 @@ namespace Microsoft.ML.Runtime.Data
             var entryPoints = new List<EntryPointNode>();
             if (columnsToNormalize.Count == 0)
             {
-                var entryPointNode = EntryPointNode.Create(env, "Transforms.NoOperation", new NopTransform.NopInput(),
-                    node.Catalog, node.Context, node.InputBindingMap, node.InputMap, node.OutputMap);
+                var entryPointNode = EntryPointNode.Create(env, "Transforms.NoOperation", new NopTransform.NopInput(), node.Context, node.InputBindingMap, node.InputMap, node.OutputMap);
                 entryPoints.Add(entryPointNode);
             }
             else
             {
                 input.Column = columnsToNormalize.ToArray();
-                var entryPointNode = EntryPointNode.Create(env, "Transforms.MinMaxNormalizer", input,
-                    node.Catalog, node.Context, node.InputBindingMap, node.InputMap, node.OutputMap);
+                var entryPointNode = EntryPointNode.Create(env, "Transforms.MinMaxNormalizer", input, node.Context, node.InputBindingMap, node.InputMap, node.OutputMap);
                 entryPoints.Add(entryPointNode);
             }
 

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/CrossValidationBinaryMacro.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/CrossValidationBinaryMacro.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             cvSplit.NumFolds = input.NumFolds;
             cvSplit.StratificationColumn = input.StratificationColumn;
             var cvSplitOutput = exp.Add(cvSplit);
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
             var predModelVars = new Var<IPredictorModel>[input.NumFolds];
             var warningsVars = new Var<IDataView>[input.NumFolds];
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             {
                 // Parse the nodes in input.Nodes into a temporary run context.
                 var context = new RunContext(env);
-                var graph = EntryPointNode.ValidateNodes(env, context, input.Nodes, node.Catalog);
+                var graph = EntryPointNode.ValidateNodes(env, context, input.Nodes);
 
                 // Rename all the variables such that they don't conflict with the ones in the outer run context.
                 var mapping = new Dictionary<string, string>();
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 var confusionMatrix = new Var<IDataView>();
                 outputMap.Add(nameof(TrainTestBinaryMacro.Output.ConfusionMatrix), confusionMatrix.VarName);
                 confusionMatrixVars[k] = confusionMatrix;
-                subGraphNodes.Add(EntryPointNode.Create(env, "Models.TrainTestBinaryEvaluator", args, node.Catalog, node.Context, inputBindingMap, inputMap, outputMap));
+                subGraphNodes.Add(EntryPointNode.Create(env, "Models.TrainTestBinaryEvaluator", args, node.Context, inputBindingMap, inputMap, outputMap));
             }
 
             exp.Reset();
@@ -203,7 +203,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             confusionMatricesOutput.OutputData.VarName = node.GetOutputVariableName(nameof(Output.ConfusionMatrix));
             exp.Add(confusionMatrices, confusionMatricesOutput);
 
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
             return new CommonOutputs.MacroOutput<Output>() { Nodes = subGraphNodes };
         }

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/CrossValidationMacro.cs
@@ -185,7 +185,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             cvSplit.NumFolds = input.NumFolds;
             cvSplit.StratificationColumn = input.StratificationColumn;
             var cvSplitOutput = exp.Add(cvSplit);
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
             var predModelVars = new Var<IPredictorModel>[input.NumFolds];
             var transformModelVars = new Var<ITransformModel>[input.NumFolds];
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             {
                 // Parse the nodes in input.Nodes into a temporary run context.
                 var context = new RunContext(env);
-                var graph = EntryPointNode.ValidateNodes(env, context, input.Nodes, node.Catalog);
+                var graph = EntryPointNode.ValidateNodes(env, context, input.Nodes);
 
                 // Rename all the variables such that they don't conflict with the ones in the outer run context.
                 var mapping = new Dictionary<string, string>();
@@ -278,7 +278,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
                         exp.Reset();
                         modelCombineOutput = exp.Add(modelCombine);
-                        subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+                        subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
                         transformModelVars[k] = modelCombineOutput.OutputModel;
                     }
                 }
@@ -297,7 +297,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
                         exp.Reset();
                         modelCombineOutput = exp.Add(modelCombine);
-                        subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+                        subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
                         predModelVars[k] = modelCombineOutput.PredictorModel;
                     }
                 }
@@ -315,7 +315,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 outputMap.Add(nameof(TrainTestMacro.Output.ConfusionMatrix), confusionMatrix.VarName);
                 confusionMatrixVars[k] = confusionMatrix;
                 const string trainTestEvaluatorMacroEntryPoint = "Models.TrainTestEvaluator";
-                subGraphNodes.Add(EntryPointNode.Create(env, trainTestEvaluatorMacroEntryPoint, args, node.Catalog, node.Context, inputBindingMap, inputMap, outputMap));
+                subGraphNodes.Add(EntryPointNode.Create(env, trainTestEvaluatorMacroEntryPoint, args, node.Context, inputBindingMap, inputMap, outputMap));
             }
 
             exp.Reset();
@@ -423,8 +423,8 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 combineConfusionMatrix.VarName = node.GetOutputVariableName(nameof(Output.ConfusionMatrix));
                 combineOutputMap.Add(nameof(TrainTestMacro.Output.ConfusionMatrix), combineConfusionMatrix.VarName);
             }
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
-            subGraphNodes.Add(EntryPointNode.Create(env, "Models.CrossValidationResultsCombiner", combineArgs, node.Catalog, node.Context, combineInputBindingMap, combineInputMap, combineOutputMap));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
+            subGraphNodes.Add(EntryPointNode.Create(env, "Models.CrossValidationResultsCombiner", combineArgs, node.Context, combineInputBindingMap, combineInputMap, combineOutputMap));
             return new CommonOutputs.MacroOutput<Output>() { Nodes = subGraphNodes };
         }
 

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/OneVersusAllMacro.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/OneVersusAllMacro.cs
@@ -66,12 +66,12 @@ namespace Microsoft.ML.Runtime.EntryPoints
             };
             var exp = new Experiment(env);
             var remapperOutNode = exp.Add(remapper);
-            var subNodes = EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog);
+            var subNodes = EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes());
             macroNodes.AddRange(subNodes);
 
             // Parse the nodes in input.Nodes into a temporary run context.
             var subGraphRunContext = new RunContext(env);
-            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, node.Catalog);
+            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes);
 
             // Rename all the variables such that they don't conflict with the ones in the outer run context.
             var mapping = new Dictionary<string, string>();
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             // Add nodes to main experiment.
             var nodes = macroExperiment.GetNodes();
-            var expNodes = EntryPointNode.ValidateNodes(env, node.Context, nodes, node.Catalog);
+            var expNodes = EntryPointNode.ValidateNodes(env, node.Context, nodes);
             macroNodes.AddRange(expNodes);
 
             return new CommonOutputs.MacroOutput<Output>() { Nodes = macroNodes };

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/TrainTestBinaryMacro.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/TrainTestBinaryMacro.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
         {
             // Parse the subgraph.
             var subGraphRunContext = new RunContext(env);
-            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, node.Catalog);
+            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes);
 
             // Change the subgraph to use the training data as input.
             var varName = input.Inputs.Data.VarName;
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             scoreNode.Data.VarName = testingVar.ToJson();
             scoreNode.PredictorModel.VarName = outputVarName;
             var scoreNodeOutput = exp.Add(scoreNode);
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
             // Add the evaluator node.
             exp.Reset();
@@ -126,7 +126,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             if (node.OutputMap.TryGetValue("ConfusionMatrix", out outVariableName))
                 evalOutput.ConfusionMatrix.VarName = outVariableName;
             exp.Add(evalNode, evalOutput);
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
             var stageId = Guid.NewGuid().ToString("N");
             foreach (var subGraphNode in subGraphNodes)

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/TrainTestMacro.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/TrainTestMacro.cs
@@ -121,10 +121,10 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             // Parse the subgraph.
             var subGraphRunContext = new RunContext(env);
-            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, node.Catalog, input.LabelColumn,
-                input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null,
-                input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null,
-                input.NameColumn.IsExplicit ? input.NameColumn.Value : null);
+            var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, label: input.LabelColumn,
+                group: input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null,
+                weight: input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null,
+                name: input.NameColumn.IsExplicit ? input.NameColumn.Value : null);
 
             // Change the subgraph to use the training data as input.
             var varName = input.Inputs.Data.VarName;
@@ -215,7 +215,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 scoreNodeOutput = exp.Add(scoreNode);
             }
 
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
             // Do not double-add previous nodes.
             exp.Reset();
@@ -256,7 +256,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     scoreNodeTrainingOutput = exp.Add(scoreNodeTraining);
                 }
 
-                subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+                subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
                 // Do not double-add previous nodes.
                 exp.Reset();
@@ -279,7 +279,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     eoTraining.ConfusionMatrix.VarName = outVariableName;
 
                 exp.Add(evalNodeTraining, evalOutputTraining);
-                subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+                subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
             }
 
             // Do not double-add previous nodes.
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 eo.ConfusionMatrix.VarName = outVariableName;
 
             exp.Add(evalNode, evalOutput);
-            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes(), node.Catalog));
+            subGraphNodes.AddRange(EntryPointNode.ValidateNodes(env, node.Context, exp.GetNodes()));
 
             // Marks as an atomic unit that can be run in
             // a distributed fashion.

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/TrainTestMacro.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/TrainTestMacro.cs
@@ -122,9 +122,9 @@ namespace Microsoft.ML.Runtime.EntryPoints
             // Parse the subgraph.
             var subGraphRunContext = new RunContext(env);
             var subGraphNodes = EntryPointNode.ValidateNodes(env, subGraphRunContext, input.Nodes, label: input.LabelColumn,
-                group: input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null,
-                weight: input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null,
-                name: input.NameColumn.IsExplicit ? input.NameColumn.Value : null);
+                input.GroupColumn.IsExplicit ? input.GroupColumn.Value : null,
+                input.WeightColumn.IsExplicit ? input.WeightColumn.Value : null,
+                input.NameColumn.IsExplicit ? input.NameColumn.Value : null);
 
             // Change the subgraph to use the training data as input.
             var varName = input.Inputs.Data.VarName;

--- a/src/Microsoft.ML.PipelineInference/Macros/PipelineSweeperMacro.cs
+++ b/src/Microsoft.ML.PipelineInference/Macros/PipelineSweeperMacro.cs
@@ -262,7 +262,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 var resultNode = new Microsoft.ML.Legacy.Models.SweepResultExtractor() { State = amlsVarObj };
                 var resultOutput = new Legacy.Models.SweepResultExtractor.Output() { State = outStateVar, Results = outDvVar };
                 resultSubgraph.Add(resultNode, resultOutput);
-                var resultSubgraphNodes = EntryPointNode.ValidateNodes(env, node.Context, resultSubgraph.GetNodes(), node.Catalog);
+                var resultSubgraphNodes = EntryPointNode.ValidateNodes(env, node.Context, resultSubgraph.GetNodes());
                 expNodes.AddRange(resultSubgraphNodes);
                 return new CommonOutputs.MacroOutput<Output>() { Nodes = expNodes };
             }
@@ -278,7 +278,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 var uniqueName = ExperimentUtils.GenerateOverallMetricVarName(p.UniqueId);
                 var uniqueNameTraining = AutoMlUtils.GenerateOverallTrainingMetricVarName(p.UniqueId);
                 var sgNode = EntryPointNode.ValidateNodes(env, node.Context,
-                    new JArray(subgraph.GetNodes().Last()), node.Catalog).Last();
+                    new JArray(subgraph.GetNodes().Last())).Last();
                 sgNode.RenameOutputVariable(trainTestOutput.OverallMetrics.VarName, uniqueName, cascadeChanges: true);
                 sgNode.RenameOutputVariable(trainTestOutput.TrainingOverallMetrics.VarName, uniqueNameTraining, cascadeChanges: true);
                 trainTestOutput.OverallMetrics.VarName = uniqueName;
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var output = new Legacy.Models.PipelineSweeper.Output() { Results = outDvVar, State = outStateVar };
             macroSubgraph.Add(macroNode, output);
 
-            var subgraphNodes = EntryPointNode.ValidateNodes(env, node.Context, macroSubgraph.GetNodes(), node.Catalog);
+            var subgraphNodes = EntryPointNode.ValidateNodes(env, node.Context, macroSubgraph.GetNodes());
             expNodes.AddRange(subgraphNodes);
 
             return new CommonOutputs.MacroOutput<Output>() { Nodes = expNodes };


### PR DESCRIPTION
ValidateNodes and EntryPointNode now use the ComponentCatalog
property of IHostEnvironment.

Following the conversation with @Ivanidzo4ka at #1135 

