### PR TITLE
Add System.Memory as dependency in ML.CpuMath.nupkgproj file

### DIFF
--- a/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
+++ b/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
@@ -6,8 +6,8 @@
     <PackageDescription>Microsoft.ML.CpuMath contains optimized math routines for ML.NET.</PackageDescription>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-   <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
+++ b/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
@@ -6,7 +6,7 @@
     <PackageDescription>Microsoft.ML.CpuMath contains optimized math routines for ML.NET.</PackageDescription>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 

--- a/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
+++ b/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <!-- This is only needed until https://github.com/dotnet/corefx/issues/31064 is addressed. -->
-    <PackageReference Include="System.Runtime.Intrinsics.Experimental" Version="4.6.0-preview1-26708-04" />
+   <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1359 

- add `System.Memory` package reference to `Microsoft.ML.CpuMath.nupkgproj` file . 
- remove `System.Runtime.Intrinsics.Experimental` package reference as it's no longer required.


