### PR TITLE
Fix zero based key input from C# classes for matrix factorization

### DIFF
--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -297,13 +297,6 @@ namespace Microsoft.ML.Runtime.Api
                     peek(GetCurrentRowObject(), Position, ref dst));
             }
 
-            private ValueGetter<TDst> CreateDirectGetter<TDst>(Delegate peekDel)
-            {
-                var peek = peekDel as Peek<TRow, TDst>;
-                Host.AssertValue(peek);
-                return (ref TDst dst) => peek(GetCurrentRowObject(), Position, ref dst);
-            }
-
             private Delegate CreateKeyGetterDelegate<TDst>(Delegate peekDel, ColumnType colType)
             {
                 // Make sure the function is dealing with key.

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -306,13 +306,20 @@ namespace Microsoft.ML.Runtime.Api
 
             private Delegate CreateKeyGetterDelegate<TDst>(Delegate peekDel, ColumnType colType)
             {
+                // Make sure the function is dealing with key.
+                Host.Check(colType.IsKey);
+                // Following equations work only with contiguous key type.
+                Host.Check(colType.AsKey.Contiguous);
+                // Following equations work only with unsigned integers.
+                Host.Check(typeof(TDst) == typeof(ulong) || typeof(TDst) == typeof(uint) ||
+                    typeof(TDst) == typeof(byte) || typeof(TDst) == typeof(bool));
+
                 // Convert delegate function to a function which can fetch the underlying value.
                 var peek = peekDel as Peek<TRow, TDst>;
                 Host.AssertValue(peek);
-                Host.Check(colType.IsKey);
 
                 TDst rawKeyValue = default;
-                ulong key = 0; // the key value as ulong
+                ulong key = 0; // the raw key value as ulong
                 ulong min = colType.AsKey.Min;
                 ulong max = min + (ulong)colType.AsKey.Count - 1;
                 ulong result = 0; // the result as ulong

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -13,7 +13,6 @@ using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Model;
 using Microsoft.ML.Runtime.Recommender;
 using Microsoft.ML.Runtime.Recommender.Internal;
-using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.Recommender;
 
 [assembly: LoadableClass(typeof(MatrixFactorizationPredictor), null, typeof(SignatureLoadModel), "Matrix Factorization Predictor Executor", MatrixFactorizationPredictor.LoaderSignature)]
@@ -347,9 +346,12 @@ namespace Microsoft.ML.Trainers.Recommender
                 var getters = new Delegate[1];
                 if (active[0])
                 {
+                    // First check if expected columns are ok and then create getters to acccess those columns' values.
                     CheckInputSchema(input.Schema, _matrixColumnIndexColumnIndex, _matrixRowIndexCololumnIndex);
-                    var matrixColumnIndexGetter = input.GetGetter<uint>(_matrixColumnIndexColumnIndex);
-                    var matrixRowIndexGetter = input.GetGetter<uint>(_matrixRowIndexCololumnIndex);
+                    var matrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberType.U4, input, _matrixColumnIndexColumnIndex);
+                    var matrixRowIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberType.U4, input, _matrixRowIndexCololumnIndex);
+
+                    // Assign the getter of the prediction score. It maps a pair of matrix column index and matrix row index to a scalar.
                     getters[0] = _parent.GetGetter(matrixColumnIndexGetter, matrixRowIndexGetter);
                 }
                 return getters;

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Trainers
         /// </summary>
 
         /// <summary>
-        /// The name of variable (i.e., Column in a <see cref="IDataView"/> type system) used be used as matrix's column index.
+        /// The name of variable (i.e., Column in a <see cref="IDataView"/> type system) used be as matrix's column index.
         /// </summary>
         public readonly string MatrixColumnIndexName;
 

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Trainers
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Latent space dimension (denoted by k). If the factorized matrix is m-by-n, " +
                 "two factor matrices found by matrix factorization are m-by-k and k-by-n, respectively. " +
-                "This value is also known as the rank of matrix factorization.")]
+                "This value is also known as the rank of matrix factorization because k is generally much smaller than m and n.")]
             [TGUI(SuggestedSweeps = "8,16,64,128")]
             [TlcModule.SweepableDiscreteParam("K", new object[] { 8, 16, 64, 128 })]
             public int K = 8;
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Trainers
             public int NumIterations = 20;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Initial learning rate. It specifies the speed of the training algorithm. " +
-                "Small value may increate the number of iterations needed to achieve a reasonable result. Large value may lead to numerical difficulty such as a infinity value.")]
+                "Small value may increase the number of iterations needed to achieve a reasonable result. Large value may lead to numerical difficulty such as a infinity value.")]
             [TGUI(SuggestedSweeps = "0.001,0.01,0.1")]
             [TlcModule.SweepableDiscreteParam("Eta", new object[] { 0.001f, 0.01f, 0.1f })]
             public double Eta = 0.1;

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -29,15 +29,15 @@ namespace Microsoft.ML.Trainers
     {
         public sealed class Arguments
         {
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Regularization parameter." +
-                "It's the weight of factor matrices' norms in the objective function minimized by matrix factorization's algorithm." +
-                "A amall value could cause over-fitting.")]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Regularization parameter. " +
+                "It's the weight of factor matrices' norms in the objective function minimized by matrix factorization's algorithm. " +
+                "A small value could cause over-fitting.")]
             [TGUI(SuggestedSweeps = "0.01,0.05,0.1,0.5,1")]
             [TlcModule.SweepableDiscreteParam("Lambda", new object[] { 0.01f, 0.05f, 0.1f, 0.5f, 1f })]
             public double Lambda = 0.1;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Latent space dimension (denoted by k). If the factorized matrix is m-by-n," +
-                "two factor matrices found by matrix factorization are m-by-k and k-by-n, respectively." +
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Latent space dimension (denoted by k). If the factorized matrix is m-by-n, " +
+                "two factor matrices found by matrix factorization are m-by-k and k-by-n, respectively. " +
                 "This value is also known as the rank of matrix factorization.")]
             [TGUI(SuggestedSweeps = "8,16,64,128")]
             [TlcModule.SweepableDiscreteParam("K", new object[] { 8, 16, 64, 128 })]
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Trainers
             [TlcModule.SweepableDiscreteParam("NumIterations", new object[] { 10, 20, 40 })]
             public int NumIterations = 20;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Initial learning rate. It specifies the speed of the training algorithm." +
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Initial learning rate. It specifies the speed of the training algorithm. " +
                 "Small value may increate the number of iterations needed to achieve a reasonable result. Large value may lead to numerical difficulty such as a infinity value.")]
             [TGUI(SuggestedSweeps = "0.001,0.01,0.1")]
             [TlcModule.SweepableDiscreteParam("Eta", new object[] { 0.001f, 0.01f, 0.1f })]


### PR DESCRIPTION
Because of the getter in IDataView created from C# classes doesn't handle key properly, matrix factorization fails whenever there is a zero-based key input. This PR fixes this issue by modifying getter upon [peek](https://github.com/dotnet/machinelearning/blob/d68388a1c9994a5b429b194b64b2b0782834cb78/src/Microsoft.ML.Api/ApiUtils.cs#L53), which doesn't care key type at all. The major fix occurs in `src/Microsoft.ML.Api/DataViewConstructionUtils.cs`.
In addition, a test based on matrix factorization is made for preventing such an error from happening again in `test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs`.

In addition, matrix factorization also got polished. We clean up unnecessary fields and make its comments better.

Fix #1442.
