### PR TITLE
-0 parsing corrected and digitsofPrecision added

### DIFF
--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -374,9 +374,9 @@ namespace Microsoft.ML.Runtime.RunTests
                         foldGetter(ref fold);
                         Assert.True(ReadOnlyMemoryUtils.EqualsStr("Standard Deviation", fold));
                         if (w == 1)
-                            Assert.Equal(1.584696, stdev, 6);
+                            Assert.Equal(1.584696, stdev, 3);
                         else
-                            Assert.Equal(1.385165, stdev, 6);
+                            Assert.Equal(1.385165, stdev, 2);
                         isWeightedGetter(ref isWeighted);
                         Assert.True(isWeighted == (w == 1));
                     }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -374,9 +374,9 @@ namespace Microsoft.ML.Runtime.RunTests
                         foldGetter(ref fold);
                         Assert.True(ReadOnlyMemoryUtils.EqualsStr("Standard Deviation", fold));
                         if (w == 1)
-                            Assert.Equal(1.584696, stdev, 3);
+                            Assert.Equal(1.585, stdev, 3);
                         else
-                            Assert.Equal(1.385165, stdev, 2);
+                            Assert.Equal(1.39, stdev, 2);
                         isWeightedGetter(ref isWeighted);
                         Assert.True(isWeighted == (w == 1));
                     }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -3630,10 +3630,10 @@ namespace Microsoft.ML.Runtime.RunTests
                     DataSaverUtils.SaveDataView(ch, saver, mcOutput.Stats, file);
             }
 
-            CheckEquality(@"../Common/EntryPoints", "lr-weights.txt");
-            CheckEquality(@"../Common/EntryPoints", "lr-stats.txt");
-            CheckEquality(@"../Common/EntryPoints", "mc-lr-weights.txt");
-            CheckEquality(@"../Common/EntryPoints", "mc-lr-stats.txt");
+            CheckEquality(@"../Common/EntryPoints", "lr-weights.txt", digitsOfPrecision: 6);
+            CheckEquality(@"../Common/EntryPoints", "lr-stats.txt", digitsOfPrecision: 6);
+            CheckEquality(@"../Common/EntryPoints", "mc-lr-weights.txt", digitsOfPrecision: 3);
+            CheckEquality(@"../Common/EntryPoints", "mc-lr-stats.txt", digitsOfPrecision: 5);
             Done();
         }
 
@@ -3675,7 +3675,7 @@ namespace Microsoft.ML.Runtime.RunTests
                         DataSaverUtils.SaveDataView(ch, saver, output.Summary, file);
                 }
 
-                CheckEquality(@"../Common/EntryPoints", "pca-weights.txt");
+                CheckEquality(@"../Common/EntryPoints", "pca-weights.txt", digitsOfPrecision: 4);
                 Done();
             }
         }

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [TestCategory("Logistic Regression")]
         public void MulticlassLRTest()
         {
-            RunOneAllTests(TestLearners.multiclassLogisticRegression, TestDatasets.iris, digitsOfPrecision: 2);
+            RunOneAllTests(TestLearners.multiclassLogisticRegression, TestDatasets.iris, digitsOfPrecision: 4);
             Done();
         }
 
@@ -1366,7 +1366,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void RandomCalibratorPerceptronTest()
         {
             var datasets = GetDatasetsForCalibratorTest();
-            RunAllTests(new[] { TestLearners.perceptronDefault }, datasets, new string[] { "numcali=200" }, "calibrateRandom", digitsOfPrecision: 1);
+            RunAllTests(new[] { TestLearners.perceptronDefault }, datasets, new string[] { "numcali=200" }, "calibrateRandom");
             Done();
         }
 

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -108,7 +108,7 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             var binaryPredictors = new[] { TestLearners.perceptron };
             var binaryClassificationDatasets = GetDatasetsForBinaryClassifierBaseTest();
-            RunAllTests(binaryPredictors, binaryClassificationDatasets);
+            RunAllTests(binaryPredictors, binaryClassificationDatasets, digitsOfPrecision: 6);
             Done();
         }
 
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [TestCategory("Logistic Regression")]
         public void MulticlassLRTest()
         {
-            RunOneAllTests(TestLearners.multiclassLogisticRegression, TestDatasets.iris, digitsOfPrecision: 4);
+            RunOneAllTests(TestLearners.multiclassLogisticRegression, TestDatasets.iris, digitsOfPrecision: 2);
             Done();
         }
 
@@ -253,7 +253,7 @@ namespace Microsoft.ML.Runtime.RunTests
                     TestLearners.binarySgdHinge
                 };
             var binaryClassificationDatasets = GetDatasetsForBinaryClassifierBaseTest();
-            RunAllTests(binaryPredictors, binaryClassificationDatasets);
+            RunAllTests(binaryPredictors, binaryClassificationDatasets, digitsOfPrecision: 5);
             Done();
         }
 
@@ -265,7 +265,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void BinaryClassifierLogisticRegressionTest()
         {
             var binaryPredictors = new[] { TestLearners.logisticRegression };
-            RunOneAllTests(TestLearners.logisticRegression, TestDatasets.breastCancer, summary: true);
+            RunOneAllTests(TestLearners.logisticRegression, TestDatasets.breastCancer, summary: true, digitsOfPrecision: 3);
             // RunOneAllTests(TestLearners.logisticRegression, TestDatasets.msm);
             Done();
         }
@@ -278,7 +278,7 @@ namespace Microsoft.ML.Runtime.RunTests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 return;
 
-            RunOneAllTests(TestLearners.symSGD, TestDatasets.breastCancer, summary: true);
+            RunOneAllTests(TestLearners.symSGD, TestDatasets.breastCancer, summary: true, digitsOfPrecision: 4);
             Done();
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             var binaryPredictors = new[] { TestLearners.logisticRegression };
             var binaryClassificationDatasets = new[] { TestDatasets.breastCancer };
-            RunAllTests(binaryPredictors, binaryClassificationDatasets, new[] { "eval=BinaryClassifier{threshold=0.95 useRawScore=-}" }, "withThreshold");
+            RunAllTests(binaryPredictors, binaryClassificationDatasets, new[] { "eval=BinaryClassifier{threshold=0.95 useRawScore=-}" }, "withThreshold", digitsOfPrecision: 3);
             Done();
         }
 
@@ -301,7 +301,7 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             var binaryPredictors = new[] { TestLearners.logisticRegressionNorm };
             var binaryClassificationDatasets = GetDatasetsForBinaryClassifierBaseTest();
-            RunAllTests(binaryPredictors, binaryClassificationDatasets);
+            RunAllTests(binaryPredictors, binaryClassificationDatasets, digitsOfPrecision: 5);
             Done();
         }
 
@@ -327,7 +327,7 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             var binaryPredictors = new[] { TestLearners.logisticRegressionBinNorm };
             var binaryClassificationDatasets = GetDatasetsForBinaryClassifierBaseTest();
-            RunAllTests(binaryPredictors, binaryClassificationDatasets);
+            RunAllTests(binaryPredictors, binaryClassificationDatasets, digitsOfPrecision: 6);
             Done();
         }
 
@@ -340,7 +340,7 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             var binaryPredictors = new[] { TestLearners.logisticRegressionGaussianNorm };
             var binaryClassificationDatasets = GetDatasetsForBinaryClassifierBaseTest();
-            RunAllTests(binaryPredictors, binaryClassificationDatasets);
+            RunAllTests(binaryPredictors, binaryClassificationDatasets, digitsOfPrecision: 4);
             Done();
         }
 
@@ -934,7 +934,7 @@ namespace Microsoft.ML.Runtime.RunTests
         [TestCategory("Regressor")]
         public void RegressorOlsTestOne()
         {
-            Run_TrainTest(TestLearners.Ols, TestDatasets.generatedRegressionDataset);
+            Run_TrainTest(TestLearners.Ols, TestDatasets.generatedRegressionDataset, digitsOfPrecision: 4);
             Done();
         }
 
@@ -1366,7 +1366,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void RandomCalibratorPerceptronTest()
         {
             var datasets = GetDatasetsForCalibratorTest();
-            RunAllTests(new[] { TestLearners.perceptronDefault }, datasets, new string[] { "numcali=200" }, "calibrateRandom");
+            RunAllTests(new[] { TestLearners.perceptronDefault }, datasets, new string[] { "numcali=200" }, "calibrateRandom", digitsOfPrecision: 1);
             Done();
         }
 
@@ -1378,7 +1378,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void NoCalibratorLinearSvmTest()
         {
             var datasets = GetDatasetsForCalibratorTest();
-            RunAllTests(new[] { TestLearners.linearSVM }, datasets, new string[] { "cali={}" }, "nocalibration");
+            RunAllTests(new[] { TestLearners.linearSVM }, datasets, new string[] { "cali={}" }, "nocalibration", digitsOfPrecision: 6);
             Done();
         }
 
@@ -1390,7 +1390,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void PAVCalibratorLinearSvmTest()
         {
             var datasets = GetDatasetsForCalibratorTest();
-            RunAllTests(new[] { TestLearners.linearSVM }, datasets, new string[] { "cali=PAV" }, "PAVcalibration");
+            RunAllTests(new[] { TestLearners.linearSVM }, datasets, new string[] { "cali=PAV" }, "PAVcalibration", digitsOfPrecision: 5);
             Done();
         }
 
@@ -1520,8 +1520,8 @@ output Out [3] from H all;
         [TestCategory("Anomaly")]
         public void PcaAnomalyTest()
         {
-            Run_TrainTest(TestLearners.PCAAnomalyDefault, TestDatasets.mnistOneClass);
-            Run_TrainTest(TestLearners.PCAAnomalyNoNorm, TestDatasets.mnistOneClass);
+            Run_TrainTest(TestLearners.PCAAnomalyDefault, TestDatasets.mnistOneClass, digitsOfPrecision: 5);
+            Run_TrainTest(TestLearners.PCAAnomalyNoNorm, TestDatasets.mnistOneClass, digitsOfPrecision: 5);
 
             // REVIEW: This next test was misbehaving in a strange way that seems to have gone away
             // mysteriously (bad build?).

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -506,6 +506,8 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private void GetNumbersFromFile(ref string firstString, ref string secondString, int digitsOfPrecision)
         {
+            // The Regex matches both positive and negative decimal point numbers present in a string.
+            // The numbers could be a part of a word. They can also be in Exponential form eg. 3E-9
             Regex _matchNumer = new Regex(@"-?\b[0-9]+\.?[0-9]*(E-[0-9]*)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
             MatchCollection firstCollection = _matchNumer.Matches(firstString);
             MatchCollection secondCollection = _matchNumer.Matches(secondString);

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -506,7 +506,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private void GetNumbersFromFile(ref string firstString, ref string secondString, int digitsOfPrecision)
         {
-            Regex _matchNumer = new Regex(@"-?[0-9]+\.?[0-9]*(E-[0-9]*)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            Regex _matchNumer = new Regex(@"-?\b[0-9]+\.?[0-9]*(E-[0-9]*)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
             MatchCollection firstCollection = _matchNumer.Matches(firstString);
             MatchCollection secondCollection = _matchNumer.Matches(secondString);
 

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -506,7 +506,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private void GetNumbersFromFile(ref string firstString, ref string secondString, int digitsOfPrecision)
         {
-            Regex _matchNumer = new Regex(@"\b[0-9]+\.?[0-9]*(E-[0-9]*)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            Regex _matchNumer = new Regex(@"-?[0-9]+\.?[0-9]*(E-[0-9]*)?\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
             MatchCollection firstCollection = _matchNumer.Matches(firstString);
             MatchCollection secondCollection = _matchNumer.Matches(secondString);
 

--- a/test/Microsoft.ML.Tests/OnnxTests.cs
+++ b/test/Microsoft.ML.Tests/OnnxTests.cs
@@ -329,7 +329,7 @@ namespace Microsoft.ML.Tests
             fileText = Regex.Replace(fileText, "\"producerVersion\": \"([^\"]+)\"", "\"producerVersion\": \"##VERSION##\"");
             File.WriteAllText(onnxAsJsonPath, fileText);
 
-            CheckEquality(subDir, "Kmeans.json");
+            CheckEquality(subDir, "Kmeans.json", digitsOfPrecision: 2);
             Done();
         }
 
@@ -452,7 +452,7 @@ namespace Microsoft.ML.Tests
             fileText = Regex.Replace(fileText, "\"producerVersion\": \"([^\"]+)\"", "\"producerVersion\": \"##VERSION##\"");
             File.WriteAllText(onnxAsJsonPath, fileText);
 
-            CheckEquality(subDir, "BinaryClassificationLRSaveModelToOnnxTest.json");
+            CheckEquality(subDir, "BinaryClassificationLRSaveModelToOnnxTest.json", digitsOfPrecision: 3);
             Done();
         }
 
@@ -514,7 +514,7 @@ namespace Microsoft.ML.Tests
             fileText = Regex.Replace(fileText, "\"producerVersion\": \"([^\"]+)\"", "\"producerVersion\": \"##VERSION##\"");
             File.WriteAllText(onnxAsJsonPath, fileText);
 
-            CheckEquality(subDir, "MultiClassificationLRSaveModelToOnnxTest.json");
+            CheckEquality(subDir, "MultiClassificationLRSaveModelToOnnxTest.json", digitsOfPrecision: 4);
             Done();
         }
 

--- a/test/Microsoft.ML.Tests/OnnxTests.cs
+++ b/test/Microsoft.ML.Tests/OnnxTests.cs
@@ -329,7 +329,7 @@ namespace Microsoft.ML.Tests
             fileText = Regex.Replace(fileText, "\"producerVersion\": \"([^\"]+)\"", "\"producerVersion\": \"##VERSION##\"");
             File.WriteAllText(onnxAsJsonPath, fileText);
 
-            CheckEquality(subDir, "Kmeans.json", digitsOfPrecision: 2);
+            CheckEquality(subDir, "Kmeans.json");
             Done();
         }
 

--- a/test/Microsoft.ML.Tests/Transformers/PcaTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/PcaTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Tests.Transformers
                     DataSaverUtils.SaveDataView(ch, saver, savedData, fs, keepHidden: true);
             }
 
-            CheckEquality("PCA", "pca.tsv");
+            CheckEquality("PCA", "pca.tsv", digitsOfPrecision: 4);
             Done();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/1199
working towards https://github.com/dotnet/machinelearning/issues/1096

This PR corrects about 20 tests by providing the precision numbers as well as parsing the -0 correctly for 3 of the tests


cc @danmosemsft @eerhardt @shauheen @tannergooding 