### PR TITLE
Always checks label in FFM trainer

### DIFF
--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -498,8 +498,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
                     throw Host.Except($"{defaultName} column '{column.Name}' is not compatible");
             }
 
-            if (LabelColumn != null)
-                CheckColumnsCompatible(LabelColumn, DefaultColumnNames.Label);
+            CheckColumnsCompatible(LabelColumn, DefaultColumnNames.Label);
 
             foreach (var feat in FeatureColumns)
             {


### PR DESCRIPTION
Fix #1498. Label column is always needed so we can't ignore this check.