### PR TITLE
Publish build logs in Azure DevOps CI.

### DIFF
--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -40,18 +40,21 @@ phases:
         mergeTestResults: true
     - task: CopyFiles@2
       displayName: Stage build logs
+      condition: failed()
       inputs:
         sourceFolder: $(Build.SourcesDirectory)
         contents: '?(msbuild.*|binclash.log|init-tools.log)'
         targetFolder: $(Build.ArtifactStagingDirectory)
     - task: CopyFiles@2
       displayName: Stage test output
+      condition: failed()
       inputs:
         sourceFolder: $(Build.SourcesDirectory)/bin
         contents: '**/TestOutput/**/*'
         targetFolder: $(Build.ArtifactStagingDirectory)
     - task: PublishBuildArtifacts@1
       displayName: Publish build and test logs
+      condition: failed()
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         artifactName: ${{ parameters.name }} $(_config_short)


### PR DESCRIPTION
Fixes #1473 by publishing logs from the build as artifacts in the Azure DevOps pipeline:

![image](https://user-images.githubusercontent.com/37886197/48021283-045ee900-e0ed-11e8-84a6-63b68ed2f48a.png)

Publishes the following files:
- msbuild.log
- msbuild.err
- msbuild.wrn
- binclash.log
- init-tools.log
- Microsoft.ML.Predictor.Tests/../TestOutput/*
