### PR TITLE
 OnnxTransform freezing - replace  tensor.CopyTo(List<float>) with tensor.CopyTo(float[]).

### DIFF
--- a/src/Microsoft.ML.OnnxTransform/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxUtils.cs
@@ -342,11 +342,8 @@ namespace Microsoft.ML.Transforms
         {
             if (typeof(T) == typeof(System.Single))
             {
-                // Sonoma only takes List<T>. We need to do an extra copy to T[]
-                var listDst = new List<System.Single>();
                 var typedDst = (System.Single[])(object)dst;
-                tensor.CopyTo(listDst);
-                listDst.CopyTo(typedDst);
+                tensor.CopyTo(typedDst);
             }
             else
                 throw new NotImplementedException($"Not implemented type {typeof(T)}");


### PR DESCRIPTION
Fixes #1228.

Reduce the number of data copies of a tensor. Use the Tensor.Copy() method to move contents directly into destination, rather than into a list[T] first, and then destination. 

