### PR TITLE
Make whitening tests work on hosted macs

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -36,4 +36,4 @@ phases:
     name: MacOS
     buildScript: ./build.sh
     queue:
-      name: DotNetCore-Mac
+      name: Hosted macOS

--- a/build.proj
+++ b/build.proj
@@ -75,12 +75,6 @@
     <MSBuild Projects="@(PkgProject)"
              Targets="Pack" />
   </Target>
-
-  <ItemGroup>
-    <TestFile Include="$(MSBuildThisFileDirectory)/test/data/external/winequality-white.csv"
-      Url="https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-white.csv"
-      DestinationFile="$(MSBuildThisFileDirectory)test/data/external/winequality-white.csv" />    
-  </ItemGroup>
   
   <ItemGroup Condition="'$(IncludeBenchmarkData)' == 'true'">
     <BenchmarkFile Update="@(BenchmarkFile)">

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -22,7 +22,7 @@ phases:
     - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)
       displayName: Build
     - ${{ if eq(parameters.name, 'MacOS') }}:
-      - script: brew install libomp && brew install mono-libgdiplus gettext && brew link gettext --force
+      - script: brew install libomp
         displayName: Install runtime dependencies
     - script: $(_buildScript) -$(_configuration) -runtests
       displayName: Run Tests

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -22,7 +22,7 @@ phases:
     - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)
       displayName: Build
     - ${{ if eq(parameters.name, 'MacOS') }}:
-      - script: brew install libomp
+      - script: brew install libomp mono-libgdiplus gettext && brew link gettext --force
         displayName: Install runtime dependencies
     - script: $(_buildScript) -$(_configuration) -runtests
       displayName: Run Tests

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -22,8 +22,8 @@ phases:
     - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)
       displayName: Build
     - ${{ if eq(parameters.name, 'MacOS') }}:
-      - script: brew install libomp
-        displayName: Install OpenMP runtime dependency
+      - script: brew install libomp && brew install mono-libgdiplus gettext && brew link gettext --force
+        displayName: Install runtime dependencies
     - script: $(_buildScript) -$(_configuration) -runtests
       displayName: Run Tests
     - task: PublishTestResults@2

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -329,6 +329,15 @@ namespace Microsoft.ML.Transforms.Projections
             return str;
         }
 
+        private string ArrayPrint(string[] array)
+        {
+            string str = "[";
+            foreach (var val in array)
+                str += val + " ";
+            str += "]";
+            return str;
+        }
+
         private void TrainModels(Float[][] columnData, int[] rowCounts, IChannel ch)
         {
             Host.AssertValue(ch);
@@ -343,6 +352,10 @@ namespace Microsoft.ML.Transforms.Projections
 
                 // Compute covariance matrix (sigma).
                 var u = new Float[ccol * ccol];
+
+                // REMOVE AFTER DEBUGGING:
+                ch.Info("Infos Name = " + ArrayPrint(Infos.Select(x => x.Name).ToArray()));
+                ch.Info("Infos Source = " + ArrayPrint(Infos.Select(x => x.Source).ToArray()));
 
                 // REMOVE AFTER DEBUGGING
                 ch.Info("Computing covariance matrix...");

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -347,6 +347,11 @@ namespace Microsoft.ML.Transforms.Projections
                 // REMOVE AFTER DEBUGGING
                 ch.Info("Computing covariance matrix...");
                 ch.Info("data = " + ArrayPrint(data));
+                ch.Info("ccol = " + ccol.ToString());
+                ch.Info("crow = " + crow.ToString());
+                ch.Info("Layout = " + Layout.ToString());
+                ch.Info("Trans = " + Mkl.Transpose.Trans.ToString());
+                ch.Info("NoTrans = " + Mkl.Transpose.NoTrans.ToString());
 
                 Mkl.Gemm(Layout, Mkl.Transpose.Trans, Mkl.Transpose.NoTrans,
                     ccol, ccol, crow, 1 / (Float)crow, data, ccol, data, ccol, 0, u, ccol);

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -342,7 +342,6 @@ namespace Microsoft.ML.Transforms.Projections
 
                 // Compute covariance matrix (sigma).
                 var u = new Float[ccol * ccol];
-
                 ch.Info("Computing covariance matrix...");
                 Mkl.Gemm(Layout, Mkl.Transpose.Trans, Mkl.Transpose.NoTrans,
                     ccol, ccol, crow, 1 / (Float)crow, data, ccol, data, ccol, 0, u, ccol);

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -356,7 +356,11 @@ namespace Microsoft.ML.Transforms.Projections
             {
                 // REMOVE AFTER DEBUGGING
                 if (rowCounts[iinfo] == 0)
+                {
+                    _models[iinfo] = new float[Infos[iinfo].TypeSrc.ValueCount * Infos[iinfo].TypeSrc.ValueCount];
+                    InvModels[iinfo] = new float[Infos[iinfo].TypeSrc.ValueCount * Infos[iinfo].TypeSrc.ValueCount];
                     continue;
+                }
 
                 var ex = _exes[iinfo];
                 var data = columnData[iinfo];

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -319,6 +319,16 @@ namespace Microsoft.ML.Transforms.Projections
             return columnData;
         }
 
+        // REMOVE AFTER DEBUG: prints array of floats
+        private string ArrayPrint(Float[] array)
+        {
+            string str = "[";
+            foreach (var val in array)
+                str += val.ToString() + " ";
+            str += "]";
+            return str;
+        }
+
         private void TrainModels(Float[][] columnData, int[] rowCounts, IChannel ch)
         {
             Host.AssertValue(ch);
@@ -337,13 +347,19 @@ namespace Microsoft.ML.Transforms.Projections
                 Mkl.Gemm(Layout, Mkl.Transpose.Trans, Mkl.Transpose.NoTrans,
                     ccol, ccol, crow, 1 / (Float)crow, data, ccol, data, ccol, 0, u, ccol);
 
+                // REMOVE AFTER DEBUGGING:
+                ch.Info("cov mat = " + ArrayPrint(u));
+
                 ch.Info("Computing SVD...");
                 var eigValues = new Float[ccol]; // Eigenvalues.
                 var unconv = new Float[ccol]; // Superdiagonal unconverged values (if any). Not used but seems to be required by MKL.
-                // After the next call, values in U will be ovewritten by left eigenvectors.
-                // Each column in U will be an eigenvector.
+                                              // After the next call, values in U will be ovewritten by left eigenvectors.
+                                              // Each column in U will be an eigenvector.
                 int r = Mkl.Svd(Layout, Mkl.SvdJob.MinOvr, Mkl.SvdJob.None,
                     ccol, ccol, u, ccol, eigValues, null, ccol, null, ccol, unconv);
+                // REMOVE AFTER DEBUGGING:
+                ch.Info("cov mat = " + ArrayPrint(eigValues));
+                ch.Info("r = " + r.ToString());
                 ch.Assert(r == 0);
                 if (r > 0)
                     throw ch.Except("SVD did not converge.");

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -338,6 +338,15 @@ namespace Microsoft.ML.Transforms.Projections
             return str;
         }
 
+        private string ArrayPrint(int[] array)
+        {
+            string str = "[";
+            foreach (var val in array)
+                str += val.ToString() + " ";
+            str += "]";
+            return str;
+        }
+
         private void TrainModels(Float[][] columnData, int[] rowCounts, IChannel ch)
         {
             Host.AssertValue(ch);

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -349,8 +349,8 @@ namespace Microsoft.ML.Transforms.Projections
                 ch.Info("Computing SVD...");
                 var eigValues = new Float[ccol]; // Eigenvalues.
                 var unconv = new Float[ccol]; // Superdiagonal unconverged values (if any). Not used but seems to be required by MKL.
-                                              // After the next call, values in U will be ovewritten by left eigenvectors.
-                                              // Each column in U will be an eigenvector.
+                // After the next call, values in U will be ovewritten by left eigenvectors.
+                // Each column in U will be an eigenvector.
                 int r = Mkl.Svd(Layout, Mkl.SvdJob.MinOvr, Mkl.SvdJob.None,
                     ccol, ccol, u, ccol, eigValues, null, ccol, null, ccol, unconv);
                 ch.Assert(r == 0);

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -343,7 +343,11 @@ namespace Microsoft.ML.Transforms.Projections
 
                 // Compute covariance matrix (sigma).
                 var u = new Float[ccol * ccol];
+
+                // REMOVE AFTER DEBUGGING
                 ch.Info("Computing covariance matrix...");
+                ch.Info("data = " + ArrayPrint(data));
+
                 Mkl.Gemm(Layout, Mkl.Transpose.Trans, Mkl.Transpose.NoTrans,
                     ccol, ccol, crow, 1 / (Float)crow, data, ccol, data, ccol, 0, u, ccol);
 
@@ -358,8 +362,9 @@ namespace Microsoft.ML.Transforms.Projections
                 int r = Mkl.Svd(Layout, Mkl.SvdJob.MinOvr, Mkl.SvdJob.None,
                     ccol, ccol, u, ccol, eigValues, null, ccol, null, ccol, unconv);
                 // REMOVE AFTER DEBUGGING:
-                ch.Info("cov mat = " + ArrayPrint(eigValues));
+                ch.Info("eig mat = " + ArrayPrint(eigValues));
                 ch.Info("r = " + r.ToString());
+
                 ch.Assert(r == 0);
                 if (r > 0)
                     throw ch.Except("SVD did not converge.");

--- a/src/Microsoft.ML.Transforms/WhiteningTransform.cs
+++ b/src/Microsoft.ML.Transforms/WhiteningTransform.cs
@@ -354,6 +354,10 @@ namespace Microsoft.ML.Transforms.Projections
 
             for (int iinfo = 0; iinfo < Infos.Length; iinfo++)
             {
+                // REMOVE AFTER DEBUGGING
+                if (rowCounts[iinfo] == 0)
+                    continue;
+
                 var ex = _exes[iinfo];
                 var data = columnData[iinfo];
                 int crow = rowCounts[iinfo];


### PR DESCRIPTION
Fixes #1506.

This PR fixes the error encountered when running tests on hosted macs.

It turns out that the problem was due to a mismatch in the parameters sizes and values that were passed  to the MKL gemm function during training. In particular, as part of the test, the transform is trained on empty data. An empty array of data was then passed to the MKL gemm function, while the parameters specifying the size of the data were were non 0. This situation was apparently handled for other OS and processors versions, but not on the hosted macs, and was therefore giving an error. 

The fix that I propose is to initialize zero matrices of the right size instead of training when provided empty data as an input.

This PR also deletes a command in the build.proj that was still downloading the wine dataset (found by @vaeksare) when building.