### PR TITLE
[Fixes] #1078: ML.Ensemble assembly is not part of any NuGet, hence, …

### DIFF
--- a/src/Microsoft.ML.Ensemble/Microsoft.ML.Ensemble.csproj
+++ b/src/Microsoft.ML.Ensemble/Microsoft.ML.Ensemble.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <IncludeInPackage>Microsoft.ML.Ensemble</IncludeInPackage>
+    <IncludeInPackage>Microsoft.ML</IncludeInPackage>
     <DefineConstants>CORECLR</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
[Fixes #1078 : ML.Ensemble assembly is not part of any NuGet, hence, removed it
Replaced Microsoft.ML.Ensemble with Microsoft.ML