### PR TITLE
Introducing official x86 CI build

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -25,6 +25,13 @@ phases:
 
 - template: /build/ci/phase-template.yml
   parameters:
+    name: Windows_NT_x86
+    buildScript: build.cmd -buildArch=x86
+    queue:
+      name: Hosted VS2017
+
+- template: /build/ci/phase-template.yml
+  parameters:
     name: MacOS
     buildScript: ./build.sh
     queue:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -21,13 +21,6 @@ phases:
     name: Windows_NT
     buildScript: build.cmd
     queue:
-      name: Hosted VS2017 
-
-- template: /build/ci/phase-template.yml
-  parameters:
-    name: Windows_NT_x86
-    buildScript: build.cmd -buildArch=x86
-    queue:
       name: Hosted VS2017
 
 - template: /build/ci/phase-template.yml

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -119,7 +119,7 @@ phases:
   queue:
     name: DotNetCore-Build
     demands: 
-      - agent.os -equals Windows_x86
+      - agent.os -equals win_x86
   steps:
 
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -119,7 +119,7 @@ phases:
   queue:
     name: DotNetCore-Build
     demands: 
-      - agent.os -equals win_x86
+      - agent.os -equals Windows_NT
   steps:
 
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -58,6 +58,53 @@ phases:
       artifactType: container
 
 ################################################################################
+- phase: Windows_x86
+################################################################################
+  variables:
+    BuildConfig: Release
+    OfficialBuildId: $(BUILD.BUILDNUMBER)
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+    DOTNET_MULTILEVEL_LOOKUP: 0
+    _SignType: real
+    _UseEsrpSigning: true
+    _TeamName: DotNetCore
+  queue:
+    name: DotNetCore-Build
+    demands: 
+      - agent.os -equals Windows_NT
+  steps:
+
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+    displayName: Install MicroBuild Signing Plugin
+    inputs:
+      signType: '$(_SignType)'
+      zipSources: false
+      esrpSigning: '$(_UseEsrpSigning)'
+    env:
+      TeamName: $(_TeamName)
+    continueOnError: false
+    condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
+
+  - script: ./build.cmd -buildNative -$(BuildConfig) -buildArch=x86
+    displayName: Build
+  
+  - task: MSBuild@1
+    displayName: Sign Windows_x86 Binaries
+    inputs:
+      solution: build/sign.proj
+      msbuildArguments: /p:SignType=$(_SignType)
+      msbuildVersion: 15.0
+    continueOnError: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Windows_x86 package assets
+    inputs:
+      pathToPublish: $(Build.SourcesDirectory)/bin/obj/packages
+      artifactName: PackageAssets
+      artifactType: container
+
+################################################################################
 - phase: Windows
 ################################################################################
   variables:
@@ -99,53 +146,6 @@ phases:
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Windows package assets
-    inputs:
-      pathToPublish: $(Build.SourcesDirectory)/bin/obj/packages
-      artifactName: PackageAssets
-      artifactType: container
-
-################################################################################
-- phase: Windows_x86
-################################################################################
-  variables:
-    BuildConfig: Release
-    OfficialBuildId: $(BUILD.BUILDNUMBER)
-    DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-    DOTNET_MULTILEVEL_LOOKUP: 0
-    _SignType: real
-    _UseEsrpSigning: true
-    _TeamName: DotNetCore
-  queue:
-    name: DotNetCore-Build
-    demands: 
-      - agent.os -equals Windows_NT
-  steps:
-
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
-    displayName: Install MicroBuild Signing Plugin
-    inputs:
-      signType: '$(_SignType)'
-      zipSources: false
-      esrpSigning: '$(_UseEsrpSigning)'
-    env:
-      TeamName: $(_TeamName)
-    continueOnError: false
-    condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
-
-  - script: ./build.cmd -$(BuildConfig) -buildArch=x86
-    displayName: Build
-  
-  - task: MSBuild@1
-    displayName: Sign Windows_x86 Binaries
-    inputs:
-      solution: build/sign.proj
-      msbuildArguments: /p:SignType=$(_SignType)
-      msbuildVersion: 15.0
-    continueOnError: false
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Windows_x86 package assets
     inputs:
       pathToPublish: $(Build.SourcesDirectory)/bin/obj/packages
       artifactName: PackageAssets

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -105,7 +105,7 @@ phases:
       artifactType: container
 
 ################################################################################
-- phase: Windows
+- phase: Windows_x64
 ################################################################################
   variables:
     BuildConfig: Release
@@ -157,8 +157,8 @@ phases:
   dependsOn:
   - Linux
   - MacOS
-  - Windows
   - Windows_x86
+  - Windows_x64
   variables:
     BuildConfig: Release
     OfficialBuildId: $(BUILD.BUILDNUMBER)

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -23,6 +23,7 @@ phases:
     - agent.os -equals linux
     container: LinuxContainer
   steps:
+  # Only build native assets to avoid conflicts.
   - script: ./build.sh -buildNative -$(BuildConfig)
     displayName: Build
 
@@ -47,6 +48,7 @@ phases:
     demands:
     - agent.os -equals Darwin
   steps:
+  # Only build native assets to avoid conflicts.
   - script: ./build.sh -buildNative -$(BuildConfig)
     displayName: Build
 
@@ -86,6 +88,7 @@ phases:
     continueOnError: false
     condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
+  # Only build native assets to avoid conflicts.
   - script: ./build.cmd -buildNative -$(BuildConfig) -buildArch=x86
     displayName: Build
   
@@ -133,11 +136,12 @@ phases:
     continueOnError: false
     condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
+  # Build both native and managed assets. 
   - script: ./build.cmd -$(BuildConfig)
     displayName: Build
   
   - task: MSBuild@1
-    displayName: Sign Windows Binaries
+    displayName: Sign Windows_x64 Binaries
     inputs:
       solution: build/sign.proj
       msbuildArguments: /p:SignType=$(_SignType)
@@ -145,7 +149,7 @@ phases:
     continueOnError: false
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish Windows package assets
+    displayName: Publish Windows_x64 package assets
     inputs:
       pathToPublish: $(Build.SourcesDirectory)/bin/obj/packages
       artifactName: PackageAssets

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -105,12 +105,60 @@ phases:
       artifactType: container
 
 ################################################################################
+- phase: Windows_x86
+################################################################################
+  variables:
+    BuildConfig: Release
+    OfficialBuildId: $(BUILD.BUILDNUMBER)
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+    DOTNET_MULTILEVEL_LOOKUP: 0
+    _SignType: real
+    _UseEsrpSigning: true
+    _TeamName: DotNetCore
+  queue:
+    name: DotNetCore-Build
+    demands: 
+      - agent.os -equals Windows
+  steps:
+
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+    displayName: Install MicroBuild Signing Plugin
+    inputs:
+      signType: '$(_SignType)'
+      zipSources: false
+      esrpSigning: '$(_UseEsrpSigning)'
+    env:
+      TeamName: $(_TeamName)
+    continueOnError: false
+    condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
+
+  - script: ./build.cmd -$(BuildConfig) -buildArch=x86
+    displayName: Build
+  
+  - task: MSBuild@1
+    displayName: Sign Windows_x86 Binaries
+    inputs:
+      solution: build/sign.proj
+      msbuildArguments: /p:SignType=$(_SignType)
+      msbuildVersion: 15.0
+    continueOnError: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Windows_x86 package assets
+    inputs:
+      pathToPublish: $(Build.SourcesDirectory)/bin/obj/packages
+      artifactName: PackageAssets
+      artifactType: container
+
+################################################################################
 - phase: Package
 ################################################################################
   dependsOn:
   - Linux
   - MacOS
   - Windows
+  - Windows_x86
   variables:
     BuildConfig: Release
     OfficialBuildId: $(BUILD.BUILDNUMBER)

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -119,7 +119,7 @@ phases:
   queue:
     name: DotNetCore-Build
     demands: 
-      - agent.os -equals Windows
+      - agent.os -equals Windows_x86
   steps:
 
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1


### PR DESCRIPTION
Fixes #1295.

Adding x86 official build. I tested the official build directly on VSTS and it succeeded. I also created a x86 App locally and tested that the nuget packages published to VSTS by the build worked.
