### PR TITLE
Fix the name for GAMs in the API Catalog

### DIFF
--- a/src/Microsoft.ML.FastTree/TreeTrainersCatalog.cs
+++ b/src/Microsoft.ML.FastTree/TreeTrainersCatalog.cs
@@ -107,7 +107,7 @@ namespace Microsoft.ML
         /// <param name="minDatapointsInLeaves">The minimal number of datapoints allowed in a leaf of the tree, out of the subsampled data.</param>
         /// <param name="learningRate">The learning rate.</param>
         /// <param name="advancedSettings">Algorithm advanced settings.</param>
-        public static BinaryClassificationGamTrainer GeneralizedAdditiveMethods(this BinaryClassificationContext.BinaryClassificationTrainers ctx,
+        public static BinaryClassificationGamTrainer GeneralizedAdditiveModels(this BinaryClassificationContext.BinaryClassificationTrainers ctx,
             string labelColumn = DefaultColumnNames.Label,
             string featureColumn = DefaultColumnNames.Features,
             string weights = null,
@@ -130,7 +130,7 @@ namespace Microsoft.ML
         /// <param name="minDatapointsInLeaves">The minimal number of datapoints allowed in a leaf of the tree, out of the subsampled data.</param>
         /// <param name="learningRate">The learning rate.</param>
         /// <param name="advancedSettings">Algorithm advanced settings.</param>
-        public static RegressionGamTrainer GeneralizedAdditiveMethods(this RegressionContext.RegressionTrainers ctx,
+        public static RegressionGamTrainer GeneralizedAdditiveModels(this RegressionContext.RegressionTrainers ctx,
             string labelColumn = DefaultColumnNames.Label,
             string featureColumn = DefaultColumnNames.Features,
             string weights = null,


### PR DESCRIPTION
This is a short fix that renames GAM Trainers in the catalog to `GeneralizedAdditiveModels` from `GeneralizedAdditiveMethods` to be consistent with the common nomenclature [1].

[1] Hastie and Tibshirani are generally considered to have introduced the methodology, for example in Hastie, Trevor and Tibshirani, Robert. (1986), [Generalized Additive Models](https://www.jstor.org/stable/2245459), Statistical Science, Vol. 1, No 3, 297-318.

Fixes #1623 
