### PR TITLE
Rename RefPredicate to InPredicate and change ref to in.

### DIFF
--- a/src/Microsoft.ML.Core/Data/InPredicate.cs
+++ b/src/Microsoft.ML.Core/Data/InPredicate.cs
@@ -4,5 +4,5 @@
 
 namespace Microsoft.ML.Runtime.Data
 {
-    public delegate bool RefPredicate<T>(ref T value);
+    public delegate bool InPredicate<T>(in T value);
 }

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -492,7 +492,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// Creates a maybe sparse copy of a VBuffer.
         /// Whether the created copy is sparse or not is determined by the proportion of non-default entries compared to the sparsity parameter.
         /// </summary>
-        public static void CreateMaybeSparseCopy<T>(ref VBuffer<T> src, ref VBuffer<T> dst, RefPredicate<T> isDefaultPredicate, float sparsityThreshold = SparsityThreshold)
+        public static void CreateMaybeSparseCopy<T>(ref VBuffer<T> src, ref VBuffer<T> dst, InPredicate<T> isDefaultPredicate, float sparsityThreshold = SparsityThreshold)
         {
             Contracts.CheckParam(0 < sparsityThreshold && sparsityThreshold < 1, nameof(sparsityThreshold));
             if (!src.IsDense || src.Length < 20)
@@ -505,7 +505,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             var sparseCountThreshold = (int)(src.Length * sparsityThreshold);
             for (int i = 0; i < src.Length; i++)
             {
-                if (!isDefaultPredicate(ref src.Values[i]))
+                if (!isDefaultPredicate(in src.Values[i]))
                     sparseCount++;
 
                 if (sparseCount > sparseCountThreshold)
@@ -527,7 +527,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 int j = 0;
                 for (int i = 0; i < src.Length; i++)
                 {
-                    if (!isDefaultPredicate(ref src.Values[i]))
+                    if (!isDefaultPredicate(in src.Values[i]))
                     {
                         Contracts.Assert(j < sparseCount);
                         indices[j] = i;

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
     using U8 = UInt64;
     using UG = UInt128;
 
-    public delegate bool TryParseMapper<T>(ref TX src, out T dst);
+    public delegate bool TryParseMapper<T>(in TX src, out T dst);
 
     /// <summary>
     /// This type exists to provide efficient delegates for conversion between standard ColumnTypes,
@@ -315,7 +315,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             _delegatesAll.Add(GetKey(kindSrc, kindDst), fn);
         }
 
-        private void AddIsNA<T>(RefPredicate<T> fn)
+        private void AddIsNA<T>(InPredicate<T> fn)
         {
             var kind = _kinds[typeof(T)];
             _isNADelegates.Add(kind, fn);
@@ -327,19 +327,19 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             _getNADelegates.Add(kind, fn);
         }
 
-        private void AddHasNA<T>(RefPredicate<VBuffer<T>> fn)
+        private void AddHasNA<T>(InPredicate<VBuffer<T>> fn)
         {
             var kind = _kinds[typeof(T)];
             _hasNADelegates.Add(kind, fn);
         }
 
-        private void AddIsDef<T>(RefPredicate<T> fn)
+        private void AddIsDef<T>(InPredicate<T> fn)
         {
             var kind = _kinds[typeof(T)];
             _isDefaultDelegates.Add(kind, fn);
         }
 
-        private void AddHasZero<T>(RefPredicate<VBuffer<T>> fn)
+        private void AddHasZero<T>(InPredicate<VBuffer<T>> fn)
         {
             var kind = _kinds[typeof(T)];
             _hasZeroDelegates.Add(kind, fn);
@@ -602,11 +602,11 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             bool identity;
             var fnConv = GetStandardConversion<U8, TDst>(NumberType.U8, NumberType.FromKind(key.RawKind), out identity);
             return
-                (ref TX src, out TDst dst) =>
+                (in TX src, out TDst dst) =>
                 {
                     ulong uu;
                     dst = default(TDst);
-                    if (!TryParseKey(ref src, min, max, out uu))
+                    if (!TryParseKey(in src, min, max, out uu))
                         return false;
                     // REVIEW: This call to fnConv should never need range checks, so could be made faster.
                     // Also, it would be nice to be able to assert that it doesn't overflow....
@@ -649,7 +649,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
                 {
                     ulong uu;
                     dst = default(TDst);
-                    if (!TryParseKey(ref src, min, max, out uu))
+                    if (!TryParseKey(in src, min, max, out uu))
                     {
                         dst = default(TDst);
                         return;
@@ -669,7 +669,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             return dst;
         }
 
-        public RefPredicate<T> GetIsDefaultPredicate<T>(ColumnType type)
+        public InPredicate<T> GetIsDefaultPredicate<T>(ColumnType type)
         {
             Contracts.CheckValue(type, nameof(type));
             Contracts.CheckParam(!type.IsVector, nameof(type));
@@ -680,18 +680,18 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             if (!t.IsStandardScalar && !t.IsKey || !_isDefaultDelegates.TryGetValue(t.RawKind, out del))
                 throw Contracts.Except("No IsDefault predicate for '{0}'", type);
 
-            return (RefPredicate<T>)del;
+            return (InPredicate<T>)del;
         }
 
-        public RefPredicate<T> GetIsNAPredicate<T>(ColumnType type)
+        public InPredicate<T> GetIsNAPredicate<T>(ColumnType type)
         {
-            RefPredicate<T> pred;
+            InPredicate<T> pred;
             if (TryGetIsNAPredicate(type, out pred))
                 return pred;
             throw Contracts.Except("No IsNA predicate for '{0}'", type);
         }
 
-        public bool TryGetIsNAPredicate<T>(ColumnType type, out RefPredicate<T> pred)
+        public bool TryGetIsNAPredicate<T>(ColumnType type, out InPredicate<T> pred)
         {
             Contracts.CheckValue(type, nameof(type));
             Contracts.CheckParam(type.RawType == typeof(T), nameof(type));
@@ -703,8 +703,8 @@ namespace Microsoft.ML.Runtime.Data.Conversion
                 return false;
             }
 
-            Contracts.Assert(del is RefPredicate<T>);
-            pred = (RefPredicate<T>)del;
+            Contracts.Assert(del is InPredicate<T>);
+            pred = (InPredicate<T>)del;
             return true;
         }
 
@@ -730,7 +730,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             return true;
         }
 
-        public RefPredicate<VBuffer<T>> GetHasMissingPredicate<T>(VectorType type)
+        public InPredicate<VBuffer<T>> GetHasMissingPredicate<T>(VectorType type)
         {
             Contracts.CheckValue(type, nameof(type));
             Contracts.CheckParam(type.ItemType.RawType == typeof(T), nameof(type));
@@ -746,7 +746,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             else if (!t.IsStandardScalar || !_hasNADelegates.TryGetValue(t.RawKind, out del))
                 throw Contracts.Except("No HasMissing predicate for '{0}'", type);
 
-            return (RefPredicate<VBuffer<T>>)del;
+            return (InPredicate<VBuffer<T>>)del;
         }
 
         /// <summary>
@@ -791,7 +791,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
 #if DEBUG
             Delegate isDefPred;
             if (_isDefaultDelegates.TryGetValue(type.RawKind, out isDefPred))
-                Contracts.Assert(!((RefPredicate<T>)isDefPred)(ref res));
+                Contracts.Assert(!((InPredicate<T>)isDefPred)(in res));
 #endif
 
             return res;
@@ -815,39 +815,39 @@ namespace Microsoft.ML.Runtime.Data.Conversion
 
         // The IsNA methods are for efficient delegates (instance instead of static).
         #region IsNA
-        private bool IsNA(ref R4 src) => R4.IsNaN(src);
-        private bool IsNA(ref R8 src) => R8.IsNaN(src);
+        private bool IsNA(in R4 src) => R4.IsNaN(src);
+        private bool IsNA(in R8 src) => R8.IsNaN(src);
         #endregion IsNA
 
         #region HasNA
-        private bool HasNA(ref VBuffer<R4> src) { for (int i = 0; i < src.Count; i++) { if (R4.IsNaN(src.Values[i])) return true; } return false; }
-        private bool HasNA(ref VBuffer<R8> src) { for (int i = 0; i < src.Count; i++) { if (R8.IsNaN(src.Values[i])) return true; } return false; }
+        private bool HasNA(in VBuffer<R4> src) { for (int i = 0; i < src.Count; i++) { if (R4.IsNaN(src.Values[i])) return true; } return false; }
+        private bool HasNA(in VBuffer<R8> src) { for (int i = 0; i < src.Count; i++) { if (R8.IsNaN(src.Values[i])) return true; } return false; }
         #endregion HasNA
 
         #region IsDefault
-        private bool IsDefault(ref I1 src) => src == default(I1);
-        private bool IsDefault(ref I2 src) => src == default(I2);
-        private bool IsDefault(ref I4 src) => src == default(I4);
-        private bool IsDefault(ref I8 src) => src == default(I8);
-        private bool IsDefault(ref R4 src) => src == 0;
-        private bool IsDefault(ref R8 src) => src == 0;
-        private bool IsDefault(ref TX src) => src.IsEmpty;
-        private bool IsDefault(ref BL src) => src == default;
-        private bool IsDefault(ref U1 src) => src == 0;
-        private bool IsDefault(ref U2 src) => src == 0;
-        private bool IsDefault(ref U4 src) => src == 0;
-        private bool IsDefault(ref U8 src) => src == 0;
-        private bool IsDefault(ref UG src) => src.Equals(default(UG));
-        private bool IsDefault(ref TS src) => src.Equals(default(TS));
-        private bool IsDefault(ref DT src) => src.Equals(default(DT));
-        private bool IsDefault(ref DZ src) => src.Equals(default(DZ));
+        private bool IsDefault(in I1 src) => src == default(I1);
+        private bool IsDefault(in I2 src) => src == default(I2);
+        private bool IsDefault(in I4 src) => src == default(I4);
+        private bool IsDefault(in I8 src) => src == default(I8);
+        private bool IsDefault(in R4 src) => src == 0;
+        private bool IsDefault(in R8 src) => src == 0;
+        private bool IsDefault(in TX src) => src.IsEmpty;
+        private bool IsDefault(in BL src) => src == default;
+        private bool IsDefault(in U1 src) => src == 0;
+        private bool IsDefault(in U2 src) => src == 0;
+        private bool IsDefault(in U4 src) => src == 0;
+        private bool IsDefault(in U8 src) => src == 0;
+        private bool IsDefault(in UG src) => src.Equals(default(UG));
+        private bool IsDefault(in TS src) => src.Equals(default(TS));
+        private bool IsDefault(in DT src) => src.Equals(default(DT));
+        private bool IsDefault(in DZ src) => src.Equals(default(DZ));
         #endregion IsDefault
 
         #region HasZero
-        private bool HasZero(ref VBuffer<U1> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
-        private bool HasZero(ref VBuffer<U2> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
-        private bool HasZero(ref VBuffer<U4> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
-        private bool HasZero(ref VBuffer<U8> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
+        private bool HasZero(in VBuffer<U1> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
+        private bool HasZero(in VBuffer<U2> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
+        private bool HasZero(in VBuffer<U4> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
+        private bool HasZero(in VBuffer<U8> src) { if (!src.IsDense) return true; for (int i = 0; i < src.Count; i++) { if (src.Values[i] == 0) return true; } return false; }
         #endregion HasZero
 
         #region GetNA
@@ -1003,10 +1003,10 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// <summary>
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// </summary>
-        public bool TryParse(ref TX src, out U1 dst)
+        public bool TryParse(in TX src, out U1 dst)
         {
             ulong res;
-            if (!TryParse(ref src, out res) || res > U1.MaxValue)
+            if (!TryParse(in src, out res) || res > U1.MaxValue)
             {
                 dst = 0;
                 return false;
@@ -1018,10 +1018,10 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// <summary>
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// </summary>
-        public bool TryParse(ref TX src, out U2 dst)
+        public bool TryParse(in TX src, out U2 dst)
         {
             ulong res;
-            if (!TryParse(ref src, out res) || res > U2.MaxValue)
+            if (!TryParse(in src, out res) || res > U2.MaxValue)
             {
                 dst = 0;
                 return false;
@@ -1033,10 +1033,10 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// <summary>
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// </summary>
-        public bool TryParse(ref TX src, out U4 dst)
+        public bool TryParse(in TX src, out U4 dst)
         {
             ulong res;
-            if (!TryParse(ref src, out res) || res > U4.MaxValue)
+            if (!TryParse(in src, out res) || res > U4.MaxValue)
             {
                 dst = 0;
                 return false;
@@ -1048,7 +1048,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// <summary>
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// </summary>
-        public bool TryParse(ref TX src, out U8 dst)
+        public bool TryParse(in TX src, out U8 dst)
         {
             if (src.IsEmpty)
             {
@@ -1067,7 +1067,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// <param name="dst">The result</param>
         /// <returns>Whether the input string was parsed successfully, that is, it was exactly length 32
         /// and had only digits and the letters 'a' through 'f' or 'A' through 'F' as characters</returns>
-        public bool TryParse(ref TX src, out UG dst)
+        public bool TryParse(in TX src, out UG dst)
         {
             var span = src.Span;
             // REVIEW: Accomodate numeric inputs?
@@ -1167,7 +1167,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// Exception is thrown for missing values.
         /// Unparsable or out of range values are mapped to zero with a false return.
         /// </summary>
-        public bool TryParseKey(ref TX src, U8 min, U8 max, out U8 dst)
+        public bool TryParseKey(in TX src, U8 min, U8 max, out U8 dst)
         {
             var span = src.Span;
             Contracts.Check(span.IsEmpty || !IsStdMissing(ref span), "Missing text value cannot be converted to unsigned integer type.");
@@ -1239,10 +1239,10 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// On failure, it sets dst to the default value.
         /// </summary>
-        public bool TryParse(ref TX src, out I1 dst)
+        public bool TryParse(in TX src, out I1 dst)
         {
             dst = default;
-            TryParseSigned(I1.MaxValue, ref src, out long? res);
+            TryParseSigned(I1.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to sbyte.");
             Contracts.Check((I1)res == res, "Overflow or underflow occured while converting value in text to sbyte.");
             dst = (I1)res;
@@ -1253,10 +1253,10 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// On failure, it sets dst to the default value.
         /// </summary>
-        public bool TryParse(ref TX src, out I2 dst)
+        public bool TryParse(in TX src, out I2 dst)
         {
             dst = default;
-            TryParseSigned(I2.MaxValue, ref src, out long? res);
+            TryParseSigned(I2.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to short.");
             Contracts.Check((I2)res == res, "Overflow or underflow occured while converting value in text to short.");
             dst = (I2)res;
@@ -1267,10 +1267,10 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// On failure, it sets dst to the defualt value.
         /// </summary>
-        public bool TryParse(ref TX src, out I4 dst)
+        public bool TryParse(in TX src, out I4 dst)
         {
             dst = default;
-            TryParseSigned(I4.MaxValue, ref src, out long? res);
+            TryParseSigned(I4.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to int32.");
             Contracts.Check((I4)res == res, "Overflow or underflow occured while converting value in text to int.");
             dst = (I4)res;
@@ -1281,10 +1281,10 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// This produces zero for empty. It returns false if the text is not parsable or overflows.
         /// On failure, it sets dst to the default value.
         /// </summary>
-        public bool TryParse(ref TX src, out I8 dst)
+        public bool TryParse(in TX src, out I8 dst)
         {
             dst = default;
-            TryParseSigned(I8.MaxValue, ref src, out long? res);
+            TryParseSigned(I8.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to long.");
             dst = (I8)res;
             return true;
@@ -1328,7 +1328,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// When it returns false, result is set to the NA value. The result can be NA on true return,
         /// since some representations of NA are not considered parse failure.
         /// </summary>
-        private void TryParseSigned(long max, ref TX text, out long? result)
+        private void TryParseSigned(long max, in TX text, out long? result)
         {
             Contracts.Assert(max > 0);
             Contracts.Assert((max & (max + 1)) == 0);
@@ -1377,7 +1377,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// This produces zero for empty. It returns false if the text is not parsable.
         /// On failure, it sets dst to the NA value.
         /// </summary>
-        public bool TryParse(ref TX src, out R4 dst)
+        public bool TryParse(in TX src, out R4 dst)
         {
             var span = src.Span;
             if (DoubleParser.TryParse(span, out dst))
@@ -1390,7 +1390,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// This produces zero for empty. It returns false if the text is not parsable.
         /// On failure, it sets dst to the NA value.
         /// </summary>
-        public bool TryParse(ref TX src, out R8 dst)
+        public bool TryParse(in TX src, out R8 dst)
         {
             var span = src.Span;
             if (DoubleParser.TryParse(span, out dst))
@@ -1399,7 +1399,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             return IsStdMissing(ref span);
         }
 
-        public bool TryParse(ref TX src, out TS dst)
+        public bool TryParse(in TX src, out TS dst)
         {
             if (src.IsEmpty)
             {
@@ -1414,7 +1414,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             return true;
         }
 
-        public bool TryParse(ref TX src, out DT dst)
+        public bool TryParse(in TX src, out DT dst)
         {
             if (src.IsEmpty)
             {
@@ -1430,7 +1430,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             return true;
         }
 
-        public bool TryParse(ref TX src, out DZ dst)
+        public bool TryParse(in TX src, out DZ dst)
         {
             if (src.IsEmpty)
             {
@@ -1447,33 +1447,33 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         }
 
         // These throw an exception for unparsable and overflow values.
-        private I1 ParseI1(ref TX src)
+        private I1 ParseI1(in TX src)
         {
-            TryParseSigned(I1.MaxValue, ref src, out long? res);
+            TryParseSigned(I1.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to sbyte.");
             Contracts.Check((I1)res == res, "Overflow or underflow occured while converting value in text to sbyte.");
             return (I1)res;
         }
 
-        private I2 ParseI2(ref TX src)
+        private I2 ParseI2(in TX src)
         {
-            TryParseSigned(I2.MaxValue, ref src, out long? res);
+            TryParseSigned(I2.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to short.");
             Contracts.Check((I2)res == res, "Overflow or underflow occured while converting value in text to short.");
             return (I2)res;
         }
 
-        private I4 ParseI4(ref TX src)
+        private I4 ParseI4(in TX src)
         {
-            TryParseSigned(I4.MaxValue, ref src, out long? res);
+            TryParseSigned(I4.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to int.");
             Contracts.Check((I4)res == res, "Overflow or underflow occured while converting value in text to int.");
             return (I4)res;
         }
 
-        private I8 ParseI8(ref TX src)
+        private I8 ParseI8(in TX src)
         {
-            TryParseSigned(I8.MaxValue, ref src, out long? res);
+            TryParseSigned(I8.MaxValue, in src, out long? res);
             Contracts.Check(res.HasValue, "Value could not be parsed from text to long.");
             return res.Value;
         }
@@ -1481,40 +1481,40 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         // These map unparsable and overflow values to zero. The unsigned integer types do not have an NA value.
         // Note that this matches the "bad" value for key-types, which will likely be the primary use for
         // unsigned integer types.
-        private U1 ParseU1(ref TX span)
+        private U1 ParseU1(in TX span)
         {
             ulong res;
-            if (!TryParse(ref span, out res))
+            if (!TryParse(in span, out res))
                 return 0;
             if (res > U1.MaxValue)
                 return 0;
             return (U1)res;
         }
 
-        private U2 ParseU2(ref TX span)
+        private U2 ParseU2(in TX span)
         {
             ulong res;
-            if (!TryParse(ref span, out res))
+            if (!TryParse(in span, out res))
                 return 0;
             if (res > U2.MaxValue)
                 return 0;
             return (U2)res;
         }
 
-        private U4 ParseU4(ref TX span)
+        private U4 ParseU4(in TX span)
         {
             ulong res;
-            if (!TryParse(ref span, out res))
+            if (!TryParse(in span, out res))
                 return 0;
             if (res > U4.MaxValue)
                 return 0;
             return (U4)res;
         }
 
-        private U8 ParseU8(ref TX span)
+        private U8 ParseU8(in TX span)
         {
             ulong res;
-            if (!TryParse(ref span, out res))
+            if (!TryParse(in span, out res))
                 return 0;
             return res;
         }
@@ -1526,7 +1526,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         /// * true, t, yes, y, 1, +1, + => true
         /// Empty string (but not missing string) succeeds and maps to false.
         /// </summary>
-        public bool TryParse(ref TX src, out BL dst)
+        public bool TryParse(in TX src, out BL dst)
         {
             var span = src.Span;
 
@@ -1637,7 +1637,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             return false;
         }
 
-        private bool TryParse(ref TX src, out TX dst)
+        private bool TryParse(in TX src, out TX dst)
         {
             dst = src;
             return true;
@@ -1645,39 +1645,39 @@ namespace Microsoft.ML.Runtime.Data.Conversion
 
         public void Convert(ref TX span, ref I1 value)
         {
-            value = ParseI1(ref span);
+            value = ParseI1(in span);
         }
         public void Convert(ref TX span, ref U1 value)
         {
-            value = ParseU1(ref span);
+            value = ParseU1(in span);
         }
         public void Convert(ref TX span, ref I2 value)
         {
-            value = ParseI2(ref span);
+            value = ParseI2(in span);
         }
         public void Convert(ref TX span, ref U2 value)
         {
-            value = ParseU2(ref span);
+            value = ParseU2(in span);
         }
         public void Convert(ref TX span, ref I4 value)
         {
-            value = ParseI4(ref span);
+            value = ParseI4(in span);
         }
         public void Convert(ref TX span, ref U4 value)
         {
-            value = ParseU4(ref span);
+            value = ParseU4(in span);
         }
         public void Convert(ref TX span, ref I8 value)
         {
-            value = ParseI8(ref span);
+            value = ParseI8(in span);
         }
         public void Convert(ref TX span, ref U8 value)
         {
-            value = ParseU8(ref span);
+            value = ParseU8(in span);
         }
         public void Convert(ref TX span, ref UG value)
         {
-            if (!TryParse(ref span, out value))
+            if (!TryParse(in span, out value))
                 Contracts.Assert(value.Equals(default(UG)));
         }
         public void Convert(ref TX src, ref R4 value)
@@ -1703,7 +1703,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         public void Convert(ref TX src, ref BL value)
         {
             // When TryParseBL returns false, it should have set value to false.
-            if (!TryParse(ref src, out value))
+            if (!TryParse(in src, out value))
                 Contracts.Assert(!value);
         }
         public void Convert(ref TX src, ref SB dst)
@@ -1713,9 +1713,9 @@ namespace Microsoft.ML.Runtime.Data.Conversion
                 dst.AppendMemory(src);
         }
 
-        public void Convert(ref TX span, ref TS value) => TryParse(ref span, out value);
-        public void Convert(ref TX span, ref DT value) => TryParse(ref span, out value);
-        public void Convert(ref TX span, ref DZ value) => TryParse(ref span, out value);
+        public void Convert(ref TX span, ref TS value) => TryParse(in span, out value);
+        public void Convert(ref TX span, ref DT value) => TryParse(in span, out value);
+        public void Convert(ref TX span, ref DZ value) => TryParse(in span, out value);
 
         #endregion FromTX
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 Contracts.Assert(0 <= irow && irow < _values.Length);
                 Contracts.Assert(index == 0);
-                return _conv(ref text, out _values[irow]);
+                return _conv(in text, out _values[irow]);
             }
 
             public void Get(ref TResult value)
@@ -337,7 +337,7 @@ namespace Microsoft.ML.Runtime.Data
                     Contracts.Assert(_indexPrev < index & index < _size);
 
                     TItem tmp = default(TItem);
-                    bool f = _conv(ref text, out tmp);
+                    bool f = _conv(in text, out tmp);
                     if (_count < _size)
                     {
                         if (_count < _size / 2)

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Runtime.Data
     public static class LambdaFilter
     {
         public static IDataView Create<TSrc>(IHostEnvironment env, string name, IDataView input,
-            string src, ColumnType typeSrc, RefPredicate<TSrc> predicate)
+            string src, ColumnType typeSrc, InPredicate<TSrc> predicate)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckNonEmpty(name, nameof(name));
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Runtime.Data
             else
             {
                 Func<IHostEnvironment, string, IDataView, int,
-                    RefPredicate<int>, ValueMapper<int, int>, Impl<int, int>> del = CreateImpl<int, int>;
+                    InPredicate<int>, ValueMapper<int, int>, Impl<int, int>> del = CreateImpl<int, int>;
                 var meth = del.GetMethodInfo().GetGenericMethodDefinition()
                     .MakeGenericMethod(typeOrig.RawType, typeof(TSrc));
                 impl = (IDataView)meth.Invoke(null, new object[] { env, name, input, colSrc, predicate, conv });
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private static Impl<T1, T2> CreateImpl<T1, T2>(
             IHostEnvironment env, string name, IDataView input, int colSrc,
-            RefPredicate<T2> pred, ValueMapper<T1, T2> conv)
+            InPredicate<T2> pred, ValueMapper<T1, T2> conv)
         {
             return new Impl<T1, T2>(env, name, input, colSrc, pred, conv);
         }
@@ -77,11 +77,11 @@ namespace Microsoft.ML.Runtime.Data
         private sealed class Impl<T1, T2> : FilterBase
         {
             private readonly int _colSrc;
-            private readonly RefPredicate<T2> _pred;
+            private readonly InPredicate<T2> _pred;
             private readonly ValueMapper<T1, T2> _conv;
 
             public Impl(IHostEnvironment env, string name, IDataView input,
-                int colSrc, RefPredicate<T2> pred, ValueMapper<T1, T2> conv = null)
+                int colSrc, InPredicate<T2> pred, ValueMapper<T1, T2> conv = null)
                 : base(env, name, input)
             {
                 Host.AssertValue(pred);
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Runtime.Data
             private sealed class RowCursor : LinkedRowFilterCursorBase
             {
                 private readonly ValueGetter<T1> _getSrc;
-                private readonly RefPredicate<T1> _pred;
+                private readonly InPredicate<T1> _pred;
                 private T1 _src;
 
                 public RowCursor(Impl<T1, T2> parent, IRowCursor input, bool[] active)
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Runtime.Data
                     if (parent._conv == null)
                     {
                         Ch.Assert(typeof(T1) == typeof(T2));
-                        _pred = (RefPredicate<T1>)(Delegate)parent._pred;
+                        _pred = (InPredicate<T1>)(Delegate)parent._pred;
                     }
                     else
                     {
@@ -168,10 +168,10 @@ namespace Microsoft.ML.Runtime.Data
                         var pred = parent._pred;
                         var conv = parent._conv;
                         _pred =
-                            (ref T1 src) =>
+                            (in T1 src) =>
                             {
                                 conv(ref _src, ref val);
-                                return pred(ref val);
+                                return pred(in val);
                             };
                     }
                 }
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Runtime.Data
                 protected override bool Accept()
                 {
                     _getSrc(ref _src);
-                    return _pred(ref _src);
+                    return _pred(in _src);
                 }
             }
 

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -461,7 +461,7 @@ namespace Microsoft.ML.Runtime.Data
                                     len++;
                                     Ch.Assert(len <= _len);
                                     getter(ref value);
-                                    if (isDefault(ref value))
+                                    if (isDefault(in value))
                                         continue;
                                     Utils.EnsureSize(ref indices, ++count);
                                     indices[count - 1] = len;
@@ -567,7 +567,7 @@ namespace Microsoft.ML.Runtime.Data
                 var type = _view.Schema.GetColumnType(_colCurr);
                 Ch.Assert(type.ItemType.RawType == typeof(T));
                 Ch.Assert(type.ValueCount > 0);
-                RefPredicate<T> isDefault = Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(type.ItemType);
+                InPredicate<T> isDefault = Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(type.ItemType);
                 int vecLen = type.ValueCount;
                 int maxPossibleSize = _rbuff.Length * vecLen;
                 const int sparseThresholdRatio = 5;
@@ -619,7 +619,7 @@ namespace Microsoft.ML.Runtime.Data
                                         if (rbuff.IsDense)
                                         {
                                             // Store it as sparse. We will densify later, if we must.
-                                            if (!isDefault(ref rbuff.Values[s]))
+                                            if (!isDefault(in rbuff.Values[s]))
                                             {
                                                 indices[_counts[s]] = rowNum;
                                                 values[_counts[s]++] = rbuff.Values[s];
@@ -630,7 +630,7 @@ namespace Microsoft.ML.Runtime.Data
                                             int ii = _rbuffIndices[r];
                                             if (ii < rbuff.Count && rbuff.Indices[ii] == s)
                                             {
-                                                if (!isDefault(ref rbuff.Values[ii]))
+                                                if (!isDefault(in rbuff.Values[ii]))
                                                 {
                                                     indices[_counts[s]] = rowNum;
                                                     values[_counts[s]++] = rbuff.Values[ii];

--- a/src/Microsoft.ML.Data/Transforms/ConvertTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConvertTransform.cs
@@ -646,13 +646,13 @@ namespace Microsoft.ML.Runtime.Data
                 ch.Assert(type.IsStandardScalar);
 
                 var conv = Conversions.Instance;
-                RefPredicate<T> isNaDel;
+                InPredicate<T> isNaDel;
                 bool hasNaPred = conv.TryGetIsNAPredicate(type, out isNaDel);
                 bool defaultIsNa = false;
                 if (hasNaPred)
                 {
                     T def = default(T);
-                    defaultIsNa = isNaDel(ref def);
+                    defaultIsNa = isNaDel(in def);
                 }
                 return new TypeNaInfo(hasNaPred, defaultIsNa);
             }

--- a/src/Microsoft.ML.Data/Transforms/KeyToValueTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValueTransform.cs
@@ -305,7 +305,7 @@ namespace Microsoft.ML.Runtime.Data
                 private readonly TValue _na;
 
                 private readonly bool _naMapsToDefault;
-                private readonly RefPredicate<TValue> _isDefault;
+                private readonly InPredicate<TValue> _isDefault;
 
                 private readonly ValueMapper<TKey, UInt32> _convertToUInt;
 
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Runtime.Data
                                         // Current slot has an explicitly defined value.
                                         Parent.Host.Assert(islotSrc < srcCount);
                                         MapKey(ref srcValues[islotSrc], ref dstItem);
-                                        if (!_isDefault(ref dstItem))
+                                        if (!_isDefault(in dstItem))
                                         {
                                             dstValues[islotDst] = dstItem;
                                             dstIndices[islotDst++] = srcIndices[islotSrc];

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -328,10 +328,10 @@ namespace Microsoft.ML.Runtime.Data
                 private abstract class TypedValue<T> : Value
                 {
                     private readonly ValueGetter<T> _getSrc;
-                    private readonly RefPredicate<T> _hasBad;
+                    private readonly InPredicate<T> _hasBad;
                     public T Src;
 
-                    protected TypedValue(RowCursor cursor, ValueGetter<T> getSrc, RefPredicate<T> hasBad)
+                    protected TypedValue(RowCursor cursor, ValueGetter<T> getSrc, InPredicate<T> hasBad)
                         : base(cursor)
                     {
                         Contracts.AssertValue(getSrc);
@@ -343,7 +343,7 @@ namespace Microsoft.ML.Runtime.Data
                     public override bool Refresh()
                     {
                         _getSrc(ref Src);
-                        return !_hasBad(ref Src);
+                        return !_hasBad(in Src);
                     }
                 }
 
@@ -351,7 +351,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     private readonly ValueGetter<T> _getter;
 
-                    public ValueOne(RowCursor cursor, ValueGetter<T> getSrc, RefPredicate<T> hasBad)
+                    public ValueOne(RowCursor cursor, ValueGetter<T> getSrc, InPredicate<T> hasBad)
                         : base(cursor, getSrc, hasBad)
                     {
                         _getter = GetValue;
@@ -373,7 +373,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     private readonly ValueGetter<VBuffer<T>> _getter;
 
-                    public ValueVec(RowCursor cursor, ValueGetter<VBuffer<T>> getSrc, RefPredicate<VBuffer<T>> hasBad)
+                    public ValueVec(RowCursor cursor, ValueGetter<VBuffer<T>> getSrc, InPredicate<VBuffer<T>> hasBad)
                         : base(cursor, getSrc, hasBad)
                     {
                         _getter = GetValue;

--- a/src/Microsoft.ML.Data/Transforms/TermTransformImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/TermTransformImpl.cs
@@ -63,9 +63,9 @@ namespace Microsoft.ML.Runtime.Data
                 // If this is a type with NA values, we should ignore those NA values for the purpose
                 // of building our term dictionary. For the other types (practically, only the UX types),
                 // we should ignore nothing.
-                RefPredicate<T> mapsToMissing;
+                InPredicate<T> mapsToMissing;
                 if (!Runtime.Data.Conversion.Conversions.Instance.TryGetIsNAPredicate(type, out mapsToMissing))
-                    mapsToMissing = (ref T val) => false;
+                    mapsToMissing = (in T val) => false;
                 return new Impl<T>(type, mapsToMissing, sorted);
             }
 
@@ -142,7 +142,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 // Because we can't know the actual mapping till we finish.
                 private readonly HashArray<T> _values;
-                private readonly RefPredicate<T> _mapsToMissing;
+                private readonly InPredicate<T> _mapsToMissing;
                 private readonly bool _sort;
 
                 public override int Count
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Runtime.Data
                 /// to the missing value. If this returns true for a value then we do not attempt
                 /// to store it in the map.</param>
                 /// <param name="sort">Indicates whether to sort mapping IDs by input values.</param>
-                public Impl(PrimitiveType type, RefPredicate<T> mapsToMissing, bool sort)
+                public Impl(PrimitiveType type, InPredicate<T> mapsToMissing, bool sort)
                     : base(type)
                 {
                     Contracts.Assert(type.RawType == typeof(T));
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 public override bool TryAdd(ref T val)
                 {
-                    return !_mapsToMissing(ref val) && _values.TryAdd(val);
+                    return !_mapsToMissing(in val) && _values.TryAdd(val);
                 }
 
                 public override TermMap Finish()
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Runtime.Data
                     term = ReadOnlyMemoryUtils.TrimSpaces(term);
                     if (term.IsEmpty)
                         ch.Warning("Empty strings ignored in 'terms' specification");
-                    else if (!tryParse(ref term, out val))
+                    else if (!tryParse(in term, out val))
                         ch.Warning("Item '{0}' ignored in 'terms' specification since it could not be parsed as '{1}'", term, ItemType);
                     else if (!TryAdd(ref val))
                         ch.Warning("Duplicate item '{0}' ignored in 'terms' specification", term);
@@ -237,7 +237,7 @@ namespace Microsoft.ML.Runtime.Data
                     term = ReadOnlyMemoryUtils.TrimSpaces(term);
                     if (term.IsEmpty)
                         ch.Warning("Empty strings ignored in 'term' specification");
-                    else if (!tryParse(ref term, out val))
+                    else if (!tryParse(in term, out val))
                         ch.Warning("Item '{0}' ignored in 'term' specification since it could not be parsed as '{1}'", term, ItemType);
                     else if (!TryAdd(ref val))
                         ch.Warning("Duplicate item '{0}' ignored in 'term' specification", term);

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1488,7 +1488,7 @@ namespace Microsoft.ML.Trainers.FastTree
                                                 out BinUpperBounds[iFeature]);
                                         }
                                         else
-                                            hasMissing = hasMissingPred(ref temp);
+                                            hasMissing = hasMissingPred(in temp);
 
                                         if (hasMissing)
                                         {

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -747,7 +747,7 @@ namespace Microsoft.ML.Runtime.Data
                 mapper =
                     (ref TInput src, ref Single dst) =>
                     {
-                        if (isNa(ref src))
+                        if (isNa(in src))
                         {
                             dst = Single.NaN;
                             return;
@@ -763,7 +763,7 @@ namespace Microsoft.ML.Runtime.Data
                 mapper =
                     (ref TInput src, ref Single dst) =>
                     {
-                        if (isNa(ref src))
+                        if (isNa(in src))
                         {
                             dst = Single.NaN;
                             return;

--- a/src/Microsoft.ML.PipelineInference/ColumnTypeInference.cs
+++ b/src/Microsoft.ML.PipelineInference/ColumnTypeInference.cs
@@ -134,7 +134,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
                             .All(x =>
                             {
                                 bool value;
-                                return Conversions.Instance.TryParse(ref x, out value);
+                                return Conversions.Instance.TryParse(in x, out value);
                             })
                             )
                         {
@@ -144,7 +144,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
                         col.SuggestedType = BoolType.Instance;
                         bool first;
 
-                        col.HasHeader = !Conversions.Instance.TryParse(ref col.RawData[0], out first);
+                        col.HasHeader = !Conversions.Instance.TryParse(in col.RawData[0], out first);
                     }
                 }
             }
@@ -159,7 +159,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
                             .All(x =>
                             {
                                 Single value;
-                                return Conversions.Instance.TryParse(ref x, out value);
+                                return Conversions.Instance.TryParse(in x, out value);
                             })
                             )
                         {

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Runtime.Learners
                 new LinearSvm(Host, new LinearSvm.Arguments());
         }
 
-        protected IDataView MapLabelsCore<T>(ColumnType type, RefPredicate<T> equalsTarget, RoleMappedData data)
+        protected IDataView MapLabelsCore<T>(ColumnType type, InPredicate<T> equalsTarget, RoleMappedData data)
         {
             Host.AssertValue(type);
             Host.Assert(type.RawType == typeof(T));
@@ -105,18 +105,18 @@ namespace Microsoft.ML.Runtime.Learners
 
             var lab = data.Schema.Label;
 
-            RefPredicate<T> isMissing;
+            InPredicate<T> isMissing;
             if (!Args.ImputeMissingLabelsAsNegative && Conversions.Instance.TryGetIsNAPredicate(type, out isMissing))
             {
                 return LambdaColumnMapper.Create(Host, "Label mapper", data.Data,
                     lab.Name, lab.Name, type, NumberType.Float,
                     (ref T src, ref float dst) =>
-                        dst = equalsTarget(ref src) ? 1 : (isMissing(ref src) ? float.NaN : default(float)));
+                        dst = equalsTarget(in src) ? 1 : (isMissing(in src) ? float.NaN : default(float)));
             }
             return LambdaColumnMapper.Create(Host, "Label mapper", data.Data,
                 lab.Name, lab.Name, type, NumberType.Float,
                 (ref T src, ref float dst) =>
-                    dst = equalsTarget(ref src) ? 1 : default(float));
+                    dst = equalsTarget(in src) ? 1 : default(float));
         }
 
         protected TScalarTrainer GetTrainer()

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -149,17 +149,17 @@ namespace Microsoft.ML.Runtime.Learners
             {
                 // Key values are 1-based.
                 uint key = (uint)(cls + 1);
-                return MapLabelsCore(NumberType.U4, (ref uint val) => key == val, data);
+                return MapLabelsCore(NumberType.U4, (in uint val) => key == val, data);
             }
             if (lab.Type == NumberType.R4)
             {
                 float key = cls;
-                return MapLabelsCore(NumberType.R4, (ref float val) => key == val, data);
+                return MapLabelsCore(NumberType.R4, (in float val) => key == val, data);
             }
             if (lab.Type == NumberType.R8)
             {
                 Double key = cls;
-                return MapLabelsCore(NumberType.R8, (ref double val) => key == val, data);
+                return MapLabelsCore(NumberType.R8, (in double val) => key == val, data);
             }
 
             throw Host.ExceptNotSupp($"Label column type is not supported by OVA: {lab.Type}");

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -149,19 +149,19 @@ namespace Microsoft.ML.Runtime.Learners
                 // Key values are 1-based.
                 uint key1 = (uint)(cls1 + 1);
                 uint key2 = (uint)(cls2 + 1);
-                return MapLabelsCore(NumberType.U4, (ref uint val) => val == key1 || val == key2, data);
+                return MapLabelsCore(NumberType.U4, (in uint val) => val == key1 || val == key2, data);
             }
             if (lab.Type == NumberType.R4)
             {
                 float key1 = cls1;
                 float key2 = cls2;
-                return MapLabelsCore(NumberType.R4, (ref float val) => val == key1 || val == key2, data);
+                return MapLabelsCore(NumberType.R4, (in float val) => val == key1 || val == key2, data);
             }
             if (lab.Type == NumberType.R8)
             {
                 double key1 = cls1;
                 double key2 = cls2;
-                return MapLabelsCore(NumberType.R8, (ref double val) => val == key1 || val == key2, data);
+                return MapLabelsCore(NumberType.R8, (in double val) => val == key1 || val == key2, data);
             }
 
             throw Host.ExceptNotSupp($"Label column type is not supported by PKPD: {lab.Type}");

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -238,8 +238,8 @@ namespace Microsoft.ML.Runtime.Data
         {
             private readonly long[] _count;
             private readonly Action _fillBuffer;
-            private readonly RefPredicate<T> _isDefault;
-            private readonly RefPredicate<T> _isMissing;
+            private readonly InPredicate<T> _isDefault;
+            private readonly InPredicate<T> _isMissing;
             private VBuffer<T> _buffer;
 
             public CountAggregator(ColumnType type, ValueGetter<T> getter)
@@ -256,7 +256,7 @@ namespace Microsoft.ML.Runtime.Data
                     };
                 _isDefault = Conversions.Instance.GetIsDefaultPredicate<T>(type);
                 if (!Conversions.Instance.TryGetIsNAPredicate<T>(type, out _isMissing))
-                    _isMissing = (ref T value) => false;
+                    _isMissing = (in T value) => false;
             }
 
             public CountAggregator(ColumnType type, ValueGetter<VBuffer<T>> getter)
@@ -267,7 +267,7 @@ namespace Microsoft.ML.Runtime.Data
                 _fillBuffer = () => getter(ref _buffer);
                 _isDefault = Conversions.Instance.GetIsDefaultPredicate<T>(type.ItemType);
                 if (!Conversions.Instance.TryGetIsNAPredicate<T>(type.ItemType, out _isMissing))
-                    _isMissing = (ref T value) => false;
+                    _isMissing = (in T value) => false;
             }
 
             public override long[] Count
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Runtime.Data
                 foreach (var kvp in value.Items())
                 {
                     var val = kvp.Value;
-                    if (!_isDefault(ref val) && !_isMissing(ref val))
+                    if (!_isDefault(in val) && !_isMissing(in val))
                         _count[kvp.Key]++;
                 }
             }

--- a/src/Microsoft.ML.Transforms/NADropTransform.cs
+++ b/src/Microsoft.ML.Transforms/NADropTransform.cs
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Runtime.Data
         private static string TestType<T>(ColumnType type)
         {
             Contracts.Assert(type.ItemType.RawType == typeof(T));
-            RefPredicate<T> isNA;
+            InPredicate<T> isNA;
             if (!Conversions.Instance.TryGetIsNAPredicate(type.ItemType, out isNA))
             {
                 return string.Format("Type '{0}' is not supported by {1} since it doesn't have an NA value",
@@ -202,9 +202,9 @@ namespace Microsoft.ML.Runtime.Data
         {
             var srcGetter = GetSrcGetter<VBuffer<TDst>>(input, iinfo);
             var buffer = default(VBuffer<TDst>);
-            var isNA = (RefPredicate<TDst>)_isNAs[iinfo];
+            var isNA = (InPredicate<TDst>)_isNAs[iinfo];
             var def = default(TDst);
-            if (isNA(ref def))
+            if (isNA(in def))
             {
                 // Case I: NA equals the default value.
                 return
@@ -216,7 +216,7 @@ namespace Microsoft.ML.Runtime.Data
             }
 
             // Case II: NA is different form default value.
-            Host.Assert(!isNA(ref def));
+            Host.Assert(!isNA(in def));
             return
                 (ref VBuffer<TDst> value) =>
                 {
@@ -225,14 +225,14 @@ namespace Microsoft.ML.Runtime.Data
                 };
         }
 
-        private void DropNAsAndDefaults<TDst>(ref VBuffer<TDst> src, ref VBuffer<TDst> dst, RefPredicate<TDst> isNA)
+        private void DropNAsAndDefaults<TDst>(ref VBuffer<TDst> src, ref VBuffer<TDst> dst, InPredicate<TDst> isNA)
         {
             Host.AssertValue(isNA);
 
             int newCount = 0;
             for (int i = 0; i < src.Count; i++)
             {
-                if (!isNA(ref src.Values[i]))
+                if (!isNA(in src.Values[i]))
                     newCount++;
             }
             Host.Assert(newCount <= src.Count);
@@ -262,7 +262,7 @@ namespace Microsoft.ML.Runtime.Data
             // Densifying sparse vectors since default value equals NA and hence should be dropped.
             for (int i = 0; i < src.Count; i++)
             {
-                if (!isNA(ref src.Values[i]))
+                if (!isNA(in src.Values[i]))
                     values[iDst++] = src.Values[i];
             }
             Host.Assert(iDst == newCount);
@@ -270,14 +270,14 @@ namespace Microsoft.ML.Runtime.Data
             dst = new VBuffer<TDst>(newCount, values, dst.Indices);
         }
 
-        private void DropNAs<TDst>(ref VBuffer<TDst> src, ref VBuffer<TDst> dst, RefPredicate<TDst> isNA)
+        private void DropNAs<TDst>(ref VBuffer<TDst> src, ref VBuffer<TDst> dst, InPredicate<TDst> isNA)
         {
             Host.AssertValue(isNA);
 
             int newCount = 0;
             for (int i = 0; i < src.Count; i++)
             {
-                if (!isNA(ref src.Values[i]))
+                if (!isNA(in src.Values[i]))
                     newCount++;
             }
             Host.Assert(newCount <= src.Count);
@@ -303,7 +303,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 for (int i = 0; i < src.Count; i++)
                 {
-                    if (!isNA(ref src.Values[i]))
+                    if (!isNA(in src.Values[i]))
                     {
                         values[iDst] = src.Values[i];
                         iDst++;
@@ -321,7 +321,7 @@ namespace Microsoft.ML.Runtime.Data
                 int offset = 0;
                 for (int i = 0; i < src.Count; i++)
                 {
-                    if (!isNA(ref src.Values[i]))
+                    if (!isNA(in src.Values[i]))
                     {
                         values[iDst] = src.Values[i];
                         indices[iDst] = src.Indices[i] - offset;

--- a/src/Microsoft.ML.Transforms/NAIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/NAIndicatorTransform.cs
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Transforms
             {
                 var getSrc = input.GetGetter<T>(ColMapNewToOld[iinfo]);
                 var src = default(T);
-                var isNA = (RefPredicate<T>)_infos[iinfo].InputIsNA;
+                var isNA = (InPredicate<T>)_infos[iinfo].InputIsNA;
 
                 ValueGetter<bool> getter;
 
@@ -253,7 +253,7 @@ namespace Microsoft.ML.Transforms
                     (ref bool dst) =>
                     {
                         getSrc(ref src);
-                        dst = isNA(ref src);
+                        dst = isNA(in src);
                     };
             }
 
@@ -266,9 +266,9 @@ namespace Microsoft.ML.Transforms
             private ValueGetter<VBuffer<bool>> ComposeGetterVec<T>(IRow input, int iinfo)
             {
                 var getSrc = input.GetGetter<VBuffer<T>>(ColMapNewToOld[iinfo]);
-                var isNA = (RefPredicate<T>)_infos[iinfo].InputIsNA;
+                var isNA = (InPredicate<T>)_infos[iinfo].InputIsNA;
                 var val = default(T);
-                var defaultIsNA = isNA(ref val);
+                var defaultIsNA = isNA(in val);
                 var src = default(VBuffer<T>);
                 var indices = new List<int>();
 
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Adds all NAs (or non-NAs) to the indices List.  Whether NAs or non-NAs have been added is indicated by the bool sense.
             /// </summary>
-            private void FindNAs<T>(ref VBuffer<T> src, RefPredicate<T> isNA, bool defaultIsNA, List<int> indices, out bool sense)
+            private void FindNAs<T>(ref VBuffer<T> src, InPredicate<T> isNA, bool defaultIsNA, List<int> indices, out bool sense)
             {
                 Host.AssertValue(isNA);
                 Host.AssertValue(indices);
@@ -301,7 +301,7 @@ namespace Microsoft.ML.Transforms
                 {
                     for (int i = 0; i < srcCount; i++)
                     {
-                        if (isNA(ref srcValues[i]))
+                        if (isNA(in srcValues[i]))
                             indices.Add(i);
                     }
                     sense = true;
@@ -311,7 +311,7 @@ namespace Microsoft.ML.Transforms
                     var srcIndices = src.Indices;
                     for (int ii = 0; ii < srcCount; ii++)
                     {
-                        if (isNA(ref srcValues[ii]))
+                        if (isNA(in srcValues[ii]))
                             indices.Add(srcIndices[ii]);
                     }
                     sense = true;
@@ -322,7 +322,7 @@ namespace Microsoft.ML.Transforms
                     var srcIndices = src.Indices;
                     for (int ii = 0; ii < srcCount; ii++)
                     {
-                        if (!isNA(ref srcValues[ii]))
+                        if (!isNA(in srcValues[ii]))
                             indices.Add(srcIndices[ii]);
                     }
                     sense = false;

--- a/src/Microsoft.ML.Transforms/TermLookupTransform.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransform.cs
@@ -385,7 +385,7 @@ namespace Microsoft.ML.Runtime.Data
                             // Try to parse the text as a key value between 1 and ulong.MaxValue. If this succeeds and res>0,
                             // we update max and min accordingly. If res==0 it means the value is missing, in which case we ignore it for
                             // computing max and min.
-                            if (Conversions.Instance.TryParseKey(ref txt, 1, ulong.MaxValue, out res))
+                            if (Conversions.Instance.TryParseKey(in txt, 1, ulong.MaxValue, out res))
                             {
                                 if (res < min && res != 0)
                                     min = res;
@@ -394,7 +394,7 @@ namespace Microsoft.ML.Runtime.Data
                             }
                             // If parsing as key did not succeed, the value can still be 0, so we try parsing it as a ulong. If it succeeds,
                             // then the value is 0, and we update min accordingly.
-                            else if (Conversions.Instance.TryParse(ref txt, out res))
+                            else if (Conversions.Instance.TryParse(in txt, out res))
                             {
                                 ch.Assert(res == 0);
                                 min = 0;


### PR DESCRIPTION
This is laying the foundation for #608. In order to allow `in VBuffer` parameters, we have to change `RefPredicate` to `InPredicate`, because you can't take a `ref` to an `in` parameter.

Working towards #608

