### PR TITLE
Increase time out on build to 45

### DIFF
--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -11,7 +11,7 @@ phases:
       _phaseName: ${{ parameters.name }}
       _arch: ${{ parameters.architecture }}
     queue:
-      timeoutInMinutes: 40
+      timeoutInMinutes: 45
       parallel: 99
       matrix:
         Build_Debug:


### PR DESCRIPTION
I'm seeing builds getting cancelled at 40 minutes which might have completed otherwise. Increasing timeout to 45 minutes, in #1561 it was suggested we should bump this as well.