### PR TITLE
TrainUtils.Train does not have consistent API usage

### DIFF
--- a/src/Microsoft.ML.Data/Commands/TrainCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainCommand.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         public static IPredictor Train(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer,
-            ICalibratorTrainerFactory calibrator, int maxCalibrationExamples)
+            IComponentFactory<ICalibratorTrainer> calibrator, int maxCalibrationExamples)
         {
             return TrainCore(env, ch, data, trainer, null, calibrator, maxCalibrationExamples, false);
         }


### PR DESCRIPTION
TrainUtils.Train does not have consistent API usage for the calibrator argument (#1023)

Updates the API signature for TrainUtils.Train to take in an IComponentFactory<ICalibratorTrainer>.

Fixes #1023