### PR TITLE
Adding third party notice and license to the Microsoft.ML NuGet

### DIFF
--- a/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
+++ b/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
@@ -20,5 +20,7 @@
   <ItemGroup>
     <Content Include="..\common\CommonPackage.props" Pack="true" PackagePath="build\netstandard2.0\$(MSBuildProjectName).props" />
     <Content Include="build\**\*" Pack="true" PackagePath="build" />
+    <Content Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    <Content Include="..\..\THIRD-PARTY-NOTICES.TXT" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adding the license file and third party notice file in the NuGet. Fixes #1297 