### PR TITLE
Printing out test scores in training phase for FastTree

### DIFF
--- a/src/Microsoft.ML.Core/Prediction/TrainContext.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainContext.cs
@@ -26,6 +26,14 @@ namespace Microsoft.ML.Runtime
         public RoleMappedData ValidationSet { get; }
 
         /// <summary>
+        /// The test set, whose uses are very similar to validation set but it should not directly and indirectly
+        /// affect the training process. One major difference between validation set and test test is that validation
+        /// can affect the training process by, for example, early stopping. Note that early stopping is a technique
+        /// which terminates the training process once the scores computed on validation set starts getting worse.
+        /// </summary>
+        public RoleMappedData TestSet { get; }
+
+        /// <summary>
         /// The initial predictor, for incremental training. Note that if a <see cref="ITrainer"/> implementor
         /// does not support incremental training, then it can ignore it similarly to how one would ignore
         /// <see cref="ValidationSet"/>. However, if the trainer does support incremental training and there
@@ -38,8 +46,9 @@ namespace Microsoft.ML.Runtime
         /// </summary>
         /// <param name="trainingSet">Will set <see cref="TrainingSet"/> to this value. This must be specified</param>
         /// <param name="validationSet">Will set <see cref="ValidationSet"/> to this value if specified</param>
+        /// <param name="testSet">Will set <see cref="TestSet"/> to this value if specified</param>
         /// <param name="initialPredictor">Will set <see cref="InitialPredictor"/> to this value if specified</param>
-        public TrainContext(RoleMappedData trainingSet, RoleMappedData validationSet = null, IPredictor initialPredictor = null)
+        public TrainContext(RoleMappedData trainingSet, RoleMappedData validationSet = null, RoleMappedData testSet = null, IPredictor initialPredictor = null)
         {
             Contracts.CheckValue(trainingSet, nameof(trainingSet));
             Contracts.CheckValueOrNull(validationSet);
@@ -50,6 +59,7 @@ namespace Microsoft.ML.Runtime
 
             TrainingSet = trainingSet;
             ValidationSet = validationSet;
+            TestSet = testSet;
             InitialPredictor = initialPredictor;
         }
     }

--- a/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
@@ -37,14 +37,14 @@ namespace Microsoft.ML.Runtime
 
         /// <summary>
         /// Whether the trainer supports validation set via <see cref="TrainContext.ValidationSet"/>. Not implementing
-        /// this interface and returning <c>true</c> from this property is an indication the trainer does not support
+        /// this interface and returning <c>false</c> from this property is an indication the trainer does not support
         /// that.
         /// </summary>
         public bool SupportsValidation { get; }
 
         /// <summary>
-        /// Whether the trainer supports test set via <see cref="TrainContext.TestSet"/>. Not implementing
-        /// this interface and returning <c>true</c> from this property is an indication the trainer does not support
+        /// Whether the trainer can use test set via <see cref="TrainContext.TestSet"/>. Not implementing
+        /// this interface and returning <c>false</c> from this property is an indication the trainer does not support
         /// that.
         /// </summary>
         public bool SupportsTest { get; }

--- a/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
+++ b/src/Microsoft.ML.Core/Prediction/TrainerInfo.cs
@@ -36,11 +36,18 @@ namespace Microsoft.ML.Runtime
         public bool WantCaching { get; }
 
         /// <summary>
-        /// Whether the trainer supports validation sets via <see cref="TrainContext.ValidationSet"/>. Not implementing
+        /// Whether the trainer supports validation set via <see cref="TrainContext.ValidationSet"/>. Not implementing
         /// this interface and returning <c>true</c> from this property is an indication the trainer does not support
         /// that.
         /// </summary>
         public bool SupportsValidation { get; }
+
+        /// <summary>
+        /// Whether the trainer supports test set via <see cref="TrainContext.TestSet"/>. Not implementing
+        /// this interface and returning <c>true</c> from this property is an indication the trainer does not support
+        /// that.
+        /// </summary>
+        public bool SupportsTest { get; }
 
         /// <summary>
         /// Whether the trainer can support incremental trainers via <see cref="TrainContext.InitialPredictor"/>. Not
@@ -58,14 +65,16 @@ namespace Microsoft.ML.Runtime
         /// <param name="caching">The value for the property <see cref="WantCaching"/></param>
         /// <param name="supportValid">The value for the property <see cref="SupportsValidation"/></param>
         /// <param name="supportIncrementalTrain">The value for the property <see cref="SupportsIncrementalTraining"/></param>
+        /// <param name="supportTest">The value for the property <see cref="SupportsTest"/></param>
         public TrainerInfo(bool normalization = true, bool calibration = false, bool caching = true,
-            bool supportValid = false, bool supportIncrementalTrain = false)
+            bool supportValid = false, bool supportIncrementalTrain = false, bool supportTest = false)
         {
             NeedNormalization = normalization;
             NeedCalibration = calibration;
             WantCaching = caching;
             SupportsValidation = supportValid;
             SupportsIncrementalTraining = supportIncrementalTrain;
+            SupportsTest = supportTest;
         }
     }
 }

--- a/src/Microsoft.ML.Data/Commands/TrainCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainCommand.cs
@@ -224,13 +224,13 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         public static IPredictor Train(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, RoleMappedData validData,
-            IComponentFactory<ICalibratorTrainer> calibrator, int maxCalibrationExamples, bool? cacheData, IPredictor inputPredictor = null)
+            IComponentFactory<ICalibratorTrainer> calibrator, int maxCalibrationExamples, bool? cacheData, IPredictor inputPredictor = null, RoleMappedData testData = null)
         {
-            return TrainCore(env, ch, data, trainer, validData, calibrator, maxCalibrationExamples, cacheData, inputPredictor);
+            return TrainCore(env, ch, data, trainer, validData, calibrator, maxCalibrationExamples, cacheData, inputPredictor, testData);
         }
 
         private static IPredictor TrainCore(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, RoleMappedData validData,
-            IComponentFactory<ICalibratorTrainer> calibrator, int maxCalibrationExamples, bool? cacheData, IPredictor inputPredictor = null)
+            IComponentFactory<ICalibratorTrainer> calibrator, int maxCalibrationExamples, bool? cacheData, IPredictor inputPredictor = null, RoleMappedData testData = null)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ch, nameof(ch));
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Runtime.Data
                 inputPredictor = null;
             }
             ch.Assert(validData == null || trainer.Info.SupportsValidation);
-            var predictor = trainer.Train(new TrainContext(data, validData, inputPredictor));
+            var predictor = trainer.Train(new TrainContext(data, validData, testData, inputPredictor));
             var caliTrainer = calibrator?.CreateComponent(env);
             return CalibratorUtils.TrainCalibratorIfNeeded(env, ch, caliTrainer, maxCalibrationExamples, trainer, predictor, data);
         }

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            // In addition to the training set, some trainers can accept two extra data sets, validation set and test set,
+            // In addition to the training set, some trainers can accept two data sets, validation set and test set,
             // in training phase. The major difference between validation set and test set is that training process may
             // indirectly use validation set to improve the model but the learned model should totally independent of test set.
             // Similar to validation set, the trainer can report the scores computed using test set.

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -162,8 +162,28 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
+            // In addition to the training set, some trainers can accept two data sets, validation set and test set,
+            // in training phase. The major difference between validation set and test set is that training process may
+            // indirectly use validation set to improve the model but the learned model should totally independent of test set.
+            // Similar to validation set, the trainer can report the scores computed using test set.
+            RoleMappedData testDataUsedInTrainer = null;
+            if (!string.IsNullOrWhiteSpace(Args.TestFile))
+            {
+                if (!trainer.Info.SupportsTest)
+                {
+                    ch.Warning("Ignoring testFile: Trainer does not accept test dataset.");
+                }
+                else
+                {
+                    ch.Trace("Constructing the test pipeline");
+                    IDataView testPipeUsedInTrainer = CreateRawLoader(dataFile: Args.TestFile);
+                    testPipeUsedInTrainer = ApplyTransformUtils.ApplyAllTransformsToData(Host, trainPipe, testPipeUsedInTrainer);
+                    testDataUsedInTrainer = new RoleMappedData(testPipeUsedInTrainer, data.Schema.GetColumnRoleNames());
+                }
+            }
+
             var predictor = TrainUtils.Train(Host, ch, data, trainer, validData,
-                Args.Calibrator, Args.MaxCalibrationExamples, Args.CacheData, inputPredictor);
+                Args.Calibrator, Args.MaxCalibrationExamples, Args.CacheData, inputPredictor, testDataUsedInTrainer);
 
             IDataLoader testPipe;
             using (var file = !string.IsNullOrEmpty(Args.OutputModelFile) ?

--- a/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainTestCommand.cs
@@ -162,18 +162,16 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            // In addition to the training set, some trainers can accept two data sets, validation set and test set,
+            // In addition to the training set, some trainers can accept two extra data sets, validation set and test set,
             // in training phase. The major difference between validation set and test set is that training process may
             // indirectly use validation set to improve the model but the learned model should totally independent of test set.
             // Similar to validation set, the trainer can report the scores computed using test set.
             RoleMappedData testDataUsedInTrainer = null;
             if (!string.IsNullOrWhiteSpace(Args.TestFile))
             {
-                if (!trainer.Info.SupportsTest)
-                {
-                    ch.Warning("Ignoring testFile: Trainer does not accept test dataset.");
-                }
-                else
+                // In contrast to the if-else block for validation above, we do not throw a warning if test file is provided
+                // because this is TrainTest command.
+                if (trainer.Info.SupportsTest)
                 {
                     ch.Trace("Constructing the test pipeline");
                     IDataView testPipeUsedInTrainer = CreateRawLoader(dataFile: Args.TestFile);

--- a/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ML.Runtime.Training
                 validRoles = MakeRoles(cachedValid);
             }
 
-            var pred = TrainModelCore(new TrainContext(trainRoles, validRoles, initPredictor));
+            var pred = TrainModelCore(new TrainContext(trainRoles, validRoles, null, initPredictor));
             return MakeTransformer(pred, trainSet.Schema);
         }
 

--- a/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
@@ -389,7 +389,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
         public RowForwardIndexer GetFeatureBinRowwiseIndexer(bool[] activeFeatures = null)
         {
             Contracts.Assert(activeFeatures == null || activeFeatures.Length >= NumFeatures);
-            var truncatedActiveFeatures = new bool[NumFeatures];
+            var truncatedActiveFeatures = Enumerable.Repeat(true, NumFeatures).ToArray();
             if (activeFeatures != null)
                 Array.Copy(activeFeatures, 0, truncatedActiveFeatures, 0, NumFeatures);
             return new RowForwardIndexer(this, truncatedActiveFeatures);

--- a/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
+++ b/src/Microsoft.ML.FastTree/Dataset/Dataset.cs
@@ -388,7 +388,11 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
         /// <returns>Row forward indexer</returns>
         public RowForwardIndexer GetFeatureBinRowwiseIndexer(bool[] activeFeatures = null)
         {
-            return new RowForwardIndexer(this, activeFeatures);
+            Contracts.Assert(activeFeatures == null || activeFeatures.Length >= NumFeatures);
+            var truncatedActiveFeatures = new bool[NumFeatures];
+            if (activeFeatures != null)
+                Array.Copy(activeFeatures, 0, truncatedActiveFeatures, 0, NumFeatures);
+            return new RowForwardIndexer(this, truncatedActiveFeatures);
         }
 
         public struct DatasetSkeletonQueryDocData

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Trainers.FastTree
         protected RoleMappedData ValidData;
         /// <summary>
         /// If not null, it's a test data set passed in from training context. It will be converted to one element in
-        /// <see cref="Tests"/> by calling <see cref="ExamplesToFastTreeBins.GetCompatibleDataset"/>.
+        /// <see cref="Tests"/> by calling <see cref="ExamplesToFastTreeBins.GetCompatibleDataset"/> in <see cref="InitializeTests"/>.
         /// </summary>
         protected RoleMappedData TestData;
         protected IParallelTraining ParallelTraining;

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -159,6 +159,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
             ValidData = context.ValidationSet;
+            TestData = context.TestSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -105,6 +105,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
             ValidData = context.ValidationSet;
+            TestData = context.TestSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -89,6 +89,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
             ValidData = context.ValidationSet;
+            TestData = context.TestSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -91,6 +91,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
             ValidData = context.ValidationSet;
+            TestData = context.TestSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -173,6 +173,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
             ValidData = context.ValidationSet;
+            TestData = context.TestSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -194,6 +194,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
             ValidData = context.ValidationSet;
+            TestData = context.TestSet;
 
             using (var ch = Host.Start("Training"))
             {

--- a/test/BaselineOutput/Common/FastForestRegression/FastForestRegression-TrainTest-housing-out.txt
+++ b/test/BaselineOutput/Common/FastForestRegression/FastForestRegression-TrainTest-housing-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 506 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
 Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -33,7 +34,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/Common/FastForestRegression/QuantileRegressorTester-TrainTest-housing-out.txt
+++ b/test/BaselineOutput/Common/FastForestRegression/QuantileRegressorTester-TrainTest-housing-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 506 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
 Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -33,7 +34,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/Common/FastRank/FastRank-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/Common/FastRank/FastRank-TrainTest-breast-cancer-out.txt
@@ -5,6 +5,8 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
 Reserved memory for tree learner: 3852 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastForestClassification/FastForestClassification-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastForestClassification/FastForestClassification-TrainTest-breast-cancer-out.txt
@@ -5,6 +5,8 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
 Reserved memory for tree learner: 3852 bytes
 Starting to train ...
 Training calibrator.
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
 Reserved memory for tree learner: 4980 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-Census.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
 Reserved memory for tree learner: 28728 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-group-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-group-out.txt
@@ -6,6 +6,9 @@ Warning: This is not ranking problem, Group Id 'GroupId' column will be ignored
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
+Warning: This is not ranking problem, Group Id 'GroupId' column will be ignored
+Warning: Skipped 16 instances with missing features during training
 Reserved memory for tree learner: 3852 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -49,7 +52,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-out.txt
@@ -5,6 +5,8 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
 Reserved memory for tree learner: 3852 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeBsr-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeBsr-TrainTest-breast-cancer-out.txt
@@ -5,6 +5,8 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
 Reserved memory for tree learner: 3852 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
 Reserved memory for tree learner: 4980 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
 Reserved memory for tree learner: 28728 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise on disk
 Reserved memory for tree learner: 5016 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise on disk
 Reserved memory for tree learner: 28812 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise on disk
 Reserved memory for tree learner: 14688 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census.Cat-out.txt
@@ -4,6 +4,7 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise on disk
 Reserved memory for tree learner: 38484 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDisk-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDisk-TrainTest-breast-cancer-out.txt
@@ -5,6 +5,8 @@ Changing data from row-wise to column-wise on disk
 Warning: 16 of 699 examples will be skipped due to missing feature values
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise on disk
+Warning: 16 of 699 examples will be skipped due to missing feature values
 Reserved memory for tree learner: 3852 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -44,7 +46,9 @@ Virtual memory usage(MB): %Number%
 --- Progress log ---
 [1] 'FastTree disk-based bins initialization' started.
 [1] 'FastTree disk-based bins initialization' finished in %Time%.
-[2] 'FastTree training' started.
-[2] 'FastTree training' finished in %Time%.
-[3] 'Saving model' started.
-[3] 'Saving model' finished in %Time%.
+[2] 'FastTree disk-based bins initialization #2' started.
+[2] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[3] 'FastTree training' started.
+[3] 'FastTree training' finished in %Time%.
+[4] 'Saving model' started.
+[4] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDrop-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeDrop-TrainTest-breast-cancer-out.txt
@@ -5,6 +5,8 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
 Reserved memory for tree learner: 3852 bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeHighMinDocs-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/FastTreeBinaryClassification/FastTreeHighMinDocs-TrainTest-breast-cancer-out.txt
@@ -5,6 +5,8 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
 Reserved memory for tree learner: 468 bytes
 Starting to train ...
 Warning: 5 of the boosting iterations failed to grow a tree. This is commonly because the minimum documents in leaf hyperparameter was set too high for this dataset.
@@ -49,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastForestClassification/FastForestClassification-CV-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastForestClassification/FastForestClassification-CV-breast-cancer-out.txt
@@ -5,7 +5,7 @@ Changing data from row-wise to column-wise
 Warning: Skipped 8 instances with missing features during training
 Processed 329 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3852 bytes
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Training calibrator.
 Not adding a normalizer.
@@ -14,7 +14,7 @@ Changing data from row-wise to column-wise
 Warning: Skipped 8 instances with missing features during training
 Processed 354 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3816 bytes
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Training calibrator.
 TEST POSITIVE RATIO:	0.3702 (134.0/(134.0+228.0))

--- a/test/BaselineOutput/SingleRelease/FastForestClassification/FastForestClassification-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastForestClassification/FastForestClassification-TrainTest-breast-cancer-out.txt
@@ -5,7 +5,9 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3852 bytes
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Training calibrator.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 4980 bytes
+Changing data from row-wise to column-wise
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-Census.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 28728 bytes
+Changing data from row-wise to column-wise
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-group-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-group-out.txt
@@ -6,7 +6,10 @@ Warning: This is not ranking problem, Group Id 'GroupId' column will be ignored
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3852 bytes
+Changing data from row-wise to column-wise
+Warning: This is not ranking problem, Group Id 'GroupId' column will be ignored
+Warning: Skipped 16 instances with missing features during training
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))
@@ -49,7 +52,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTree-TrainTest-breast-cancer-out.txt
@@ -5,7 +5,9 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3852 bytes
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeBsr-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeBsr-TrainTest-breast-cancer-out.txt
@@ -5,7 +5,9 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3852 bytes
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 4980 bytes
+Changing data from row-wise to column-wise
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategorical-TrainTest-Census.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 28728 bytes
+Changing data from row-wise to column-wise
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -50,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [3] 'FastTree in-memory bins initialization' finished in %Time%.
 [4] 'FastTree feature conversion' started.
 [4] 'FastTree feature conversion' finished in %Time%.
-[5] 'FastTree training' started.
-[5] 'FastTree training' finished in %Time%.
-[6] 'Saving model' started.
-[6] 'Saving model' finished in %Time%.
+[5] 'FastTree data preparation #2' started.
+[5] 'FastTree data preparation #2' finished in %Time%.
+[6] 'FastTree feature conversion #2' started.
+[6] 'FastTree feature conversion #2' finished in %Time%.
+[7] 'FastTree training' started.
+[7] 'FastTree training' finished in %Time%.
+[8] 'Saving model' started.
+[8] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 5016 bytes
+Changing data from row-wise to column-wise on disk
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeCategoricalDisk-TrainTest-Census.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 28812 bytes
+Changing data from row-wise to column-wise on disk
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census-Cat-Only.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census-Cat-Only.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 14688 bytes
+Changing data from row-wise to column-wise on disk
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census.Cat-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDisk-TrainTest-Census.Cat-out.txt
@@ -4,7 +4,8 @@ Making per-feature arrays
 Changing data from row-wise to column-wise on disk
 Processed 32561 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 38484 bytes
+Changing data from row-wise to column-wise on disk
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.2362 (3846.0/(3846.0+12435.0))
@@ -46,7 +47,9 @@ Virtual memory usage(MB): %Number%
 [1] 'Building term dictionary' finished in %Time%.
 [2] 'FastTree disk-based bins initialization' started.
 [2] 'FastTree disk-based bins initialization' finished in %Time%.
-[3] 'FastTree training' started.
-[3] 'FastTree training' finished in %Time%.
-[4] 'Saving model' started.
-[4] 'Saving model' finished in %Time%.
+[3] 'FastTree disk-based bins initialization #2' started.
+[3] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[4] 'FastTree training' started.
+[4] 'FastTree training' finished in %Time%.
+[5] 'Saving model' started.
+[5] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDisk-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDisk-TrainTest-breast-cancer-out.txt
@@ -5,7 +5,9 @@ Changing data from row-wise to column-wise on disk
 Warning: 16 of 699 examples will be skipped due to missing feature values
 Processed 683 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3852 bytes
+Changing data from row-wise to column-wise on disk
+Warning: 16 of 699 examples will be skipped due to missing feature values
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))
@@ -44,7 +46,9 @@ Virtual memory usage(MB): %Number%
 --- Progress log ---
 [1] 'FastTree disk-based bins initialization' started.
 [1] 'FastTree disk-based bins initialization' finished in %Time%.
-[2] 'FastTree training' started.
-[2] 'FastTree training' finished in %Time%.
-[3] 'Saving model' started.
-[3] 'Saving model' finished in %Time%.
+[2] 'FastTree disk-based bins initialization #2' started.
+[2] 'FastTree disk-based bins initialization #2' finished in %Time%.
+[3] 'FastTree training' started.
+[3] 'FastTree training' finished in %Time%.
+[4] 'Saving model' started.
+[4] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDrop-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeDrop-TrainTest-breast-cancer-out.txt
@@ -5,7 +5,9 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 3852 bytes
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))
@@ -48,7 +50,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeHighMinDocs-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/FastTreeBinaryClassification/FastTreeHighMinDocs-TrainTest-breast-cancer-out.txt
@@ -5,7 +5,9 @@ Changing data from row-wise to column-wise
 Warning: Skipped 16 instances with missing features during training
 Processed 683 instances
 Binning and forming Feature objects
-Reserved memory for tree learner: 468 bytes
+Changing data from row-wise to column-wise
+Warning: Skipped 16 instances with missing features during training
+Reserved memory for tree learner: %Number% bytes
 Starting to train ...
 Warning: 5 of the boosting iterations failed to grow a tree. This is commonly because the minimum documents in leaf hyperparameter was set too high for this dataset.
 Not training a calibrator because it is not needed.
@@ -49,7 +51,11 @@ Virtual memory usage(MB): %Number%
 [2] 'FastTree in-memory bins initialization' finished in %Time%.
 [3] 'FastTree feature conversion' started.
 [3] 'FastTree feature conversion' finished in %Time%.
-[4] 'FastTree training' started.
-[4] 'FastTree training' finished in %Time%.
-[5] 'Saving model' started.
-[5] 'Saving model' finished in %Time%.
+[4] 'FastTree data preparation #2' started.
+[4] 'FastTree data preparation #2' finished in %Time%.
+[5] 'FastTree feature conversion #2' started.
+[5] 'FastTree feature conversion #2' finished in %Time%.
+[6] 'FastTree training' started.
+[6] 'FastTree training' finished in %Time%.
+[7] 'Saving model' started.
+[7] 'Saving model' finished in %Time%.


### PR DESCRIPTION
The current `FastTree` (defined in `FastTree.cs`) has a nice framework for handling the presence of training, validation, and test sets. This PR exposes this functionality to users by

1. Extend `MLContext` defined in `TrainContext.cs`
2. Create `Test` (defined in `Test.cs` under `FastTree` project) following what we having been doing for validation set.
3. Make sure that the test data set can be accessed in `FastTree.InitializeTests()` when using `Train` or `TrainTest` commands.

Fixes #1572.

Let's see an example command of how this works.

Command: `machinelearning>dotnet bin\AnyCPU.Debug\Microsoft.ML.Console\netcoreapp2.1\MML.dll train data=breast-cancer.txt loader=text{col=Label:R4:0 col=Features:R4:1-9} valid=breast-cancer.txt test=..\TLC\Samples\breast-cancer.txt tr=frr{tf=1 iter=2} out=model.zip`

Expected outcome printed on screen:
```
Starting to train ...
train.L1=0.291333712794827
train.L2=0.483948548949904
valid.L1=0.291333712794827
valid.L2=0.483948548949904
test[0].L1=0.291333712794827
test[0].L2=0.483948548949904
train.L1=0.244367572749215
train.L2=0.399588099386731
valid.L1=0.244367572749215
valid.L2=0.399588099386731
test[0].L1=0.244367572749215
test[0].L2=0.399588099386731
```
train*/valid*/test* are scores computed using the specified training/validation/test set.