### PR TITLE
Fix unassigned public field

### DIFF
--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -403,6 +403,7 @@ namespace Microsoft.ML.Trainers.Recommender
             MatrixColumnIndexColumnType = trainSchema.GetColumnType(xCol);
             if (!trainSchema.TryGetColumnIndex(MatrixRowIndexColumnName, out int yCol))
                 throw Host.ExceptSchemaMismatch(nameof(yCol), RecommenderUtils.MatrixRowIndexKind.Value, MatrixRowIndexColumnName);
+            MatrixRowIndexColumnType = trainSchema.GetColumnType(yCol);
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, model);
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -181,6 +181,18 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Train a matrix factorization model.
             var model = pipeline.Fit(dataView);
 
+            // Check if the expected types in the trained model are expected.
+            Assert.True(model.MatrixColumnIndexColumnName == "MatrixColumnIndex");
+            Assert.True(model.MatrixRowIndexColumnName == "MatrixRowIndex");
+            Assert.True(model.MatrixColumnIndexColumnType.IsKey);
+            Assert.True(model.MatrixRowIndexColumnType.IsKey);
+            var matColKeyType = model.MatrixColumnIndexColumnType.AsKey;
+            Assert.True(matColKeyType.Min == _synthesizedMatrixFirstColumnIndex);
+            Assert.True(matColKeyType.Count == _synthesizedMatrixColumnCount);
+            var matRowKeyType = model.MatrixRowIndexColumnType.AsKey;
+            Assert.True(matRowKeyType.Min == _synthesizedMatrixFirstRowIndex);
+            Assert.True(matRowKeyType.Count == _synthesizedMatrixRowCount);
+
             // Apply the trained model to the training set
             var prediction = model.Transform(dataView);
 


### PR DESCRIPTION
A public field, `MatrixRowIndexColumnType`, is not assigned. Now it will get its value in the constructor.

Fixes #1468.