### PR TITLE
fix conditional in for loop of GetDependencies()

### DIFF
--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Runtime.Data
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
         {
             Func<int, bool> toReturn = predicate;
-            for (int i = _innerMappers.Length - 1; i <= 0; --i)
+            for (int i = _innerMappers.Length - 1; i >= 0; --i)
                 toReturn = _innerMappers[i].GetDependencies(toReturn);
             return toReturn;
         }


### PR DESCRIPTION
Just a minor unintended one character change in the condition check of a loop in GetDependencies method of CompositeRowToRowMapper.
fixes #1325