### PR TITLE
Remove lazy parameters for GetRowCount

### DIFF
--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -397,7 +397,7 @@ namespace Microsoft.ML.Runtime.Api
                 }
             }
 
-            public abstract long? GetRowCount(bool lazy = true);
+            public abstract long? GetRowCount();
 
             public abstract IRowCursor GetRowCursor(Func<int, bool> predicate, IRandom rand = null);
 
@@ -555,7 +555,7 @@ namespace Microsoft.ML.Runtime.Api
                 get { return true; }
             }
 
-            public override long? GetRowCount(bool lazy = true)
+            public override long? GetRowCount()
             {
                 return _data.Count;
             }
@@ -654,7 +654,7 @@ namespace Microsoft.ML.Runtime.Api
                 get { return false; }
             }
 
-            public override long? GetRowCount(bool lazy = true)
+            public override long? GetRowCount()
             {
                 return (_data as ICollection<TRow>)?.Count;
             }
@@ -735,7 +735,7 @@ namespace Microsoft.ML.Runtime.Api
                 get { return false; }
             }
 
-            public override long? GetRowCount(bool lazy = true)
+            public override long? GetRowCount()
             {
                 return null;
             }

--- a/src/Microsoft.ML.Api/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Api/StatefulFilterTransform.cs
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Runtime.Api
 
         public Schema Schema => _bindings.Schema;
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
             // REVIEW: currently stateful map is implemented via filter, and this is sub-optimal.
             return null;

--- a/src/Microsoft.ML.Core/Data/IDataView.cs
+++ b/src/Microsoft.ML.Core/Data/IDataView.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Runtime.Data
         /// not YET know the number of rows, but may in the future. Its implementation's computation
         /// complexity should be O(1).
         ///
-        /// Most implementation will return the same answer from time to time. Some, like a cache, might
+        /// Most implementation will return the same answer every time. Some, like a cache, might
         /// return null until the cache is fully populated.
         /// </summary>
         long? GetRowCount();

--- a/src/Microsoft.ML.Core/Data/IDataView.cs
+++ b/src/Microsoft.ML.Core/Data/IDataView.cs
@@ -82,17 +82,15 @@ namespace Microsoft.ML.Runtime.Data
         bool CanShuffle { get; }
 
         /// <summary>
-        /// Returns the number of rows if known. Null means unknown. If lazy is true, then
-        /// this is permitted to return null when it might return a non-null value on a subsequent
-        /// call. This indicates, that the transform does not YET know the number of rows, but
-        /// may in the future. If lazy is false, then this is permitted to do some work (no more
-        /// that it would normally do for cursoring) to determine the number of rows.
+        /// Returns the number of rows if known. Returning null means that the row count is unknown but
+        /// it might return a non-null value on a subsequent call. This indicates, that the transform does
+        /// not YET know the number of rows, but may in the future. Its implementation's computation
+        /// complexity should be O(1).
         ///
-        /// Most components will return the same answer whether lazy is true or false. Some, like
-        /// a cache, might return null until the cache is fully populated (when lazy is true). When
-        /// lazy is false, such a cache would block until the cache was populated.
+        /// Most implementation will return the same answer from time to time. Some, like a cache, might
+        /// return null until the cache is fully populated.
         /// </summary>
-        long? GetRowCount(bool lazy = true);
+        long? GetRowCount();
 
         /// <summary>
         /// Get a row cursor. The active column indices are those for which needCol(col) returns true.

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         public static long ComputeRowCount(IDataView view)
         {
-            long? countNullable = view.GetRowCount(lazy: false);
+            long? countNullable = view.GetRowCount();
             if (countNullable != null)
                 return countNullable.Value;
             long count = 0;

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -541,7 +541,7 @@ namespace Microsoft.ML.Runtime.Data
                 return new IRowCursor[] { GetRowCursor(needCol, rand) };
             }
 
-            public long? GetRowCount(bool lazy = true)
+            public long? GetRowCount()
             {
                 return 1;
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -761,7 +761,7 @@ namespace Microsoft.ML.Runtime.Data.IO
 
         private long RowCount { get { return _header.RowCount; } }
 
-        public long? GetRowCount(bool lazy = true) { return RowCount; }
+        public long? GetRowCount() { return RowCount; }
 
         public bool CanShuffle { get { return true; } }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -557,9 +557,9 @@ namespace Microsoft.ML.Runtime.Data
             return string.Format("xf{0:00}", index);
         }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
-            return View.GetRowCount(lazy);
+            return View.GetRowCount();
         }
 
         public bool CanShuffle => View.CanShuffle;

--- a/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
@@ -287,7 +287,7 @@ namespace Microsoft.ML.Runtime.Data
 
         public Schema Schema { get; }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
             return null;
         }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1352,7 +1352,7 @@ namespace Microsoft.ML.Runtime.Data
                 _files = files;
             }
 
-            public long? GetRowCount(bool lazy = true)
+            public long? GetRowCount()
             {
                 // We don't know how many rows there are.
                 // REVIEW: Should we try to support RowCount?

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -420,7 +420,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 if (_outputSchema)
                     WriteSchemaAsComment(writer, header);
 
-                double rowCount = data.GetRowCount(true) ?? double.NaN;
+                double rowCount = data.GetRowCount() ?? double.NaN;
                 using (var pch = !_silent ? _host.StartProgressChannel("TextSaver: saving data") : null)
                 {
                     long stateCount = 0;

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -662,7 +662,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             }
         }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
             return _header.RowCount;
         }

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -91,7 +91,7 @@ namespace Microsoft.ML.Runtime.Data
                     _counts = null;
                     break;
                 }
-                long? count = dv.GetRowCount(true);
+                long? count = dv.GetRowCount();
                 if (count == null || count < 0 || count > int.MaxValue)
                 {
                     _canShuffle = false;
@@ -127,12 +127,12 @@ namespace Microsoft.ML.Runtime.Data
             }
         }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
             long sum = 0;
             foreach (var source in _sources)
             {
-                var cur = source.GetRowCount(lazy);
+                var cur = source.GetRowCount();
                 if (cur == null)
                     return null;
                 _host.Check(cur.Value >= 0, "One of the sources returned a negative row count");

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -197,7 +197,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public Schema Schema { get { return _schema; } }
 
-            public long? GetRowCount(bool lazy = true) { return _rowCount; }
+            public long? GetRowCount() { return _rowCount; }
 
             public bool CanShuffle { get { return true; } }
 

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -193,12 +193,15 @@ namespace Microsoft.ML.Data
 
         public Schema Schema => _subsetInput.Schema;
 
-        public long? GetRowCount(bool lazy = true)
+        /// <summary>
+        /// This implementation can cost more than O(1) operations because it tries its best to
+        /// compute the actual row count.
+        /// </summary>
+        /// <returns>number of rows</returns>
+        public long? GetRowCount()
         {
             if (_rowCount < 0)
             {
-                if (lazy)
-                    return null;
                 if (_cacheDefaultWaiter == null)
                     KickoffFiller(new int[0]);
                 _host.Assert(_cacheDefaultWaiter != null);
@@ -317,7 +320,7 @@ namespace Microsoft.ML.Data
             _host.CheckValue(predicate, nameof(predicate));
             // The seeker needs to know the row count when it validates the row index to move to.
             // Calling GetRowCount here to force a wait indirectly so that _rowCount will have a valid value.
-            GetRowCount(false);
+            GetRowCount();
             _host.Assert(_rowCount >= 0);
             var waiter = WaiterWaiter.Create(this, predicate);
             if (waiter.IsTrivial)

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -194,20 +194,12 @@ namespace Microsoft.ML.Data
         public Schema Schema => _subsetInput.Schema;
 
         /// <summary>
-        /// This implementation can cost more than O(1) operations because it tries its best to
-        /// compute the actual row count.
+        /// Return the number of rows if available.
         /// </summary>
-        /// <returns>number of rows</returns>
         public long? GetRowCount()
         {
             if (_rowCount < 0)
-            {
-                if (_cacheDefaultWaiter == null)
-                    KickoffFiller(new int[0]);
-                _host.Assert(_cacheDefaultWaiter != null);
-                _cacheDefaultWaiter.Wait(long.MaxValue);
-                _host.Assert(_rowCount >= 0);
-            }
+                return null;
             return _rowCount;
         }
 

--- a/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Runtime.Data
             Schema = schema;
         }
 
-        public long? GetRowCount(bool lazy = true) => 0;
+        public long? GetRowCount() => 0;
 
         public IRowCursor GetRowCursor(Func<int, bool> needCol, IRandom rand = null)
         {

--- a/src/Microsoft.ML.Data/DataView/OpaqueDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/OpaqueDataView.cs
@@ -21,9 +21,9 @@ namespace Microsoft.ML.Runtime.Data
             _source = source;
         }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
-            return _source.GetRowCount(lazy);
+            return _source.GetRowCount();
         }
 
         public IRowCursor GetRowCursor(Func<int, bool> predicate, IRandom rand = null)

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -274,7 +274,7 @@ namespace Microsoft.ML.Runtime.Data
             return _view.GetRowCursorSet(out consolidator, predicate, n, rand);
         }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
             // Not a passthrough.
             return RowCount;
@@ -818,9 +818,9 @@ namespace Microsoft.ML.Runtime.Data
                 _schema = new SchemaImpl(this, nameToCol);
             }
 
-            public long? GetRowCount(bool lazy = true)
+            public long? GetRowCount()
             {
-                return _input.GetRowCount(lazy);
+                return _input.GetRowCount();
             }
 
             /// <summary>
@@ -1503,7 +1503,7 @@ namespace Microsoft.ML.Runtime.Data
                 _schemaImpl = new SchemaImpl(this);
             }
 
-            public long? GetRowCount(bool lazy = true)
+            public long? GetRowCount()
             {
                 var type = _data.Schema.GetColumnType(_col);
                 int valueCount = type.ValueCount;

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -54,12 +54,12 @@ namespace Microsoft.ML.Runtime.Data
 
         public Schema Schema => _compositeSchema.AsSchema;
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
             long min = -1;
             foreach (var source in _sources)
             {
-                var cur = source.GetRowCount(lazy);
+                var cur = source.GetRowCount();
                 if (cur == null)
                     return null;
                 _host.Check(cur.Value >= 0, "One of the sources returned a negative row count");

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -635,9 +635,9 @@ namespace Microsoft.ML.Runtime.Data
             _transform.Save(ctx);
         }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
-            return _transform.GetRowCount(lazy);
+            return _transform.GetRowCount();
         }
 
         public IRowCursor GetRowCursor(Func<int, bool> needCol, IRandom rand = null)

--- a/src/Microsoft.ML.Data/Transforms/NopTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/NopTransform.cs
@@ -103,9 +103,9 @@ namespace Microsoft.ML.Runtime.Data
 
         public Schema Schema => Source.Schema;
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
-            return Source.GetRowCount(lazy);
+            return Source.GetRowCount();
         }
 
         public IRowCursor GetRowCursor(Func<int, bool> predicate, IRandom rand = null)

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -144,9 +144,9 @@ namespace Microsoft.ML.Runtime.Data
 
         protected abstract BindingsBase GetBindings();
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
-            return Source.GetRowCount(lazy);
+            return Source.GetRowCount();
         }
 
         public IRowCursor[] GetRowCursorSet(out IRowCursorConsolidator consolidator, Func<int, bool> predicate, int n, IRandom rand = null)

--- a/src/Microsoft.ML.Data/Transforms/SelectColumnsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/SelectColumnsTransform.cs
@@ -628,7 +628,7 @@ namespace Microsoft.ML.Transforms
 
             Schema ISchematized.Schema => _mapper.Schema;
 
-            public long? GetRowCount(bool lazy = true) => Source.GetRowCount(lazy);
+            public long? GetRowCount() => Source.GetRowCount();
 
             public IRowCursor GetRowCursor(Func<int, bool> needCol, IRandom rand = null)
             {

--- a/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
@@ -169,11 +169,11 @@ namespace Microsoft.ML.Transforms
         /// Returns the computed count of rows remaining after skip and take operation.
         /// Returns null if count is unknown.
         /// </summary>
-        public override long? GetRowCount(bool lazy = true)
+        public override long? GetRowCount()
         {
             if (_take == 0)
                 return 0;
-            long? count = Source.GetRowCount(lazy);
+            long? count = Source.GetRowCount();
             if (count == null)
                 return null;
 

--- a/src/Microsoft.ML.Data/Transforms/TermTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/TermTransform.cs
@@ -507,7 +507,7 @@ namespace Microsoft.ML.Transforms.Categorical
             {
                 var header = new ProgressHeader(new[] { "Total Terms" }, new[] { "examples" });
                 var trainer = Trainer.Create(cursor, colSrc, autoConvert, int.MaxValue, bldr);
-                double rowCount = termData.GetRowCount(true) ?? double.NaN;
+                double rowCount = termData.GetRowCount() ?? double.NaN;
                 long rowCur = 0;
                 pch.SetHeader(header,
                     e =>
@@ -606,7 +606,7 @@ namespace Microsoft.ML.Transforms.Categorical
                 using (var pch = env.StartProgressChannel("Building term dictionary"))
                 {
                     long rowCur = 0;
-                    double rowCount = trainingData.GetRowCount(true) ?? double.NaN;
+                    double rowCount = trainingData.GetRowCount() ?? double.NaN;
                     var header = new ProgressHeader(new[] { "Total Terms" }, new[] { "examples" });
 
                     itrainer = 0;

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Runtime.Data
 
         public abstract void Save(ModelSaveContext ctx);
 
-        public abstract long? GetRowCount(bool lazy = true);
+        public abstract long? GetRowCount();
 
         public virtual bool CanShuffle { get { return Source.CanShuffle; } }
 
@@ -104,7 +104,7 @@ namespace Microsoft.ML.Runtime.Data
         {
         }
 
-        public sealed override long? GetRowCount(bool lazy = true) { return Source.GetRowCount(lazy); }
+        public sealed override long? GetRowCount() { return Source.GetRowCount(); }
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Runtime.Data
         {
         }
 
-        public override long? GetRowCount(bool lazy = true) => null;
+        public override long? GetRowCount() => null;
 
         public sealed override Schema Schema => Source.Schema;
 

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1862,7 +1862,7 @@ namespace Microsoft.ML.Trainers.FastTree
                     ch.Info("Changing data from row-wise to column-wise");
 
                     long pos = 0;
-                    double rowCountDbl = (double?)_data.Data.GetRowCount(lazy: true) ?? Double.NaN;
+                    double rowCountDbl = (double?)_data.Data.GetRowCount() ?? Double.NaN;
                     pch.SetHeader(new ProgressHeader("examples"),
                         e => e.SetProgress(0, pos, rowCountDbl));
                     // REVIEW: Should we ignore rows with bad label, weight, or group? The previous code seemed to let

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -384,7 +384,7 @@ namespace Microsoft.ML.Runtime.Data
 
         public Schema Schema { get; }
 
-        public long? GetRowCount(bool lazy = true)
+        public long? GetRowCount()
         {
             return _rowCount;
         }

--- a/src/Microsoft.ML.PipelineInference/AutoInference.cs
+++ b/src/Microsoft.ML.PipelineInference/AutoInference.cs
@@ -470,7 +470,7 @@ namespace Microsoft.ML.Runtime.PipelineInference
             env.CheckValue(trainData, nameof(trainData));
             env.CheckValue(testData, nameof(testData));
 
-            int numOfRows = (int)(trainData.GetRowCount(false) ?? 1000);
+            int numOfRows = (int)(trainData.GetRowCount() ?? 1000);
             AutoMlMlState amls = new AutoMlMlState(env, metric, autoMlEngine, terminator, trainerKind, trainData, testData);
             bestPipeline = amls.InferPipelines(numTransformLevels, batchSize, numOfRows);
             return amls;

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -447,7 +447,7 @@ namespace Microsoft.ML.Runtime.Learners
             {
                 // REVIEW: maybe it makes sense for the factory to capture the good row count after
                 // the first successful cursoring?
-                Double totalCount = data.Data.GetRowCount(true) ?? Double.NaN;
+                Double totalCount = data.Data.GetRowCount() ?? Double.NaN;
 
                 long exCount = 0;
                 pch.SetHeader(new ProgressHeader(null, new[] { "examples" }),

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -359,9 +359,9 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
         public override Schema Schema => _transform.Schema;
 
-        public override long? GetRowCount(bool lazy = true)
+        public override long? GetRowCount()
         {
-            return _transform.GetRowCount(lazy);
+            return _transform.GetRowCount();
         }
 
         public override IRowCursor[] GetRowCursorSet(out IRowCursorConsolidator consolidator, Func<int, bool> predicate, int n, IRandom rand = null)

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -356,9 +356,9 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             public override Schema Schema => _bindings.Schema;
 
-            public override long? GetRowCount(bool lazy = true)
+            public override long? GetRowCount()
             {
-                return _transform.GetRowCount(lazy);
+                return _transform.GetRowCount();
             }
 
             public override IRowCursor[] GetRowCursorSet(out IRowCursorConsolidator consolidator, Func<int, bool> predicate, int n, IRandom rand = null)

--- a/src/Microsoft.ML.Transforms/CountFeatureSelectionTransformer.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelectionTransformer.cs
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Transforms
 
             var aggregators = new CountAggregator[size];
             long rowCur = 0;
-            double rowCount = input.GetRowCount(true) ?? double.NaN;
+            double rowCount = input.GetRowCount() ?? double.NaN;
             using (var pch = env.StartProgressChannel("Aggregating counts"))
             using (var cursor = input.GetRowCursor(col => activeInput[col]))
             {

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Transforms
             _groupSchema.Save(ctx);
         }
 
-        public override long? GetRowCount(bool lazy = true)
+        public override long? GetRowCount()
         {
             // We have no idea how many total rows we'll have.
             return null;

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Transforms.Text
                 invDocFreqs = new double[Infos.Length][];
 
                 long totalDocs = 0;
-                Double rowCount = trainingData.GetRowCount(true) ?? Double.NaN;
+                Double rowCount = trainingData.GetRowCount() ?? Double.NaN;
                 var buffers = new VBuffer<float>[Infos.Length];
                 pch.SetHeader(new ProgressHeader(new[] { "Total n-grams" }, new[] { "documents" }),
                     e => e.SetProgress(0, totalDocs, rowCount));

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -149,13 +149,13 @@ namespace Microsoft.ML.Transforms
             _schemaImpl.Save(ctx);
         }
 
-        public override long? GetRowCount(bool lazy = true)
+        public override long? GetRowCount()
         {
             // Row count is known if the input's row count is known, and pivot column sizes are fixed.
             var commonSize = _schemaImpl.GetCommonPivotColumnSize();
             if (commonSize > 0)
             {
-                long? srcRowCount = Source.GetRowCount(true);
+                long? srcRowCount = Source.GetRowCount();
                 if (srcRowCount.HasValue && srcRowCount.Value <= (long.MaxValue / commonSize))
                     return srcRowCount.Value * commonSize;
             }

--- a/src/Microsoft.ML.Transforms/VectorWhitening.cs
+++ b/src/Microsoft.ML.Transforms/VectorWhitening.cs
@@ -341,7 +341,7 @@ namespace Microsoft.ML.Transforms.Projections
         // A more reliable solution is to turely iterate through all rows via a RowCursor.
         private static long GetRowCount(IDataView inputData, params ColumnInfo[] columns)
         {
-            long? rows = inputData.GetRowCount(lazy: false);
+            long? rows = inputData.GetRowCount();
             if (rows != null)
                 return rows.GetValueOrDefault();
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -157,7 +157,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 var filter = LambdaTransform.CreateFilter<BreastCancerExample, object>(env, idv,
                     (input, state) => input.Label == 0, null);
 
-                Assert.Null(filter.GetRowCount(false));
+                Assert.Null(filter.GetRowCount());
 
                 // test re-apply
                 var applied = env.CreateDataView(data);


### PR DESCRIPTION
Fixes #1531. In most cases, the `GetRowCount` is as lazy as before but in some places such as `CacheDataView` in `CacheDataView.cs`, it could need more than O(1) time to wait until the actual number of rows is available.