### PR TITLE
Fix TextLoader.Argument (HasHeader=true) for Iris dataset

### DIFF
--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -23,23 +23,6 @@ namespace Microsoft.ML.Runtime.RunTests
     {
         public const string IrisDataPath = "iris.data";
 
-        protected static TextLoader.Arguments MakeIrisTextLoaderArgs()
-        {
-            return new TextLoader.Arguments()
-            {
-                Separator = "comma",
-                HasHeader = true,
-                Column = new[]
-                {
-                    new TextLoader.Column("SepalLength", DataKind.R4, 0),
-                    new TextLoader.Column("SepalWidth", DataKind.R4, 1),
-                    new TextLoader.Column("PetalLength", DataKind.R4, 2),
-                    new TextLoader.Column("PetalWidth",DataKind.R4, 3),
-                    new TextLoader.Column("Label", DataKind.Text, 4)
-                }
-            };
-        }
-
         /// <summary>
         /// 'Workout test' for an estimator.
         /// Checks the following traits:

--- a/test/Microsoft.ML.Tests/Scenarios/Api/ApiScenariosTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/ApiScenariosTests.cs
@@ -57,7 +57,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             return new TextLoader.Arguments()
             {
                 Separator = "comma",
-                HasHeader = true,
                 Column = new[]
                 {
                     new TextLoader.Column("SepalLength", DataKind.R4, 0),

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
 
             // Pipeline.
-            var pipeline = new RandomizedPcaTrainer(Env, featureColumn, rank:10);
+            var pipeline = new RandomizedPcaTrainer(Env, featureColumn, rank: 10);
 
             TestEstimatorCore(pipeline, data);
             Done();
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                     }).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             // Pipeline.
-            var pipeline = new TextFeaturizingEstimator (Env, "SentimentText", "Features");
+            var pipeline = new TextFeaturizingEstimator(Env, "SentimentText", "Features");
 
             return (pipeline, data);
         }
@@ -177,18 +177,15 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
         private (IEstimator<ITransformer>, IDataView) GetMultiClassPipeline()
         {
-
             var data = new TextLoader(Env, new TextLoader.Arguments()
             {
                 Separator = "comma",
-                HasHeader = true,
                 Column = new[]
                         {
                             new TextLoader.Column("Features", DataKind.R4, new [] { new TextLoader.Range(0, 3) }),
                             new TextLoader.Column("Label", DataKind.Text, 4)
                         }
-                })
-                .Read(GetDataPath(IrisDataPath));
+            }).Read(GetDataPath(IrisDataPath));
 
             var pipeline = new ValueToKeyMappingEstimator(Env, "Label");
 


### PR DESCRIPTION
Fixes #1537 

Dropped `HasHeader=true` from  `GetMultiClassPipeline` and `MakeIrisTextLoaderArgs`
