### PR TITLE
adding more logging to failures.

### DIFF
--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -551,14 +551,20 @@ namespace Microsoft.ML.Runtime.RunTests
                 // would fail the inRange == true check, but would suceed the following, and we doconsider those two numbers 
                 // (1.82844949 - 1.8284502) = -0.00000071
 
+                double delta2 = 0;
                 if (!inRange)
                 {
-                    delta = Math.Round(f1 - f2, digitsOfPrecision);
-                    inRange = delta >= -allowedVariance && delta <= allowedVariance;
+                    delta2 = Math.Round(f1 - f2, digitsOfPrecision);
+                    inRange = delta2 >= -allowedVariance && delta2 <= allowedVariance;
                 }
 
                 if(!inRange)
                 {
+                    Fail(_allowMismatch, $"Output and baseline mismatch at line {i}." + Environment.NewLine +
+                        $"Values to compare are {firstCollection[i]} and {secondCollection[i]}" + Environment.NewLine +
+                        $"\t AllowedVariance: {allowedVariance}" + Environment.NewLine +
+                        $"\t delta: {delta}" + Environment.NewLine +
+                        $"\t delta2: {delta2}" +Environment.NewLine);
                     return false;
                 }
             }

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -517,12 +517,12 @@ namespace Microsoft.ML.Runtime.RunTests
 
             if (firstCollection.Count == secondCollection.Count)
             {
-                if(!MatchNumberWithTolerance(firstCollection, secondCollection, digitsOfPrecision))
+                if (!MatchNumberWithTolerance(firstCollection, secondCollection, digitsOfPrecision))
                 {
                     return false;
                 }
             }
-                
+
             firstString = MatchNumbers.Replace(firstString, "%Number%");
             secondString = MatchNumbers.Replace(secondString, "%Number%");
             return true;
@@ -558,13 +558,13 @@ namespace Microsoft.ML.Runtime.RunTests
                     inRange = delta2 >= -allowedVariance && delta2 <= allowedVariance;
                 }
 
-                if(!inRange)
+                if (!inRange)
                 {
                     Fail(_allowMismatch, $"Output and baseline mismatch at line {i}." + Environment.NewLine +
                         $"Values to compare are {firstCollection[i]} and {secondCollection[i]}" + Environment.NewLine +
                         $"\t AllowedVariance: {allowedVariance}" + Environment.NewLine +
                         $"\t delta: {delta}" + Environment.NewLine +
-                        $"\t delta2: {delta2}" +Environment.NewLine);
+                        $"\t delta2: {delta2}" + Environment.NewLine);
                     return false;
                 }
             }


### PR DESCRIPTION
Fixes #1477 by adding more logging around the failure on the baselines number comparison. 

Logging on failures looks like this now:

```
Values to compare are 0.49224 and 0.49223705031518167
	 AllowedVariance: 1E-07
	 delta: 2.9E-06
	 delta2: 2.9E-06

*** Failure: Output and baseline mismatch at line 3: 'FieldAwareFactorizationMachine\FieldAwareFactorizationMachine-CV-breast-cancer.txt
```'
