### PR TITLE
Add Git submodule init to Windows build instructions

### DIFF
--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -40,6 +40,8 @@ The following are the minimum requirements:
 
 ## Building Instructions
 
+In order to fetch dependencies which come through Git submodules the following command needs to be run before building: `git submodule update --init`.
+
 ### Building From Visual Studio 2017
 
 First, set up the required tools, from a (non-admin) Command Prompt window:


### PR DESCRIPTION
Submodules must also be initialised in Windows to fetch the necessary dependencies.

Related to issue #1399.

