### PR TITLE
PredictionFunction doesn't reuse output

### DIFF
--- a/src/Microsoft.ML.Api/PredictionFunction.cs
+++ b/src/Microsoft.ML.Api/PredictionFunction.cs
@@ -17,6 +17,11 @@ namespace Microsoft.ML.Runtime.Data
     {
         private readonly PredictionEngine<TSrc, TDst> _engine;
 
+        /// <summary>
+        /// Create an instance of <see cref="PredictionFunction{TSrc, TDst}"/>.
+        /// </summary>
+        /// <param name="env">The host environment.</param>
+        /// <param name="transformer">The model (transformer) to use for prediction.</param>
         public PredictionFunction(IHostEnvironment env, ITransformer transformer)
         {
             Contracts.CheckValue(env, nameof(env));
@@ -26,7 +31,21 @@ namespace Microsoft.ML.Runtime.Data
             _engine = env.CreatePredictionEngine<TSrc, TDst>(transformer);
         }
 
+        /// <summary>
+        /// Perform one prediction using the model.
+        /// </summary>
+        /// <param name="example">The object that holds values to predict from.</param>
+        /// <returns>The object populated with prediction results.</returns>
         public TDst Predict(TSrc example) => _engine.Predict(example);
+
+        /// <summary>
+        /// Perform one prediction using the model.
+        /// Reuses the provided prediction object, which is more efficient in high-load scenarios.
+        /// </summary>
+        /// <param name="example">The object that holds values to predict from.</param>
+        /// <param name="prediction">The object to store the predictions in. If it's <c>null</c>, a new object is created,
+        /// otherwise the provided object is used.</param>
+        public void Predict(TSrc example, ref TDst prediction) => _engine.Predict(example, ref prediction);
     }
 
     public static class PredictionFunctionExtensions


### PR DESCRIPTION
Fixes #1279 
Fixes #1138 

Predict call no longer reuses the output object.
To retain the capability for efficient prediction, I added another overload to Predict which takes the output object as a parameter.