### PR TITLE
Convert ValueMapper to use 'in' parameters

### DIFF
--- a/src/Microsoft.ML.Core/Data/IValueMapper.cs
+++ b/src/Microsoft.ML.Core/Data/IValueMapper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.ML.Runtime.Data
     /// Delegate type to map/convert among three values, for example, one input with two
     /// outputs, or two inputs with one output.
     /// </summary>
-    public delegate void ValueMapper<TVal1, TVal2, TVal3>(ref TVal1 val1, ref TVal2 val2, ref TVal3 val3);
+    public delegate void ValueMapper<TVal1, TVal2, TVal3>(in TVal1 val1, ref TVal2 val2, ref TVal3 val3);
 
     /// <summary>
     /// Interface for mapping a single input value (of an indicated ColumnType) to

--- a/src/Microsoft.ML.Core/Data/IValueMapper.cs
+++ b/src/Microsoft.ML.Core/Data/IValueMapper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Runtime.Data
     /// <summary>
     /// Delegate type to map/convert a value.
     /// </summary>
-    public delegate void ValueMapper<TSrc, TDst>(ref TSrc src, ref TDst dst);
+    public delegate void ValueMapper<TSrc, TDst>(in TSrc src, ref TDst dst);
 
     /// <summary>
     /// Delegate type to map/convert among three values, for example, one input with two

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -239,7 +239,7 @@ namespace Microsoft.ML.Runtime.Data
             var value = default(T);
             var sb = default(StringBuilder);
             schema.GetMetadata(kind, col, ref value);
-            conv(ref value, ref sb);
+            conv(in value, ref sb);
 
             itw.Write(": '{0}'", sb);
         }
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Runtime.Data
                     else
                         itw.Write(", ");
                     var val = item.Value;
-                    conv(ref val, ref sb);
+                    conv(in val, ref sb);
                     itw.Write("[{0}] '{1}'", item.Key, sb);
                     count++;
                 }

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -534,32 +534,32 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             if (count > 0)
             {
                 return
-                    (ref TSrc src, ref SB dst) =>
+                    (in TSrc src, ref SB dst) =>
                     {
                         ulong tmp = 0;
-                        convSrc(ref src, ref tmp);
+                        convSrc(in src, ref tmp);
                         if (tmp == 0 || tmp > (ulong)count)
                             ClearDst(ref dst);
                         else
                         {
                             tmp = tmp + min - 1;
-                            convU8(ref tmp, ref dst);
+                            convU8(in tmp, ref dst);
                         }
                     };
             }
             else
             {
                 return
-                    (ref TSrc src, ref SB dst) =>
+                    (in TSrc src, ref SB dst) =>
                     {
                         U8 tmp = 0;
-                        convSrc(ref src, ref tmp);
+                        convSrc(in src, ref tmp);
                         if (tmp == 0 || min > 1 && tmp > U8.MaxValue - min + 1)
                             ClearDst(ref dst);
                         else
                         {
                             tmp = tmp + min - 1;
-                            convU8(ref tmp, ref dst);
+                            convU8(in tmp, ref dst);
                         }
                     };
             }
@@ -610,7 +610,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
                         return false;
                     // REVIEW: This call to fnConv should never need range checks, so could be made faster.
                     // Also, it would be nice to be able to assert that it doesn't overflow....
-                    fnConv(ref uu, ref dst);
+                    fnConv(in uu, ref dst);
                     return true;
                 };
         }
@@ -645,7 +645,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             bool identity;
             var fnConv = GetStandardConversion<U8, TDst>(NumberType.U8, NumberType.FromKind(key.RawKind), out identity);
             return
-                (ref TX src, ref TDst dst) =>
+                (in TX src, ref TDst dst) =>
                 {
                     ulong uu;
                     dst = default(TDst);
@@ -656,7 +656,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
                     }
                     // REVIEW: This call to fnConv should never need range checks, so could be made faster.
                     // Also, it would be nice to be able to assert that it doesn't overflow....
-                    fnConv(ref uu, ref dst);
+                    fnConv(in uu, ref dst);
                 };
         }
 
@@ -856,126 +856,126 @@ namespace Microsoft.ML.Runtime.Data.Conversion
         #endregion GetNA
 
         #region ToI1
-        public void Convert(ref I1 src, ref I1 dst) => dst = src;
-        public void Convert(ref I2 src, ref I1 dst) => dst = (I1)src;
-        public void Convert(ref I4 src, ref I1 dst) => dst = (I1)src;
-        public void Convert(ref I8 src, ref I1 dst) => dst = (I1)src;
+        public void Convert(in I1 src, ref I1 dst) => dst = src;
+        public void Convert(in I2 src, ref I1 dst) => dst = (I1)src;
+        public void Convert(in I4 src, ref I1 dst) => dst = (I1)src;
+        public void Convert(in I8 src, ref I1 dst) => dst = (I1)src;
         #endregion ToI1
 
         #region ToI2
-        public void Convert(ref I1 src, ref I2 dst) => dst = src;
-        public void Convert(ref I2 src, ref I2 dst) => dst = src;
-        public void Convert(ref I4 src, ref I2 dst) => dst = (I2)src;
-        public void Convert(ref I8 src, ref I2 dst) => dst = (I2)src;
+        public void Convert(in I1 src, ref I2 dst) => dst = src;
+        public void Convert(in I2 src, ref I2 dst) => dst = src;
+        public void Convert(in I4 src, ref I2 dst) => dst = (I2)src;
+        public void Convert(in I8 src, ref I2 dst) => dst = (I2)src;
         #endregion ToI2
 
         #region ToI4
-        public void Convert(ref I1 src, ref I4 dst) => dst = src;
-        public void Convert(ref I2 src, ref I4 dst) => dst = src;
-        public void Convert(ref I4 src, ref I4 dst) => dst = src;
-        public void Convert(ref I8 src, ref I4 dst) => dst = (I4)src;
+        public void Convert(in I1 src, ref I4 dst) => dst = src;
+        public void Convert(in I2 src, ref I4 dst) => dst = src;
+        public void Convert(in I4 src, ref I4 dst) => dst = src;
+        public void Convert(in I8 src, ref I4 dst) => dst = (I4)src;
         #endregion ToI4
 
         #region ToI8
-        public void Convert(ref I1 src, ref I8 dst) => dst = src;
-        public void Convert(ref I2 src, ref I8 dst) => dst = src;
-        public void Convert(ref I4 src, ref I8 dst) => dst = src;
-        public void Convert(ref I8 src, ref I8 dst) => dst = src;
+        public void Convert(in I1 src, ref I8 dst) => dst = src;
+        public void Convert(in I2 src, ref I8 dst) => dst = src;
+        public void Convert(in I4 src, ref I8 dst) => dst = src;
+        public void Convert(in I8 src, ref I8 dst) => dst = src;
 
-        public void Convert(ref TS src, ref I8 dst) => dst = (I8)src.Ticks;
-        public void Convert(ref DT src, ref I8 dst) => dst = (I8)src.Ticks;
-        public void Convert(ref DZ src, ref I8 dst) => dst = (I8)src.UtcDateTime.Ticks;
+        public void Convert(in TS src, ref I8 dst) => dst = (I8)src.Ticks;
+        public void Convert(in DT src, ref I8 dst) => dst = (I8)src.Ticks;
+        public void Convert(in DZ src, ref I8 dst) => dst = (I8)src.UtcDateTime.Ticks;
         #endregion ToI8
 
         #region ToU1
-        public void Convert(ref U1 src, ref U1 dst) => dst = src;
-        public void Convert(ref U2 src, ref U1 dst) => dst = src <= U1.MaxValue ? (U1)src : (U1)0;
-        public void Convert(ref U4 src, ref U1 dst) => dst = src <= U1.MaxValue ? (U1)src : (U1)0;
-        public void Convert(ref U8 src, ref U1 dst) => dst = src <= U1.MaxValue ? (U1)src : (U1)0;
-        public void Convert(ref UG src, ref U1 dst) => dst = src.Hi == 0 && src.Lo <= U1.MaxValue ? (U1)src.Lo : (U1)0;
+        public void Convert(in U1 src, ref U1 dst) => dst = src;
+        public void Convert(in U2 src, ref U1 dst) => dst = src <= U1.MaxValue ? (U1)src : (U1)0;
+        public void Convert(in U4 src, ref U1 dst) => dst = src <= U1.MaxValue ? (U1)src : (U1)0;
+        public void Convert(in U8 src, ref U1 dst) => dst = src <= U1.MaxValue ? (U1)src : (U1)0;
+        public void Convert(in UG src, ref U1 dst) => dst = src.Hi == 0 && src.Lo <= U1.MaxValue ? (U1)src.Lo : (U1)0;
         #endregion ToU1
 
         #region ToU2
-        public void Convert(ref U1 src, ref U2 dst) => dst = src;
-        public void Convert(ref U2 src, ref U2 dst) => dst = src;
-        public void Convert(ref U4 src, ref U2 dst) => dst = src <= U2.MaxValue ? (U2)src : (U2)0;
-        public void Convert(ref U8 src, ref U2 dst) => dst = src <= U2.MaxValue ? (U2)src : (U2)0;
-        public void Convert(ref UG src, ref U2 dst) => dst = src.Hi == 0 && src.Lo <= U2.MaxValue ? (U2)src.Lo : (U2)0;
+        public void Convert(in U1 src, ref U2 dst) => dst = src;
+        public void Convert(in U2 src, ref U2 dst) => dst = src;
+        public void Convert(in U4 src, ref U2 dst) => dst = src <= U2.MaxValue ? (U2)src : (U2)0;
+        public void Convert(in U8 src, ref U2 dst) => dst = src <= U2.MaxValue ? (U2)src : (U2)0;
+        public void Convert(in UG src, ref U2 dst) => dst = src.Hi == 0 && src.Lo <= U2.MaxValue ? (U2)src.Lo : (U2)0;
         #endregion ToU2
 
         #region ToU4
-        public void Convert(ref U1 src, ref U4 dst) => dst = src;
-        public void Convert(ref U2 src, ref U4 dst) => dst = src;
-        public void Convert(ref U4 src, ref U4 dst) => dst = src;
-        public void Convert(ref U8 src, ref U4 dst) => dst = src <= U4.MaxValue ? (U4)src : (U4)0;
-        public void Convert(ref UG src, ref U4 dst) => dst = src.Hi == 0 && src.Lo <= U4.MaxValue ? (U4)src.Lo : (U4)0;
+        public void Convert(in U1 src, ref U4 dst) => dst = src;
+        public void Convert(in U2 src, ref U4 dst) => dst = src;
+        public void Convert(in U4 src, ref U4 dst) => dst = src;
+        public void Convert(in U8 src, ref U4 dst) => dst = src <= U4.MaxValue ? (U4)src : (U4)0;
+        public void Convert(in UG src, ref U4 dst) => dst = src.Hi == 0 && src.Lo <= U4.MaxValue ? (U4)src.Lo : (U4)0;
         #endregion ToU4
 
         #region ToU8
-        public void Convert(ref U1 src, ref U8 dst) => dst = src;
-        public void Convert(ref U2 src, ref U8 dst) => dst = src;
-        public void Convert(ref U4 src, ref U8 dst) => dst = src;
-        public void Convert(ref U8 src, ref U8 dst) => dst = src;
-        public void Convert(ref UG src, ref U8 dst) => dst = src.Hi == 0 ? src.Lo : (U8)0;
+        public void Convert(in U1 src, ref U8 dst) => dst = src;
+        public void Convert(in U2 src, ref U8 dst) => dst = src;
+        public void Convert(in U4 src, ref U8 dst) => dst = src;
+        public void Convert(in U8 src, ref U8 dst) => dst = src;
+        public void Convert(in UG src, ref U8 dst) => dst = src.Hi == 0 ? src.Lo : (U8)0;
         #endregion ToU8
 
         #region ToUG
-        public void Convert(ref U1 src, ref UG dst) => dst = new UG(src, 0);
-        public void Convert(ref U2 src, ref UG dst) => dst = new UG(src, 0);
-        public void Convert(ref U4 src, ref UG dst) => dst = new UG(src, 0);
-        public void Convert(ref U8 src, ref UG dst) => dst = new UG(src, 0);
-        public void Convert(ref UG src, ref UG dst) => dst = src;
+        public void Convert(in U1 src, ref UG dst) => dst = new UG(src, 0);
+        public void Convert(in U2 src, ref UG dst) => dst = new UG(src, 0);
+        public void Convert(in U4 src, ref UG dst) => dst = new UG(src, 0);
+        public void Convert(in U8 src, ref UG dst) => dst = new UG(src, 0);
+        public void Convert(in UG src, ref UG dst) => dst = src;
         #endregion ToUG
 
         #region ToR4
-        public void Convert(ref I1 src, ref R4 dst) => dst = (R4)src;
-        public void Convert(ref I2 src, ref R4 dst) => dst = (R4)src;
-        public void Convert(ref I4 src, ref R4 dst) => dst = (R4)src;
-        public void Convert(ref I8 src, ref R4 dst) => dst = (R4)src;
-        public void Convert(ref U1 src, ref R4 dst) => dst = src;
-        public void Convert(ref U2 src, ref R4 dst) => dst = src;
-        public void Convert(ref U4 src, ref R4 dst) => dst = src;
+        public void Convert(in I1 src, ref R4 dst) => dst = (R4)src;
+        public void Convert(in I2 src, ref R4 dst) => dst = (R4)src;
+        public void Convert(in I4 src, ref R4 dst) => dst = (R4)src;
+        public void Convert(in I8 src, ref R4 dst) => dst = (R4)src;
+        public void Convert(in U1 src, ref R4 dst) => dst = src;
+        public void Convert(in U2 src, ref R4 dst) => dst = src;
+        public void Convert(in U4 src, ref R4 dst) => dst = src;
         // REVIEW: The 64-bit JIT has a bug in that it rounds incorrectly from ulong
         // to floating point when the high bit of the ulong is set. Should we work around the bug
         // or just live with it? See the DoubleParser code for details.
-        public void Convert(ref U8 src, ref R4 dst) => dst = src;
+        public void Convert(in U8 src, ref R4 dst) => dst = src;
 
-        public void Convert(ref TS src, ref R4 dst) => dst = (R4)src.Ticks;
-        public void Convert(ref DT src, ref R4 dst) => dst = (R4)src.Ticks;
-        public void Convert(ref DZ src, ref R4 dst) => dst = (R4)src.UtcDateTime.Ticks;
+        public void Convert(in TS src, ref R4 dst) => dst = (R4)src.Ticks;
+        public void Convert(in DT src, ref R4 dst) => dst = (R4)src.Ticks;
+        public void Convert(in DZ src, ref R4 dst) => dst = (R4)src.UtcDateTime.Ticks;
         #endregion ToR4
 
         #region ToR8
-        public void Convert(ref I1 src, ref R8 dst) => dst = (R8)src;
-        public void Convert(ref I2 src, ref R8 dst) => dst = (R8)src;
-        public void Convert(ref I4 src, ref R8 dst) => dst = (R8)src;
-        public void Convert(ref I8 src, ref R8 dst) => dst = (R8)src;
-        public void Convert(ref U1 src, ref R8 dst) => dst = src;
-        public void Convert(ref U2 src, ref R8 dst) => dst = src;
-        public void Convert(ref U4 src, ref R8 dst) => dst = src;
+        public void Convert(in I1 src, ref R8 dst) => dst = (R8)src;
+        public void Convert(in I2 src, ref R8 dst) => dst = (R8)src;
+        public void Convert(in I4 src, ref R8 dst) => dst = (R8)src;
+        public void Convert(in I8 src, ref R8 dst) => dst = (R8)src;
+        public void Convert(in U1 src, ref R8 dst) => dst = src;
+        public void Convert(in U2 src, ref R8 dst) => dst = src;
+        public void Convert(in U4 src, ref R8 dst) => dst = src;
         // REVIEW: The 64-bit JIT has a bug in that it rounds incorrectly from ulong
         // to floating point when the high bit of the ulong is set. Should we work around the bug
         // or just live with it? See the DoubleParser code for details.
-        public void Convert(ref U8 src, ref R8 dst) => dst = src;
+        public void Convert(in U8 src, ref R8 dst) => dst = src;
 
-        public void Convert(ref TS src, ref R8 dst) => dst = (R8)src.Ticks;
-        public void Convert(ref DT src, ref R8 dst) => dst = (R8)src.Ticks;
-        public void Convert(ref DZ src, ref R8 dst) => dst = (R8)src.UtcDateTime.Ticks;
+        public void Convert(in TS src, ref R8 dst) => dst = (R8)src.Ticks;
+        public void Convert(in DT src, ref R8 dst) => dst = (R8)src.Ticks;
+        public void Convert(in DZ src, ref R8 dst) => dst = (R8)src.UtcDateTime.Ticks;
         #endregion ToR8
 
         #region ToStringBuilder
-        public void Convert(ref I1 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
-        public void Convert(ref I2 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
-        public void Convert(ref I4 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
-        public void Convert(ref I8 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
-        public void Convert(ref U1 src, ref SB dst) => ClearDst(ref dst).Append(src);
-        public void Convert(ref U2 src, ref SB dst) => ClearDst(ref dst).Append(src);
-        public void Convert(ref U4 src, ref SB dst) => ClearDst(ref dst).Append(src);
-        public void Convert(ref U8 src, ref SB dst) => ClearDst(ref dst).Append(src);
-        public void Convert(ref UG src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("0x{0:x16}{1:x16}", src.Hi, src.Lo); }
-        public void Convert(ref R4 src, ref SB dst) { ClearDst(ref dst); if (R4.IsNaN(src)) dst.AppendFormat(CultureInfo.InvariantCulture, "{0}", "?"); else dst.AppendFormat(CultureInfo.InvariantCulture, "{0:R}", src); }
-        public void Convert(ref R8 src, ref SB dst) { ClearDst(ref dst); if (R8.IsNaN(src)) dst.AppendFormat(CultureInfo.InvariantCulture, "{0}", "?"); else dst.AppendFormat(CultureInfo.InvariantCulture, "{0:G17}", src); }
-        public void Convert(ref BL src, ref SB dst)
+        public void Convert(in I1 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
+        public void Convert(in I2 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
+        public void Convert(in I4 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
+        public void Convert(in I8 src, ref SB dst) { ClearDst(ref dst); dst.Append(src); }
+        public void Convert(in U1 src, ref SB dst) => ClearDst(ref dst).Append(src);
+        public void Convert(in U2 src, ref SB dst) => ClearDst(ref dst).Append(src);
+        public void Convert(in U4 src, ref SB dst) => ClearDst(ref dst).Append(src);
+        public void Convert(in U8 src, ref SB dst) => ClearDst(ref dst).Append(src);
+        public void Convert(in UG src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("0x{0:x16}{1:x16}", src.Hi, src.Lo); }
+        public void Convert(in R4 src, ref SB dst) { ClearDst(ref dst); if (R4.IsNaN(src)) dst.AppendFormat(CultureInfo.InvariantCulture, "{0}", "?"); else dst.AppendFormat(CultureInfo.InvariantCulture, "{0:R}", src); }
+        public void Convert(in R8 src, ref SB dst) { ClearDst(ref dst); if (R8.IsNaN(src)) dst.AppendFormat(CultureInfo.InvariantCulture, "{0}", "?"); else dst.AppendFormat(CultureInfo.InvariantCulture, "{0:G17}", src); }
+        public void Convert(in BL src, ref SB dst)
         {
             ClearDst(ref dst);
             if (!src)
@@ -983,19 +983,19 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             else
                 dst.Append("1");
         }
-        public void Convert(ref TS src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("{0:c}", src); }
-        public void Convert(ref DT src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("{0:o}", src); }
-        public void Convert(ref DZ src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("{0:o}", src); }
+        public void Convert(in TS src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("{0:c}", src); }
+        public void Convert(in DT src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("{0:o}", src); }
+        public void Convert(in DZ src, ref SB dst) { ClearDst(ref dst); dst.AppendFormat("{0:o}", src); }
         #endregion ToStringBuilder
 
         #region FromR4
-        public void Convert(ref R4 src, ref R4 dst) => dst = src;
-        public void Convert(ref R4 src, ref R8 dst) => dst = src;
+        public void Convert(in R4 src, ref R4 dst) => dst = src;
+        public void Convert(in R4 src, ref R8 dst) => dst = src;
         #endregion FromR4
 
         #region FromR8
-        public void Convert(ref R8 src, ref R4 dst) => dst = (R4)src;
-        public void Convert(ref R8 src, ref R8 dst) => dst = src;
+        public void Convert(in R8 src, ref R4 dst) => dst = (R4)src;
+        public void Convert(in R8 src, ref R8 dst) => dst = src;
         #endregion FromR8
 
         #region FromTX
@@ -1666,44 +1666,44 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             return true;
         }
 
-        public void Convert(ref TX span, ref I1 value)
+        public void Convert(in TX span, ref I1 value)
         {
             value = ParseI1(in span);
         }
-        public void Convert(ref TX span, ref U1 value)
+        public void Convert(in TX span, ref U1 value)
         {
             value = ParseU1(in span);
         }
-        public void Convert(ref TX span, ref I2 value)
+        public void Convert(in TX span, ref I2 value)
         {
             value = ParseI2(in span);
         }
-        public void Convert(ref TX span, ref U2 value)
+        public void Convert(in TX span, ref U2 value)
         {
             value = ParseU2(in span);
         }
-        public void Convert(ref TX span, ref I4 value)
+        public void Convert(in TX span, ref I4 value)
         {
             value = ParseI4(in span);
         }
-        public void Convert(ref TX span, ref U4 value)
+        public void Convert(in TX span, ref U4 value)
         {
             value = ParseU4(in span);
         }
-        public void Convert(ref TX span, ref I8 value)
+        public void Convert(in TX span, ref I8 value)
         {
             value = ParseI8(in span);
         }
-        public void Convert(ref TX span, ref U8 value)
+        public void Convert(in TX span, ref U8 value)
         {
             value = ParseU8(in span);
         }
-        public void Convert(ref TX span, ref UG value)
+        public void Convert(in TX span, ref UG value)
         {
             if (!TryParse(in span, out value))
                 Contracts.Assert(value.Equals(default(UG)));
         }
-        public void Convert(ref TX src, ref R4 value)
+        public void Convert(in TX src, ref R4 value)
         {
             var span = src.Span;
             if (DoubleParser.TryParse(span, out value))
@@ -1711,7 +1711,7 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             // Unparsable is mapped to NA.
             value = R4.NaN;
         }
-        public void Convert(ref TX src, ref R8 value)
+        public void Convert(in TX src, ref R8 value)
         {
             var span = src.Span;
             if (DoubleParser.TryParse(span, out value))
@@ -1719,37 +1719,37 @@ namespace Microsoft.ML.Runtime.Data.Conversion
             // Unparsable is mapped to NA.
             value = R8.NaN;
         }
-        public void Convert(ref TX span, ref TX value)
+        public void Convert(in TX span, ref TX value)
         {
             value = span;
         }
-        public void Convert(ref TX src, ref BL value)
+        public void Convert(in TX src, ref BL value)
         {
             // When TryParseBL returns false, it should have set value to false.
             if (!TryParse(in src, out value))
                 Contracts.Assert(!value);
         }
-        public void Convert(ref TX src, ref SB dst)
+        public void Convert(in TX src, ref SB dst)
         {
             ClearDst(ref dst);
             if (!src.IsEmpty)
                 dst.AppendMemory(src);
         }
 
-        public void Convert(ref TX span, ref TS value) => TryParse(in span, out value);
-        public void Convert(ref TX span, ref DT value) => TryParse(in span, out value);
-        public void Convert(ref TX span, ref DZ value) => TryParse(in span, out value);
+        public void Convert(in TX span, ref TS value) => TryParse(in span, out value);
+        public void Convert(in TX span, ref DT value) => TryParse(in span, out value);
+        public void Convert(in TX span, ref DZ value) => TryParse(in span, out value);
 
         #endregion FromTX
 
         #region FromBL
-        public void Convert(ref BL src, ref I1 dst) => dst = (I1)(object)src;
-        public void Convert(ref BL src, ref I2 dst) => dst = (I2)(object)src;
-        public void Convert(ref BL src, ref I4 dst) => dst = (I4)(object)src;
-        public void Convert(ref BL src, ref I8 dst) => dst = (I8)(object)src;
-        public void Convert(ref BL src, ref R4 dst) => dst = System.Convert.ToSingle(src);
-        public void Convert(ref BL src, ref R8 dst) => dst = System.Convert.ToDouble(src);
-        public void Convert(ref BL src, ref BL dst) => dst = src;
+        public void Convert(in BL src, ref I1 dst) => dst = (I1)(object)src;
+        public void Convert(in BL src, ref I2 dst) => dst = (I2)(object)src;
+        public void Convert(in BL src, ref I4 dst) => dst = (I4)(object)src;
+        public void Convert(in BL src, ref I8 dst) => dst = (I8)(object)src;
+        public void Convert(in BL src, ref R4 dst) => dst = System.Convert.ToSingle(src);
+        public void Convert(in BL src, ref R8 dst) => dst = System.Convert.ToDouble(src);
+        public void Convert(in BL src, ref BL dst) => dst = src;
         #endregion FromBL
     }
 }

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -1342,7 +1342,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!Conversions.Instance.TryGetStringConversion<T>(colType, out conversion))
             {
                 var error = $"Cannot display {colType}";
-                conversion = (ref T src, ref StringBuilder builder) =>
+                conversion = (in T src, ref StringBuilder builder) =>
                 {
                     if (builder == null)
                         builder = new StringBuilder();
@@ -1357,7 +1357,7 @@ namespace Microsoft.ML.Runtime.Data
                 (ref ReadOnlyMemory<char> value) =>
                 {
                     floatGetter(ref v);
-                    conversion(ref v, ref dst);
+                    conversion(in v, ref dst);
                     string text = dst.ToString();
                     value = text.AsMemory();
                 };
@@ -1384,7 +1384,7 @@ namespace Microsoft.ML.Runtime.Data
                             x =>
                             {
                                 var v = x.Value;
-                                conversion(ref v, ref dst);
+                                conversion(in v, ref dst);
                                 return dst.ToString();
                             }));
                     value = string.Format("<{0}{1}>", stringRep, suffix).AsMemory();

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Runtime.Data
                 (ref TDst dst) =>
                 {
                     getter(ref src);
-                    conv(ref src, ref dst);
+                    conv(in src, ref dst);
                 };
         }
 
@@ -134,7 +134,7 @@ namespace Microsoft.ML.Runtime.Data
                 (ref StringBuilder dst) =>
                 {
                     getter(ref src);
-                    conv(ref src, ref dst);
+                    conv(in src, ref dst);
                 };
         }
 
@@ -278,7 +278,7 @@ namespace Microsoft.ML.Runtime.Data
                     // REVIEW: This would be faster if there were loops for each std conversion.
                     // Consider adding those to the Conversions class.
                     for (int i = 0; i < count; i++)
-                        conv(ref src.Values[i], ref values[i]);
+                        conv(in src.Values[i], ref values[i]);
 
                     if (!src.IsDense)
                     {

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -1228,7 +1228,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             int count = _header.RowCount <= int.MaxValue ? (int)_header.RowCount : 0;
             KeyType type = new KeyType(DataKind.U8, 0, count);
             // We are mapping the row index as expressed as a long, into a key value, so we must increment by one.
-            ValueMapper<long, ulong> mapper = (ref long src, ref ulong dst) => dst = (ulong)(src + 1);
+            ValueMapper<long, ulong> mapper = (in long src, ref ulong dst) => dst = (ulong)(src + 1);
             var entry = new TableOfContentsEntry(this, rowIndexName, type, mapper);
             return entry;
         }
@@ -1710,7 +1710,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 {
                     Ectx.Check(_curr != null, _badCursorState);
                     long src = _curr.RowIndexLim - _remaining - 1;
-                    _mapper(ref src, ref value);
+                    _mapper(in src, ref value);
                 }
 
                 public override Delegate GetGetter()

--- a/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
@@ -610,7 +610,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 return (ref TValue value) =>
                 {
-                    conv(ref _colValues[col], ref value);
+                    conv(in _colValues[col], ref value);
                 };
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -1015,7 +1015,7 @@ namespace Microsoft.ML.Runtime.Data
                                 int csrc = default;
                                 try
                                 {
-                                    Conversions.Instance.Convert(ref spanT, ref csrc);
+                                    Conversions.Instance.Convert(in spanT, ref csrc);
                                 }
                                 catch
                                 {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -116,28 +116,28 @@ namespace Microsoft.ML.Runtime.Data.IO
                     Conv = Conversions.Instance.GetStringConversion<T>(type);
 
                 var d = default(T);
-                Conv(ref d, ref Sb);
+                Conv(in d, ref Sb);
                 Default = Sb.ToString();
             }
 
-            protected void MapText(ref ReadOnlyMemory<char> src, ref StringBuilder sb)
+            protected void MapText(in ReadOnlyMemory<char> src, ref StringBuilder sb)
             {
                 TextSaverUtils.MapText(src.Span, ref sb, Sep);
             }
 
-            protected void MapTimeSpan(ref TimeSpan src, ref StringBuilder sb)
+            protected void MapTimeSpan(in TimeSpan src, ref StringBuilder sb)
             {
-                TextSaverUtils.MapTimeSpan(ref src, ref sb);
+                TextSaverUtils.MapTimeSpan(in src, ref sb);
             }
 
-            protected void MapDateTime(ref DateTime src, ref StringBuilder sb)
+            protected void MapDateTime(in DateTime src, ref StringBuilder sb)
             {
-                TextSaverUtils.MapDateTime(ref src, ref sb);
+                TextSaverUtils.MapDateTime(in src, ref sb);
             }
 
-            protected void MapDateTimeZone(ref DateTimeOffset src, ref StringBuilder sb)
+            protected void MapDateTimeZone(in DateTimeOffset src, ref StringBuilder sb)
             {
-                TextSaverUtils.MapDateTimeZone(ref src, ref sb);
+                TextSaverUtils.MapDateTimeZone(in src, ref sb);
             }
         }
 
@@ -170,7 +170,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 {
                     for (int i = 0; i < _src.Length; i++)
                     {
-                        Conv(ref _src.Values[i], ref Sb);
+                        Conv(in _src.Values[i], ref Sb);
                         appendItem(Sb, i);
                     }
                 }
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 {
                     for (int i = 0; i < _src.Count; i++)
                     {
-                        Conv(ref _src.Values[i], ref Sb);
+                        Conv(in _src.Values[i], ref Sb);
                         appendItem(Sb, _src.Indices[i]);
                     }
                 }
@@ -195,7 +195,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                     var name = _slotNames.Values[i];
                     if (name.IsEmpty)
                         continue;
-                    MapText(ref name, ref Sb);
+                    MapText(in name, ref Sb);
                     int index = _slotNames.IsDense ? i : _slotNames.Indices[i];
                     appendItem(Sb, index);
                 }
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             public override void WriteData(Action<StringBuilder, int> appendItem, out int length)
             {
                 _getSrc(ref _src);
-                Conv(ref _src, ref Sb);
+                Conv(in _src, ref Sb);
                 appendItem(Sb, 0);
                 length = 1;
             }
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             public override void WriteHeader(Action<StringBuilder, int> appendItem, out int length)
             {
                 var span = _columnName.AsMemory();
-                MapText(ref span, ref Sb);
+                MapText(in span, ref Sb);
                 appendItem(Sb, 0);
                 length = 1;
             }
@@ -846,7 +846,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             }
         }
 
-        internal static void MapTimeSpan(ref TimeSpan src, ref StringBuilder sb)
+        internal static void MapTimeSpan(in TimeSpan src, ref StringBuilder sb)
         {
             if (sb == null)
                 sb = new StringBuilder();
@@ -856,7 +856,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             sb.AppendFormat("\"{0:c}\"", src);
         }
 
-        internal static void MapDateTime(ref DateTime src, ref StringBuilder sb)
+        internal static void MapDateTime(in DateTime src, ref StringBuilder sb)
         {
             if (sb == null)
                 sb = new StringBuilder();
@@ -866,7 +866,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             sb.AppendFormat("\"{0:o}\"", src);
         }
 
-        internal static void MapDateTimeZone(ref DateTimeOffset src, ref StringBuilder sb)
+        internal static void MapDateTimeZone(in DateTimeOffset src, ref StringBuilder sb)
         {
             if (sb == null)
                 sb = new StringBuilder();

--- a/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Runtime.Data
                         (ref T2 v2) =>
                         {
                             getSrc(ref v1);
-                            _map1(ref v1, ref v2);
+                            _map1(in v1, ref v2);
                         };
                     return getter;
                 }
@@ -178,8 +178,8 @@ namespace Microsoft.ML.Runtime.Data
                         (ref T3 v3) =>
                         {
                             getSrc(ref v1);
-                            _map1(ref v1, ref v2);
-                            _map2(ref v2, ref v3);
+                            _map1(in v1, ref v2);
+                            _map2(in v2, ref v3);
                         };
                     return getter;
                 }

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -170,7 +170,7 @@ namespace Microsoft.ML.Runtime.Data
                         _pred =
                             (in T1 src) =>
                             {
-                                conv(ref _src, ref val);
+                                conv(in _src, ref val);
                                 return pred(in val);
                             };
                     }

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -372,7 +372,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.Check(typeSrc.RawType == typeof(TSrc));
             return LambdaColumnMapper.Create(env, registrationName, input, inputColName, outputColName, typeSrc, TextType.Instance,
-                (ref TSrc src, ref ReadOnlyMemory<char> dst) => dst = value.AsMemory());
+                (in TSrc src, ref ReadOnlyMemory<char> dst) => dst = value.AsMemory());
         }
 
         /// <summary>
@@ -406,7 +406,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.Check(typeSrc.RawType == typeof(TSrc));
             return LambdaColumnMapper.Create(env, registrationName, input, inputColName, outputColName, typeSrc,
-                new KeyType(DataKind.U4, 0, keyCount), (ref TSrc src, ref uint dst) =>
+                new KeyType(DataKind.U4, 0, keyCount), (in TSrc src, ref uint dst) =>
                 {
                     if (value < 0 || value > keyCount)
                         dst = 0;
@@ -507,7 +507,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (def.Equals(default(T)))
                 {
                     mapper =
-                        (ref VBuffer<T> src, ref VBuffer<T> dst) =>
+                        (in VBuffer<T> src, ref VBuffer<T> dst) =>
                         {
                             Contracts.Assert(src.Length == Utils.Size(map));
 
@@ -533,7 +533,7 @@ namespace Microsoft.ML.Runtime.Data
                             naIndices.Add(j);
                     }
                     mapper =
-                        (ref VBuffer<T> src, ref VBuffer<T> dst) =>
+                        (in VBuffer<T> src, ref VBuffer<T> dst) =>
                         {
                             Contracts.Assert(src.Length == Utils.Size(map));
                             var values = dst.Values;
@@ -622,7 +622,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 var keyMapperCur = keyValueMappers[i];
                 ValueMapper<uint, uint> mapper =
-                    (ref uint src, ref uint dst) =>
+                    (in uint src, ref uint dst) =>
                     {
                         if (src == 0 || src > keyMapperCur.Length)
                             dst = 0;
@@ -653,7 +653,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (!views[i].Schema.TryGetColumnIndex(columnName, out var index))
                     throw env.Except($"Data view {i} doesn't contain a column '{columnName}'");
                 ValueMapper<uint, uint> mapper =
-                    (ref uint src, ref uint dst) =>
+                    (in uint src, ref uint dst) =>
                     {
                         if (src > keyCount)
                             dst = 0;
@@ -689,7 +689,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 var keyMapperCur = keyValueMappers[i];
                 ValueMapper<VBuffer<uint>, VBuffer<uint>> mapper =
-                    (ref VBuffer<uint> src, ref VBuffer<uint> dst) =>
+                    (in VBuffer<uint> src, ref VBuffer<uint> dst) =>
                     {
                         var values = dst.Values;
                         if (Utils.Size(values) < src.Count)
@@ -984,7 +984,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             return LambdaColumnMapper.Create(env, "ChangeToVarLength", idv, variableSizeVectorColumnName,
                        variableSizeVectorColumnName + "_VarLength", typeSrc, new VectorType(typeSrc.ItemType.AsPrimitive),
-                       (ref VBuffer<TSrc> src, ref VBuffer<TSrc> dst) => src.CopyTo(ref dst));
+                       (in VBuffer<TSrc> src, ref VBuffer<TSrc> dst) => src.CopyTo(ref dst));
         }
 
         private static List<string> GetMetricNames(IChannel ch, Schema schema, IRow row, Func<int, bool> ignoreCol,

--- a/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 perInst = LambdaColumnMapper.Create(Host, "ConvertToDouble", perInst, schema.Label.Name,
                     schema.Label.Name, perInst.Schema.GetColumnType(labelCol), NumberType.R8,
-                    (ref uint src, ref double dst) => dst = src == 0 ? double.NaN : src - 1 + (double)labelType.AsKey.Min);
+                    (in uint src, ref double dst) => dst = src == 0 ? double.NaN : src - 1 + (double)labelType.AsKey.Min);
             }
 
             var perInstSchema = perInst.Schema;

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -509,7 +509,7 @@ namespace Microsoft.ML.Runtime.Data
                     var name = data.Schema.GetColumnName(i);
                     var index = _index ?? type.VectorSize / 2;
                     output = LambdaColumnMapper.Create(Host, "Quantile Regression", output, name, name, type, NumberType.R8,
-                        (ref VBuffer<Double> src, ref Double dst) => dst = src.GetItemOrDefault(index));
+                        (in VBuffer<Double> src, ref Double dst) => dst = src.GetItemOrDefault(index));
                     output = new ChooseColumnsByIndexTransform(Host,
                         new ChooseColumnsByIndexTransform.Arguments() { Drop = true, Index = new[] { i } }, output);
                 }

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -250,7 +250,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             Host.Check(typeof(TDist) == typeof(Float));
             var map = GetMapper<TIn, Float>();
             ValueMapper<TIn, Float, Float> del =
-                (ref TIn src, ref Float score, ref Float prob) =>
+                (in TIn src, ref Float score, ref Float prob) =>
                 {
                     map(in src, ref score);
                     prob = Calibrator.PredictProbability(score);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             ValueMapper<TIn, Float, Float> del =
                 (ref TIn src, ref Float score, ref Float prob) =>
                 {
-                    map(ref src, ref score);
+                    map(in src, ref score);
                     prob = Calibrator.PredictProbability(score);
                 };
             return (ValueMapper<TIn, TOut, TDist>)(Delegate)del;

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Runtime.Data
                 (ref TDst dst) =>
                 {
                     featureGetter(ref features);
-                    map(ref features, ref dst);
+                    map(in features, ref dst);
                 };
         }
 
@@ -667,7 +667,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     featureGetter(ref features);
                     Contracts.Check(features.Length == featureCount || featureCount == 0);
-                    map(ref features, ref value);
+                    map(in features, ref value);
                 };
             return del;
         }

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -546,7 +546,7 @@ namespace Microsoft.ML.Runtime.Data
                     if (featureGetter != null)
                         featureGetter(ref features);
 
-                    mapper(ref features, ref score, ref prob);
+                    mapper(in features, ref score, ref prob);
                     cachedPosition = input.Position;
                 }
             }

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -56,11 +56,11 @@ namespace Microsoft.ML.Runtime.Data
                 // REVIEW: We could optimize for identity, but it's probably not worthwhile.
                 var keyMapper = conv.GetStandardConversion<T, uint>(type, NumberType.U4, out identity);
                 return
-                    (ref T src, ref StringBuilder dst) =>
+                    (in T src, ref StringBuilder dst) =>
                     {
                         ClearDst(ref dst);
                         uint intermediate = 0;
-                        keyMapper(ref src, ref intermediate);
+                        keyMapper(in src, ref intermediate);
                         if (intermediate == 0)
                             return;
                         keyValues.GetItemOrDefault((int)(intermediate - 1), ref value);
@@ -77,13 +77,13 @@ namespace Microsoft.ML.Runtime.Data
             StringBuilder sb = null;
             char[] buffer = null;
             return
-                (ref KeyValuePair<int, T> pair, ref StringBuilder dst) =>
+                (in KeyValuePair<int, T> pair, ref StringBuilder dst) =>
                 {
                     ClearDst(ref dst);
                     dst.Append(pair.Key);
                     dst.Append(':');
                     var subval = pair.Value;
-                    submap(ref subval, ref sb);
+                    submap(in subval, ref sb);
                     AppendToEnd(sb, dst, ref buffer);
                 };
         }
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Runtime.Data
             _stringifyMapper = mapper;
             _comparer = new PairEqualityComparer(comparer);
             _slotToValueSet = new Dictionary<int, HashSet<Pair>>();
-            _copier = copier ?? ((ref T src, ref T dst) => dst = src);
+            _copier = copier ?? ((in T src, ref T dst) => dst = src);
         }
 
         private ReadOnlyMemory<char> Textify(ref StringBuilder sb, ref StringBuilder temp, ref char[] cbuffer, ref Pair[] buffer, HashSet<Pair> pairs)
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Runtime.Data
             if (count == 1)
             {
                 var value = buffer[0].Value;
-                _stringifyMapper(ref value, ref temp);
+                _stringifyMapper(in value, ref temp);
                 return Utils.Size(temp) > 0 ? temp.ToString().AsMemory() : String.Empty.AsMemory();
             }
 
@@ -215,7 +215,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (i > 0)
                     sb.Append(',');
                 var value = pair.Value;
-                _stringifyMapper(ref value, ref temp);
+                _stringifyMapper(in value, ref temp);
                 InvertHashUtils.AppendToEnd(temp, sb, ref cbuffer);
             }
             sb.Append('}');
@@ -293,7 +293,7 @@ namespace Microsoft.ML.Runtime.Data
             else
                 pairSet = _slotToValueSet[dstSlot] = new HashSet<Pair>(_comparer);
             T dst = default(T);
-            _copier(ref key, ref dst);
+            _copier(in key, ref dst);
             pairSet.Add(new Pair(dst, pairSet.Count));
         }
 

--- a/src/Microsoft.ML.Data/Transforms/KeyToValueTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValueTransform.cs
@@ -333,7 +333,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 private void MapKey(ref TKey src, ref TValue dst)
                 {
                     uint uintSrc = 0;
-                    _convertToUInt(ref src, ref uintSrc);
+                    _convertToUInt(in src, ref uintSrc);
                     // Assign to NA if key value is not in valid range.
                     if (0 < uintSrc && uintSrc <= _values.Length)
                         dst = _values[uintSrc - 1];

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Transforms
                 Ch.Assert(Parent._type.IsKey);
                 _srcGetter(ref _value);
                 ulong value = 0;
-                _conv(ref _value, ref value);
+                _conv(in _value, ref value);
                 if (value == 0 || value > (ulong)_count)
                     return false;
                 if (!CheckBounds(((Double)(uint)value - 0.5) / _count))

--- a/src/Microsoft.ML.Data/Transforms/TermTransformImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/TermTransformImpl.cs
@@ -632,7 +632,7 @@ namespace Microsoft.ML.Transforms.Categorical
                     }
                 }
 
-                private void KeyMapper(ref ReadOnlyMemory<char> src, ref uint dst)
+                private void KeyMapper(in ReadOnlyMemory<char> src, ref uint dst)
                 {
                     var nstr = ReadOnlyMemoryUtils.FindInPool(src, _pool);
                     if (nstr == null)
@@ -717,7 +717,7 @@ namespace Microsoft.ML.Transforms.Categorical
                 public override ValueMapper<T, uint> GetKeyMapper()
                 {
                     return
-                        (ref T src, ref uint dst) =>
+                        (in T src, ref uint dst) =>
                         {
                             int val;
                             if (_values.TryGetIndex(src, out val))
@@ -751,7 +751,7 @@ namespace Microsoft.ML.Transforms.Categorical
                     for (int i = 0; i < _values.Count; ++i)
                     {
                         T val = _values.GetItem(i);
-                        stringMapper(ref val, ref sb);
+                        stringMapper(in val, ref sb);
                         writer.WriteLine("{0}\t{1}", i, sb.ToString());
                     }
                 }
@@ -792,7 +792,7 @@ namespace Microsoft.ML.Transforms.Categorical
                 values = new ReadOnlyMemory<char>[src.Length];
             for (int i = 0; i < src.Length; ++i)
             {
-                stringMapper(ref src.Values[i], ref sb);
+                stringMapper(in src.Values[i], ref sb);
                 values[i] = sb.ToString().AsMemory();
             }
             dst = new VBuffer<ReadOnlyMemory<char>>(src.Length, values, dst.Indices);
@@ -888,7 +888,7 @@ namespace Microsoft.ML.Transforms.Categorical
                 {
                     T src = default(T);
                     uint dst = 0;
-                    map(ref src, ref dst);
+                    map(in src, ref dst);
                     return dst;
                 }
 
@@ -915,7 +915,7 @@ namespace Microsoft.ML.Transforms.Categorical
                             (ref uint dst) =>
                             {
                                 getSrc(ref src);
-                                map(ref src, ref dst);
+                                map(in src, ref dst);
                             };
                         return retVal;
                     }
@@ -965,7 +965,7 @@ namespace Microsoft.ML.Transforms.Categorical
                                     int count = src.Count;
                                     for (int islot = 0; islot < count; islot++)
                                     {
-                                        map(ref values[islot], ref dstItem);
+                                        map(in values[islot], ref dstItem);
                                         if (dstItem != 0)
                                         {
                                             int slot = indices != null ? indices[islot] : islot;
@@ -1003,7 +1003,7 @@ namespace Microsoft.ML.Transforms.Categorical
                                     {
                                         for (int slot = 0; slot < src.Length; ++slot)
                                         {
-                                            map(ref values[slot], ref dstItem);
+                                            map(in values[slot], ref dstItem);
                                             if (dstItem != 0)
                                                 bldr.AddFeature(slot, dstItem);
                                         }
@@ -1019,7 +1019,7 @@ namespace Microsoft.ML.Transforms.Categorical
                                             {
                                                 // This was an explicitly defined value.
                                                 _host.Assert(islot < src.Count);
-                                                map(ref values[islot], ref dstItem);
+                                                map(in values[islot], ref dstItem);
                                                 if (dstItem != 0)
                                                     bldr.AddFeature(slot, dstItem);
                                                 nextExplicitSlot = ++islot == src.Count ? src.Length : indices[islot];
@@ -1130,7 +1130,7 @@ namespace Microsoft.ML.Transforms.Categorical
                             foreach (var pair in keyVals.Items(all: true))
                             {
                                 T keyVal = pair.Value;
-                                conv(ref keyVal, ref convKeyVal);
+                                conv(in keyVal, ref convKeyVal);
                                 // The builder for the key values should not have any missings.
                                 _host.Assert(0 < convKeyVal && convKeyVal <= srcMeta.Length);
                                 srcMeta.GetItemOrDefault((int)(convKeyVal - 1), ref values[pair.Key]);
@@ -1213,13 +1213,13 @@ namespace Microsoft.ML.Transforms.Categorical
                     foreach (var pair in keyVals.Items(all: true))
                     {
                         T keyVal = pair.Value;
-                        conv(ref keyVal, ref convKeyVal);
+                        conv(in keyVal, ref convKeyVal);
                         // The key mapping will not have admitted missing keys.
                         _host.Assert(0 < convKeyVal && convKeyVal <= srcMeta.Length);
                         srcMeta.GetItemOrDefault((int)(convKeyVal - 1), ref metaVal);
-                        keyStringMapper(ref keyVal, ref sb);
+                        keyStringMapper(in keyVal, ref sb);
                         writer.Write("{0}\t{1}", pair.Key, sb.ToString());
-                        metaStringMapper(ref metaVal, ref sb);
+                        metaStringMapper(in metaVal, ref sb);
                         writer.WriteLine("\t{0}", sb.ToString());
                     }
                     return true;

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             var name = data.Schema.Feature.Name;
             var view = LambdaColumnMapper.Create(
                 host, "FeatureSelector", data.Data, name, name, type, type,
-                (ref VBuffer<Single> src, ref VBuffer<Single> dst) => SelectFeatures(in src, features, card, ref dst));
+                (in VBuffer<Single> src, ref VBuffer<Single> dst) => SelectFeatures(in src, features, card, ref dst));
 
             var res = new RoleMappedData(view, data.Schema.GetColumnRoleNames());
             return res;

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseStacking.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 (ref TOutput dst, TOutput[] src, Single[] weights) =>
                 {
                     FillFeatureBuffer(src, ref feat);
-                    map(ref feat, ref dst);
+                    map(in feat, ref dst);
                 };
             return res;
         }
@@ -160,10 +160,10 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                             if (model.SelectedFeatures != null)
                             {
                                 EnsembleUtils.SelectFeatures(in cursor.Features, model.SelectedFeatures, model.Cardinality, ref vBuffers[i]);
-                                maps[i](ref vBuffers[i], ref predictions[i]);
+                                maps[i](in vBuffers[i], ref predictions[i]);
                             }
                             else
-                                maps[i](ref cursor.Features, ref predictions[i]);
+                                maps[i](in cursor.Features, ref predictions[i]);
                         });
 
                         Utils.EnsureSize(ref labels, count + 1);

--- a/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseDiverseSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseDiverseSelector.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubModelSelector
                 while (cursor.MoveNext())
                 {
                     Utils.EnsureSize(ref preds, count + 1);
-                    map(ref cursor.Features, ref preds[count]);
+                    map(in cursor.Features, ref preds[count]);
                     count++;
                 }
             }

--- a/src/Microsoft.ML.Ensemble/Trainer/EnsembleDistributionPredictor.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/EnsembleDistributionPredictor.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             var probabilities = new Single[_mappers.Length];
             var vBuffers = new VBuffer<Single>[_mappers.Length];
             ValueMapper<VBuffer<Single>, Single> del =
-                (ref VBuffer<Single> src, ref Single dst) =>
+                (in VBuffer<Single> src, ref Single dst) =>
                 {
                     if (InputType.VectorSize > 0)
                         Host.Check(src.Length == InputType.VectorSize);

--- a/src/Microsoft.ML.Ensemble/Trainer/EnsembleDistributionPredictor.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/EnsembleDistributionPredictor.cs
@@ -142,10 +142,10 @@ namespace Microsoft.ML.Runtime.Ensemble
                         if (model.SelectedFeatures != null)
                         {
                             EnsembleUtils.SelectFeatures(in tmp, model.SelectedFeatures, model.Cardinality, ref vBuffers[i]);
-                            maps[i](ref vBuffers[i], ref predictions[i], ref probabilities[i]);
+                            maps[i](in vBuffers[i], ref predictions[i], ref probabilities[i]);
                         }
                         else
-                            maps[i](ref tmp, ref predictions[i], ref probabilities[i]);
+                            maps[i](in tmp, ref predictions[i], ref probabilities[i]);
                     });
 
                     // REVIEW: DistributionEnsemble - AveragedWeights are used only in one of the two PredictDistributions overloads
@@ -168,7 +168,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             var probabilities = new Single[_mappers.Length];
             var vBuffers = new VBuffer<Single>[_mappers.Length];
             ValueMapper<VBuffer<Single>, Single, Single> del =
-                (ref VBuffer<Single> src, ref Single score, ref Single prob) =>
+                (in VBuffer<Single> src, ref Single score, ref Single prob) =>
                 {
                     if (InputType.VectorSize > 0)
                         Host.Check(src.Length == InputType.VectorSize);
@@ -180,10 +180,10 @@ namespace Microsoft.ML.Runtime.Ensemble
                         if (model.SelectedFeatures != null)
                         {
                             EnsembleUtils.SelectFeatures(in tmp, model.SelectedFeatures, model.Cardinality, ref vBuffers[i]);
-                            maps[i](ref vBuffers[i], ref predictions[i], ref probabilities[i]);
+                            maps[i](in vBuffers[i], ref predictions[i], ref probabilities[i]);
                         }
                         else
-                            maps[i](ref tmp, ref predictions[i], ref probabilities[i]);
+                            maps[i](in tmp, ref predictions[i], ref probabilities[i]);
                     });
 
                     combine(ref score, predictions, _averagedWeights);

--- a/src/Microsoft.ML.Ensemble/Trainer/EnsemblePredictor.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/EnsemblePredictor.cs
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 maps[i] = _mappers[i].GetMapper<VBuffer<Single>, Single>();
 
             ValueMapper<VBuffer<Single>, Single> del =
-                (ref VBuffer<Single> src, ref Single dst) =>
+                (in VBuffer<Single> src, ref Single dst) =>
                 {
                     if (InputType.VectorSize > 0)
                         Host.Check(src.Length == InputType.VectorSize);
@@ -134,10 +134,10 @@ namespace Microsoft.ML.Runtime.Ensemble
                         if (model.SelectedFeatures != null)
                         {
                             EnsembleUtils.SelectFeatures(in tmp, model.SelectedFeatures, model.Cardinality, ref buffers[i]);
-                            maps[i](ref buffers[i], ref predictions[i]);
+                            maps[i](in buffers[i], ref predictions[i]);
                         }
                         else
-                            maps[i](ref tmp, ref predictions[i]);
+                            maps[i](in tmp, ref predictions[i]);
                     });
 
                     combine(ref dst, predictions, Weights);

--- a/src/Microsoft.ML.Ensemble/Trainer/Multiclass/EnsembleMultiClassPredictor.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/Multiclass/EnsembleMultiClassPredictor.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             }
 
             ValueMapper<VBuffer<Single>, VBuffer<Single>> del =
-                (ref VBuffer<Single> src, ref VBuffer<Single> dst) =>
+                (in VBuffer<Single> src, ref VBuffer<Single> dst) =>
                 {
                     if (_inputType.VectorSize > 0)
                         Host.Check(src.Length == _inputType.VectorSize);
@@ -133,10 +133,10 @@ namespace Microsoft.ML.Runtime.Ensemble
                         if (model.SelectedFeatures != null)
                         {
                             EnsembleUtils.SelectFeatures(in tmp, model.SelectedFeatures, model.Cardinality, ref features[i]);
-                            maps[i](ref features[i], ref predictions[i]);
+                            maps[i](in features[i], ref predictions[i]);
                         }
                         else
-                            maps[i](ref tmp, ref predictions[i]);
+                            maps[i](in tmp, ref predictions[i]);
 
                         // individual maps delegates will return always the same VBuffer length
                         Host.Check(predictions[i].Length == _mappers[i].OutputType.VectorSize);

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1334,11 +1334,11 @@ namespace Microsoft.ML.Trainers.FastTree
                 if (identity)
                 {
                     ValueMapper<VBuffer<T1>, VBuffer<T1>> identityResult =
-                        (ref VBuffer<T1> src, ref VBuffer<T1> dst) => src.CopyTo(ref dst);
+                        (in VBuffer<T1> src, ref VBuffer<T1> dst) => src.CopyTo(ref dst);
                     return (ValueMapper<VBuffer<T1>, VBuffer<T2>>)(object)identityResult;
                 }
                 return
-                    (ref VBuffer<T1> src, ref VBuffer<T2> dst) =>
+                    (in VBuffer<T1> src, ref VBuffer<T2> dst) =>
                     {
                         var indices = dst.Indices;
                         var values = dst.Values;
@@ -1351,7 +1351,7 @@ namespace Microsoft.ML.Trainers.FastTree
                             }
                             Utils.EnsureSize(ref values, src.Count);
                             for (int i = 0; i < src.Count; ++i)
-                                conv(ref src.Values[i], ref values[i]);
+                                conv(in src.Values[i], ref values[i]);
                         }
                         dst = new VBuffer<T2>(src.Length, src.Count, values, indices);
                     };
@@ -1458,7 +1458,7 @@ namespace Microsoft.ML.Trainers.FastTree
                                             ch.Assert(maxBins > 0);
                                             finder = finder ?? new BinFinder();
                                             // Must copy over, as bin calculation is potentially destructive.
-                                            copier(ref temp, ref doubleTemp);
+                                            copier(in temp, ref doubleTemp);
                                             hasMissing = !CalculateBins(finder, in doubleTemp, maxBins, 0,
                                                 out BinUpperBounds[iFeature]);
                                         }
@@ -1682,7 +1682,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 Contracts.Assert(cursor.Position == iFeature);
 
                 getter(ref temp);
-                copier(ref temp, ref doubleTemp);
+                copier(in temp, ref doubleTemp);
             }
 
             private static ValueGetter<VBuffer<T>> SubsetGetter<T>(ValueGetter<VBuffer<T>> getter, SlotDropper slotDropper)
@@ -2915,7 +2915,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return (ValueMapper<TIn, TOut>)(Delegate)del;
         }
 
-        protected virtual void Map(ref VBuffer<Float> src, ref Float dst)
+        protected virtual void Map(in VBuffer<Float> src, ref Float dst)
         {
             if (InputType.VectorSize > 0)
                 Host.Check(src.Length == InputType.VectorSize);
@@ -2934,7 +2934,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             BufferBuilder<Float> builder = null;
             ValueMapper<VBuffer<Float>, VBuffer<Float>> del =
-                (ref VBuffer<Float> src, ref VBuffer<Float> dst) =>
+                (in VBuffer<Float> src, ref VBuffer<Float> dst) =>
                 {
                     WhatTheFeatureMap(in src, ref dst, ref builder);
                     Runtime.Numeric.VectorUtils.SparsifyNormalize(ref dst, top, bottom, normalize);

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -489,12 +489,12 @@ namespace Microsoft.ML.Trainers.FastTree
             return new FastTreeTweediePredictor(env, ctx);
         }
 
-        protected override void Map(ref VBuffer<float> src, ref float dst)
+        protected override void Map(in VBuffer<float> src, ref float dst)
         {
             // The value learnt and predicted by the trees is the log of the expected value,
             // as seen in equation 9 of the paper. So for the actual prediction, we take its
             // exponent.
-            base.Map(ref src, ref dst);
+            base.Map(in src, ref dst);
             // REVIEW: Some packages like R's GBM apparently clamp the input to the exponent
             // in the range [-19, 19]. We have historically taken a dim view of this sort of thing
             // ourselves, but if our views prove problematic we can reconsider. (An upper clamp of 19

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -799,7 +799,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return (ValueMapper<TIn, TOut>)(Delegate)del;
         }
 
-        private void Map(ref VBuffer<float> features, ref float response)
+        private void Map(in VBuffer<float> features, ref float response)
         {
             Host.CheckParam(features.Length == _inputLength, nameof(features), "Bad length of input");
 

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        protected override void Map(ref VBuffer<float> src, ref float dst)
+        protected override void Map(in VBuffer<float> src, ref float dst)
         {
             if (InputType.VectorSize > 0)
                 Host.Check(src.Length == InputType.VectorSize);
@@ -113,7 +113,7 @@ namespace Microsoft.ML.Trainers.FastTree
         public ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper(float[] quantiles)
         {
             return
-                (ref VBuffer<float> src, ref VBuffer<float> dst) =>
+                (in VBuffer<float> src, ref VBuffer<float> dst) =>
                 {
                     // REVIEW: Should make this more efficient - it repeatedly allocates too much stuff.
                     float[] weights = null;

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -746,14 +746,14 @@ namespace Microsoft.ML.Runtime.Data
             if (seed == 0)
             {
                 mapper =
-                    (ref TInput src, ref Single dst) =>
+                    (in TInput src, ref Single dst) =>
                     {
                         if (isNa(in src))
                         {
                             dst = Single.NaN;
                             return;
                         }
-                        converter(ref src, ref temp);
+                        converter(in src, ref temp);
                         dst = (Single)(temp - 1);
                     };
             }
@@ -762,14 +762,14 @@ namespace Microsoft.ML.Runtime.Data
                 ch.Check(type.Count > 0, "Label must be of known cardinality.");
                 int[] permutation = Utils.GetRandomPermutation(RandomUtils.Create(seed), type.Count);
                 mapper =
-                    (ref TInput src, ref Single dst) =>
+                    (in TInput src, ref Single dst) =>
                     {
                         if (isNa(in src))
                         {
                             dst = Single.NaN;
                             return;
                         }
-                        converter(ref src, ref temp);
+                        converter(in src, ref temp);
                         dst = (Single)permutation[(int)(temp - 1)];
                     };
             }

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -294,7 +294,7 @@ namespace Microsoft.ML.Trainers.HalLearners
                 while (cursor.MoveNext())
                 {
                     var features = cursor.Features;
-                    lrMap(ref features, ref yh);
+                    lrMap(in features, ref yh);
                     var e = cursor.Label - yh;
                     rss += e * e;
                     var ydm = cursor.Label - yMean;

--- a/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ML.Trainers.KMeans
             Host.Check(typeof(TOut) == typeof(VBuffer<Float>));
 
             ValueMapper<VBuffer<Float>, VBuffer<Float>> del =
-                (ref VBuffer<Float> src, ref VBuffer<Float> dst) =>
+                (in VBuffer<Float> src, ref VBuffer<Float> dst) =>
                 {
                     if (src.Length != _dimensionality)
                         throw Host.Except($"Incorrect number of features: expected {_dimensionality}, got {src.Length}");

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -561,7 +561,7 @@ namespace Microsoft.ML.Trainers.PCA
             Host.Check(typeof(TOut) == typeof(float));
 
             ValueMapper<VBuffer<float>, float> del =
-                (ref VBuffer<float> src, ref float dst) =>
+                (in VBuffer<float> src, ref float dst) =>
                 {
                     Host.Check(src.Length == _dimension);
                     dst = Score(in src);

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -545,7 +545,7 @@ namespace Microsoft.ML.Runtime.Data
                 return (ref TValue value) =>
                 {
                     TSource val = (TSource)_columnValues[activeIdx][_curDataSetRow];
-                    valueConverter(ref val, ref value);
+                    valueConverter(in val, ref value);
                 };
             }
             #endregion
@@ -676,41 +676,41 @@ namespace Microsoft.ML.Runtime.Data
                 _ch = channel;
             }
 
-            public void Conv(ref byte[] src, ref VBuffer<Byte> dst) => dst = src != null ? new VBuffer<byte>(src.Length, src) : new VBuffer<byte>(0, new byte[0]);
+            public void Conv(in byte[] src, ref VBuffer<Byte> dst) => dst = src != null ? new VBuffer<byte>(src.Length, src) : new VBuffer<byte>(0, new byte[0]);
 
-            public void Conv(ref sbyte? src, ref sbyte dst) => dst = (sbyte)src;
+            public void Conv(in sbyte? src, ref sbyte dst) => dst = (sbyte)src;
 
-            public void Conv(ref byte src, ref byte dst) => dst = src;
+            public void Conv(in byte src, ref byte dst) => dst = src;
 
-            public void Conv(ref short? src, ref short dst) => dst = (short)src;
+            public void Conv(in short? src, ref short dst) => dst = (short)src;
 
-            public void Conv(ref ushort src, ref ushort dst) => dst = src;
+            public void Conv(in ushort src, ref ushort dst) => dst = src;
 
-            public void Conv(ref int? src, ref int dst) => dst = (int)src;
+            public void Conv(in int? src, ref int dst) => dst = (int)src;
 
-            public void Conv(ref long? src, ref long dst) => dst = (long)src;
+            public void Conv(in long? src, ref long dst) => dst = (long)src;
 
-            public void Conv(ref float? src, ref Single dst) => dst = src ?? Single.NaN;
+            public void Conv(in float? src, ref Single dst) => dst = src ?? Single.NaN;
 
-            public void Conv(ref double? src, ref Double dst) => dst = src ?? Double.NaN;
+            public void Conv(in double? src, ref Double dst) => dst = src ?? Double.NaN;
 
-            public void Conv(ref decimal? src, ref Double dst) => dst = src != null ? Decimal.ToDouble((decimal)src) : Double.NaN;
+            public void Conv(in decimal? src, ref Double dst) => dst = src != null ? Decimal.ToDouble((decimal)src) : Double.NaN;
 
-            public void Conv(ref string src, ref ReadOnlyMemory<char> dst) => dst = src.AsMemory();
+            public void Conv(in string src, ref ReadOnlyMemory<char> dst) => dst = src.AsMemory();
 
             //Behavior for NA values is undefined.
-            public void Conv(ref bool src, ref bool dst) => dst = src;
+            public void Conv(in bool src, ref bool dst) => dst = src;
 
-            public void Conv(ref DateTimeOffset src, ref DateTimeOffset dst) => dst = src;
+            public void Conv(in DateTimeOffset src, ref DateTimeOffset dst) => dst = src;
 
-            public void Conv(ref IList src, ref ReadOnlyMemory<char> dst) => dst = ConvertListToString(src).AsMemory();
+            public void Conv(in IList src, ref ReadOnlyMemory<char> dst) => dst = ConvertListToString(src).AsMemory();
 
             /// <summary>
             ///  Converts a System.Numerics.BigInteger value to a UInt128 data type value.
             /// </summary>
             /// <param name="src">BigInteger value.</param>
             /// <param name="dst">UInt128 object.</param>
-            public void Conv(ref BigInteger src, ref UInt128 dst)
+            public void Conv(in BigInteger src, ref UInt128 dst)
             {
                 try
                 {
@@ -732,7 +732,7 @@ namespace Microsoft.ML.Runtime.Data
             /// </summary>
             /// <param name="src">Parquet Interval value (int : months, int : days, int : milliseconds).</param>
             /// <param name="dst">TimeSpan object.</param>
-            public void Conv(ref Interval src, ref TimeSpan dst)
+            public void Conv(in Interval src, ref TimeSpan dst)
             {
                 dst = TimeSpan.FromDays(src.Months * 30 + src.Days) + TimeSpan.FromMilliseconds(src.Millis);
             }

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -200,7 +200,7 @@ namespace Microsoft.ML.Trainers.Recommender
                 {
                     matrixColumnIndexGetter(ref matrixColumnIndex);
                     matrixRowIndexGetter(ref matrixRowIndex);
-                    mapper(ref matrixColumnIndex, ref matrixRowIndex, ref value);
+                    mapper(in matrixColumnIndex, ref matrixRowIndex, ref value);
                 };
             return del;
         }
@@ -228,7 +228,7 @@ namespace Microsoft.ML.Trainers.Recommender
             return mapper as ValueMapper<TMatrixColumnIndexIn, TMatrixRowIndexIn, TOut>;
         }
 
-        private void MapperCore(ref uint srcCol, ref uint srcRow, ref float dst)
+        private void MapperCore(in uint srcCol, ref uint srcRow, ref float dst)
         {
             // REVIEW: The key-type version a bit more "strict" than the predictor
             // version, since the predictor version can't know the maximum bound during

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
@@ -287,7 +287,7 @@ namespace Microsoft.ML.Runtime.Learners
             Contracts.Check(typeof(TOut) == typeof(Float));
 
             ValueMapper<VBuffer<Float>, Float> del =
-                (ref VBuffer<Float> src, ref Float dst) =>
+                (in VBuffer<Float> src, ref Float dst) =>
                 {
                     if (src.Length != Weight.Length)
                         throw Contracts.Except("Input is of length {0}, but predictor expected length {1}", src.Length, Weight.Length);
@@ -380,7 +380,7 @@ namespace Microsoft.ML.Runtime.Learners
             Contracts.Check(typeof(TDstContributions) == typeof(VBuffer<Float>));
 
             ValueMapper<VBuffer<Float>, VBuffer<Float>> del =
-                (ref VBuffer<Float> src, ref VBuffer<Float> dstContributions) =>
+                (in VBuffer<Float> src, ref VBuffer<Float> dstContributions) =>
                 {
                     GetFeatureContributions(in src, ref dstContributions, top, bottom, normalize);
                 };

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -736,7 +736,7 @@ namespace Microsoft.ML.Runtime.Learners
             Host.Check(typeof(TDst) == typeof(VBuffer<float>), "Invalid destination type in GetMapper");
 
             ValueMapper<VBuffer<float>, VBuffer<float>> del =
-                (ref VBuffer<float> src, ref VBuffer<float> dst) =>
+                (in VBuffer<float> src, ref VBuffer<float> dst) =>
                 {
                     Host.Check(src.Length == _numFeatures);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -110,12 +110,12 @@ namespace Microsoft.ML.Runtime.Learners
             {
                 return LambdaColumnMapper.Create(Host, "Label mapper", data.Data,
                     lab.Name, lab.Name, type, NumberType.Float,
-                    (ref T src, ref float dst) =>
+                    (in T src, ref float dst) =>
                         dst = equalsTarget(in src) ? 1 : (isMissing(in src) ? float.NaN : default(float)));
             }
             return LambdaColumnMapper.Create(Host, "Label mapper", data.Data,
                 lab.Name, lab.Name, type, NumberType.Float,
-                (ref T src, ref float dst) =>
+                (in T src, ref float dst) =>
                     dst = equalsTarget(in src) ? 1 : default(float));
         }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -370,7 +370,7 @@ namespace Microsoft.ML.Trainers
             absentFeatureLogProb += Math.Log(absentFeatureCount + 1) - Math.Log(labelOccurrenceCount + _labelCount);
         }
 
-        private void Map(ref VBuffer<float> src, ref VBuffer<float> dst)
+        private void Map(in VBuffer<float> src, ref VBuffer<float> dst)
         {
             Host.Check(src.Length == _featureCount, "Invalid number of features passed.");
             float[] labelScores = (dst.Length >= _labelCount) ? dst.Values : new float[_labelCount];

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -487,7 +487,7 @@ namespace Microsoft.ML.Runtime.Learners
                     maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
 
                 return
-                    (ref VBuffer<float> src, ref VBuffer<float> dst) =>
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
                     {
                         if (InputType.VectorSize > 0)
                             Contracts.Check(src.Length == InputType.VectorSize);
@@ -497,7 +497,7 @@ namespace Microsoft.ML.Runtime.Learners
                             values = new float[maps.Length];
 
                         var tmp = src;
-                        Parallel.For(0, maps.Length, i => maps[i](ref tmp, ref values[i]));
+                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref values[i]));
                         dst = new VBuffer<float>(maps.Length, values, dst.Indices);
                     };
             }
@@ -556,7 +556,7 @@ namespace Microsoft.ML.Runtime.Learners
                     maps[i] = _mappers[i].GetMapper<VBuffer<float>, float, float>();
 
                 return
-                    (ref VBuffer<float> src, ref VBuffer<float> dst) =>
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
                     {
                         if (InputType.VectorSize > 0)
                             Contracts.Check(src.Length == InputType.VectorSize);

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -570,7 +570,7 @@ namespace Microsoft.ML.Runtime.Learners
                             i =>
                             {
                                 float score = 0;
-                                maps[i](ref tmp, ref score, ref values[i]);
+                                maps[i](in tmp, ref score, ref values[i]);
                             });
                         Normalize(values, maps.Length);
                         dst = new VBuffer<float>(maps.Length, values, dst.Indices);

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -450,7 +450,7 @@ namespace Microsoft.ML.Runtime.Learners
 
             var buffer = new Double[_numClasses];
             ValueMapper<VBuffer<float>, VBuffer<float>> del =
-                (ref VBuffer<float> src, ref VBuffer<float> dst) =>
+                (in VBuffer<float> src, ref VBuffer<float> dst) =>
                 {
                     if (InputType.VectorSize > 0)
                         Host.Check(src.Length == InputType.VectorSize);

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -461,7 +461,7 @@ namespace Microsoft.ML.Runtime.Learners
                     {
                         float score = 0;
                         float prob = 0;
-                        maps[i](ref tmp, ref score, ref prob);
+                        maps[i](in tmp, ref score, ref prob);
                         buffer[i] = prob;
                     });
 

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Runtime.Learners
             dst = PredictCore();
         }
 
-        private void MapDist(ref VBuffer<float> src, ref float score, ref float prob)
+        private void MapDist(in VBuffer<float> src, ref float score, ref float prob)
         {
             score = PredictCore();
             prob = (score + 1) / 2;
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Runtime.Learners
             dst = _raw;
         }
 
-        private void MapDist(ref VBuffer<float> src, ref float score, ref float prob)
+        private void MapDist(in VBuffer<float> src, ref float score, ref float prob)
         {
             score = _raw;
             prob = _prob;

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -216,7 +216,7 @@ namespace Microsoft.ML.Runtime.Learners
             }
         }
 
-        private void Map(ref VBuffer<float> src, ref float dst)
+        private void Map(in VBuffer<float> src, ref float dst)
         {
             dst = PredictCore();
         }
@@ -436,7 +436,7 @@ namespace Microsoft.ML.Runtime.Learners
             return (ValueMapper<TIn, TOut, TDist>)(Delegate)del;
         }
 
-        private void Map(ref VBuffer<float> src, ref float dst)
+        private void Map(in VBuffer<float> src, ref float dst)
         {
             dst = _raw;
         }

--- a/src/Microsoft.ML.Transforms/HashJoinTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoinTransform.cs
@@ -451,7 +451,7 @@ namespace Microsoft.ML.Runtime.Data
             dst = new VBuffer<ReadOnlyMemory<char>>(n, output, dst.Indices);
         }
 
-        private delegate uint HashDelegate<TSrc>(ref TSrc value, uint seed);
+        private delegate uint HashDelegate<TSrc>(in TSrc value, uint seed);
 
         // generic method generators
         private static MethodInfo _methGetterOneToOne;
@@ -518,7 +518,7 @@ namespace Microsoft.ML.Runtime.Data
                 (ref uint dst) =>
                 {
                     getSrc(ref src);
-                    dst = (hashFunction(ref src, hashSeed) & mask) + 1; // +1 to offset from zero, which has special meaning for KeyType
+                    dst = (hashFunction(in src, hashSeed) & mask) + 1; // +1 to offset from zero, which has special meaning for KeyType
                 };
         }
 
@@ -578,7 +578,7 @@ namespace Microsoft.ML.Runtime.Data
                             // REVIEW: some legacy code hashes 0 for srcSlot in ord- case, do we need to preserve this behavior?
                             if (ordered)
                                 hash = Hashing.MurmurRound(hash, (uint)srcSlot);
-                            hash = hashFunction(ref values[srcSlot], hash);
+                            hash = hashFunction(in values[srcSlot], hash);
                         }
 
                         hashes[i] = (Hashing.MixHash(hash) & mask) + 1; // +1 to offset from zero, which has special meaning for KeyType
@@ -636,7 +636,7 @@ namespace Microsoft.ML.Runtime.Data
                     {
                         if (ordered)
                             hash = Hashing.MurmurRound(hash, (uint)srcSlot);
-                        hash = hashFunction(ref values[srcSlot], hash);
+                        hash = hashFunction(in values[srcSlot], hash);
                     }
                     dst = (Hashing.MixHash(hash) & mask) + 1; // +1 to offset from zero, which has special meaning for KeyType
                 };
@@ -658,9 +658,9 @@ namespace Microsoft.ML.Runtime.Data
             var sb = default(StringBuilder);
             var conv = Conversions.Instance.GetStringConversion<TSrc>();
             return
-                (ref TSrc value, uint seed) =>
+                (in TSrc value, uint seed) =>
                 {
-                    conv(ref value, ref sb);
+                    conv(in value, ref sb);
                     return Hashing.MurmurHash(seed, sb, 0, sb.Length);
                 };
         }
@@ -681,12 +681,12 @@ namespace Microsoft.ML.Runtime.Data
             return Hash;
         }
 
-        private uint Hash(ref float value, uint seed)
+        private uint Hash(in float value, uint seed)
         {
             return Hashing.MurmurRound(seed, FloatUtils.GetBits(value));
         }
 
-        private uint Hash(ref double value, uint seed)
+        private uint Hash(in double value, uint seed)
         {
             ulong v = FloatUtils.GetBits(value);
             uint hash = Hashing.MurmurRound(seed, Utils.GetLo(v));

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -465,7 +465,7 @@ namespace Microsoft.ML.Transforms
                 var tmp = default(VBuffer<T>);
                 var labels = default(VBuffer<int>);
                 trans.GetSingleSlotValue(labelCol, ref tmp);
-                BinKeys<T>(labeColumnType)(ref tmp, ref labels);
+                BinKeys<T>(labeColumnType)(in tmp, ref labels);
                 VBufferUtils.Densify(ref labels);
                 var values = labels.Values;
                 if (labels.Length < values.Length)
@@ -535,7 +535,7 @@ namespace Microsoft.ML.Transforms
                     {
                         min = 0;
                         lim = type.KeyCount + 1;
-                        mapper(ref src, ref dst);
+                        mapper(in src, ref dst);
                     };
             }
 
@@ -652,7 +652,7 @@ namespace Microsoft.ML.Transforms
                 if (identity)
                 {
                     mapper = (ValueMapper<T, int>)(Delegate)(ValueMapper<uint, int>)(
-                        (ref uint src, ref int dst) =>
+                        (in uint src, ref int dst) =>
                         {
                             dst = (int)src;
                         });
@@ -660,10 +660,10 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     mapper =
-                        (ref T src, ref int dst) =>
+                        (in T src, ref int dst) =>
                         {
                             uint t = 0;
-                            conv(ref src, ref t);
+                            conv(in src, ref t);
                             dst = (int)t;
                         };
                 }
@@ -683,9 +683,9 @@ namespace Microsoft.ML.Transforms
                 lim = min + bounds.Length + 1;
                 int offset = min;
                 ValueMapper<int, int> mapper =
-                    (ref int src, ref int dst) =>
+                    (in int src, ref int dst) =>
                         dst = offset + 1 + bounds.FindIndexSorted((Single)src);
-                mapper.MapVector(ref input, ref output);
+                mapper.MapVector(in input, ref output);
                 _singles.Clear();
             }
 
@@ -711,9 +711,9 @@ namespace Microsoft.ML.Transforms
                 lim = min + bounds.Length + 1;
                 int offset = min;
                 ValueMapper<Single, int> mapper =
-                    (ref Single src, ref int dst) =>
+                    (in Single src, ref int dst) =>
                         dst = Single.IsNaN(src) ? offset : offset + 1 + bounds.FindIndexSorted(src);
-                mapper.MapVector(ref input, ref output);
+                mapper.MapVector(in input, ref output);
                 _singles.Clear();
             }
 
@@ -738,9 +738,9 @@ namespace Microsoft.ML.Transforms
                 var offset = min = -1 - bounds.FindIndexSorted(0);
                 lim = min + bounds.Length + 1;
                 ValueMapper<Double, int> mapper =
-                    (ref Double src, ref int dst) =>
+                    (in Double src, ref int dst) =>
                         dst = Double.IsNaN(src) ? offset : offset + 1 + bounds.FindIndexSorted(src);
-                mapper.MapVector(ref input, ref output);
+                mapper.MapVector(in input, ref output);
                 _doubles.Clear();
             }
 
@@ -748,10 +748,10 @@ namespace Microsoft.ML.Transforms
             {
                 if (_boolMapper == null)
                     _boolMapper = CreateVectorMapper<bool, int>(BinOneBool);
-                _boolMapper(ref input, ref output);
+                _boolMapper(in input, ref output);
             }
 
-            private void BinOneBool(ref bool src, ref int dst)
+            private void BinOneBool(in bool src, ref int dst)
             {
                 dst = Convert.ToInt32(src);
             }
@@ -767,13 +767,13 @@ namespace Microsoft.ML.Transforms
 #if DEBUG
             TSrc tmpSrc = default(TSrc);
             TDst tmpDst = default(TDst);
-            map(ref tmpSrc, ref tmpDst);
+            map(in tmpSrc, ref tmpDst);
             Contracts.Assert(tmpDst.Equals(default(TDst)));
 #endif
             return map.MapVector;
         }
 
-        private static void MapVector<TSrc, TDst>(this ValueMapper<TSrc, TDst> map, ref VBuffer<TSrc> input, ref VBuffer<TDst> output)
+        private static void MapVector<TSrc, TDst>(this ValueMapper<TSrc, TDst> map, in VBuffer<TSrc> input, ref VBuffer<TDst> output)
         {
             var values = output.Values;
             if (Utils.Size(values) < input.Count)
@@ -781,7 +781,7 @@ namespace Microsoft.ML.Transforms
             for (int i = 0; i < input.Count; i++)
             {
                 TSrc val = input.Values[i];
-                map(ref val, ref values[i]);
+                map(in val, ref values[i]);
             }
 
             var indices = output.Indices;

--- a/src/Microsoft.ML.Transforms/NAReplaceTransform.cs
+++ b/src/Microsoft.ML.Transforms/NAReplaceTransform.cs
@@ -452,7 +452,7 @@ namespace Microsoft.ML.Transforms
                 // Handles converting input strings to correct types.
                 var srcTxt = srcStr.AsMemory();
                 var strToT = Runtime.Data.Conversion.Conversions.Instance.GetStandardConversion<ReadOnlyMemory<char>, T>(TextType.Instance, dstType.ItemType, out bool identity);
-                strToT(ref srcTxt, ref val);
+                strToT(in srcTxt, ref val);
                 // Make sure that the srcTxt can legitimately be converted to dstType, throw error otherwise.
                 if (isNA(in val))
                     throw Contracts.Except("No conversion of '{0}' to '{1}'", srcStr, dstType.ItemType);

--- a/src/Microsoft.ML.Transforms/TermLookupTransform.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransform.cs
@@ -229,7 +229,7 @@ namespace Microsoft.ML.Transforms.Categorical
                     //Empty string will map to NA for R4 and R8, the only two types that can
                     //handle missing values.
                     var bad = String.Empty.AsMemory();
-                    conv(ref bad, ref _badValue);
+                    conv(in bad, ref _badValue);
                 }
             }
 

--- a/src/Microsoft.ML.Transforms/Text/NgramHashTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashTransform.cs
@@ -931,12 +931,12 @@ namespace Microsoft.ML.Transforms.Text
                     Contracts.AssertValue(srcMap);
 
                     stringMapper =
-                        (ref NGram src, ref StringBuilder dst) =>
+                        (in NGram src, ref StringBuilder dst) =>
                         {
                             Contracts.Assert(src.ISrcCol == 0);
                             if (src.Lim == 1)
                             {
-                                srcMap(ref src.Grams[0], ref dst);
+                                srcMap(in src.Grams[0], ref dst);
                                 return;
                             }
                             ClearDst(ref dst);
@@ -944,7 +944,7 @@ namespace Microsoft.ML.Transforms.Text
                             {
                                 if (i > 0)
                                     dst.Append('|');
-                                srcMap(ref src.Grams[i], ref temp);
+                                srcMap(in src.Grams[i], ref temp);
                                 InvertHashUtils.AppendToEnd(temp, dst, ref buffer);
                             }
                         };
@@ -964,7 +964,7 @@ namespace Microsoft.ML.Transforms.Text
                     // We need to disambiguate the column name. This will be the same as the above format,
                     // just instead of "<Stuff>" it would be with "ColumnName:<Stuff>".
                     stringMapper =
-                        (ref NGram src, ref StringBuilder dst) =>
+                        (in NGram src, ref StringBuilder dst) =>
                         {
                             var srcMap = _srcTextGetters[srcIndices[src.ISrcCol]];
                             Contracts.AssertValue(srcMap);
@@ -975,7 +975,7 @@ namespace Microsoft.ML.Transforms.Text
                             {
                                 if (i > 0)
                                     dst.Append('|');
-                                srcMap(ref src.Grams[i], ref temp);
+                                srcMap(in src.Grams[i], ref temp);
                                 InvertHashUtils.AppendToEnd(temp, dst, ref buffer);
                             }
                         };
@@ -983,7 +983,7 @@ namespace Microsoft.ML.Transforms.Text
 
                 var collector = _iinfoToCollector[iinfo] = new InvertHashCollector<NGram>(
                     _parent._bindings.Types[iinfo].VectorSize, _invertHashMaxCounts[iinfo],
-                    stringMapper, EqualityComparer<NGram>.Default, (ref NGram src, ref NGram dst) => dst = src.Clone());
+                    stringMapper, EqualityComparer<NGram>.Default, (in NGram src, ref NGram dst) => dst = src.Clone());
 
                 return
                     (uint[] ngram, int lim, int icol, ref bool more) =>

--- a/test/Microsoft.ML.Core.Tests/UnitTests/DataTypes.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/DataTypes.cs
@@ -31,13 +31,13 @@ namespace Microsoft.ML.Runtime.RunTests
 
             float fVal = float.NaN;
             StringBuilder textFVal = default;
-            r4ToSB(ref fVal, ref textFVal);
+            r4ToSB(in fVal, ref textFVal);
 
             Assert.True("?" == textFVal.ToString());
 
             fVal = 0;
             var fValTX = textFVal.ToString().AsMemory();
-            txToR4(ref fValTX, ref fVal);
+            txToR4(in fValTX, ref fVal);
 
             Assert.Equal(fVal, float.NaN);
         }
@@ -55,13 +55,13 @@ namespace Microsoft.ML.Runtime.RunTests
 
             double dVal = double.NaN;
             StringBuilder textDVal = default;
-            r8ToSB(ref dVal, ref textDVal);
+            r8ToSB(in dVal, ref textDVal);
 
             Assert.True("?" == textDVal.ToString());
 
             dVal = 0;
             var dValTX = textDVal.ToString().AsMemory();
-            txToR8(ref dValTX, ref dVal);
+            txToR8(in dValTX, ref dVal);
 
             Assert.Equal(dVal, double.NaN);
         }
@@ -78,31 +78,31 @@ namespace Microsoft.ML.Runtime.RunTests
             sbyte maxValue = sbyte.MaxValue;
             ReadOnlyMemory<char> src = minValue.ToString().AsMemory();
             sbyte dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, minValue);
 
             //2. sbyte.MaxValue in text to sbyte.
             src = maxValue.ToString().AsMemory();
             dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, maxValue);
 
             //3. ERROR condition: sbyte.MinValue - 1 in text to sbyte.
             src = (sbyte.MinValue - 1).ToString().AsMemory();
             dst = 0;
-            var ex = Assert.ThrowsAny<Exception>(() => mapper(ref src, ref dst));
+            var ex = Assert.ThrowsAny<Exception>(() => mapper(in src, ref dst));
             Assert.Equal("Value could not be parsed from text to sbyte.", ex.Message);
 
             //4. ERROR condition: sbyte.MaxValue + 1 in text to sbyte.
             src = (sbyte.MaxValue + 1).ToString().AsMemory();
             dst = 0;
-            ex = Assert.ThrowsAny<Exception>(() => mapper(ref src, ref dst));
+            ex = Assert.ThrowsAny<Exception>(() => mapper(in src, ref dst));
             Assert.Equal("Value could not be parsed from text to sbyte.", ex.Message);
 
             //5. Empty string in text to sbyte.
             src = default;
             dst = -1;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(default, dst);
         }
 
@@ -118,31 +118,31 @@ namespace Microsoft.ML.Runtime.RunTests
             short maxValue = short.MaxValue;
             ReadOnlyMemory<char> src = minValue.ToString().AsMemory();
             short dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, minValue);
 
             //2. short.MaxValue in text to short.
             src = maxValue.ToString().AsMemory();
             dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, maxValue);
 
             //3. ERROR condition: short.MinValue - 1 in text to short.
             src = (minValue - 1).ToString().AsMemory();
             dst = 0;
-            var ex = Assert.ThrowsAny<Exception>(() => mapper(ref src, ref dst));
+            var ex = Assert.ThrowsAny<Exception>(() => mapper(in src, ref dst));
             Assert.Equal("Value could not be parsed from text to short.", ex.Message);
 
             //4. ERROR condition: short.MaxValue + 1 in text to short.
             src = (maxValue + 1).ToString().AsMemory();
             dst = 0;
-            ex = Assert.ThrowsAny<Exception>(() => mapper(ref src, ref dst));
+            ex = Assert.ThrowsAny<Exception>(() => mapper(in src, ref dst));
             Assert.Equal("Value could not be parsed from text to short.", ex.Message);
 
             //5. Empty value in text to short.
             src = default;
             dst = -1;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(default, dst);
         }
 
@@ -158,31 +158,31 @@ namespace Microsoft.ML.Runtime.RunTests
             int maxValue = int.MaxValue;
             ReadOnlyMemory<char> src = minValue.ToString().AsMemory();
             int dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, minValue);
 
             //2. int.MaxValue in text to int.
             src = maxValue.ToString().AsMemory();
             dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, maxValue);
 
             //3. ERROR condition: int.MinValue - 1 in text to int.
             src = ((long)minValue - 1).ToString().AsMemory();
             dst = 0;
-            var ex = Assert.ThrowsAny<Exception>(() => mapper(ref src, ref dst));
+            var ex = Assert.ThrowsAny<Exception>(() => mapper(in src, ref dst));
             Assert.Equal("Value could not be parsed from text to int.", ex.Message);
 
             //4. ERROR condition: int.MaxValue + 1 in text to int.
             src = ((long)maxValue + 1).ToString().AsMemory();
             dst = 0;
-            ex = Assert.ThrowsAny<Exception>(() => mapper(ref src, ref dst));
+            ex = Assert.ThrowsAny<Exception>(() => mapper(in src, ref dst));
             Assert.Equal("Value could not be parsed from text to int.", ex.Message);
 
             //5. Empty value in text to int.
             src = default;
             dst = -1;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(default, dst);
         }
 
@@ -198,31 +198,31 @@ namespace Microsoft.ML.Runtime.RunTests
             var maxValue = long.MaxValue;
             ReadOnlyMemory<char> src = minValue.ToString().AsMemory();
             var dst = default(long);
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, minValue);
 
             //2. long.MaxValue in text to long.
             src = maxValue.ToString().AsMemory();
             dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, maxValue);
 
             //3. long.MinValue - 1 in text to long.
             src = (minValue - 1).ToString().AsMemory();
             dst = 0;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(dst, (long)minValue - 1);
 
             //4. ERROR condition: long.MaxValue + 1 in text to long.
             src = ((ulong)maxValue + 1).ToString().AsMemory();
             dst = 0;
-            var ex = Assert.ThrowsAny<Exception>(() => mapper(ref src, ref dst));
+            var ex = Assert.ThrowsAny<Exception>(() => mapper(in src, ref dst));
             Assert.Equal("Value could not be parsed from text to long.", ex.Message);
 
             //5. Empty value in text to long.
             src = default;
             dst = -1;
-            mapper(ref src, ref dst);
+            mapper(in src, ref dst);
             Assert.Equal(default, dst);
         }
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.ML.Runtime.RunTests
             }).Data;
 
             ValueMapper<ReadOnlyMemory<char>, bool> labelToBinary =
-                (ref ReadOnlyMemory<char> src, ref bool dst) =>
+                (in ReadOnlyMemory<char> src, ref bool dst) =>
                 {
                     if (ReadOnlyMemoryUtils.EqualsStr("Sport", src))
                         dst = true;

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -496,11 +496,11 @@ namespace Microsoft.ML.Runtime.RunTests
             where TDst : struct
         {
             TDst v = default(TDst);
-            conv(ref src, ref v);
+            conv(in src, ref v);
             if (EqualityComparer<TDst>.Default.Equals(dst, v))
                 return true;
             TSrc vSrc = default;
-            convBack(ref v, ref vSrc);
+            convBack(in v, ref vSrc);
             if (EqualityComparer<TDst>.Default.Equals(dst, default(TDst)) && !EqualityComparer<TSrc>.Default.Equals(src, vSrc))
                 return true;
             Fail($"Values different values in VerifyMatch<{typeof(TSrc).Name}, {typeof(TDst).Name}>: converted from {typeof(TSrc).Name} to {typeof(TDst).Name}: {v}. Parsed from text: {dst}");


### PR DESCRIPTION
ValueMapper takes in a source value, and maps it to a destination value. The source value that is passed "in" is current passed by `ref`, which isn't correct because we don't want ValueMapper implementations to modify this value.
Change ValueMapper (both versions) to use `in` parameters instead.

This is a follow-up to #1454 requested in the [PR feedback](https://github.com/dotnet/machinelearning/pull/1454#pullrequestreview-170020651).

Working towards #608