### PR TITLE
Baseline comparisons with tolerance should not exit when values don't match (#218)

### DIFF
--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -519,7 +519,7 @@ namespace Microsoft.ML.Runtime.RunTests
             {
                 if(!MatchNumberWithTolerance(firstCollection, secondCollection, digitsOfPrecision))
                 {
-                    return false;        
+                    return false;
                 }
             }
                 

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -495,9 +495,9 @@ namespace Microsoft.ML.Runtime.RunTests
                     }
 
                     count++;
-                    GetNumbersFromFile(ref line1, ref line2, digitsOfPrecision);
+                    var inRange = GetNumbersFromFile(ref line1, ref line2, digitsOfPrecision);
 
-                    if (line1 != line2)
+                    if (!inRange || line1 != line2)
                     {
                         if (line1 == null || line2 == null)
                             Fail("Output and baseline different lengths: '{0}'", relPath);
@@ -509,19 +509,26 @@ namespace Microsoft.ML.Runtime.RunTests
             }
         }
 
-        private void GetNumbersFromFile(ref string firstString, ref string secondString, int digitsOfPrecision)
+        private bool GetNumbersFromFile(ref string firstString, ref string secondString, int digitsOfPrecision)
         {
-            
+
             MatchCollection firstCollection = MatchNumbers.Matches(firstString);
             MatchCollection secondCollection = MatchNumbers.Matches(secondString);
 
             if (firstCollection.Count == secondCollection.Count)
-                MatchNumberWithTolerance(firstCollection, secondCollection, digitsOfPrecision);
+            {
+                if(!MatchNumberWithTolerance(firstCollection, secondCollection, digitsOfPrecision))
+                {
+                    return false;        
+                }
+            }
+                
             firstString = MatchNumbers.Replace(firstString, "%Number%");
             secondString = MatchNumbers.Replace(secondString, "%Number%");
+            return true;
         }
 
-        private void MatchNumberWithTolerance(MatchCollection firstCollection, MatchCollection secondCollection, int digitsOfPrecision)
+        private bool MatchNumberWithTolerance(MatchCollection firstCollection, MatchCollection secondCollection, int digitsOfPrecision)
         {
             for (int i = 0; i < firstCollection.Count; i++)
             {
@@ -547,9 +554,16 @@ namespace Microsoft.ML.Runtime.RunTests
                 if (!inRange)
                 {
                     delta = Math.Round(f1 - f2, digitsOfPrecision);
-                    Assert.InRange(delta, -allowedVariance, allowedVariance);
+                    inRange = delta >= -allowedVariance && delta <= allowedVariance;
+                }
+
+                if(!inRange)
+                {
+                    return false;
                 }
             }
+
+            return true;
         }
 
         private static double Round(double value, int digitsOfPrecision)


### PR DESCRIPTION
Fix #218 
call Fail() with a detailed error message saying which file and which line the error occurred in, and continue comparing the rest of the files in the unit test.