### PR TITLE
Enable calibration in OVA

### DIFF
--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Runtime.Learners
 
             if (_args.UseProbabilities)
             {
-                var calibratedModel = transformer.Model as TScalarPredictor;
+                var calibratedModel = transformer.Model as TDistPredictor;
 
                 // REVIEW: restoring the RoleMappedData, as much as we can.
                 // not having the weight column on the data passed to the TrainCalibrator should be addressed.


### PR DESCRIPTION
Partial fix for #1387 

- Calibration was being skipped for OVA. This PR fixes that issue. (Accuracy drop mentioned in #1387 improves from 0.4 to 0.8)

- Still need to find root cause for not getting expected accuracy (0.98) when using OVA + AveragedPerceptron.