### PR TITLE
Mark UInt128 and other obvious readonly structs as readonly.

### DIFF
--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -924,7 +924,7 @@ namespace Microsoft.ML.Runtime.CommandLine
             }
         }
 
-        private struct ArgumentHelpStrings
+        private readonly struct ArgumentHelpStrings
         {
             public readonly string Syntax;
             public readonly string Help;

--- a/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/ComponentCatalog.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Runtime
             /// <summary>
             /// Used for dictionary lookup based on signature and name.
             /// </summary>
-            internal struct Key : IEquatable<Key>
+            internal readonly struct Key : IEquatable<Key>
             {
                 public readonly string Name;
                 public readonly Type Signature;

--- a/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
+++ b/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
@@ -176,7 +176,7 @@ namespace Microsoft.ML.Runtime
     /// <summary>
     /// A channel message.
     /// </summary>
-    public struct ChannelMessage
+    public readonly struct ChannelMessage
     {
         public readonly ChannelMessageKind Kind;
         public readonly MessageSensitivity Sensitivity;

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Runtime.Data
         /// be used when possible for consistency reasons. However, practitioners should not be afraid to declare custom
         /// roles if approppriate for their task.
         /// </summary>
-        public struct ColumnRole
+        public readonly struct ColumnRole
         {
             /// <summary>
             /// Role for features. Commonly used as the independent variables given to trainers, and scorers.

--- a/src/Microsoft.ML.Core/Data/UInt128.cs
+++ b/src/Microsoft.ML.Core/Data/UInt128.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ML.Runtime.Data
     /// <summary>
     /// A sixteen-byte unsigned integer.
     /// </summary>
-    public struct UInt128 : IComparable<UInt128>, IEquatable<UInt128>
+    public readonly struct UInt128 : IComparable<UInt128>, IEquatable<UInt128>
     {
         // The low order bits. Corresponds to H1 in the Murmur algorithms.
         public readonly ulong Lo;

--- a/src/Microsoft.ML.Core/Utilities/BinFinder.cs
+++ b/src/Microsoft.ML.Core/Utilities/BinFinder.cs
@@ -282,7 +282,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
     {
         // Potential drop location for another peg, together with its energy improvement.
         // PlacePegs uses a heap of these. Note that this is a struct so size matters.
-        private struct Segment
+        private readonly struct Segment
         {
             public readonly int Min;
             public readonly int Split;

--- a/src/Microsoft.ML.Core/Utilities/Contracts.cs
+++ b/src/Microsoft.ML.Core/Utilities/Contracts.cs
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Runtime
         /// there will be performance implications. There shouldn't be, since checks rarely happen in
         /// tight loops.
         /// </summary>
-        private struct SensitiveExceptionContext : IExceptionContext
+        private readonly struct SensitiveExceptionContext : IExceptionContext
         {
             /// <summary>
             /// We will run this instances <see cref="IExceptionContext.Process{TException}(TException)"/> first.

--- a/src/Microsoft.ML.Core/Utilities/MinWaiter.cs
+++ b/src/Microsoft.ML.Core/Utilities/MinWaiter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// is the minimum at a point when all waiters have registered, the event
         /// will be signaled.
         /// </summary>
-        private struct WaitStats
+        private readonly struct WaitStats
         {
             public readonly long Line;
             public readonly ManualResetEventSlim Event;

--- a/src/Microsoft.ML.Core/Utilities/OrderedWaiter.cs
+++ b/src/Microsoft.ML.Core/Utilities/OrderedWaiter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// This is an event-line pair. The intended usage is, when the line
         /// is hit by the containing ordered waiter, the thread will be hit.
         /// </summary>
-        private struct WaitStats
+        private readonly struct WaitStats
         {
             public readonly long Line;
             public readonly ManualResetEventSlim Event;

--- a/src/Microsoft.ML.Core/Utilities/Random.cs
+++ b/src/Microsoft.ML.Core/Utilities/Random.cs
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Runtime
     /// </summary>
     public sealed class TauswortheHybrid : IRandom
     {
-        public struct State
+        public readonly struct State
         {
             public readonly uint U1;
             public readonly uint U2;

--- a/src/Microsoft.ML.Core/Utilities/SupervisedBinFinder.cs
+++ b/src/Microsoft.ML.Core/Utilities/SupervisedBinFinder.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
     /// </summary>
     public sealed class SupervisedBinFinder
     {
-        private struct ValuePair<T> : IComparable<ValuePair<T>>
+        private readonly struct ValuePair<T> : IComparable<ValuePair<T>>
             where T : IComparable<T>
         {
             public readonly T Value;

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -354,7 +354,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private sealed class FoldHelper
         {
-            public struct FoldResult
+            public readonly struct FoldResult
             {
                 public readonly Dictionary<string, IDataView> Metrics;
                 public readonly Schema ScoreSchema;

--- a/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Data.Commands
             _host.CheckValue(args, nameof(args));
         }
 
-        private struct TypeNaInfo
+        private readonly struct TypeNaInfo
         {
             public readonly bool HasNa;
             public readonly bool DefaultIsNa;

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -1154,7 +1154,7 @@ namespace Microsoft.ML.Runtime.Data
             private IRowCursor _currentCursor;
             private bool _disposed;
 
-            private struct CursorStats
+            private readonly struct CursorStats
             {
                 public readonly long Batch;
                 public readonly int CursorIdx;

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Runtime.Data.IO
         /// This is a simple struct to associate a source index with a codec, without having to have
         /// parallel structures everywhere.
         /// </summary>
-        private struct ColumnCodec
+        private readonly struct ColumnCodec
         {
             public readonly int SourceIndex;
             public readonly IValueCodec Codec;
@@ -149,7 +149,7 @@ namespace Microsoft.ML.Runtime.Data.IO
         /// also have a dual usage if <see cref="Exception"/> is non-null of indicating
         /// a source worker threw an exception.
         /// </summary>
-        private struct Block
+        private readonly struct Block
         {
             /// <summary>
             /// Take one guess.

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BlockLookup.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BlockLookup.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ML.Runtime.Data.IO
     /// This structure is utilized by both the binary loader and binary saver to hold
     /// information on the location of blocks written to an .IDV binary file.
     /// </summary>
-    internal struct BlockLookup
+    internal readonly struct BlockLookup
     {
         /// <summary>The offset of the block into the file.</summary>
         public readonly long BlockOffset;

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Runtime.Data
             public KeyValuePair<string, IComponentFactory<IDataView, IDataTransform>>[] Transform;
         }
 
-        private struct TransformEx
+        private readonly struct TransformEx
         {
             public readonly string Tag;
             public readonly string ArgsString;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
@@ -347,7 +347,7 @@ namespace Microsoft.ML.Runtime.Data
             // abort situations.
             private const int TimeOut = 100;
 
-            private struct LineBatch
+            private readonly struct LineBatch
             {
                 public readonly string Path;
                 // Total lines, up to the first line of this batch.
@@ -378,7 +378,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            private struct LineInfo
+            private readonly struct LineInfo
             {
                 public readonly long Line;
                 public readonly string Text;

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -653,7 +653,7 @@ namespace Microsoft.ML.Runtime.Data
                 return new Wrapper(new TrivialWaiter(parent));
             }
 
-            public struct Wrapper : IWaiter
+            public readonly struct Wrapper : IWaiter
             {
                 private readonly TrivialWaiter _waiter;
 
@@ -722,7 +722,7 @@ namespace Microsoft.ML.Runtime.Data
                 return new Wrapper(new WaiterWaiter(parent, pred));
             }
 
-            public struct Wrapper : IWaiter
+            public readonly struct Wrapper : IWaiter
             {
                 private readonly WaiterWaiter _waiter;
 
@@ -836,7 +836,7 @@ namespace Microsoft.ML.Runtime.Data
                 return new Wrapper(new SequenceIndex<TWaiter>(waiter));
             }
 
-            public struct Wrapper : IIndex
+            public readonly struct Wrapper : IIndex
             {
                 private readonly SequenceIndex<TWaiter> _index;
 
@@ -927,7 +927,7 @@ namespace Microsoft.ML.Runtime.Data
                 return new Wrapper(new RandomIndex<TWaiter>(waiter, perm));
             }
 
-            public struct Wrapper : IIndex
+            public readonly struct Wrapper : IIndex
             {
                 private readonly RandomIndex<TWaiter> _index;
 
@@ -1097,7 +1097,7 @@ namespace Microsoft.ML.Runtime.Data
                 return new Wrapper(new BlockSequenceIndex<TWaiter>(waiter, scheduler));
             }
 
-            public struct Wrapper : IIndex
+            public readonly struct Wrapper : IIndex
             {
                 private readonly BlockSequenceIndex<TWaiter> _index;
 
@@ -1205,7 +1205,7 @@ namespace Microsoft.ML.Runtime.Data
                 return new Wrapper(new BlockRandomIndex<TWaiter>(waiter, scheduler, perm));
             }
 
-            public struct Wrapper : IIndex
+            public readonly struct Wrapper : IIndex
             {
                 private readonly BlockRandomIndex<TWaiter> _index;
 

--- a/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
     /// </summary>
     public sealed class InputBuilder
     {
-        private struct Attributes
+        private readonly struct Attributes
         {
             public readonly ArgumentAttribute Input;
             public readonly TlcModule.RangeAttribute Range;

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             public abstract class CountersBase
             {
-                protected struct Info
+                protected readonly struct Info
                 {
                     public readonly Single Label;
                     public readonly Single Score;

--- a/src/Microsoft.ML.Data/Model/Pfa/PfaContext.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/PfaContext.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
         private readonly HashSet<string> _types;
         private readonly IHost _host;
 
-        private struct VariableBlock
+        private readonly struct VariableBlock
         {
             public readonly string Type;
             public readonly KeyValuePair<string, JToken>[] Locals;
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             }
         }
 
-        private struct CellBlock
+        private readonly struct CellBlock
         {
             public readonly string Name;
             public readonly JToken Type;
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             }
         }
 
-        private struct FuncBlock
+        private readonly struct FuncBlock
         {
             public readonly string Name;
             public readonly JArray Params;

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -1489,7 +1489,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
     public class PavCalibratorTrainer : CalibratorTrainerBase
     {
         // a piece of the piecwise function
-        private struct Piece
+        private readonly struct Piece
         {
             public readonly Float MinX; // end of interval.
             public readonly Float MaxX; // beginning of interval.
@@ -1743,7 +1743,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
 
     public sealed class CalibrationDataStore : IEnumerable<CalibrationDataStore.DataItem>
     {
-        public struct DataItem
+        public readonly struct DataItem
         {
             // The actual binary label of this example.
             public readonly bool Target;

--- a/src/Microsoft.ML.Data/StaticPipe/StaticPipeInternalUtils.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/StaticPipeInternalUtils.cs
@@ -259,7 +259,7 @@ namespace Microsoft.ML.StaticPipe.Runtime
         /// <typeparam name="TLeaf">The base type in the base world.</typeparam>
         private static class NameUtil<TLeaf>
         {
-            private struct Info
+            private readonly struct Info
             {
                 public readonly Type Type;
                 public readonly object Item;

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -107,7 +107,7 @@ namespace Microsoft.ML.Runtime.Data
         /// but also maintain the order in which it was inserted, assuming that
         /// we're using something like a hashset where order is not preserved.
         /// </summary>
-        private struct Pair
+        private readonly struct Pair
         {
             public readonly T Value;
             public readonly int Order;

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Transforms.Categorical
         private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Sort;
         private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumTerms;
 
-        private struct Config
+        private readonly struct Config
         {
             public readonly KeyValueOrder Order;
             public readonly int Max;

--- a/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
@@ -912,7 +912,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             private readonly Dataset _dataset;
             private readonly FeatureFlockBase.FlockForwardIndexerBase[] _flockIndexers;
 
-            public struct Row
+            public readonly struct Row
             {
                 private readonly RowForwardIndexer _indexer;
                 private readonly int _rowIndex;

--- a/src/Microsoft.ML.FastTree/Dataset/FeatureFlock.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/FeatureFlock.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
     /// are then used in <see cref="LeastSquaresRegressionTreeLearner"/> to find splitting on which bin will yield the
     /// best least squares solution
     /// </summary>
-    public struct PerBinStats
+    public readonly struct PerBinStats
     {
         /// <summary>Sum of all target values in a partition for the bin.</summary>
         public readonly Double SumTargets;

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -235,7 +235,7 @@ namespace Microsoft.ML.Trainers.SymSgd
         /// This struct holds the information about the size, label and isDense of each instance
         /// to be able to pass it to the native code.
         /// </summary>
-        private struct InstanceProperties
+        private readonly struct InstanceProperties
         {
             public readonly int FeatureCount;
             public readonly float Label;

--- a/src/Microsoft.ML.Maml/HelpCommand.cs
+++ b/src/Microsoft.ML.Maml/HelpCommand.cs
@@ -398,7 +398,7 @@ namespace Microsoft.ML.Runtime.Tools
             }
         }
 
-        public struct Component
+        public readonly struct Component
         {
             public readonly string Kind;
             public readonly ComponentCatalog.LoadableClassInfo Info;

--- a/src/Microsoft.ML.PipelineInference/ColumnGroupingInference.cs
+++ b/src/Microsoft.ML.PipelineInference/ColumnGroupingInference.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             }
         }
 
-        public struct InferenceResult
+        public readonly struct InferenceResult
         {
             public readonly GroupingColumn[] Columns;
 

--- a/src/Microsoft.ML.PipelineInference/ColumnTypeInference.cs
+++ b/src/Microsoft.ML.PipelineInference/ColumnTypeInference.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             public ReadOnlyMemory<char>[] RawData { get { return _data; } }
         }
 
-        public struct Column
+        public readonly struct Column
         {
             public readonly int ColumnIndex;
             public readonly string SuggestedName;
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             }
         }
 
-        public struct InferenceResult
+        public readonly struct InferenceResult
         {
             public readonly Column[] Columns;
             public readonly bool HasHeader;

--- a/src/Microsoft.ML.PipelineInference/PurposeInference.cs
+++ b/src/Microsoft.ML.PipelineInference/PurposeInference.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             }
         }
 
-        public struct Column
+        public readonly struct Column
         {
             public readonly int ColumnIndex;
             public readonly ColumnPurpose Purpose;
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             }
         }
 
-        public struct InferenceResult
+        public readonly struct InferenceResult
         {
             public readonly Column[] Columns;
 

--- a/src/Microsoft.ML.PipelineInference/RecipeInference.cs
+++ b/src/Microsoft.ML.PipelineInference/RecipeInference.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
 {
     public static class RecipeInference
     {
-        public struct SuggestedRecipe
+        public readonly struct SuggestedRecipe
         {
             public readonly string Description;
             public readonly TransformInference.SuggestedTransform[] Transforms;
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             public override string ToString() => Description;
         }
 
-        public struct InferenceResult
+        public readonly struct InferenceResult
         {
             public readonly SuggestedRecipe[] SuggestedRecipes;
             public InferenceResult(SuggestedRecipe[] suggestedRecipes)

--- a/src/Microsoft.ML.PipelineInference/TextFileContents.cs
+++ b/src/Microsoft.ML.PipelineInference/TextFileContents.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
     /// </summary>
     public static class TextFileContents
     {
-        public struct ColumnSplitResult
+        public readonly struct ColumnSplitResult
         {
             public readonly bool IsSuccess;
             public readonly string Separator;

--- a/src/Microsoft.ML.PipelineInference/TransformInference.cs
+++ b/src/Microsoft.ML.PipelineInference/TransformInference.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             public override string ToString() => ExpertType.Name;
         }
 
-        public struct TransformString : IEquatable<TransformString>
+        public readonly struct TransformString : IEquatable<TransformString>
         {
             public readonly string Kind;
             public readonly string Settings;
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             }
         }
 
-        public struct InferenceResult
+        public readonly struct InferenceResult
         {
             public readonly SuggestedTransform[] SuggestedTransforms;
 
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             }
         }
 
-        public struct Column
+        public readonly struct Column
         {
             public readonly Data.ColumnType Type;
             public readonly string Name;

--- a/src/Microsoft.ML.StandardLearners/Optimizer/Optimizer.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/Optimizer.cs
@@ -547,7 +547,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 return (Float)(p1.A - (p1.A - p0.A) * num / denom);
             }
 
-            private struct PointValueDeriv
+            private readonly struct PointValueDeriv
             {
                 public readonly Float A;
                 public readonly Float V;

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearClassificationTrainer.cs
@@ -1134,7 +1134,7 @@ namespace Microsoft.ML.Trainers
         protected sealed class IdToIdxLookup
         {
             // Utilizing this struct gives better cache behavior than using parallel arrays.
-            private struct Entry
+            private readonly struct Entry
             {
                 public readonly long ItNext;
                 public readonly UInt128 Value;

--- a/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Runtime.Learners
     /// <summary>
     /// Represents a coefficient statistics object.
     /// </summary>
-    public struct CoefficientStatistics
+    public readonly struct CoefficientStatistics
     {
         public readonly string Name;
         public readonly Single Estimate;

--- a/src/Microsoft.ML.Transforms/CategoricalHashTransform.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalHashTransform.cs
@@ -342,7 +342,7 @@ namespace Microsoft.ML.Transforms.Categorical
         private const bool DefOrdered = OneHotHashEncodingEstimator.Defaults.Ordered;
         private const int DefInvertHash = OneHotHashEncodingEstimator.Defaults.InvertHash;
 
-        private struct Config
+        private readonly struct Config
         {
             public readonly int HashBits;
             public readonly uint Seed;

--- a/src/Microsoft.ML.Transforms/CategoricalTransform.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalTransform.cs
@@ -368,7 +368,7 @@ namespace Microsoft.ML.Transforms.Categorical
         private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumTerms;
         private const OneHotVectorOutputKind DefOut = (OneHotVectorOutputKind)OneHotEncodingEstimator.Defaults.OutKind;
 
-        private struct Config
+        private readonly struct Config
         {
             public readonly KeyValueOrder Order;
             public readonly int Max;

--- a/src/Microsoft.ML.Transforms/NAReplaceTransform.cs
+++ b/src/Microsoft.ML.Transforms/NAReplaceTransform.cs
@@ -999,7 +999,7 @@ namespace Microsoft.ML.Transforms
     /// </summary>
     public static class NAReplacerExtensions
     {
-        private struct Config
+        private readonly struct Config
         {
             public readonly bool ImputeBySlot;
             public readonly NAReplaceTransform.ColumnInfo.ReplacementMode ReplacementMode;

--- a/src/Microsoft.ML.Transforms/RffTransform.cs
+++ b/src/Microsoft.ML.Transforms/RffTransform.cs
@@ -693,7 +693,7 @@ namespace Microsoft.ML.Transforms.Projections
 
     public static class RffExtenensions
     {
-        private struct Config
+        private readonly struct Config
         {
             public readonly int NewDim;
             public readonly bool UseSin;

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -213,7 +213,7 @@ namespace Microsoft.ML.Transforms
                 }
             }
 
-            public struct PivotColumnInfo
+            public readonly struct PivotColumnInfo
             {
                 public readonly string Name;
                 public readonly int Index;

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/DiagnosticResult.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/DiagnosticResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
     /// <summary>
     /// Location where the diagnostic appears, as determined by path, line number, and column number.
     /// </summary>
-    public struct DiagnosticResultLocation
+    public readonly struct DiagnosticResultLocation
     {
         public string Path { get; }
         public int Line { get; }

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Runtime.RunTests
         /// When hardware dependent baseline values should be tolerated, scope the code
         /// that does the comparisons with an instance of this disposable struct.
         /// </summary>
-        protected struct MismatchContext : IDisposable
+        protected readonly struct MismatchContext : IDisposable
         {
             // The test class instance.
             private readonly BaseTestBaseline _host;


### PR DESCRIPTION
This is a follow-up to #1475. Using the `in` keyword with structs that aren't marked as `readonly` can cause perf issues due to hidden copies being made.

`UInt128` is used in `ValueMapper` and potentially other places that may use the `in` keyword. Marking it as `readonly`, and while I was here - going through all `struct` declarations and marking the obvious ones as `readonly` as well.

