### PR TITLE
Introduce VBufferMutationContext and hide VBuffer.Count

### DIFF
--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -319,8 +319,8 @@ namespace Microsoft.ML.Runtime.Data
             IReadOnlyList<ColumnInfo> list;
             if ((list = schema?.GetColumns(role)) == null || list.Count != 1 || !schema.Schema.HasSlotNames(list[0].Index, vectorSize))
             {
-                VBufferMutationContext.Create(ref slotNames, vectorSize, 0)
-                    .Complete(ref slotNames);
+                slotNames = VBufferMutationContext.Create(ref slotNames, vectorSize, 0)
+                    .CreateBuffer();
             }
             else
                 schema.Schema.GetMetadata(Kinds.SlotNames, list[0].Index, ref slotNames);

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -319,8 +319,7 @@ namespace Microsoft.ML.Runtime.Data
             IReadOnlyList<ColumnInfo> list;
             if ((list = schema?.GetColumns(role)) == null || list.Count != 1 || !schema.Schema.HasSlotNames(list[0].Index, vectorSize))
             {
-                slotNames = VBufferMutationContext.Create(ref slotNames, vectorSize, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref slotNames, vectorSize, 0);
             }
             else
                 schema.Schema.GetMetadata(Kinds.SlotNames, list[0].Index, ref slotNames);

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -318,7 +318,10 @@ namespace Microsoft.ML.Runtime.Data
 
             IReadOnlyList<ColumnInfo> list;
             if ((list = schema?.GetColumns(role)) == null || list.Count != 1 || !schema.Schema.HasSlotNames(list[0].Index, vectorSize))
-                slotNames = new VBuffer<ReadOnlyMemory<char>>(vectorSize, 0, slotNames.Values, slotNames.Indices);
+            {
+                VBufferMutationContext.Create(ref slotNames, vectorSize, 0)
+                    .Complete(ref slotNames);
+            }
             else
                 schema.Schema.GetMetadata(Kinds.SlotNames, list[0].Index, ref slotNames);
         }
@@ -447,21 +450,22 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     int previousEndIndex = -1;
                     isValid = true;
-                    for (int i = 0; i < catIndices.Values.Length; i += 2)
+                    var catIndicesValues = catIndices.GetValues();
+                    for (int i = 0; i < catIndicesValues.Length; i += 2)
                     {
-                        if (catIndices.Values[i] > catIndices.Values[i + 1] ||
-                            catIndices.Values[i] <= previousEndIndex ||
-                            catIndices.Values[i] >= columnSlotsCount ||
-                            catIndices.Values[i + 1] >= columnSlotsCount)
+                        if (catIndicesValues[i] > catIndicesValues[i + 1] ||
+                            catIndicesValues[i] <= previousEndIndex ||
+                            catIndicesValues[i] >= columnSlotsCount ||
+                            catIndicesValues[i + 1] >= columnSlotsCount)
                         {
                             isValid = false;
                             break;
                         }
 
-                        previousEndIndex = catIndices.Values[i + 1];
+                        previousEndIndex = catIndicesValues[i + 1];
                     }
                     if (isValid)
-                        categoricalFeatures = catIndices.Values.Select(val => val).ToArray();
+                        categoricalFeatures = catIndicesValues.ToArray();
                 }
             }
 

--- a/src/Microsoft.ML.Core/Data/VBuffer.cs
+++ b/src/Microsoft.ML.Core/Data/VBuffer.cs
@@ -123,14 +123,14 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         public void CopyToDense(ref VBuffer<T> dst)
         {
-            // create a dense mutation context
-            var mutation = VBufferEditor.Create(ref dst, Length, Length);
+            // create a dense editor
+            var editor = VBufferEditor.Create(ref dst, Length);
 
             if (!IsDense)
-                CopyTo(mutation.Values);
+                CopyTo(editor.Values);
             else if (Length > 0)
-                _values.AsSpan(0, Length).CopyTo(mutation.Values);
-            dst = mutation.Commit();
+                _values.AsSpan(0, Length).CopyTo(editor.Values);
+            dst = editor.Commit();
         }
 
         /// <summary>
@@ -138,24 +138,24 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         public void CopyTo(ref VBuffer<T> dst)
         {
-            var mutation = VBufferEditor.Create(ref dst, Length, _count);
+            var editor = VBufferEditor.Create(ref dst, Length, _count);
             if (IsDense)
             {
                 if (Length > 0)
                 {
-                    _values.AsSpan(0, Length).CopyTo(mutation.Values);
+                    _values.AsSpan(0, Length).CopyTo(editor.Values);
                 }
-                dst = mutation.Commit();
+                dst = editor.Commit();
                 Contracts.Assert(dst.IsDense);
             }
             else
             {
                 if (_count > 0)
                 {
-                    _values.AsSpan(0, _count).CopyTo(mutation.Values);
-                    _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
+                    _values.AsSpan(0, _count).CopyTo(editor.Values);
+                    _indices.AsSpan(0, _count).CopyTo(editor.Indices);
                 }
-                dst = mutation.Commit();
+                dst = editor.Commit();
             }
         }
 
@@ -169,12 +169,12 @@ namespace Microsoft.ML.Runtime.Data
 
             if (IsDense)
             {
-                var mutation = VBufferEditor.Create(ref dst, length, length);
+                var editor = VBufferEditor.Create(ref dst, length, length);
                 if (length > 0)
                 {
-                    _values.AsSpan(srcMin, length).CopyTo(mutation.Values);
+                    _values.AsSpan(srcMin, length).CopyTo(editor.Values);
                 }
-                dst = mutation.Commit();
+                dst = editor.Commit();
                 Contracts.Assert(dst.IsDense);
             }
             else
@@ -186,22 +186,22 @@ namespace Microsoft.ML.Runtime.Data
                     int copyLim = _indices.FindIndexSorted(copyMin, _count, srcMin + length);
                     Contracts.Assert(copyMin <= copyLim);
                     copyCount = copyLim - copyMin;
-                    var mutation = VBufferEditor.Create(ref dst, length, copyCount);
+                    var editor = VBufferEditor.Create(ref dst, length, copyCount);
                     if (copyCount > 0)
                     {
-                        _values.AsSpan(copyMin, copyCount).CopyTo(mutation.Values);
+                        _values.AsSpan(copyMin, copyCount).CopyTo(editor.Values);
                         if (copyCount < length)
                         {
                             for (int i = 0; i < copyCount; ++i)
-                                mutation.Indices[i] = _indices[i + copyMin] - srcMin;
+                                editor.Indices[i] = _indices[i + copyMin] - srcMin;
                         }
                     }
-                    dst = mutation.Commit();
+                    dst = editor.Commit();
                 }
                 else
                 {
-                    var mutation = VBufferEditor.Create(ref dst, length, copyCount);
-                    dst = mutation.Commit();
+                    var editor = VBufferEditor.Create(ref dst, length, copyCount);
+                    dst = editor.Commit();
                 }
             }
         }
@@ -253,12 +253,12 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.CheckParam(0 <= length && length <= Utils.Size(src), nameof(length));
             Contracts.CheckParam(0 <= srcIndex && srcIndex <= Utils.Size(src) - length, nameof(srcIndex));
-            var mutation = VBufferEditor.Create(ref dst, length, length);
+            var editor = VBufferEditor.Create(ref dst, length, length);
             if (length > 0)
             {
-                src.AsSpan(srcIndex, length).CopyTo(mutation.Values);
+                src.AsSpan(srcIndex, length).CopyTo(editor.Values);
             }
-            dst = mutation.Commit();
+            dst = editor.Commit();
         }
 
         public IEnumerable<KeyValuePair<int, T>> Items(bool all = false)

--- a/src/Microsoft.ML.Core/Data/VBuffer.cs
+++ b/src/Microsoft.ML.Core/Data/VBuffer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Runtime.Data
         public void CopyToDense(ref VBuffer<T> dst)
         {
             // create a dense mutation context
-            var mutation = VBufferMutationContext.Create(ref dst, Length, Length);
+            var mutation = VBufferEditor.Create(ref dst, Length, Length);
 
             if (!IsDense)
                 CopyTo(mutation.Values);
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         public void CopyTo(ref VBuffer<T> dst)
         {
-            var mutation = VBufferMutationContext.Create(ref dst, Length, _count);
+            var mutation = VBufferEditor.Create(ref dst, Length, _count);
             if (IsDense)
             {
                 if (Length > 0)
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Runtime.Data
 
             if (IsDense)
             {
-                var mutation = VBufferMutationContext.Create(ref dst, length, length);
+                var mutation = VBufferEditor.Create(ref dst, length, length);
                 if (length > 0)
                 {
                     _values.AsSpan(srcMin, length).CopyTo(mutation.Values);
@@ -186,7 +186,7 @@ namespace Microsoft.ML.Runtime.Data
                     int copyLim = _indices.FindIndexSorted(copyMin, _count, srcMin + length);
                     Contracts.Assert(copyMin <= copyLim);
                     copyCount = copyLim - copyMin;
-                    var mutation = VBufferMutationContext.Create(ref dst, length, copyCount);
+                    var mutation = VBufferEditor.Create(ref dst, length, copyCount);
                     if (copyCount > 0)
                     {
                         _values.AsSpan(copyMin, copyCount).CopyTo(mutation.Values);
@@ -200,7 +200,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
                 else
                 {
-                    var mutation = VBufferMutationContext.Create(ref dst, length, copyCount);
+                    var mutation = VBufferEditor.Create(ref dst, length, copyCount);
                     dst = mutation.Commit();
                 }
             }
@@ -253,7 +253,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.CheckParam(0 <= length && length <= Utils.Size(src), nameof(length));
             Contracts.CheckParam(0 <= srcIndex && srcIndex <= Utils.Size(src) - length, nameof(srcIndex));
-            var mutation = VBufferMutationContext.Create(ref dst, length, length);
+            var mutation = VBufferEditor.Create(ref dst, length, length);
             if (length > 0)
             {
                 src.AsSpan(srcIndex, length).CopyTo(mutation.Values);
@@ -299,12 +299,12 @@ namespace Microsoft.ML.Runtime.Data
         public override string ToString()
             => IsDense ? $"Dense vector of size {Length}" : $"Sparse vector of size {Length}, {_count} explicit values";
 
-        internal VBufferMutationContext<T> GetMutableContext()
+        internal VBufferEditor<T> GetEditor()
         {
-            return GetMutableContext(Length, _count);
+            return GetEditor(Length, _count);
         }
 
-        internal VBufferMutationContext<T> GetMutableContext(
+        internal VBufferEditor<T> GetEditor(
             int newLogicalLength,
             int? valuesCount,
             int maxCapacity = Utils.ArrayMaxSize,
@@ -332,7 +332,7 @@ namespace Microsoft.ML.Runtime.Data
                 Utils.EnsureSize(ref indices, valuesCount.Value, maxCapacity, keepOldOnResize, out createdNewIndices);
             }
 
-            return new VBufferMutationContext<T>(
+            return new VBufferEditor<T>(
                 newLogicalLength,
                 valuesCount.Value,
                 values,

--- a/src/Microsoft.ML.Core/Data/VBuffer.cs
+++ b/src/Microsoft.ML.Core/Data/VBuffer.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ML.Runtime.Data
                 CopyTo(mutation.Values);
             else if (Length > 0)
                 _values.AsSpan(0, Length).CopyTo(mutation.Values);
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     _values.AsSpan(0, Length).CopyTo(mutation.Values);
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 Contracts.Assert(dst.IsDense);
             }
             else
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Runtime.Data
                     _values.AsSpan(0, _count).CopyTo(mutation.Values);
                     _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             }
         }
 
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     _values.AsSpan(srcMin, length).CopyTo(mutation.Values);
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 Contracts.Assert(dst.IsDense);
             }
             else
@@ -196,12 +196,12 @@ namespace Microsoft.ML.Runtime.Data
                                 mutation.Indices[i] = _indices[i + copyMin] - srcMin;
                         }
                     }
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 }
                 else
                 {
                     var mutation = VBufferMutationContext.Create(ref dst, length, copyCount);
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 }
             }
         }
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 src.AsSpan(srcIndex, length).CopyTo(mutation.Values);
             }
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         public IEnumerable<KeyValuePair<int, T>> Items(bool all = false)

--- a/src/Microsoft.ML.Core/Data/VBufferEditor.cs
+++ b/src/Microsoft.ML.Core/Data/VBufferEditor.cs
@@ -2,35 +2,34 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.ML.Runtime.Internal.Utilities;
 using System;
 
 namespace Microsoft.ML.Runtime.Data
 {
     /// <summary>
-    /// Various methods for creating <see cref="VBufferMutationContext{T}"/> instances.
+    /// Various methods for creating <see cref="VBufferEditor{T}"/> instances.
     /// </summary>
-    public static class VBufferMutationContext
+    public static class VBufferEditor
     {
         /// <summary>
-        /// Creates a mutation context with the same shape (length and density)
-        /// as the <paramref name="destination"/>.
+        /// Creates a <see cref="VBufferEditor{T}"/> with the same shape
+        /// (length and density) as the <paramref name="destination"/>.
         /// </summary>
-        public static VBufferMutationContext<T> CreateFromBuffer<T>(
+        public static VBufferEditor<T> CreateFromBuffer<T>(
             ref VBuffer<T> destination)
         {
-            return destination.GetMutableContext();
+            return destination.GetEditor();
         }
 
         /// <summary>
-        /// Creates a mutation context using <paramref name="destination"/>'s values
-        /// and indices buffers.
+        /// Creates a <see cref="VBufferEditor{T}"/> using
+        /// <paramref name="destination"/>'s values and indices buffers.
         /// </summary>
         /// <param name="destination">
         /// The destination buffer.
         /// </param>
         /// <param name="newLogicalLength">
-        /// The new length of the buffer being mutated.
+        /// The logical length of the new buffer being edited.
         /// </param>
         /// <param name="valuesCount">
         /// The optional number of physical values to be represented in the buffer.
@@ -43,27 +42,27 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="requireIndicesOnDense">
         /// True means to ensure the Indices buffer is available, even if the buffer will be dense.
         /// </param>
-        public static VBufferMutationContext<T> Create<T>(
+        public static VBufferEditor<T> Create<T>(
             ref VBuffer<T> destination,
             int newLogicalLength,
             int? valuesCount = null,
             bool keepOldOnResize = false,
             bool requireIndicesOnDense = false)
         {
-            return destination.GetMutableContext(
+            return destination.GetEditor(
                 newLogicalLength,
                 valuesCount,
                 keepOldOnResize: keepOldOnResize,
                 requireIndicesOnDense: requireIndicesOnDense);
         }
 
-        internal static VBufferMutationContext<T> Create<T>(
+        internal static VBufferEditor<T> Create<T>(
             ref VBuffer<T> destination,
             int newLogicalLength,
             int valuesCount,
             int maxValuesCapacity)
         {
-            return destination.GetMutableContext(
+            return destination.GetEditor(
                 newLogicalLength,
                 valuesCount,
                 maxValuesCapacity);
@@ -71,10 +70,10 @@ namespace Microsoft.ML.Runtime.Data
     }
 
     /// <summary>
-    /// An object capable of mutation a <see cref="VBuffer{T}"/> by filling out
+    /// An object capable of editing a <see cref="VBuffer{T}"/> by filling out
     /// <see cref="Values"/> (and <see cref="Indices"/> if the buffer is not dense).
     /// </summary>
-    public readonly ref struct VBufferMutationContext<T>
+    public readonly ref struct VBufferEditor<T>
     {
         private readonly int _logicalLength;
         private readonly T[] _values;
@@ -100,7 +99,7 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         public bool CreatedNewIndices { get; }
 
-        internal VBufferMutationContext(int logicalLength,
+        internal VBufferEditor(int logicalLength,
             int physicalValuesCount,
             T[] values,
             int[] indices,
@@ -147,7 +146,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <remarks>
         /// CommitTruncated allows to modify the length of the explicitly
         /// defined values.
-        /// This is useful in sparse situations where the <see cref="VBufferMutationContext{T}"/>
+        /// This is useful in sparse situations where the <see cref="VBufferEditor{T}"/>
         /// was created with a larger physical value count than was needed
         /// because the final value count was not known at creation time.
         /// </remarks>

--- a/src/Microsoft.ML.Core/Data/VBufferMutationContext.cs
+++ b/src/Microsoft.ML.Core/Data/VBufferMutationContext.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Runtime.Internal.Utilities;
+using System;
+
+namespace Microsoft.ML.Runtime.Data
+{
+    /// <summary>
+    /// Various methods for creating <see cref="VBufferMutationContext{T}"/> instances.
+    /// </summary>
+    public static class VBufferMutationContext
+    {
+        /// <summary>
+        /// Creates a mutation context with the same shape (length and density)
+        /// as the <paramref name="destination"/>.
+        /// </summary>
+        public static VBufferMutationContext<T> CreateFromBuffer<T>(
+            ref VBuffer<T> destination)
+        {
+            return destination.GetMutableContext();
+        }
+
+        /// <summary>
+        /// Creates a mutation context using <paramref name="destination"/>'s values
+        /// and indices buffers.
+        /// </summary>
+        /// <param name="destination">
+        /// The destination buffer.
+        /// </param>
+        /// <param name="newLogicalLength">
+        /// The new length of the buffer being mutated.
+        /// </param>
+        /// <param name="valuesCount">
+        /// The optional number of physical values to be represented in the buffer.
+        /// The buffer will be dense if <paramref name="valuesCount"/> is omitted.
+        /// </param>
+        /// <param name="keepOldOnResize">
+        /// True means that the old buffer values and indices are preserved, if possible (Array.Resize is called).
+        /// False means that a new array will be allocated, if necessary.
+        /// </param>
+        /// <param name="requireIndicesOnDense">
+        /// True means to ensure the Indices buffer is available, even if the buffer will be dense.
+        /// </param>
+        public static VBufferMutationContext<T> Create<T>(
+            ref VBuffer<T> destination,
+            int newLogicalLength,
+            int? valuesCount = null,
+            bool keepOldOnResize = false,
+            bool requireIndicesOnDense = false)
+        {
+            return destination.GetMutableContext(
+                newLogicalLength,
+                valuesCount,
+                keepOldOnResize: keepOldOnResize,
+                requireIndicesOnDense: requireIndicesOnDense);
+        }
+
+        internal static VBufferMutationContext<T> Create<T>(
+            ref VBuffer<T> destination,
+            int newLogicalLength,
+            int valuesCount,
+            int maxValuesCapacity)
+        {
+            return destination.GetMutableContext(
+                newLogicalLength,
+                valuesCount,
+                maxValuesCapacity);
+        }
+    }
+
+    /// <summary>
+    /// An object capable of mutation a <see cref="VBuffer{T}"/> by filling out
+    /// <see cref="Values"/> (and <see cref="Indices"/> if the buffer is not dense).
+    /// </summary>
+    public ref struct VBufferMutationContext<T>
+    {
+        private readonly int _logicalLength;
+        private readonly T[] _values;
+        private readonly int[] _indices;
+
+        /// <summary>
+        /// The mutable span of values.
+        /// </summary>
+        public readonly Span<T> Values;
+
+        /// <summary>
+        /// The mutable span of indices.
+        /// </summary>
+        public readonly Span<int> Indices;
+
+        /// <summary>
+        /// Gets a value indicating whether a new Values array was allocated.
+        /// </summary>
+        public bool CreatedNewValues { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a new Indices array was allocated.
+        /// </summary>
+        public bool CreatedNewIndices { get; }
+
+        internal VBufferMutationContext(int logicalLength,
+            int physicalValuesCount,
+            T[] values,
+            int[] indices,
+            bool requireIndicesOnDense,
+            bool createdNewValues,
+            bool createdNewIndices)
+        {
+            _logicalLength = logicalLength;
+            _values = values;
+            _indices = indices;
+
+            bool isDense = logicalLength == physicalValuesCount;
+
+            Values = _values.AsSpan(0, physicalValuesCount);
+            Indices = !isDense || requireIndicesOnDense ? _indices.AsSpan(0, physicalValuesCount) : default;
+
+            CreatedNewValues = createdNewValues;
+            CreatedNewIndices = createdNewIndices;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="VBuffer{T}"/> using the current
+        /// Values and Indices.
+        /// </summary>
+        /// <param name="physicalValuesCount">
+        /// An optional size that allows reducing the number of physical values to be
+        /// represented in the created buffer.
+        /// This is useful in sparse situations where the mutation context was created
+        /// with a larger physical value count than was needed
+        /// because the final value count was not known at creation time.
+        /// </param>
+        /// <returns></returns>
+        public VBuffer<T> CreateBuffer(int? physicalValuesCount = null)
+        {
+            int count = Values.Length;
+            if (physicalValuesCount.HasValue)
+            {
+                Contracts.Check(physicalValuesCount.Value <= count, "Updating physicalValuesCount during Complete cannot be greater than the original physicalValuesCount value used in Create.");
+                count = physicalValuesCount.Value;
+            }
+
+            return new VBuffer<T>(_logicalLength, count, _values, _indices);
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Data/VBufferMutationContext.cs
+++ b/src/Microsoft.ML.Core/Data/VBufferMutationContext.cs
@@ -132,7 +132,9 @@ namespace Microsoft.ML.Runtime.Data
         /// with a larger physical value count than was needed
         /// because the final value count was not known at creation time.
         /// </param>
-        /// <returns></returns>
+        /// <returns>
+        /// The newly created <see cref="VBuffer{T}"/>.
+        /// </returns>
         public VBuffer<T> CreateBuffer(int? physicalValuesCount = null)
         {
             int count = Values.Length;

--- a/src/Microsoft.ML.Core/Utilities/MathUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/MathUtils.cs
@@ -133,40 +133,23 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         }
 
         /// <summary>
-        /// Finds the first index of the max element of the array.
+        /// Finds the first index of the max element of the span.
         /// NaNs are ignored. If all the elements to consider are NaNs, -1 is
         /// returned. The caller should distinguish in this case between two
         /// possibilities:
         /// 1) The number of the element to consider is zero.
         /// 2) All the elements to consider are NaNs.
         /// </summary>
-        /// <param name="a">an array</param>
+        /// <param name="a">The span of floats.</param>
         /// <returns>the first index of the max element</returns>
-        public static int ArgMax(Float[] a)
+        public static int ArgMax(ReadOnlySpan<Float> a)
         {
-            return ArgMax(a, Utils.Size(a));
-        }
-
-        /// <summary>
-        /// Finds the first index of the max element of the array.
-        /// NaNs are ignored. If all the elements to consider are NaNs, -1 is
-        /// returned. The caller should distinguish in this case between two
-        /// possibilities:
-        /// 1) The number of the element to consider is zero.
-        /// 2) All the elements to consider are NaNs.
-        /// </summary>
-        /// <param name="a">an array</param>
-        /// <param name="count">number of the element in the array to consider</param>
-        /// <returns>the first index of the max element</returns>
-        public static int ArgMax(Float[] a, int count)
-        {
-            Contracts.Assert(0 <= count && count <= Utils.Size(a));
-            if (count == 0)
+            if (a.IsEmpty)
                 return -1;
 
             int amax = -1;
             Float max = Float.NegativeInfinity;
-            for (int i = count - 1; i >= 0; i--)
+            for (int i = a.Length - 1; i >= 0; i--)
             {
                 if (max <= a[i])
                 {
@@ -179,40 +162,23 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         }
 
         /// <summary>
-        /// Finds the first index of the minimum element of the array.
+        /// Finds the first index of the minimum element of the span.
         /// NaNs are ignored. If all the elements to consider are NaNs, -1 is
         /// returned. The caller should distinguish in this case between two
         /// possibilities:
         /// 1) The number of the element to consider is zero.
         /// 2) All the elements to consider are NaNs.
         /// </summary>
-        /// <param name="a">an array</param>
+        /// <param name="a">The span of floats.</param>
         /// <returns>the first index of the minimum element</returns>
-        public static int ArgMin(Float[] a)
+        public static int ArgMin(ReadOnlySpan<Float> a)
         {
-            return ArgMin(a, Utils.Size(a));
-        }
-
-        /// <summary>
-        /// Finds the first index of the minimum element of the array.
-        /// NaNs are ignored. If all the elements to consider are NaNs, -1 is
-        /// returned. The caller should distinguish in this case between two
-        /// possibilities:
-        /// 1) The number of the element to consider is zero.
-        /// 2) All the elements to consider are NaNs.
-        /// </summary>
-        /// <param name="a">an array</param>
-        /// <param name="count">number of the element in the array to consider</param>
-        /// <returns>the first index of the minimum element</returns>
-        public static int ArgMin(Float[] a, int count)
-        {
-            Contracts.Assert(0 <= count && count <= Utils.Size(a));
-            if (count == 0)
+            if (a.IsEmpty)
                 return -1;
 
             int amin = -1;
             Float min = Float.PositiveInfinity;
-            for (int i = count - 1; i >= 0; i--)
+            for (int i = a.Length - 1; i >= 0; i--)
             {
                 if (min >= a[i])
                 {

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -187,18 +187,6 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// In case of duplicates it returns the index of the first one.
         /// It guarantees that items before the returned index are &lt; value, while those at and after the returned index are &gt;= value.
         /// </summary>
-        public static int FindIndexSorted(this int[] input, int value)
-        {
-            Contracts.AssertValue(input);
-            return FindIndexSorted(input, 0, input.Length, value);
-        }
-
-        /// <summary>
-        /// Assumes input is sorted and finds value using BinarySearch.
-        /// If value is not found, returns the logical index of 'value' in the sorted list i.e index of the first element greater than value.
-        /// In case of duplicates it returns the index of the first one.
-        /// It guarantees that items before the returned index are &lt; value, while those at and after the returned index are &gt;= value.
-        /// </summary>
         public static int FindIndexSorted(this IList<int> input, int value)
         {
             Contracts.AssertValue(input);
@@ -237,6 +225,17 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         public static bool TryFindIndexSorted(this int[] input, int min, int lim, int value, out int index)
         {
             index = input.FindIndexSorted(min, lim, value);
+            return index < lim && input[index] == value;
+        }
+
+        /// <summary>
+        /// Akin to <c>FindIndexSorted</c>, except stores the found index in the output
+        /// <c>index</c> parameter, and returns whether that index is a valid index
+        /// pointing to a value equal to the input parameter <c>value</c>.
+        /// </summary>
+        public static bool TryFindIndexSorted(ReadOnlySpan<int> input, int min, int lim, int value, out int index)
+        {
+            index = FindIndexSorted(input, min, lim, value);
             return index < lim && input[index] == value;
         }
 
@@ -466,9 +465,8 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             return res;
         }
 
-        public static void FillIdentity(int[] a, int lim)
+        public static void FillIdentity(Span<int> a, int lim)
         {
-            Contracts.AssertValue(a);
             Contracts.Assert(0 <= lim & lim <= a.Length);
 
             for (int i = 0; i < lim; ++i)
@@ -857,12 +855,19 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// </param>
         /// <returns>The new size, that is no less than <paramref name="min"/> and no more that <paramref name="max"/>.</returns>
         public static int EnsureSize<T>(ref T[] array, int min, int max, bool keepOld = true)
+            => EnsureSize(ref array, min, max, keepOld, out bool _);
+
+        public static int EnsureSize<T>(ref T[] array, int min, int max, bool keepOld, out bool resized)
         {
             Contracts.CheckParam(min <= max, nameof(max), "min must not exceed max");
             // This code adapted from the private method EnsureCapacity code of List<T>.
             int size = Utils.Size(array);
             if (size >= min)
+            {
+                resized = false;
                 return size;
+            }
+
             int newSize = size == 0 ? 4 : size * 2;
             // This constant taken from the internal code of system\array.cs of mscorlib.
             if ((uint)newSize > max)
@@ -873,6 +878,8 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 Array.Resize(ref array, newSize);
             else
                 array = new T[newSize];
+
+            resized = true;
             return newSize;
         }
 
@@ -1097,6 +1104,35 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 }
             }
             return null;
+        }
+
+        public static int Count<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
+        {
+            Contracts.CheckValue(predicate, nameof(predicate));
+
+            int result = 0;
+            for (int i = 0; i < source.Length; i++)
+            {
+                if (predicate(source[i]))
+                {
+                    result++;
+                }
+            }
+            return result;
+        }
+
+        public static bool All<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
+        {
+            Contracts.CheckValue(predicate, nameof(predicate));
+
+            for (int i = 0; i < source.Length; i++)
+            {
+                if (!predicate(source[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -1114,9 +1114,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             for (int i = 0; i < source.Length; i++)
             {
                 if (predicate(source[i]))
-                {
                     result++;
-                }
             }
             return result;
         }
@@ -1128,9 +1126,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             for (int i = 0; i < source.Length; i++)
             {
                 if (!predicate(source[i]))
-                {
                     return false;
-                }
             }
             return true;
         }

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -421,7 +421,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             if (needIndices)
                 mutation.Indices[idx] = slot;
             mutation.Values[idx] = value;
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -465,7 +465,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 for (int i = 0; i < values.Length; ++i)
                     mutation.Values[indices[i]] = values[i];
             }
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -492,7 +492,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 var newIndicesMutation = VBufferMutationContext.Create(ref dst, dst.Length, denseCount);
                 Utils.FillIdentity(newIndicesMutation.Indices, denseCount);
                 newIndicesMutation.Values.Clear();
-                newIndicesMutation.Complete(ref dst);
+                dst = newIndicesMutation.CreateBuffer();
                 return;
             }
             int lim = Utils.FindIndexSorted(dstIndices, 0, dstValues.Length, denseCount);
@@ -514,7 +514,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 mutation.Values[ii] = i >= 0 && dstIndices[i] == ii ? dstValues[i--] : default(T);
                 mutation.Indices[ii] = ii;
             }
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -563,7 +563,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 Contracts.Assert(j == sparseCount);
             }
 
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -768,7 +768,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 mutation.Values.Clear();
                 for (int i = 0; i < srcValues.Length; i++)
                     manip(mutation.Indices[i] = srcIndices[i], srcValues[i], ref mutation.Values[i]);
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
                 return;
             }
 
@@ -861,7 +861,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         dIndex = --dI >= 0 ? dstIndices[dI] : -1;
                     }
                 }
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
                 return;
             }
 
@@ -926,7 +926,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     Contracts.Assert(srcIndices[sI] == bIndex);
                     mutation.Indices[dI] = sI++;
                 }
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
                 Densify(ref dst);
 
                 mutation = VBufferMutationContext.Create(ref dst,
@@ -936,7 +936,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 srcIndices.CopyTo(mutation.Indices);
                 for (sI = 0; sI < srcValues.Length; sI++)
                     manip(srcIndices[sI], srcValues[sI], ref mutation.Values[sI]);
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
                 return;
             }
 
@@ -963,8 +963,8 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             {
                 if (srcValues.Length == 0)
                 {
-                    VBufferMutationContext.Create(ref res, length, 0)
-                        .Complete(ref res);
+                    res = VBufferMutationContext.Create(ref res, length, 0)
+                        .CreateBuffer();
                 }
                 else if (src.IsDense)
                 {
@@ -972,7 +972,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     var mutation = VBufferMutationContext.Create(ref res, length);
                     for (int i = 0; i < length; i++)
                         manip(i, srcValues[i], default(TDst), ref mutation.Values[i]);
-                    mutation.Complete(ref res);
+                    res = mutation.CreateBuffer();
                 }
                 else
                 {
@@ -988,7 +988,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         mutation.Indices[ii] = i;
                         manip(i, srcValues[ii], default(TDst), ref mutation.Values[ii]);
                     }
-                    mutation.Complete(ref res);
+                    res = mutation.CreateBuffer();
                 }
             }
             else if (dst.IsDense)
@@ -1008,14 +1008,14 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         for (int j = 0; j < length; j++)
                             mutation.Values[j] = dstValues[j];
                     }
-                    mutation.Complete(ref res);
+                    res = mutation.CreateBuffer();
                 }
                 else if (src.IsDense)
                 {
                     Contracts.Assert(srcValues.Length == src.Length);
                     for (int i = 0; i < length; i++)
                         manip(i, srcValues[i], dstValues[i], ref mutation.Values[i]);
-                    mutation.Complete(ref res);
+                    res = mutation.CreateBuffer();
                 }
                 else
                 {
@@ -1054,7 +1054,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                                 mutation.Values[j] = dstValues[j];
                         }
                     }
-                    mutation.Complete(ref res);
+                    res = mutation.CreateBuffer();
                 }
             }
             else
@@ -1083,7 +1083,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                             mutation.Values[jj] = dstValues[jj];
                         }
                     }
-                    mutation.Complete(ref res);
+                    res = mutation.CreateBuffer();
                 }
                 else if (src.IsDense)
                 {
@@ -1101,7 +1101,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         else
                             manip(i, srcValues[i], default(TDst), ref mutation.Values[i]);
                     }
-                    mutation.Complete(ref res);
+                    res = mutation.CreateBuffer();
                 }
                 else
                 {
@@ -1183,7 +1183,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
 
                         Contracts.Assert(ii == srcValues.Length && jj == dstCount);
                         Contracts.Assert(i == length && j == length);
-                        mutation.Complete(ref res);
+                        res = mutation.CreateBuffer();
                     }
                 }
             }
@@ -1209,8 +1209,8 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             // equal lengths, but I don't care here.
             if (srcValues.Length == 0)
             {
-                VBufferMutationContext.Create(ref dst, src.Length, 0)
-                    .Complete(ref dst);
+                dst = VBufferMutationContext.Create(ref dst, src.Length, 0)
+                    .CreateBuffer();
                 return;
             }
             var mutation = VBufferMutationContext.Create(ref dst,
@@ -1231,7 +1231,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 for (int i = 0; i < srcValues.Length; ++i)
                     values[i] = func(srcIndices[i], srcValues[i]);
             }
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -1263,8 +1263,8 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             if (aValues.Length == 0 && bValues.Length == 0)
             {
                 // Case 1. Output will be empty.
-                VBufferMutationContext.Create(ref dst, a.Length, 0)
-                    .Complete(ref dst);
+                dst = VBufferMutationContext.Create(ref dst, a.Length, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -1303,7 +1303,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     for (int i = 0; i < a.Length; i++)
                         mutation.Values[i] = func(i, aValues[i], bValues[i]);
                 }
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
                 return;
             }
 
@@ -1421,7 +1421,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     indices[newI++] = index;
                 }
             }
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -1439,7 +1439,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     mutation.Values[i] = src[i];
                 }
             }
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -720,7 +720,11 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             {
                 // Major case 2, with src.Dense.
                 if (!dst.IsDense)
+                {
                     Densify(ref dst);
+                    mutation = VBufferMutationContext.Create(ref dst, dst.Length, dst.Count);
+                }
+
                 // Both are now dense. Both cases of outer are covered.
                 for (int i = 0; i < srcValues.Length; i++)
                     manip(i, srcValues[i], ref mutation.Values[i]);

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -417,7 +417,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             if (needIndices)
                 mutation.Indices[idx] = slot;
             mutation.Values[idx] = value;
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -461,7 +461,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 for (int i = 0; i < values.Length; ++i)
                     mutation.Values[indices[i]] = values[i];
             }
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -488,7 +488,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 var newIndicesMutation = VBufferMutationContext.Create(ref dst, dst.Length, denseCount);
                 Utils.FillIdentity(newIndicesMutation.Indices, denseCount);
                 newIndicesMutation.Values.Clear();
-                dst = newIndicesMutation.CreateBuffer();
+                dst = newIndicesMutation.Commit();
                 return;
             }
             int lim = Utils.FindIndexSorted(dstIndices, 0, dstValues.Length, denseCount);
@@ -510,7 +510,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 mutation.Values[ii] = i >= 0 && dstIndices[i] == ii ? dstValues[i--] : default(T);
                 mutation.Indices[ii] = ii;
             }
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -559,7 +559,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 Contracts.Assert(j == sparseCount);
             }
 
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -764,7 +764,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 mutation.Values.Clear();
                 for (int i = 0; i < srcValues.Length; i++)
                     manip(mutation.Indices[i] = srcIndices[i], srcValues[i], ref mutation.Values[i]);
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 return;
             }
 
@@ -857,7 +857,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         dIndex = --dI >= 0 ? dstIndices[dI] : -1;
                     }
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 return;
             }
 
@@ -922,7 +922,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     Contracts.Assert(srcIndices[sI] == bIndex);
                     mutation.Indices[dI] = sI++;
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 Densify(ref dst);
 
                 mutation = VBufferMutationContext.Create(ref dst,
@@ -932,7 +932,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 srcIndices.CopyTo(mutation.Indices);
                 for (sI = 0; sI < srcValues.Length; sI++)
                     manip(srcIndices[sI], srcValues[sI], ref mutation.Values[sI]);
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 return;
             }
 
@@ -967,7 +967,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     var mutation = VBufferMutationContext.Create(ref res, length);
                     for (int i = 0; i < length; i++)
                         manip(i, srcValues[i], default(TDst), ref mutation.Values[i]);
-                    res = mutation.CreateBuffer();
+                    res = mutation.Commit();
                 }
                 else
                 {
@@ -983,7 +983,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         mutation.Indices[ii] = i;
                         manip(i, srcValues[ii], default(TDst), ref mutation.Values[ii]);
                     }
-                    res = mutation.CreateBuffer();
+                    res = mutation.Commit();
                 }
             }
             else if (dst.IsDense)
@@ -1003,14 +1003,14 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         for (int j = 0; j < length; j++)
                             mutation.Values[j] = dstValues[j];
                     }
-                    res = mutation.CreateBuffer();
+                    res = mutation.Commit();
                 }
                 else if (src.IsDense)
                 {
                     Contracts.Assert(srcValues.Length == src.Length);
                     for (int i = 0; i < length; i++)
                         manip(i, srcValues[i], dstValues[i], ref mutation.Values[i]);
-                    res = mutation.CreateBuffer();
+                    res = mutation.Commit();
                 }
                 else
                 {
@@ -1049,7 +1049,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                                 mutation.Values[j] = dstValues[j];
                         }
                     }
-                    res = mutation.CreateBuffer();
+                    res = mutation.Commit();
                 }
             }
             else
@@ -1078,7 +1078,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                             mutation.Values[jj] = dstValues[jj];
                         }
                     }
-                    res = mutation.CreateBuffer();
+                    res = mutation.Commit();
                 }
                 else if (src.IsDense)
                 {
@@ -1096,7 +1096,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                         else
                             manip(i, srcValues[i], default(TDst), ref mutation.Values[i]);
                     }
-                    res = mutation.CreateBuffer();
+                    res = mutation.Commit();
                 }
                 else
                 {
@@ -1178,7 +1178,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
 
                         Contracts.Assert(ii == srcValues.Length && jj == dstCount);
                         Contracts.Assert(i == length && j == length);
-                        res = mutation.CreateBuffer();
+                        res = mutation.Commit();
                     }
                 }
             }
@@ -1225,7 +1225,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                 for (int i = 0; i < srcValues.Length; ++i)
                     values[i] = func(srcIndices[i], srcValues[i]);
             }
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -1296,7 +1296,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     for (int i = 0; i < a.Length; i++)
                         mutation.Values[i] = func(i, aValues[i], bValues[i]);
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 return;
             }
 
@@ -1414,7 +1414,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     indices[newI++] = index;
                 }
             }
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -1432,7 +1432,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
                     mutation.Values[i] = src[i];
                 }
             }
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -1442,7 +1442,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         public static void Resize<T>(ref VBuffer<T> dst, int newLogicalLength, int? valuesCount = null)
         {
             dst = VBufferMutationContext.Create(ref dst, newLogicalLength, valuesCount)
-                .CreateBuffer();
+                .Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -436,10 +436,9 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             var values = dst.GetValues();
             var mutation = VBufferMutationContext.Create(
                 ref dst,
-                dst.Length,
-                out bool createdNewValues, out bool _);
+                dst.Length);
 
-            if (!createdNewValues)
+            if (!mutation.CreatedNewValues)
             {
                 // Densify in place.
                 for (int i = values.Length; --i >= 0; )

--- a/src/Microsoft.ML.CpuMath/AlignedArray.cs
+++ b/src/Microsoft.ML.CpuMath/AlignedArray.cs
@@ -146,7 +146,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         // valuesSrc contains only the non-zero entries. Those are copied into their logical positions in the dense array.
         // rgposSrc contains the logical positions + offset of the non-zero entries in the dense array.
         // rgposSrc runs parallel to the valuesSrc array.
-        public void CopyFrom(int[] rgposSrc, Float[] valuesSrc, int posMin, int iposMin, int iposLim, bool zeroItems)
+        public void CopyFrom(ReadOnlySpan<int> rgposSrc, ReadOnlySpan<Float> valuesSrc, int posMin, int iposMin, int iposLim, bool zeroItems)
         {
             Contracts.Assert(rgposSrc != null);
             Contracts.Assert(valuesSrc != null);

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             }
         }
 
-        public static void MatrixTimesSource(AlignedArray matrix, int[] rgposSrc, AlignedArray sourceValues,
+        public static void MatrixTimesSource(AlignedArray matrix, ReadOnlySpan<int> rgposSrc, AlignedArray sourceValues,
             int posMin, int iposMin, int iposLimit, AlignedArray destination, int stride)
         {
             Contracts.AssertValue(rgposSrc);

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netstandard.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
         public static void MatrixTimesSource(bool transpose, AlignedArray matrix, AlignedArray source, AlignedArray destination, int stride) => SseUtils.MatTimesSrc(transpose, matrix, source, destination, stride);
 
-        public static void MatrixTimesSource(AlignedArray matrix, int[] rgposSrc, AlignedArray sourceValues,
+        public static void MatrixTimesSource(AlignedArray matrix, ReadOnlySpan<int> rgposSrc, AlignedArray sourceValues,
             int posMin, int iposMin, int iposLimit, AlignedArray destination, int stride) => SseUtils.MatTimesSrc(matrix, rgposSrc, sourceValues, posMin, iposMin, iposLimit, destination, stride);
 
         public static void Add(float value, Span<float> destination) => SseUtils.Add(value, destination);

--- a/src/Microsoft.ML.CpuMath/Sse.cs
+++ b/src/Microsoft.ML.CpuMath/Sse.cs
@@ -57,13 +57,12 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             }
         }
 
-        public static void MatTimesSrc(AlignedArray mat, int[] rgposSrc, AlignedArray srcValues,
+        public static void MatTimesSrc(AlignedArray mat, ReadOnlySpan<int> rgposSrc, AlignedArray srcValues,
             int posMin, int iposMin, int iposLim, AlignedArray dst, int crun)
         {
             Contracts.Assert(Compat(mat));
             Contracts.Assert(Compat(srcValues));
             Contracts.Assert(Compat(dst));
-            Contracts.AssertValue(rgposSrc);
             Contracts.Assert(0 <= iposMin && iposMin <= iposLim && iposLim <= rgposSrc.Length);
             Contracts.Assert(mat.Size == dst.Size * srcValues.Size);
 

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -276,7 +276,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         }
 
         // Partial sparse source vector.
-        public static unsafe void MatMulP(AlignedArray mat, int[] rgposSrc, AlignedArray src,
+        public static unsafe void MatMulP(AlignedArray mat, ReadOnlySpan<int> rgposSrc, AlignedArray src,
                                 int posMin, int iposMin, int iposEnd, AlignedArray dst, int crow, int ccol)
         {
             MatMulP(mat.Items, rgposSrc, src.Items, posMin, iposMin, iposEnd, dst.Items, crow, ccol);

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -279,7 +279,7 @@ namespace Microsoft.ML.Runtime.Data
             var value = default(VBuffer<T>);
             schema.GetMetadata(kind, col, ref value);
 
-            itw.Write(": Length={0}, Count={0}", value.Length, value.Count);
+            itw.Write(": Length={0}, Count={0}", value.Length, value.GetValues().Length);
 
             using (itw.Nest())
             {

--- a/src/Microsoft.ML.Data/Data/BufferBuilder.cs
+++ b/src/Microsoft.ML.Data/Data/BufferBuilder.cs
@@ -448,17 +448,17 @@ namespace Microsoft.ML.Runtime.Data
 
             if (_dense)
             {
-                var mutation = VBufferEditor.Create(ref buffer, _length);
-                _values.AsSpan(0, _length).CopyTo(mutation.Values);
-                buffer = mutation.Commit();
+                var editor = VBufferEditor.Create(ref buffer, _length);
+                _values.AsSpan(0, _length).CopyTo(editor.Values);
+                buffer = editor.Commit();
             }
             else
             {
                 Contracts.Assert(_count < _length);
-                var mutation = VBufferEditor.Create(ref buffer, _length, _count);
-                _values.AsSpan(0, _count).CopyTo(mutation.Values);
-                _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
-                buffer = mutation.Commit();
+                var editor = VBufferEditor.Create(ref buffer, _length, _count);
+                _values.AsSpan(0, _count).CopyTo(editor.Values);
+                _indices.AsSpan(0, _count).CopyTo(editor.Indices);
+                buffer = editor.Commit();
             }
         }
     }

--- a/src/Microsoft.ML.Data/Data/BufferBuilder.cs
+++ b/src/Microsoft.ML.Data/Data/BufferBuilder.cs
@@ -448,14 +448,14 @@ namespace Microsoft.ML.Runtime.Data
 
             if (_dense)
             {
-                var mutation = VBufferMutationContext.Create(ref buffer, _length);
+                var mutation = VBufferEditor.Create(ref buffer, _length);
                 _values.AsSpan(0, _length).CopyTo(mutation.Values);
                 buffer = mutation.Commit();
             }
             else
             {
                 Contracts.Assert(_count < _length);
-                var mutation = VBufferMutationContext.Create(ref buffer, _length, _count);
+                var mutation = VBufferEditor.Create(ref buffer, _length, _count);
                 _values.AsSpan(0, _count).CopyTo(mutation.Values);
                 _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
                 buffer = mutation.Commit();

--- a/src/Microsoft.ML.Data/Data/BufferBuilder.cs
+++ b/src/Microsoft.ML.Data/Data/BufferBuilder.cs
@@ -382,45 +382,6 @@ namespace Microsoft.ML.Runtime.Data
             return false;
         }
 
-        private void GetResult(ref T[] values, ref int[] indices, out int count, out int length)
-        {
-            if (_count == 0)
-            {
-                count = 0;
-                length = _length;
-                return;
-            }
-
-            if (!_dense)
-            {
-                if (!_sorted)
-                    SortAndSumDups();
-                if (!_dense && _count >= _length / 2)
-                    MakeDense();
-            }
-
-            if (_dense)
-            {
-                if (Utils.Size(values) < _length)
-                    values = new T[_length];
-                Array.Copy(_values, values, _length);
-                count = _length;
-                length = _length;
-            }
-            else
-            {
-                Contracts.Assert(_count < _length);
-                if (Utils.Size(values) < _count)
-                    values = new T[_count];
-                if (Utils.Size(indices) < _count)
-                    indices = new int[_count];
-                Array.Copy(_values, values, _count);
-                Array.Copy(_indices, indices, _count);
-                count = _count;
-                length = _length;
-            }
-        }
-
         public void Reset(int length, bool dense)
         {
             ResetImpl(length, dense);
@@ -435,7 +396,7 @@ namespace Microsoft.ML.Runtime.Data
             if (count == 0)
                 return;
 
-            var values = buffer.Values;
+            var values = buffer.GetValues();
             if (buffer.IsDense)
             {
                 Contracts.Assert(count == buffer.Length);
@@ -454,7 +415,7 @@ namespace Microsoft.ML.Runtime.Data
             else
             {
                 // REVIEW: Validate indices!
-                var indices = buffer.Indices;
+                var indices = buffer.GetIndices();
                 if (_dense)
                 {
                     for (int i = 0; i < count; i++)
@@ -471,24 +432,35 @@ namespace Microsoft.ML.Runtime.Data
 
         public void GetResult(ref VBuffer<T> buffer)
         {
-            var values = buffer.Values;
-            var indices = buffer.Indices;
-
             if (IsEmpty)
             {
-                buffer = new VBuffer<T>(_length, 0, values, indices);
+                VBufferMutationContext.Create(ref buffer, _length, 0)
+                    .Complete(ref buffer);
                 return;
             }
 
-            int count;
-            int length;
-            GetResult(ref values, ref indices, out count, out length);
-            Contracts.Assert(0 <= count && count <= length);
+            if (!_dense)
+            {
+                if (!_sorted)
+                    SortAndSumDups();
+                if (!_dense && _count >= _length / 2)
+                    MakeDense();
+            }
 
-            if (count == length)
-                buffer = new VBuffer<T>(length, values, indices);
+            if (_dense)
+            {
+                var mutation = VBufferMutationContext.Create(ref buffer, _length);
+                _values.AsSpan(0, _length).CopyTo(mutation.Values);
+                mutation.Complete(ref buffer);
+            }
             else
-                buffer = new VBuffer<T>(length, count, values, indices);
+            {
+                Contracts.Assert(_count < _length);
+                var mutation = VBufferMutationContext.Create(ref buffer, _length, _count);
+                _values.AsSpan(0, _count).CopyTo(mutation.Values);
+                _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
+                mutation.Complete(ref buffer);
+            }
         }
     }
 }

--- a/src/Microsoft.ML.Data/Data/BufferBuilder.cs
+++ b/src/Microsoft.ML.Data/Data/BufferBuilder.cs
@@ -392,11 +392,11 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.Check(0 <= index && index <= _length - buffer.Length);
 
-            int count = buffer.Count;
+            var values = buffer.GetValues();
+            int count = values.Length;
             if (count == 0)
                 return;
 
-            var values = buffer.GetValues();
             if (buffer.IsDense)
             {
                 Contracts.Assert(count == buffer.Length);

--- a/src/Microsoft.ML.Data/Data/BufferBuilder.cs
+++ b/src/Microsoft.ML.Data/Data/BufferBuilder.cs
@@ -434,8 +434,8 @@ namespace Microsoft.ML.Runtime.Data
         {
             if (IsEmpty)
             {
-                VBufferMutationContext.Create(ref buffer, _length, 0)
-                    .Complete(ref buffer);
+                buffer = VBufferMutationContext.Create(ref buffer, _length, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -451,7 +451,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 var mutation = VBufferMutationContext.Create(ref buffer, _length);
                 _values.AsSpan(0, _length).CopyTo(mutation.Values);
-                mutation.Complete(ref buffer);
+                buffer = mutation.CreateBuffer();
             }
             else
             {
@@ -459,7 +459,7 @@ namespace Microsoft.ML.Runtime.Data
                 var mutation = VBufferMutationContext.Create(ref buffer, _length, _count);
                 _values.AsSpan(0, _count).CopyTo(mutation.Values);
                 _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
-                mutation.Complete(ref buffer);
+                buffer = mutation.CreateBuffer();
             }
         }
     }

--- a/src/Microsoft.ML.Data/Data/BufferBuilder.cs
+++ b/src/Microsoft.ML.Data/Data/BufferBuilder.cs
@@ -450,7 +450,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 var mutation = VBufferMutationContext.Create(ref buffer, _length);
                 _values.AsSpan(0, _length).CopyTo(mutation.Values);
-                buffer = mutation.CreateBuffer();
+                buffer = mutation.Commit();
             }
             else
             {
@@ -458,7 +458,7 @@ namespace Microsoft.ML.Runtime.Data
                 var mutation = VBufferMutationContext.Create(ref buffer, _length, _count);
                 _values.AsSpan(0, _count).CopyTo(mutation.Values);
                 _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
-                buffer = mutation.CreateBuffer();
+                buffer = mutation.Commit();
             }
         }
     }

--- a/src/Microsoft.ML.Data/Data/BufferBuilder.cs
+++ b/src/Microsoft.ML.Data/Data/BufferBuilder.cs
@@ -434,8 +434,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             if (IsEmpty)
             {
-                buffer = VBufferMutationContext.Create(ref buffer, _length, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref buffer, _length, 0);
                 return;
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -1109,29 +1109,29 @@ namespace Microsoft.ML.Runtime.Data.IO
                     int length = FixedLength ? _size : _lengths[_vectorIndex];
                     int count = _counts[_vectorIndex];
 
-                    int[] indices = value.Indices;
-                    T[] values = value.Values;
                     if (count < 0)
                     {
                         // dense
+                        var mutation = VBufferMutationContext.Create(ref value, length);
                         if (length > 0)
                         {
-                            Utils.EnsureSize(ref values, length);
-                            Array.Copy(_values, _valuesOffset, values, 0, length);
+                            _values.AsSpan(_valuesOffset, length)
+                                .CopyTo(mutation.Values);
                         }
-                        value = new VBuffer<T>(length, values, indices);
+                        mutation.Complete(ref value);
                     }
                     else
                     {
                         // sparse
+                        var mutation = VBufferMutationContext.Create(ref value, length, count);
                         if (count > 0)
                         {
-                            Utils.EnsureSize(ref values, count);
-                            Utils.EnsureSize(ref indices, count);
-                            Array.Copy(_values, _valuesOffset, values, 0, count);
-                            Array.Copy(_indices, _indicesOffset, indices, 0, count);
+                            _values.AsSpan(_valuesOffset, count)
+                                .CopyTo(mutation.Values);
+                            _indices.AsSpan(_indicesOffset, count)
+                                .CopyTo(mutation.Indices);
                         }
-                        value = new VBuffer<T>(length, count, values, indices);
+                        mutation.Complete(ref value);
                     }
                 }
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -1118,7 +1118,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                             _values.AsSpan(_valuesOffset, length)
                                 .CopyTo(mutation.Values);
                         }
-                        value = mutation.CreateBuffer();
+                        value = mutation.Commit();
                     }
                     else
                     {
@@ -1131,7 +1131,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                             _indices.AsSpan(_indicesOffset, count)
                                 .CopyTo(mutation.Indices);
                         }
-                        value = mutation.CreateBuffer();
+                        value = mutation.Commit();
                     }
                 }
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -1112,26 +1112,26 @@ namespace Microsoft.ML.Runtime.Data.IO
                     if (count < 0)
                     {
                         // dense
-                        var mutation = VBufferEditor.Create(ref value, length);
+                        var editor = VBufferEditor.Create(ref value, length);
                         if (length > 0)
                         {
                             _values.AsSpan(_valuesOffset, length)
-                                .CopyTo(mutation.Values);
+                                .CopyTo(editor.Values);
                         }
-                        value = mutation.Commit();
+                        value = editor.Commit();
                     }
                     else
                     {
                         // sparse
-                        var mutation = VBufferEditor.Create(ref value, length, count);
+                        var editor = VBufferEditor.Create(ref value, length, count);
                         if (count > 0)
                         {
                             _values.AsSpan(_valuesOffset, count)
-                                .CopyTo(mutation.Values);
+                                .CopyTo(editor.Values);
                             _indices.AsSpan(_indicesOffset, count)
-                                .CopyTo(mutation.Indices);
+                                .CopyTo(editor.Indices);
                         }
-                        value = mutation.Commit();
+                        value = editor.Commit();
                     }
                 }
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -1112,7 +1112,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                     if (count < 0)
                     {
                         // dense
-                        var mutation = VBufferMutationContext.Create(ref value, length);
+                        var mutation = VBufferEditor.Create(ref value, length);
                         if (length > 0)
                         {
                             _values.AsSpan(_valuesOffset, length)
@@ -1123,7 +1123,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                     else
                     {
                         // sparse
-                        var mutation = VBufferMutationContext.Create(ref value, length, count);
+                        var mutation = VBufferEditor.Create(ref value, length, count);
                         if (count > 0)
                         {
                             _values.AsSpan(_valuesOffset, count)

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -1118,7 +1118,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                             _values.AsSpan(_valuesOffset, length)
                                 .CopyTo(mutation.Values);
                         }
-                        mutation.Complete(ref value);
+                        value = mutation.CreateBuffer();
                     }
                     else
                     {
@@ -1131,7 +1131,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                             _indices.AsSpan(_indicesOffset, count)
                                 .CopyTo(mutation.Indices);
                         }
-                        mutation.Complete(ref value);
+                        value = mutation.CreateBuffer();
                     }
                 }
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -401,28 +401,23 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     AssertValid();
 
-                    var values = dst.Values;
-                    var indices = dst.Indices;
-
                     if (_count == 0)
                     {
-                        dst = new VBuffer<TItem>(_size, 0, values, indices);
+                        VBufferMutationContext.Create(ref dst, _size, 0)
+                            .Complete(ref dst);
                         return;
                     }
 
-                    if (Utils.Size(values) < _count)
-                        values = new TItem[_count];
-                    Array.Copy(_values, values, _count);
+                    var mutation = VBufferMutationContext.Create(ref dst, _size, _count);
+                    _values.AsSpan(0, _count).CopyTo(mutation.Values);
                     if (_count == _size)
                     {
-                        dst = new VBuffer<TItem>(_size, values, indices);
+                        mutation.Complete(ref dst);
                         return;
                     }
 
-                    if (Utils.Size(indices) < _count)
-                        indices = new int[_count];
-                    Array.Copy(_indices, indices, _count);
-                    dst = new VBuffer<TItem>(_size, _count, values, indices);
+                    _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
+                    mutation.Complete(ref dst);
                 }
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -403,8 +403,7 @@ namespace Microsoft.ML.Runtime.Data
 
                     if (_count == 0)
                     {
-                        dst = VBufferMutationContext.Create(ref dst, _size, 0)
-                            .CreateBuffer();
+                        VBufferUtils.Resize(ref dst, _size, 0);
                         return;
                     }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -407,16 +407,16 @@ namespace Microsoft.ML.Runtime.Data
                         return;
                     }
 
-                    var mutation = VBufferEditor.Create(ref dst, _size, _count);
-                    _values.AsSpan(0, _count).CopyTo(mutation.Values);
+                    var editor = VBufferEditor.Create(ref dst, _size, _count);
+                    _values.AsSpan(0, _count).CopyTo(editor.Values);
                     if (_count == _size)
                     {
-                        dst = mutation.Commit();
+                        dst = editor.Commit();
                         return;
                     }
 
-                    _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
-                    dst = mutation.Commit();
+                    _indices.AsSpan(0, _count).CopyTo(editor.Indices);
+                    dst = editor.Commit();
                 }
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -407,7 +407,7 @@ namespace Microsoft.ML.Runtime.Data
                         return;
                     }
 
-                    var mutation = VBufferMutationContext.Create(ref dst, _size, _count);
+                    var mutation = VBufferEditor.Create(ref dst, _size, _count);
                     _values.AsSpan(0, _count).CopyTo(mutation.Values);
                     if (_count == _size)
                     {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -411,12 +411,12 @@ namespace Microsoft.ML.Runtime.Data
                     _values.AsSpan(0, _count).CopyTo(mutation.Values);
                     if (_count == _size)
                     {
-                        dst = mutation.CreateBuffer();
+                        dst = mutation.Commit();
                         return;
                     }
 
                     _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 }
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -403,8 +403,8 @@ namespace Microsoft.ML.Runtime.Data
 
                     if (_count == 0)
                     {
-                        VBufferMutationContext.Create(ref dst, _size, 0)
-                            .Complete(ref dst);
+                        dst = VBufferMutationContext.Create(ref dst, _size, 0)
+                            .CreateBuffer();
                         return;
                     }
 
@@ -412,12 +412,12 @@ namespace Microsoft.ML.Runtime.Data
                     _values.AsSpan(0, _count).CopyTo(mutation.Values);
                     if (_count == _size)
                     {
-                        mutation.Complete(ref dst);
+                        dst = mutation.CreateBuffer();
                         return;
                     }
 
                     _indices.AsSpan(0, _count).CopyTo(mutation.Indices);
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 }
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -166,20 +166,22 @@ namespace Microsoft.ML.Runtime.Data.IO
             public override void WriteData(Action<StringBuilder, int> appendItem, out int length)
             {
                 _getSrc(ref _src);
+                var srcValues = _src.GetValues();
                 if (_src.IsDense)
                 {
-                    for (int i = 0; i < _src.Length; i++)
+                    for (int i = 0; i < srcValues.Length; i++)
                     {
-                        Conv(in _src.Values[i], ref Sb);
+                        Conv(in srcValues[i], ref Sb);
                         appendItem(Sb, i);
                     }
                 }
                 else
                 {
-                    for (int i = 0; i < _src.Count; i++)
+                    var srcIndices = _src.GetIndices();
+                    for (int i = 0; i < srcValues.Length; i++)
                     {
-                        Conv(in _src.Values[i], ref Sb);
-                        appendItem(Sb, _src.Indices[i]);
+                        Conv(in srcValues[i], ref Sb);
+                        appendItem(Sb, srcIndices[i]);
                     }
                 }
                 length = _src.Length;
@@ -190,13 +192,15 @@ namespace Microsoft.ML.Runtime.Data.IO
                 length = _slotCount;
                 if (_slotNames.Count == 0)
                     return;
+                var slotNamesValues = _slotNames.GetValues();
+                var slotNamesIndices = _slotNames.GetIndices();
                 for (int i = 0; i < _slotNames.Count; i++)
                 {
-                    var name = _slotNames.Values[i];
+                    var name = slotNamesValues[i];
                     if (name.IsEmpty)
                         continue;
                     MapText(in name, ref Sb);
-                    int index = _slotNames.IsDense ? i : _slotNames.Indices[i];
+                    int index = _slotNames.IsDense ? i : slotNamesIndices[i];
                     appendItem(Sb, index);
                 }
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -190,11 +190,12 @@ namespace Microsoft.ML.Runtime.Data.IO
             public override void WriteHeader(Action<StringBuilder, int> appendItem, out int length)
             {
                 length = _slotCount;
-                if (_slotNames.Count == 0)
-                    return;
                 var slotNamesValues = _slotNames.GetValues();
+                if (slotNamesValues.Length == 0)
+                    return;
+
                 var slotNamesIndices = _slotNames.GetIndices();
-                for (int i = 0; i < _slotNames.Count; i++)
+                for (int i = 0; i < slotNamesValues.Length; i++)
                 {
                     var name = slotNamesValues[i];
                     if (name.IsEmpty)

--- a/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Runtime.Data
         public void GetColumnSource(int col, out int srcIndex, out int srcCol)
         {
             CheckColumnInRange(col);
-            if (!_cumulativeColCounts.TryFindIndexSorted(0, _cumulativeColCounts.Length, col, out srcIndex))
+            if (!Utils.TryFindIndexSorted(_cumulativeColCounts, 0, _cumulativeColCounts.Length, col, out srcIndex))
                 srcIndex--;
             Contracts.Assert(0 <= srcIndex && srcIndex < _cumulativeColCounts.Length);
             srcCol = col - _cumulativeColCounts[srcIndex];

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1308,8 +1308,7 @@ namespace Microsoft.ML.Runtime.Data
                                     int scount = slim - smin;
                                     if (scount == 0)
                                     {
-                                        value = VBufferMutationContext.Create(ref value, len, 0)
-                                            .CreateBuffer();
+                                        VBufferUtils.Resize(ref value, len, 0);
                                         return;
                                     }
 

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1294,12 +1294,12 @@ namespace Microsoft.ML.Runtime.Data
                                 (ref VBuffer<T> value) =>
                                 {
                                     EnsureValid();
-                                    VBufferEditor<T> mutation;
+                                    VBufferEditor<T> editor;
                                     if (_inputValue.IsDense)
                                     {
-                                        mutation = VBufferEditor.Create(ref value, len);
-                                        _inputValue.GetValues().Slice(min, len).CopyTo(mutation.Values);
-                                        value = mutation.Commit();
+                                        editor = VBufferEditor.Create(ref value, len);
+                                        _inputValue.GetValues().Slice(min, len).CopyTo(editor.Values);
+                                        value = editor.Commit();
                                         return;
                                     }
                                     // In the sparse case we have ranges on Indices/Values to consider.
@@ -1312,20 +1312,20 @@ namespace Microsoft.ML.Runtime.Data
                                         return;
                                     }
 
-                                    mutation = VBufferEditor.Create(ref value, len, scount);
+                                    editor = VBufferEditor.Create(ref value, len, scount);
                                     bool isDense = len == scount;
                                     if (!isDense)
                                     {
-                                        _inputValue.GetIndices().Slice(smin, scount).CopyTo(mutation.Indices);
+                                        _inputValue.GetIndices().Slice(smin, scount).CopyTo(editor.Indices);
 
                                         if (min != 0)
                                         {
                                             for (int i = 0; i < scount; ++i)
-                                                mutation.Indices[i] -= min;
+                                                editor.Indices[i] -= min;
                                         }
                                     }
-                                    _inputValue.GetValues().Slice(smin, scount).CopyTo(mutation.Values);
-                                    value = mutation.Commit();
+                                    _inputValue.GetValues().Slice(smin, scount).CopyTo(editor.Values);
+                                    value = editor.Commit();
                                 };
                         }
 

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1299,7 +1299,7 @@ namespace Microsoft.ML.Runtime.Data
                                     {
                                         mutation = VBufferMutationContext.Create(ref value, len);
                                         _inputValue.GetValues().Slice(min, len).CopyTo(mutation.Values);
-                                        value = mutation.CreateBuffer();
+                                        value = mutation.Commit();
                                         return;
                                     }
                                     // In the sparse case we have ranges on Indices/Values to consider.
@@ -1325,7 +1325,7 @@ namespace Microsoft.ML.Runtime.Data
                                         }
                                     }
                                     _inputValue.GetValues().Slice(smin, scount).CopyTo(mutation.Values);
-                                    value = mutation.CreateBuffer();
+                                    value = mutation.Commit();
                                 };
                         }
 

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1294,10 +1294,10 @@ namespace Microsoft.ML.Runtime.Data
                                 (ref VBuffer<T> value) =>
                                 {
                                     EnsureValid();
-                                    VBufferMutationContext<T> mutation;
+                                    VBufferEditor<T> mutation;
                                     if (_inputValue.IsDense)
                                     {
-                                        mutation = VBufferMutationContext.Create(ref value, len);
+                                        mutation = VBufferEditor.Create(ref value, len);
                                         _inputValue.GetValues().Slice(min, len).CopyTo(mutation.Values);
                                         value = mutation.Commit();
                                         return;
@@ -1312,7 +1312,7 @@ namespace Microsoft.ML.Runtime.Data
                                         return;
                                     }
 
-                                    mutation = VBufferMutationContext.Create(ref value, len, scount);
+                                    mutation = VBufferEditor.Create(ref value, len, scount);
                                     bool isDense = len == scount;
                                     if (!isDense)
                                     {

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1281,7 +1281,7 @@ namespace Microsoft.ML.Runtime.Data
                                     {
                                         mutation = VBufferMutationContext.Create(ref value, len);
                                         _inputValue.GetValues().Slice(min, len).CopyTo(mutation.Values);
-                                        mutation.Complete(ref value);
+                                        value = mutation.CreateBuffer();
                                         return;
                                     }
                                     // In the sparse case we have ranges on Indices/Values to consider.
@@ -1290,8 +1290,8 @@ namespace Microsoft.ML.Runtime.Data
                                     int scount = slim - smin;
                                     if (scount == 0)
                                     {
-                                        VBufferMutationContext.Create(ref value, len, 0)
-                                            .Complete(ref value);
+                                        value = VBufferMutationContext.Create(ref value, len, 0)
+                                            .CreateBuffer();
                                         return;
                                     }
 
@@ -1308,7 +1308,7 @@ namespace Microsoft.ML.Runtime.Data
                                         }
                                     }
                                     _inputValue.GetValues().Slice(smin, scount).CopyTo(mutation.Values);
-                                    mutation.Complete(ref value);
+                                    value = mutation.CreateBuffer();
                                 };
                         }
 

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -108,8 +108,7 @@ namespace Microsoft.ML.Runtime.Numeric
             if (count == 0)
             {
                 // dst is a zero vector.
-                dst = VBufferMutationContext.Create(ref dst, length, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref dst, length, 0);
                 return;
             }
 
@@ -392,14 +391,13 @@ namespace Microsoft.ML.Runtime.Numeric
                 {
                     // Due to sparsity preservation from src, dst must be dense, in the same way.
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length);
-                    if (!mutation.CreatedNewValues) // We need to clear it
+                    if (!mutation.CreatedNewValues) // We need to clear it.
                         mutation.Values.Clear();
                     dst = mutation.CreateBuffer();
                 }
                 else
                 {
-                    dst = VBufferMutationContext.Create(ref dst, src.Length, 0)
-                        .CreateBuffer();
+                    VBufferUtils.Resize(ref dst, src.Length, 0);
                 }
             }
             else if (c == -1)

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     mutation.Values.Clear();
                 else
                     CpuMathUtils.Scale(c, srcValues, mutation.Values, length);
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             }
             else
             {
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     mutation.Values.Clear();
                 else
                     CpuMathUtils.Scale(c, srcValues, mutation.Values, count);
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             }
         }
 
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Runtime.Numeric
             {
                 var mutation = VBufferMutationContext.Create(ref res, length);
                 CpuMathUtils.AddScaleCopy(c, srcValues, dst.GetValues(), mutation.Values, length);
-                res = mutation.CreateBuffer();
+                res = mutation.Commit();
                 return;
             }
 
@@ -367,7 +367,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     }
                 }
             }
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         /// <summary>
@@ -393,7 +393,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length);
                     if (!mutation.CreatedNewValues) // We need to clear it.
                         mutation.Values.Clear();
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 }
                 else
                 {

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             if (c == 1 || dst.GetValues().Length == 0)
                 return;
-            var mutation = VBufferMutationContext.CreateFromBuffer(ref dst);
+            var mutation = VBufferEditor.CreateFromBuffer(ref dst);
             if (c != 0)
                 CpuMathUtils.Scale(c, mutation.Values);
             else // Maintain density of dst.
@@ -115,7 +115,7 @@ namespace Microsoft.ML.Runtime.Numeric
             if (src.IsDense)
             {
                 // Maintain the density of src to dst in order to avoid slow down of L-BFGS.
-                var mutation = VBufferMutationContext.Create(ref dst, length);
+                var mutation = VBufferEditor.Create(ref dst, length);
                 Contracts.Assert(length == count);
                 if (c == 0)
                     mutation.Values.Clear();
@@ -125,7 +125,7 @@ namespace Microsoft.ML.Runtime.Numeric
             }
             else
             {
-                var mutation = VBufferMutationContext.Create(ref dst, length, count);
+                var mutation = VBufferEditor.Create(ref dst, length, count);
                 src.GetIndices().CopyTo(mutation.Indices);
                 if (c == 0)
                     mutation.Values.Clear();
@@ -148,7 +148,7 @@ namespace Microsoft.ML.Runtime.Numeric
 
             if (dst.IsDense)
             {
-                var mutation = VBufferMutationContext.Create(ref dst, dst.Length);
+                var mutation = VBufferEditor.Create(ref dst, dst.Length);
                 if (src.IsDense)
                     CpuMathUtils.Add(srcValues, mutation.Values, src.Length);
                 else
@@ -176,7 +176,7 @@ namespace Microsoft.ML.Runtime.Numeric
 
             if (dst.IsDense)
             {
-                var mutation = VBufferMutationContext.Create(ref dst, dst.Length);
+                var mutation = VBufferEditor.Create(ref dst, dst.Length);
                 if (src.IsDense)
                     CpuMathUtils.AddScale(c, srcValues, mutation.Values, src.Length);
                 else
@@ -207,7 +207,7 @@ namespace Microsoft.ML.Runtime.Numeric
             Contracts.Assert(length > 0);
             if (dst.IsDense && src.IsDense)
             {
-                var mutation = VBufferMutationContext.Create(ref res, length);
+                var mutation = VBufferEditor.Create(ref res, length);
                 CpuMathUtils.AddScaleCopy(c, srcValues, dst.GetValues(), mutation.Values, length);
                 res = mutation.Commit();
                 return;
@@ -247,12 +247,12 @@ namespace Microsoft.ML.Runtime.Numeric
             var srcValues = src.GetValues();
             if (srcValues.Length == 0 || c == 0)
                 return;
-            VBufferMutationContext<float> mutation;
+            VBufferEditor<float> mutation;
             Span<float> values;
             if (dst.IsDense)
             {
                 // This is by far the most common case.
-                mutation = VBufferMutationContext.Create(ref dst, dst.Length);
+                mutation = VBufferEditor.Create(ref dst, dst.Length);
                 values = mutation.Values.Slice(offset);
                 if (src.IsDense)
                     CpuMathUtils.AddScale(c, srcValues, values, srcValues.Length);
@@ -295,7 +295,7 @@ namespace Microsoft.ML.Runtime.Numeric
             }
             // Extend dst so that it has room for this additional stuff. Shift things over as well.
             var dstValues = dst.GetValues();
-            mutation = VBufferMutationContext.Create(ref dst,
+            mutation = VBufferEditor.Create(ref dst,
                 dst.Length,
                 dstValues.Length + gapCount,
                 keepOldOnResize: true);
@@ -390,7 +390,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 if (src.Length > 0 && src.IsDense)
                 {
                     // Due to sparsity preservation from src, dst must be dense, in the same way.
-                    var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+                    var mutation = VBufferEditor.Create(ref dst, src.Length);
                     if (!mutation.CreatedNewValues) // We need to clear it.
                         mutation.Values.Clear();
                     dst = mutation.Commit();

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -108,8 +108,8 @@ namespace Microsoft.ML.Runtime.Numeric
             if (count == 0)
             {
                 // dst is a zero vector.
-                VBufferMutationContext.Create(ref dst, length, 0)
-                    .Complete(ref dst);
+                dst = VBufferMutationContext.Create(ref dst, length, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     mutation.Values.Clear();
                 else
                     CpuMathUtils.Scale(c, srcValues, mutation.Values, length);
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             }
             else
             {
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     mutation.Values.Clear();
                 else
                     CpuMathUtils.Scale(c, srcValues, mutation.Values, count);
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             }
         }
 
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Runtime.Numeric
             {
                 var mutation = VBufferMutationContext.Create(ref res, length);
                 CpuMathUtils.AddScaleCopy(c, srcValues, dst.GetValues(), mutation.Values, length);
-                mutation.Complete(ref res);
+                res = mutation.CreateBuffer();
                 return;
             }
 
@@ -368,7 +368,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     }
                 }
             }
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -394,12 +394,12 @@ namespace Microsoft.ML.Runtime.Numeric
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length);
                     if (!mutation.CreatedNewValues) // We need to clear it
                         mutation.Values.Clear();
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 }
                 else
                 {
-                    VBufferMutationContext.Create(ref dst, src.Length, 0)
-                        .Complete(ref dst);
+                    dst = VBufferMutationContext.Create(ref dst, src.Length, 0)
+                        .CreateBuffer();
                 }
             }
             else if (c == -1)

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -383,11 +383,8 @@ namespace Microsoft.ML.Runtime.Numeric
                 if (src.Length > 0 && src.IsDense)
                 {
                     // Due to sparsity preservation from src, dst must be dense, in the same way.
-                    var mutation = VBufferMutationContext.Create(ref dst,
-                        src.Length,
-                        out bool createdNewValues,
-                        out bool _);
-                    if (!createdNewValues) // We need to clear it
+                    var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+                    if (!mutation.CreatedNewValues) // We need to clear it
                         mutation.Values.Clear();
                     mutation.Complete(ref dst);
                 }

--- a/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
@@ -165,8 +165,8 @@ namespace Microsoft.ML.Runtime.Numeric
 
             if (a.IsDense && dst.IsDense)
             {
-                var mutation = VBufferEditor.CreateFromBuffer(ref dst);
-                CpuMathUtils.MulElementWise(a.GetValues(), dst.GetValues(), mutation.Values, a.Length);
+                var editor = VBufferEditor.CreateFromBuffer(ref dst);
+                CpuMathUtils.MulElementWise(a.GetValues(), dst.GetValues(), editor.Values, a.Length);
             }
             else
                 VBufferUtils.ApplyWithEitherDefined(in a, ref dst, (int ind, Float v1, ref Float v2) => { v2 *= v1; });

--- a/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
@@ -33,8 +33,8 @@ namespace Microsoft.ML.Runtime.Numeric
             if (b.Count == 0)
                 return 0;
             if (b.IsDense)
-                return CpuMathUtils.DotProductDense(a, b.Values, b.Length);
-            return CpuMathUtils.DotProductSparse(a, b.Values, b.Indices, b.Count);
+                return CpuMathUtils.DotProductDense(a, b.GetValues(), b.Length);
+            return CpuMathUtils.DotProductSparse(a, b.GetValues(), b.GetIndices(), b.Count);
         }
 
         public static Float DotProduct(in VBuffer<Float> a, in VBuffer<Float> b)
@@ -47,13 +47,13 @@ namespace Microsoft.ML.Runtime.Numeric
             if (a.IsDense)
             {
                 if (b.IsDense)
-                    return CpuMathUtils.DotProductDense(a.Values, b.Values, a.Length);
-                return CpuMathUtils.DotProductSparse(a.Values, b.Values, b.Indices, b.Count);
+                    return CpuMathUtils.DotProductDense(a.GetValues(), b.GetValues(), a.Length);
+                return CpuMathUtils.DotProductSparse(a.GetValues(), b.GetValues(), b.GetIndices(), b.Count);
             }
 
             if (b.IsDense)
-                return CpuMathUtils.DotProductSparse(b.Values, a.Values, a.Indices, a.Count);
-            return DotProductSparse(a.Values, a.Indices, 0, a.Count, b.Values, b.Indices, 0, b.Count, 0);
+                return CpuMathUtils.DotProductSparse(b.GetValues(), a.GetValues(), a.GetIndices(), a.Count);
+            return DotProductSparse(a.GetValues(), a.GetIndices(), 0, a.Count, b.GetValues(), b.GetIndices(), 0, b.Count);
         }
 
         /// <summary>
@@ -75,10 +75,12 @@ namespace Microsoft.ML.Runtime.Numeric
             var bottomHeap = new Heap<KeyValuePair<int, Float>>((left, right) => right.Value > left.Value, bottom + 1);
             bool isDense = a.IsDense;
 
+            var aValues = a.GetValues();
+            var aIndices = a.GetIndices();
             for (int i = 0; i < a.Count; i++)
             {
-                int idx = isDense ? i : a.Indices[i];
-                var value = a.Values[i];
+                int idx = isDense ? i : aIndices[i];
+                var value = aValues[i];
 
                 if (value < 0 && bottom > 0)
                 {
@@ -108,22 +110,21 @@ namespace Microsoft.ML.Runtime.Numeric
             }
 
             var newCount = topHeap.Count + bottomHeap.Count;
-            var indices = a.Indices;
-            Utils.EnsureSize(ref indices, newCount);
-            Contracts.Assert(Utils.Size(a.Values) >= newCount);
+            var mutation = VBufferMutationContext.Create(ref a, a.Length, newCount);
+            var indices = mutation.Indices;
             int count = 0;
             while (topHeap.Count > 0)
             {
                 var pair = topHeap.Pop();
                 indices[count] = pair.Key;
-                a.Values[count++] = pair.Value;
+                mutation.Values[count++] = pair.Value;
             }
 
             while (bottomHeap.Count > 0)
             {
                 var pair = bottomHeap.Pop();
                 indices[count] = pair.Key;
-                a.Values[count++] = pair.Value;
+                mutation.Values[count++] = pair.Value;
             }
 
             Contracts.Assert(count == newCount);
@@ -132,7 +133,7 @@ namespace Microsoft.ML.Runtime.Numeric
             {
                 for (var i = 0; i < newCount; i++)
                 {
-                    var value = a.Values[i];
+                    var value = mutation.Values[i];
                     var absValue = Math.Abs(value);
                     if (absValue > absMax)
                         absMax = absValue;
@@ -142,13 +143,13 @@ namespace Microsoft.ML.Runtime.Numeric
                 {
                     var ratio = 1 / absMax;
                     for (var i = 0; i < newCount; i++)
-                        a.Values[i] = ratio * a.Values[i];
+                        mutation.Values[i] = ratio * mutation.Values[i];
                 }
             }
 
             if (indices != null)
                 Array.Sort(indices, a.Values, 0, newCount);
-            a = new VBuffer<float>(a.Length, newCount, a.Values, indices);
+            mutation.Complete(ref a);
         }
 
         /// <summary>
@@ -159,27 +160,24 @@ namespace Microsoft.ML.Runtime.Numeric
             Contracts.Check(a.Length == dst.Length, "Vectors must have the same dimensionality.");
 
             if (a.IsDense && dst.IsDense)
-                CpuMathUtils.MulElementWise(a.Values, dst.Values, dst.Values, a.Length);
+            {
+                var mutation = VBufferMutationContext.Create(ref dst, dst.Length, dst.Count);
+                CpuMathUtils.MulElementWise(a.GetValues(), dst.GetValues(), mutation.Values, a.Length);
+            }
             else
                 VBufferUtils.ApplyWithEitherDefined(in a, ref dst, (int ind, Float v1, ref Float v2) => { v2 *= v1; });
         }
 
-        private static Float L2DistSquaredSparse(Float[] valuesA, int[] indicesA, int countA, Float[] valuesB, int[] indicesB, int countB, int length)
+        private static Float L2DistSquaredSparse(ReadOnlySpan<Float> valuesA, ReadOnlySpan<int> indicesA, ReadOnlySpan<Float> valuesB, ReadOnlySpan<int> indicesB)
         {
-            Contracts.AssertValueOrNull(valuesA);
-            Contracts.AssertValueOrNull(indicesA);
-            Contracts.AssertValueOrNull(valuesB);
-            Contracts.AssertValueOrNull(indicesB);
-            Contracts.Assert(0 <= countA && countA <= Utils.Size(indicesA));
-            Contracts.Assert(0 <= countB && countB <= Utils.Size(indicesB));
-            Contracts.Assert(countA <= Utils.Size(valuesA));
-            Contracts.Assert(countB <= Utils.Size(valuesB));
+            Contracts.Assert(valuesA.Length == indicesA.Length);
+            Contracts.Assert(valuesB.Length == indicesB.Length);
 
             Float res = 0;
 
             int ia = 0;
             int ib = 0;
-            while (ia < countA && ib < countB)
+            while (ia < indicesA.Length && ib < indicesB.Length)
             {
                 int diff = indicesA[ia] - indicesB[ib];
                 Float d;
@@ -202,14 +200,14 @@ namespace Microsoft.ML.Runtime.Numeric
                 res += d * d;
             }
 
-            while (ia < countA)
+            while (ia < indicesA.Length)
             {
                 var d = valuesA[ia];
                 res += d * d;
                 ia++;
             }
 
-            while (ib < countB)
+            while (ib < indicesB.Length)
             {
                 var d = valuesB[ib];
                 res += d * d;
@@ -219,30 +217,21 @@ namespace Microsoft.ML.Runtime.Numeric
             return res;
         }
 
-        private static Float L2DistSquaredHalfSparse(Float[] valuesA, int lengthA, Float[] valuesB, int[] indicesB, int countB)
+        private static Float L2DistSquaredHalfSparse(ReadOnlySpan<Float> valuesA, ReadOnlySpan<Float> valuesB, ReadOnlySpan<int> indicesB)
         {
-            Contracts.AssertValueOrNull(valuesA);
-            Contracts.AssertValueOrNull(valuesB);
-            Contracts.AssertValueOrNull(indicesB);
-            Contracts.Assert(0 <= lengthA && lengthA <= Utils.Size(valuesA));
-            Contracts.Assert(0 <= countB && countB <= Utils.Size(indicesB));
-            Contracts.Assert(countB <= Utils.Size(valuesB));
-
-            var normA = CpuMathUtils.SumSq(valuesA.AsSpan(0, lengthA));
-            if (countB == 0)
+            var normA = CpuMathUtils.SumSq(valuesA);
+            if (valuesB.Length == 0)
                 return normA;
-            var normB = CpuMathUtils.SumSq(valuesB.AsSpan(0, countB));
-            var dotP = CpuMathUtils.DotProductSparse(valuesA, valuesB, indicesB, countB);
+            var normB = CpuMathUtils.SumSq(valuesB);
+            var dotP = CpuMathUtils.DotProductSparse(valuesA, valuesB, indicesB, valuesB.Length);
             var res = normA + normB - 2 * dotP;
             return res < 0 ? 0 : res;
         }
 
-        private static Float L2DiffSquaredDense(Float[] valuesA, Float[] valuesB, int length)
+        private static Float L2DiffSquaredDense(ReadOnlySpan<Float> valuesA, ReadOnlySpan<Float> valuesB, int length)
         {
-            Contracts.AssertValueOrNull(valuesA);
-            Contracts.AssertValueOrNull(valuesB);
-            Contracts.Assert(0 <= length && length <= Utils.Size(valuesA));
-            Contracts.Assert(0 <= length && length <= Utils.Size(valuesB));
+            Contracts.Assert(0 <= length && length <= valuesA.Length);
+            Contracts.Assert(0 <= length && length <= valuesB.Length);
 
             if (length == 0)
                 return 0;
@@ -267,27 +256,31 @@ namespace Microsoft.ML.Runtime.Numeric
             if (a.IsDense)
             {
                 if (b.IsDense)
-                    return CpuMathUtils.DotProductDense(a.Values.AsSpan(offset), b.Values, b.Length);
-                return CpuMathUtils.DotProductSparse(a.Values.AsSpan(offset), b.Values, b.Indices, b.Count);
+                    return CpuMathUtils.DotProductDense(a.GetValues().Slice(offset), b.GetValues(), b.Length);
+                return CpuMathUtils.DotProductSparse(a.GetValues().Slice(offset), b.GetValues(), b.GetIndices(), b.Count);
             }
             else
             {
                 Float result = 0;
-                int aMin = Utils.FindIndexSorted(a.Indices, 0, a.Count, offset);
-                int aLim = Utils.FindIndexSorted(a.Indices, 0, a.Count, offset + b.Length);
+                var aValues = a.GetValues();
+                var aIndices = a.GetIndices();
+                var bValues = b.GetValues();
+                var bIndices = b.GetIndices();
+                int aMin = Utils.FindIndexSorted(aIndices, 0, a.Count, offset);
+                int aLim = Utils.FindIndexSorted(aIndices, 0, a.Count, offset + b.Length);
                 if (b.IsDense)
                 {
                     for (int iA = aMin; iA < aLim; ++iA)
-                        result += a.Values[iA] * b.Values[a.Indices[iA] - offset];
+                        result += aValues[iA] * bValues[aIndices[iA] - offset];
                     return result;
                 }
                 for (int iA = aMin, iB = 0; iA < aLim && iB < b.Count; )
                 {
-                    int aIndex = a.Indices[iA];
-                    int bIndex = b.Indices[iB];
+                    int aIndex = aIndices[iA];
+                    int bIndex = bIndices[iB];
                     int comp = (aIndex - offset) - bIndex;
                     if (comp == 0)
-                        result += a.Values[iA++] * b.Values[iB++];
+                        result += aValues[iA++] * bValues[iB++];
                     else if (comp < 0)
                         iA++;
                     else
@@ -314,16 +307,16 @@ namespace Microsoft.ML.Runtime.Numeric
                 return 0;
 
             if (b.IsDense)
-                return CpuMathUtils.DotProductDense(a.AsSpan(offset), b.Values, b.Length);
-            return CpuMathUtils.DotProductSparse(a.AsSpan(offset), b.Values, b.Indices, b.Count);
+                return CpuMathUtils.DotProductDense(a.AsSpan(offset), b.GetValues(), b.Length);
+            return CpuMathUtils.DotProductSparse(a.AsSpan(offset), b.GetValues(), b.GetIndices(), b.Count);
         }
 
-        private static Float DotProductSparse(Float[] aValues, int[] aIndices, int ia, int iaLim, Float[] bValues, int[] bIndices, int ib, int ibLim, int offset)
+        private static Float DotProductSparse(ReadOnlySpan<Float> aValues, ReadOnlySpan<int> aIndices, int ia, int iaLim, ReadOnlySpan<Float> bValues, ReadOnlySpan<int> bIndices, int ib, int ibLim)
         {
-            Contracts.AssertValue(aValues);
-            Contracts.AssertValue(aIndices);
-            Contracts.AssertValue(bValues);
-            Contracts.AssertValue(bIndices);
+            Contracts.AssertNonEmpty(aValues);
+            Contracts.AssertNonEmpty(aIndices);
+            Contracts.AssertNonEmpty(bValues);
+            Contracts.AssertNonEmpty(bIndices);
             Contracts.Assert(0 <= ia && ia < iaLim && iaLim <= aIndices.Length);
             Contracts.Assert(0 <= ib && ib < ibLim && ibLim <= bIndices.Length);
 
@@ -334,7 +327,7 @@ namespace Microsoft.ML.Runtime.Numeric
 
             for (; ; )
             {
-                int d = aIndices[ia] - offset - bIndices[ib];
+                int d = aIndices[ia] - bIndices[ib];
                 if (d == 0)
                 {
                     res += aValues[ia] * bValues[ib];
@@ -347,7 +340,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 {
                     ia++;
                     if (d < -thresh)
-                        ia = Utils.FindIndexSorted(aIndices, ia, iaLim, bIndices[ib] + offset);
+                        ia = Utils.FindIndexSorted(aIndices, ia, iaLim, bIndices[ib]);
                     if (ia >= iaLim)
                         break;
                 }
@@ -355,7 +348,7 @@ namespace Microsoft.ML.Runtime.Numeric
                 {
                     ib++;
                     if (d > thresh)
-                        ib = Utils.FindIndexSorted(bIndices, ib, ibLim, aIndices[ia] - offset);
+                        ib = Utils.FindIndexSorted(bIndices, ib, ibLim, aIndices[ia]);
                     if (ib >= ibLim)
                         break;
                 }
@@ -401,12 +394,12 @@ namespace Microsoft.ML.Runtime.Numeric
             if (a.IsDense)
             {
                 if (b.IsDense)
-                    return L2DiffSquaredDense(a.Values, b.Values, b.Length);
-                return L2DistSquaredHalfSparse(a.Values, a.Length, b.Values, b.Indices, b.Count);
+                    return L2DiffSquaredDense(a.GetValues(), b.GetValues(), b.Length);
+                return L2DistSquaredHalfSparse(a.GetValues(), b.GetValues(), b.GetIndices());
             }
             if (b.IsDense)
-                return L2DistSquaredHalfSparse(b.Values, b.Length, a.Values, a.Indices, a.Count);
-            return L2DistSquaredSparse(a.Values, a.Indices, a.Count, b.Values, b.Indices, b.Count, a.Length);
+                return L2DistSquaredHalfSparse(b.GetValues(), a.GetValues(), a.GetIndices());
+            return L2DistSquaredSparse(a.GetValues(), a.GetIndices(), b.GetValues(), b.GetIndices());
         }
 
         /// <summary>
@@ -420,8 +413,8 @@ namespace Microsoft.ML.Runtime.Numeric
             Contracts.CheckValue(a, nameof(a));
             Contracts.Check(Utils.Size(a) == b.Length, "Vectors must have the same dimensionality.");
             if (b.IsDense)
-                return L2DiffSquaredDense(a, b.Values, b.Length);
-            return L2DistSquaredHalfSparse(a, a.Length, b.Values, b.Indices, b.Count);
+                return L2DiffSquaredDense(a, b.GetValues(), b.Length);
+            return L2DistSquaredHalfSparse(a.AsSpan(0, a.Length), b.GetValues(), b.GetIndices());
         }
 
         /// <summary>
@@ -451,12 +444,14 @@ namespace Microsoft.ML.Runtime.Numeric
             if (src.Count == 0 || c == 0)
                 return;
 
+            var srcValues = src.GetValues();
             if (src.IsDense)
-                CpuMathUtils.AddScale(c, src.Values, dst, src.Count);
+                CpuMathUtils.AddScale(c, srcValues, dst, src.Count);
             else
             {
+                var srcIndices = src.GetIndices();
                 for (int i = 0; i < src.Count; i++)
-                    dst[src.Indices[i]] += c * src.Values[i];
+                    dst[srcIndices[i]] += c * srcValues[i];
             }
         }
 
@@ -477,15 +472,17 @@ namespace Microsoft.ML.Runtime.Numeric
             if (src.Count == 0 || c == 0)
                 return;
 
+            var srcValues = src.GetValues();
             if (src.IsDense)
             {
                 for (int i = 0; i < src.Length; i++)
-                    dst[i + offset] += c * src.Values[i];
+                    dst[i + offset] += c * srcValues[i];
             }
             else
             {
+                var srcIndices = src.GetIndices();
                 for (int i = 0; i < src.Count; i++)
-                    dst[src.Indices[i] + offset] += c * src.Values[i];
+                    dst[srcIndices[i] + offset] += c * srcValues[i];
             }
         }
 

--- a/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Runtime.Numeric
 
             if (a.IsDense && dst.IsDense)
             {
-                var mutation = VBufferMutationContext.CreateFromBuffer(ref dst);
+                var mutation = VBufferEditor.CreateFromBuffer(ref dst);
                 CpuMathUtils.MulElementWise(a.GetValues(), dst.GetValues(), mutation.Values, a.Length);
             }
             else

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -615,7 +615,7 @@ namespace Microsoft.ML.Runtime.Data
             var keyNamesVBuffer = new VBuffer<ReadOnlyMemory<char>>(keyNames.Count, keyNames.Keys.ToArray());
             ValueGetter<VBuffer<ReadOnlyMemory<char>>> keyValueGetter =
                     (ref VBuffer<ReadOnlyMemory<char>> dst) =>
-                        dst = new VBuffer<ReadOnlyMemory<char>>(keyNamesVBuffer.Length, keyNamesVBuffer.Count, keyNamesVBuffer.Values, keyNamesVBuffer.Indices);
+                        keyNamesVBuffer.CopyTo(ref dst);
 
             // For each input data view, create the reconciled key column by wrapping it in a LambdaColumnMapper.
             for (int i = 0; i < dvCount; i++)
@@ -683,7 +683,7 @@ namespace Microsoft.ML.Runtime.Data
             var keyNamesVBuffer = new VBuffer<ReadOnlyMemory<char>>(keyNames.Count, keyNames.Keys.ToArray());
             ValueGetter<VBuffer<ReadOnlyMemory<char>>> keyValueGetter =
                     (ref VBuffer<ReadOnlyMemory<char>> dst) =>
-                        dst = new VBuffer<ReadOnlyMemory<char>>(keyNamesVBuffer.Length, keyNamesVBuffer.Count, keyNamesVBuffer.Values, keyNamesVBuffer.Indices);
+                        keyNamesVBuffer.CopyTo(ref dst);
 
             for (int i = 0; i < dvCount; i++)
             {

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -692,7 +692,7 @@ namespace Microsoft.ML.Runtime.Data
                     (in VBuffer<uint> src, ref VBuffer<uint> dst) =>
                     {
                         var srcValues = src.GetValues();
-                        var mutation = VBufferEditor.Create(
+                        var editor = VBufferEditor.Create(
                             ref dst,
                             src.Length,
                             srcValues.Length);
@@ -701,9 +701,9 @@ namespace Microsoft.ML.Runtime.Data
                             for (int j = 0; j < src.Length; j++)
                             {
                                 if (srcValues[j] == 0 || srcValues[j] > keyMapperCur.Length)
-                                    mutation.Values[j] = 0;
+                                    editor.Values[j] = 0;
                                 else
-                                    mutation.Values[j] = (uint)keyMapperCur[srcValues[j] - 1] + 1;
+                                    editor.Values[j] = (uint)keyMapperCur[srcValues[j] - 1] + 1;
                             }
                         }
                         else
@@ -712,13 +712,13 @@ namespace Microsoft.ML.Runtime.Data
                             for (int j = 0; j < srcValues.Length; j++)
                             {
                                 if (srcValues[j] == 0 || srcValues[j] > keyMapperCur.Length)
-                                    mutation.Values[j] = 0;
+                                    editor.Values[j] = 0;
                                 else
-                                    mutation.Values[j] = (uint)keyMapperCur[srcValues[j] - 1] + 1;
-                                mutation.Indices[j] = srcIndices[j];
+                                    editor.Values[j] = (uint)keyMapperCur[srcValues[j] - 1] + 1;
+                                editor.Indices[j] = srcIndices[j];
                             }
                         }
-                        dst = mutation.Commit();
+                        dst = editor.Commit();
                     };
 
                 ValueGetter<VBuffer<ReadOnlyMemory<char>>> slotNamesGetter = null;

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -691,35 +691,34 @@ namespace Microsoft.ML.Runtime.Data
                 ValueMapper<VBuffer<uint>, VBuffer<uint>> mapper =
                     (in VBuffer<uint> src, ref VBuffer<uint> dst) =>
                     {
-                        var values = dst.Values;
-                        if (Utils.Size(values) < src.Count)
-                            values = new uint[src.Count];
+                        var srcValues = src.GetValues();
+                        var mutation = VBufferMutationContext.Create(
+                            ref dst,
+                            src.Length,
+                            srcValues.Length);
                         if (src.IsDense)
                         {
                             for (int j = 0; j < src.Length; j++)
                             {
-                                if (src.Values[j] == 0 || src.Values[j] > keyMapperCur.Length)
-                                    values[j] = 0;
+                                if (srcValues[j] == 0 || srcValues[j] > keyMapperCur.Length)
+                                    mutation.Values[j] = 0;
                                 else
-                                    values[j] = (uint)keyMapperCur[src.Values[j] - 1] + 1;
+                                    mutation.Values[j] = (uint)keyMapperCur[srcValues[j] - 1] + 1;
                             }
-                            dst = new VBuffer<uint>(src.Length, values, dst.Indices);
                         }
                         else
                         {
-                            var indices = dst.Indices;
-                            if (Utils.Size(indices) < src.Count)
-                                indices = new int[src.Count];
-                            for (int j = 0; j < src.Count; j++)
+                            var srcIndices = src.GetIndices();
+                            for (int j = 0; j < srcValues.Length; j++)
                             {
-                                if (src.Values[j] == 0 || src.Values[j] > keyMapperCur.Length)
-                                    values[j] = 0;
+                                if (srcValues[j] == 0 || srcValues[j] > keyMapperCur.Length)
+                                    mutation.Values[j] = 0;
                                 else
-                                    values[j] = (uint)keyMapperCur[src.Values[j] - 1] + 1;
-                                indices[j] = src.Indices[j];
+                                    mutation.Values[j] = (uint)keyMapperCur[srcValues[j] - 1] + 1;
+                                mutation.Indices[j] = srcIndices[j];
                             }
-                            dst = new VBuffer<uint>(src.Length, src.Count, values, indices);
                         }
+                        mutation.Complete(ref dst);
                     };
 
                 ValueGetter<VBuffer<ReadOnlyMemory<char>>> slotNamesGetter = null;
@@ -1388,9 +1387,10 @@ namespace Microsoft.ML.Runtime.Data
             var confusionTable = GetConfusionTableAsArray(confusionDataView, countCol, labelNames.Length,
                 labelIndexToConfIndexMap, numConfusionTableLabels, out precisionSums, out recallSums);
 
+            var predictedLabelNames = GetPredictedLabelNames(in labelNames, labelIndexToConfIndexMap);
             var confusionTableString = GetConfusionTableAsString(confusionTable, recallSums, precisionSums,
-               labelNames.Values.Where((t, i) => labelIndexToConfIndexMap[i] >= 0).ToArray(),
-               sampled: numConfusionTableLabels < labelNames.Count, binary: binary);
+               predictedLabelNames,
+               sampled: numConfusionTableLabels < labelNames.Length, binary: binary);
 
             int weightIndex;
             if (confusionDataView.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.Weight, out weightIndex))
@@ -1398,13 +1398,27 @@ namespace Microsoft.ML.Runtime.Data
                 confusionTable = GetConfusionTableAsArray(confusionDataView, weightIndex, labelNames.Length,
                    labelIndexToConfIndexMap, numConfusionTableLabels, out precisionSums, out recallSums);
                 weightedConfusionTable = GetConfusionTableAsString(confusionTable, recallSums, precisionSums,
-                    labelNames.Values.Where((t, i) => labelIndexToConfIndexMap[i] >= 0).ToArray(),
-                    sampled: numConfusionTableLabels < labelNames.Count, prefix: "Weighted ", binary: binary);
+                    predictedLabelNames,
+                    sampled: numConfusionTableLabels < labelNames.Length, prefix: "Weighted ", binary: binary);
             }
             else
                 weightedConfusionTable = null;
 
             return confusionTableString;
+        }
+
+        private static List<ReadOnlyMemory<char>> GetPredictedLabelNames(in VBuffer<ReadOnlyMemory<char>> labelNames, int[] labelIndexToConfIndexMap)
+        {
+            List<ReadOnlyMemory<char>> result = new List<ReadOnlyMemory<char>>();
+            var values = labelNames.GetValues();
+            for (int i = 0; i < values.Length; i++)
+            {
+                if (labelIndexToConfIndexMap[i] >= 0)
+                {
+                    result.Add(values[i]);
+                }
+            }
+            return result;
         }
 
         // This methods is given a data view and a column index of the counts, and computes three arrays: the confusion table,
@@ -1537,7 +1551,7 @@ namespace Microsoft.ML.Runtime.Data
 
         // Get a string representation of a confusion table.
         private static string GetConfusionTableAsString(double[][] confusionTable, double[] rowSums, double[] columnSums,
-            ReadOnlyMemory<char>[] predictedLabelNames, string prefix = "", bool sampled = false, bool binary = true)
+            List<ReadOnlyMemory<char>> predictedLabelNames, string prefix = "", bool sampled = false, bool binary = true)
         {
             int numLabels = Utils.Size(confusionTable);
 
@@ -1555,7 +1569,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 // The row label will also include the index, so a user can easily match against the header.
                 // In such a case, a label like "Foo" would be presented as something like "5. Foo".
-                rowDigitLen = Math.Max(predictedLabelNames.Length - 1, 0).ToString().Length;
+                rowDigitLen = Math.Max(predictedLabelNames.Count - 1, 0).ToString().Length;
                 Contracts.Assert(rowDigitLen >= 1);
                 rowLabelLen += rowDigitLen + 2;
             }

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -718,7 +718,7 @@ namespace Microsoft.ML.Runtime.Data
                                 mutation.Indices[j] = srcIndices[j];
                             }
                         }
-                        dst = mutation.CreateBuffer();
+                        dst = mutation.Commit();
                     };
 
                 ValueGetter<VBuffer<ReadOnlyMemory<char>>> slotNamesGetter = null;

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -692,7 +692,7 @@ namespace Microsoft.ML.Runtime.Data
                     (in VBuffer<uint> src, ref VBuffer<uint> dst) =>
                     {
                         var srcValues = src.GetValues();
-                        var mutation = VBufferMutationContext.Create(
+                        var mutation = VBufferEditor.Create(
                             ref dst,
                             src.Length,
                             srcValues.Length);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -718,7 +718,7 @@ namespace Microsoft.ML.Runtime.Data
                                 mutation.Indices[j] = srcIndices[j];
                             }
                         }
-                        mutation.Complete(ref dst);
+                        dst = mutation.CreateBuffer();
                     };
 
                 ValueGetter<VBuffer<ReadOnlyMemory<char>>> slotNamesGetter = null;

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -573,8 +573,8 @@ namespace Microsoft.ML.Runtime.Data
             {
                 VBuffer<double> Fetch(string name) => Fetch<VBuffer<double>>(ectx, overallResult, name);
 
-                Dcg = Fetch(RankerEvaluator.Dcg).Values;
-                Ndcg = Fetch(RankerEvaluator.Ndcg).Values;
+                Dcg = Fetch(RankerEvaluator.Dcg).GetValues().ToArray();
+                Ndcg = Fetch(RankerEvaluator.Ndcg).GetValues().ToArray();
             }
         }
     }

--- a/src/Microsoft.ML.Data/Transforms/ConcatTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConcatTransform.cs
@@ -722,7 +722,7 @@ namespace Microsoft.ML.Runtime.Data
                                         .MarkSensitive(MessageSensitivity.Schema);
                                 }
                                 dstLength = checked(dstLength + tmpBufs[i].Length);
-                                dstCount = checked(dstCount + tmpBufs[i].Count);
+                                dstCount = checked(dstCount + tmpBufs[i].GetValues().Length);
                             }
                             else
                             {
@@ -749,22 +749,24 @@ namespace Microsoft.ML.Runtime.Data
                                 if (_srcTypes[j].IsVector)
                                 {
                                     var buffer = tmpBufs[j];
-                                    Contracts.Assert(buffer.Count <= dstCount - count);
+                                    var bufferValues = buffer.GetValues();
+                                    Contracts.Assert(bufferValues.Length <= dstCount - count);
                                     Contracts.Assert(buffer.Length <= dstLength - offset);
                                     if (buffer.IsDense)
                                     {
-                                        for (int i = 0; i < buffer.Length; i++)
+                                        for (int i = 0; i < bufferValues.Length; i++)
                                         {
-                                            values[count] = buffer.Values[i];
+                                            values[count] = bufferValues[i];
                                             indices[count++] = offset + i;
                                         }
                                     }
                                     else
                                     {
-                                        for (int i = 0; i < buffer.Count; i++)
+                                        var bufferIndices = buffer.GetIndices();
+                                        for (int i = 0; i < bufferValues.Length; i++)
                                         {
-                                            values[count] = buffer.Values[i];
-                                            indices[count++] = offset + buffer.Indices[i];
+                                            values[count] = bufferValues[i];
+                                            indices[count++] = offset + bufferIndices[i];
                                         }
                                     }
                                     offset += buffer.Length;

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -701,8 +701,8 @@ namespace Microsoft.ML.Transforms
         // Delegates onto instance methods are more efficient than delegates onto static methods.
         private void VecTrivialGetter<TDst>(ref VBuffer<TDst> value)
         {
-            VBufferMutationContext.Create(ref value, 1, 0)
-                .Complete(ref value);
+            value = VBufferMutationContext.Create(ref value, 1, 0)
+                .CreateBuffer();
         }
 
         private Delegate MakeVecGetter(IRow input, int iinfo)

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -701,7 +701,8 @@ namespace Microsoft.ML.Transforms
         // Delegates onto instance methods are more efficient than delegates onto static methods.
         private void VecTrivialGetter<TDst>(ref VBuffer<TDst> value)
         {
-            value = new VBuffer<TDst>(1, 0, value.Values, value.Indices);
+            VBufferMutationContext.Create(ref value, 1, 0)
+                .Complete(ref value);
         }
 
         private Delegate MakeVecGetter(IRow input, int iinfo)

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -701,8 +701,7 @@ namespace Microsoft.ML.Transforms
         // Delegates onto instance methods are more efficient than delegates onto static methods.
         private void VecTrivialGetter<TDst>(ref VBuffer<TDst> value)
         {
-            value = VBufferMutationContext.Create(ref value, 1, 0)
-                .CreateBuffer();
+            VBufferUtils.Resize(ref value, 1, 0);
         }
 
         private Delegate MakeVecGetter(IRow input, int iinfo)

--- a/src/Microsoft.ML.Data/Transforms/HashTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/HashTransform.cs
@@ -756,7 +756,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     if (!src.IsDense)
                         src.GetIndices().CopyTo(mutation.Indices);
 
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
             }
             // It is not sparsity preserving.
@@ -784,7 +784,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     for (int i = 0; i < srcValues.Length; ++i)
                         mutation.Values[srcIndices[i]] = hasher.HashCore(seed, mask, srcValues[i]);
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             };
         }
 
@@ -826,7 +826,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         srcIndices.CopyTo(mutation.Indices);
 
                     }
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
             }
             // It is not sparsity preserving.
@@ -856,7 +856,7 @@ namespace Microsoft.ML.Transforms.Conversions
                             Contracts.Assert(false, "this should have never happened.");
                     }
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             };
         }
 

--- a/src/Microsoft.ML.Data/Transforms/HashTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/HashTransform.cs
@@ -749,7 +749,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         VBufferUtils.Resize(ref dst, src.Length, 0);
                         return;
                     }
-                    var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);
+                    var mutation = VBufferEditor.Create(ref dst, src.Length, srcValues.Length);
 
                     for (int i = 0; i < srcValues.Length; ++i)
                         mutation.Values[i] = hasher.HashCore(seed, mask, srcValues[i]);
@@ -763,7 +763,7 @@ namespace Microsoft.ML.Transforms.Conversions
             return (ref VBuffer<uint> dst) =>
             {
                 srcGetter(ref src);
-                var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+                var mutation = VBufferEditor.Create(ref dst, src.Length);
 
                 var srcValues = src.GetValues();
                 if (src.IsDense)
@@ -811,7 +811,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         VBufferUtils.Resize(ref dst, src.Length, 0);
                         return;
                     }
-                    var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);
+                    var mutation = VBufferEditor.Create(ref dst, src.Length, srcValues.Length);
 
                     if (src.IsDense)
                     {
@@ -833,7 +833,7 @@ namespace Microsoft.ML.Transforms.Conversions
             return (ref VBuffer<uint> dst) =>
             {
                 srcGetter(ref src);
-                var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+                var mutation = VBufferEditor.Create(ref dst, src.Length);
 
                 var srcValues = src.GetValues();
                 if (src.IsDense)

--- a/src/Microsoft.ML.Data/Transforms/HashTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/HashTransform.cs
@@ -746,8 +746,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     var srcValues = src.GetValues();
                     if (srcValues.Length == 0)
                     {
-                        dst = VBufferMutationContext.Create(ref dst, src.Length, 0)
-                            .CreateBuffer();
+                        VBufferUtils.Resize(ref dst, src.Length, 0);
                         return;
                     }
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);
@@ -809,8 +808,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     var srcValues = src.GetValues();
                     if (srcValues.Length == 0)
                     {
-                        dst = VBufferMutationContext.Create(ref dst, src.Length, 0)
-                            .CreateBuffer();
+                        VBufferUtils.Resize(ref dst, src.Length, 0);
                         return;
                     }
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);

--- a/src/Microsoft.ML.Data/Transforms/HashTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/HashTransform.cs
@@ -746,8 +746,8 @@ namespace Microsoft.ML.Transforms.Conversions
                     var srcValues = src.GetValues();
                     if (srcValues.Length == 0)
                     {
-                        VBufferMutationContext.Create(ref dst, src.Length, 0)
-                            .Complete(ref dst);
+                        dst = VBufferMutationContext.Create(ref dst, src.Length, 0)
+                            .CreateBuffer();
                         return;
                     }
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);
@@ -757,7 +757,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     if (!src.IsDense)
                         src.GetIndices().CopyTo(mutation.Indices);
 
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
             }
             // It is not sparsity preserving.
@@ -785,7 +785,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     for (int i = 0; i < srcValues.Length; ++i)
                         mutation.Values[srcIndices[i]] = hasher.HashCore(seed, mask, srcValues[i]);
                 }
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             };
         }
 
@@ -809,8 +809,8 @@ namespace Microsoft.ML.Transforms.Conversions
                     var srcValues = src.GetValues();
                     if (srcValues.Length == 0)
                     {
-                        VBufferMutationContext.Create(ref dst, src.Length, 0)
-                            .Complete(ref dst);
+                        dst = VBufferMutationContext.Create(ref dst, src.Length, 0)
+                            .CreateBuffer();
                         return;
                     }
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);
@@ -828,7 +828,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         srcIndices.CopyTo(mutation.Indices);
 
                     }
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
             }
             // It is not sparsity preserving.
@@ -858,7 +858,7 @@ namespace Microsoft.ML.Transforms.Conversions
                             Contracts.Assert(false, "this should have never happened.");
                     }
                 }
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             };
         }
 

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -412,7 +412,7 @@ namespace Microsoft.ML.Runtime.Data
             ctx.SaveTextStream("Terms.txt",
                 writer =>
                 {
-                    writer.WriteLine("# Number of terms = {0} of length {1}", v.Count, v.Length);
+                    writer.WriteLine("# Number of terms = {0} of length {1}", v.GetValues().Length, v.Length);
                     foreach (var pair in v.Items())
                     {
                         var text = pair.Value;

--- a/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
@@ -567,7 +567,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         int lenDst = checked(size * lenSrc);
                         var values = src.GetValues();
                         int cntSrc = values.Length;
-                        var mutation = VBufferMutationContext.Create(ref dst, lenDst, cntSrc);
+                        var mutation = VBufferEditor.Create(ref dst, lenDst, cntSrc);
 
                         int count = 0;
                         if (src.IsDense)

--- a/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
@@ -596,7 +596,7 @@ namespace Microsoft.ML.Transforms.Conversions
                                 mutation.Indices[count++] = indices[islot] * size + (int)key;
                             }
                         }
-                        mutation.Complete(ref dst, count);
+                        dst = mutation.CreateBuffer(count);
                     };
             }
 

--- a/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
@@ -523,8 +523,8 @@ namespace Microsoft.ML.Transforms.Conversions
                         Host.Check(cv == 0 || src.Length == cv);
 
                         // The indices are irrelevant in the bagging case.
-                        var values = src.Values;
-                        int count = src.Count;
+                        var values = src.GetValues();
+                        int count = values.Length;
                         for (int slot = 0; slot < count; slot++)
                         {
                             uint key = values[slot] - 1;
@@ -564,17 +564,11 @@ namespace Microsoft.ML.Transforms.Conversions
                         Host.Check(lenSrc == cv || cv == 0);
 
                         // Since we generate values in order, no need for a builder.
-                        var valuesDst = dst.Values;
-                        var indicesDst = dst.Indices;
-
                         int lenDst = checked(size * lenSrc);
-                        int cntSrc = src.Count;
-                        if (Utils.Size(valuesDst) < cntSrc)
-                            valuesDst = new float[cntSrc];
-                        if (Utils.Size(indicesDst) < cntSrc)
-                            indicesDst = new int[cntSrc];
+                        var values = src.GetValues();
+                        int cntSrc = values.Length;
+                        var mutation = VBufferMutationContext.Create(ref dst, lenDst, cntSrc);
 
-                        var values = src.Values;
                         int count = 0;
                         if (src.IsDense)
                         {
@@ -585,24 +579,24 @@ namespace Microsoft.ML.Transforms.Conversions
                                 uint key = values[slot] - 1;
                                 if (key >= (uint)size)
                                     continue;
-                                valuesDst[count] = 1;
-                                indicesDst[count++] = slot * size + (int)key;
+                                mutation.Values[count] = 1;
+                                mutation.Indices[count++] = slot * size + (int)key;
                             }
                         }
                         else
                         {
-                            var indices = src.Indices;
+                            var indices = src.GetIndices();
                             for (int islot = 0; islot < cntSrc; islot++)
                             {
                                 Host.Assert(count < cntSrc);
                                 uint key = values[islot] - 1;
                                 if (key >= (uint)size)
                                     continue;
-                                valuesDst[count] = 1;
-                                indicesDst[count++] = indices[islot] * size + (int)key;
+                                mutation.Values[count] = 1;
+                                mutation.Indices[count++] = indices[islot] * size + (int)key;
                             }
                         }
-                        dst = new VBuffer<float>(lenDst, count, valuesDst, indicesDst);
+                        mutation.Complete(ref dst, count);
                     };
             }
 

--- a/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
@@ -567,7 +567,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         int lenDst = checked(size * lenSrc);
                         var values = src.GetValues();
                         int cntSrc = values.Length;
-                        var mutation = VBufferEditor.Create(ref dst, lenDst, cntSrc);
+                        var editor = VBufferEditor.Create(ref dst, lenDst, cntSrc);
 
                         int count = 0;
                         if (src.IsDense)
@@ -579,8 +579,8 @@ namespace Microsoft.ML.Transforms.Conversions
                                 uint key = values[slot] - 1;
                                 if (key >= (uint)size)
                                     continue;
-                                mutation.Values[count] = 1;
-                                mutation.Indices[count++] = slot * size + (int)key;
+                                editor.Values[count] = 1;
+                                editor.Indices[count++] = slot * size + (int)key;
                             }
                         }
                         else
@@ -592,11 +592,11 @@ namespace Microsoft.ML.Transforms.Conversions
                                 uint key = values[islot] - 1;
                                 if (key >= (uint)size)
                                     continue;
-                                mutation.Values[count] = 1;
-                                mutation.Indices[count++] = indices[islot] * size + (int)key;
+                                editor.Values[count] = 1;
+                                editor.Indices[count++] = indices[islot] * size + (int)key;
                             }
                         }
-                        dst = mutation.CommitTruncated(count);
+                        dst = editor.CommitTruncated(count);
                     };
             }
 

--- a/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVectorTransform.cs
@@ -596,7 +596,7 @@ namespace Microsoft.ML.Transforms.Conversions
                                 mutation.Indices[count++] = indices[islot] * size + (int)key;
                             }
                         }
-                        dst = mutation.CreateBuffer(count);
+                        dst = mutation.CommitTruncated(count);
                     };
             }
 

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
@@ -356,14 +356,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             var size = _min.Length;
             Contracts.Check(value.Length == size);
             _trainCount++;
-            var count = value.Count;
+            var values = value.GetValues();
+            var count = values.Length;
             Contracts.Assert(0 <= count & count <= size);
             if (count == 0)
                 return;
 
             if (count == size)
             {
-                var values = value.Values;
                 for (int j = 0; j < count; j++)
                 {
                     var val = values[j];
@@ -373,8 +373,7 @@ namespace Microsoft.ML.Transforms.Normalizers
             }
             else
             {
-                var indices = value.Indices;
-                var values = value.Values;
+                var indices = value.GetIndices();
                 for (int k = 0; k < count; k++)
                 {
                     var val = values[k];
@@ -459,14 +458,14 @@ namespace Microsoft.ML.Transforms.Normalizers
         {
             _trainCount++;
             var size = _mean.Length;
-            var count = value.Count;
+            var values = value.GetValues();
+            var count = values.Length;
             Contracts.Assert(0 <= count & count <= size);
             if (count == 0)
                 return;
 
             if (count == size)
             {
-                var values = value.Values;
                 for (int j = 0; j < count; j++)
                 {
                     var origVal = values[j];
@@ -475,8 +474,7 @@ namespace Microsoft.ML.Transforms.Normalizers
             }
             else
             {
-                var indices = value.Indices;
-                var values = value.Values;
+                var indices = value.GetIndices();
                 for (int k = 0; k < count; k++)
                 {
                     var origVal = values[k];
@@ -706,7 +704,8 @@ namespace Microsoft.ML.Transforms.Normalizers
                     {
                         Contracts.Assert(input.Length == scale.Length);
                         int size = scale.Length;
-                        int count = input.Count;
+                        var values = input.GetValues();
+                        int count = values.Length;
                         Contracts.Assert(0 <= count & count <= size);
 
                         // We always start with sparse, since we may make things sparser than the source.
@@ -714,7 +713,6 @@ namespace Microsoft.ML.Transforms.Normalizers
                         if (count == 0)
                             return;
 
-                        var values = input.Values;
                         if (count >= size)
                         {
                             for (int i = 0; i < size; i++)
@@ -723,7 +721,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                         }
 
                         // The input is sparse.
-                        var indices = input.Indices;
+                        var indices = input.GetIndices();
                         for (int ii = 0; ii < count; ii++)
                         {
                             int i = indices[ii];
@@ -737,7 +735,8 @@ namespace Microsoft.ML.Transforms.Normalizers
                     {
                         Contracts.Assert(input.Length == scale.Length);
                         int size = scale.Length;
-                        int count = input.Count;
+                        var values = input.GetValues();
+                        int count = values.Length;
                         Contracts.Assert(0 <= count & count <= size);
 
                         // We always start with sparse, since we may make things sparser than the source.
@@ -750,7 +749,6 @@ namespace Microsoft.ML.Transforms.Normalizers
                             return;
                         }
 
-                        var values = input.Values;
                         if (count >= size)
                         {
                             for (int i = 0; i < size; i++)
@@ -759,7 +757,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                         }
 
                         // The input is sparse.
-                        var indices = input.Indices;
+                        var indices = input.GetIndices();
                         int ii = 0;
                         int ivSrc = indices[ii];
                         Contracts.Assert(ivSrc < size);
@@ -783,7 +781,8 @@ namespace Microsoft.ML.Transforms.Normalizers
                         Contracts.Assert(input.Length == scale.Length);
 
                         int size = scale.Length;
-                        int count = input.Count;
+                        var values = input.GetValues();
+                        int count = values.Length;
                         Contracts.Assert(0 <= count & count <= size);
 
                         // We always start with sparse, since we may make things sparser than the source.
@@ -796,7 +795,6 @@ namespace Microsoft.ML.Transforms.Normalizers
                             return;
                         }
 
-                        var values = input.Values;
                         if (count >= size)
                         {
                             for (int i = 0; i < size; i++)
@@ -805,7 +803,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                         }
 
                         // The input is sparse.
-                        var indices = input.Indices;
+                        var indices = input.GetIndices();
                         int ii = 0;
                         int ivSrc = indices[ii];
                         int inz = 0;
@@ -983,7 +981,8 @@ namespace Microsoft.ML.Transforms.Normalizers
                     {
                         Contracts.Assert(input.Length == mean.Length);
                         int size = mean.Length;
-                        int count = input.Count;
+                        var values = input.GetValues();
+                        int count = values.Length;
                         Contracts.Assert(0 <= count & count <= size);
 
                         // We always start with sparse, since we may make things sparser than the source.
@@ -992,7 +991,6 @@ namespace Microsoft.ML.Transforms.Normalizers
                         if (count == 0)
                             return;
 
-                        var values = input.Values;
                         if (count >= size)
                         {
                             for (int i = 0; i < size; i++)
@@ -1009,7 +1007,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                         }
 
                         // The input is sparse.
-                        var indices = input.Indices;
+                        var indices = input.GetIndices();
                         for (int ii = 0; ii < indices.Length; ii++)
                         {
                             var ivDst = indices[ii];
@@ -1101,14 +1099,14 @@ namespace Microsoft.ML.Transforms.Normalizers
                             (ref TFloat dst) =>
                             {
                                 getSrc(ref dst);
-                                GetResult(ref dst, ref dst);
+                                GetResult(dst, ref dst);
                             };
                         return del;
                     }
 
-                    private void GetResult(ref TFloat input, ref TFloat value)
+                    private void GetResult(TFloat input, ref TFloat value)
                     {
-                        value = BinUtils.GetValue(ref input, _binUpperBounds, _den, _offset);
+                        value = BinUtils.GetValue(input, _binUpperBounds, _den, _offset);
                     }
                 }
 
@@ -1197,7 +1195,8 @@ namespace Microsoft.ML.Transforms.Normalizers
                     {
                         Contracts.Assert(input.Length == _binUpperBounds.Length);
                         int size = _binUpperBounds.Length;
-                        int count = input.Count;
+                        var values = input.GetValues();
+                        int count = values.Length;
                         Contracts.Assert(0 <= count & count <= size);
 
                         // We always start with sparse, since we may make things sparser than the source.
@@ -1208,18 +1207,17 @@ namespace Microsoft.ML.Transforms.Normalizers
                             return;
                         }
 
-                        var values = input.Values;
                         if (count >= size)
                         {
                             if (_offset != null)
                             {
                                 for (int i = 0; i < size; i++)
-                                    bldr.AddFeature(i, BinUtils.GetValue(ref values[i], _binUpperBounds[i], _den[i], _offset[i]));
+                                    bldr.AddFeature(i, BinUtils.GetValue(values[i], _binUpperBounds[i], _den[i], _offset[i]));
                             }
                             else
                             {
                                 for (int i = 0; i < size; i++)
-                                    bldr.AddFeature(i, BinUtils.GetValue(ref values[i], _binUpperBounds[i], _den[i]));
+                                    bldr.AddFeature(i, BinUtils.GetValue(values[i], _binUpperBounds[i], _den[i]));
                             }
                             bldr.GetResult(ref value);
                             return;
@@ -1228,7 +1226,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                         // The input is sparse.
                         if (_offset != null)
                         {
-                            var indices = input.Indices;
+                            var indices = input.GetIndices();
                             int ii = 0;
                             int ivSrc = indices[ii];
                             Contracts.Assert(ivSrc < size);
@@ -1239,13 +1237,13 @@ namespace Microsoft.ML.Transforms.Normalizers
                                 if (ivDst == ivSrc)
                                 {
                                     bldr.AddFeature(ivDst,
-                                        BinUtils.GetValue(ref values[ii], _binUpperBounds[ivDst], _den[ivDst], _offset[ivDst]));
+                                        BinUtils.GetValue(values[ii], _binUpperBounds[ivDst], _den[ivDst], _offset[ivDst]));
                                     ivSrc = ++ii < count ? indices[ii] : size;
                                     Contracts.Assert(ii == count || ivSrc < size);
                                 }
                                 else
                                     bldr.AddFeature(ivDst,
-                                        BinUtils.GetValue(ref zero, _binUpperBounds[ivDst], _den[ivDst], _offset[ivDst]));
+                                        BinUtils.GetValue(zero, _binUpperBounds[ivDst], _den[ivDst], _offset[ivDst]));
                             }
                         }
                         else
@@ -1255,7 +1253,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                             {
                                 int i = indices[ii];
                                 Contracts.Assert(0 <= i & i < size);
-                                bldr.AddFeature(i, BinUtils.GetValue(ref values[ii], _binUpperBounds[i], _den[i]));
+                                bldr.AddFeature(i, BinUtils.GetValue(values[ii], _binUpperBounds[i], _den[i]));
                             }
                         }
 
@@ -1376,7 +1374,7 @@ namespace Microsoft.ML.Transforms.Normalizers
 
         internal static partial class BinUtils
         {
-            public static TFloat GetValue(ref TFloat input, TFloat[] binUpperBounds, TFloat den, TFloat offset)
+            public static TFloat GetValue(TFloat input, TFloat[] binUpperBounds, TFloat den, TFloat offset)
             {
                 if (TFloat.IsNaN(input))
                     return input;
@@ -1387,7 +1385,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 return value;
             }
 
-            public static TFloat GetValue(ref TFloat input, TFloat[] binUpperBounds, TFloat den)
+            public static TFloat GetValue(TFloat input, TFloat[] binUpperBounds, TFloat den)
             {
                 if (TFloat.IsNaN(input))
                     return input;
@@ -1803,21 +1801,20 @@ namespace Microsoft.ML.Transforms.Normalizers
                     int size = _values.Length;
                     Host.Check(buffer.Length == size);
 
-                    int count = buffer.Count;
+                    var values = buffer.GetValues();
+                    int count = values.Length;
                     Host.Assert(0 <= count & count <= size);
                     if (count == 0)
                         return true;
 
                     if (count == size)
                     {
-                        var values = buffer.Values;
                         for (int j = 0; j < count; j++)
                             _values[j].Add(values[j]);
                     }
                     else
                     {
-                        var indices = buffer.Indices;
-                        var values = buffer.Values;
+                        var indices = buffer.GetIndices();
                         for (int k = 0; k < count; k++)
                         {
                             var val = values[k];

--- a/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
+++ b/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
@@ -107,8 +107,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
             if (newLength == 0)
             {
                 // All slots dropped.
-                VBufferMutationContext.Create(ref dst, 1, 0)
-                    .Complete(ref dst);
+                dst = VBufferMutationContext.Create(ref dst, 1, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -140,7 +140,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                     mutation.Values[iDst++] = srcValues[iSrc++];
                 }
                 Contracts.Assert(iDst == newLength);
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
                 return;
             }
 
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                 Contracts.Assert(index <= max);
             }
 
-            mutation.Complete(ref dst, iiDst);
+            dst = mutation.CreateBuffer(iiDst);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
+++ b/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
@@ -115,11 +115,11 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
 
             // End of the trivial cases
             // At this point, we need to drop some slots and keep some slots.
-            VBufferMutationContext<TDst> mutation;
+            VBufferEditor<TDst> mutation;
             var srcValues = src.GetValues();
             if (src.IsDense)
             {
-                mutation = VBufferMutationContext.Create(ref dst, newLength);
+                mutation = VBufferEditor.Create(ref dst, newLength);
 
                 int iDst = 0;
                 int iSrc = 0;
@@ -151,7 +151,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
 
             Contracts.Assert(newCount <= src.Length);
 
-            mutation = VBufferMutationContext.Create(
+            mutation = VBufferEditor.Create(
                 ref dst,
                 newLength,
                 newCount,

--- a/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
+++ b/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
@@ -139,7 +139,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                     mutation.Values[iDst++] = srcValues[iSrc++];
                 }
                 Contracts.Assert(iDst == newLength);
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
                 return;
             }
 
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                 Contracts.Assert(index <= max);
             }
 
-            dst = mutation.CreateBuffer(iiDst);
+            dst = mutation.CommitTruncated(iiDst);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
+++ b/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
@@ -115,11 +115,11 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
 
             // End of the trivial cases
             // At this point, we need to drop some slots and keep some slots.
-            VBufferEditor<TDst> mutation;
+            VBufferEditor<TDst> editor;
             var srcValues = src.GetValues();
             if (src.IsDense)
             {
-                mutation = VBufferEditor.Create(ref dst, newLength);
+                editor = VBufferEditor.Create(ref dst, newLength);
 
                 int iDst = 0;
                 int iSrc = 0;
@@ -129,17 +129,17 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                     while (iSrc < lim)
                     {
                         Contracts.Assert(iDst <= iSrc);
-                        mutation.Values[iDst++] = srcValues[iSrc++];
+                        editor.Values[iDst++] = srcValues[iSrc++];
                     }
                     iSrc = SlotsMax[i] + 1;
                 }
                 while (iSrc < src.Length)
                 {
                     Contracts.Assert(iDst <= iSrc);
-                    mutation.Values[iDst++] = srcValues[iSrc++];
+                    editor.Values[iDst++] = srcValues[iSrc++];
                 }
                 Contracts.Assert(iDst == newLength);
-                dst = mutation.Commit();
+                dst = editor.Commit();
                 return;
             }
 
@@ -151,7 +151,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
 
             Contracts.Assert(newCount <= src.Length);
 
-            mutation = VBufferEditor.Create(
+            editor = VBufferEditor.Create(
                 ref dst,
                 newLength,
                 newCount,
@@ -172,8 +172,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                 if (index < min)
                 {
                     Contracts.Assert(iiDst <= iiSrc);
-                    mutation.Indices[iiDst] = index - iOffset;
-                    mutation.Values[iiDst++] = srcValues[iiSrc++];
+                    editor.Indices[iiDst] = index - iOffset;
+                    editor.Values[iiDst++] = srcValues[iiSrc++];
                     continue;
                 }
                 if (index <= max)
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                 Contracts.Assert(index <= max);
             }
 
-            dst = mutation.CommitTruncated(iiDst);
+            dst = editor.CommitTruncated(iiDst);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
+++ b/src/Microsoft.ML.Data/Utilities/SlotDropper.cs
@@ -107,8 +107,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
             if (newLength == 0)
             {
                 // All slots dropped.
-                dst = VBufferMutationContext.Create(ref dst, 1, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref dst, 1, 0);
                 return;
             }
 

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length);
                     for (int i = 0; i < srcValues.Length; i++)
                         mutation.Values[i] = !includedIndices[i] ? defaultValue : srcValues[i];
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 }
                 else
                 {
@@ -75,7 +75,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     }
 
                     Contracts.Assert(count == cardinality);
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 }
             }
             else
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     }
                 }
 
-                mutation.Complete(ref dst, count);
+                dst = mutation.CreateBuffer(count);
             }
         }
     }

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -47,27 +47,20 @@ namespace Microsoft.ML.Runtime.Ensemble
             Contracts.Assert(cardinality == Utils.GetCardinality(includedIndices));
             Contracts.Assert(cardinality < src.Length);
 
-            var values = dst.Values;
-            var indices = dst.Indices;
-
             var srcValues = src.GetValues();
             if (src.IsDense)
             {
                 if (cardinality >= src.Length / 2)
                 {
                     T defaultValue = default;
-                    if (Utils.Size(values) < src.Length)
-                        values = new T[src.Length];
+                    var mutation = VBufferMutationContext.Create(ref dst, src.Length);
                     for (int i = 0; i < srcValues.Length; i++)
-                        values[i] = !includedIndices[i] ? defaultValue : srcValues[i];
-                    dst = new VBuffer<T>(src.Length, values, indices);
+                        mutation.Values[i] = !includedIndices[i] ? defaultValue : srcValues[i];
+                    mutation.Complete(ref dst);
                 }
                 else
                 {
-                    if (Utils.Size(values) < cardinality)
-                        values = new T[cardinality];
-                    if (Utils.Size(indices) < cardinality)
-                        indices = new int[cardinality];
+                    var mutation = VBufferMutationContext.Create(ref dst, src.Length, cardinality);
 
                     int count = 0;
                     for (int i = 0; i < srcValues.Length; i++)
@@ -75,28 +68,19 @@ namespace Microsoft.ML.Runtime.Ensemble
                         if (includedIndices[i])
                         {
                             Contracts.Assert(count < cardinality);
-                            values[count] = srcValues[i];
-                            indices[count] = i;
+                            mutation.Values[count] = srcValues[i];
+                            mutation.Indices[count] = i;
                             count++;
                         }
                     }
 
                     Contracts.Assert(count == cardinality);
-                    dst = new VBuffer<T>(src.Length, count, values, indices);
+                    mutation.Complete(ref dst);
                 }
             }
             else
             {
-                int valuesSize = Utils.Size(values);
-                int indicesSize = Utils.Size(indices);
-
-                if (valuesSize < srcValues.Length || indicesSize < srcValues.Length)
-                {
-                    if (valuesSize < cardinality)
-                        values = new T[cardinality];
-                    if (indicesSize < cardinality)
-                        indices = new int[cardinality];
-                }
+                var mutation = VBufferMutationContext.Create(ref dst, src.Length, cardinality);
 
                 int count = 0;
                 var srcIndices = src.GetIndices();
@@ -104,13 +88,14 @@ namespace Microsoft.ML.Runtime.Ensemble
                 {
                     if (includedIndices[srcIndices[i]])
                     {
-                        values[count] = srcValues[i];
-                        indices[count] = srcIndices[i];
+                        mutation.Values[count] = srcValues[i];
+                        mutation.Indices[count] = srcIndices[i];
                         count++;
                     }
                 }
 
-                dst = new VBuffer<T>(src.Length, count, values, indices);
+                // TODO: eerhardt - this should be new VBuffer(src.Length, count);
+                mutation.Complete(ref dst);
             }
         }
     }

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     var mutation = VBufferMutationContext.Create(ref dst, src.Length);
                     for (int i = 0; i < srcValues.Length; i++)
                         mutation.Values[i] = !includedIndices[i] ? defaultValue : srcValues[i];
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 }
                 else
                 {
@@ -75,7 +75,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     }
 
                     Contracts.Assert(count == cardinality);
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 }
             }
             else
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     }
                 }
 
-                dst = mutation.CreateBuffer(count);
+                dst = mutation.CommitTruncated(count);
             }
         }
     }

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -94,8 +94,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     }
                 }
 
-                // TODO: eerhardt - this should be new VBuffer(src.Length, count);
-                mutation.Complete(ref dst);
+                mutation.Complete(ref dst, count);
             }
         }
     }

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -53,14 +53,14 @@ namespace Microsoft.ML.Runtime.Ensemble
                 if (cardinality >= src.Length / 2)
                 {
                     T defaultValue = default;
-                    var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+                    var mutation = VBufferEditor.Create(ref dst, src.Length);
                     for (int i = 0; i < srcValues.Length; i++)
                         mutation.Values[i] = !includedIndices[i] ? defaultValue : srcValues[i];
                     dst = mutation.Commit();
                 }
                 else
                 {
-                    var mutation = VBufferMutationContext.Create(ref dst, src.Length, cardinality);
+                    var mutation = VBufferEditor.Create(ref dst, src.Length, cardinality);
 
                     int count = 0;
                     for (int i = 0; i < srcValues.Length; i++)
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             }
             else
             {
-                var mutation = VBufferMutationContext.Create(ref dst, src.Length, cardinality);
+                var mutation = VBufferEditor.Create(ref dst, src.Length, cardinality);
 
                 int count = 0;
                 var srcIndices = src.GetIndices();

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -53,14 +53,14 @@ namespace Microsoft.ML.Runtime.Ensemble
                 if (cardinality >= src.Length / 2)
                 {
                     T defaultValue = default;
-                    var mutation = VBufferEditor.Create(ref dst, src.Length);
+                    var editor = VBufferEditor.Create(ref dst, src.Length);
                     for (int i = 0; i < srcValues.Length; i++)
-                        mutation.Values[i] = !includedIndices[i] ? defaultValue : srcValues[i];
-                    dst = mutation.Commit();
+                        editor.Values[i] = !includedIndices[i] ? defaultValue : srcValues[i];
+                    dst = editor.Commit();
                 }
                 else
                 {
-                    var mutation = VBufferEditor.Create(ref dst, src.Length, cardinality);
+                    var editor = VBufferEditor.Create(ref dst, src.Length, cardinality);
 
                     int count = 0;
                     for (int i = 0; i < srcValues.Length; i++)
@@ -68,19 +68,19 @@ namespace Microsoft.ML.Runtime.Ensemble
                         if (includedIndices[i])
                         {
                             Contracts.Assert(count < cardinality);
-                            mutation.Values[count] = srcValues[i];
-                            mutation.Indices[count] = i;
+                            editor.Values[count] = srcValues[i];
+                            editor.Indices[count] = i;
                             count++;
                         }
                     }
 
                     Contracts.Assert(count == cardinality);
-                    dst = mutation.Commit();
+                    dst = editor.Commit();
                 }
             }
             else
             {
-                var mutation = VBufferEditor.Create(ref dst, src.Length, cardinality);
+                var editor = VBufferEditor.Create(ref dst, src.Length, cardinality);
 
                 int count = 0;
                 var srcIndices = src.GetIndices();
@@ -88,13 +88,13 @@ namespace Microsoft.ML.Runtime.Ensemble
                 {
                     if (includedIndices[srcIndices[i]])
                     {
-                        mutation.Values[count] = srcValues[i];
-                        mutation.Indices[count] = srcIndices[i];
+                        editor.Values[count] = srcValues[i];
+                        editor.Indices[count] = srcIndices[i];
                         count++;
                     }
                 }
 
-                dst = mutation.CommitTruncated(count);
+                dst = editor.CommitTruncated(count);
             }
         }
     }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
@@ -35,11 +35,11 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 return;
             }
 
-            var mutation = VBufferEditor.Create(ref dst, len);
-            if (!mutation.CreatedNewValues)
-                mutation.Values.Clear();
+            var editor = VBufferEditor.Create(ref dst, len);
+            if (!editor.CreatedNewValues)
+                editor.Values.Clear();
             // Set the output to values.
-            dst = mutation.Commit();
+            dst = editor.Commit();
 
             Single weightTotal;
             if (weights == null)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             if (!mutation.CreatedNewValues)
                 mutation.Values.Clear();
             // Set the output to values.
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
 
             Single weightTotal;
             if (weights == null)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 return;
             }
 
-            var mutation = VBufferMutationContext.Create(ref dst, len);
+            var mutation = VBufferEditor.Create(ref dst, len);
             if (!mutation.CreatedNewValues)
                 mutation.Values.Clear();
             // Set the output to values.

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
@@ -35,14 +35,11 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 return;
             }
 
-            var values = dst.Values;
-            if (Utils.Size(values) < len)
-                values = new Single[len];
-            else
-                Array.Clear(values, 0, len);
-
+            var mutation = VBufferMutationContext.Create(ref dst, len);
+            if (!mutation.CreatedNewValues)
+                mutation.Values.Clear();
             // Set the output to values.
-            dst = new VBuffer<Single>(len, values, dst.Indices);
+            mutation.Complete(ref dst);
 
             Single weightTotal;
             if (weights == null)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiAverager.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             if (!mutation.CreatedNewValues)
                 mutation.Values.Clear();
             // Set the output to values.
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
 
             Single weightTotal;
             if (weights == null)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
@@ -98,12 +98,10 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         protected void GetNaNOutput(ref VBuffer<Single> dst, int len)
         {
             Contracts.Assert(len >= 0);
-            var values = dst.Values;
-            if (Utils.Size(values) < len)
-                values = new Single[len];
+            var mutation = VBufferMutationContext.Create(ref dst, len);
             for (int i = 0; i < len; i++)
-                values[i] = Single.NaN;
-            dst = new VBuffer<Single>(len, values, dst.Indices);
+                mutation.Values[i] = Single.NaN;
+            mutation.Complete(ref dst);
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             var mutation = VBufferMutationContext.Create(ref dst, len);
             for (int i = 0; i < len; i++)
                 mutation.Values[i] = Single.NaN;
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         protected void GetNaNOutput(ref VBuffer<Single> dst, int len)
         {
             Contracts.Assert(len >= 0);
-            var mutation = VBufferMutationContext.Create(ref dst, len);
+            var mutation = VBufferEditor.Create(ref dst, len);
             for (int i = 0; i < len; i++)
                 mutation.Values[i] = Single.NaN;
             dst = mutation.Commit();

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
@@ -98,10 +98,10 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         protected void GetNaNOutput(ref VBuffer<Single> dst, int len)
         {
             Contracts.Assert(len >= 0);
-            var mutation = VBufferEditor.Create(ref dst, len);
+            var editor = VBufferEditor.Create(ref dst, len);
             for (int i = 0; i < len; i++)
-                mutation.Values[i] = Single.NaN;
-            dst = mutation.Commit();
+                editor.Values[i] = Single.NaN;
+            dst = editor.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseMultiCombiner.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             var mutation = VBufferMutationContext.Create(ref dst, len);
             for (int i = 0; i < len; i++)
                 mutation.Values[i] = Single.NaN;
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
@@ -25,9 +25,9 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         {
             Contracts.AssertNonEmpty(src);
             int len = src.Length;
-            var mutation = VBufferEditor.Create(ref dst, len);
-            src.CopyTo(mutation.Values);
-            dst = mutation.Commit();
+            var editor = VBufferEditor.Create(ref dst, len);
+            src.CopyTo(editor.Values);
+            dst = editor.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
@@ -25,11 +25,9 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         {
             Contracts.AssertNonEmpty(src);
             int len = src.Length;
-            var values = dst.Values;
-            if (Utils.Size(values) < len)
-                values = new Single[len];
-            Array.Copy(src, values, len);
-            dst = new VBuffer<Single>(len, values, dst.Indices);
+            var mutation = VBufferMutationContext.Create(ref dst, len);
+            src.CopyTo(mutation.Values);
+            mutation.Complete(ref dst);
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
         {
             Contracts.AssertNonEmpty(src);
             int len = src.Length;
-            var mutation = VBufferMutationContext.Create(ref dst, len);
+            var mutation = VBufferEditor.Create(ref dst, len);
             src.CopyTo(mutation.Values);
             dst = mutation.Commit();
         }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             int len = src.Length;
             var mutation = VBufferMutationContext.Create(ref dst, len);
             src.CopyTo(mutation.Values);
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/BaseScalarStacking.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             int len = src.Length;
             var mutation = VBufferMutationContext.Create(ref dst, len);
             src.CopyTo(mutation.Values);
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
@@ -81,9 +81,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                         return;
                     }
 
-                    var values = dst.Values;
-                    if (Utils.Size(values) < len)
-                        values = new Single[len];
+                    var mutation = VBufferMutationContext.Create(ref dst, len);
 
                     int count = src.Length;
                     if (Utils.Size(raw) < count)
@@ -92,11 +90,11 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                     {
                         for (int j = 0; j < count; j++)
                             raw[j] = i < src[j].Length ? src[j].GetItemOrDefault(i) : 0;
-                        values[i] = MathUtils.GetMedianInPlace(raw, count);
+                        mutation.Values[i] = MathUtils.GetMedianInPlace(raw, count);
                     }
 
                     // Set the output to values.
-                    dst = new VBuffer<Single>(len, values, dst.Indices);
+                    mutation.Complete(ref dst);
                 };
         }
     }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                         return;
                     }
 
-                    var mutation = VBufferMutationContext.Create(ref dst, len);
+                    var mutation = VBufferEditor.Create(ref dst, len);
 
                     int count = src.Length;
                     if (Utils.Size(raw) < count)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                         return;
                     }
 
-                    var mutation = VBufferEditor.Create(ref dst, len);
+                    var editor = VBufferEditor.Create(ref dst, len);
 
                     int count = src.Length;
                     if (Utils.Size(raw) < count)
@@ -90,11 +90,11 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                     {
                         for (int j = 0; j < count; j++)
                             raw[j] = i < src[j].Length ? src[j].GetItemOrDefault(i) : 0;
-                        mutation.Values[i] = MathUtils.GetMedianInPlace(raw, count);
+                        editor.Values[i] = MathUtils.GetMedianInPlace(raw, count);
                     }
 
                     // Set the output to values.
-                    dst = mutation.Commit();
+                    dst = editor.Commit();
                 };
         }
     }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                     }
 
                     // Set the output to values.
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
         }
     }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiMedian.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                     }
 
                     // Set the output to values.
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
         }
     }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 Contracts.Assert(iv <= len);
             }
             Contracts.Assert(iv == len);
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
@@ -83,17 +83,17 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             for (int i = 0; i < src.Length; i++)
                 len += src[i].Length;
 
-            var mutation = VBufferEditor.Create(ref dst, len);
+            var editor = VBufferEditor.Create(ref dst, len);
 
             int iv = 0;
             for (int i = 0; i < src.Length; i++)
             {
-                src[i].CopyTo(mutation.Values, iv);
+                src[i].CopyTo(editor.Values, iv);
                 iv += src[i].Length;
                 Contracts.Assert(iv <= len);
             }
             Contracts.Assert(iv == len);
-            dst = mutation.Commit();
+            dst = editor.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
@@ -83,19 +83,17 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             for (int i = 0; i < src.Length; i++)
                 len += src[i].Length;
 
-            var values = dst.Values;
-            if (Utils.Size(values) < len)
-                values = new Single[len];
-            dst = new VBuffer<Single>(len, values, dst.Indices);
+            var mutation = VBufferMutationContext.Create(ref dst, len);
 
             int iv = 0;
             for (int i = 0; i < src.Length; i++)
             {
-                src[i].CopyTo(values, iv);
+                src[i].CopyTo(mutation.Values, iv);
                 iv += src[i].Length;
                 Contracts.Assert(iv <= len);
             }
             Contracts.Assert(iv == len);
+            mutation.Complete(ref dst);
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             for (int i = 0; i < src.Length; i++)
                 len += src[i].Length;
 
-            var mutation = VBufferMutationContext.Create(ref dst, len);
+            var mutation = VBufferEditor.Create(ref dst, len);
 
             int iv = 0;
             for (int i = 0; i < src.Length; i++)

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiStacking.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 Contracts.Assert(iv <= len);
             }
             Contracts.Assert(iv == len);
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
@@ -82,9 +82,9 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             }
 
             int len = GetClassCount(src);
-            var mutation = VBufferEditor.Create(ref dst, len);
-            if (!mutation.CreatedNewValues)
-                mutation.Values.Clear();
+            var editor = VBufferEditor.Create(ref dst, len);
+            if (!editor.CreatedNewValues)
+                editor.Values.Clear();
 
             int voteCount = 0;
             for (int i = 0; i < count; i++)
@@ -92,17 +92,17 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 int index = VectorUtils.ArgMax(in src[i]);
                 if (index >= 0)
                 {
-                    mutation.Values[index]++;
+                    editor.Values[index]++;
                     voteCount++;
                 }
             }
 
             // Normalize by dividing by the number of votes.
             for (int i = 0; i < len; i++)
-                mutation.Values[i] /= voteCount;
+                editor.Values[i] /= voteCount;
 
             // Set the output to values.
-            dst = mutation.Commit();
+            dst = editor.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 mutation.Values[i] /= voteCount;
 
             // Set the output to values.
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             }
 
             int len = GetClassCount(src);
-            var mutation = VBufferMutationContext.Create(ref dst, len);
+            var mutation = VBufferEditor.Create(ref dst, len);
             if (!mutation.CreatedNewValues)
                 mutation.Values.Clear();
 

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
@@ -77,8 +77,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             int count = Utils.Size(src);
             if (count == 0)
             {
-                dst = VBufferMutationContext.Create(ref dst, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref dst, 0);
                 return;
             }
 

--- a/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
+++ b/src/Microsoft.ML.Ensemble/OutputCombiners/MultiVoting.cs
@@ -77,8 +77,8 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
             int count = Utils.Size(src);
             if (count == 0)
             {
-                VBufferMutationContext.Create(ref dst, 0)
-                    .Complete(ref dst);
+                dst = VBufferMutationContext.Create(ref dst, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Runtime.Ensemble.OutputCombiners
                 mutation.Values[i] /= voteCount;
 
             // Set the output to values.
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.FastTree/BinFile/BinFinder.cs
+++ b/src/Microsoft.ML.FastTree/BinFile/BinFinder.cs
@@ -54,9 +54,9 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
         /// <paramref name="counts"/></returns>
         private int FindDistinctCounts(in VBuffer<Double> values, double[] valueBuffer, double[] distinctValues, int[] counts)
         {
-            var valueValues = values.GetValues();
-            var valuesCount = valueValues.Length;
-            if (valuesCount == 0)
+            var explicitValues = values.GetValues();
+            var explicitValuesCount = explicitValues.Length;
+            if (explicitValuesCount == 0)
             {
                 if (values.Length == 0)
                     return 0;
@@ -66,9 +66,9 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             }
 
             // Get histogram of values
-            Contracts.Assert(valueBuffer.Length >= valuesCount);
-            valueValues.CopyTo(valueBuffer);
-            Array.Sort(valueBuffer, 0, valuesCount);
+            Contracts.Assert(valueBuffer.Length >= explicitValuesCount);
+            explicitValues.CopyTo(valueBuffer);
+            Array.Sort(valueBuffer, 0, explicitValuesCount);
             // Note that Array.Sort will, by MSDN documentation, make NaN be the first item of a sorted
             // list (that is, NaN is considered to be ordered "below" any other value for the purpose of
             // a sort, including negative infinity). So when checking if values contains no NaN values, it
@@ -80,13 +80,13 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             {
                 // Implicit zeros at the head.
                 distinctValues[0] = 0;
-                counts[0] = values.Length - valuesCount;
+                counts[0] = values.Length - explicitValuesCount;
                 idist = 1;
             }
             double last = distinctValues[idist] = valueBuffer[0];
             counts[idist] = 1;
 
-            for (int i = 1; i < valuesCount; ++i)
+            for (int i = 1; i < explicitValuesCount; ++i)
             {
                 double curr = valueBuffer[i];
                 if (curr != last)
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                     {
                         // This boundary is going from negative, to non-negative, and there are "implicit" zeros.
                         distinctValues[idist] = 0;
-                        counts[idist] = values.Length - valuesCount;
+                        counts[idist] = values.Length - explicitValuesCount;
                         if (curr == 0)
                         {
                             // No need to do any more work.
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             {
                 // Implicit zeros at the tail.
                 distinctValues[++idist] = 0;
-                counts[idist] = values.Length - valuesCount;
+                counts[idist] = values.Length - explicitValuesCount;
             }
 
             return idist + 1;

--- a/src/Microsoft.ML.FastTree/BinFile/BinFinder.cs
+++ b/src/Microsoft.ML.FastTree/BinFile/BinFinder.cs
@@ -17,6 +17,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
     {
         private readonly GreedyBinFinder _finder;
         private double[] _distinctValues;
+        private double[] _distinctCountsBuffer;
         private int[] _counts;
 
         private static double[] _trivialBinUpperBounds; // Will be initialized to a single element positive infinity array.
@@ -43,15 +44,19 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
         /// The scheme is destructive, because it modifies the arrays within <paramref name="values"/>.
         /// </summary>
         /// <param name="values">The values we are binning</param>
+        /// <param name="valueBuffer">A buffer space to work over the values, so the original
+        /// values aren't modified.</param>
         /// <param name="distinctValues">This working array will be filled with a sorted list of the
         /// distinct values detected within <paramref name="values"/></param>
         /// <param name="counts">This working array will be filled with a sorted list of the distinct
         /// values detected within <paramref name="values"/></param>
         /// <returns>The logical length of both <paramref name="distinctValues"/> and
         /// <paramref name="counts"/></returns>
-        private int FindDistinctCounts(in VBuffer<Double> values, double[] distinctValues, int[] counts)
+        private int FindDistinctCounts(in VBuffer<Double> values, double[] valueBuffer, double[] distinctValues, int[] counts)
         {
-            if (values.Count == 0)
+            var valueValues = values.GetValues();
+            var valuesCount = valueValues.Length;
+            if (valuesCount == 0)
             {
                 if (values.Length == 0)
                     return 0;
@@ -59,30 +64,31 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                 counts[0] = values.Length;
                 return 1;
             }
-            var valArray = values.Values;
 
             // Get histogram of values
-            Array.Sort(valArray, 0, values.Count);
+            Contracts.Assert(valueBuffer.Length >= valuesCount);
+            valueValues.CopyTo(valueBuffer);
+            Array.Sort(valueBuffer, 0, valuesCount);
             // Note that Array.Sort will, by MSDN documentation, make NaN be the first item of a sorted
             // list (that is, NaN is considered to be ordered "below" any other value for the purpose of
             // a sort, including negative infinity). So when checking if values contains no NaN values, it
             // suffices to check only the first item.
-            if (double.IsNaN(valArray[0]))
+            if (double.IsNaN(valueBuffer[0]))
                 return -1;
             int idist = 0; // Index into the "distinct" arrays.
-            if (!values.IsDense && valArray[0] > 0)
+            if (!values.IsDense && valueBuffer[0] > 0)
             {
                 // Implicit zeros at the head.
                 distinctValues[0] = 0;
-                counts[0] = values.Length - values.Count;
+                counts[0] = values.Length - valuesCount;
                 idist = 1;
             }
-            double last = distinctValues[idist] = valArray[0];
+            double last = distinctValues[idist] = valueBuffer[0];
             counts[idist] = 1;
 
-            for (int i = 1; i < values.Count; ++i)
+            for (int i = 1; i < valuesCount; ++i)
             {
-                double curr = valArray[i];
+                double curr = valueBuffer[i];
                 if (curr != last)
                 {
                     Contracts.Assert(curr > last);
@@ -92,7 +98,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                     {
                         // This boundary is going from negative, to non-negative, and there are "implicit" zeros.
                         distinctValues[idist] = 0;
-                        counts[idist] = values.Length - values.Count;
+                        counts[idist] = values.Length - valuesCount;
                         if (curr == 0)
                         {
                             // No need to do any more work.
@@ -117,7 +123,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             {
                 // Implicit zeros at the tail.
                 distinctValues[++idist] = 0;
-                counts[idist] = values.Length - values.Count;
+                counts[idist] = values.Length - valuesCount;
             }
 
             return idist + 1;
@@ -224,17 +230,19 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             Contracts.Assert(maxBins > 0);
             Contracts.Assert(minPerLeaf >= 0);
 
-            if (values.Count == 0)
+            var valuesCount = values.GetValues().Length;
+            if (valuesCount == 0)
             {
                 binUpperBounds = TrivialBinUpperBounds;
                 return true;
             }
 
-            int arraySize = values.IsDense ? values.Count : values.Count + 1;
+            int arraySize = values.IsDense ? valuesCount : valuesCount + 1;
+            Utils.EnsureSize(ref _distinctCountsBuffer, arraySize, arraySize, keepOld: false);
             Utils.EnsureSize(ref _distinctValues, arraySize, arraySize, keepOld: false);
             Utils.EnsureSize(ref _counts, arraySize, arraySize, keepOld: false);
 
-            int numValues = FindDistinctCounts(in values, _distinctValues, _counts);
+            int numValues = FindDistinctCounts(in values, _distinctCountsBuffer, _distinctValues, _counts);
             if (numValues < 0)
             {
                 binUpperBounds = null;

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1358,7 +1358,7 @@ namespace Microsoft.ML.Trainers.FastTree
                     (in VBuffer<T1> src, ref VBuffer<T2> dst) =>
                     {
                         var srcValues = src.GetValues();
-                        var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);
+                        var mutation = VBufferEditor.Create(ref dst, src.Length, srcValues.Length);
                         if (srcValues.Length > 0)
                         {
                             if (!src.IsDense)

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1368,7 +1368,7 @@ namespace Microsoft.ML.Trainers.FastTree
                             for (int i = 0; i < srcValues.Length; ++i)
                                 conv(in srcValues[i], ref mutation.Values[i]);
                         }
-                        mutation.Complete(ref dst);
+                        dst = mutation.CreateBuffer();
                     };
             }
 

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1358,17 +1358,17 @@ namespace Microsoft.ML.Trainers.FastTree
                     (in VBuffer<T1> src, ref VBuffer<T2> dst) =>
                     {
                         var srcValues = src.GetValues();
-                        var mutation = VBufferEditor.Create(ref dst, src.Length, srcValues.Length);
+                        var editor = VBufferEditor.Create(ref dst, src.Length, srcValues.Length);
                         if (srcValues.Length > 0)
                         {
                             if (!src.IsDense)
                             {
-                                src.GetIndices().CopyTo(mutation.Indices);
+                                src.GetIndices().CopyTo(editor.Indices);
                             }
                             for (int i = 0; i < srcValues.Length; ++i)
-                                conv(in srcValues[i], ref mutation.Values[i]);
+                                conv(in srcValues[i], ref editor.Values[i]);
                         }
-                        dst = mutation.Commit();
+                        dst = editor.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1357,20 +1357,18 @@ namespace Microsoft.ML.Trainers.FastTree
                 return
                     (in VBuffer<T1> src, ref VBuffer<T2> dst) =>
                     {
-                        var indices = dst.Indices;
-                        var values = dst.Values;
-                        if (src.Count > 0)
+                        var srcValues = src.GetValues();
+                        var mutation = VBufferMutationContext.Create(ref dst, src.Length, srcValues.Length);
+                        if (srcValues.Length > 0)
                         {
                             if (!src.IsDense)
                             {
-                                Utils.EnsureSize(ref indices, src.Count);
-                                Array.Copy(src.Indices, indices, src.Count);
+                                src.GetIndices().CopyTo(mutation.Indices);
                             }
-                            Utils.EnsureSize(ref values, src.Count);
-                            for (int i = 0; i < src.Count; ++i)
-                                conv(in src.Values[i], ref values[i]);
+                            for (int i = 0; i < srcValues.Length; ++i)
+                                conv(in srcValues[i], ref mutation.Values[i]);
                         }
-                        dst = new VBuffer<T2>(src.Length, src.Count, values, indices);
+                        mutation.Complete(ref dst);
                     };
             }
 

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1368,7 +1368,7 @@ namespace Microsoft.ML.Trainers.FastTree
                             for (int i = 0; i < srcValues.Length; ++i)
                                 conv(in srcValues[i], ref mutation.Values[i]);
                         }
-                        dst = mutation.CreateBuffer();
+                        dst = mutation.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/RegressionTree.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/RegressionTree.cs
@@ -798,7 +798,6 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             if (feat.IsDense)
                 return GetLeafCore(feat.GetValues(), path);
             return GetLeafCore(feat.GetIndices(), feat.GetValues(), path);
-
         }
 
         private Float GetFeatureValue(Float x, int node)
@@ -907,7 +906,6 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             if (NumLeaves == 1)
                 return 0;
 
-            int count = featIndices.Length;
             int node = root;
 
             while (node >= 0)
@@ -922,13 +920,13 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
 
                     //REVIEW: Consider experimenting with bitmap instead of doing log(n) binary search.
                     int newNode = LteChild[node];
-                    int end = Utils.FindIndexSorted(featIndices, 0, count, CategoricalSplitFeatureRanges[node][1]);
-                    for (int i = Utils.FindIndexSorted(featIndices, 0, count, CategoricalSplitFeatureRanges[node][0]);
+                    int end = featIndices.FindIndexSorted(0, count, CategoricalSplitFeatureRanges[node][1]);
+                    for (int i = featIndices.FindIndexSorted(0, count, CategoricalSplitFeatureRanges[node][0]);
                          i < count && i <= end;
                          ++i)
                     {
                         int index = featIndices[i];
-                        if (Utils.TryFindIndexSorted(CategoricalSplitFeatures[node], 0, CategoricalSplitFeatures[node].Length, index, out int ii))
+                        if (CategoricalSplitFeatures[node].TryFindIndexSorted(0, CategoricalSplitFeatures[node].Length, index, out int ii))
                         {
                             Float val = GetFeatureValue(featValues[i], node);
                             if (val > 0.0f)
@@ -946,7 +944,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                     Float val = 0;
                     int ifeat = SplitFeatures[node];
 
-                    int ii = Utils.FindIndexSorted(featIndices, 0, count, ifeat);
+                    int ii = featIndices.FindIndexSorted(0, count, ifeat);
                     if (ii < count && featIndices[ii] == ifeat)
                         val = featValues[ii];
                     val = GetFeatureValue(val, node);

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -791,7 +791,7 @@ namespace Microsoft.ML.Trainers.HalLearners
                     score = float.MaxValue;
                 mutation.Values[i] = score;
             }
-            weights = mutation.CreateBuffer();
+            weights = mutation.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -278,10 +278,11 @@ namespace Microsoft.ML.Trainers.HalLearners
             for (int i = 0; i < beta.Length; ++i)
                 ch.Check(FloatUtils.IsFinite(beta[i]), "Non-finite values detected in OLS solution");
 
-            var weights = VBufferUtils.CreateDense<float>(beta.Length - 1);
-            var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights);
+            var weightsValues = new float[beta.Length - 1];
             for (int i = 1; i < beta.Length; ++i)
-                weightsMutation.Values[i - 1] = (float)beta[i];
+                weightsValues[i - 1] = (float)beta[i];
+            var weights = new VBuffer<float>(weightsValues.Length, weightsValues);
+
             var bias = (float)beta[0];
             if (!(_l2Weight > 0) && m == n)
             {

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -790,7 +790,7 @@ namespace Microsoft.ML.Trainers.HalLearners
                     score = float.MaxValue;
                 mutation.Values[i] = score;
             }
-            mutation.Complete(ref weights);
+            weights = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -783,7 +783,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             }
 
             var size = _pValues.Length - 1;
-            var mutation = VBufferMutationContext.Create(ref weights, size);
+            var mutation = VBufferEditor.Create(ref weights, size);
             for (int i = 0; i < size; i++)
             {
                 var score = -(float)Math.Log(_pValues[i + 1]);

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -783,15 +783,15 @@ namespace Microsoft.ML.Trainers.HalLearners
             }
 
             var size = _pValues.Length - 1;
-            var mutation = VBufferEditor.Create(ref weights, size);
+            var editor = VBufferEditor.Create(ref weights, size);
             for (int i = 0; i < size; i++)
             {
                 var score = -(float)Math.Log(_pValues[i + 1]);
                 if (score > float.MaxValue)
                     score = float.MaxValue;
-                mutation.Values[i] = score;
+                editor.Values[i] = score;
             }
-            weights = mutation.Commit();
+            weights = editor.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -654,7 +654,7 @@ namespace Microsoft.ML.Trainers.SymSgd
             else
                 weights = VBufferUtils.CreateDense<float>(numFeatures);
 
-            var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights);
+            var weightsMutation = VBufferEditor.CreateFromBuffer(ref weights);
 
             // Reference: Parasail. SymSGD.
             bool tuneLR = _args.LearningRate == null;

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -654,6 +654,8 @@ namespace Microsoft.ML.Trainers.SymSgd
             else
                 weights = VBufferUtils.CreateDense<float>(numFeatures);
 
+            var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights);
+
             // Reference: Parasail. SymSGD.
             bool tuneLR = _args.LearningRate == null;
             var lr = _args.LearningRate ?? 1.0f;
@@ -688,7 +690,7 @@ namespace Microsoft.ML.Trainers.SymSgd
                             pch.SetHeader(new ProgressHeader(new[] { "iterations" }),
                                 entry => entry.SetProgress(0, state.PassIteration, _args.NumberOfIterations));
                             // If fully loaded, call the SymSGDNative and do not come back until learned for all iterations.
-                            Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weights.Values, ref bias, numFeatures,
+                            Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weightsMutation.Values, ref bias, numFeatures,
                                 _args.NumberOfIterations, numThreads, tuneNumLocIter, ref numLocIter, _args.Tolerance, _args.Shuffle, shouldInitialize, stateGCHandle);
                             shouldInitialize = false;
                         }
@@ -709,7 +711,7 @@ namespace Microsoft.ML.Trainers.SymSgd
                                 // If all of this leaves us with 0 passes, then set numPassesForThisBatch to 1
                                 numPassesForThisBatch = Math.Max(1, numPassesForThisBatch);
                                 state.PassIteration = iter;
-                                Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weights.Values, ref bias, numFeatures,
+                                Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weightsMutation.Values, ref bias, numFeatures,
                                     numPassesForThisBatch, numThreads, tuneNumLocIter, ref numLocIter, _args.Tolerance, _args.Shuffle, shouldInitialize, stateGCHandle);
                                 shouldInitialize = false;
 
@@ -730,7 +732,7 @@ namespace Microsoft.ML.Trainers.SymSgd
 
                         // Maps back the dense features that are mislocated
                         if (numThreads > 1)
-                            Native.MapBackWeightVector(weights.Values, stateGCHandle);
+                            Native.MapBackWeightVector(weightsMutation.Values, stateGCHandle);
                         Native.DeallocateSequentially(stateGCHandle);
                     }
                 }
@@ -784,7 +786,7 @@ namespace Microsoft.ML.Trainers.SymSgd
             /// <param name="shouldInitialize">Specifies if this is the first time to run SymSGD</param>
             /// <param name="stateGCHandle"></param>
             public static void LearnAll(InputDataManager inputDataManager, bool tuneLR,
-                ref float lr, float l2Const, float piw, float[] weightVector, ref float bias, int numFeatres, int numPasses,
+                ref float lr, float l2Const, float piw, Span<float> weightVector, ref float bias, int numFeatres, int numPasses,
                 int numThreads, bool tuneNumLocIter, ref int numLocIter, float tolerance, bool needShuffle, bool shouldInitialize, GCHandle stateGCHandle)
             {
                 inputDataManager.PrepareCursoring();
@@ -838,7 +840,7 @@ namespace Microsoft.ML.Trainers.SymSgd
             /// </summary>
             /// <param name="weightVector">The weight vector</param>
             /// <param name="stateGCHandle"></param>
-            public static void MapBackWeightVector(float[] weightVector, GCHandle stateGCHandle)
+            public static void MapBackWeightVector(Span<float> weightVector, GCHandle stateGCHandle)
             {
                 fixed (float* pweightVector = &weightVector[0])
                     MapBackWeightVector(pweightVector, (State*)stateGCHandle.AddrOfPinnedObject());

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -654,7 +654,7 @@ namespace Microsoft.ML.Trainers.SymSgd
             else
                 weights = VBufferUtils.CreateDense<float>(numFeatures);
 
-            var weightsMutation = VBufferEditor.CreateFromBuffer(ref weights);
+            var weightsEditor = VBufferEditor.CreateFromBuffer(ref weights);
 
             // Reference: Parasail. SymSGD.
             bool tuneLR = _args.LearningRate == null;
@@ -690,7 +690,7 @@ namespace Microsoft.ML.Trainers.SymSgd
                             pch.SetHeader(new ProgressHeader(new[] { "iterations" }),
                                 entry => entry.SetProgress(0, state.PassIteration, _args.NumberOfIterations));
                             // If fully loaded, call the SymSGDNative and do not come back until learned for all iterations.
-                            Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weightsMutation.Values, ref bias, numFeatures,
+                            Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weightsEditor.Values, ref bias, numFeatures,
                                 _args.NumberOfIterations, numThreads, tuneNumLocIter, ref numLocIter, _args.Tolerance, _args.Shuffle, shouldInitialize, stateGCHandle);
                             shouldInitialize = false;
                         }
@@ -711,7 +711,7 @@ namespace Microsoft.ML.Trainers.SymSgd
                                 // If all of this leaves us with 0 passes, then set numPassesForThisBatch to 1
                                 numPassesForThisBatch = Math.Max(1, numPassesForThisBatch);
                                 state.PassIteration = iter;
-                                Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weightsMutation.Values, ref bias, numFeatures,
+                                Native.LearnAll(inputDataManager, tuneLR, ref lr, l2Const, piw, weightsEditor.Values, ref bias, numFeatures,
                                     numPassesForThisBatch, numThreads, tuneNumLocIter, ref numLocIter, _args.Tolerance, _args.Shuffle, shouldInitialize, stateGCHandle);
                                 shouldInitialize = false;
 
@@ -732,7 +732,7 @@ namespace Microsoft.ML.Trainers.SymSgd
 
                         // Maps back the dense features that are mislocated
                         if (numThreads > 1)
-                            Native.MapBackWeightVector(weightsMutation.Values, stateGCHandle);
+                            Native.MapBackWeightVector(weightsEditor.Values, stateGCHandle);
                         Native.DeallocateSequentially(stateGCHandle);
                     }
                 }

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -478,8 +478,8 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
 
                         if (src == null)
                         {
-                            VBufferMutationContext.Create(ref dst, size, 0)
-                                .Complete(ref dst);
+                            dst = VBufferMutationContext.Create(ref dst, size, 0)
+                                .CreateBuffer();
                             return;
                         }
 
@@ -607,7 +607,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                             }
                         }
 
-                        mutation.Complete(ref dst);
+                        dst = mutation.CreateBuffer();
                     };
             }
 

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -485,16 +485,16 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                         Host.Check(src.PixelFormat == System.Drawing.Imaging.PixelFormat.Format32bppArgb);
                         Host.Check(src.Height == height && src.Width == width);
 
-                        var mutation = VBufferEditor.Create(ref dst, size);
-                        var values = mutation.Values;
+                        var editor = VBufferEditor.Create(ref dst, size);
+                        var values = editor.Values;
 
                         float offset = ex.Offset;
                         float scale = ex.Scale;
                         Contracts.Assert(scale != 0);
 
                         // REVIEW: split the getter into 2 specialized getters, one for float case and one for byte case.
-                        Span<float> vf = typeof(TValue) == typeof(float) ? MemoryMarshal.Cast<TValue, float>(mutation.Values) : default;
-                        Span<byte> vb = typeof(TValue) == typeof(byte) ? MemoryMarshal.Cast<TValue, byte>(mutation.Values) : default;
+                        Span<float> vf = typeof(TValue) == typeof(float) ? MemoryMarshal.Cast<TValue, float>(editor.Values) : default;
+                        Span<byte> vb = typeof(TValue) == typeof(byte) ? MemoryMarshal.Cast<TValue, byte>(editor.Values) : default;
                         Contracts.Assert(!vf.IsEmpty || !vb.IsEmpty);
                         bool needScale = offset != 0 || scale != 1;
                         Contracts.Assert(!needScale || !vf.IsEmpty);
@@ -607,7 +607,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                             }
                         }
 
-                        dst = mutation.Commit();
+                        dst = editor.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -607,7 +607,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                             }
                         }
 
-                        dst = mutation.CreateBuffer();
+                        dst = mutation.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -478,8 +478,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
 
                         if (src == null)
                         {
-                            dst = VBufferMutationContext.Create(ref dst, size, 0)
-                                .CreateBuffer();
+                            VBufferUtils.Resize(ref dst, size, 0);
                             return;
                         }
 
@@ -493,6 +492,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                         float scale = ex.Scale;
                         Contracts.Assert(scale != 0);
 
+                        // REVIEW: split the getter into 2 specialized getters, one for float case and one for byte case.
                         Span<float> vf = typeof(TValue) == typeof(float) ? MemoryMarshal.Cast<TValue, float>(mutation.Values) : default;
                         Span<byte> vb = typeof(TValue) == typeof(byte) ? MemoryMarshal.Cast<TValue, byte>(mutation.Values) : default;
                         Contracts.Assert(!vf.IsEmpty || !vb.IsEmpty);

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.ML.Core.Data;
 using Microsoft.ML.Runtime;
@@ -439,6 +440,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
 
             //REVIEW Rewrite it to where TValue : IConvertible
             private ValueGetter<VBuffer<TValue>> GetGetterCore<TValue>(IRow input, int iinfo, out Action disposer)
+                where TValue : struct
             {
                 var type = _types[iinfo];
                 var dims = type.Dimensions;
@@ -476,26 +478,26 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
 
                         if (src == null)
                         {
-                            dst = new VBuffer<TValue>(size, 0, dst.Values, dst.Indices);
+                            VBufferMutationContext.Create(ref dst, size, 0)
+                                .Complete(ref dst);
                             return;
                         }
 
                         Host.Check(src.PixelFormat == System.Drawing.Imaging.PixelFormat.Format32bppArgb);
                         Host.Check(src.Height == height && src.Width == width);
 
-                        var values = dst.Values;
-                        if (Utils.Size(values) < size)
-                            values = new TValue[size];
+                        var mutation = VBufferMutationContext.Create(ref dst, size);
+                        var values = mutation.Values;
 
                         float offset = ex.Offset;
                         float scale = ex.Scale;
                         Contracts.Assert(scale != 0);
 
-                        var vf = values as float[];
-                        var vb = values as byte[];
-                        Contracts.Assert(vf != null || vb != null);
+                        Span<float> vf = typeof(TValue) == typeof(float) ? MemoryMarshal.Cast<TValue, float>(mutation.Values) : default;
+                        Span<byte> vb = typeof(TValue) == typeof(byte) ? MemoryMarshal.Cast<TValue, byte>(mutation.Values) : default;
+                        Contracts.Assert(!vf.IsEmpty || !vb.IsEmpty);
                         bool needScale = offset != 0 || scale != 1;
-                        Contracts.Assert(!needScale || vf != null);
+                        Contracts.Assert(!needScale || !vf.IsEmpty);
 
                         bool a = ex.Alpha;
                         bool r = ex.Red;
@@ -512,7 +514,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                                 for (int y = 0; y < h; ++y)
                                 {
                                     var pb = src.GetPixel(x, y);
-                                    if (vb != null)
+                                    if (!vb.IsEmpty)
                                     {
                                         if (a) { vb[idst++] = pb.A; }
                                         if (r) { vb[idst++] = pb.R; }
@@ -543,7 +545,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                             {
                                 // The image only has rgb but we need to supply alpha as well, so fake it up,
                                 // assuming that it is 0xFF.
-                                if (vf != null)
+                                if (!vf.IsEmpty)
                                 {
                                     Single v = (0xFF - offset) * scale;
                                     for (int i = 0; i < cpix; i++)
@@ -566,7 +568,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                                 int idstBase = idstMin + y * w;
 
                                 // Note that the bytes are in order BGR[A]. We arrange the layers in order ARGB.
-                                if (vb != null)
+                                if (!vb.IsEmpty)
                                 {
                                     for (int x = 0; x < w; x++, idstBase++)
                                     {
@@ -605,7 +607,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                             }
                         }
 
-                        dst = new VBuffer<TValue>(size, values, dst.Indices);
+                        mutation.Complete(ref dst);
                     };
             }
 

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -485,7 +485,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                         Host.Check(src.PixelFormat == System.Drawing.Imaging.PixelFormat.Format32bppArgb);
                         Host.Check(src.Height == height && src.Width == width);
 
-                        var mutation = VBufferMutationContext.Create(ref dst, size);
+                        var mutation = VBufferEditor.Create(ref dst, size);
                         var values = mutation.Values;
 
                         float offset = ex.Offset;

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -655,7 +655,7 @@ namespace Microsoft.ML.Trainers.KMeans
             if (pointRowIndex != -1) // if the space was available for cur in initializationState.
             {
                 // pointNorm is necessary for using triangle inequality.
-                float pointNorm = VectorUtils.NormSquared(point);
+                float pointNorm = VectorUtils.NormSquared(in point);
                 // We have cached distance information for this point.
                 bestCluster = initializationState.GetBestCluster(pointRowIndex);
                 float bestWeight = initializationState.GetBestWeight(pointRowIndex);
@@ -788,6 +788,8 @@ namespace Microsoft.ML.Trainers.KMeans
                 // The final chosen points, to be approximately clustered to determine starting
                 // centroids.
                 VBuffer<float>[] clusters = new VBuffer<float>[totalSamples];
+                VBuffer<float>[] readOnlyClusters = null;
+
                 // L2s, kept for distance trick.
                 float[] clustersL2s = new float[totalSamples];
 
@@ -859,6 +861,9 @@ namespace Microsoft.ML.Trainers.KMeans
                             clusterCount++;
                         }
                         ch.Assert(clusterCount - clusterPrevCount <= numSamplesPerRound);
+
+                        KMeansUtils.UpdateReadOnlyCache(clusters, ref readOnlyClusters);
+
                         logicalExternalRounds++;
                         pCh.Checkpoint(logicalExternalRounds, numRounds + 2);
                     }
@@ -1316,9 +1321,11 @@ namespace Microsoft.ML.Trainers.KMeans
             Initialize(ch, cursorFactory, totalTrainingInstances, numThreads, k, dimensionality, accelMemBudgetInMb,
                 out state, out workState, out reducedState);
             float[] centroidL2s = new float[k];
+            VBuffer<float>[] readOnlyCentroids = new VBuffer<float>[centroids.Length];
+            KMeansUtils.UpdateReadOnlyCache(centroids, ref readOnlyCentroids);
 
             for (int i = 0; i < k; i++)
-                centroidL2s[i] = VectorUtils.NormSquared(centroids[i]);
+                centroidL2s[i] = VectorUtils.NormSquared(in readOnlyCentroids[i]);
 
             using (var pch = host.StartProgressChannel("KMeansTrain"))
             {
@@ -1345,7 +1352,7 @@ namespace Microsoft.ML.Trainers.KMeans
                             ops[i] = new Action(() =>
                             {
                                 using (var cursor = set[chunkId])
-                                    ProcessChunk(cursor, state, workState[chunkId], k, centroids, centroidL2s);
+                                    ProcessChunk(cursor, state, workState[chunkId], k, readOnlyCentroids, centroidL2s);
                             });
                         }
 
@@ -1357,7 +1364,7 @@ namespace Microsoft.ML.Trainers.KMeans
                     else
                     {
                         using (var cursor = cursorFactory.Create())
-                            ProcessChunk(cursor, state, reducedState, k, centroids, centroidL2s);
+                            ProcessChunk(cursor, state, reducedState, k, readOnlyCentroids, centroidL2s);
                     }
 
                     WorkChunkState.Reduce(workState, reducedState);
@@ -1394,11 +1401,13 @@ namespace Microsoft.ML.Trainers.KMeans
                     }
 #endif
                     reducedState.UpdateClusters(centroids, centroidL2s, state.Delta, ref state.DeltaMax);
+                    KMeansUtils.UpdateReadOnlyCache(centroids, ref readOnlyCentroids);
+
                     isConverged = reducedState.AverageScoreDelta < convergenceThreshold;
                     state.Iteration++;
 
                     if (state.Iteration % 100 == 0)
-                        KMeansUtils.VerifyModelConsistency(centroids);
+                        KMeansUtils.VerifyModelConsistency(readOnlyCentroids);
                 }
             }
         }
@@ -1794,6 +1803,24 @@ namespace Microsoft.ML.Trainers.KMeans
         {
             foreach (var centroid in centroids)
                 Contracts.Check(centroid.Items().Select(x => x.Value).All(FloatUtils.IsFinite), "Model training failed: non-finite coordinates are generated");
+        }
+
+        /// <summary>
+        /// Checks that all coordinates of all centroids are finite, and throws otherwise
+        /// </summary>
+        public static void VerifyModelConsistency(VBuffer<float>[] centroids)
+        {
+            for (int i = 0; i < centroids.Length; i++)
+                Contracts.Check(centroids[i].GetValues().All(FloatUtils.IsFinite), "Model training failed: non-finite coordinates are generated");
+        }
+
+        public static void UpdateReadOnlyCache(VBuffer<float>[] source, ref VBuffer<float>[] destination)
+        {
+            Utils.EnsureSize(ref destination, source.Length);
+            for (int i = 0; i < source.Length; i++)
+            {
+                destination[i] = source[i];
+            }
         }
     }
 }

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Trainers.KMeans
                             "Not enough distinct instances to populate {0} clusters (only found {1} distinct instances)", k, i);
                     }
 
-                    candidate.CopyTo(centroids[i].Values);
+                    candidate.CopyToDense(ref centroids[i]);
                     centroidL2s[i] = cachedCandidateL2 ?? VectorUtils.NormSquared(candidate);
                 }
             }
@@ -1389,8 +1389,10 @@ namespace Microsoft.ML.Trainers.KMeans
 
                         for (int i = 0; i < k; i++)
                         {
+                            var reducedStateCacheValues = reducedState.CachedSumDebug[i].GetValues();
+                            var cachedSumCopyValues = cachedSumCopy[i].GetValues();
                             for (int j = 0; j < dimensionality; j++)
-                                Contracts.Assert(AlmostEq(reducedState.CachedSumDebug[i].Values[j], cachedSumCopy[i].Values[j]));
+                                Contracts.Assert(AlmostEq(reducedStateCacheValues[j], cachedSumCopyValues[j]));
                         }
                     }
 #endif

--- a/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
@@ -148,9 +148,9 @@ namespace Microsoft.ML.Trainers.KMeans
                 {
                     if (src.Length != _dimensionality)
                         throw Host.Except($"Incorrect number of features: expected {_dimensionality}, got {src.Length}");
-                    var mutation = VBufferEditor.Create(ref dst, _k);
-                    Map(in src, mutation.Values);
-                    dst = mutation.Commit();
+                    var editor = VBufferEditor.Create(ref dst, _k);
+                    Map(in src, editor.Values);
+                    dst = editor.Commit();
                 };
 
             return (ValueMapper<TIn, TOut>)(Delegate)del;

--- a/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
@@ -148,19 +148,17 @@ namespace Microsoft.ML.Trainers.KMeans
                 {
                     if (src.Length != _dimensionality)
                         throw Host.Except($"Incorrect number of features: expected {_dimensionality}, got {src.Length}");
-                    var values = dst.Values;
-                    if (Utils.Size(values) < _k)
-                        values = new Float[_k];
-                    Map(in src, values);
-                    dst = new VBuffer<Float>(_k, values, dst.Indices);
+                    var mutation = VBufferMutationContext.Create(ref dst, _k);
+                    Map(in src, mutation.Values);
+                    mutation.Complete(ref dst);
                 };
 
             return (ValueMapper<TIn, TOut>)(Delegate)del;
         }
 
-        private void Map(in VBuffer<Float> src, Float[] distances)
+        private void Map(in VBuffer<Float> src, Span<Float> distances)
         {
-            Host.Assert(Utils.Size(distances) >= _k);
+            Host.Assert(distances.Length >= _k);
 
             Float instanceL2 = VectorUtils.NormSquared(in src);
             for (int i = 0; i < _k; i++)

--- a/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Trainers.KMeans
         {
             Host.Assert(Utils.Size(distances) >= _k);
 
-            Float instanceL2 = VectorUtils.NormSquared(src);
+            Float instanceL2 = VectorUtils.NormSquared(in src);
             for (int i = 0; i < _k; i++)
             {
                 Float distance = Math.Max(0,

--- a/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Trainers.KMeans
                         throw Host.Except($"Incorrect number of features: expected {_dimensionality}, got {src.Length}");
                     var mutation = VBufferMutationContext.Create(ref dst, _k);
                     Map(in src, mutation.Values);
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
 
             return (ValueMapper<TIn, TOut>)(Delegate)del;

--- a/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Trainers.KMeans
                         throw Host.Except($"Incorrect number of features: expected {_dimensionality}, got {src.Length}");
                     var mutation = VBufferMutationContext.Create(ref dst, _k);
                     Map(in src, mutation.Values);
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
 
             return (ValueMapper<TIn, TOut>)(Delegate)del;

--- a/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPredictor.cs
@@ -148,7 +148,7 @@ namespace Microsoft.ML.Trainers.KMeans
                 {
                     if (src.Length != _dimensionality)
                         throw Host.Except($"Incorrect number of features: expected {_dimensionality}, got {src.Length}");
-                    var mutation = VBufferMutationContext.Create(ref dst, _k);
+                    var mutation = VBufferEditor.Create(ref dst, _k);
                     Map(in src, mutation.Values);
                     dst = mutation.Commit();
                 };

--- a/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
+++ b/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
@@ -75,9 +75,10 @@ namespace Microsoft.ML.Legacy.Models
                     elements = new double[type.VectorSize, type.VectorSize];
 
                 countGetter(ref countValues);
-                for (int i = 0; i < countValues.Length; i++)
+                ReadOnlySpan<double> values = countValues.GetValues();
+                for (int i = 0; i < values.Length; i++)
                 {
-                    elements[valuesRowIndex, i] = countValues.Values[i];
+                    elements[valuesRowIndex, i] = values[i];
                 }
 
                 valuesRowIndex++;

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/FeatureCombiner.cs
@@ -129,10 +129,11 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 return null;
             var sb = new StringBuilder();
             var pre = "";
-            for (int i = 0; i < metadata.Length; i++)
+            var metadataValues = metadata.GetValues();
+            for (int i = 0; i < metadataValues.Length; i++)
             {
                 sb.Append(pre);
-                sb.AppendMemory(metadata.Values[i]);
+                sb.AppendMemory(metadataValues[i]);
                 pre = ",";
             }
             return sb.ToString();

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -282,9 +282,9 @@ namespace Microsoft.ML.Transforms
                     var outputTensors = _parent.Model.Run(inputTensors);
                     Contracts.Assert(outputTensors.Count() > 0);
 
-                    var mutation = VBufferEditor.Create(ref dst, _outputColType.VectorSize);
-                    OnnxUtils.CopyTo(outputTensors[0], mutation.Values);
-                    dst = mutation.Commit();
+                    var editor = VBufferEditor.Create(ref dst, _outputColType.VectorSize);
+                    OnnxUtils.CopyTo(outputTensors[0], editor.Values);
+                    dst = editor.Commit();
                 };
 
                 return valueGetter;

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -282,12 +282,9 @@ namespace Microsoft.ML.Transforms
                     var outputTensors = _parent.Model.Run(inputTensors);
                     Contracts.Assert(outputTensors.Count() > 0);
 
-                    var values = dst.Values;
-                    if (Utils.Size(values) < _outputColType.VectorSize)
-                        values = new T[_outputColType.VectorSize];
-
-                    OnnxUtils.CopyTo(outputTensors[0], values);
-                    dst = new VBuffer<T>(values.Length, values, dst.Indices);
+                    var mutation = VBufferMutationContext.Create(ref dst, _outputColType.VectorSize);
+                    OnnxUtils.CopyTo(outputTensors[0], mutation.Values);
+                    mutation.Complete(ref dst);
                 };
 
                 return valueGetter;

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -284,7 +284,7 @@ namespace Microsoft.ML.Transforms
 
                     var mutation = VBufferMutationContext.Create(ref dst, _outputColType.VectorSize);
                     OnnxUtils.CopyTo(outputTensors[0], mutation.Values);
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
 
                 return valueGetter;

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -284,7 +284,7 @@ namespace Microsoft.ML.Transforms
 
                     var mutation = VBufferMutationContext.Create(ref dst, _outputColType.VectorSize);
                     OnnxUtils.CopyTo(outputTensors[0], mutation.Values);
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
 
                 return valueGetter;

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -282,7 +282,7 @@ namespace Microsoft.ML.Transforms
                     var outputTensors = _parent.Model.Run(inputTensors);
                     Contracts.Assert(outputTensors.Count() > 0);
 
-                    var mutation = VBufferMutationContext.Create(ref dst, _outputColType.VectorSize);
+                    var mutation = VBufferEditor.Create(ref dst, _outputColType.VectorSize);
                     OnnxUtils.CopyTo(outputTensors[0], mutation.Values);
                     dst = mutation.Commit();
                 };

--- a/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
@@ -247,7 +247,7 @@ namespace Microsoft.ML.Runtime.Numeric
         /// </summary>
         /// <param name="f"></param>
         /// <param name="x"></param>
-        public static void TestAllCoords(DifferentiableFunction f, ref VBuffer<Float> x)
+        public static void TestAllCoords(DifferentiableFunction f, in VBuffer<Float> x)
         {
             // REVIEW: Delete this method?
             VBuffer<Float> grad = default(VBuffer<Float>);
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Runtime.Numeric
         /// <param name="f">Function to test</param>
         /// <param name="x">Point at which to test</param>
         /// <param name="coords">List of coordinates to test</param>
-        public static void TestCoords(DifferentiableFunction f, ref VBuffer<Float> x, IList<int> coords)
+        public static void TestCoords(DifferentiableFunction f, in VBuffer<Float> x, IList<int> coords)
         {
             // REVIEW: Delete this method?
             VBuffer<Float> grad = default(VBuffer<Float>);

--- a/src/Microsoft.ML.StandardLearners/Optimizer/LineSearch.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/LineSearch.cs
@@ -530,7 +530,7 @@ namespace Microsoft.ML.Runtime.Numeric
             GDOptimizer gdo = new GDOptimizer(term, null, true);
             print = true;
             CreateWrapped(out init, 0, 0);
-            gdo.Minimize(QuadTest2D, ref init, ref ans);
+            gdo.Minimize(QuadTest2D, in init, ref ans);
             QuadTest2D(in ans, ref grad);
             Console.WriteLine(VectorUtils.Norm(grad));
         }

--- a/src/Microsoft.ML.StandardLearners/Optimizer/OptimizationMonitor.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/OptimizationMonitor.cs
@@ -85,7 +85,7 @@ namespace Microsoft.ML.Runtime.Numeric
         {
             Console.Error.Write(_checkingMessage);
             Console.Error.Flush();
-            var x = state.X;
+            VBuffer<float> x = state.X;
             var lastDir = state.LastDir;
             Float checkResult = GradientTester.Test(state.Function, in x, ref lastDir, true, ref _newGrad, ref _newX);
             for (int i = 0; i < _checkingMessage.Length; i++)

--- a/src/Microsoft.ML.StandardLearners/Optimizer/Optimizer.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/Optimizer.cs
@@ -645,7 +645,7 @@ namespace Microsoft.ML.Runtime.Numeric
                     double? improvement = null;
                     double x;
                     int end;
-                    if (message != null && DoubleParser.TryParse(message.AsMemory().Span, out x, out end))
+                    if (message != null && DoubleParser.TryParse(message.AsSpan(), out x, out end))
                         improvement = x;
 
                     pch.Checkpoint(state.Value, improvement, state.Iter);

--- a/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
@@ -387,96 +387,102 @@ namespace Microsoft.ML.Runtime.Numeric
             Contracts.Assert(x.Length == xprev.Length, "Vectors must have the same dimensionality.");
             Contracts.Assert(FloatUtils.IsFinite(xprev.GetValues()));
 
-            if (!FloatUtils.IsFinite(x.GetValues()))
+            var xValues = x.GetValues();
+            if (!FloatUtils.IsFinite(xValues))
                 return true;
 
+            var xprevValues = xprev.GetValues();
             if (x.IsDense && xprev.IsDense)
             {
-                for (int i = 0; i < x.Length; i++)
+                for (int i = 0; i < xValues.Length; i++)
                 {
-                    if (x.Values[i] != xprev.Values[i])
+                    if (xValues[i] != xprevValues[i])
                         return false;
                 }
             }
             else if (xprev.IsDense)
             {
+                var xIndices = x.GetIndices();
                 int j = 0;
-                for (int ii = 0; ii < x.Count; ii++)
+                for (int ii = 0; ii < xValues.Length; ii++)
                 {
-                    int i = x.Indices[ii];
+                    int i = xIndices[ii];
                     while (j < i)
                     {
-                        if (xprev.Values[j++] != 0)
+                        if (xprevValues[j++] != 0)
                             return false;
                     }
                     Contracts.Assert(i == j);
-                    if (x.Values[ii] != xprev.Values[j++])
+                    if (xValues[ii] != xprevValues[j++])
                         return false;
                 }
 
-                while (j < xprev.Length)
+                while (j < xprevValues.Length)
                 {
-                    if (xprev.Values[j++] != 0)
+                    if (xprevValues[j++] != 0)
                         return false;
                 }
             }
             else if (x.IsDense)
             {
+                var xprevIndices = xprev.GetIndices();
                 int i = 0;
-                for (int jj = 0; jj < xprev.Count; jj++)
+                for (int jj = 0; jj < xprevValues.Length; jj++)
                 {
-                    int j = xprev.Indices[jj];
+                    int j = xprevIndices[jj];
                     while (i < j)
                     {
-                        if (x.Values[i++] != 0)
+                        if (xValues[i++] != 0)
                             return false;
                     }
                     Contracts.Assert(j == i);
-                    if (x.Values[i++] != xprev.Values[jj])
+                    if (xValues[i++] != xprevValues[jj])
                         return false;
                 }
 
-                while (i < x.Length)
+                while (i < xValues.Length)
                 {
-                    if (x.Values[i++] != 0)
+                    if (xValues[i++] != 0)
                         return false;
                 }
             }
             else
             {
                 // Both sparse.
+                var xIndices = x.GetIndices();
+                var xprevIndices = xprev.GetIndices();
                 int ii = 0;
                 int jj = 0;
-                while (ii < x.Count && jj < xprev.Count)
+                while (ii < xValues.Length && jj < xprevValues.Length)
                 {
-                    int i = x.Indices[ii];
-                    int j = xprev.Indices[jj];
+                    int i = xIndices[ii];
+                    int j = xprevIndices[jj];
                     if (i == j)
                     {
-                        if (x.Values[ii++] != xprev.Values[jj++])
+                        if (xValues[ii++] != xprevValues[jj++])
                             return false;
                     }
                     else if (i < j)
                     {
-                        if (x.Values[ii++] != 0)
+                        if (xValues[ii++] != 0)
                             return false;
                     }
                     else
                     {
-                        if (xprev.Values[jj++] != 0)
+                        if (xprevValues[jj++] != 0)
                             return false;
                     }
                 }
 
-                while (ii < x.Count)
+                while (ii < xValues.Length)
                 {
-                    if (x.Values[ii++] != 0)
+                    if (xValues[ii++] != 0)
                         return false;
                 }
 
-                while (jj < xprev.Count)
+                while (jj < xprevValues.Length)
                 {
-                    if (xprev.Values[jj++] != 0)
+                    if (xprevValues[jj++] != 0)
                         return false;
                 }
             }

--- a/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
@@ -349,7 +349,7 @@ namespace Microsoft.ML.Runtime.Numeric
         /// <param name="function">Function to minimize</param>
         /// <param name="initial">Initial point</param>
         /// <param name="result">Approximate minimum</param>
-        public void Minimize(DifferentiableFunction function, ref VBuffer<Float> initial, ref VBuffer<Float> result)
+        public void Minimize(DifferentiableFunction function, in VBuffer<Float> initial, ref VBuffer<Float> result)
         {
             Contracts.Check(FloatUtils.IsFinite(initial.GetValues()), "The initial vector contains NaNs or infinite values.");
             LineFunc lineFunc = new LineFunc(function, in initial, UseCG);

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearPredictorUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearPredictorUtils.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Runtime.Learners
 
                         writer.Write(FloatUtils.ToRoundTripString(value));
                         writer.Write("*");
-                        if (featureNames.Count > 0)
+                        if (featureNames.GetValues().Length > 0)
                             writer.Write(FeatureNameAsCode(featureNames.GetItemOrDefault(idx).ToString(), idx));
                         else
                             writer.Write("f_" + idx);
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Runtime.Learners
                         var name = featureNames.GetItemOrDefault(idx);
 
                         inputBuilder.AppendLine("[Input:" + numNonZeroWeights + "]");
-                        inputBuilder.AppendLine("Name=" + (featureNames.Count == 0 ? "Feature_" + idx : name.IsEmpty ? $"f{idx}" : name.ToString()));
+                        inputBuilder.AppendLine("Name=" + (featureNames.GetValues().Length == 0 ? "Feature_" + idx : name.IsEmpty ? $"f{idx}" : name.ToString()));
                         inputBuilder.AppendLine("Transform=linear");
                         inputBuilder.AppendLine("Slope=1");
                         inputBuilder.AppendLine("Intercept=0");

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -595,11 +595,15 @@ namespace Microsoft.ML.Runtime.Learners
             Contracts.AssertValueOrNull(progress);
 
             float scaleFactor = 1 / (float)WeightSum;
-            VBuffer<float> xDense = default(VBuffer<float>);
+            VBuffer<float> xDense = default;
             if (x.IsDense)
                 xDense = x;
             else
-                x.CopyToDense(ref xDense);
+            {
+                VBuffer<float> xDenseTemp = default;
+                x.CopyToDense(ref xDenseTemp);
+                xDense = xDenseTemp;
+            }
 
             IProgressChannel pch = progress != null ? progress.StartProgressChannel("Gradient") : null;
             float loss;
@@ -613,7 +617,7 @@ namespace Microsoft.ML.Runtime.Learners
             if (L2Weight > 0)
             {
                 Contracts.Assert(xDense.IsDense);
-                var values = xDense.Values;
+                var values = xDense.GetValues();
                 Double r = 0;
                 for (int i = BiasCount; i < values.Length; i++)
                 {

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -157,8 +157,9 @@ namespace Microsoft.ML.Runtime.Learners
             VectorUtils.AddMultWithOffset(in feat, mult, ref grad, 1); // Note that 0th L-BFGS weight is for bias.
             // Add bias using this strange trick that has advantage of working well for dense and sparse arrays.
             // Due to the call to EnsureBiases, we know this region is dense.
-            Contracts.Assert(grad.Count >= BiasCount && (grad.IsDense || grad.Indices[BiasCount - 1] == BiasCount - 1));
-            grad.Values[0] += mult;
+            var mutation = VBufferMutationContext.CreateFromBuffer(ref grad);
+            Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
+            mutation.Values[0] += mult;
 
             return weight * datumLoss;
         }
@@ -298,7 +299,7 @@ namespace Microsoft.ML.Runtime.Learners
                     // Increment the first entry of hessian.
                     hessian[0] += variance;
 
-                    var values = cursor.Features.Values;
+                    var values = cursor.Features.GetValues();
                     if (cursor.Features.IsDense)
                     {
                         int ioff = 1;
@@ -324,8 +325,8 @@ namespace Microsoft.ML.Runtime.Learners
                     }
                     else
                     {
-                        var indices = cursor.Features.Indices;
-                        for (int ii = 0; ii < cursor.Features.Count; ++ii)
+                        var indices = cursor.Features.GetIndices();
+                        for (int ii = 0; ii < values.Length; ++ii)
                         {
                             int i = indices[ii];
                             int wi = i + 1;

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -157,9 +157,9 @@ namespace Microsoft.ML.Runtime.Learners
             VectorUtils.AddMultWithOffset(in feat, mult, ref grad, 1); // Note that 0th L-BFGS weight is for bias.
             // Add bias using this strange trick that has advantage of working well for dense and sparse arrays.
             // Due to the call to EnsureBiases, we know this region is dense.
-            var mutation = VBufferEditor.CreateFromBuffer(ref grad);
-            Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
-            mutation.Values[0] += mult;
+            var editor = VBufferEditor.CreateFromBuffer(ref grad);
+            Contracts.Assert(editor.Values.Length >= BiasCount && (grad.IsDense || editor.Indices[BiasCount - 1] == BiasCount - 1));
+            editor.Values[0] += mult;
 
             return weight * datumLoss;
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -157,7 +157,7 @@ namespace Microsoft.ML.Runtime.Learners
             VectorUtils.AddMultWithOffset(in feat, mult, ref grad, 1); // Note that 0th L-BFGS weight is for bias.
             // Add bias using this strange trick that has advantage of working well for dense and sparse arrays.
             // Due to the call to EnsureBiases, we know this region is dense.
-            var mutation = VBufferMutationContext.CreateFromBuffer(ref grad);
+            var mutation = VBufferEditor.CreateFromBuffer(ref grad);
             Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
             mutation.Values[0] += mult;
 

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -665,11 +665,12 @@ namespace Microsoft.ML.Runtime.Learners
                     {
                         if (fw.IsDense)
                         {
+                            var fwValues = fw.GetValues();
                             for (int i = 0; i < fw.Length; i++)
                             {
-                                if (fw.Values[i] != 0)
+                                if (fwValues[i] != 0)
                                 {
-                                    ctx.Writer.Write(fw.Values[i]);
+                                    ctx.Writer.Write(fwValues[i]);
                                     count++;
                                 }
                             }
@@ -697,21 +698,11 @@ namespace Microsoft.ML.Runtime.Learners
         private static int NonZeroCount(in VBuffer<float> vector)
         {
             int count = 0;
-            if (!vector.IsDense)
+            var values = vector.GetValues();
+            for (int i = 0; i < values.Length; i++)
             {
-                for (int i = 0; i < vector.Count; i++)
-                {
-                    if (vector.Values[i] != 0)
-                        count++;
-                }
-            }
-            else
-            {
-                for (int i = 0; i < vector.Length; i++)
-                {
-                    if (vector.Values[i] != 0)
-                        count++;
-                }
+                if (values[i] != 0)
+                    count++;
             }
             return count;
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Runtime.Learners
                 float mult = weight * (modelProb - probLabel);
                 VectorUtils.AddMultWithOffset(in feat, mult, ref grad, start);
                 // Due to the call to EnsureBiases, we know this region is dense.
-                var mutation = VBufferMutationContext.CreateFromBuffer(ref grad);
+                var mutation = VBufferEditor.CreateFromBuffer(ref grad);
                 Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
                 mutation.Values[c] += mult;
             }

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -218,9 +218,9 @@ namespace Microsoft.ML.Runtime.Learners
                 float mult = weight * (modelProb - probLabel);
                 VectorUtils.AddMultWithOffset(in feat, mult, ref grad, start);
                 // Due to the call to EnsureBiases, we know this region is dense.
-                var mutation = VBufferEditor.CreateFromBuffer(ref grad);
-                Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
-                mutation.Values[c] += mult;
+                var editor = VBufferEditor.CreateFromBuffer(ref grad);
+                Contracts.Assert(editor.Values.Length >= BiasCount && (grad.IsDense || editor.Indices[BiasCount - 1] == BiasCount - 1));
+                editor.Values[c] += mult;
             }
 
             Contracts.Check(FloatUtils.IsFinite(datumLoss), "Data contain bad values.");

--- a/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Runtime.Learners
         internal LinearModelStatistics(IHostEnvironment env, long trainingExampleCount, int paramCount, Single deviance, Single nullDeviance, in VBuffer<Single> coeffStdError)
             : this(env, trainingExampleCount, paramCount, deviance, nullDeviance)
         {
-            _env.Assert(coeffStdError.Count == _paramCount);
+            _env.Assert(coeffStdError.GetValues().Length == _paramCount);
             _coeffStdError = coeffStdError;
         }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -411,7 +411,7 @@ namespace Microsoft.ML.Trainers
                     (float)(logProb + (_absentFeaturesLogProb[iLabel] - absentFeatureLogProb));
             }
 
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -380,7 +380,7 @@ namespace Microsoft.ML.Trainers
             var srcValues = src.GetValues();
             var srcIndices = src.GetIndices();
 
-            var mutation = VBufferMutationContext.Create(ref dst, _labelCount);
+            var mutation = VBufferEditor.Create(ref dst, _labelCount);
             Span<float> labelScores = mutation.Values;
             for (int iLabel = 0; iLabel < _labelCount; iLabel += 1)
             {

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -133,20 +133,22 @@ namespace Microsoft.ML.Trainers
                     labelHistogram[cursor.Label] += 1;
                     labelCount = labelCount < size ? size : labelCount;
 
+                    var featureValues = cursor.Features.GetValues();
                     if (cursor.Features.IsDense)
                     {
-                        for (int i = 0; i < cursor.Features.Count; i += 1)
+                        for (int i = 0; i < featureValues.Length; i += 1)
                         {
-                            if (cursor.Features.Values[i] > 0)
+                            if (featureValues[i] > 0)
                                 featureHistogram[cursor.Label][i] += 1;
                         }
                     }
                     else
                     {
-                        for (int i = 0; i < cursor.Features.Count; i += 1)
+                        var featureIndices = cursor.Features.GetIndices();
+                        for (int i = 0; i < featureValues.Length; i += 1)
                         {
-                            if (cursor.Features.Values[i] > 0)
-                                featureHistogram[cursor.Label][cursor.Features.Indices[i]] += 1;
+                            if (featureValues[i] > 0)
+                                featureHistogram[cursor.Label][featureIndices[i]] += 1;
                         }
                     }
 
@@ -374,7 +376,12 @@ namespace Microsoft.ML.Trainers
         private void Map(in VBuffer<float> src, ref VBuffer<float> dst)
         {
             Host.Check(src.Length == _featureCount, "Invalid number of features passed.");
-            float[] labelScores = (dst.Length >= _labelCount) ? dst.Values : new float[_labelCount];
+
+            var srcValues = src.GetValues();
+            var srcIndices = src.GetIndices();
+
+            var mutation = VBufferMutationContext.Create(ref dst, _labelCount);
+            Span<float> labelScores = mutation.Values;
             for (int iLabel = 0; iLabel < _labelCount; iLabel += 1)
             {
                 double labelOccurrenceCount = _labelHistogram[iLabel];
@@ -384,18 +391,18 @@ namespace Microsoft.ML.Trainers
                 {
                     if (src.IsDense)
                     {
-                        for (int iFeature = 0; iFeature < src.Count; iFeature += 1)
+                        for (int iFeature = 0; iFeature < srcValues.Length; iFeature += 1)
                         {
                             ComputeLabelProbabilityFromFeature(labelOccurrenceCount, iLabel, iFeature,
-                                src.Values[iFeature], ref logProb, ref absentFeatureLogProb);
+                                srcValues[iFeature], ref logProb, ref absentFeatureLogProb);
                         }
                     }
                     else
                     {
-                        for (int iFeature = 0; iFeature < src.Count; iFeature += 1)
+                        for (int iFeature = 0; iFeature < srcValues.Length; iFeature += 1)
                         {
-                            ComputeLabelProbabilityFromFeature(labelOccurrenceCount, iLabel, src.Indices[iFeature],
-                                src.Values[iFeature], ref logProb, ref absentFeatureLogProb);
+                            ComputeLabelProbabilityFromFeature(labelOccurrenceCount, iLabel, srcIndices[iFeature],
+                                srcValues[iFeature], ref logProb, ref absentFeatureLogProb);
                         }
                     }
                 }
@@ -404,7 +411,7 @@ namespace Microsoft.ML.Trainers
                     (float)(logProb + (_absentFeaturesLogProb[iLabel] - absentFeatureLogProb));
             }
 
-            dst = new VBuffer<float>(_labelCount, labelScores, dst.Indices);
+            mutation.Complete(ref dst);
         }
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -380,8 +380,8 @@ namespace Microsoft.ML.Trainers
             var srcValues = src.GetValues();
             var srcIndices = src.GetIndices();
 
-            var mutation = VBufferEditor.Create(ref dst, _labelCount);
-            Span<float> labelScores = mutation.Values;
+            var editor = VBufferEditor.Create(ref dst, _labelCount);
+            Span<float> labelScores = editor.Values;
             for (int iLabel = 0; iLabel < _labelCount; iLabel += 1)
             {
                 double labelOccurrenceCount = _labelHistogram[iLabel];
@@ -411,7 +411,7 @@ namespace Microsoft.ML.Trainers
                     (float)(logProb + (_absentFeaturesLogProb[iLabel] - absentFeatureLogProb));
             }
 
-            dst = mutation.Commit();
+            dst = editor.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -411,7 +411,7 @@ namespace Microsoft.ML.Trainers
                     (float)(logProb + (_absentFeaturesLogProb[iLabel] - absentFeatureLogProb));
             }
 
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -119,8 +119,8 @@ namespace Microsoft.ML.Trainers.Online
                 _batch++;
                 _numBatchExamples = 0;
                 _biasUpdate = 0;
-                VBufferMutationContext.Create(ref _weightsUpdate, _weightsUpdate.Length, 0)
-                    .Complete(ref _weightsUpdate);
+                _weightsUpdate = VBufferMutationContext.Create(ref _weightsUpdate, _weightsUpdate.Length, 0)
+                    .CreateBuffer();
             }
 
             private void FinishBatch(in VBuffer<Float> weightsUpdate, Float weightsUpdateScale)

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -119,8 +119,7 @@ namespace Microsoft.ML.Trainers.Online
                 _batch++;
                 _numBatchExamples = 0;
                 _biasUpdate = 0;
-                _weightsUpdate = VBufferMutationContext.Create(ref _weightsUpdate, _weightsUpdate.Length, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref _weightsUpdate, _weightsUpdate.Length, 0);
             }
 
             private void FinishBatch(in VBuffer<Float> weightsUpdate, Float weightsUpdateScale)

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -119,7 +119,8 @@ namespace Microsoft.ML.Trainers.Online
                 _batch++;
                 _numBatchExamples = 0;
                 _biasUpdate = 0;
-                _weightsUpdate = new VBuffer<Float>(_weightsUpdate.Length, 0, _weightsUpdate.Values, _weightsUpdate.Indices);
+                VBufferMutationContext.Create(ref _weightsUpdate, _weightsUpdate.Length, 0)
+                    .Complete(ref _weightsUpdate);
             }
 
             private void FinishBatch(in VBuffer<Float> weightsUpdate, Float weightsUpdateScale)
@@ -147,7 +148,7 @@ namespace Microsoft.ML.Trainers.Online
                     Float currentBiasUpdate = trueOutput * weight;
                     _biasUpdate += currentBiasUpdate;
                     // Only aggregate in the case where we're handling multiple instances.
-                    if (_weightsUpdate.Count == 0)
+                    if (_weightsUpdate.GetValues().Length == 0)
                     {
                         VectorUtils.ScaleInto(in feat, currentBiasUpdate, ref _weightsUpdate);
                         _weightsUpdateScale = 1;
@@ -160,7 +161,7 @@ namespace Microsoft.ML.Trainers.Online
                 {
                     if (_batchSize == 1 && loss < 0)
                     {
-                        Contracts.Assert(_weightsUpdate.Count == 0);
+                        Contracts.Assert(_weightsUpdate.GetValues().Length == 0);
                         // If we aren't aggregating multiple instances, just use the instance's
                         // vector directly.
                         Float currentBiasUpdate = trueOutput * weight;

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -138,9 +138,9 @@ namespace Microsoft.ML.Trainers
             float mult = -(y - lambda) * weight;
             VectorUtils.AddMultWithOffset(in feat, mult, ref grad, 1);
             // Due to the call to EnsureBiases, we know this region is dense.
-            var mutation = VBufferEditor.CreateFromBuffer(ref grad);
-            Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
-            mutation.Values[0] += mult;
+            var editor = VBufferEditor.CreateFromBuffer(ref grad);
+            Contracts.Assert(editor.Values.Length >= BiasCount && (grad.IsDense || editor.Indices[BiasCount - 1] == BiasCount - 1));
+            editor.Values[0] += mult;
             // From the computer's perspective exp(infinity)==infinity
             // so inf-inf=nan, but in reality, infinity is just a large
             // number we can't represent, and exp(X)-X for X=inf is just inf.

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -138,8 +138,9 @@ namespace Microsoft.ML.Trainers
             float mult = -(y - lambda) * weight;
             VectorUtils.AddMultWithOffset(in feat, mult, ref grad, 1);
             // Due to the call to EnsureBiases, we know this region is dense.
-            Contracts.Assert(grad.Count >= BiasCount && (grad.IsDense || grad.Indices[BiasCount - 1] == BiasCount - 1));
-            grad.Values[0] += mult;
+            var mutation = VBufferMutationContext.CreateFromBuffer(ref grad);
+            Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
+            mutation.Values[0] += mult;
             // From the computer's perspective exp(infinity)==infinity
             // so inf-inf=nan, but in reality, infinity is just a large
             // number we can't represent, and exp(X)-X for X=inf is just inf.

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Trainers
             float mult = -(y - lambda) * weight;
             VectorUtils.AddMultWithOffset(in feat, mult, ref grad, 1);
             // Due to the call to EnsureBiases, we know this region is dense.
-            var mutation = VBufferMutationContext.CreateFromBuffer(ref grad);
+            var mutation = VBufferEditor.CreateFromBuffer(ref grad);
             Contracts.Assert(mutation.Values.Length >= BiasCount && (grad.IsDense || mutation.Indices[BiasCount - 1] == BiasCount - 1));
             mutation.Values[0] += mult;
             // From the computer's perspective exp(infinity)==infinity

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -772,7 +772,7 @@ namespace Microsoft.ML.Trainers
                 while (cursor.MoveNext())
                 {
                     long idx = getIndexFromId(cursor.Id);
-                    var features = cursor.Features;
+                    VBuffer<float> features = cursor.Features;
                     var label = cursor.Label;
                     float invariant;
                     if (invariants != null)
@@ -830,9 +830,9 @@ namespace Microsoft.ML.Trainers
                                 }
 
                                 if (features.IsDense)
-                                    CpuMathUtils.SdcaL1UpdateDense(primalUpdate, features.Count, features.Values, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                    CpuMathUtils.SdcaL1UpdateDense(primalUpdate, features.Count, features.GetValues(), l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
                                 else if (features.Count > 0)
-                                    CpuMathUtils.SdcaL1UpdateSparse(primalUpdate, features.Count, features.Values, features.Indices, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                    CpuMathUtils.SdcaL1UpdateSparse(primalUpdate, features.Count, features.GetValues(), features.GetIndices(), l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
                             }
 
                             break;
@@ -919,6 +919,7 @@ namespace Microsoft.ML.Trainers
             var lossSum = new CompensatedSum();
             var dualLossSum = new CompensatedSum();
             var biasTotal = biasReg[0] + biasUnreg[0];
+            VBuffer<float> firstWeights = weights[0];
 
             using (var cursor = cursorFactory.Create())
             {
@@ -955,7 +956,7 @@ namespace Microsoft.ML.Trainers
             var dualityGap = metrics[(int)MetricKind.DualityGap] = newLoss - newDualLoss;
             metrics[(int)MetricKind.BiasUnreg] = biasUnreg[0];
             metrics[(int)MetricKind.BiasReg] = biasReg[0];
-            metrics[(int)MetricKind.L1Sparsity] = Args.L1Threshold == 0 ? 1 : (Double)weights[0].Values.Count(w => w != 0) / weights.Length;
+            metrics[(int)MetricKind.L1Sparsity] = Args.L1Threshold == 0 ? 1 : (Double)firstWeights.GetValues().Count(w => w != 0) / weights.Length;
 
             bool converged = dualityGap / newLoss < Args.ConvergenceTolerance;
 
@@ -964,7 +965,7 @@ namespace Microsoft.ML.Trainers
                 // Maintain a copy of weights and bias with best primal loss thus far.
                 // This is some extra work and uses extra memory, but it seems worth doing it.
                 // REVIEW: Sparsify bestWeights?
-                weights[0].CopyTo(ref bestWeights[0]);
+                firstWeights.CopyTo(ref bestWeights[0]);
                 bestBiasReg[0] = biasReg[0];
                 bestBiasUnreg[0] = biasUnreg[0];
                 bestPrimalLoss = metrics[(int)MetricKind.Loss];

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -829,10 +829,11 @@ namespace Microsoft.ML.Trainers
                                         : 0;
                                 }
 
+                                var featureValues = features.GetValues();
                                 if (features.IsDense)
-                                    CpuMathUtils.SdcaL1UpdateDense(primalUpdate, features.Count, features.GetValues(), l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
-                                else if (features.Count > 0)
-                                    CpuMathUtils.SdcaL1UpdateSparse(primalUpdate, features.Count, features.GetValues(), features.GetIndices(), l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                    CpuMathUtils.SdcaL1UpdateDense(primalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                else if (featureValues.Length > 0)
+                                    CpuMathUtils.SdcaL1UpdateSparse(primalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
                             }
 
                             break;

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Trainers
                     }
                     else
                     {
-                        normSquared = VectorUtils.NormSquared(features);
+                        normSquared = VectorUtils.NormSquared(in features);
                         if (Args.BiasLearningRate == 0)
                             normSquared += 1;
 
@@ -241,9 +241,9 @@ namespace Microsoft.ML.Trainers
                                     }
 
                                     if (features.IsDense)
-                                        CpuMathUtils.SdcaL1UpdateDense(-primalUpdate, features.Count, features.Values, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                        CpuMathUtils.SdcaL1UpdateDense(-primalUpdate, features.Count, features.GetValues(), l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
                                     else if (features.Count > 0)
-                                        CpuMathUtils.SdcaL1UpdateSparse(-primalUpdate, features.Count, features.Values, features.Indices, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                        CpuMathUtils.SdcaL1UpdateSparse(-primalUpdate, features.Count, features.GetValues(), features.GetIndices(), l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
                                 }
 
                                 break;
@@ -268,9 +268,9 @@ namespace Microsoft.ML.Trainers
                             : 0;
 
                         if (features.IsDense)
-                            CpuMathUtils.SdcaL1UpdateDense(labelPrimalUpdate, features.Count, features.Values, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                            CpuMathUtils.SdcaL1UpdateDense(labelPrimalUpdate, features.Count, features.GetValues(), l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
                         else if (features.Count > 0)
-                            CpuMathUtils.SdcaL1UpdateSparse(labelPrimalUpdate, features.Count, features.Values, features.Indices, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                            CpuMathUtils.SdcaL1UpdateSparse(labelPrimalUpdate, features.Count, features.GetValues(), features.GetIndices(), l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
                     }
 
                     rowCount++;

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -240,10 +240,11 @@ namespace Microsoft.ML.Trainers
                                         : 0;
                                     }
 
+                                    var featureValues = features.GetValues();
                                     if (features.IsDense)
-                                        CpuMathUtils.SdcaL1UpdateDense(-primalUpdate, features.Count, features.GetValues(), l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
-                                    else if (features.Count > 0)
-                                        CpuMathUtils.SdcaL1UpdateSparse(-primalUpdate, features.Count, features.GetValues(), features.GetIndices(), l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                        CpuMathUtils.SdcaL1UpdateDense(-primalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                    else if (featureValues.Length > 0)
+                                        CpuMathUtils.SdcaL1UpdateSparse(-primalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
                                 }
 
                                 break;
@@ -267,10 +268,11 @@ namespace Microsoft.ML.Trainers
                             ? intermediateBias - Math.Sign(intermediateBias) * l1Threshold
                             : 0;
 
+                        var featureValues = features.GetValues();
                         if (features.IsDense)
-                            CpuMathUtils.SdcaL1UpdateDense(labelPrimalUpdate, features.Count, features.GetValues(), l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
-                        else if (features.Count > 0)
-                            CpuMathUtils.SdcaL1UpdateSparse(labelPrimalUpdate, features.Count, features.GetValues(), features.GetIndices(), l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                            CpuMathUtils.SdcaL1UpdateDense(labelPrimalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                        else if (featureValues.Length > 0)
+                            CpuMathUtils.SdcaL1UpdateSparse(labelPrimalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
                     }
 
                     rowCount++;

--- a/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
@@ -115,8 +115,12 @@ namespace Microsoft.ML.Transforms.TensorFlow
                     Contracts.Assert(metadataType.IsKnownSizeVector && metadataType.ItemType.IsText);
                     schema.GetMetadata(TensorFlowUtils.InputOps, i, ref inputOps);
                 }
-                yield return (name, opType.ToString(), type,
-                    Utils.Size(inputOps.Values) > 0 ? inputOps.Values.Select(input => input.ToString()).ToArray() : new string[0]);
+                var inputOpsValues = inputOps.GetValues();
+                string[] inputOpsResult = new string[inputOpsValues.Length];
+                for (int j = 0; j < inputOpsValues.Length; j++)
+                    inputOpsResult[j] = inputOpsValues[j].ToString();
+
+                yield return (name, opType.ToString(), type, inputOpsResult);
             }
         }
 
@@ -328,16 +332,10 @@ namespace Microsoft.ML.Transforms.TensorFlow
             return LoadTFSession(env, bytes, modelPath);
         }
 
-        internal static unsafe void FetchData<T>(IntPtr data, T[] result)
+        internal static unsafe void FetchData<T>(IntPtr data, Span<T> result)
         {
-            var size = result.Length;
-
-            GCHandle handle = GCHandle.Alloc(result, GCHandleType.Pinned);
-            IntPtr target = handle.AddrOfPinnedObject();
-
-            Int64 sizeInBytes = size * Marshal.SizeOf((typeof(T)));
-            Buffer.MemoryCopy(data.ToPointer(), target.ToPointer(), sizeInBytes, sizeInBytes);
-            handle.Free();
+            var dataSpan = new Span<T>(data.ToPointer(), result.Length);
+            dataSpan.CopyTo(result);
         }
 
         internal static bool IsTypeSupported(TFDataType tfoutput)

--- a/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
@@ -115,10 +115,10 @@ namespace Microsoft.ML.Transforms.TensorFlow
                     Contracts.Assert(metadataType.IsKnownSizeVector && metadataType.ItemType.IsText);
                     schema.GetMetadata(TensorFlowUtils.InputOps, i, ref inputOps);
                 }
-                var inputOpsValues = inputOps.GetValues();
-                string[] inputOpsResult = new string[inputOpsValues.Length];
-                for (int j = 0; j < inputOpsValues.Length; j++)
-                    inputOpsResult[j] = inputOpsValues[j].ToString();
+
+                string[] inputOpsResult = inputOps.DenseValues()
+                    .Select(input => input.ToString())
+                    .ToArray();
 
                 yield return (name, opType.ToString(), type, inputOpsResult);
             }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -929,7 +929,7 @@ namespace Microsoft.ML.Transforms
 
                     var mutation = VBufferMutationContext.Create(ref dst, (int)tensorSize);
                     TensorFlowUtils.FetchData<T>(tensor.Data, mutation.Values);
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
                 return valuegetter;
             }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -927,9 +927,9 @@ namespace Microsoft.ML.Transforms
                     var tensor = outputCache.Outputs[_parent.Outputs[iinfo]];
                     var tensorSize = tensor.Shape.Where(x => x > 0).Aggregate((x, y) => x * y);
 
-                    var mutation = VBufferEditor.Create(ref dst, (int)tensorSize);
-                    TensorFlowUtils.FetchData<T>(tensor.Data, mutation.Values);
-                    dst = mutation.Commit();
+                    var editor = VBufferEditor.Create(ref dst, (int)tensorSize);
+                    TensorFlowUtils.FetchData<T>(tensor.Data, editor.Values);
+                    dst = editor.Commit();
                 };
                 return valuegetter;
             }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -929,7 +929,7 @@ namespace Microsoft.ML.Transforms
 
                     var mutation = VBufferMutationContext.Create(ref dst, (int)tensorSize);
                     TensorFlowUtils.FetchData<T>(tensor.Data, mutation.Values);
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
                 return valuegetter;
             }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -927,7 +927,7 @@ namespace Microsoft.ML.Transforms
                     var tensor = outputCache.Outputs[_parent.Outputs[iinfo]];
                     var tensorSize = tensor.Shape.Where(x => x > 0).Aggregate((x, y) => x * y);
 
-                    var mutation = VBufferMutationContext.Create(ref dst, (int)tensorSize);
+                    var mutation = VBufferEditor.Create(ref dst, (int)tensorSize);
                     TensorFlowUtils.FetchData<T>(tensor.Data, mutation.Values);
                     dst = mutation.Commit();
                 };

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -927,12 +927,9 @@ namespace Microsoft.ML.Transforms
                     var tensor = outputCache.Outputs[_parent.Outputs[iinfo]];
                     var tensorSize = tensor.Shape.Where(x => x > 0).Aggregate((x, y) => x * y);
 
-                    var values = dst.Values;
-                    if (Utils.Size(values) < tensorSize)
-                        values = new T[tensorSize];
-
-                    TensorFlowUtils.FetchData<T>(tensor.Data, values);
-                    dst = new VBuffer<T>(values.Length, values, dst.Indices);
+                    var mutation = VBufferMutationContext.Create(ref dst, (int)tensorSize);
+                    TensorFlowUtils.FetchData<T>(tensor.Data, mutation.Values);
+                    mutation.Complete(ref dst);
                 };
                 return valuegetter;
             }
@@ -1058,7 +1055,7 @@ namespace Microsoft.ML.Transforms
             private readonly ValueGetter<VBuffer<T>> _srcgetter;
             private readonly TFShape _tfShape;
             private VBuffer<T> _vBuffer;
-            private VBuffer<T> _vBufferDense;
+            private T[] _denseData;
             private readonly T[] _bufferedData;
             private int _position;
 
@@ -1067,7 +1064,7 @@ namespace Microsoft.ML.Transforms
                 _srcgetter = input.GetGetter<VBuffer<T>>(colIndex);
                 _tfShape = tfShape;
                 _vBuffer = default;
-                _vBufferDense = default;
+                _denseData = default;
 
                 long size = 0;
                 _position = 0;
@@ -1083,8 +1080,11 @@ namespace Microsoft.ML.Transforms
             public TFTensor GetTensor()
             {
                 _srcgetter(ref _vBuffer);
-                _vBuffer.CopyToDense(ref _vBufferDense);
-                return TFTensor.Create(_vBufferDense.Values, _vBufferDense.Length, _tfShape);
+
+                Utils.EnsureSize(ref _denseData, _vBuffer.Length, keepOld: false);
+                _vBuffer.CopyTo(_denseData);
+
+                return TFTensor.Create(_denseData, _vBuffer.Length, _tfShape);
             }
 
             public void BufferTrainingData()

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -581,8 +581,7 @@ namespace Microsoft.ML.Transforms.Projections
 
                 if (count == 0)
                 {
-                    dst = VBufferMutationContext.Create(ref dst, length, 0)
-                        .CreateBuffer();
+                    VBufferUtils.Resize(ref dst, length, 0);
                     return;
                 }
                 ectx.Assert(count > 0);

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -595,18 +595,18 @@ namespace Microsoft.ML.Transforms.Projections
                 if (normScale < MinScale)
                     normScale = 1;
 
-                VBufferEditor<float> mutation;
+                VBufferEditor<float> editor;
                 if (offset == 0)
                 {
-                    mutation = VBufferEditor.Create(ref dst, length, count);
-                    var dstValues = mutation.Values;
+                    editor = VBufferEditor.Create(ref dst, length, count);
+                    var dstValues = editor.Values;
                     if (!src.IsDense)
                     {
-                        src.GetIndices().CopyTo(mutation.Indices);
+                        src.GetIndices().CopyTo(editor.Indices);
                     }
 
                     CpuMathUtils.Scale(normScale, src.GetValues(), dstValues, count);
-                    dst = mutation.Commit();
+                    dst = editor.Commit();
 
                     return;
                 }
@@ -614,11 +614,11 @@ namespace Microsoft.ML.Transforms.Projections
                 // Subtracting the mean requires a dense representation.
                 src.CopyToDense(ref dst);
 
-                mutation = VBufferEditor.CreateFromBuffer(ref dst);
+                editor = VBufferEditor.CreateFromBuffer(ref dst);
                 if (normScale != 1)
-                    CpuMathUtils.ScaleAdd(normScale, -offset, mutation.Values);
+                    CpuMathUtils.ScaleAdd(normScale, -offset, editor.Values);
                 else
-                    CpuMathUtils.Add(-offset, mutation.Values);
+                    CpuMathUtils.Add(-offset, editor.Values);
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -606,7 +606,7 @@ namespace Microsoft.ML.Transforms.Projections
                     }
 
                     CpuMathUtils.Scale(normScale, src.GetValues(), dstValues, count);
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
 
                     return;
                 }

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -581,8 +581,8 @@ namespace Microsoft.ML.Transforms.Projections
 
                 if (count == 0)
                 {
-                    VBufferMutationContext.Create(ref dst, length, 0)
-                        .Complete(ref dst);
+                    dst = VBufferMutationContext.Create(ref dst, length, 0)
+                        .CreateBuffer();
                     return;
                 }
                 ectx.Assert(count > 0);
@@ -607,7 +607,7 @@ namespace Microsoft.ML.Transforms.Projections
                     }
 
                     CpuMathUtils.Scale(normScale, src.GetValues(), dstValues, count);
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
 
                     return;
                 }

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -595,10 +595,10 @@ namespace Microsoft.ML.Transforms.Projections
                 if (normScale < MinScale)
                     normScale = 1;
 
-                VBufferMutationContext<float> mutation;
+                VBufferEditor<float> mutation;
                 if (offset == 0)
                 {
-                    mutation = VBufferMutationContext.Create(ref dst, length, count);
+                    mutation = VBufferEditor.Create(ref dst, length, count);
                     var dstValues = mutation.Values;
                     if (!src.IsDense)
                     {
@@ -614,7 +614,7 @@ namespace Microsoft.ML.Transforms.Projections
                 // Subtracting the mean requires a dense representation.
                 src.CopyToDense(ref dst);
 
-                mutation = VBufferMutationContext.CreateFromBuffer(ref dst);
+                mutation = VBufferEditor.CreateFromBuffer(ref dst);
                 if (normScale != 1)
                     CpuMathUtils.ScaleAdd(normScale, -offset, mutation.Values);
                 else

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -483,8 +483,9 @@ namespace Microsoft.ML.Transforms.Projections
                                 (ref VBuffer<float> dst) =>
                                 {
                                     getSrc(ref src);
-                                    var mean = Mean(src.Values, src.Count, src.Length);
-                                    var divisor = StdDev(src.Values, src.Count, src.Length, mean);
+                                    var srcValues = src.GetValues();
+                                    var mean = Mean(srcValues, src.Length);
+                                    var divisor = StdDev(srcValues, src.Length, mean);
                                     FillValues(Host, in src, ref dst, divisor, scale, mean);
                                 };
                             return del;
@@ -493,8 +494,9 @@ namespace Microsoft.ML.Transforms.Projections
                                (ref VBuffer<float> dst) =>
                                {
                                    getSrc(ref src);
-                                   var mean = Mean(src.Values, src.Count, src.Length);
-                                   var divisor = L2Norm(src.Values, src.Count, mean);
+                                   var srcValues = src.GetValues();
+                                   var mean = Mean(srcValues, src.Length);
+                                   var divisor = L2Norm(srcValues, mean);
                                    FillValues(Host, in src, ref dst, divisor, scale, mean);
                                };
                             return del;
@@ -503,8 +505,9 @@ namespace Microsoft.ML.Transforms.Projections
                                (ref VBuffer<float> dst) =>
                                {
                                    getSrc(ref src);
-                                   var mean = Mean(src.Values, src.Count, src.Length);
-                                   var divisor = L1Norm(src.Values, src.Count, mean);
+                                   var srcValues = src.GetValues();
+                                   var mean = Mean(srcValues, src.Length);
+                                   var divisor = L1Norm(srcValues, mean);
                                    FillValues(Host, in src, ref dst, divisor, scale, mean);
                                };
                             return del;
@@ -513,8 +516,9 @@ namespace Microsoft.ML.Transforms.Projections
                                (ref VBuffer<float> dst) =>
                                {
                                    getSrc(ref src);
-                                   var mean = Mean(src.Values, src.Count, src.Length);
-                                   var divisor = LInfNorm(src.Values, src.Count, mean);
+                                   var srcValues = src.GetValues();
+                                   var mean = Mean(srcValues, src.Length);
+                                   var divisor = LInfNorm(srcValues, mean);
                                    FillValues(Host, in src, ref dst, divisor, scale, mean);
                                };
                             return del;
@@ -531,7 +535,7 @@ namespace Microsoft.ML.Transforms.Projections
                             (ref VBuffer<float> dst) =>
                             {
                                 getSrc(ref src);
-                                var divisor = StdDev(src.Values, src.Count, src.Length);
+                                var divisor = StdDev(src.GetValues(), src.Length);
                                 FillValues(Host, in src, ref dst, divisor, scale);
                             };
                         return del;
@@ -540,7 +544,7 @@ namespace Microsoft.ML.Transforms.Projections
                            (ref VBuffer<float> dst) =>
                            {
                                getSrc(ref src);
-                               var divisor = L2Norm(src.Values, src.Count);
+                               var divisor = L2Norm(src.GetValues());
                                FillValues(Host, in src, ref dst, divisor, scale);
                            };
                         return del;
@@ -549,7 +553,7 @@ namespace Microsoft.ML.Transforms.Projections
                            (ref VBuffer<float> dst) =>
                            {
                                getSrc(ref src);
-                               var divisor = L1Norm(src.Values, src.Count);
+                               var divisor = L1Norm(src.GetValues());
                                FillValues(Host, in src, ref dst, divisor, scale);
                            };
                         return del;
@@ -558,7 +562,7 @@ namespace Microsoft.ML.Transforms.Projections
                            (ref VBuffer<float> dst) =>
                            {
                                getSrc(ref src);
-                               var divisor = LInfNorm(src.Values, src.Count);
+                               var divisor = LInfNorm(src.GetValues());
                                FillValues(Host, in src, ref dst, divisor, scale);
                            };
                         return del;
@@ -570,14 +574,15 @@ namespace Microsoft.ML.Transforms.Projections
 
             private static void FillValues(IExceptionContext ectx, in VBuffer<float> src, ref VBuffer<float> dst, float divisor, float scale, float offset = 0)
             {
-                int count = src.Count;
+                var srcValues = src.GetValues();
+                int count = srcValues.Length;
                 int length = src.Length;
-                ectx.Assert(Utils.Size(src.Values) >= count);
                 ectx.Assert(divisor >= 0);
 
                 if (count == 0)
                 {
-                    dst = new VBuffer<float>(length, 0, dst.Values, dst.Indices);
+                    VBufferMutationContext.Create(ref dst, length, 0)
+                        .Complete(ref dst);
                     return;
                 }
                 ectx.Assert(count > 0);
@@ -591,21 +596,18 @@ namespace Microsoft.ML.Transforms.Projections
                 if (normScale < MinScale)
                     normScale = 1;
 
+                VBufferMutationContext<float> mutation;
                 if (offset == 0)
                 {
-                    var dstValues = dst.Values;
-                    if (Utils.Size(dstValues) < count)
-                        dstValues = new float[count];
-                    var dstIndices = dst.Indices;
+                    mutation = VBufferMutationContext.Create(ref dst, length, count);
+                    var dstValues = mutation.Values;
                     if (!src.IsDense)
                     {
-                        if (Utils.Size(dstIndices) < count)
-                            dstIndices = new int[count];
-                        Array.Copy(src.Indices, dstIndices, count);
+                        src.GetIndices().CopyTo(mutation.Indices);
                     }
 
-                    CpuMathUtils.Scale(normScale, src.Values, dstValues, count);
-                    dst = new VBuffer<float>(length, count, dstValues, dstIndices);
+                    CpuMathUtils.Scale(normScale, src.GetValues(), dstValues, count);
+                    mutation.Complete(ref dst);
 
                     return;
                 }
@@ -613,10 +615,11 @@ namespace Microsoft.ML.Transforms.Projections
                 // Subtracting the mean requires a dense representation.
                 src.CopyToDense(ref dst);
 
+                mutation = VBufferMutationContext.CreateFromBuffer(ref dst);
                 if (normScale != 1)
-                    CpuMathUtils.ScaleAdd(normScale, -offset, dst.Values.AsSpan(0, length));
+                    CpuMathUtils.ScaleAdd(normScale, -offset, mutation.Values);
                 else
-                    CpuMathUtils.Add(-offset, dst.Values.AsSpan(0, length));
+                    CpuMathUtils.Add(-offset, mutation.Values);
             }
 
             /// <summary>
@@ -624,21 +627,21 @@ namespace Microsoft.ML.Transforms.Projections
             /// based on centered values (i.e. after subtracting the mean). But since the centered
             /// values mean is approximately zero, we can use variance of non-centered values.
             /// </summary>
-            private static float StdDev(float[] values, int count, int length)
+            private static float StdDev(ReadOnlySpan<float> values, int length)
             {
-                Contracts.Assert(0 <= count && count <= length);
-                if (count == 0)
+                Contracts.Assert(0 <= values.Length && values.Length <= length);
+                if (values.Length == 0)
                     return 0;
                 // We need a mean to compute variance.
-                var tmpMean = CpuMathUtils.Sum(values.AsSpan(0, count)) / length;
+                var tmpMean = CpuMathUtils.Sum(values) / length;
                 float sumSq = 0;
-                if (count != length && tmpMean != 0)
+                if (values.Length != length && tmpMean != 0)
                 {
                     // Sparse representation.
                     float meanSq = tmpMean * tmpMean;
-                    sumSq = (length - count) * meanSq;
+                    sumSq = (length - values.Length) * meanSq;
                 }
-                sumSq += CpuMathUtils.SumSq(tmpMean, values.AsSpan(0, count));
+                sumSq += CpuMathUtils.SumSq(tmpMean, values);
                 return MathUtils.Sqrt(sumSq / length);
             }
 
@@ -646,19 +649,19 @@ namespace Microsoft.ML.Transforms.Projections
             /// Compute Standard Deviation.
             /// We have two overloads of StdDev instead of one with <see cref="Nullable{Float}"/> mean for perf reasons.
             /// </summary>
-            private static float StdDev(float[] values, int count, int length, float mean)
+            private static float StdDev(ReadOnlySpan<float> values, int length, float mean)
             {
-                Contracts.Assert(0 <= count && count <= length);
-                if (count == 0)
+                Contracts.Assert(0 <= values.Length && values.Length <= length);
+                if (values.Length == 0)
                     return 0;
                 float sumSq = 0;
-                if (count != length && mean != 0)
+                if (values.Length != length && mean != 0)
                 {
                     // Sparse representation.
                     float meanSq = mean * mean;
-                    sumSq = (length - count) * meanSq;
+                    sumSq = (length - values.Length) * meanSq;
                 }
-                sumSq += CpuMathUtils.SumSq(mean, values.AsSpan(0, count));
+                sumSq += CpuMathUtils.SumSq(mean, values);
                 return MathUtils.Sqrt(sumSq / length);
             }
 
@@ -666,40 +669,40 @@ namespace Microsoft.ML.Transforms.Projections
             /// Compute L2-norm. L2-norm computation doesn't subtract the mean from the source values.
             /// However, we substract the mean here in case subMean is true (if subMean is false, mean is zero).
             /// </summary>
-            private static float L2Norm(float[] values, int count, float mean = 0)
+            private static float L2Norm(ReadOnlySpan<float> values, float mean = 0)
             {
-                if (count == 0)
+                if (values.Length == 0)
                     return 0;
-                return MathUtils.Sqrt(CpuMathUtils.SumSq(mean, values.AsSpan(0, count)));
+                return MathUtils.Sqrt(CpuMathUtils.SumSq(mean, values));
             }
 
             /// <summary>
             /// Compute L1-norm. L1-norm computation doesn't subtract the mean from the source values.
             /// However, we substract the mean here in case subMean is true (if subMean is false, mean is zero).
             /// </summary>
-            private static float L1Norm(float[] values, int count, float mean = 0)
+            private static float L1Norm(ReadOnlySpan<float> values, float mean = 0)
             {
-                if (count == 0)
+                if (values.Length == 0)
                     return 0;
-                return CpuMathUtils.SumAbs(mean, values.AsSpan(0, count));
+                return CpuMathUtils.SumAbs(mean, values);
             }
 
             /// <summary>
             /// Compute LInf-norm. LInf-norm computation doesn't subtract the mean from the source values.
             /// However, we substract the mean here in case subMean is true (if subMean is false, mean is zero).
             /// </summary>
-            private static float LInfNorm(float[] values, int count, float mean = 0)
+            private static float LInfNorm(ReadOnlySpan<float> values, float mean = 0)
             {
-                if (count == 0)
+                if (values.Length == 0)
                     return 0;
-                return CpuMathUtils.MaxAbsDiff(mean, values.AsSpan(0, count));
+                return CpuMathUtils.MaxAbsDiff(mean, values);
             }
 
-            private static float Mean(float[] src, int count, int length)
+            private static float Mean(ReadOnlySpan<float> src, int length)
             {
-                if (length == 0 || count == 0)
+                if (length == 0 || src.Length == 0)
                     return 0;
-                return CpuMathUtils.Sum(src.AsSpan(0, count)) / length;
+                return CpuMathUtils.Sum(src) / length;
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/KeyToBinaryVectorTransform.cs
+++ b/src/Microsoft.ML.Transforms/KeyToBinaryVectorTransform.cs
@@ -341,7 +341,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     sb.Append('.');
 
                     int len = sb.Length;
-                    foreach (var key in bits.Values)
+                    foreach (var key in bits.GetValues())
                     {
                         sb.Length = len;
                         sb.AppendMemory(key);

--- a/src/Microsoft.ML.Transforms/Microsoft.ML.Transforms.csproj
+++ b/src/Microsoft.ML.Transforms/Microsoft.ML.Transforms.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeInPackage>Microsoft.ML</IncludeInPackage>
     <DefineConstants>CORECLR</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -266,7 +266,7 @@ namespace Microsoft.ML.Runtime.Data
             }
             Host.Assert(iDst == newCount);
 
-            dst = mutation.CreateBuffer();
+            dst = mutation.Commit();
         }
 
         private void DropNAs<TDst>(ref VBuffer<TDst> src, ref VBuffer<TDst> dst, InPredicate<TDst> isNA)
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Runtime.Data
                     }
                 }
                 Host.Assert(iDst == newCount);
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             }
             else
             {
@@ -329,7 +329,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
                 Host.Assert(iDst == newCount);
                 Host.Assert(offset == srcValues.Length - newCount);
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Runtime.Data
             int iDst = 0;
 
             // Densifying sparse vectors since default value equals NA and hence should be dropped.
-            var mutation = VBufferMutationContext.Create(ref dst, newCount);
+            var mutation = VBufferEditor.Create(ref dst, newCount);
             for (int i = 0; i < srcValues.Length; i++)
             {
                 if (!isNA(in srcValues[i]))
@@ -297,7 +297,7 @@ namespace Microsoft.ML.Runtime.Data
             int iDst = 0;
             if (src.IsDense)
             {
-                var mutation = VBufferMutationContext.Create(ref dst, newCount);
+                var mutation = VBufferEditor.Create(ref dst, newCount);
                 for (int i = 0; i < srcValues.Length; i++)
                 {
                     if (!isNA(in srcValues[i]))
@@ -312,7 +312,7 @@ namespace Microsoft.ML.Runtime.Data
             else
             {
                 var newLength = src.Length - srcValues.Length - newCount;
-                var mutation = VBufferMutationContext.Create(ref dst, newLength, newCount);
+                var mutation = VBufferEditor.Create(ref dst, newLength, newCount);
 
                 var srcIndices = src.GetIndices();
                 int offset = 0;

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -258,15 +258,15 @@ namespace Microsoft.ML.Runtime.Data
             int iDst = 0;
 
             // Densifying sparse vectors since default value equals NA and hence should be dropped.
-            var mutation = VBufferEditor.Create(ref dst, newCount);
+            var editor = VBufferEditor.Create(ref dst, newCount);
             for (int i = 0; i < srcValues.Length; i++)
             {
                 if (!isNA(in srcValues[i]))
-                    mutation.Values[iDst++] = srcValues[i];
+                    editor.Values[iDst++] = srcValues[i];
             }
             Host.Assert(iDst == newCount);
 
-            dst = mutation.Commit();
+            dst = editor.Commit();
         }
 
         private void DropNAs<TDst>(ref VBuffer<TDst> src, ref VBuffer<TDst> dst, InPredicate<TDst> isNA)
@@ -297,22 +297,22 @@ namespace Microsoft.ML.Runtime.Data
             int iDst = 0;
             if (src.IsDense)
             {
-                var mutation = VBufferEditor.Create(ref dst, newCount);
+                var editor = VBufferEditor.Create(ref dst, newCount);
                 for (int i = 0; i < srcValues.Length; i++)
                 {
                     if (!isNA(in srcValues[i]))
                     {
-                        mutation.Values[iDst] = srcValues[i];
+                        editor.Values[iDst] = srcValues[i];
                         iDst++;
                     }
                 }
                 Host.Assert(iDst == newCount);
-                dst = mutation.Commit();
+                dst = editor.Commit();
             }
             else
             {
                 var newLength = src.Length - srcValues.Length - newCount;
-                var mutation = VBufferEditor.Create(ref dst, newLength, newCount);
+                var editor = VBufferEditor.Create(ref dst, newLength, newCount);
 
                 var srcIndices = src.GetIndices();
                 int offset = 0;
@@ -320,8 +320,8 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     if (!isNA(in srcValues[i]))
                     {
-                        mutation.Values[iDst] = srcValues[i];
-                        mutation.Indices[iDst] = srcIndices[i] - offset;
+                        editor.Values[iDst] = srcValues[i];
+                        editor.Indices[iDst] = srcIndices[i] - offset;
                         iDst++;
                     }
                     else
@@ -329,7 +329,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
                 Host.Assert(iDst == newCount);
                 Host.Assert(offset == srcValues.Length - newCount);
-                dst = mutation.Commit();
+                dst = editor.Commit();
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -240,8 +240,7 @@ namespace Microsoft.ML.Runtime.Data
 
             if (newCount == 0)
             {
-                dst = VBufferMutationContext.Create(ref dst, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref dst, 0);
                 return;
             }
 
@@ -251,8 +250,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (!dst.IsDense)
                 {
                     Host.Assert(dst.GetValues().Length == newCount);
-                    dst = VBufferMutationContext.Create(ref dst, newCount)
-                        .CreateBuffer();
+                    VBufferUtils.Resize(ref dst, newCount);
                 }
                 return;
             }
@@ -286,8 +284,7 @@ namespace Microsoft.ML.Runtime.Data
 
             if (newCount == 0)
             {
-                dst = VBufferMutationContext.Create(ref dst, src.Length - srcValues.Length, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref dst, src.Length - srcValues.Length, 0);
                 return;
             }
 

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -240,8 +240,8 @@ namespace Microsoft.ML.Runtime.Data
 
             if (newCount == 0)
             {
-                VBufferMutationContext.Create(ref dst, 0)
-                    .Complete(ref dst);
+                dst = VBufferMutationContext.Create(ref dst, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -251,8 +251,8 @@ namespace Microsoft.ML.Runtime.Data
                 if (!dst.IsDense)
                 {
                     Host.Assert(dst.GetValues().Length == newCount);
-                    VBufferMutationContext.Create(ref dst, newCount)
-                        .Complete(ref dst);
+                    dst = VBufferMutationContext.Create(ref dst, newCount)
+                        .CreateBuffer();
                 }
                 return;
             }
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Runtime.Data
             }
             Host.Assert(iDst == newCount);
 
-            mutation.Complete(ref dst);
+            dst = mutation.CreateBuffer();
         }
 
         private void DropNAs<TDst>(ref VBuffer<TDst> src, ref VBuffer<TDst> dst, InPredicate<TDst> isNA)
@@ -286,8 +286,8 @@ namespace Microsoft.ML.Runtime.Data
 
             if (newCount == 0)
             {
-                VBufferMutationContext.Create(ref dst, src.Length - srcValues.Length, 0)
-                    .Complete(ref dst);
+                dst = VBufferMutationContext.Create(ref dst, src.Length - srcValues.Length, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -310,7 +310,7 @@ namespace Microsoft.ML.Runtime.Data
                     }
                 }
                 Host.Assert(iDst == newCount);
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             }
             else
             {
@@ -332,7 +332,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
                 Host.Assert(iDst == newCount);
                 Host.Assert(offset == srcValues.Length - newCount);
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -280,19 +280,19 @@ namespace Microsoft.ML.Transforms
                 return;
             }
 
-            var mutation = VBufferEditor.Create(ref result, 2, 1);
+            var editor = VBufferEditor.Create(ref result, 2, 1);
             if (Float.IsNaN(input))
             {
-                mutation.Values[0] = 1;
-                mutation.Indices[0] = 1;
+                editor.Values[0] = 1;
+                editor.Indices[0] = 1;
             }
             else
             {
-                mutation.Values[0] = input;
-                mutation.Indices[0] = 0;
+                editor.Values[0] = input;
+                editor.Indices[0] = 0;
             }
 
-            result = mutation.Commit();
+            result = editor.Commit();
         }
 
         // This converts in place.
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Transforms
             ectx.Check(0 <= size & size < int.MaxValue / 2);
 
             var values = buffer.GetValues();
-            var mutation = VBufferEditor.Create(ref buffer, size * 2, values.Length);
+            var editor = VBufferEditor.Create(ref buffer, size * 2, values.Length);
             int iivDst = 0;
             if (buffer.IsDense)
             {
@@ -316,13 +316,13 @@ namespace Microsoft.ML.Transforms
                         continue;
                     if (Float.IsNaN(val))
                     {
-                        mutation.Values[iivDst] = 1;
-                        mutation.Indices[iivDst] = 2 * ivSrc + 1;
+                        editor.Values[iivDst] = 1;
+                        editor.Indices[iivDst] = 2 * ivSrc + 1;
                     }
                     else
                     {
-                        mutation.Values[iivDst] = val;
-                        mutation.Indices[iivDst] = 2 * ivSrc;
+                        editor.Values[iivDst] = val;
+                        editor.Indices[iivDst] = 2 * ivSrc;
                     }
                     iivDst++;
                 }
@@ -344,20 +344,20 @@ namespace Microsoft.ML.Transforms
                     ivPrev = iv;
                     if (Float.IsNaN(val))
                     {
-                        mutation.Values[iivDst] = 1;
-                        mutation.Indices[iivDst] = 2 * iv + 1;
+                        editor.Values[iivDst] = 1;
+                        editor.Indices[iivDst] = 2 * iv + 1;
                     }
                     else
                     {
-                        mutation.Values[iivDst] = val;
-                        mutation.Indices[iivDst] = 2 * iv;
+                        editor.Values[iivDst] = val;
+                        editor.Indices[iivDst] = 2 * iv;
                     }
                     iivDst++;
                 }
             }
 
             ectx.Assert(0 <= iivDst & iivDst <= values.Length);
-            buffer = mutation.CommitTruncated(iivDst);
+            buffer = editor.CommitTruncated(iivDst);
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -276,8 +276,7 @@ namespace Microsoft.ML.Transforms
         {
             if (input == 0)
             {
-                result = VBufferMutationContext.Create(ref result, 2, 0)
-                    .CreateBuffer();
+                VBufferUtils.Resize(ref result, 2, 0);
                 return;
             }
 

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Transforms
                 mutation.Indices[0] = 0;
             }
 
-            result = mutation.CreateBuffer();
+            result = mutation.Commit();
         }
 
         // This converts in place.
@@ -357,7 +357,7 @@ namespace Microsoft.ML.Transforms
             }
 
             ectx.Assert(0 <= iivDst & iivDst <= values.Length);
-            buffer = mutation.CreateBuffer(iivDst);
+            buffer = mutation.CommitTruncated(iivDst);
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -276,8 +276,8 @@ namespace Microsoft.ML.Transforms
         {
             if (input == 0)
             {
-                VBufferMutationContext.Create(ref result, 2, 0)
-                    .Complete(ref result);
+                result = VBufferMutationContext.Create(ref result, 2, 0)
+                    .CreateBuffer();
                 return;
             }
 
@@ -293,7 +293,7 @@ namespace Microsoft.ML.Transforms
                 mutation.Indices[0] = 0;
             }
 
-            mutation.Complete(ref result);
+            result = mutation.CreateBuffer();
         }
 
         // This converts in place.
@@ -358,7 +358,7 @@ namespace Microsoft.ML.Transforms
             }
 
             ectx.Assert(0 <= iivDst & iivDst <= values.Length);
-            mutation.Complete(ref buffer, iivDst);
+            buffer = mutation.CreateBuffer(iivDst);
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -280,7 +280,7 @@ namespace Microsoft.ML.Transforms
                 return;
             }
 
-            var mutation = VBufferMutationContext.Create(ref result, 2, 1);
+            var mutation = VBufferEditor.Create(ref result, 2, 1);
             if (Float.IsNaN(input))
             {
                 mutation.Values[0] = 1;
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Transforms
             ectx.Check(0 <= size & size < int.MaxValue / 2);
 
             var values = buffer.GetValues();
-            var mutation = VBufferMutationContext.Create(ref buffer, size * 2, values.Length);
+            var mutation = VBufferEditor.Create(ref buffer, size * 2, values.Length);
             int iivDst = 0;
             if (buffer.IsDense)
             {

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
@@ -294,8 +294,8 @@ namespace Microsoft.ML.Transforms
 
                 // Find the indices of all of the NAs.
                 indices.Clear();
-                var srcValues = src.Values;
-                var srcCount = src.Count;
+                var srcValues = src.GetValues();
+                var srcCount = srcValues.Length;
                 if (src.IsDense)
                 {
                     for (int i = 0; i < srcCount; i++)
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Transforms
                 }
                 else if (!defaultIsNA)
                 {
-                    var srcIndices = src.Indices;
+                    var srcIndices = src.GetIndices();
                     for (int ii = 0; ii < srcCount; ii++)
                     {
                         if (isNA(in srcValues[ii]))
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     // Note that this adds non-NAs to indices -- this is indicated by sense being false.
-                    var srcIndices = src.Indices;
+                    var srcIndices = src.GetIndices();
                     for (int ii = 0; ii < srcCount; ii++)
                     {
                         if (!isNA(in srcValues[ii]))

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -734,10 +734,8 @@ namespace Microsoft.ML.Transforms
                 Host.AssertValue(isNA);
 
                 int srcSize = src.Length;
-                int srcCount = src.Count;
-                var srcValues = src.Values;
-                Host.Assert(Utils.Size(srcValues) >= srcCount);
-                var srcIndices = src.Indices;
+                var srcValues = src.GetValues();
+                int srcCount = srcValues.Length;
 
                 var dstValues = dst.Values;
                 var dstIndices = dst.Indices;
@@ -768,8 +766,8 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     // The source vector is sparse.
-                    Host.Assert(Utils.Size(srcIndices) >= srcCount);
                     Host.Assert(srcCount < srcSize);
+                    var srcIndices = src.GetIndices();
 
                     // Allocate more space if necessary.
                     // REVIEW: One thing that changing the code to simply ensure that there are srcCount indices in the arrays
@@ -818,10 +816,8 @@ namespace Microsoft.ML.Transforms
                 Host.AssertValue(isNA);
 
                 int srcSize = src.Length;
-                int srcCount = src.Count;
-                var srcValues = src.Values;
-                Host.Assert(Utils.Size(srcValues) >= srcCount);
-                var srcIndices = src.Indices;
+                var srcValues = src.GetValues();
+                int srcCount = srcValues.Length;
 
                 var dstValues = dst.Values;
                 var dstIndices = dst.Indices;
@@ -830,7 +826,6 @@ namespace Microsoft.ML.Transforms
                 Utils.EnsureSize(ref dstValues, srcCount, srcSize, keepOld: false);
 
                 int iivDst = 0;
-                Host.Assert(Utils.Size(srcValues) >= srcCount);
                 if (src.IsDense)
                 {
                     // The source vector is dense.
@@ -852,8 +847,8 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     // The source vector is sparse.
-                    Host.Assert(Utils.Size(srcIndices) >= srcCount);
                     Host.Assert(srcCount < srcSize);
+                    var srcIndices = src.GetIndices();
 
                     // Allocate more space if necessary.
                     // REVIEW: One thing that changing the code to simply ensure that there are srcCount indices in the arrays

--- a/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
@@ -185,9 +185,8 @@ namespace Microsoft.ML.Transforms
 
             protected sealed override void ProcessRow(in VBuffer<TItem> src)
             {
-                var srcCount = src.Count;
-                var srcValues = src.Values;
-                Ch.Assert(Utils.Size(srcValues) >= srcCount);
+                var srcValues = src.GetValues();
+                var srcCount = srcValues.Length;
 
                 for (int slot = 0; slot < srcCount; slot++)
                     ProcessValue(in srcValues[slot]);
@@ -210,9 +209,8 @@ namespace Microsoft.ML.Transforms
 
             protected sealed override void ProcessRow(in VBuffer<TItem> src)
             {
-                var srcCount = src.Count;
-                var srcValues = src.Values;
-                Ch.Assert(Utils.Size(srcValues) >= srcCount);
+                var srcValues = src.GetValues();
+                var srcCount = srcValues.Length;
                 if (src.IsDense)
                 {
                     // The src vector is dense.
@@ -222,8 +220,7 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     // The src vector is sparse.
-                    var srcIndices = src.Indices;
-                    Ch.Assert(Utils.Size(srcIndices) >= srcCount);
+                    var srcIndices = src.GetIndices();
                     for (int islot = 0; islot < srcCount; islot++)
                         ProcessValue(in srcValues[islot], srcIndices[islot]);
                 }

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -774,7 +774,7 @@ namespace Microsoft.ML.Transforms
         private static void MapVector<TSrc, TDst>(this ValueMapper<TSrc, TDst> map, in VBuffer<TSrc> input, ref VBuffer<TDst> output)
         {
             var inputValues = input.GetValues();
-            var mutation = VBufferMutationContext.Create(ref output, input.Length, inputValues.Length);
+            var mutation = VBufferEditor.Create(ref output, input.Length, inputValues.Length);
             for (int i = 0; i < inputValues.Length; i++)
             {
                 TSrc val = inputValues[i];

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -406,28 +406,28 @@ namespace Microsoft.ML.Transforms
                 {
                     var tmp = default(VBuffer<int>);
                     trans.GetSingleSlotValue(labelCol, ref tmp);
-                    BinInts(ref tmp, ref labels, _numBins, out min, out lim);
+                    BinInts(in tmp, ref labels, _numBins, out min, out lim);
                     _numLabels = lim - min;
                 }
                 else if (labelType == NumberType.R4)
                 {
                     var tmp = default(VBuffer<Single>);
                     trans.GetSingleSlotValue(labelCol, ref tmp);
-                    BinSingles(ref tmp, ref labels, _numBins, out min, out lim);
+                    BinSingles(in tmp, ref labels, _numBins, out min, out lim);
                     _numLabels = lim - min;
                 }
                 else if (labelType == NumberType.R8)
                 {
                     var tmp = default(VBuffer<Double>);
                     trans.GetSingleSlotValue(labelCol, ref tmp);
-                    BinDoubles(ref tmp, ref labels, _numBins, out min, out lim);
+                    BinDoubles(in tmp, ref labels, _numBins, out min, out lim);
                     _numLabels = lim - min;
                 }
                 else if (labelType.IsBool)
                 {
                     var tmp = default(VBuffer<bool>);
                     trans.GetSingleSlotValue(labelCol, ref tmp);
-                    BinBools(ref tmp, ref labels);
+                    BinBools(in tmp, ref labels);
                     _numLabels = 3;
                     min = -1;
                     lim = 2;
@@ -485,7 +485,7 @@ namespace Microsoft.ML.Transforms
                     return ComputeMutualInformation(trans, col,
                         (ref VBuffer<int> src, ref VBuffer<int> dst, out int min, out int lim) =>
                         {
-                            BinInts(ref src, ref dst, _numBins, out min, out lim);
+                            BinInts(in src, ref dst, _numBins, out min, out lim);
                         });
                 }
                 if (type.ItemType == NumberType.R4)
@@ -493,7 +493,7 @@ namespace Microsoft.ML.Transforms
                     return ComputeMutualInformation(trans, col,
                         (ref VBuffer<Single> src, ref VBuffer<int> dst, out int min, out int lim) =>
                         {
-                            BinSingles(ref src, ref dst, _numBins, out min, out lim);
+                            BinSingles(in src, ref dst, _numBins, out min, out lim);
                         });
                 }
                 if (type.ItemType == NumberType.R8)
@@ -501,7 +501,7 @@ namespace Microsoft.ML.Transforms
                     return ComputeMutualInformation(trans, col,
                         (ref VBuffer<Double> src, ref VBuffer<int> dst, out int min, out int lim) =>
                         {
-                            BinDoubles(ref src, ref dst, _numBins, out min, out lim);
+                            BinDoubles(in src, ref dst, _numBins, out min, out lim);
                         });
                 }
                 if (type.ItemType.IsBool)
@@ -511,7 +511,7 @@ namespace Microsoft.ML.Transforms
                         {
                             min = -1;
                             lim = 2;
-                            BinBools(ref src, ref dst);
+                            BinBools(in src, ref dst);
                         });
                 }
                 Contracts.Assert(0 < type.ItemType.KeyCount && type.ItemType.KeyCount < Utils.ArrayMaxSize);
@@ -610,12 +610,13 @@ namespace Microsoft.ML.Transforms
             private void FillTable(in VBuffer<int> features, int offset, int numFeatures)
             {
                 Contracts.Assert(_labels.Length == features.Length);
+                var featureValues = features.GetValues();
                 if (features.IsDense)
                 {
                     for (int i = 0; i < _labels.Length; i++)
                     {
                         var label = _labels[i];
-                        var feature = features.Values[i] - offset;
+                        var feature = featureValues[i] - offset;
                         Contracts.Assert(0 <= label && label < _numLabels);
                         Contracts.Assert(0 <= feature && feature < numFeatures);
                         _contingencyTable[label][feature]++;
@@ -623,23 +624,24 @@ namespace Microsoft.ML.Transforms
                     return;
                 }
 
+                var featureIndices = features.GetIndices();
                 int ii = 0;
                 for (int i = 0; i < _labels.Length; i++)
                 {
                     var label = _labels[i];
                     int feature;
-                    if (ii == features.Count || i < features.Indices[ii])
+                    if (ii == featureIndices.Length || i < featureIndices[ii])
                         feature = -offset;
                     else
                     {
-                        feature = features.Values[ii] - offset;
+                        feature = featureValues[ii] - offset;
                         ii++;
                     }
                     Contracts.Assert(0 <= label && label < _numLabels);
                     Contracts.Assert(0 <= feature && feature < numFeatures);
                     _contingencyTable[label][feature]++;
                 }
-                Contracts.Assert(ii == features.Count);
+                Contracts.Assert(ii == featureIndices.Length);
             }
 
             /// <summary>
@@ -673,12 +675,12 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Maps Ints.
             /// </summary>
-            private void BinInts(ref VBuffer<int> input, ref VBuffer<int> output,
+            private void BinInts(in VBuffer<int> input, ref VBuffer<int> output,
                 int numBins, out int min, out int lim)
             {
                 Contracts.Assert(_singles.Count == 0);
 
-                var bounds = _binFinder.FindBins(numBins, _singles, input.Length - input.Count);
+                var bounds = _binFinder.FindBins(numBins, _singles, input.Length - input.GetValues().Length);
                 min = -1 - bounds.FindIndexSorted(0);
                 lim = min + bounds.Length + 1;
                 int offset = min;
@@ -692,21 +694,19 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Maps from Singles to ints. NaNs (and only NaNs) are mapped to the first bin.
             /// </summary>
-            private void BinSingles(ref VBuffer<Single> input, ref VBuffer<int> output,
+            private void BinSingles(in VBuffer<Single> input, ref VBuffer<int> output,
                 int numBins, out int min, out int lim)
             {
                 Contracts.Assert(_singles.Count == 0);
-                if (input.Values != null)
+                var inputValues = input.GetValues();
+                for (int i = 0; i < inputValues.Length; i++)
                 {
-                    for (int i = 0; i < input.Count; i++)
-                    {
-                        var val = input.Values[i];
-                        if (!Single.IsNaN(val))
-                            _singles.Add(val);
-                    }
+                    var val = inputValues[i];
+                    if (!Single.IsNaN(val))
+                        _singles.Add(val);
                 }
 
-                var bounds = _binFinder.FindBins(numBins, _singles, input.Length - input.Count);
+                var bounds = _binFinder.FindBins(numBins, _singles, input.Length - inputValues.Length);
                 min = -1 - bounds.FindIndexSorted(0);
                 lim = min + bounds.Length + 1;
                 int offset = min;
@@ -720,21 +720,19 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Maps from Doubles to ints. NaNs (and only NaNs) are mapped to the first bin.
             /// </summary>
-            private void BinDoubles(ref VBuffer<Double> input, ref VBuffer<int> output,
+            private void BinDoubles(in VBuffer<Double> input, ref VBuffer<int> output,
                 int numBins, out int min, out int lim)
             {
                 Contracts.Assert(_doubles.Count == 0);
-                if (input.Values != null)
+                var inputValues = input.GetValues();
+                for (int i = 0; i < inputValues.Length; i++)
                 {
-                    for (int i = 0; i < input.Count; i++)
-                    {
-                        var val = input.Values[i];
-                        if (!Double.IsNaN(val))
-                            _doubles.Add(val);
-                    }
+                    var val = inputValues[i];
+                    if (!Double.IsNaN(val))
+                        _doubles.Add(val);
                 }
 
-                var bounds = _binFinder.FindBins(numBins, _doubles, input.Length - input.Count);
+                var bounds = _binFinder.FindBins(numBins, _doubles, input.Length - inputValues.Length);
                 var offset = min = -1 - bounds.FindIndexSorted(0);
                 lim = min + bounds.Length + 1;
                 ValueMapper<Double, int> mapper =
@@ -744,7 +742,7 @@ namespace Microsoft.ML.Transforms
                 _doubles.Clear();
             }
 
-            private void BinBools(ref VBuffer<bool> input, ref VBuffer<int> output)
+            private void BinBools(in VBuffer<bool> input, ref VBuffer<int> output)
             {
                 if (_boolMapper == null)
                     _boolMapper = CreateVectorMapper<bool, int>(BinOneBool);
@@ -775,24 +773,20 @@ namespace Microsoft.ML.Transforms
 
         private static void MapVector<TSrc, TDst>(this ValueMapper<TSrc, TDst> map, in VBuffer<TSrc> input, ref VBuffer<TDst> output)
         {
-            var values = output.Values;
-            if (Utils.Size(values) < input.Count)
-                values = new TDst[input.Count];
-            for (int i = 0; i < input.Count; i++)
+            var inputValues = input.GetValues();
+            var mutation = VBufferMutationContext.Create(ref output, input.Length, inputValues.Length);
+            for (int i = 0; i < inputValues.Length; i++)
             {
-                TSrc val = input.Values[i];
-                map(in val, ref values[i]);
+                TSrc val = inputValues[i];
+                map(in val, ref mutation.Values[i]);
             }
 
-            var indices = output.Indices;
-            if (!input.IsDense && input.Count > 0)
+            if (!input.IsDense && inputValues.Length > 0)
             {
-                if (Utils.Size(indices) < input.Count)
-                    indices = new int[input.Count];
-                Array.Copy(input.Indices, indices, input.Count);
+                input.GetIndices().CopyTo(mutation.Indices);
             }
 
-            output = new VBuffer<TDst>(input.Length, input.Count, values, indices);
+            mutation.Complete(ref output);
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -774,19 +774,19 @@ namespace Microsoft.ML.Transforms
         private static void MapVector<TSrc, TDst>(this ValueMapper<TSrc, TDst> map, in VBuffer<TSrc> input, ref VBuffer<TDst> output)
         {
             var inputValues = input.GetValues();
-            var mutation = VBufferEditor.Create(ref output, input.Length, inputValues.Length);
+            var editor = VBufferEditor.Create(ref output, input.Length, inputValues.Length);
             for (int i = 0; i < inputValues.Length; i++)
             {
                 TSrc val = inputValues[i];
-                map(in val, ref mutation.Values[i]);
+                map(in val, ref editor.Values[i]);
             }
 
             if (!input.IsDense && inputValues.Length > 0)
             {
-                input.GetIndices().CopyTo(mutation.Indices);
+                input.GetIndices().CopyTo(editor.Indices);
             }
 
-            output = mutation.Commit();
+            output = editor.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -786,7 +786,7 @@ namespace Microsoft.ML.Transforms
                 input.GetIndices().CopyTo(mutation.Indices);
             }
 
-            output = mutation.CreateBuffer();
+            output = mutation.Commit();
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -786,7 +786,7 @@ namespace Microsoft.ML.Transforms
                 input.GetIndices().CopyTo(mutation.Indices);
             }
 
-            mutation.Complete(ref output);
+            output = mutation.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -615,9 +615,11 @@ namespace Microsoft.ML.Transforms.Projections
                 {
                     // This overload of MatTimesSrc ignores the values in slots that are not in src.Indices, so there is
                     // no need to zero them out.
-                    featuresAligned.CopyFrom(src.Indices, src.Values, 0, 0, src.Count, zeroItems: false);
-                    CpuMathUtils.MatrixTimesSource(transformInfo.RndFourierVectors, src.Indices, featuresAligned, 0, 0,
-                        src.Count, productAligned, transformInfo.NewDim);
+                    var srcValues = src.GetValues();
+                    var srcIndices = src.GetIndices();
+                    featuresAligned.CopyFrom(srcIndices, srcValues, 0, 0, srcValues.Length, zeroItems: false);
+                    CpuMathUtils.MatrixTimesSource(transformInfo.RndFourierVectors, srcIndices, featuresAligned, 0, 0,
+                        srcValues.Length, productAligned, transformInfo.NewDim);
                 }
 
                 for (int i = 0; i < transformInfo.NewDim; i++)

--- a/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
@@ -468,7 +468,7 @@ namespace Microsoft.ML.Transforms.Text
                         }
                     }
 
-                    var mutation = VBufferMutationContext.Create(ref dst, len);
+                    var mutation = VBufferEditor.Create(ref dst, len);
                     if (len > 0)
                     {
                         int index = 0;
@@ -511,7 +511,7 @@ namespace Microsoft.ML.Transforms.Text
                     if (_parent._useMarkerChars)
                         len += TextMarkersCount;
 
-                    var mutation = VBufferMutationContext.Create(ref dst, len);
+                    var mutation = VBufferEditor.Create(ref dst, len);
                     if (len > 0)
                     {
                         int index = 0;

--- a/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
@@ -487,7 +487,7 @@ namespace Microsoft.ML.Transforms.Text
                         Contracts.Assert(index == len);
                     }
 
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
 
                 ValueGetter<VBuffer<ushort>> getterWithUnitSep = (ref VBuffer<ushort> dst) =>
@@ -544,7 +544,7 @@ namespace Microsoft.ML.Transforms.Text
                         Contracts.Assert(index == len);
                     }
 
-                    dst = mutation.CreateBuffer();
+                    dst = mutation.Commit();
                 };
                 return _parent._isSeparatorStartEnd ? getterWithStartEndSep : getterWithUnitSep;
             }

--- a/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
@@ -457,39 +457,37 @@ namespace Microsoft.ML.Transforms.Text
                     getSrc(ref src);
 
                     int len = 0;
-                    for (int i = 0; i < src.Count; i++)
+                    var srcValues = src.GetValues();
+                    for (int i = 0; i < srcValues.Length; i++)
                     {
-                        if (!src.Values[i].IsEmpty)
+                        if (!srcValues[i].IsEmpty)
                         {
-                            len += src.Values[i].Length;
+                            len += srcValues[i].Length;
                             if (_parent._useMarkerChars)
                                 len += TextMarkersCount;
                         }
                     }
 
-                    var values = dst.Values;
+                    var mutation = VBufferMutationContext.Create(ref dst, len);
                     if (len > 0)
                     {
-                        if (Utils.Size(values) < len)
-                            values = new ushort[len];
-
                         int index = 0;
-                        for (int i = 0; i < src.Count; i++)
+                        for (int i = 0; i < srcValues.Length; i++)
                         {
-                            if (src.Values[i].IsEmpty)
+                            if (srcValues[i].IsEmpty)
                                 continue;
                             if (_parent._useMarkerChars)
-                                values[index++] = TextStartMarker;
-                            var span = src.Values[i].Span;
-                            for (int ich = 0; ich < src.Values[i].Length; ich++)
-                                values[index++] = span[ich];
+                                mutation.Values[index++] = TextStartMarker;
+                            var span = srcValues[i].Span;
+                            for (int ich = 0; ich < srcValues[i].Length; ich++)
+                                mutation.Values[index++] = span[ich];
                             if (_parent._useMarkerChars)
-                                values[index++] = TextEndMarker;
+                                mutation.Values[index++] = TextEndMarker;
                         }
                         Contracts.Assert(index == len);
                     }
 
-                    dst = new VBuffer<ushort>(len, values, dst.Indices);
+                    mutation.Complete(ref dst);
                 };
 
                 ValueGetter<VBuffer<ushort>> getterWithUnitSep = (ref VBuffer<ushort> dst) =>
@@ -498,11 +496,12 @@ namespace Microsoft.ML.Transforms.Text
 
                     int len = 0;
 
-                    for (int i = 0; i < src.Count; i++)
+                    var srcValues = src.GetValues();
+                    for (int i = 0; i < srcValues.Length; i++)
                     {
-                        if (!src.Values[i].IsEmpty)
+                        if (!srcValues[i].IsEmpty)
                         {
-                            len += src.Values[i].Length;
+                            len += srcValues[i].Length;
 
                             if (i > 0)
                                 len += 1;  // add UnitSeparator character to len that will be added
@@ -512,12 +511,9 @@ namespace Microsoft.ML.Transforms.Text
                     if (_parent._useMarkerChars)
                         len += TextMarkersCount;
 
-                    var values = dst.Values;
+                    var mutation = VBufferMutationContext.Create(ref dst, len);
                     if (len > 0)
                     {
-                        if (Utils.Size(values) < len)
-                            values = new ushort[len];
-
                         int index = 0;
 
                         // ReadOnlyMemory can be a result of either concatenating text columns together
@@ -527,33 +523,32 @@ namespace Microsoft.ML.Transforms.Text
                         // Therefore, prepend and append start and end markers only once i.e. at the start and at end of vector.
                         // Insert UnitSeparator after every piece of text in the vector.
                         if (_parent._useMarkerChars)
-                            values[index++] = TextStartMarker;
+                            mutation.Values[index++] = TextStartMarker;
 
-                        for (int i = 0; i < src.Count; i++)
+                        for (int i = 0; i < srcValues.Length; i++)
                         {
-                            if (src.Values[i].IsEmpty)
+                            if (srcValues[i].IsEmpty)
                                 continue;
 
                             if (i > 0)
-                                values[index++] = UnitSeparator;
+                                mutation.Values[index++] = UnitSeparator;
 
-                            var span = src.Values[i].Span;
-                            for (int ich = 0; ich < src.Values[i].Length; ich++)
-                                values[index++] = span[ich];
+                            var span = srcValues[i].Span;
+                            for (int ich = 0; ich < srcValues[i].Length; ich++)
+                                mutation.Values[index++] = span[ich];
                         }
 
                         if (_parent._useMarkerChars)
-                            values[index++] = TextEndMarker;
+                            mutation.Values[index++] = TextEndMarker;
 
                         Contracts.Assert(index == len);
                     }
 
-                    dst = new VBuffer<ushort>(len, values, dst.Indices);
+                    mutation.Complete(ref dst);
                 };
                 return _parent._isSeparatorStartEnd ? getterWithStartEndSep : getterWithUnitSep;
             }
         }
-
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
@@ -487,7 +487,7 @@ namespace Microsoft.ML.Transforms.Text
                         Contracts.Assert(index == len);
                     }
 
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
 
                 ValueGetter<VBuffer<ushort>> getterWithUnitSep = (ref VBuffer<ushort> dst) =>
@@ -544,7 +544,7 @@ namespace Microsoft.ML.Transforms.Text
                         Contracts.Assert(index == len);
                     }
 
-                    mutation.Complete(ref dst);
+                    dst = mutation.CreateBuffer();
                 };
                 return _parent._isSeparatorStartEnd ? getterWithStartEndSep : getterWithUnitSep;
             }

--- a/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/CharTokenizeTransform.cs
@@ -468,7 +468,7 @@ namespace Microsoft.ML.Transforms.Text
                         }
                     }
 
-                    var mutation = VBufferEditor.Create(ref dst, len);
+                    var editor = VBufferEditor.Create(ref dst, len);
                     if (len > 0)
                     {
                         int index = 0;
@@ -477,17 +477,17 @@ namespace Microsoft.ML.Transforms.Text
                             if (srcValues[i].IsEmpty)
                                 continue;
                             if (_parent._useMarkerChars)
-                                mutation.Values[index++] = TextStartMarker;
+                                editor.Values[index++] = TextStartMarker;
                             var span = srcValues[i].Span;
                             for (int ich = 0; ich < srcValues[i].Length; ich++)
-                                mutation.Values[index++] = span[ich];
+                                editor.Values[index++] = span[ich];
                             if (_parent._useMarkerChars)
-                                mutation.Values[index++] = TextEndMarker;
+                                editor.Values[index++] = TextEndMarker;
                         }
                         Contracts.Assert(index == len);
                     }
 
-                    dst = mutation.Commit();
+                    dst = editor.Commit();
                 };
 
                 ValueGetter<VBuffer<ushort>> getterWithUnitSep = (ref VBuffer<ushort> dst) =>
@@ -511,7 +511,7 @@ namespace Microsoft.ML.Transforms.Text
                     if (_parent._useMarkerChars)
                         len += TextMarkersCount;
 
-                    var mutation = VBufferEditor.Create(ref dst, len);
+                    var editor = VBufferEditor.Create(ref dst, len);
                     if (len > 0)
                     {
                         int index = 0;
@@ -523,7 +523,7 @@ namespace Microsoft.ML.Transforms.Text
                         // Therefore, prepend and append start and end markers only once i.e. at the start and at end of vector.
                         // Insert UnitSeparator after every piece of text in the vector.
                         if (_parent._useMarkerChars)
-                            mutation.Values[index++] = TextStartMarker;
+                            editor.Values[index++] = TextStartMarker;
 
                         for (int i = 0; i < srcValues.Length; i++)
                         {
@@ -531,20 +531,20 @@ namespace Microsoft.ML.Transforms.Text
                                 continue;
 
                             if (i > 0)
-                                mutation.Values[index++] = UnitSeparator;
+                                editor.Values[index++] = UnitSeparator;
 
                             var span = srcValues[i].Span;
                             for (int ich = 0; ich < srcValues[i].Length; ich++)
-                                mutation.Values[index++] = span[ich];
+                                editor.Values[index++] = span[ich];
                         }
 
                         if (_parent._useMarkerChars)
-                            mutation.Values[index++] = TextEndMarker;
+                            editor.Values[index++] = TextEndMarker;
 
                         Contracts.Assert(index == len);
                     }
 
-                    dst = mutation.Commit();
+                    dst = editor.Commit();
                 };
                 return _parent._isSeparatorStartEnd ? getterWithStartEndSep : getterWithUnitSep;
             }

--- a/src/Microsoft.ML.Transforms/Text/LdaSingleBox.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaSingleBox.cs
@@ -181,7 +181,7 @@ namespace Microsoft.ML.Runtime.TextAnalytics
             LdaInterface.SetAlphaSum(_engine, averageDocLength);
         }
 
-        public int LoadDoc(int[] termID, double[] termVal, int termNum, int numVocab)
+        public int LoadDoc(ReadOnlySpan<int> termID, ReadOnlySpan<double> termVal, int termNum, int numVocab)
         {
             Contracts.Check(numVocab == NumVocab);
             Contracts.Check(termNum > 0);
@@ -189,12 +189,14 @@ namespace Microsoft.ML.Runtime.TextAnalytics
             Contracts.Check(termVal.Length >= termNum);
 
             int[] pID = new int[termNum];
-            int[] pVal = termVal.Select(item => (int)item).ToArray();
-            Array.Copy(termID, pID, termNum);
+            int[] pVal = new int[termVal.Length];
+            for (int i = 0; i < termVal.Length; i++)
+                pVal[i] = (int)termVal[i];
+            termID.Slice(0, termNum).CopyTo(pID);
             return LdaInterface.FeedInData(_engine, pID, pVal, termNum, NumVocab);
         }
 
-        public int LoadDocDense(double[] termVal, int termNum, int numVocab)
+        public int LoadDocDense(ReadOnlySpan<double> termVal, int termNum, int numVocab)
         {
             Contracts.Check(numVocab == NumVocab);
             Contracts.Check(termNum > 0);
@@ -202,9 +204,10 @@ namespace Microsoft.ML.Runtime.TextAnalytics
             Contracts.Check(termVal.Length >= termNum);
 
             int[] pID = new int[termNum];
-            int[] pVal = termVal.Select(item => (int)item).ToArray();
+            int[] pVal = new int[termVal.Length];
+            for (int i = 0; i < termVal.Length; i++)
+                pVal[i] = (int)termVal[i];
             return LdaInterface.FeedInDataDense(_engine, pVal, termNum, NumVocab);
-
         }
 
         public List<KeyValuePair<int, float>> GetDocTopicVector(int docID)
@@ -244,17 +247,19 @@ namespace Microsoft.ML.Runtime.TextAnalytics
             return topicRet;
         }
 
-        public List<KeyValuePair<int, float>> TestDoc(int[] termID, double[] termVal, int termNum, int numBurninIter, bool reset)
+        public List<KeyValuePair<int, float>> TestDoc(ReadOnlySpan<int> termID, ReadOnlySpan<double> termVal, int termNum, int numBurninIter, bool reset)
         {
             Contracts.Check(termNum > 0);
             Contracts.Check(termVal.Length >= termNum);
             Contracts.Check(termID.Length >= termNum);
 
             int[] pID = new int[termNum];
-            int[] pVal = termVal.Select(item => (int)item).ToArray();
+            int[] pVal = new int[termVal.Length];
+            for (int i = 0; i < termVal.Length; i++)
+                pVal[i] = (int)termVal[i];
             int[] pTopic = new int[NumTopic];
             int[] pProb = new int[NumTopic];
-            Array.Copy(termID, pID, termNum);
+            termID.Slice(0, termNum).CopyTo(pID);
 
             int numTopicReturn = NumTopic;
 
@@ -273,12 +278,14 @@ namespace Microsoft.ML.Runtime.TextAnalytics
             return topicRet;
         }
 
-        public List<KeyValuePair<int, float>> TestDocDense(double[] termVal, int termNum, int numBurninIter, bool reset)
+        public List<KeyValuePair<int, float>> TestDocDense(ReadOnlySpan<double> termVal, int termNum, int numBurninIter, bool reset)
         {
             Contracts.Check(termNum > 0);
             Contracts.Check(numBurninIter > 0);
             Contracts.Check(termVal.Length >= termNum);
-            int[] pVal = termVal.Select(item => (int)item).ToArray();
+            int[] pVal = new int[termVal.Length];
+            for (int i = 0; i < termVal.Length; i++)
+                pVal[i] = (int)termVal[i];
             int[] pTopic = new int[NumTopic];
             int[] pProb = new int[NumTopic];
 

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -858,7 +858,7 @@ namespace Microsoft.ML.Transforms.Text
                     return;
                 }
 
-                VBufferMutationContext<float> mutation;
+                VBufferEditor<float> mutation;
                 // Make sure all the frequencies are valid and truncate if the sum gets too large.
                 int docSize = 0;
                 int termNum = 0;
@@ -870,7 +870,7 @@ namespace Microsoft.ML.Transforms.Text
                         // REVIEW: Should this log a warning message? And what should it produce?
                         // It currently produces a vbuffer of all NA values.
                         // REVIEW: Need a utility method to do this...
-                        mutation = VBufferMutationContext.Create(ref dst, len);
+                        mutation = VBufferEditor.Create(ref dst, len);
                         for (int k = 0; k < len; k++)
                             mutation.Values[k] = Float.NaN;
                         dst = mutation.Commit();
@@ -894,7 +894,7 @@ namespace Microsoft.ML.Transforms.Text
                 int count = retTopics.Count;
                 Contracts.Assert(count <= len);
 
-                mutation = VBufferMutationContext.Create(ref dst, len, count);
+                mutation = VBufferEditor.Create(ref dst, len, count);
                 double normalizer = 0;
                 for (int i = 0; i < count; i++)
                 {

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -505,9 +505,10 @@ namespace Microsoft.ML.Transforms.Text
                         getters[i](ref src);
 
                         // compute term, doc instance#.
-                        for (int termID = 0; termID < src.Count; termID++)
+                        var srcValues = src.GetValues();
+                        for (int termID = 0; termID < srcValues.Length; termID++)
                         {
-                            int termFreq = GetFrequency(src.Values[termID]);
+                            int termFreq = GetFrequency(srcValues[termID]);
                             if (termFreq < 0)
                             {
                                 // Ignore this row.
@@ -792,9 +793,10 @@ namespace Microsoft.ML.Transforms.Text
                 int docSize = 0;
                 int termNum = 0;
 
-                for (int i = 0; i < input.Count; i++)
+                var inputValues = input.GetValues();
+                for (int i = 0; i < inputValues.Length; i++)
                 {
-                    int termFreq = GetFrequency(input.Values[i]);
+                    int termFreq = GetFrequency(inputValues[i]);
                     if (termFreq < 0)
                     {
                         // Ignore this row.
@@ -814,9 +816,9 @@ namespace Microsoft.ML.Transforms.Text
 
                 int actualSize = 0;
                 if (input.IsDense)
-                    actualSize = _ldaTrainer.LoadDocDense(input.Values, termNum, input.Length);
+                    actualSize = _ldaTrainer.LoadDocDense(inputValues, termNum, input.Length);
                 else
-                    actualSize = _ldaTrainer.LoadDoc(input.Indices, input.Values, termNum, input.Length);
+                    actualSize = _ldaTrainer.LoadDoc(input.GetIndices(), inputValues, termNum, input.Length);
 
                 ectx.Assert(actualSize == 2 * docSize + 1, string.Format("The doc size are distinct. Actual: {0}, Expected: {1}", actualSize, 2 * docSize + 1));
                 return actualSize;
@@ -849,30 +851,30 @@ namespace Microsoft.ML.Transforms.Text
                 }
 
                 int len = InfoEx.NumTopic;
-                var values = dst.Values;
-                var indices = dst.Indices;
-                if (src.Count == 0)
+                var srcValues = src.GetValues();
+                if (srcValues.Length == 0)
                 {
-                    dst = new VBuffer<Float>(len, 0, values, indices);
+                    VBufferMutationContext.Create(ref dst, len, 0)
+                        .Complete(ref dst);
                     return;
                 }
 
+                VBufferMutationContext<float> mutation;
                 // Make sure all the frequencies are valid and truncate if the sum gets too large.
                 int docSize = 0;
                 int termNum = 0;
-                for (int i = 0; i < src.Count; i++)
+                for (int i = 0; i < srcValues.Length; i++)
                 {
-                    int termFreq = GetFrequency(src.Values[i]);
+                    int termFreq = GetFrequency(srcValues[i]);
                     if (termFreq < 0)
                     {
                         // REVIEW: Should this log a warning message? And what should it produce?
                         // It currently produces a vbuffer of all NA values.
                         // REVIEW: Need a utility method to do this...
-                        if (Utils.Size(values) < len)
-                            values = new Float[len];
+                        mutation = VBufferMutationContext.Create(ref dst, len);
                         for (int k = 0; k < len; k++)
-                            values[k] = Float.NaN;
-                        dst = new VBuffer<Float>(len, values, indices);
+                            mutation.Values[k] = Float.NaN;
+                        mutation.Complete(ref dst);
                         return;
                     }
 
@@ -886,17 +888,14 @@ namespace Microsoft.ML.Transforms.Text
                 // REVIEW: Too much memory allocation here on each prediction.
                 List<KeyValuePair<int, float>> retTopics;
                 if (src.IsDense)
-                    retTopics = _ldaTrainer.TestDocDense(src.Values, termNum, numBurninIter, reset);
+                    retTopics = _ldaTrainer.TestDocDense(srcValues, termNum, numBurninIter, reset);
                 else
-                    retTopics = _ldaTrainer.TestDoc(src.Indices.Take(src.Count).ToArray(), src.Values.Take(src.Count).ToArray(), termNum, numBurninIter, reset);
+                    retTopics = _ldaTrainer.TestDoc(src.GetIndices(), srcValues, termNum, numBurninIter, reset);
 
                 int count = retTopics.Count;
                 Contracts.Assert(count <= len);
-                if (Utils.Size(values) < count)
-                    values = new Float[count];
-                if (count < len && Utils.Size(indices) < count)
-                    indices = new int[count];
 
+                mutation = VBufferMutationContext.Create(ref dst, len, count);
                 double normalizer = 0;
                 for (int i = 0; i < count; i++)
                 {
@@ -906,22 +905,22 @@ namespace Microsoft.ML.Transforms.Text
                     Contracts.Assert(0 <= index && index < len);
                     if (count < len)
                     {
-                        Contracts.Assert(i == 0 || indices[i - 1] < index);
-                        indices[i] = index;
+                        Contracts.Assert(i == 0 || mutation.Indices[i - 1] < index);
+                        mutation.Indices[i] = index;
                     }
                     else
                         Contracts.Assert(index == i);
 
-                    values[i] = value;
+                    mutation.Values[i] = value;
                     normalizer += value;
                 }
 
                 if (normalizer > 0)
                 {
                     for (int i = 0; i < count; i++)
-                        values[i] = (Float)(values[i] / normalizer);
+                        mutation.Values[i] = (Float)(mutation.Values[i] / normalizer);
                 }
-                dst = new VBuffer<Float>(len, count, values, indices);
+                mutation.Complete(ref dst);
             }
 
             public void Dispose()

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -854,8 +854,8 @@ namespace Microsoft.ML.Transforms.Text
                 var srcValues = src.GetValues();
                 if (srcValues.Length == 0)
                 {
-                    VBufferMutationContext.Create(ref dst, len, 0)
-                        .Complete(ref dst);
+                    dst = VBufferMutationContext.Create(ref dst, len, 0)
+                        .CreateBuffer();
                     return;
                 }
 
@@ -874,7 +874,7 @@ namespace Microsoft.ML.Transforms.Text
                         mutation = VBufferMutationContext.Create(ref dst, len);
                         for (int k = 0; k < len; k++)
                             mutation.Values[k] = Float.NaN;
-                        mutation.Complete(ref dst);
+                        dst = mutation.CreateBuffer();
                         return;
                     }
 
@@ -920,7 +920,7 @@ namespace Microsoft.ML.Transforms.Text
                     for (int i = 0; i < count; i++)
                         mutation.Values[i] = (Float)(mutation.Values[i] / normalizer);
                 }
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             }
 
             public void Dispose()

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -873,7 +873,7 @@ namespace Microsoft.ML.Transforms.Text
                         mutation = VBufferMutationContext.Create(ref dst, len);
                         for (int k = 0; k < len; k++)
                             mutation.Values[k] = Float.NaN;
-                        dst = mutation.CreateBuffer();
+                        dst = mutation.Commit();
                         return;
                     }
 
@@ -919,7 +919,7 @@ namespace Microsoft.ML.Transforms.Text
                     for (int i = 0; i < count; i++)
                         mutation.Values[i] = (Float)(mutation.Values[i] / normalizer);
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             }
 
             public void Dispose()

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -858,7 +858,7 @@ namespace Microsoft.ML.Transforms.Text
                     return;
                 }
 
-                VBufferEditor<float> mutation;
+                VBufferEditor<float> editor;
                 // Make sure all the frequencies are valid and truncate if the sum gets too large.
                 int docSize = 0;
                 int termNum = 0;
@@ -870,10 +870,10 @@ namespace Microsoft.ML.Transforms.Text
                         // REVIEW: Should this log a warning message? And what should it produce?
                         // It currently produces a vbuffer of all NA values.
                         // REVIEW: Need a utility method to do this...
-                        mutation = VBufferEditor.Create(ref dst, len);
+                        editor = VBufferEditor.Create(ref dst, len);
                         for (int k = 0; k < len; k++)
-                            mutation.Values[k] = Float.NaN;
-                        dst = mutation.Commit();
+                            editor.Values[k] = Float.NaN;
+                        dst = editor.Commit();
                         return;
                     }
 
@@ -894,7 +894,7 @@ namespace Microsoft.ML.Transforms.Text
                 int count = retTopics.Count;
                 Contracts.Assert(count <= len);
 
-                mutation = VBufferEditor.Create(ref dst, len, count);
+                editor = VBufferEditor.Create(ref dst, len, count);
                 double normalizer = 0;
                 for (int i = 0; i < count; i++)
                 {
@@ -904,22 +904,22 @@ namespace Microsoft.ML.Transforms.Text
                     Contracts.Assert(0 <= index && index < len);
                     if (count < len)
                     {
-                        Contracts.Assert(i == 0 || mutation.Indices[i - 1] < index);
-                        mutation.Indices[i] = index;
+                        Contracts.Assert(i == 0 || editor.Indices[i - 1] < index);
+                        editor.Indices[i] = index;
                     }
                     else
                         Contracts.Assert(index == i);
 
-                    mutation.Values[i] = value;
+                    editor.Values[i] = value;
                     normalizer += value;
                 }
 
                 if (normalizer > 0)
                 {
                     for (int i = 0; i < count; i++)
-                        mutation.Values[i] = (Float)(mutation.Values[i] / normalizer);
+                        editor.Values[i] = (Float)(editor.Values[i] / normalizer);
                 }
-                dst = mutation.Commit();
+                dst = editor.Commit();
             }
 
             public void Dispose()

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -854,8 +854,7 @@ namespace Microsoft.ML.Transforms.Text
                 var srcValues = src.GetValues();
                 if (srcValues.Length == 0)
                 {
-                    dst = VBufferMutationContext.Create(ref dst, len, 0)
-                        .CreateBuffer();
+                    VBufferUtils.Resize(ref dst, len, 0);
                     return;
                 }
 

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -320,10 +320,10 @@ namespace Microsoft.ML.Transforms.Text
                     ctx.SaveTextStream(string.Format("{0}-ngrams.txt", Infos[i].Name),
                         writer =>
                         {
-                            var ngramNameValues = ngramsNames.GetValues();
-                            writer.WriteLine("# Number of Ngrams terms = {0}", ngramNameValues.Length);
-                            for (int j = 0; j < ngramNameValues.Length; j++)
-                                writer.WriteLine("{0}\t{1}", j, ngramNameValues[j]);
+                            var explicitNgramNames = ngramsNames.GetValues();
+                            writer.WriteLine("# Number of Ngrams terms = {0}", explicitNgramNames.Length);
+                            for (int j = 0; j < explicitNgramNames.Length; j++)
+                                writer.WriteLine("{0}\t{1}", j, explicitNgramNames[j]);
                         });
                 }
             }

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -315,14 +315,15 @@ namespace Microsoft.ML.Transforms.Text
                 if (_slotNamesTypes[i] != null)
                 {
                     GetSlotNames(i, ref ngramsNames);
-                    Host.Assert(_ngramMaps[i].Count == ngramsNames.Count);
+                    Host.Assert(_ngramMaps[i].Count == ngramsNames.GetValues().Length);
                     Host.Assert(ngramsNames.IsDense);
                     ctx.SaveTextStream(string.Format("{0}-ngrams.txt", Infos[i].Name),
                         writer =>
                         {
-                            writer.WriteLine("# Number of Ngrams terms = {0}", ngramsNames.Count);
-                            for (int j = 0; j < ngramsNames.Count; j++)
-                                writer.WriteLine("{0}\t{1}", j, ngramsNames.Values[j]);
+                            var ngramNameValues = ngramsNames.GetValues();
+                            writer.WriteLine("# Number of Ngrams terms = {0}", ngramNameValues.Length);
+                            for (int j = 0; j < ngramNameValues.Length; j++)
+                                writer.WriteLine("{0}\t{1}", j, ngramNameValues[j]);
                         });
                 }
             }

--- a/src/Microsoft.ML.Transforms/Text/NgramUtils.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramUtils.cs
@@ -73,12 +73,13 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.Assert(icol >= 0);
             Contracts.Assert(keyMax > 0);
 
+            var srcValues = src.GetValues();
             uint curKey = 0;
             if (src.IsDense)
             {
                 for (int i = 0; i < src.Length; i++)
                 {
-                    curKey = src.Values[i];
+                    curKey = srcValues[i];
                     if (curKey > keyMax)
                         curKey = 0;
 
@@ -92,13 +93,14 @@ namespace Microsoft.ML.Runtime.Data
             else
             {
                 var queueSize = _queue.Capacity;
+                var srcIndices = src.GetIndices();
 
                 int iindex = 0;
                 for (int i = 0; i < src.Length; i++)
                 {
-                    if (iindex < src.Count && i == src.Indices[iindex])
+                    if (iindex < srcIndices.Length && i == srcIndices[iindex])
                     {
-                        curKey = src.Values[iindex];
+                        curKey = srcValues[iindex];
                         if (curKey > keyMax)
                             curKey = 0;
                         iindex++;

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemoverTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemoverTransform.cs
@@ -464,16 +464,17 @@ namespace Microsoft.ML.Transforms.Text
                     getSrc(ref src);
                     list.Clear();
 
-                    for (int i = 0; i < src.Count; i++)
+                    var srcValues = src.GetValues();
+                    for (int i = 0; i < srcValues.Length; i++)
                     {
-                        if (src.Values[i].IsEmpty)
+                        if (srcValues[i].IsEmpty)
                             continue;
                         buffer.Clear();
-                        ReadOnlyMemoryUtils.AddLowerCaseToStringBuilder(src.Values[i].Span, buffer);
+                        ReadOnlyMemoryUtils.AddLowerCaseToStringBuilder(srcValues[i].Span, buffer);
 
                         // REVIEW nihejazi: Consider using a trie for string matching (Aho-Corasick, etc.)
                         if (StopWords[(int)langToUse].Get(buffer) == null)
-                            list.Add(src.Values[i]);
+                            list.Add(srcValues[i]);
                     }
 
                     VBufferUtils.Copy(list, ref dst, list.Count);
@@ -936,16 +937,17 @@ namespace Microsoft.ML.Transforms.Text
                     getSrc(ref src);
                     list.Clear();
 
-                    for (int i = 0; i < src.Count; i++)
+                    var srcValues = src.GetValues();
+                    for (int i = 0; i < srcValues.Length; i++)
                     {
-                        if (src.Values[i].IsEmpty)
+                        if (srcValues[i].IsEmpty)
                             continue;
                         buffer.Clear();
-                        ReadOnlyMemoryUtils.AddLowerCaseToStringBuilder(src.Values[i].Span, buffer);
+                        ReadOnlyMemoryUtils.AddLowerCaseToStringBuilder(srcValues[i].Span, buffer);
 
                         // REVIEW nihejazi: Consider using a trie for string matching (Aho-Corasick, etc.)
                         if (_stopWordsMap.Get(buffer) == null)
-                            list.Add(src.Values[i]);
+                            list.Add(srcValues[i]);
                     }
 
                     VBufferUtils.Copy(list, ref dst, list.Count);

--- a/src/Microsoft.ML.Transforms/Text/TextNormalizerTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextNormalizerTransform.cs
@@ -308,7 +308,7 @@ namespace Microsoft.ML.Transforms.Text
                     (ref ReadOnlyMemory<char> dst) =>
                     {
                         getSrc(ref src);
-                        NormalizeSrc(ref src, ref dst, buffer);
+                        NormalizeSrc(in src, ref dst, buffer);
                     };
             }
 
@@ -325,9 +325,10 @@ namespace Microsoft.ML.Transforms.Text
                     {
                         getSrc(ref src);
                         list.Clear();
-                        for (int i = 0; i < src.Count; i++)
+                        var srcValues = src.GetValues();
+                        for (int i = 0; i < srcValues.Length; i++)
                         {
-                            NormalizeSrc(ref src.Values[i], ref temp, buffer);
+                            NormalizeSrc(in srcValues[i], ref temp, buffer);
                             if (!temp.IsEmpty)
                                 list.Add(temp);
                         }
@@ -336,7 +337,7 @@ namespace Microsoft.ML.Transforms.Text
                     };
             }
 
-            private void NormalizeSrc(ref ReadOnlyMemory<char> src, ref ReadOnlyMemory<char> dst, StringBuilder buffer)
+            private void NormalizeSrc(in ReadOnlyMemory<char> src, ref ReadOnlyMemory<char> dst, StringBuilder buffer)
             {
                 Host.AssertValue(buffer);
 

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Transforms.Text
                 }
             }
 
-            public bool GetWordVector(ref ReadOnlyMemory<char> word, float[] wordVector)
+            public bool GetWordVector(in ReadOnlyMemory<char> word, float[] wordVector)
             {
                 NormStr str = _pool.Get(word);
                 if (str != null)
@@ -583,38 +583,37 @@ namespace Microsoft.ML.Transforms.Text
                     {
                         int deno = 0;
                         srcGetter(ref src);
-                        var values = dst.Values;
-                        if (Utils.Size(values) != 3 * dimension)
-                            values = new float[3 * dimension];
+                        var mutation = VBufferMutationContext.Create(ref dst, 3 * dimension);
                         int offset = 2 * dimension;
                         for (int i = 0; i < dimension; i++)
                         {
-                            values[i] = float.MaxValue;
-                            values[i + dimension] = 0;
-                            values[i + offset] = float.MinValue;
+                            mutation.Values[i] = float.MaxValue;
+                            mutation.Values[i + dimension] = 0;
+                            mutation.Values[i + offset] = float.MinValue;
                         }
-                        for (int word = 0; word < src.Count; word++)
+                        var srcValues = src.GetValues();
+                        for (int word = 0; word < srcValues.Length; word++)
                         {
-                            if (_parent._currentVocab.GetWordVector(ref src.Values[word], wordVector))
+                            if (_parent._currentVocab.GetWordVector(in srcValues[word], wordVector))
                             {
                                 deno++;
                                 for (int i = 0; i < dimension; i++)
                                 {
                                     float currentTerm = wordVector[i];
-                                    if (values[i] > currentTerm)
-                                        values[i] = currentTerm;
-                                    values[dimension + i] += currentTerm;
-                                    if (values[offset + i] < currentTerm)
-                                        values[offset + i] = currentTerm;
+                                    if (mutation.Values[i] > currentTerm)
+                                        mutation.Values[i] = currentTerm;
+                                    mutation.Values[dimension + i] += currentTerm;
+                                    if (mutation.Values[offset + i] < currentTerm)
+                                        mutation.Values[offset + i] = currentTerm;
                                 }
                             }
                         }
 
                         if (deno != 0)
                             for (int index = 0; index < dimension; index++)
-                                values[index + dimension] /= deno;
+                                mutation.Values[index + dimension] /= deno;
 
-                        dst = new VBuffer<float>(values.Length, values, dst.Indices);
+                        mutation.Complete(ref dst);
                     };
             }
         }

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
@@ -613,7 +613,7 @@ namespace Microsoft.ML.Transforms.Text
                             for (int index = 0; index < dimension; index++)
                                 mutation.Values[index + dimension] /= deno;
 
-                        dst = mutation.CreateBuffer();
+                        dst = mutation.Commit();
                     };
             }
         }

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
@@ -583,13 +583,13 @@ namespace Microsoft.ML.Transforms.Text
                     {
                         int deno = 0;
                         srcGetter(ref src);
-                        var mutation = VBufferEditor.Create(ref dst, 3 * dimension);
+                        var editor = VBufferEditor.Create(ref dst, 3 * dimension);
                         int offset = 2 * dimension;
                         for (int i = 0; i < dimension; i++)
                         {
-                            mutation.Values[i] = float.MaxValue;
-                            mutation.Values[i + dimension] = 0;
-                            mutation.Values[i + offset] = float.MinValue;
+                            editor.Values[i] = float.MaxValue;
+                            editor.Values[i + dimension] = 0;
+                            editor.Values[i + offset] = float.MinValue;
                         }
                         var srcValues = src.GetValues();
                         for (int word = 0; word < srcValues.Length; word++)
@@ -600,20 +600,20 @@ namespace Microsoft.ML.Transforms.Text
                                 for (int i = 0; i < dimension; i++)
                                 {
                                     float currentTerm = wordVector[i];
-                                    if (mutation.Values[i] > currentTerm)
-                                        mutation.Values[i] = currentTerm;
-                                    mutation.Values[dimension + i] += currentTerm;
-                                    if (mutation.Values[offset + i] < currentTerm)
-                                        mutation.Values[offset + i] = currentTerm;
+                                    if (editor.Values[i] > currentTerm)
+                                        editor.Values[i] = currentTerm;
+                                    editor.Values[dimension + i] += currentTerm;
+                                    if (editor.Values[offset + i] < currentTerm)
+                                        editor.Values[offset + i] = currentTerm;
                                 }
                             }
                         }
 
                         if (deno != 0)
                             for (int index = 0; index < dimension; index++)
-                                mutation.Values[index + dimension] /= deno;
+                                editor.Values[index + dimension] /= deno;
 
-                        dst = mutation.Commit();
+                        dst = editor.Commit();
                     };
             }
         }

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
@@ -583,7 +583,7 @@ namespace Microsoft.ML.Transforms.Text
                     {
                         int deno = 0;
                         srcGetter(ref src);
-                        var mutation = VBufferMutationContext.Create(ref dst, 3 * dimension);
+                        var mutation = VBufferEditor.Create(ref dst, 3 * dimension);
                         int offset = 2 * dimension;
                         for (int i = 0; i < dimension; i++)
                         {

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsTransform.cs
@@ -613,7 +613,7 @@ namespace Microsoft.ML.Transforms.Text
                             for (int index = 0; index < dimension; index++)
                                 mutation.Values[index + dimension] /= deno;
 
-                        mutation.Complete(ref dst);
+                        dst = mutation.CreateBuffer();
                     };
             }
         }

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
@@ -322,9 +322,7 @@ namespace Microsoft.ML.Transforms.Text
 
                         var mutation = VBufferMutationContext.Create(ref dst, terms.Count);
                         for (int i = 0; i < terms.Count; i++)
-                        {
                             mutation.Values[i] = terms[i];
-                        }
                         dst = mutation.CreateBuffer();
                     };
             }

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
@@ -323,7 +323,7 @@ namespace Microsoft.ML.Transforms.Text
                         var mutation = VBufferMutationContext.Create(ref dst, terms.Count);
                         for (int i = 0; i < terms.Count; i++)
                             mutation.Values[i] = terms[i];
-                        dst = mutation.CreateBuffer();
+                        dst = mutation.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
@@ -320,7 +320,7 @@ namespace Microsoft.ML.Transforms.Text
                         for (int i = 0; i < srcValues.Length; i++)
                             AddTerms(srcValues[i], separators, terms);
 
-                        var mutation = VBufferMutationContext.Create(ref dst, terms.Count);
+                        var mutation = VBufferEditor.Create(ref dst, terms.Count);
                         for (int i = 0; i < terms.Count; i++)
                             mutation.Values[i] = terms[i];
                         dst = mutation.Commit();

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
@@ -316,18 +316,16 @@ namespace Microsoft.ML.Transforms.Text
                         getSrc(ref src);
                         terms.Clear();
 
-                        for (int i = 0; i < src.Count; i++)
-                            AddTerms(src.Values[i], separators, terms);
+                        var srcValues = src.GetValues();
+                        for (int i = 0; i < srcValues.Length; i++)
+                            AddTerms(srcValues[i], separators, terms);
 
-                        var values = dst.Values;
-                        if (terms.Count > 0)
+                        var mutation = VBufferMutationContext.Create(ref dst, terms.Count);
+                        for (int i = 0; i < terms.Count; i++)
                         {
-                            if (Utils.Size(values) < terms.Count)
-                                values = new ReadOnlyMemory<char>[terms.Count];
-                            terms.CopyTo(values);
+                            mutation.Values[i] = terms[i];
                         }
-
-                        dst = new VBuffer<ReadOnlyMemory<char>>(terms.Count, values, dst.Indices);
+                        mutation.Complete(ref dst);
                     };
             }
 

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
@@ -320,10 +320,10 @@ namespace Microsoft.ML.Transforms.Text
                         for (int i = 0; i < srcValues.Length; i++)
                             AddTerms(srcValues[i], separators, terms);
 
-                        var mutation = VBufferEditor.Create(ref dst, terms.Count);
+                        var editor = VBufferEditor.Create(ref dst, terms.Count);
                         for (int i = 0; i < terms.Count; i++)
-                            mutation.Values[i] = terms[i];
-                        dst = mutation.Commit();
+                            editor.Values[i] = terms[i];
+                        dst = editor.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizeTransform.cs
@@ -325,7 +325,7 @@ namespace Microsoft.ML.Transforms.Text
                         {
                             mutation.Values[i] = terms[i];
                         }
-                        mutation.Complete(ref dst);
+                        dst = mutation.CreateBuffer();
                     };
             }
 

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -631,18 +631,20 @@ namespace Microsoft.ML.Transforms
                             cachedIndex = 0;
                         }
 
+                        var rowValues = row.GetValues();
                         if (_pivotColPosition >= row.Length)
                             value = naValue;
                         else if (row.IsDense)
-                            value = row.Values[_pivotColPosition];
+                            value = rowValues[_pivotColPosition];
                         else
                         {
                             // The row is sparse.
-                            while (cachedIndex < row.Count && _pivotColPosition > row.Indices[cachedIndex])
+                            var rowIndices = row.GetIndices();
+                            while (cachedIndex < rowIndices.Length && _pivotColPosition > rowIndices[cachedIndex])
                                 cachedIndex++;
 
-                            if (cachedIndex < row.Count && _pivotColPosition == row.Indices[cachedIndex])
-                                value = row.Values[cachedIndex];
+                            if (cachedIndex < rowIndices.Length && _pivotColPosition == rowIndices[cachedIndex])
+                                value = rowValues[cachedIndex];
                             else
                                 value = default(T);
                         }

--- a/src/Microsoft.ML.Transforms/VectorWhitening.cs
+++ b/src/Microsoft.ML.Transforms/VectorWhitening.cs
@@ -748,7 +748,7 @@ namespace Microsoft.ML.Transforms.Projections
                         offs += length;
                     }
                 }
-                dst = mutation.CreateBuffer();
+                dst = mutation.Commit();
             }
 
             private static float DotProduct(float[] a, int aOffset, ReadOnlySpan<float> b, ReadOnlySpan<int> indices, int count)

--- a/src/Microsoft.ML.Transforms/VectorWhitening.cs
+++ b/src/Microsoft.ML.Transforms/VectorWhitening.cs
@@ -729,7 +729,7 @@ namespace Microsoft.ML.Transforms.Projections
                 int length = src.Length;
 
                 // Since the whitening process produces dense vector, always use dense representation of dst.
-                var mutation = VBufferMutationContext.Create(ref dst, cdst);
+                var mutation = VBufferEditor.Create(ref dst, cdst);
                 if (src.IsDense)
                 {
                     Mkl.Gemv(Mkl.Layout.RowMajor, Mkl.Transpose.NoTrans, cdst, length,

--- a/src/Microsoft.ML.Transforms/VectorWhitening.cs
+++ b/src/Microsoft.ML.Transforms/VectorWhitening.cs
@@ -748,7 +748,7 @@ namespace Microsoft.ML.Transforms.Projections
                         offs += length;
                     }
                 }
-                mutation.Complete(ref dst);
+                dst = mutation.CreateBuffer();
             }
 
             private static float DotProduct(float[] a, int aOffset, float[] b, int[] indices, int count)

--- a/src/Microsoft.ML.Transforms/VectorWhitening.cs
+++ b/src/Microsoft.ML.Transforms/VectorWhitening.cs
@@ -613,10 +613,19 @@ namespace Microsoft.ML.Transforms.Projections
                 MinOvr = (byte)'O',
             }
 
+            public static unsafe void Gemv(Layout layout, Transpose trans, int m, int n, float alpha,
+                float[] a, int lda, ReadOnlySpan<float> x, int incx, float beta, Span<float> y, int incy)
+            {
+                fixed (float* pA = a)
+                fixed (float* pX = x)
+                fixed (float* pY = y)
+                    Gemv(layout, trans, m, n, alpha, pA, lda, pX, incx, beta, pY, incy);
+            }
+
             // See: https://software.intel.com/en-us/node/520750
             [DllImport(DllName, EntryPoint = "cblas_sgemv")]
-            public static extern void Gemv(Layout layout, Transpose trans, int m, int n, float alpha,
-                float[] a, int lda, float[] x, int incx, float beta, float[] y, int incy);
+            private static unsafe extern void Gemv(Layout layout, Transpose trans, int m, int n, float alpha,
+                float* a, int lda, float* x, int incx, float beta, float* y, int incy);
 
             // See: https://software.intel.com/en-us/node/520775
             [DllImport(DllName, EntryPoint = "cblas_sgemm")]
@@ -715,33 +724,31 @@ namespace Microsoft.ML.Transforms.Projections
 
             private static void FillValues(float[] model, ref VBuffer<float> src, ref VBuffer<float> dst, int cdst)
             {
-                int count = src.Count;
+                var values = src.GetValues();
+                int count = values.Length;
                 int length = src.Length;
-                var values = src.Values;
-                var indices = src.Indices;
-                Contracts.Assert(Utils.Size(values) >= count);
 
                 // Since the whitening process produces dense vector, always use dense representation of dst.
-                var a = Utils.Size(dst.Values) >= cdst ? dst.Values : new float[cdst];
+                var mutation = VBufferMutationContext.Create(ref dst, cdst);
                 if (src.IsDense)
                 {
                     Mkl.Gemv(Mkl.Layout.RowMajor, Mkl.Transpose.NoTrans, cdst, length,
-                        1, model, length, values, 1, 0, a, 1);
+                        1, model, length, values, 1, 0, mutation.Values, 1);
                 }
                 else
                 {
-                    Contracts.Assert(Utils.Size(indices) >= count);
+                    var indices = src.GetIndices();
 
                     int offs = 0;
                     for (int i = 0; i < cdst; i++)
                     {
                         // Returns a dot product of dense vector 'model' starting from offset 'offs' and sparse vector 'values'
                         // with first 'count' valid elements and their corresponding 'indices'.
-                        a[i] = CpuMathUtils.DotProductSparse(model.AsSpan(offs), values, indices, count);
+                        mutation.Values[i] = CpuMathUtils.DotProductSparse(model.AsSpan(offs), values, indices, count);
                         offs += length;
                     }
                 }
-                dst = new VBuffer<float>(cdst, a, dst.Indices);
+                mutation.Complete(ref dst);
             }
 
             private static float DotProduct(float[] a, int aOffset, float[] b, int[] indices, int count)

--- a/src/Microsoft.ML.Transforms/VectorWhitening.cs
+++ b/src/Microsoft.ML.Transforms/VectorWhitening.cs
@@ -729,11 +729,11 @@ namespace Microsoft.ML.Transforms.Projections
                 int length = src.Length;
 
                 // Since the whitening process produces dense vector, always use dense representation of dst.
-                var mutation = VBufferEditor.Create(ref dst, cdst);
+                var editor = VBufferEditor.Create(ref dst, cdst);
                 if (src.IsDense)
                 {
                     Mkl.Gemv(Mkl.Layout.RowMajor, Mkl.Transpose.NoTrans, cdst, length,
-                        1, model, length, values, 1, 0, mutation.Values, 1);
+                        1, model, length, values, 1, 0, editor.Values, 1);
                 }
                 else
                 {
@@ -744,11 +744,11 @@ namespace Microsoft.ML.Transforms.Projections
                     {
                         // Returns a dot product of dense vector 'model' starting from offset 'offs' and sparse vector 'values'
                         // with first 'count' valid elements and their corresponding 'indices'.
-                        mutation.Values[i] = CpuMathUtils.DotProductSparse(model.AsSpan(offs), values, indices, count);
+                        editor.Values[i] = CpuMathUtils.DotProductSparse(model.AsSpan(offs), values, indices, count);
                         offs += length;
                     }
                 }
-                dst = mutation.Commit();
+                dst = editor.Commit();
             }
 
             private static float DotProduct(float[] a, int aOffset, ReadOnlySpan<float> b, ReadOnlySpan<int> indices, int count)

--- a/src/Microsoft.ML.Transforms/VectorWhitening.cs
+++ b/src/Microsoft.ML.Transforms/VectorWhitening.cs
@@ -751,7 +751,7 @@ namespace Microsoft.ML.Transforms.Projections
                 dst = mutation.CreateBuffer();
             }
 
-            private static float DotProduct(float[] a, int aOffset, float[] b, int[] indices, int count)
+            private static float DotProduct(float[] a, int aOffset, ReadOnlySpan<float> b, ReadOnlySpan<int> indices, int count)
             {
                 Contracts.Assert(count <= indices.Length);
                 return CpuMathUtils.DotProductSparse(a.AsSpan(aOffset), b, indices, count);

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Runtime.RunTests
             return values;
         }
 
-        [Fact(Skip = "Need CoreTLC specific baseline update")]
+        [Fact]
         [TestCategory("Transposer")]
         public void TransposerTest()
         {


### PR DESCRIPTION
This PR executes on proposed changes (1) and (5) in https://github.com/dotnet/machinelearning/issues/608#issuecomment-433185895.

> 1. Keep Length, but hide/private Count

> 5. The most drastic proposed change is how to actually mutate a VBuffer.

This introduces `VBufferMutationContext`, and uses it in almost all the places where VBuffers are mutated. There are a few stragglers that I will fix in a subsequent PR, but I thought this change was large enough, so I cut it off once I could make `.Count` private.

Working towards #608.