### PR TITLE
Publish test artifacts on timeout and not just failure

### DIFF
--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -20,6 +20,7 @@ phases:
           _configuration: Release
           _config_short: R
       ${{ insert }}: ${{ parameters.queue }}
+    timeoutInMinutes: 30
     steps:
     - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)
       displayName: Build
@@ -28,7 +29,6 @@ phases:
         displayName: Install runtime dependencies
     - script: $(_buildScript) -$(_configuration) -runtests
       displayName: Run Tests
-      timeout: 30 # in minutes
     - task: PublishTestResults@2
       displayName: Publish Test Results
       condition: succeededOrFailed()

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -6,12 +6,12 @@ parameters:
 
 phases:
   - phase: ${{ parameters.name }}
-    timeoutInMinutes: 30
     variables:
       _buildScript: ${{ parameters.buildScript }}
       _phaseName: ${{ parameters.name }}
       _arch: ${{ parameters.architecture }}
     queue:
+      timeoutInMinutes: 30
       parallel: 99
       matrix:
         Build_Debug:

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -28,6 +28,7 @@ phases:
         displayName: Install runtime dependencies
     - script: $(_buildScript) -$(_configuration) -runtests
       displayName: Run Tests
+      timeout: 30 # in minutes
     - task: PublishTestResults@2
       displayName: Publish Test Results
       condition: succeededOrFailed()
@@ -40,21 +41,21 @@ phases:
         mergeTestResults: true
     - task: CopyFiles@2
       displayName: Stage build logs
-      condition: failed()
+      condition: not(succeeded())
       inputs:
         sourceFolder: $(Build.SourcesDirectory)
         contents: '?(msbuild.*|binclash.log|init-tools.log)'
         targetFolder: $(Build.ArtifactStagingDirectory)
     - task: CopyFiles@2
       displayName: Stage test output
-      condition: failed()
+      condition: not(succeeded())
       inputs:
         sourceFolder: $(Build.SourcesDirectory)/bin
         contents: '**/TestOutput/**/*'
         targetFolder: $(Build.ArtifactStagingDirectory)
     - task: PublishBuildArtifacts@1
       displayName: Publish build and test logs
-      condition: failed()
+      condition: not(succeeded())
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         artifactName: ${{ parameters.name }} $(_config_short)

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -6,6 +6,7 @@ parameters:
 
 phases:
   - phase: ${{ parameters.name }}
+    timeoutInMinutes: 30
     variables:
       _buildScript: ${{ parameters.buildScript }}
       _phaseName: ${{ parameters.name }}
@@ -20,7 +21,6 @@ phases:
           _configuration: Release
           _config_short: R
       ${{ insert }}: ${{ parameters.queue }}
-    timeoutInMinutes: 30
     steps:
     - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)
       displayName: Build

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -11,7 +11,7 @@ phases:
       _phaseName: ${{ parameters.name }}
       _arch: ${{ parameters.architecture }}
     queue:
-      timeoutInMinutes: 30
+      timeoutInMinutes: 40
       parallel: 99
       matrix:
         Build_Debug:


### PR DESCRIPTION
Fixes #1556.

In this PR I add a condition so that we post test artifacts not just in case of failures, but also in case of timeouts, by using `not(succeeded())` condition.

I also set the timeout limit for the running the tests to 40 min (this does not include the build time). Still working on the right syntax for the timeout setting.
