### PR TITLE
Hash estimator/transformer applicable to all numerics and bool

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/HashTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/HashTransform.cs
@@ -525,11 +525,11 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// The usage of this interface may seem a bit strange, but it is deliberately structured in this way.
         /// One will note all implementors of this interface are structs, and that where used, you never use
-        /// the interface itself but instead a type. This is due to how .NET and the JIT handles generic.
-        /// For value types, it will actually generate new assembly code, which will allow effectively code
-        /// generation in a way that would not happen if the hasher implementor was a class, or if the hasher
-        /// implementation was just passed in with a delegate, or the hashing logic was encapsulated as the
-        /// abstract method of some class.
+        /// the interface itself, but instead an implementing type. This is due to how .NET and the JIT handles
+        /// generic types that are also value types. For value types, it will actually generate new assembly
+        /// code, which will allow effectively code generation in a way that would not happen if the hasher
+        /// implementor was a class, or if the hasher implementation was just passed in with a delegate, or
+        /// the hashing logic was encapsulated as the abstract method of some class.
         ///
         /// In a prior time, there were methods for all possible combinations of types, scalarness, vector
         /// sparsity/density, whether the hash was sparsity preserving or not, whether it was ordered or not.
@@ -777,7 +777,7 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     // First fill in the values of the destination. This strategy assumes, of course,
-                    // that it is more performant to intiialize then fill in the exceptional (non-sparse)
+                    // that it is more performant to initialize then fill in the exceptional (non-sparse)
                     // values, rather than having complicated logic to do a simultaneous traversal of the
                     // sparse vs. dense array.
                     for (int i = 0; i < src.Length; ++i)

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -1,0 +1,185 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.ML.Data;
+using Microsoft.ML.Transforms;
+using Microsoft.ML.Runtime;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Api;
+using Microsoft.ML.Runtime.Learners;
+using System.Linq;
+
+namespace Microsoft.ML.Benchmarks
+{
+    public class HashBench
+    {
+        private sealed class Counted : ICounted
+        {
+            public long Position { get; set; }
+
+            public long Batch => 0;
+
+            public ValueGetter<UInt128> GetIdGetter()
+                => (ref UInt128 val) => val = new UInt128((ulong)Position, 0);
+        }
+
+        private const int Count = 100_000;
+
+        private readonly IHostEnvironment _env = new LocalEnvironment();
+
+        private Counted _counted;
+        private ValueGetter<uint> _getter;
+        private ValueGetter<VBuffer<uint>> _vecGetter;
+
+        private void InitMap<T>(T val, ColumnType type, int hashBits = 20)
+        {
+            var col = RowColumnUtils.GetColumn("Foo", type, ref val);
+            _counted = new Counted();
+            var inRow = RowColumnUtils.GetRow(_counted, col);
+            // One million features is a nice, typical number.
+            var info = new HashTransformer.ColumnInfo("Foo", "Bar", hashBits: hashBits);
+            var xf = new HashTransformer(_env, new[] { info });
+            var mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper.Schema.TryGetColumnIndex("Bar", out int outCol);
+            var outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            if (type.IsVector)
+                _vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            else
+                _getter = outRow.GetGetter<uint>(outCol);
+        }
+
+        /// <summary>
+        /// All the scalar mappers have the same output type.
+        /// </summary>
+        private void RunScalar()
+        {
+            uint val = default;
+            for (int i = 0; i < Count; ++i)
+            {
+                _getter(ref val);
+                ++_counted.Position;
+            }
+        }
+
+        private void InitDenseVecMap<T>(T[] vals, PrimitiveType itemType, int hashBits = 20)
+        {
+            var vbuf = new VBuffer<T>(vals.Length, vals);
+            InitMap(vbuf, new VectorType(itemType, vals.Length), hashBits);
+        }
+
+        /// <summary>
+        /// All the vector mappers have the same output type.
+        /// </summary>
+        private void RunVector()
+        {
+            VBuffer<uint> val = default;
+            for (int i = 0; i < Count; ++i)
+            {
+                _vecGetter(ref val);
+                ++_counted.Position;
+            }
+        }
+
+        [GlobalSetup(Target = nameof(HashScalarString))]
+        public void SetupHashScalarString()
+        {
+            InitMap("Hello".AsMemory(), TextType.Instance);
+        }
+
+        [Benchmark]
+        public void HashScalarString()
+        {
+            RunScalar();
+        }
+
+        [GlobalSetup(Target = nameof(HashScalarFloat))]
+        public void SetupHashScalarFloat()
+        {
+            InitMap(5.0f, NumberType.R4);
+        }
+
+        [Benchmark]
+        public void HashScalarFloat()
+        {
+            RunScalar();
+        }
+
+        [GlobalSetup(Target = nameof(HashScalarDouble))]
+        public void SetupHashScalarDouble()
+        {
+            InitMap(5.0, NumberType.R8);
+        }
+
+        [Benchmark]
+        public void HashScalarDouble()
+        {
+            RunScalar();
+        }
+
+        [GlobalSetup(Target = nameof(HashScalarKey))]
+        public void SetupHashScalarKey()
+        {
+            InitMap(6u, new KeyType(DataKind.U4, 0, 100));
+        }
+
+        [Benchmark]
+        public void HashScalarKey()
+        {
+            RunScalar();
+        }
+
+
+
+        [GlobalSetup(Target = nameof(HashVectorString))]
+        public void SetupHashVectorString()
+        {
+            var tokens = "Hello my friend, stay awhile and listen! ".Split().Select(token => token.AsMemory()).ToArray();
+            InitDenseVecMap(tokens, TextType.Instance);
+        }
+
+        [Benchmark]
+        public void HashVectorString()
+        {
+            RunVector();
+        }
+
+        [GlobalSetup(Target = nameof(HashVectorFloat))]
+        public void SetupHashVectorFloat()
+        {
+            InitDenseVecMap(new[] { 1f, 2f, 3f, 4f, 5f }, NumberType.R4);
+        }
+
+        [Benchmark]
+        public void HashVectorFloat()
+        {
+            RunVector();
+        }
+
+        [GlobalSetup(Target = nameof(HashVectorDouble))]
+        public void SetupHashVectorDouble()
+        {
+            InitDenseVecMap(new[] { 1d, 2d, 3d, 4d, 5d }, NumberType.R8);
+        }
+
+        [Benchmark]
+        public void HashVectorDouble()
+        {
+            RunVector();
+        }
+
+        [GlobalSetup(Target = nameof(HashVectorKey))]
+        public void SetupHashVectorKey()
+        {
+            InitDenseVecMap(new[] { 1u, 2u, 0u, 4u, 5u }, new KeyType(DataKind.U4, 0, 100));
+        }
+
+        [Benchmark]
+        public void HashVectorKey()
+        {
+            RunVector();
+        }
+    }
+}

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.ML.Runtime.Api;
 using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Model;
 using Microsoft.ML.Runtime.RunTests;
 using Microsoft.ML.Runtime.Tools;
@@ -89,7 +90,7 @@ namespace Microsoft.ML.Tests.Transformers
             result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, HashA, ref keys);
             Assert.True(keys.Length == 1024);
             //REVIEW: This is weird. I specified invertHash to 1 so I expect only one value to be in key values, but i got two.
-            Assert.Equal(keys.Items().Select(x => x.Value.ToString()), new string[2] {"2.5", "3.5" });
+            Assert.Equal(keys.Items().Select(x => x.Value.ToString()), new string[2] { "2.5", "3.5" });
 
             types = result.Schema.GetMetadataTypes(HashAUnlim);
             Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues });
@@ -129,6 +130,182 @@ namespace Microsoft.ML.Tests.Transformers
                 ms.Position = 0;
                 var loadedView = ModelFileUtils.LoadTransforms(Env, dataView, ms);
             }
+        }
+
+        private sealed class Counted : ICounted
+        {
+            public long Position => 0;
+            public long Batch => 0;
+            public ValueGetter<UInt128> GetIdGetter() => (ref UInt128 val) => val = default;
+        }
+
+        private void HashTestCore<T>(T val, PrimitiveType type, uint expected, uint expectedOrdered, uint expectedOrdered3)
+        {
+            const int bits = 10;
+
+            var col = RowColumnUtils.GetColumn("Foo", type, ref val);
+            var inRow = RowColumnUtils.GetRow(new Counted(), col);
+
+            // First do an unordered hash.
+            var info = new HashTransformer.ColumnInfo("Foo", "Bar", hashBits: bits);
+            var xf = new HashTransformer(Env, new[] { info });
+            var mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper.Schema.TryGetColumnIndex("Bar", out int outCol);
+            var outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+
+            var getter = outRow.GetGetter<uint>(outCol);
+            uint result = 0;
+            getter(ref result);
+            Assert.Equal(expected, result);
+
+            // Next do an ordered hash.
+            info = new HashTransformer.ColumnInfo("Foo", "Bar", hashBits: bits, ordered: true);
+            xf = new HashTransformer(Env, new[] { info });
+            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper.Schema.TryGetColumnIndex("Bar", out outCol);
+            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+
+            getter = outRow.GetGetter<uint>(outCol);
+            getter(ref result);
+            Assert.Equal(expectedOrdered, result);
+
+            // Next build up a vector to make sure that hashing is consistent between scalar values
+            // at least in the first position, and in the unordered case, the last position.
+            const int vecLen = 5;
+            var denseVec = new VBuffer<T>(vecLen, Utils.CreateArray(vecLen, val));
+            col = RowColumnUtils.GetColumn("Foo", new VectorType(type, vecLen), ref denseVec);
+            inRow = RowColumnUtils.GetRow(new Counted(), col);
+
+            info = new HashTransformer.ColumnInfo("Foo", "Bar", hashBits: bits, ordered: false);
+            xf = new HashTransformer(Env, new[] { info });
+            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper.Schema.TryGetColumnIndex("Bar", out outCol);
+            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+
+            var vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            VBuffer<uint> vecResult = default;
+            vecGetter(ref vecResult);
+
+            Assert.Equal(vecLen, vecResult.Length);
+            // They all should equal this in this case.
+            Assert.All(vecResult.DenseValues(), v => Assert.Equal(expected, v));
+
+            // Now do ordered with the dense vector.
+            info = new HashTransformer.ColumnInfo("Foo", "Bar", hashBits: bits, ordered: true);
+            xf = new HashTransformer(Env, new[] { info });
+            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper.Schema.TryGetColumnIndex("Bar", out outCol);
+            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            vecGetter(ref vecResult);
+
+            Assert.Equal(vecLen, vecResult.Length);
+            Assert.Equal(expectedOrdered, vecResult.GetItemOrDefault(0));
+            Assert.Equal(expectedOrdered3, vecResult.GetItemOrDefault(3));
+            Assert.All(vecResult.DenseValues(), v => Assert.True((v == 0) == (expectedOrdered == 0)));
+
+            // Let's now do a sparse vector.
+            var sparseVec = new VBuffer<T>(10, 3, Utils.CreateArray(3, val), new[] { 0, 3, 7 });
+            col = RowColumnUtils.GetColumn("Foo", new VectorType(type, vecLen), ref sparseVec);
+            inRow = RowColumnUtils.GetRow(new Counted(), col);
+
+            info = new HashTransformer.ColumnInfo("Foo", "Bar", hashBits: bits, ordered: false);
+            xf = new HashTransformer(Env, new[] { info });
+            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper.Schema.TryGetColumnIndex("Bar", out outCol);
+            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            vecGetter(ref vecResult);
+
+            Assert.Equal(10, vecResult.Length);
+            Assert.Equal(expected, vecResult.GetItemOrDefault(0));
+            Assert.Equal(expected, vecResult.GetItemOrDefault(3));
+            Assert.Equal(expected, vecResult.GetItemOrDefault(7));
+
+            info = new HashTransformer.ColumnInfo("Foo", "Bar", hashBits: bits, ordered: true);
+            xf = new HashTransformer(Env, new[] { info });
+            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper.Schema.TryGetColumnIndex("Bar", out outCol);
+            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            vecGetter(ref vecResult);
+
+            Assert.Equal(10, vecResult.Length);
+            Assert.Equal(expectedOrdered, vecResult.GetItemOrDefault(0));
+            Assert.Equal(expectedOrdered3, vecResult.GetItemOrDefault(3));
+        }
+
+        private void HashTestPositiveIntegerCore(ulong value, uint expected, uint expectedOrdered, uint expectedOrdered3)
+        {
+            uint eKey = value == 0 ? 0 : expected;
+            uint eoKey = value == 0 ? 0 : expectedOrdered;
+            uint e3Key = value == 0 ? 0 : expectedOrdered3;
+
+            if (value <= byte.MaxValue)
+            {
+                HashTestCore((byte)value, NumberType.U1, expected, expectedOrdered, expectedOrdered3);
+                HashTestCore((byte)value, new KeyType(DataKind.U1, 0, byte.MaxValue - 1), eKey, eoKey, e3Key);
+            }
+            if (value <= ushort.MaxValue)
+            {
+                HashTestCore((ushort)value, NumberType.U2, expected, expectedOrdered, expectedOrdered3);
+                HashTestCore((ushort)value, new KeyType(DataKind.U2, 0, ushort.MaxValue - 1), eKey, eoKey, e3Key);
+            }
+            if (value <= uint.MaxValue)
+            {
+                HashTestCore((uint)value, NumberType.U4, expected, expectedOrdered, expectedOrdered3);
+                HashTestCore((uint)value, new KeyType(DataKind.U4, 0, int.MaxValue - 1), eKey, eoKey, e3Key);
+            }
+            HashTestCore(value, NumberType.U8, expected, expectedOrdered, expectedOrdered3);
+            HashTestCore((ulong)value, new KeyType(DataKind.U8, 0, 0), eKey, eoKey, e3Key);
+
+            HashTestCore(new UInt128(value, 0), NumberType.UG, expected, expectedOrdered, expectedOrdered3);
+
+            // Next let's check signed numbers.
+
+            if (value <= (ulong)sbyte.MaxValue)
+                HashTestCore((sbyte)value, NumberType.I1, expected, expectedOrdered, expectedOrdered3);
+            if (value <= (ulong)short.MaxValue)
+                HashTestCore((short)value, NumberType.I2, expected, expectedOrdered, expectedOrdered3);
+            if (value <= int.MaxValue)
+                HashTestCore((int)value, NumberType.I4, expected, expectedOrdered, expectedOrdered3);
+            if (value <= long.MaxValue)
+                HashTestCore((long)value, NumberType.I8, expected, expectedOrdered, expectedOrdered3);
+        }
+
+        [Fact]
+        public void TestHashIntegerNumbers()
+        {
+            HashTestPositiveIntegerCore(0, 848, 567, 518);
+            HashTestPositiveIntegerCore(1, 492, 523, 1013);
+            HashTestPositiveIntegerCore(2, 676, 512, 863);
+        }
+
+        [Fact]
+        public void TestHashString()
+        {
+            HashTestCore("".AsMemory(), TextType.Instance, 0, 0, 0);
+            HashTestCore("hello".AsMemory(), TextType.Instance, 326, 636, 307);
+        }
+
+        [Fact]
+        public void TestHashFloatingPointNumbers()
+        {
+            HashTestCore(1f, NumberType.R4, 933, 67, 270);
+            HashTestCore(-1f, NumberType.R4, 505, 589, 245);
+            HashTestCore(0f, NumberType.R4, 848, 567, 518);
+            // Note that while we have the hash for numeric types be equal, the same is not necessarily the case for floating point numbers.
+            HashTestCore(1d, NumberType.R8, 671, 728, 123);
+            HashTestCore(-1d, NumberType.R8, 803, 699, 790);
+            HashTestCore(0d, NumberType.R8, 848, 567, 518);
+        }
+
+        [Fact]
+        public void TestHashBool()
+        {
+            // These are the same for the hashes of 0 and 1.
+            HashTestCore(false, BoolType.Instance, 848, 567, 518);
+            HashTestCore(true, BoolType.Instance, 492, 523, 1013);
         }
     }
 }


### PR DESCRIPTION
Fixes #1031. Hashes all numeric types, and boolean types. "Time" types are omitted, because I don't anticipate great desire for them, but they could potentially be more easily added.

I engaged in some trickery around the JIT's handlings of generics and value types in order to maintain efficiency of the previous "explicit" implementation. Please see the comment starting line 526 in the last commit (as of the time of writing) for more info.

There are to start three commits, that are deliberately structured in a way so as to be useful:

1. Introduction of benchmarks,
2. Simplification of code,
3. Expanding of types.

The benchmarking is somewhat interesting. The variation between different runs of the benchmarks was all over the place with the old code (for some reason), but not on the new code for some reason. I'm not quite sure why. Anyway these were the first runs from each.

## Before

|            Method |        Mean |      Error |     StdDev |
| ----------------- |------------ |----------- |----------- |
|  HashScalarString |  4,738.1 us | 146.250 us | 168.421 us |
|   HashScalarFloat |  1,172.0 us |  30.922 us |  34.370 us |
|  HashScalarDouble |  1,535.2 us |  28.194 us |  26.373 us |
|     HashScalarKey |    965.2 us |  18.733 us |  18.398 us |
|  HashVectorString | 28,295.6 us | 554.444 us | 569.373 us |
|   HashVectorFloat | 10,442.6 us |   6.021 us |   5.338 us |
|  HashVectorDouble | 12,501.8 us | 240.539 us | 267.359 us |
|     HashVectorKey |  9,839.5 us | 270.684 us | 265.848 us |

## After

|            Method |        Mean |      Error |     StdDev |
| -----------------:|------------:|-----------:|-----------:|
|  HashScalarString |  4,769.2 us | 125.379 us | 144.387 us |
|   HashScalarFloat |  1,094.3 us |   4.808 us |   3.754 us |
|  HashScalarDouble |  1,529.9 us |  33.315 us |  29.533 us |
|     HashScalarKey |    960.3 us |  17.989 us |  19.248 us |
|  HashVectorString | 28,513.9 us | 520.837 us | 487.191 us |
|   HashVectorFloat |  9,932.0 us | 231.398 us | 257.198 us |
|  HashVectorDouble | 12,264.1 us | 286.483 us | 329.915 us |
|     HashVectorKey |  9,118.8 us | 178.890 us | 167.334 us || 
