### PR TITLE
Kill all dotnet processes after build

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -22,7 +22,11 @@ set _json=%~dp0config.json
 :: a relative path to the binclash logger
 
 pushd "%~dp0"
+:: start building
 call "%_dotnet%" "%_toolRuntime%\run.exe" "%_json%" %*
+
+:: shutdown all dotnet build processes
+call "%_dotnet%" "build-server" "shutdown"
 popd
 
 exit /b %ERRORLEVEL%

--- a/run.cmd
+++ b/run.cmd
@@ -22,10 +22,9 @@ set _json=%~dp0config.json
 :: a relative path to the binclash logger
 
 pushd "%~dp0"
-:: start building
 call "%_dotnet%" "%_toolRuntime%\run.exe" "%_json%" %*
 
-:: shutdown all dotnet build processes
+:: Terminate all dotnet build processes.
 call "%_dotnet%" "build-server" "shutdown"
 popd
 


### PR DESCRIPTION
Fixes #1357.

As explained in more detail in the issue, a process must be leaking during one of the build jobs (the windows one), and is likely not terminating dotnet.exe. Subsequent attempts to clean the repo fail.

In this PR I implement the fix that is suggested in the issue: call dotnet build-server shutdown after the build process terminates. 

I manually queued this change 10 times on VSTS, and the error that we were seeing has not appeared again. There 2 other errors that did show up 2 times, but seem to be unrelated to this.

