### PR TITLE
sweeping the space of link formats

### DIFF
--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
@@ -36,7 +36,19 @@ namespace Microsoft.ML.StaticPipe
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        ///  [!code-csharp[SDCA](../../../docs/samples/Microsoft.ML.Samples.StaticPipe/Trainers.cs?range=5-8,12-70) "The SDCA regression example."]
+        ///  [!code-csharp[SDCA](../../../docs/samples/Microsoft.ML.Samples/Trainers.cs?range=5-8,12-70 "The SDCA regression example.")]
+        /// ]]></format>
+        /// </example>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[SDCA](/Microsoft.ML.Samples/Trainers.cs?range=5-8,12-70 "The SDCA regression example.")]
+        /// ]]></format>
+        /// </example>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[SDCA](~/Microsoft.ML.Samples/Trainers.cs?range=5-8,12-70 "The SDCA regression example.")]
         /// ]]></format>
         /// </example>
         public static Scalar<float> Sdca(this RegressionContext.RegressionTrainers ctx,


### PR DESCRIPTION
Trying to correct the link format for the sample referenced from the documentation. 
