### PR TITLE
Correct Git clone command for Linux building

### DIFF
--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -3,7 +3,7 @@ Building ML.NET on Linux and macOS
 ## Building
 
 1. Install the prerequisites ([Linux](#user-content-linux), [macOS](#user-content-macos))
-2. Clone the machine learning repo `git clone https://github.com/dotnet/machinelearning.git`
+2. Clone the machine learning repo `git clone --recursive https://github.com/dotnet/machinelearning.git`
 3. Navigate to the `machinelearning` directory
 4. Run the build script `./build.sh`
 


### PR DESCRIPTION
libmf has been introduced through a Git submodule and submodules need to be initialised before building. Adding the '--recursive' flag performs the needed initialisation.

Fixes #1399.


