### PR TITLE
Fixes #1550 - Type mismatch in TransformSamples.SampleInfertDataWithFeatures

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ConcatTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ConcatTransform.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic
     {
         class SampleInfertDataWithFeatures
         {
-            public VBuffer<int> Features { get; set; }
+            public VBuffer<float> Features { get; set; }
         }
 
         public static void ConcatTransform()


### PR DESCRIPTION
Fixes #1550

Type mismatch in TransformSamples.SampleInfertDataWithFeatures
