### PR TITLE
[Fixes] #525: Renamed the NGramNgramExtractor class to a better name

### DIFF
--- a/src/Microsoft.ML.Legacy/CSharpApi.cs
+++ b/src/Microsoft.ML.Legacy/CSharpApi.cs
@@ -20110,14 +20110,14 @@ namespace Microsoft.ML
             internal override string ComponentName => "FastTreeTweedieRegression";
         }
 
-        public abstract class NgramExtractor : ComponentKind {}
+        public abstract class NgramExtractClass : ComponentKind {}
 
 
 
         /// <summary>
         /// Extracts NGrams from text and convert them to vector using dictionary.
         /// </summary>
-        public sealed class NGramNgramExtractor : NgramExtractor
+        public sealed class NGramNgramText2Vector : NgramExtractClass
         {
             /// <summary>
             /// Ngram length


### PR DESCRIPTION
Fixes #525 : Updated the following:
1. Renamed the NGramNgramExtractor to NGramNgramText2Vector.
2. Renamed the NgramExtractor to NgramExtractClass.