### PR TITLE
Complete VBuffer redesign

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -2,15 +2,14 @@
 
   <!-- Core Product Dependencies -->
   <PropertyGroup>
-	<MathNumericPackageVersion>4.6.0</MathNumericPackageVersion>
     <NewtonsoftJsonPackageVersion>10.0.3</NewtonsoftJsonPackageVersion>
     <SystemCodeDomPackageVersion>4.4.0</SystemCodeDomPackageVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
-    <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
     <SystemMemoryVersion>4.5.1</SystemMemoryVersion>
     <SystemReflectionEmitLightweightPackageVersion>4.3.0</SystemReflectionEmitLightweightPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.5.2</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemThreadingTasksDataflowPackageVersion>4.8.0</SystemThreadingTasksDataflowPackageVersion>
+    <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
+    <MathNumericPackageVersion>4.6.0</MathNumericPackageVersion>
   </PropertyGroup>
 
   <!-- Other/Non-Core Product Dependencies -->

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -2,14 +2,15 @@
 
   <!-- Core Product Dependencies -->
   <PropertyGroup>
+	<MathNumericPackageVersion>4.6.0</MathNumericPackageVersion>
     <NewtonsoftJsonPackageVersion>10.0.3</NewtonsoftJsonPackageVersion>
     <SystemCodeDomPackageVersion>4.4.0</SystemCodeDomPackageVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
+    <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
     <SystemMemoryVersion>4.5.1</SystemMemoryVersion>
     <SystemReflectionEmitLightweightPackageVersion>4.3.0</SystemReflectionEmitLightweightPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.5.2</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemThreadingTasksDataflowPackageVersion>4.8.0</SystemThreadingTasksDataflowPackageVersion>
-    <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
-	<MathNumericPackageVersion>4.6.0</MathNumericPackageVersion>
   </PropertyGroup>
 
   <!-- Other/Non-Core Product Dependencies -->

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ConcatTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ConcatTransform.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Samples.Dynamic
             Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
             foreach (var featureRow in featuresColumn)
             {
-                foreach (var value in featureRow.Features.Values)
+                foreach (var value in featureRow.Features.GetValues())
                     Console.Write($"{value} ");
                 Console.WriteLine("");
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValue_Term.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValue_Term.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Samples.Dynamic
                 Console.WriteLine($"{columnName} column obtained post-transformation.");
                 foreach (var row in column)
                 {
-                    foreach (var value in row.Values)
+                    foreach (var value in row.GetValues())
                         Console.Write($"{value} ");
                     Console.WriteLine("");
                 }
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             foreach (var row in originalColumnBack)
             {
-                foreach (var value in row.Values)
+                foreach (var value in row.GetValues())
                     Console.Write($"{value} ");
                 Console.WriteLine("");
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic
                 Console.WriteLine($"{columnName} column obtained post-transformation.");
                 foreach (var featureRow in column)
                 {
-                    foreach (var value in featureRow.Values)
+                    foreach (var value in featureRow.GetValues())
                         Console.Write($"{value} ");
                     Console.WriteLine("");
                 }

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
@@ -54,8 +54,9 @@ namespace Microsoft.ML.Samples.Static
             VBuffer<float> weights = default;
             pred.GetFeatureWeights(ref weights);
 
-            Console.WriteLine($"weight 0 - {weights.Values[0]}");
-            Console.WriteLine($"weight 1 - {weights.Values[1]}");
+            var weightsValues = weights.GetValues();
+            Console.WriteLine($"weight 0 - {weightsValues[0]}");
+            Console.WriteLine($"weight 1 - {weightsValues[1]}");
 
             // Evaluate how the model is doing on the test data
             var dataWithPredictions = model.Transform(testData);

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
@@ -52,8 +52,9 @@ namespace Microsoft.ML.Samples.Static
             VBuffer<float> weights = default;
             pred.GetFeatureWeights(ref weights);
 
-            Console.WriteLine($"weight 0 - {weights.Values[0]}");
-            Console.WriteLine($"weight 1 - {weights.Values[1]}");
+            var weightsValues = weights.GetValues();
+            Console.WriteLine($"weight 0 - {weightsValues[0]}");
+            Console.WriteLine($"weight 1 - {weightsValues[1]}");
 
             // Evaluate how the model is doing on the test data
             var dataWithPredictions = model.Transform(testData);

--- a/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
+++ b/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
@@ -11,7 +11,6 @@
     <PackageReference Include="MathNet.Numerics.Signed" Version="$(MathNumericPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPackageVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowPackageVersion)" />
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />

--- a/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
+++ b/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
@@ -11,6 +11,7 @@
     <PackageReference Include="MathNet.Numerics.Signed" Version="$(MathNumericPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPackageVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowPackageVersion)" />
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -238,10 +238,10 @@ namespace Microsoft.ML.Runtime.Api
                 {
                     peek(GetCurrentRowObject(), Position, ref buf);
                     var n = Utils.Size(buf);
-                    var dstMutation = VBufferMutationContext.Create(ref dst, n);
+                    var dstEditor = VBufferEditor.Create(ref dst, n);
                     for (int i = 0; i < n; i++)
-                        dstMutation.Values[i] = convert(buf[i]);
-                    dst = dstMutation.CreateBuffer();
+                        dstEditor.Values[i] = convert(buf[i]);
+                    dst = dstEditor.Commit();
                 });
             }
 
@@ -266,10 +266,10 @@ namespace Microsoft.ML.Runtime.Api
                 {
                     peek(GetCurrentRowObject(), Position, ref buf);
                     var n = Utils.Size(buf);
-                    var dstMutation = VBufferMutationContext.Create(ref dst, n);
+                    var dstEditor = VBufferEditor.Create(ref dst, n);
                     if (buf != null)
-                        buf.AsSpan(0, n).CopyTo(dstMutation.Values);
-                    dst = dstMutation.CreateBuffer();
+                        buf.AsSpan(0, n).CopyTo(dstEditor.Values);
+                    dst = dstEditor.Commit();
                 });
             }
 
@@ -954,12 +954,12 @@ namespace Microsoft.ML.Runtime.Api
         {
             var value = (string[])(object)Value;
             var n = Utils.Size(value);
-            var dstMutation = VBufferMutationContext.Create(ref dst, n);
+            var dstEditor = VBufferEditor.Create(ref dst, n);
 
             for (int i = 0; i < n; i++)
-                dstMutation.Values[i] = value[i].AsMemory();
+                dstEditor.Values[i] = value[i].AsMemory();
 
-            dst = dstMutation.CreateBuffer();
+            dst = dstEditor.Commit();
         }
 
         private ValueGetter<VBuffer<TDst>> GetArrayGetter<TDst>()
@@ -968,10 +968,10 @@ namespace Microsoft.ML.Runtime.Api
             var n = Utils.Size(value);
             return (ref VBuffer<TDst> dst) =>
             {
-                var dstMutation = VBufferMutationContext.Create(ref dst, n);
+                var dstEditor = VBufferEditor.Create(ref dst, n);
                 if (value != null)
-                    value.AsSpan(0, n).CopyTo(dstMutation.Values);
-                dst = dstMutation.CreateBuffer();
+                    value.AsSpan(0, n).CopyTo(dstEditor.Values);
+                dst = dstEditor.Commit();
             };
         }
 

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -238,11 +238,10 @@ namespace Microsoft.ML.Runtime.Api
                 {
                     peek(GetCurrentRowObject(), Position, ref buf);
                     var n = Utils.Size(buf);
-                    dst = new VBuffer<TDst>(n, Utils.Size(dst.Values) < n
-                        ? new TDst[n]
-                        : dst.Values, dst.Indices);
+                    var dstMutation = VBufferMutationContext.Create(ref dst, n);
                     for (int i = 0; i < n; i++)
-                        dst.Values[i] = convert(buf[i]);
+                        dstMutation.Values[i] = convert(buf[i]);
+                    dst = dstMutation.CreateBuffer();
                 });
             }
 
@@ -267,10 +266,10 @@ namespace Microsoft.ML.Runtime.Api
                 {
                     peek(GetCurrentRowObject(), Position, ref buf);
                     var n = Utils.Size(buf);
-                    dst = new VBuffer<TDst>(n, Utils.Size(dst.Values) < n ? new TDst[n] : dst.Values,
-                        dst.Indices);
+                    var dstMutation = VBufferMutationContext.Create(ref dst, n);
                     if (buf != null)
-                        Array.Copy(buf, dst.Values, n);
+                        buf.AsSpan(0, n).CopyTo(dstMutation.Values);
+                    dst = dstMutation.CreateBuffer();
                 });
             }
 
@@ -955,11 +954,12 @@ namespace Microsoft.ML.Runtime.Api
         {
             var value = (string[])(object)Value;
             var n = Utils.Size(value);
-            dst = new VBuffer<ReadOnlyMemory<char>>(n, Utils.Size(dst.Values) < n ? new ReadOnlyMemory<char>[n] : dst.Values, dst.Indices);
+            var dstMutation = VBufferMutationContext.Create(ref dst, n);
 
             for (int i = 0; i < n; i++)
-                dst.Values[i] = value[i].AsMemory();
+                dstMutation.Values[i] = value[i].AsMemory();
 
+            dst = dstMutation.CreateBuffer();
         }
 
         private ValueGetter<VBuffer<TDst>> GetArrayGetter<TDst>()
@@ -968,9 +968,10 @@ namespace Microsoft.ML.Runtime.Api
             var n = Utils.Size(value);
             return (ref VBuffer<TDst> dst) =>
             {
-                dst = new VBuffer<TDst>(n, Utils.Size(dst.Values) < n ? new TDst[n] : dst.Values, dst.Indices);
+                var dstMutation = VBufferMutationContext.Create(ref dst, n);
                 if (value != null)
-                    Array.Copy(value, dst.Values, n);
+                    value.AsSpan(0, n).CopyTo(dstMutation.Values);
+                dst = dstMutation.CreateBuffer();
             };
         }
 

--- a/src/Microsoft.ML.Api/Microsoft.ML.Api.csproj
+++ b/src/Microsoft.ML.Api/Microsoft.ML.Api.csproj
@@ -14,8 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
-     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPackageVersion)" />
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPackageVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.Api/Microsoft.ML.Api.csproj
+++ b/src/Microsoft.ML.Api/Microsoft.ML.Api.csproj
@@ -14,9 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPackageVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
+     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
+     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.Core/Data/VBuffer.cs
+++ b/src/Microsoft.ML.Core/Data/VBuffer.cs
@@ -31,17 +31,6 @@ namespace Microsoft.ML.Runtime.Data
         public readonly int Length;
 
         /// <summary>
-        /// The values. Only the first Count of these are valid.
-        /// </summary>
-        public T[] Values => _values;
-
-        /// <summary>
-        /// The indices. For a dense representation, this array is not used. For a sparse representation
-        /// it is parallel to values and specifies the logical indices for the corresponding values.
-        /// </summary>
-        public int[] Indices => _indices;
-
-        /// <summary>
         /// The explicitly represented values.
         /// </summary>
         public ReadOnlySpan<T> GetValues() => _values.AsSpan(0, _count);

--- a/src/Microsoft.ML.Core/Data/VBufferEditor.cs
+++ b/src/Microsoft.ML.Core/Data/VBufferEditor.cs
@@ -60,16 +60,12 @@ namespace Microsoft.ML.Runtime.Data
             ref VBuffer<T> destination,
             int newLogicalLength,
             int valuesCount,
-            int maxValuesCapacity,
-            bool keepOldOnResize = false,
-            bool requireIndicesOnDense = false)
+            int maxValuesCapacity)
         {
             return destination.GetEditor(
                 newLogicalLength,
                 valuesCount,
-                maxValuesCapacity,
-                keepOldOnResize,
-                requireIndicesOnDense);
+                maxValuesCapacity);
         }
     }
 

--- a/src/Microsoft.ML.Core/Data/VBufferEditor.cs
+++ b/src/Microsoft.ML.Core/Data/VBufferEditor.cs
@@ -60,12 +60,16 @@ namespace Microsoft.ML.Runtime.Data
             ref VBuffer<T> destination,
             int newLogicalLength,
             int valuesCount,
-            int maxValuesCapacity)
+            int maxValuesCapacity,
+            bool keepOldOnResize = false,
+            bool requireIndicesOnDense = false)
         {
             return destination.GetEditor(
                 newLogicalLength,
                 valuesCount,
-                maxValuesCapacity);
+                maxValuesCapacity,
+                keepOldOnResize,
+                requireIndicesOnDense);
         }
     }
 

--- a/src/Microsoft.ML.Core/Utilities/HashArray.cs
+++ b/src/Microsoft.ML.Core/Utilities/HashArray.cs
@@ -228,16 +228,15 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         }
 
         /// <summary>
-        /// Copies all items to the passed in array. Requires the passed in array to be at least the
+        /// Copies all items to the passed in span. Requires the passed in span to be at least the
         /// same length as Count.
         /// </summary>
-        public void CopyTo(TItem[] array)
+        public void CopyTo(Span<TItem> destination)
         {
-            Contracts.Check(array != null);
-            Contracts.Check(array.Length >= _ct);
+            Contracts.Check(destination.Length >= _ct);
 
             for (int i = 0; i < _ct; i++)
-                array[i] = _entries[i].Value;
+                destination[i] = _entries[i].Value;
         }
 
         private static class HashHelpers

--- a/src/Microsoft.ML.Core/Utilities/MathUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/MathUtils.cs
@@ -199,18 +199,14 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// <summary>
         /// computes the "softmax" function: log sum_i exp x_i
         /// </summary>
-        /// <param name="inputs">Array of numbers to softmax</param>
-        /// <param name="count">the number of input array elements to process</param>
+        /// <param name="inputs">Span of numbers to softmax</param>
         /// <returns>the softmax of the numbers</returns>
         /// <remarks>may have slightly lower roundoff error if inputs are sorted, smallest first</remarks>
-        public static Float SoftMax(Float[] inputs, int count)
+        public static Float SoftMax(ReadOnlySpan<float> inputs)
         {
-            Contracts.AssertValue(inputs);
-            Contracts.Assert(0 < count & count <= inputs.Length);
-
             int maxIdx = 0;
             Float max = Float.NegativeInfinity;
-            for (int i = 0; i < count; i++)
+            for (int i = 0; i < inputs.Length; i++)
             {
                 if (inputs[i] > max)
                 {
@@ -222,13 +218,13 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             if (Float.IsNegativeInfinity(max))
                 return Float.NegativeInfinity;
 
-            if (count == 1)
+            if (inputs.Length == 1)
                 return max;
 
             double intermediate = 0.0;
             Float cutoff = max - LogTolerance;
 
-            for (int i = 0; i < count; i++)
+            for (int i = 0; i < inputs.Length; i++)
             {
                 if (i == maxIdx)
                     continue;

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -182,6 +182,25 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         }
 
         /// <summary>
+        /// Copies the values from src to dst.
+        /// </summary>
+        /// <remarks>
+        /// This can be removed once we have the APIs from https://github.com/dotnet/corefx/issues/33006.
+        /// </remarks>
+        public static void CopyTo<T>(this List<T> src, Span<T> dst, int? count = null)
+        {
+            Contracts.Assert(src != null);
+            Contracts.Assert(!count.HasValue || (0 <= count && count <= src.Count));
+            Contracts.Assert(src.Count <= dst.Length);
+
+            count = count ?? src.Count;
+            for (int i = 0; i < count; i++)
+            {
+                dst[i] = src[i];
+            }
+        }
+
+        /// <summary>
         /// Assumes input is sorted and finds value using BinarySearch.
         /// If value is not found, returns the logical index of 'value' in the sorted list i.e index of the first element greater than value.
         /// In case of duplicates it returns the index of the first one.
@@ -675,9 +694,9 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// and between an inclusive lower and exclusive upper bound for
         /// the first and last items, respectively.
         /// </summary>
-        public static bool IsIncreasing(int min, int[] values, int lim)
+        public static bool IsIncreasing(int min, ReadOnlySpan<int> values, int lim)
         {
-            if (Utils.Size(values) < 1)
+            if (values.Length < 1)
                 return true;
 
             var prev = values[0];
@@ -697,9 +716,9 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
         /// is sorted and unique, and between an inclusive lower and exclusive
         /// upper bound for the first and last items, respectively.
         /// </summary>
-        public static bool IsIncreasing(int min, int[] values, int len, int lim)
+        public static bool IsIncreasing(int min, ReadOnlySpan<int> values, int len, int lim)
         {
-            Contracts.Check(Utils.Size(values) >= len);
+            Contracts.Check(values.Length >= len);
             if (len < 1)
                 return true;
 

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -1444,15 +1444,5 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             dst = VBufferEditor.Create(ref dst, newLogicalLength, valuesCount)
                 .Commit();
         }
-
-        /// <summary>
-        /// Updates the logical length and number of physical values to be represented in
-        /// <paramref name="dst"/>, while preserving the underlying buffers.
-        /// </summary>
-        public static void Resize<T>(ref VBuffer<T> dst, int newLogicalLength, int? valuesCount = null)
-        {
-            dst = VBufferMutationContext.Create(ref dst, newLogicalLength, valuesCount)
-                .CreateBuffer();
-        }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -1444,5 +1444,15 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             dst = VBufferEditor.Create(ref dst, newLogicalLength, valuesCount)
                 .Commit();
         }
+
+        /// <summary>
+        /// Updates the logical length and number of physical values to be represented in
+        /// <paramref name="dst"/>, while preserving the underlying buffers.
+        /// </summary>
+        public static void Resize<T>(ref VBuffer<T> dst, int newLogicalLength, int? valuesCount = null)
+        {
+            dst = VBufferMutationContext.Create(ref dst, newLogicalLength, valuesCount)
+                .CreateBuffer();
+        }
     }
 }

--- a/src/Microsoft.ML.CpuMath/AlignedArray.cs
+++ b/src/Microsoft.ML.CpuMath/AlignedArray.cs
@@ -125,21 +125,16 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             Array.Copy(Items, start + _base, dst, index, count);
         }
 
-        public void CopyFrom(Float[] src, int index, int count)
+        public void CopyFrom(ReadOnlySpan<Float> src)
         {
-            Contracts.Assert(0 <= count && count <= _size);
-            Contracts.Assert(src != null);
-            Contracts.Assert(0 <= index && index <= src.Length - count);
-            Array.Copy(src, index, Items, _base, count);
+            Contracts.Assert(src.Length <= _size);
+            src.CopyTo(Items.AsSpan(_base));
         }
 
-        public void CopyFrom(int start, Float[] src, int index, int count)
+        public void CopyFrom(int start, ReadOnlySpan<Float> src)
         {
-            Contracts.Assert(0 <= count);
-            Contracts.Assert(0 <= start && start <= _size - count);
-            Contracts.Assert(src != null);
-            Contracts.Assert(0 <= index && index <= src.Length - count);
-            Array.Copy(src, index, Items, start + _base, count);
+            Contracts.Assert(0 <= start && start <= _size - src.Length);
+            src.CopyTo(Items.AsSpan(start + _base));
         }
 
         // Copies values from a sparse vector.

--- a/src/Microsoft.ML.CpuMath/AlignedMatrix.cs
+++ b/src/Microsoft.ML.CpuMath/AlignedMatrix.cs
@@ -180,7 +180,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.AssertValue(src);
             Contracts.Assert(0 <= index && index <= src.Length - _size);
-            _items.CopyFrom(src, index, _size);
+            _items.CopyFrom(src.AsSpan(index, _size));
             index += _size;
         }
 
@@ -198,7 +198,7 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
             Contracts.Assert(0 <= count && count <= src.Length);
             Contracts.Assert(0 <= ivDst && ivDst <= _size - count);
             Contracts.Assert(0 <= ivSrc && ivSrc <= src.Length - count);
-            _items.CopyFrom(ivDst, src, ivSrc, _size);
+            _items.CopyFrom(ivDst, src.AsSpan(ivSrc, _size));
         }
 
         /// <summary>
@@ -461,14 +461,14 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
             if (ColCount == ColCountPhy)
             {
-                Items.CopyFrom(src, ivSrc, ValueCount);
+                Items.CopyFrom(src.AsSpan(ivSrc, ValueCount));
                 ivSrc += ValueCount;
             }
             else
             {
                 for (int row = 0; row < RowCount; row++)
                 {
-                    Items.CopyFrom(row * ColCountPhy, src, ivSrc, ColCount);
+                    Items.CopyFrom(row * ColCountPhy, src.AsSpan(ivSrc, ColCount));
                     ivSrc += ColCount;
                 }
             }

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -269,21 +269,21 @@ namespace Microsoft.ML.Runtime.Data
 
                 var srcValues = src.GetValues();
                 int count = srcValues.Length;
-                var mutation = VBufferMutationContext.Create(ref dst, src.Length, count);
+                var editor = VBufferEditor.Create(ref dst, src.Length, count);
                 if (count > 0)
                 {
                     // REVIEW: This would be faster if there were loops for each std conversion.
                     // Consider adding those to the Conversions class.
                     for (int i = 0; i < count; i++)
-                        conv(in srcValues[i], ref mutation.Values[i]);
+                        conv(in srcValues[i], ref editor.Values[i]);
 
                     if (!src.IsDense)
                     {
                         var srcIndices = src.GetIndices();
-                        srcIndices.CopyTo(mutation.Indices);
+                        srcIndices.CopyTo(editor.Indices);
                     }
                 }
-                dst = mutation.CreateBuffer();
+                dst = editor.Commit();
             };
         }
 
@@ -441,15 +441,15 @@ namespace Microsoft.ML.Runtime.Data
                     getSrc(ref src);
                     // Unfortunately defaults in one to not translate to defaults of the other,
                     // so this will not be sparsity preserving. Assume a dense output.
-                    var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+                    var editor = VBufferEditor.Create(ref dst, src.Length);
                     foreach (var kv in src.Items(all: true))
                     {
                         if (0 < kv.Value && kv.Value <= keyMax)
-                            mutation.Values[kv.Key] = kv.Value - 1;
+                            editor.Values[kv.Key] = kv.Value - 1;
                         else
-                            mutation.Values[kv.Key] = Single.NaN;
+                            editor.Values[kv.Key] = Single.NaN;
                     }
-                    dst = mutation.CreateBuffer();
+                    dst = editor.Commit();
                 };
         }
 

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -267,29 +267,23 @@ namespace Microsoft.ML.Runtime.Data
                 if (size > 0)
                     Contracts.Check(src.Length == size);
 
-                var values = dst.Values;
-                var indices = dst.Indices;
                 var srcValues = src.GetValues();
                 int count = srcValues.Length;
+                var mutation = VBufferMutationContext.Create(ref dst, src.Length, count);
                 if (count > 0)
                 {
-                    if (Utils.Size(values) < count)
-                        values = new TDst[count];
-
                     // REVIEW: This would be faster if there were loops for each std conversion.
                     // Consider adding those to the Conversions class.
                     for (int i = 0; i < count; i++)
-                        conv(in srcValues[i], ref values[i]);
+                        conv(in srcValues[i], ref mutation.Values[i]);
 
                     if (!src.IsDense)
                     {
                         var srcIndices = src.GetIndices();
-                        if (Utils.Size(indices) < count)
-                            indices = new int[count];
-                        srcIndices.CopyTo(indices);
+                        srcIndices.CopyTo(mutation.Indices);
                     }
                 }
-                dst = new VBuffer<TDst>(src.Length, count, values, indices);
+                dst = mutation.CreateBuffer();
             };
         }
 
@@ -447,16 +441,15 @@ namespace Microsoft.ML.Runtime.Data
                     getSrc(ref src);
                     // Unfortunately defaults in one to not translate to defaults of the other,
                     // so this will not be sparsity preserving. Assume a dense output.
-                    Single[] vals = dst.Values;
-                    Utils.EnsureSize(ref vals, src.Length);
+                    var mutation = VBufferMutationContext.Create(ref dst, src.Length);
                     foreach (var kv in src.Items(all: true))
                     {
                         if (0 < kv.Value && kv.Value <= keyMax)
-                            vals[kv.Key] = kv.Value - 1;
+                            mutation.Values[kv.Key] = kv.Value - 1;
                         else
-                            vals[kv.Key] = Single.NaN;
+                            mutation.Values[kv.Key] = Single.NaN;
                     }
-                    dst = new VBuffer<Single>(src.Length, vals, dst.Indices);
+                    dst = mutation.CreateBuffer();
                 };
         }
 

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -1471,19 +1471,13 @@ namespace Microsoft.ML.Data
                     Ctx.Assert(valueCount <= len);
                     Ctx.Assert(valueCount == len || indexCount == valueCount);
 
-                    T[] values = value.Values;
-                    Utils.EnsureSize(ref values, valueCount);
-                    _values.CopyTo(_valueBoundaries[idx], values, valueCount);
-                    int[] indices = value.Indices;
+                    var mutation = VBufferMutationContext.Create(ref value, len, valueCount);
+                    _values.CopyTo(_valueBoundaries[idx], mutation.Values, valueCount);
 
                     if (valueCount < len)
-                    {
-                        Utils.EnsureSize(ref indices, indexCount);
-                        _indices.CopyTo(_indexBoundaries[idx], indices, indexCount);
-                        value = new VBuffer<T>(len, indexCount, values, indices);
-                    }
-                    else
-                        value = new VBuffer<T>(len, values, indices);
+                        _indices.CopyTo(_indexBoundaries[idx], mutation.Indices, indexCount);
+
+                    value = mutation.CreateBuffer();
                 }
 
                 public override void Freeze()

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -1471,13 +1471,13 @@ namespace Microsoft.ML.Data
                     Ctx.Assert(valueCount <= len);
                     Ctx.Assert(valueCount == len || indexCount == valueCount);
 
-                    var mutation = VBufferMutationContext.Create(ref value, len, valueCount);
-                    _values.CopyTo(_valueBoundaries[idx], mutation.Values, valueCount);
+                    var editor = VBufferEditor.Create(ref value, len, valueCount);
+                    _values.CopyTo(_valueBoundaries[idx], editor.Values, valueCount);
 
                     if (valueCount < len)
-                        _indices.CopyTo(_indexBoundaries[idx], mutation.Indices, indexCount);
+                        _indices.CopyTo(_indexBoundaries[idx], editor.Indices, indexCount);
 
-                    value = mutation.CreateBuffer();
+                    value = editor.Commit();
                 }
 
                 public override void Freeze()

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -100,14 +100,14 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
 
                 Contracts.Assert(nameList.Count == indexList.Count);
 
-                var mutation = VBufferMutationContext.Create(ref dst, _collection.Count, nameList.Count);
-                nameList.CopyTo(mutation.Values);
+                var editor = VBufferEditor.Create(ref dst, _collection.Count, nameList.Count);
+                nameList.CopyTo(editor.Values);
                 if (nameList.Count < _collection.Count)
                 {
-                    indexList.CopyTo(mutation.Indices);
+                    indexList.CopyTo(editor.Indices);
                 }
 
-                dst = mutation.CreateBuffer();
+                dst = editor.Commit();
             }
         }
 

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -98,20 +98,16 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
                     indexList.Add(kvp.Key);
                 }
 
-                var vals = dst.Values;
-                if (Utils.Size(vals) < nameList.Count)
-                    vals = new ReadOnlyMemory<char>[nameList.Count];
-                Array.Copy(nameList.ToArray(), vals, nameList.Count);
+                Contracts.Assert(nameList.Count == indexList.Count);
+
+                var mutation = VBufferMutationContext.Create(ref dst, _collection.Count, nameList.Count);
+                nameList.CopyTo(mutation.Values);
                 if (nameList.Count < _collection.Count)
                 {
-                    var indices = dst.Indices;
-                    if (Utils.Size(indices) < indexList.Count)
-                        indices = new int[indexList.Count];
-                    Array.Copy(indexList.ToArray(), indices, indexList.Count);
-                    dst = new VBuffer<ReadOnlyMemory<char>>(_collection.Count, nameList.Count, vals, indices);
+                    indexList.CopyTo(mutation.Indices);
                 }
-                else
-                    dst = new VBuffer<ReadOnlyMemory<char>>(_collection.Count, vals, dst.Indices);
+
+                dst = mutation.CreateBuffer();
             }
         }
 

--- a/src/Microsoft.ML.Data/Depricated/Vector/GenericSpanSortHelper.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/GenericSpanSortHelper.cs
@@ -3,16 +3,22 @@
 // See the LICENSE file in the project root for more information.
 
 /*============================================================
-** Purpose: class to sort Spans
-**
-** Taken from https://github.com/dotnet/coreclr/blob/480defd204b58fae05b692937295c6533673d3a2/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs#L871-L1112
-** and changed to support Span instead of arrays.
-**
-** This can be removed once https://github.com/dotnet/corefx/issues/15329 is fixed.
+* Purpose: class to sort Spans
+*
+* Taken from https://github.com/dotnet/coreclr/blob/480defd204b58fae05b692937295c6533673d3a2/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs#L871-L1112
+* and changed to support Span instead of arrays.
+*
+* Code changes from coreclr:
+*  1. Name changed from GenericArraySortHelper => GenericSpanSortHelper
+*  2. Changed Array usages to Span
+*  3. Change Sort method to static
+*  4. Changed single-line, multi-variable declarations to be multi-line.
+*  5. Contracts.Assert => Contracts.Assert
+*
+*This can be removed once https://github.com/dotnet/corefx/issues/15329 is fixed.
 ===========================================================*/
 
 using System;
-using System.Diagnostics;
 
 namespace Microsoft.ML.Runtime.Numeric
 {
@@ -40,8 +46,8 @@ namespace Microsoft.ML.Runtime.Numeric
     {
         public static void Sort(Span<TKey> keys, Span<TValue> values, int index, int length)
         {
-            Debug.Assert(keys != null, "Check the arguments in the caller!");
-            Debug.Assert(index >= 0 && length >= 0 && (keys.Length - index >= length), "Check the arguments in the caller!");
+            Contracts.Assert(keys != null, "Check the arguments in the caller!");
+            Contracts.Assert(index >= 0 && length >= 0 && (keys.Length - index >= length), "Check the arguments in the caller!");
 
             IntrospectiveSort(keys, values, index, length);
         }
@@ -79,13 +85,13 @@ namespace Microsoft.ML.Runtime.Numeric
 
         internal static void IntrospectiveSort(Span<TKey> keys, Span<TValue> values, int left, int length)
         {
-            Debug.Assert(keys != null);
-            Debug.Assert(values != null);
-            Debug.Assert(left >= 0);
-            Debug.Assert(length >= 0);
-            Debug.Assert(length <= keys.Length);
-            Debug.Assert(length + left <= keys.Length);
-            Debug.Assert(length + left <= values.Length);
+            Contracts.Assert(keys != null);
+            Contracts.Assert(values != null);
+            Contracts.Assert(left >= 0);
+            Contracts.Assert(length >= 0);
+            Contracts.Assert(length <= keys.Length);
+            Contracts.Assert(length + left <= keys.Length);
+            Contracts.Assert(length + left <= values.Length);
 
             if (length < 2)
                 return;
@@ -95,10 +101,10 @@ namespace Microsoft.ML.Runtime.Numeric
 
         private static void IntroSort(Span<TKey> keys, Span<TValue> values, int lo, int hi, int depthLimit)
         {
-            Debug.Assert(keys != null);
-            Debug.Assert(values != null);
-            Debug.Assert(lo >= 0);
-            Debug.Assert(hi < keys.Length);
+            Contracts.Assert(keys != null);
+            Contracts.Assert(values != null);
+            Contracts.Assert(lo >= 0);
+            Contracts.Assert(hi < keys.Length);
 
             while (hi > lo)
             {
@@ -142,11 +148,11 @@ namespace Microsoft.ML.Runtime.Numeric
 
         private static int PickPivotAndPartition(Span<TKey> keys, Span<TValue> values, int lo, int hi)
         {
-            Debug.Assert(keys != null);
-            Debug.Assert(values != null);
-            Debug.Assert(lo >= 0);
-            Debug.Assert(hi > lo);
-            Debug.Assert(hi < keys.Length);
+            Contracts.Assert(keys != null);
+            Contracts.Assert(values != null);
+            Contracts.Assert(lo >= 0);
+            Contracts.Assert(hi > lo);
+            Contracts.Assert(hi < keys.Length);
 
             // Compute median-of-three.  But also partition them, since we've done the comparison.
             int middle = lo + ((hi - lo) / 2);
@@ -187,11 +193,11 @@ namespace Microsoft.ML.Runtime.Numeric
 
         private static void Heapsort(Span<TKey> keys, Span<TValue> values, int lo, int hi)
         {
-            Debug.Assert(keys != null);
-            Debug.Assert(values != null);
-            Debug.Assert(lo >= 0);
-            Debug.Assert(hi > lo);
-            Debug.Assert(hi < keys.Length);
+            Contracts.Assert(keys != null);
+            Contracts.Assert(values != null);
+            Contracts.Assert(lo >= 0);
+            Contracts.Assert(hi > lo);
+            Contracts.Assert(hi < keys.Length);
 
             int n = hi - lo + 1;
             for (int i = n / 2; i >= 1; i = i - 1)
@@ -207,9 +213,9 @@ namespace Microsoft.ML.Runtime.Numeric
 
         private static void DownHeap(Span<TKey> keys, Span<TValue> values, int i, int n, int lo)
         {
-            Debug.Assert(keys != null);
-            Debug.Assert(lo >= 0);
-            Debug.Assert(lo < keys.Length);
+            Contracts.Assert(keys != null);
+            Contracts.Assert(lo >= 0);
+            Contracts.Assert(lo < keys.Length);
 
             TKey d = keys[lo + i - 1];
             TValue dValue = values[lo + i - 1];
@@ -233,11 +239,11 @@ namespace Microsoft.ML.Runtime.Numeric
 
         private static void InsertionSort(Span<TKey> keys, Span<TValue> values, int lo, int hi)
         {
-            Debug.Assert(keys != null);
-            Debug.Assert(values != null);
-            Debug.Assert(lo >= 0);
-            Debug.Assert(hi >= lo);
-            Debug.Assert(hi <= keys.Length);
+            Contracts.Assert(keys != null);
+            Contracts.Assert(values != null);
+            Contracts.Assert(lo >= 0);
+            Contracts.Assert(hi >= lo);
+            Contracts.Assert(hi <= keys.Length);
 
             int i;
             int j;

--- a/src/Microsoft.ML.Data/Depricated/Vector/GenericSpanSortHelper.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/GenericSpanSortHelper.cs
@@ -1,0 +1,263 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*============================================================
+** Purpose: class to sort Spans
+**
+** Taken from https://github.com/dotnet/coreclr/blob/480defd204b58fae05b692937295c6533673d3a2/src/System.Private.CoreLib/shared/System/Collections/Generic/ArraySortHelper.cs#L871-L1112
+** and changed to support Span instead of arrays.
+**
+** This can be removed once https://github.com/dotnet/corefx/issues/15329 is fixed.
+===========================================================*/
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.ML.Runtime.Numeric
+{
+    internal static class IntrospectiveSortUtilities
+    {
+        // This is the threshold where Introspective sort switches to Insertion sort.
+        // Empirically, 16 seems to speed up most cases without slowing down others, at least for integers.
+        // Large value types may benefit from a smaller number.
+        internal const int IntrosortSizeThreshold = 16;
+
+        internal static int FloorLog2PlusOne(int n)
+        {
+            int result = 0;
+            while (n >= 1)
+            {
+                result++;
+                n = n / 2;
+            }
+            return result;
+        }
+    }
+
+    internal partial class GenericSpanSortHelper<TKey, TValue>
+        where TKey : IComparable<TKey>
+    {
+        public static void Sort(Span<TKey> keys, Span<TValue> values, int index, int length)
+        {
+            Debug.Assert(keys != null, "Check the arguments in the caller!");
+            Debug.Assert(index >= 0 && length >= 0 && (keys.Length - index >= length), "Check the arguments in the caller!");
+
+            IntrospectiveSort(keys, values, index, length);
+        }
+
+        private static void SwapIfGreaterWithItems(Span<TKey> keys, Span<TValue> values, int a, int b)
+        {
+            if (a != b)
+            {
+                if (keys[a] != null && keys[a].CompareTo(keys[b]) > 0)
+                {
+                    TKey key = keys[a];
+                    keys[a] = keys[b];
+                    keys[b] = key;
+
+                    TValue value = values[a];
+                    values[a] = values[b];
+                    values[b] = value;
+                }
+            }
+        }
+
+        private static void Swap(Span<TKey> keys, Span<TValue> values, int i, int j)
+        {
+            if (i != j)
+            {
+                TKey k = keys[i];
+                keys[i] = keys[j];
+                keys[j] = k;
+
+                TValue v = values[i];
+                values[i] = values[j];
+                values[j] = v;
+            }
+        }
+
+        internal static void IntrospectiveSort(Span<TKey> keys, Span<TValue> values, int left, int length)
+        {
+            Debug.Assert(keys != null);
+            Debug.Assert(values != null);
+            Debug.Assert(left >= 0);
+            Debug.Assert(length >= 0);
+            Debug.Assert(length <= keys.Length);
+            Debug.Assert(length + left <= keys.Length);
+            Debug.Assert(length + left <= values.Length);
+
+            if (length < 2)
+                return;
+
+            IntroSort(keys, values, left, length + left - 1, 2 * IntrospectiveSortUtilities.FloorLog2PlusOne(length));
+        }
+
+        private static void IntroSort(Span<TKey> keys, Span<TValue> values, int lo, int hi, int depthLimit)
+        {
+            Debug.Assert(keys != null);
+            Debug.Assert(values != null);
+            Debug.Assert(lo >= 0);
+            Debug.Assert(hi < keys.Length);
+
+            while (hi > lo)
+            {
+                int partitionSize = hi - lo + 1;
+                if (partitionSize <= IntrospectiveSortUtilities.IntrosortSizeThreshold)
+                {
+                    if (partitionSize == 1)
+                    {
+                        return;
+                    }
+                    if (partitionSize == 2)
+                    {
+                        SwapIfGreaterWithItems(keys, values, lo, hi);
+                        return;
+                    }
+                    if (partitionSize == 3)
+                    {
+                        SwapIfGreaterWithItems(keys, values, lo, hi - 1);
+                        SwapIfGreaterWithItems(keys, values, lo, hi);
+                        SwapIfGreaterWithItems(keys, values, hi - 1, hi);
+                        return;
+                    }
+
+                    InsertionSort(keys, values, lo, hi);
+                    return;
+                }
+
+                if (depthLimit == 0)
+                {
+                    Heapsort(keys, values, lo, hi);
+                    return;
+                }
+                depthLimit--;
+
+                int p = PickPivotAndPartition(keys, values, lo, hi);
+                // Note we've already partitioned around the pivot and do not have to move the pivot again.
+                IntroSort(keys, values, p + 1, hi, depthLimit);
+                hi = p - 1;
+            }
+        }
+
+        private static int PickPivotAndPartition(Span<TKey> keys, Span<TValue> values, int lo, int hi)
+        {
+            Debug.Assert(keys != null);
+            Debug.Assert(values != null);
+            Debug.Assert(lo >= 0);
+            Debug.Assert(hi > lo);
+            Debug.Assert(hi < keys.Length);
+
+            // Compute median-of-three.  But also partition them, since we've done the comparison.
+            int middle = lo + ((hi - lo) / 2);
+
+            // Sort lo, mid and hi appropriately, then pick mid as the pivot.
+            SwapIfGreaterWithItems(keys, values, lo, middle);  // swap the low with the mid point
+            SwapIfGreaterWithItems(keys, values, lo, hi);   // swap the low with the high
+            SwapIfGreaterWithItems(keys, values, middle, hi); // swap the middle with the high
+
+            TKey pivot = keys[middle];
+            Swap(keys, values, middle, hi - 1);
+            int left = lo;
+            int right = hi - 1;  // We already partitioned lo and hi and put the pivot in hi - 1.  And we pre-increment & decrement below.
+
+            while (left < right)
+            {
+                if (pivot == null)
+                {
+                    while (left < (hi - 1) && keys[++left] == null) ;
+                    while (right > lo && keys[--right] != null) ;
+                }
+                else
+                {
+                    while (pivot.CompareTo(keys[++left]) > 0) ;
+                    while (pivot.CompareTo(keys[--right]) < 0) ;
+                }
+
+                if (left >= right)
+                    break;
+
+                Swap(keys, values, left, right);
+            }
+
+            // Put pivot in the right location.
+            Swap(keys, values, left, (hi - 1));
+            return left;
+        }
+
+        private static void Heapsort(Span<TKey> keys, Span<TValue> values, int lo, int hi)
+        {
+            Debug.Assert(keys != null);
+            Debug.Assert(values != null);
+            Debug.Assert(lo >= 0);
+            Debug.Assert(hi > lo);
+            Debug.Assert(hi < keys.Length);
+
+            int n = hi - lo + 1;
+            for (int i = n / 2; i >= 1; i = i - 1)
+            {
+                DownHeap(keys, values, i, n, lo);
+            }
+            for (int i = n; i > 1; i = i - 1)
+            {
+                Swap(keys, values, lo, lo + i - 1);
+                DownHeap(keys, values, 1, i - 1, lo);
+            }
+        }
+
+        private static void DownHeap(Span<TKey> keys, Span<TValue> values, int i, int n, int lo)
+        {
+            Debug.Assert(keys != null);
+            Debug.Assert(lo >= 0);
+            Debug.Assert(lo < keys.Length);
+
+            TKey d = keys[lo + i - 1];
+            TValue dValue = values[lo + i - 1];
+            int child;
+            while (i <= n / 2)
+            {
+                child = 2 * i;
+                if (child < n && (keys[lo + child - 1] == null || keys[lo + child - 1].CompareTo(keys[lo + child]) < 0))
+                {
+                    child++;
+                }
+                if (keys[lo + child - 1] == null || keys[lo + child - 1].CompareTo(d) < 0)
+                    break;
+                keys[lo + i - 1] = keys[lo + child - 1];
+                values[lo + i - 1] = values[lo + child - 1];
+                i = child;
+            }
+            keys[lo + i - 1] = d;
+            values[lo + i - 1] = dValue;
+        }
+
+        private static void InsertionSort(Span<TKey> keys, Span<TValue> values, int lo, int hi)
+        {
+            Debug.Assert(keys != null);
+            Debug.Assert(values != null);
+            Debug.Assert(lo >= 0);
+            Debug.Assert(hi >= lo);
+            Debug.Assert(hi <= keys.Length);
+
+            int i;
+            int j;
+            TKey t;
+            TValue tValue;
+            for (i = lo; i < hi; i++)
+            {
+                j = i;
+                t = keys[i + 1];
+                tValue = values[i + 1];
+                while (j >= lo && (t == null || t.CompareTo(keys[j]) < 0))
+                {
+                    keys[j + 1] = keys[j];
+                    values[j + 1] = values[j];
+                    j--;
+                }
+                keys[j + 1] = t;
+                values[j + 1] = tValue;
+            }
+        }
+    }
+
+}

--- a/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VBufferMathUtils.cs
@@ -29,9 +29,9 @@ namespace Microsoft.ML.Runtime.Numeric
         /// <summary>
         /// Returns the L2 norm squared of the vector (sum of squares of the components).
         /// </summary>
-        public static Float NormSquared(Float[] a, int offset, int count)
+        public static Float NormSquared(ReadOnlySpan<Float> a)
         {
-            return CpuMathUtils.SumSq(a.AsSpan(offset, count));
+            return CpuMathUtils.SumSq(a);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
@@ -439,11 +439,10 @@ namespace Microsoft.ML.Runtime.Numeric
         /// Adds a multiple of a <see cref="VBuffer{T}"/> to a <see cref="Float"/> array.
         /// </summary>
         /// <param name="src">Buffer to add</param>
-        /// <param name="dst">Array to add to</param>
+        /// <param name="dst">Span to add to</param>
         /// <param name="c">Coefficient</param>
-        public static void AddMult(in VBuffer<Float> src, Float[] dst, Float c)
+        public static void AddMult(in VBuffer<Float> src, Span<Float> dst, Float c)
         {
-            Contracts.CheckValue(dst, nameof(dst));
             Contracts.CheckParam(src.Length == dst.Length, nameof(dst), "Arrays must have the same dimensionality.");
 
             var srcValues = src.GetValues();

--- a/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
+++ b/src/Microsoft.ML.Data/Depricated/Vector/VectorUtils.cs
@@ -113,22 +113,20 @@ namespace Microsoft.ML.Runtime.Numeric
             }
 
             var newCount = topHeap.Count + bottomHeap.Count;
-            var indices = a.Indices;
-            Utils.EnsureSize(ref indices, newCount);
-            Contracts.Assert(Utils.Size(a.Values) >= newCount);
+            var aEditor = VBufferEditor.Create(ref a, a.Length, newCount, requireIndicesOnDense: true);
             int count = 0;
             while (topHeap.Count > 0)
             {
                 var pair = topHeap.Pop();
-                indices[count] = pair.Key;
-                a.Values[count++] = pair.Value;
+                aEditor.Indices[count] = pair.Key;
+                aEditor.Values[count++] = pair.Value;
             }
 
             while (bottomHeap.Count > 0)
             {
                 var pair = bottomHeap.Pop();
-                indices[count] = pair.Key;
-                a.Values[count++] = pair.Value;
+                aEditor.Indices[count] = pair.Key;
+                aEditor.Values[count++] = pair.Value;
             }
 
             Contracts.Assert(count == newCount);
@@ -137,7 +135,7 @@ namespace Microsoft.ML.Runtime.Numeric
             {
                 for (var i = 0; i < newCount; i++)
                 {
-                    var value = a.Values[i];
+                    var value = aEditor.Values[i];
                     var absValue = Math.Abs(value);
                     if (absValue > absMax)
                         absMax = absValue;
@@ -147,13 +145,13 @@ namespace Microsoft.ML.Runtime.Numeric
                 {
                     var ratio = 1 / absMax;
                     for (var i = 0; i < newCount; i++)
-                        a.Values[i] = ratio * a.Values[i];
+                        aEditor.Values[i] = ratio * aEditor.Values[i];
                 }
             }
 
-            if (indices != null)
-                Array.Sort(indices, a.Values, 0, newCount);
-            a = new VBuffer<float>(a.Length, newCount, a.Values, indices);
+            if (!aEditor.Indices.IsEmpty)
+                GenericSpanSortHelper<int, float>.Sort(aEditor.Indices, aEditor.Values, 0, newCount);
+            a = aEditor.Commit();
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -731,12 +731,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<Single> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var values = dst.Values;
-                        if (Utils.Size(values) < _numClusters)
-                            values = new Single[_numClusters];
+                        var mutation = VBufferMutationContext.Create(ref dst, _numClusters);
                         for (int i = 0; i < _numClusters; i++)
-                            values[i] = scores.GetItemOrDefault(sortedIndices[i]);
-                        dst = new VBuffer<Single>(_numClusters, values);
+                            mutation.Values[i] = scores.GetItemOrDefault(sortedIndices[i]);
+                        dst = mutation.CreateBuffer();
                     };
                 getters[SortedClusterScoreCol] = topKScoresFn;
             }
@@ -747,12 +745,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<uint> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var values = dst.Values;
-                        if (Utils.Size(values) < _numClusters)
-                            values = new uint[_numClusters];
+                        var mutation = VBufferMutationContext.Create(ref dst, _numClusters);
                         for (int i = 0; i < _numClusters; i++)
-                            values[i] = (uint)sortedIndices[i] + 1;
-                        dst = new VBuffer<uint>(_numClusters, values);
+                            mutation.Values[i] = (uint)sortedIndices[i] + 1;
+                        dst = mutation.CreateBuffer();
                     };
                 getters[SortedClusterCol] = topKClassesFn;
             }
@@ -783,12 +779,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var values = dst.Values;
-                    if (Utils.Size(values) < numTopClusters)
-                        values = new ReadOnlyMemory<char>[numTopClusters];
+                    var mutation = VBufferMutationContext.Create(ref dst, numTopClusters);
                     for (int i = 1; i <= numTopClusters; i++)
-                        values[i - 1] = $"#{i} {suffix}".AsMemory();
-                    dst = new VBuffer<ReadOnlyMemory<char>>(numTopClusters, values);
+                        mutation.Values[i - 1] = $"#{i} {suffix}".AsMemory();
+                    dst = mutation.CreateBuffer();
                 };
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -731,10 +731,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<Single> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var mutation = VBufferMutationContext.Create(ref dst, _numClusters);
+                        var editor = VBufferEditor.Create(ref dst, _numClusters);
                         for (int i = 0; i < _numClusters; i++)
-                            mutation.Values[i] = scores.GetItemOrDefault(sortedIndices[i]);
-                        dst = mutation.CreateBuffer();
+                            editor.Values[i] = scores.GetItemOrDefault(sortedIndices[i]);
+                        dst = editor.Commit();
                     };
                 getters[SortedClusterScoreCol] = topKScoresFn;
             }
@@ -745,10 +745,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<uint> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var mutation = VBufferMutationContext.Create(ref dst, _numClusters);
+                        var editor = VBufferEditor.Create(ref dst, _numClusters);
                         for (int i = 0; i < _numClusters; i++)
-                            mutation.Values[i] = (uint)sortedIndices[i] + 1;
-                        dst = mutation.CreateBuffer();
+                            editor.Values[i] = (uint)sortedIndices[i] + 1;
+                        dst = editor.Commit();
                     };
                 getters[SortedClusterCol] = topKClassesFn;
             }
@@ -779,10 +779,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var mutation = VBufferMutationContext.Create(ref dst, numTopClusters);
+                    var editor = VBufferEditor.Create(ref dst, numTopClusters);
                     for (int i = 1; i <= numTopClusters; i++)
-                        mutation.Values[i - 1] = $"#{i} {suffix}".AsMemory();
-                    dst = mutation.CreateBuffer();
+                        editor.Values[i - 1] = $"#{i} {suffix}".AsMemory();
+                    dst = editor.Commit();
                 };
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -201,12 +201,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var values = dst.Values;
-                    if (Utils.Size(values) < dictionaries.Length)
-                        values = new ReadOnlyMemory<char>[dictionaries.Length];
+                    var mutation = VBufferMutationContext.Create(ref dst, dictionaries.Length);
                     for (int i = 0; i < dictionaries.Length; i++)
-                        values[i] = dictionaries[i].ColName.AsMemory();
-                    dst = new VBuffer<ReadOnlyMemory<char>>(dictionaries.Length, values, dst.Indices);
+                        mutation.Values[i] = dictionaries[i].ColName.AsMemory();
+                    dst = mutation.CreateBuffer();
                 };
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -201,10 +201,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var mutation = VBufferMutationContext.Create(ref dst, dictionaries.Length);
+                    var editor = VBufferEditor.Create(ref dst, dictionaries.Length);
                     for (int i = 0; i < dictionaries.Length; i++)
-                        mutation.Values[i] = dictionaries[i].ColName.AsMemory();
-                    dst = mutation.CreateBuffer();
+                        editor.Values[i] = dictionaries[i].ColName.AsMemory();
+                    dst = editor.Commit();
                 };
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -505,11 +505,11 @@ namespace Microsoft.ML.Runtime.Data
                         (in VBuffer<T> src, ref VBuffer<T> dst) =>
                         {
                             Contracts.Assert(src.Length == Utils.Size(map));
-                            var mutation = VBufferMutationContext.Create(ref dst, slotNames.Count);
+                            var editor = VBufferEditor.Create(ref dst, slotNames.Count);
 
                             foreach (var kvp in src.Items())
-                                mutation.Values[map[kvp.Key]] = kvp.Value;
-                            dst = mutation.CreateBuffer();
+                                editor.Values[map[kvp.Key]] = kvp.Value;
+                            dst = editor.Commit();
                         };
                 }
                 else
@@ -529,13 +529,13 @@ namespace Microsoft.ML.Runtime.Data
                         (in VBuffer<T> src, ref VBuffer<T> dst) =>
                         {
                             Contracts.Assert(src.Length == Utils.Size(map));
-                            var mutation = VBufferMutationContext.Create(ref dst, slotNames.Count);
+                            var editor = VBufferEditor.Create(ref dst, slotNames.Count);
 
                             foreach (var kvp in src.Items(true))
-                                mutation.Values[map[kvp.Key]] = kvp.Value;
+                                editor.Values[map[kvp.Key]] = kvp.Value;
                             foreach (var j in naIndices)
-                                mutation.Values[j] = def;
-                            dst = mutation.CreateBuffer();
+                                editor.Values[j] = def;
+                            dst = editor.Commit();
                         };
                 }
 
@@ -1018,10 +1018,10 @@ namespace Microsoft.ML.Runtime.Data
                         schema.GetMetadata(MetadataUtils.Kinds.SlotNames, i, ref names);
                     else
                     {
-                        var mutation = VBufferMutationContext.Create(ref names, type.VectorSize);
+                        var editor = VBufferEditor.Create(ref names, type.VectorSize);
                         for (int j = 0; j < type.VectorSize; j++)
-                            mutation.Values[j] = string.Format("Label_{0}", j).AsMemory();
-                        names = mutation.CreateBuffer();
+                            editor.Values[j] = string.Format("Label_{0}", j).AsMemory();
+                        names = editor.Commit();
                     }
                     foreach (var name in names.Items(all: true))
                         metricNames.Add(string.Format("{0}{1}", metricName, name.Value));

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -490,12 +490,7 @@ namespace Microsoft.ML.Runtime.Data
             ValueGetter<VBuffer<ReadOnlyMemory<char>>> slotNamesGetter =
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var values = dst.Values;
-                    if (Utils.Size(values) < reconciledSlotNames.Length)
-                        values = new ReadOnlyMemory<char>[reconciledSlotNames.Length];
-
-                    Array.Copy(reconciledSlotNames.Values, values, reconciledSlotNames.Length);
-                    dst = new VBuffer<ReadOnlyMemory<char>>(reconciledSlotNames.Length, values, dst.Indices);
+                    reconciledSlotNames.CopyTo(ref dst);
                 };
 
             // For each input data view, create the reconciled key column by wrapping it in a LambdaColumnMapper.
@@ -510,13 +505,11 @@ namespace Microsoft.ML.Runtime.Data
                         (in VBuffer<T> src, ref VBuffer<T> dst) =>
                         {
                             Contracts.Assert(src.Length == Utils.Size(map));
+                            var mutation = VBufferMutationContext.Create(ref dst, slotNames.Count);
 
-                            var values = dst.Values;
-                            if (Utils.Size(values) < slotNames.Count)
-                                values = new T[slotNames.Count];
                             foreach (var kvp in src.Items())
-                                values[map[kvp.Key]] = kvp.Value;
-                            dst = new VBuffer<T>(slotNames.Count, values, dst.Indices);
+                                mutation.Values[map[kvp.Key]] = kvp.Value;
+                            dst = mutation.CreateBuffer();
                         };
                 }
                 else
@@ -536,15 +529,13 @@ namespace Microsoft.ML.Runtime.Data
                         (in VBuffer<T> src, ref VBuffer<T> dst) =>
                         {
                             Contracts.Assert(src.Length == Utils.Size(map));
-                            var values = dst.Values;
-                            if (Utils.Size(values) < slotNames.Count)
-                                values = new T[slotNames.Count];
+                            var mutation = VBufferMutationContext.Create(ref dst, slotNames.Count);
 
                             foreach (var kvp in src.Items(true))
-                                values[map[kvp.Key]] = kvp.Value;
+                                mutation.Values[map[kvp.Key]] = kvp.Value;
                             foreach (var j in naIndices)
-                                values[j] = def;
-                            dst = new VBuffer<T>(slotNames.Count, values, dst.Indices);
+                                mutation.Values[j] = def;
+                            dst = mutation.CreateBuffer();
                         };
                 }
 
@@ -1027,12 +1018,10 @@ namespace Microsoft.ML.Runtime.Data
                         schema.GetMetadata(MetadataUtils.Kinds.SlotNames, i, ref names);
                     else
                     {
-                        var namesArray = names.Values;
-                        if (Utils.Size(namesArray) < type.VectorSize)
-                            namesArray = new ReadOnlyMemory<char>[type.VectorSize];
+                        var mutation = VBufferMutationContext.Create(ref names, type.VectorSize);
                         for (int j = 0; j < type.VectorSize; j++)
-                            namesArray[j] = string.Format("Label_{0}", j).AsMemory();
-                        names = new VBuffer<ReadOnlyMemory<char>>(type.VectorSize, namesArray);
+                            mutation.Values[j] = string.Format("Label_{0}", j).AsMemory();
+                        names = mutation.CreateBuffer();
                     }
                     foreach (var name in names.Items(all: true))
                         metricNames.Add(string.Format("{0}{1}", metricName, name.Value));

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -246,11 +246,11 @@ namespace Microsoft.ML.Runtime.Data
                     _fnLoss = new double[size];
                 }
 
-                public void Update(Float[] score, Float[] label, int length, Float weight)
+                public void Update(ReadOnlySpan<float> score, ReadOnlySpan<float> label, int length, Float weight)
                 {
                     Contracts.Assert(length == _l1Loss.Length);
-                    Contracts.Assert(Utils.Size(score) >= length);
-                    Contracts.Assert(Utils.Size(label) >= length);
+                    Contracts.Assert(score.Length >= length);
+                    Contracts.Assert(label.Length >= length);
 
                     Double wht = weight;
                     Double l1 = 0;
@@ -340,22 +340,22 @@ namespace Microsoft.ML.Runtime.Data
                     }
                 }
 
-                Float[] label;
+                ReadOnlySpan<float> label;
                 if (!_label.IsDense)
                 {
                     _label.CopyTo(_labelArr);
                     label = _labelArr;
                 }
                 else
-                    label = _label.Values;
-                Float[] score;
+                    label = _label.GetValues();
+                ReadOnlySpan<float> score;
                 if (!_score.IsDense)
                 {
                     _score.CopyTo(_scoreArr);
                     score = _scoreArr;
                 }
                 else
-                    score = _score.Values;
+                    score = _score.GetValues();
                 UnweightedCounters.Update(score, label, _size, 1);
                 if (WeightedCounters != null)
                     WeightedCounters.Update(score, label, _size, weight);
@@ -363,13 +363,10 @@ namespace Microsoft.ML.Runtime.Data
 
             public void GetSlotNames(ref VBuffer<ReadOnlyMemory<char>> slotNames)
             {
-                var values = slotNames.Values;
-                if (Utils.Size(values) < _size)
-                    values = new ReadOnlyMemory<char>[_size];
-
+                var mutation = VBufferMutationContext.Create(ref slotNames, _size);
                 for (int i = 0; i < _size; i++)
-                    values[i] = string.Format("(Label_{0})", i).AsMemory();
-                slotNames = new VBuffer<ReadOnlyMemory<char>>(_size, values);
+                    mutation.Values[i] = string.Format("(Label_{0})", i).AsMemory();
+                slotNames = mutation.CreateBuffer();
             }
         }
     }
@@ -605,12 +602,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var values = dst.Values;
-                    if (Utils.Size(values) < length)
-                        values = new ReadOnlyMemory<char>[length];
+                    var mutation = VBufferMutationContext.Create(ref dst, length);
                     for (int i = 0; i < length; i++)
-                        values[i] = string.Format("{0}_{1}", prefix, i).AsMemory();
-                    dst = new VBuffer<ReadOnlyMemory<char>>(length, values);
+                        mutation.Values[i] = string.Format("{0}_{1}", prefix, i).AsMemory();
+                    dst = mutation.CreateBuffer();
                 };
         }
     }

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -363,10 +363,10 @@ namespace Microsoft.ML.Runtime.Data
 
             public void GetSlotNames(ref VBuffer<ReadOnlyMemory<char>> slotNames)
             {
-                var mutation = VBufferMutationContext.Create(ref slotNames, _size);
+                var editor = VBufferEditor.Create(ref slotNames, _size);
                 for (int i = 0; i < _size; i++)
-                    mutation.Values[i] = string.Format("(Label_{0})", i).AsMemory();
-                slotNames = mutation.CreateBuffer();
+                    editor.Values[i] = string.Format("(Label_{0})", i).AsMemory();
+                slotNames = editor.Commit();
             }
         }
     }
@@ -602,10 +602,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var mutation = VBufferMutationContext.Create(ref dst, length);
+                    var editor = VBufferEditor.Create(ref dst, length);
                     for (int i = 0; i < length; i++)
-                        mutation.Values[i] = string.Format("{0}_{1}", prefix, i).AsMemory();
-                    dst = mutation.CreateBuffer();
+                        editor.Values[i] = string.Format("{0}_{1}", prefix, i).AsMemory();
+                    dst = editor.Commit();
                 };
         }
     }

--- a/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
@@ -487,10 +487,10 @@ namespace Microsoft.ML.Runtime.Data
 
             public void GetSlotNames(ref VBuffer<ReadOnlyMemory<char>> slotNames)
             {
-                var mutation = VBufferMutationContext.Create(ref slotNames, ClassNames.Length);
+                var editor = VBufferEditor.Create(ref slotNames, ClassNames.Length);
                 for (int i = 0; i < ClassNames.Length; i++)
-                    mutation.Values[i] = string.Format("(class {0})", ClassNames[i]).AsMemory();
-                slotNames = mutation.CreateBuffer();
+                    editor.Values[i] = string.Format("(class {0})", ClassNames[i]).AsMemory();
+                slotNames = editor.Commit();
             }
         }
 
@@ -801,10 +801,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<float> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
+                        var editor = VBufferEditor.Create(ref dst, _numClasses);
                         for (int i = 0; i < _numClasses; i++)
-                            mutation.Values[i] = scores.GetItemOrDefault(sortedIndices[i]);
-                        dst = mutation.CreateBuffer();
+                            editor.Values[i] = scores.GetItemOrDefault(sortedIndices[i]);
+                        dst = editor.Commit();
                     };
                 getters[SortedScoresCol] = topKScoresFn;
             }
@@ -815,10 +815,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<uint> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
+                        var editor = VBufferEditor.Create(ref dst, _numClasses);
                         for (int i = 0; i < _numClasses; i++)
-                            mutation.Values[i] = (uint)sortedIndices[i] + 1;
-                        dst = mutation.CreateBuffer();
+                            editor.Values[i] = (uint)sortedIndices[i] + 1;
+                        dst = editor.Commit();
                     };
                 getters[SortedClassesCol] = topKClassesFn;
             }
@@ -878,10 +878,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var mutation = VBufferMutationContext.Create(ref dst, numTopClasses);
+                    var editor = VBufferEditor.Create(ref dst, numTopClasses);
                     for (int i = 1; i <= numTopClasses; i++)
-                        mutation.Values[i - 1] = string.Format("#{0} {1}", i, suffix).AsMemory();
-                    dst = mutation.CreateBuffer();
+                        editor.Values[i - 1] = string.Format("#{0} {1}", i, suffix).AsMemory();
+                    dst = editor.Commit();
                 };
         }
 
@@ -890,10 +890,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
+                    var editor = VBufferEditor.Create(ref dst, _numClasses);
                     for (int i = 0; i < _numClasses; i++)
-                        mutation.Values[i] = _classNames[i];
-                    dst = mutation.CreateBuffer();
+                        editor.Values[i] = _classNames[i];
+                    dst = editor.Commit();
                 };
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MulticlassClassifierEvaluator.cs
@@ -487,13 +487,10 @@ namespace Microsoft.ML.Runtime.Data
 
             public void GetSlotNames(ref VBuffer<ReadOnlyMemory<char>> slotNames)
             {
-                var values = slotNames.Values;
-                if (Utils.Size(values) < ClassNames.Length)
-                    values = new ReadOnlyMemory<char>[ClassNames.Length];
-
+                var mutation = VBufferMutationContext.Create(ref slotNames, ClassNames.Length);
                 for (int i = 0; i < ClassNames.Length; i++)
-                    values[i] = string.Format("(class {0})", ClassNames[i]).AsMemory();
-                slotNames = new VBuffer<ReadOnlyMemory<char>>(ClassNames.Length, values);
+                    mutation.Values[i] = string.Format("(class {0})", ClassNames[i]).AsMemory();
+                slotNames = mutation.CreateBuffer();
             }
         }
 
@@ -804,12 +801,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<float> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var values = dst.Values;
-                        if (Utils.Size(values) < _numClasses)
-                            values = new float[_numClasses];
+                        var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
                         for (int i = 0; i < _numClasses; i++)
-                            values[i] = scores.GetItemOrDefault(sortedIndices[i]);
-                        dst = new VBuffer<float>(_numClasses, values);
+                            mutation.Values[i] = scores.GetItemOrDefault(sortedIndices[i]);
+                        dst = mutation.CreateBuffer();
                     };
                 getters[SortedScoresCol] = topKScoresFn;
             }
@@ -820,12 +815,10 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<uint> dst) =>
                     {
                         updateCacheIfNeeded();
-                        var values = dst.Values;
-                        if (Utils.Size(values) < _numClasses)
-                            values = new uint[_numClasses];
+                        var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
                         for (int i = 0; i < _numClasses; i++)
-                            values[i] = (uint)sortedIndices[i] + 1;
-                        dst = new VBuffer<uint>(_numClasses, values);
+                            mutation.Values[i] = (uint)sortedIndices[i] + 1;
+                        dst = mutation.CreateBuffer();
                     };
                 getters[SortedClassesCol] = topKClassesFn;
             }
@@ -885,12 +878,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var values = dst.Values;
-                    if (Utils.Size(values) < numTopClasses)
-                        values = new ReadOnlyMemory<char>[numTopClasses];
+                    var mutation = VBufferMutationContext.Create(ref dst, numTopClasses);
                     for (int i = 1; i <= numTopClasses; i++)
-                        values[i - 1] = string.Format("#{0} {1}", i, suffix).AsMemory();
-                    dst = new VBuffer<ReadOnlyMemory<char>>(numTopClasses, values);
+                        mutation.Values[i - 1] = string.Format("#{0} {1}", i, suffix).AsMemory();
+                    dst = mutation.CreateBuffer();
                 };
         }
 
@@ -899,12 +890,10 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var values = dst.Values;
-                    if (Utils.Size(values) < _numClasses)
-                        values = new ReadOnlyMemory<char>[_numClasses];
+                    var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
                     for (int i = 0; i < _numClasses; i++)
-                        values[i] = _classNames[i];
-                    dst = new VBuffer<ReadOnlyMemory<char>>(_numClasses, values);
+                        mutation.Values[i] = _classNames[i];
+                    dst = mutation.CreateBuffer();
                 };
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Runtime.Data
             schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, scoreInfo.Index, ref quantiles);
             Host.Assert(quantiles.IsDense && quantiles.Length == scoreSize);
 
-            return new QuantileRegressionPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, schema.Label.Name, scoreSize, quantiles.Values);
+            return new QuantileRegressionPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, schema.Label.Name, scoreSize, quantiles);
         }
 
         protected override void CheckScoreAndLabelTypes(RoleMappedSchema schema)
@@ -142,6 +142,9 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     Contracts.Check(score.Length == TotalL1Loss.Length, "Vectors must have the same dimensionality.");
 
+                    var totalL1LossMutation = VBufferMutationContext.CreateFromBuffer(ref TotalL1Loss);
+                    var totalL2LossMutation = VBufferMutationContext.CreateFromBuffer(ref TotalL2Loss);
+
                     var scoreValues = score.GetValues();
                     if (score.IsDense)
                     {
@@ -150,8 +153,8 @@ namespace Microsoft.ML.Runtime.Data
                         {
                             var diff = Math.Abs((Double)label - scoreValues[i]);
                             var weightedDiff = diff * weight;
-                            TotalL1Loss.Values[i] += weightedDiff;
-                            TotalL2Loss.Values[i] += diff * weightedDiff;
+                            totalL1LossMutation.Values[i] += weightedDiff;
+                            totalL2LossMutation.Values[i] += diff * weightedDiff;
                         }
                         return;
                     }
@@ -162,8 +165,8 @@ namespace Microsoft.ML.Runtime.Data
                     {
                         var diff = Math.Abs((Double)label - scoreValues[i]);
                         var weightedDiff = diff * weight;
-                        TotalL1Loss.Values[scoreIndices[i]] += weightedDiff;
-                        TotalL2Loss.Values[scoreIndices[i]] += diff * weightedDiff;
+                        totalL1LossMutation.Values[scoreIndices[i]] += weightedDiff;
+                        totalL2LossMutation.Values[scoreIndices[i]] += diff * weightedDiff;
                     }
                 }
 
@@ -171,19 +174,21 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     Contracts.Check(loss.Length == TotalL1Loss.Length, "Vectors must have the same dimensionality.");
 
+                    var totalLossMutation = VBufferMutationContext.CreateFromBuffer(ref TotalLoss);
+
                     var lossValues = loss.GetValues();
                     if (loss.IsDense)
                     {
                         // Both are dense.
                         for (int i = 0; i < lossValues.Length; i++)
-                            TotalLoss.Values[i] += lossValues[i] * weight;
+                            totalLossMutation.Values[i] += lossValues[i] * weight;
                         return;
                     }
 
                     // loss is sparse, and _totalL1Loss is dense.
                     var lossIndices = loss.GetIndices();
                     for (int i = 0; i < lossValues.Length; i++)
-                        TotalLoss.Values[lossIndices[i]] += lossValues[i] * weight;
+                        totalLossMutation.Values[lossIndices[i]] += lossValues[i] * weight;
                 }
 
                 protected override void Normalize(in VBuffer<Double> src, ref VBuffer<Double> dst)
@@ -191,13 +196,12 @@ namespace Microsoft.ML.Runtime.Data
                     Contracts.Assert(SumWeights > 0);
                     Contracts.Assert(src.IsDense);
 
-                    var values = dst.Values;
-                    if (Utils.Size(values) < src.Length)
-                        values = new Double[src.Length];
+                    var mutation = VBufferMutationContext.Create(ref dst, src.Length);
                     var inv = 1 / SumWeights;
-                    for (int i = 0; i < src.Length; i++)
-                        values[i] = src.Values[i] * inv;
-                    dst = new VBuffer<Double>(src.Length, values);
+                    var srcValues = src.GetValues();
+                    for (int i = 0; i < srcValues.Length; i++)
+                        mutation.Values[i] = srcValues[i] * inv;
+                    dst = mutation.CreateBuffer();
                 }
 
                 protected override VBuffer<Double> Zero()
@@ -277,15 +281,17 @@ namespace Microsoft.ML.Runtime.Data
         public const string L2 = "L2-loss";
 
         private readonly int _scoreSize;
-        private readonly ReadOnlyMemory<char>[] _quantiles;
+        private readonly VBuffer<ReadOnlyMemory<char>> _quantiles;
         private readonly ColumnType _outputType;
 
-        public QuantileRegressionPerInstanceEvaluator(IHostEnvironment env, ISchema schema, string scoreCol, string labelCol, int scoreSize, ReadOnlyMemory<char>[] quantiles)
+        public QuantileRegressionPerInstanceEvaluator(IHostEnvironment env, ISchema schema, string scoreCol, string labelCol, int scoreSize, VBuffer<ReadOnlyMemory<char>> quantiles)
             : base(env, schema, scoreCol, labelCol)
         {
             Host.CheckParam(scoreSize > 0, nameof(scoreSize), "must be greater than 0");
-            if (Utils.Size(quantiles) != scoreSize)
-                throw Host.ExceptParam(nameof(quantiles), "array must be of length '{0}'", scoreSize);
+            if (!quantiles.IsDense)
+                throw Host.ExceptParam(nameof(quantiles), "buffer must be dense");
+            if (quantiles.Length != scoreSize)
+                throw Host.ExceptParam(nameof(quantiles), "buffer must be of length '{0}'", scoreSize);
             CheckInputColumnTypes(schema);
             _scoreSize = scoreSize;
             _quantiles = quantiles;
@@ -304,9 +310,10 @@ namespace Microsoft.ML.Runtime.Data
 
             _scoreSize = ctx.Reader.ReadInt32();
             Host.CheckDecode(_scoreSize > 0);
-            _quantiles = new ReadOnlyMemory<char>[_scoreSize];
+            ReadOnlyMemory<char>[] quantiles = new ReadOnlyMemory<char>[_scoreSize];
             for (int i = 0; i < _scoreSize; i++)
-                _quantiles[i] = ctx.LoadNonEmptyString().AsMemory();
+                quantiles[i] = ctx.LoadNonEmptyString().AsMemory();
+            _quantiles = new VBuffer<ReadOnlyMemory<char>>(quantiles.Length, quantiles);
             _outputType = new VectorType(NumberType.R8, _scoreSize);
         }
 
@@ -333,8 +340,9 @@ namespace Microsoft.ML.Runtime.Data
             base.Save(ctx);
             Host.Assert(_scoreSize > 0);
             ctx.Writer.Write(_scoreSize);
+            var quantiles = _quantiles.GetValues();
             for (int i = 0; i < _scoreSize; i++)
-                ctx.SaveNonEmptyString(_quantiles[i].ToString());
+                ctx.SaveNonEmptyString(quantiles[i].ToString());
         }
 
         public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
@@ -364,12 +372,11 @@ namespace Microsoft.ML.Runtime.Data
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
-                    var values = dst.Values;
-                    if (Utils.Size(values) < _scoreSize)
-                        values = new ReadOnlyMemory<char>[_scoreSize];
+                    var mutation = VBufferMutationContext.Create(ref dst, _scoreSize);
+                    var quantiles = _quantiles.GetValues();
                     for (int i = 0; i < _scoreSize; i++)
-                        values[i] = string.Format("{0} ({1})", prefix, _quantiles[i]).AsMemory();
-                    dst = new VBuffer<ReadOnlyMemory<char>>(_scoreSize, values);
+                        mutation.Values[i] = string.Format("{0} ({1})", prefix, quantiles[i]).AsMemory();
+                    dst = mutation.CreateBuffer();
                 };
         }
 
@@ -400,8 +407,9 @@ namespace Microsoft.ML.Runtime.Data
                         labelGetter(ref label);
                         scoreGetter(ref score);
                         var lab = (Double)label;
+                        var l1Mutation = VBufferMutationContext.CreateFromBuffer(ref l1);
                         foreach (var s in score.Items(all: true))
-                            l1.Values[s.Key] = Math.Abs(lab - s.Value);
+                            l1Mutation.Values[s.Key] = Math.Abs(lab - s.Value);
                         cachedPosition = input.Position;
                     }
                 };
@@ -426,7 +434,7 @@ namespace Microsoft.ML.Runtime.Data
                     (ref VBuffer<Double> dst) =>
                     {
                         updateCacheIfNeeded();
-                        dst = new VBuffer<Double>(_scoreSize, 0, dst.Values, dst.Indices);
+                        VBufferUtils.Resize(ref dst, _scoreSize, 0);
                         VBufferUtils.ApplyWith(in l1, ref dst, sqr);
                     };
                 getters[L2Col] = l2Fn;

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -522,19 +522,19 @@ namespace Microsoft.ML.Runtime.Data
                 return
                     (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                     {
-                        var mutation = VBufferMutationContext.Create(ref dst, UnweightedCounters.TruncationLevel);
+                        var editor = VBufferEditor.Create(ref dst, UnweightedCounters.TruncationLevel);
                         for (int i = 0; i < UnweightedCounters.TruncationLevel; i++)
-                            mutation.Values[i] = string.Format("{0}@{1}", prefix, i + 1).AsMemory();
-                        dst = mutation.CreateBuffer();
+                            editor.Values[i] = string.Format("{0}@{1}", prefix, i + 1).AsMemory();
+                        dst = editor.Commit();
                     };
             }
 
             public void GetSlotNames(ref VBuffer<ReadOnlyMemory<char>> slotNames)
             {
-                var mutation = VBufferMutationContext.Create(ref slotNames, UnweightedCounters.TruncationLevel);
+                var editor = VBufferEditor.Create(ref slotNames, UnweightedCounters.TruncationLevel);
                 for (int i = 0; i < UnweightedCounters.TruncationLevel; i++)
-                    mutation.Values[i] = string.Format("@{0}", i + 1).AsMemory();
-                slotNames = mutation.CreateBuffer();
+                    editor.Values[i] = string.Format("@{0}", i + 1).AsMemory();
+                slotNames = editor.Commit();
             }
         }
 
@@ -699,12 +699,12 @@ namespace Microsoft.ML.Runtime.Data
                 private void SlotNamesGetter(int iinfo, ref VBuffer<ReadOnlyMemory<char>> dst)
                 {
                     Contracts.Assert(0 <= iinfo && iinfo < InfoCount);
-                    var mutation = VBufferMutationContext.Create(ref dst, _truncationLevel);
+                    var editor = VBufferEditor.Create(ref dst, _truncationLevel);
                     for (int i = 0; i < _truncationLevel; i++)
-                        mutation.Values[i] =
+                        editor.Values[i] =
                             string.Format("{0}@{1}", iinfo == NdcgCol ? Ndcg : iinfo == DcgCol ? Dcg : MaxDcg,
                                 i + 1).AsMemory();
-                    dst = mutation.CreateBuffer();
+                    dst = editor.Commit();
                 }
             }
 
@@ -794,9 +794,9 @@ namespace Microsoft.ML.Runtime.Data
             private void Copy(Double[] src, ref VBuffer<Double> dst)
             {
                 Host.AssertValue(src);
-                var mutation = VBufferMutationContext.Create(ref dst, src.Length);
-                src.CopyTo(mutation.Values);
-                dst = mutation.CreateBuffer();
+                var editor = VBufferEditor.Create(ref dst, src.Length);
+                src.CopyTo(editor.Values);
+                dst = editor.Commit();
             }
 
             protected override ValueGetter<short> GetLabelGetter(IRow row)

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -522,25 +522,19 @@ namespace Microsoft.ML.Runtime.Data
                 return
                     (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                     {
-                        var values = dst.Values;
-                        if (Utils.Size(values) < UnweightedCounters.TruncationLevel)
-                            values = new ReadOnlyMemory<char>[UnweightedCounters.TruncationLevel];
-
+                        var mutation = VBufferMutationContext.Create(ref dst, UnweightedCounters.TruncationLevel);
                         for (int i = 0; i < UnweightedCounters.TruncationLevel; i++)
-                            values[i] = string.Format("{0}@{1}", prefix, i + 1).AsMemory();
-                        dst = new VBuffer<ReadOnlyMemory<char>>(UnweightedCounters.TruncationLevel, values);
+                            mutation.Values[i] = string.Format("{0}@{1}", prefix, i + 1).AsMemory();
+                        dst = mutation.CreateBuffer();
                     };
             }
 
             public void GetSlotNames(ref VBuffer<ReadOnlyMemory<char>> slotNames)
             {
-                var values = slotNames.Values;
-                if (Utils.Size(values) < UnweightedCounters.TruncationLevel)
-                    values = new ReadOnlyMemory<char>[UnweightedCounters.TruncationLevel];
-
+                var mutation = VBufferMutationContext.Create(ref slotNames, UnweightedCounters.TruncationLevel);
                 for (int i = 0; i < UnweightedCounters.TruncationLevel; i++)
-                    values[i] = string.Format("@{0}", i + 1).AsMemory();
-                slotNames = new VBuffer<ReadOnlyMemory<char>>(UnweightedCounters.TruncationLevel, values);
+                    mutation.Values[i] = string.Format("@{0}", i + 1).AsMemory();
+                slotNames = mutation.CreateBuffer();
             }
         }
 
@@ -705,14 +699,12 @@ namespace Microsoft.ML.Runtime.Data
                 private void SlotNamesGetter(int iinfo, ref VBuffer<ReadOnlyMemory<char>> dst)
                 {
                     Contracts.Assert(0 <= iinfo && iinfo < InfoCount);
-                    var values = dst.Values;
-                    if (Utils.Size(values) < _truncationLevel)
-                        values = new ReadOnlyMemory<char>[_truncationLevel];
+                    var mutation = VBufferMutationContext.Create(ref dst, _truncationLevel);
                     for (int i = 0; i < _truncationLevel; i++)
-                        values[i] =
+                        mutation.Values[i] =
                             string.Format("{0}@{1}", iinfo == NdcgCol ? Ndcg : iinfo == DcgCol ? Dcg : MaxDcg,
                                 i + 1).AsMemory();
-                    dst = new VBuffer<ReadOnlyMemory<char>>(_truncationLevel, values);
+                    dst = mutation.CreateBuffer();
                 }
             }
 
@@ -802,11 +794,9 @@ namespace Microsoft.ML.Runtime.Data
             private void Copy(Double[] src, ref VBuffer<Double> dst)
             {
                 Host.AssertValue(src);
-                var values = dst.Values;
-                if (Utils.Size(values) < src.Length)
-                    values = new Double[src.Length];
-                src.CopyTo(values, 0);
-                dst = new VBuffer<Double>(src.Length, values);
+                var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+                src.CopyTo(mutation.Values);
+                dst = mutation.CreateBuffer();
             }
 
             protected override ValueGetter<short> GetLabelGetter(IRow row)

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -754,12 +754,10 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.Assert(Utils.Size(_slotNames) > 0);
 
                 int size = Utils.Size(_slotNames);
-                var values = dst.Values;
-                if (Utils.Size(values) < size)
-                    values = new ReadOnlyMemory<char>[size];
+                var mutation = VBufferMutationContext.Create(ref dst, size);
                 for (int i = 0; i < _slotNames.Length; i++)
-                    values[i] = _slotNames[i].AsMemory();
-                dst = new VBuffer<ReadOnlyMemory<char>>(size, values, dst.Indices);
+                    mutation.Values[i] = _slotNames[i].AsMemory();
+                dst = mutation.CreateBuffer();
             }
         }
     }

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -754,10 +754,10 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.Assert(Utils.Size(_slotNames) > 0);
 
                 int size = Utils.Size(_slotNames);
-                var mutation = VBufferMutationContext.Create(ref dst, size);
+                var editor = VBufferEditor.Create(ref dst, size);
                 for (int i = 0; i < _slotNames.Length; i++)
-                    mutation.Values[i] = _slotNames[i].AsMemory();
-                dst = mutation.CreateBuffer();
+                    editor.Values[i] = _slotNames[i].AsMemory();
+                dst = editor.Commit();
             }
         }
     }

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -731,15 +731,10 @@ namespace Microsoft.ML.Runtime.Data
                             }
                         }
 
-                        var values = dst.Values;
-                        var indices = dst.Indices;
                         if (dstCount <= dstLength / 2)
                         {
                             // Concatenate into a sparse representation.
-                            if (Utils.Size(values) < dstCount)
-                                values = new T[dstCount];
-                            if (Utils.Size(indices) < dstCount)
-                                indices = new int[dstCount];
+                            var mutation = VBufferMutationContext.Create(ref dst, dstLength, dstCount);
 
                             int offset = 0;
                             int count = 0;
@@ -756,8 +751,8 @@ namespace Microsoft.ML.Runtime.Data
                                     {
                                         for (int i = 0; i < bufferValues.Length; i++)
                                         {
-                                            values[count] = bufferValues[i];
-                                            indices[count++] = offset + i;
+                                            mutation.Values[count] = bufferValues[i];
+                                            mutation.Indices[count++] = offset + i;
                                         }
                                     }
                                     else
@@ -765,8 +760,8 @@ namespace Microsoft.ML.Runtime.Data
                                         var bufferIndices = buffer.GetIndices();
                                         for (int i = 0; i < bufferValues.Length; i++)
                                         {
-                                            values[count] = bufferValues[i];
-                                            indices[count++] = offset + bufferIndices[i];
+                                            mutation.Values[count] = bufferValues[i];
+                                            mutation.Indices[count++] = offset + bufferIndices[i];
                                         }
                                     }
                                     offset += buffer.Length;
@@ -775,20 +770,19 @@ namespace Microsoft.ML.Runtime.Data
                                 {
                                     Contracts.Assert(count < dstCount);
                                     srcGetterOnes[j](ref tmp);
-                                    values[count] = tmp;
-                                    indices[count++] = offset;
+                                    mutation.Values[count] = tmp;
+                                    mutation.Indices[count++] = offset;
                                     offset++;
                                 }
                             }
                             Contracts.Assert(count <= dstCount);
                             Contracts.Assert(offset == dstLength);
-                            dst = new VBuffer<T>(dstLength, count, values, indices);
+                            dst = mutation.CreateBuffer(count);
                         }
                         else
                         {
                             // Concatenate into a dense representation.
-                            if (Utils.Size(values) < dstLength)
-                                values = new T[dstLength];
+                            var mutation = VBufferMutationContext.Create(ref dst, dstLength);
 
                             int offset = 0;
                             for (int j = 0; j < SrcIndices.Length; j++)
@@ -796,17 +790,17 @@ namespace Microsoft.ML.Runtime.Data
                                 Contracts.Assert(tmpBufs[j].Length <= dstLength - offset);
                                 if (_srcTypes[j].IsVector)
                                 {
-                                    tmpBufs[j].CopyTo(values, offset);
+                                    tmpBufs[j].CopyTo(mutation.Values, offset);
                                     offset += tmpBufs[j].Length;
                                 }
                                 else
                                 {
                                     srcGetterOnes[j](ref tmp);
-                                    values[offset++] = tmp;
+                                    mutation.Values[offset++] = tmp;
                                 }
                             }
                             Contracts.Assert(offset == dstLength);
-                            dst = new VBuffer<T>(dstLength, values, indices);
+                            dst = mutation.CreateBuffer();
                         }
                     };
                     return result;

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 Host.Check(keyMetadata.Length == typeKey.ItemType.KeyCount);
 
                 VBufferUtils.Densify(ref keyMetadata);
-                return new KeyToValueMap<TKey, TValue>(this, typeKey.ItemType.AsKey, typeVal.ItemType.AsPrimitive, keyMetadata.Values, iinfo);
+                return new KeyToValueMap<TKey, TValue>(this, typeKey.ItemType.AsKey, typeVal.ItemType.AsPrimitive, keyMetadata, iinfo);
             }
             /// <summary>
             /// A map is an object capable of creating the association from an input type, to an output
@@ -300,7 +300,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
             private class KeyToValueMap<TKey, TValue> : KeyToValueMap
             {
-                private readonly TValue[] _values;
+                private readonly VBuffer<TValue> _values;
                 private readonly TValue _na;
 
                 private readonly bool _naMapsToDefault;
@@ -308,10 +308,10 @@ namespace Microsoft.ML.Transforms.Conversions
 
                 private readonly ValueMapper<TKey, UInt32> _convertToUInt;
 
-                public KeyToValueMap(Mapper parent, KeyType typeKey, PrimitiveType typeVal, TValue[] values, int iinfo)
+                public KeyToValueMap(Mapper parent, KeyType typeKey, PrimitiveType typeVal, VBuffer<TValue> values, int iinfo)
                     : base(parent, typeVal, iinfo)
                 {
-                    Parent.Host.AssertValue(values);
+                    Parent.Host.Assert(values.IsDense);
                     Parent.Host.Assert(typeKey.RawType == typeof(TKey));
                     Parent.Host.Assert(TypeOutput.RawType == typeof(TValue));
                     _values = values;
@@ -331,11 +331,16 @@ namespace Microsoft.ML.Transforms.Conversions
 
                 private void MapKey(in TKey src, ref TValue dst)
                 {
+                    MapKey(in src, _values.GetValues(), ref dst);
+                }
+
+                private void MapKey(in TKey src, ReadOnlySpan<TValue> values, ref TValue dst)
+                {
                     uint uintSrc = 0;
                     _convertToUInt(in src, ref uintSrc);
                     // Assign to NA if key value is not in valid range.
-                    if (0 < uintSrc && uintSrc <= _values.Length)
-                        dst = _values[uintSrc - 1];
+                    if (0 < uintSrc && uintSrc <= values.Length)
+                        dst = values[(int)(uintSrc - 1)];
                     else
                         dst = _na;
                 }
@@ -369,7 +374,6 @@ namespace Microsoft.ML.Transforms.Conversions
                     {
                         var src = default(VBuffer<TKey>);
                         var dstItem = default(TValue);
-                        int maxSize = TypeOutput.IsKnownSizeVector ? TypeOutput.VectorSize : Utils.ArrayMaxSize;
                         ValueGetter<VBuffer<TKey>> getSrc = input.GetGetter<VBuffer<TKey>>(Parent.ColMapNewToOld[InfoIndex]);
                         ValueGetter<VBuffer<TValue>> retVal =
                             (ref VBuffer<TValue> dst) =>
@@ -378,18 +382,14 @@ namespace Microsoft.ML.Transforms.Conversions
                                 int srcSize = src.Length;
                                 var srcValues = src.GetValues();
                                 int srcCount = srcValues.Length;
-                                var dstValues = dst.Values;
-                                var dstIndices = dst.Indices;
 
-                                int islotDst = 0;
-
+                                var keyValues = _values.GetValues();
                                 if (src.IsDense)
                                 {
-                                    Utils.EnsureSize(ref dstValues, srcSize, maxSize, keepOld: false);
-
+                                    var mutation = VBufferMutationContext.Create(ref dst, srcSize);
                                     for (int slot = 0; slot < srcSize; ++slot)
                                     {
-                                        MapKey(in srcValues[slot], ref dstValues[slot]);
+                                        MapKey(in srcValues[slot], keyValues, ref mutation.Values[slot]);
 
                                         // REVIEW:
                                         // The current implementation always maps dense to dense, even if the resulting columns could benefit from
@@ -400,13 +400,13 @@ namespace Microsoft.ML.Transforms.Conversions
                                         // defaults is hit. We assume that if the user was willing to densify the data into key values that they will
                                         // be fine with this output being dense.
                                     }
-                                    islotDst = srcSize;
+                                    dst = mutation.CreateBuffer();
                                 }
                                 else if (!_naMapsToDefault)
                                 {
                                     // Sparse input will always result in dense output unless the key metadata maps back to key types.
                                     // Currently this always maps sparse to dense, as long as the output type's NA does not equal its default value.
-                                    Utils.EnsureSize(ref dstValues, srcSize, maxSize, keepOld: false);
+                                    var mutation = VBufferMutationContext.Create(ref dst, srcSize);
 
                                     var srcIndices = src.GetIndices();
                                     int nextExplicitSlot = srcCount == 0 ? srcSize : srcIndices[0];
@@ -417,37 +417,37 @@ namespace Microsoft.ML.Transforms.Conversions
                                         {
                                             // Current slot has an explicitly defined value.
                                             Parent.Host.Assert(islot < srcCount);
-                                            MapKey(in srcValues[islot], ref dstValues[slot]);
+                                            MapKey(in srcValues[islot], keyValues, ref mutation.Values[slot]);
                                             nextExplicitSlot = ++islot == srcCount ? srcSize : srcIndices[islot];
                                             Parent.Host.Assert(slot < nextExplicitSlot);
                                         }
                                         else
                                         {
                                             Parent.Host.Assert(slot < nextExplicitSlot);
-                                            dstValues[slot] = _na;
+                                            mutation.Values[slot] = _na;
                                         }
                                     }
-                                    islotDst = srcSize;
+                                    dst = mutation.CreateBuffer();
                                 }
                                 else
                                 {
                                     // As the default value equals the NA value for the output type, we produce sparse output.
-                                    Utils.EnsureSize(ref dstValues, srcCount, maxSize, keepOld: false);
-                                    Utils.EnsureSize(ref dstIndices, srcCount, maxSize, keepOld: false);
+                                    var mutation = VBufferMutationContext.Create(ref dst, srcSize, srcCount);
                                     var srcIndices = src.GetIndices();
+                                    var islotDst = 0;
                                     for (int islotSrc = 0; islotSrc < srcCount; ++islotSrc)
                                     {
                                         // Current slot has an explicitly defined value.
                                         Parent.Host.Assert(islotSrc < srcCount);
-                                        MapKey(in srcValues[islotSrc], ref dstItem);
+                                        MapKey(in srcValues[islotSrc], keyValues, ref dstItem);
                                         if (!_isDefault(in dstItem))
                                         {
-                                            dstValues[islotDst] = dstItem;
-                                            dstIndices[islotDst++] = srcIndices[islotSrc];
+                                            mutation.Values[islotDst] = dstItem;
+                                            mutation.Indices[islotDst++] = srcIndices[islotSrc];
                                         }
                                     }
+                                    dst = mutation.CreateBuffer(islotDst);
                                 }
-                                dst = new VBuffer<TValue>(srcSize, islotDst, dstValues, dstIndices);
                             };
                         return retVal;
                     }
@@ -469,8 +469,9 @@ namespace Microsoft.ML.Transforms.Conversions
                     if (TypeOutput.IsText)
                     {
                         jsonValues = new JArray();
-                        for (int i = 0; i < _values.Length; ++i)
-                            jsonValues.Add(_values[i].ToString());
+                        var keyValues = _values.GetValues();
+                        for (int i = 0; i < keyValues.Length; ++i)
+                            jsonValues.Add(keyValues[i].ToString());
                     }
                     else
                         jsonValues = new JArray(_values);

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -388,9 +388,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 var keys = new ReadOnlyMemory<char>[keyCount];
                 namesKeySrc.CopyTo(keys);
 
-                var values = dst.Values;
-                if (Utils.Size(values) < slotLim)
-                    values = new ReadOnlyMemory<char>[slotLim];
+                var mutation = VBufferMutationContext.Create(ref dst, slotLim);
 
                 var sb = new StringBuilder();
                 int slot = 0;
@@ -409,12 +407,12 @@ namespace Microsoft.ML.Transforms.Conversions
                     {
                         sb.Length = len;
                         sb.AppendMemory(key);
-                        values[slot++] = sb.ToString().AsMemory();
+                        mutation.Values[slot++] = sb.ToString().AsMemory();
                     }
                 }
                 Host.Assert(slot == slotLim);
 
-                dst = new VBuffer<ReadOnlyMemory<char>>(slotLim, values, dst.Indices);
+                dst = mutation.CreateBuffer();
             }
 
             private void GetCategoricalSlotRanges(int iinfo, ref VBuffer<int> dst)
@@ -475,20 +473,15 @@ namespace Microsoft.ML.Transforms.Conversions
                         getSrc(ref src);
                         if (src == 0 || src > size)
                         {
-                            dst = new VBuffer<float>(size, 0, dst.Values, dst.Indices);
+                            VBufferUtils.Resize(ref dst, size, 0);
                             return;
                         }
 
-                        var values = dst.Values;
-                        var indices = dst.Indices;
-                        if (Utils.Size(values) < 1)
-                            values = new float[1];
-                        if (Utils.Size(indices) < 1)
-                            indices = new int[1];
-                        values[0] = 1;
-                        indices[0] = (int)src - 1;
+                        var mutation = VBufferMutationContext.Create(ref dst, size, 1);
+                        mutation.Values[0] = 1;
+                        mutation.Indices[0] = (int)src - 1;
 
-                        dst = new VBuffer<float>(size, 1, values, indices);
+                        dst = mutation.CreateBuffer();
                     };
             }
 

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -388,7 +388,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 var keys = new ReadOnlyMemory<char>[keyCount];
                 namesKeySrc.CopyTo(keys);
 
-                var mutation = VBufferMutationContext.Create(ref dst, slotLim);
+                var editor = VBufferEditor.Create(ref dst, slotLim);
 
                 var sb = new StringBuilder();
                 int slot = 0;
@@ -407,12 +407,12 @@ namespace Microsoft.ML.Transforms.Conversions
                     {
                         sb.Length = len;
                         sb.AppendMemory(key);
-                        mutation.Values[slot++] = sb.ToString().AsMemory();
+                        editor.Values[slot++] = sb.ToString().AsMemory();
                     }
                 }
                 Host.Assert(slot == slotLim);
 
-                dst = mutation.CreateBuffer();
+                dst = editor.Commit();
             }
 
             private void GetCategoricalSlotRanges(int iinfo, ref VBuffer<int> dst)
@@ -477,11 +477,11 @@ namespace Microsoft.ML.Transforms.Conversions
                             return;
                         }
 
-                        var mutation = VBufferMutationContext.Create(ref dst, size, 1);
-                        mutation.Values[0] = 1;
-                        mutation.Indices[0] = (int)src - 1;
+                        var editor = VBufferEditor.Create(ref dst, size, 1);
+                        editor.Values[0] = 1;
+                        editor.Indices[0] = (int)src - 1;
 
-                        dst = mutation.CreateBuffer();
+                        dst = editor.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnDbl.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnDbl.cs
@@ -1241,7 +1241,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                         }
                         else
                         {
-                            var indices = input.Indices;
+                            var indices = input.GetIndices();
                             for (int ii = 0; ii < values.Length; ii++)
                             {
                                 int i = indices[ii];
@@ -1410,7 +1410,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in val))
                         return false;
-                    _buffer.Values[0] = val;
+                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = val;
                     Aggregator.ProcessValue(in _buffer);
                     return true;
                 }
@@ -1554,7 +1554,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in origVal))
                         return false;
-                    _buffer.Values[0] = origVal;
+                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = origVal;
                     _aggregator.ProcessValue(in _buffer);
                     return true;
                 }
@@ -1886,7 +1886,7 @@ namespace Microsoft.ML.Transforms.Normalizers
 
                 protected override bool AcceptColumnValue(in VBuffer<TFloat> colValuesBuffer)
                 {
-                    return !colValuesBuffer.Values.Any(TFloat.IsNaN);
+                    return !VBufferUtils.HasNaNs(in colValuesBuffer);
                 }
 
                 public override IColumnFunction CreateColumnFunction()

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnDbl.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnDbl.cs
@@ -1410,7 +1410,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in val))
                         return false;
-                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = val;
+                    VBufferEditor.CreateFromBuffer(ref _buffer).Values[0] = val;
                     Aggregator.ProcessValue(in _buffer);
                     return true;
                 }
@@ -1554,7 +1554,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in origVal))
                         return false;
-                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = origVal;
+                    VBufferEditor.CreateFromBuffer(ref _buffer).Values[0] = origVal;
                     _aggregator.ProcessValue(in _buffer);
                     return true;
                 }

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
@@ -1417,7 +1417,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in val))
                         return false;
-                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = val;
+                    VBufferEditor.CreateFromBuffer(ref _buffer).Values[0] = val;
                     Aggregator.ProcessValue(in _buffer);
                     return true;
                 }
@@ -1561,7 +1561,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in origVal))
                         return false;
-                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = origVal;
+                    VBufferEditor.CreateFromBuffer(ref _buffer).Values[0] = origVal;
                     _aggregator.ProcessValue(in _buffer);
                     return true;
                 }

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
@@ -1248,7 +1248,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                         }
                         else
                         {
-                            var indices = input.Indices;
+                            var indices = input.GetIndices();
                             for (int ii = 0; ii < count; ii++)
                             {
                                 int i = indices[ii];
@@ -1417,7 +1417,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in val))
                         return false;
-                    _buffer.Values[0] = val;
+                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = val;
                     Aggregator.ProcessValue(in _buffer);
                     return true;
                 }
@@ -1561,7 +1561,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 {
                     if (!base.ProcessValue(in origVal))
                         return false;
-                    _buffer.Values[0] = origVal;
+                    VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = origVal;
                     _aggregator.ProcessValue(in _buffer);
                     return true;
                 }
@@ -1894,7 +1894,7 @@ namespace Microsoft.ML.Transforms.Normalizers
 
                 protected override bool AcceptColumnValue(in VBuffer<TFloat> colValuesBuffer)
                 {
-                    return !colValuesBuffer.Values.Any(TFloat.IsNaN);
+                    return !VBufferUtils.HasNaNs(in colValuesBuffer);
                 }
 
                 public override IColumnFunction CreateColumnFunction()

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -650,19 +650,17 @@ namespace Microsoft.ML.Transforms.Categorical
 
                 public override void GetTerms(ref VBuffer<ReadOnlyMemory<char>> dst)
                 {
-                    ReadOnlyMemory<char>[] values = dst.Values;
-                    if (Utils.Size(values) < _pool.Count)
-                        values = new ReadOnlyMemory<char>[_pool.Count];
+                    var mutation = VBufferMutationContext.Create(ref dst, _pool.Count);
                     int slot = 0;
                     foreach (var nstr in _pool)
                     {
-                        Contracts.Assert(0 <= nstr.Id & nstr.Id < values.Length);
+                        Contracts.Assert(0 <= nstr.Id & nstr.Id < mutation.Values.Length);
                         Contracts.Assert(nstr.Id == slot);
-                        values[nstr.Id] = nstr.Value;
+                        mutation.Values[nstr.Id] = nstr.Value;
                         slot++;
                     }
 
-                    dst = new VBuffer<ReadOnlyMemory<char>>(_pool.Count, values, dst.Indices);
+                    dst = mutation.CreateBuffer();
                 }
 
                 internal override void WriteTextTerms(TextWriter writer)
@@ -733,16 +731,14 @@ namespace Microsoft.ML.Transforms.Categorical
                 {
                     if (Count == 0)
                     {
-                        dst = new VBuffer<T>(0, dst.Values, dst.Indices);
+                        VBufferUtils.Resize(ref dst, 0);
                         return;
                     }
-                    T[] values = dst.Values;
-                    if (Utils.Size(values) < Count)
-                        values = new T[Count];
+                    var mutation = VBufferMutationContext.Create(ref dst, Count);
                     Contracts.AssertValue(_values);
                     Contracts.Assert(_values.Count == Count);
-                    _values.CopyTo(values);
-                    dst = new VBuffer<T>(Count, values, dst.Indices);
+                    _values.CopyTo(mutation.Values);
+                    dst = mutation.CreateBuffer();
                 }
 
                 internal override void WriteTextTerms(TextWriter writer)
@@ -784,20 +780,19 @@ namespace Microsoft.ML.Transforms.Categorical
             Contracts.Assert(typeof(T) != typeof(ReadOnlyMemory<char>));
 
             StringBuilder sb = null;
-            ReadOnlyMemory<char>[] values = dst.Values;
 
             // We'd obviously have to adjust this a bit, if we ever had sparse metadata vectors.
             // The way the term map metadata getters are structured right now, this is impossible.
             Contracts.Assert(src.IsDense);
 
-            if (Utils.Size(values) < src.Length)
-                values = new ReadOnlyMemory<char>[src.Length];
-            for (int i = 0; i < src.Length; ++i)
+            var mutation = VBufferMutationContext.Create(ref dst, src.Length);
+            var srcValues = src.GetValues();
+            for (int i = 0; i < srcValues.Length; ++i)
             {
-                stringMapper(in src.Values[i], ref sb);
-                values[i] = sb.ToString().AsMemory();
+                stringMapper(in srcValues[i], ref sb);
+                mutation.Values[i] = sb.ToString().AsMemory();
             }
-            dst = new VBuffer<ReadOnlyMemory<char>>(src.Length, values, dst.Indices);
+            dst = mutation.CreateBuffer();
         }
 
         /// <summary>
@@ -956,7 +951,7 @@ namespace Microsoft.ML.Transforms.Categorical
                                     {
                                         // REVIEW: Should the VBufferBuilder be changed so that it can
                                         // build vectors of length zero?
-                                        dst = new VBuffer<uint>(cval, dst.Values, dst.Indices);
+                                        VBufferUtils.Resize(ref dst, cval);
                                         return;
                                     }
 
@@ -991,7 +986,7 @@ namespace Microsoft.ML.Transforms.Categorical
                                     {
                                         // REVIEW: Should the VBufferBuilder be changed so that it can
                                         // build vectors of length zero?
-                                        dst = new VBuffer<uint>(cval, dst.Values, dst.Indices);
+                                        VBufferUtils.Resize(ref dst, cval);
                                         return;
                                     }
 
@@ -1125,9 +1120,7 @@ namespace Microsoft.ML.Transforms.Categorical
 
                             VBuffer<T> keyVals = default(VBuffer<T>);
                             TypedMap.GetTerms(ref keyVals);
-                            TMeta[] values = dst.Values;
-                            if (Utils.Size(values) < TypedMap.OutputType.KeyCount)
-                                values = new TMeta[TypedMap.OutputType.KeyCount];
+                            var mutation = VBufferMutationContext.Create(ref dst, TypedMap.OutputType.KeyCount);
                             uint convKeyVal = 0;
                             foreach (var pair in keyVals.Items(all: true))
                             {
@@ -1135,9 +1128,9 @@ namespace Microsoft.ML.Transforms.Categorical
                                 conv(in keyVal, ref convKeyVal);
                                 // The builder for the key values should not have any missings.
                                 _host.Assert(0 < convKeyVal && convKeyVal <= srcMeta.Length);
-                                srcMeta.GetItemOrDefault((int)(convKeyVal - 1), ref values[pair.Key]);
+                                srcMeta.GetItemOrDefault((int)(convKeyVal - 1), ref mutation.Values[pair.Key]);
                             }
-                            dst = new VBuffer<TMeta>(TypedMap.OutputType.KeyCount, values, dst.Indices);
+                            dst = mutation.CreateBuffer();
                         };
 
                     if (IsTextMetadata && !srcMetaType.IsText)

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1003,22 +1003,6 @@ namespace Microsoft.ML.Trainers.FastTree
             return conv;
         }
 
-        protected void GetFeatureNames(RoleMappedData data, ref VBuffer<ReadOnlyMemory<char>> names)
-        {
-            // The existing implementations will have verified this by the time this utility
-            // function is called.
-            Host.AssertValue(data);
-            var feat = data.Schema.Feature;
-            Host.AssertValue(feat);
-            Host.Assert(feat.Type.ValueCount > 0);
-
-            var sch = data.Schema.Schema;
-            if (sch.HasSlotNames(feat.Index, feat.Type.ValueCount))
-                sch.GetMetadata(MetadataUtils.Kinds.SlotNames, feat.Index, ref names);
-            else
-                names = new VBuffer<ReadOnlyMemory<char>>(feat.Type.ValueCount, 0, names.Values, names.Indices);
-        }
-
 #if !CORECLR
         protected void GetFeatureIniContent(RoleMappedData data, ref VBuffer<ReadOnlyMemory<char>> content)
         {
@@ -2550,8 +2534,7 @@ namespace Microsoft.ML.Trainers.FastTree
             public void CopyTo(int length, ref VBuffer<Double> dst)
             {
                 Contracts.Assert(0 <= length);
-                int[] indices = dst.Indices;
-                Double[] values = dst.Values;
+                VBufferMutationContext<double> mutation;
                 if (!_isSparse)
                 {
                     Contracts.Assert(_dense.Count <= length);
@@ -2559,29 +2542,28 @@ namespace Microsoft.ML.Trainers.FastTree
                         Sparsify();
                     else
                     {
-                        Utils.EnsureSize(ref values, length, keepOld: false);
+                        mutation = VBufferMutationContext.Create(ref dst, length);
                         if (_dense.Count < length)
                         {
-                            _dense.CopyTo(values, 0);
-                            Array.Clear(values, _dense.Count, length - _dense.Count);
+                            _dense.CopyTo(mutation.Values);
+                            mutation.Values.Slice(_dense.Count, length - _dense.Count).Clear();
                         }
                         else
-                            _dense.CopyTo(0, values, 0, length);
-                        dst = new VBuffer<Double>(length, values, indices);
+                            _dense.CopyTo(mutation.Values, length);
+                        dst = mutation.CreateBuffer();
                         return;
                     }
                 }
                 int count = _sparse.Count;
                 Contracts.Assert(count <= length);
-                Utils.EnsureSize(ref indices, count);
-                Utils.EnsureSize(ref values, count);
+                mutation = VBufferMutationContext.Create(ref dst, length, count);
                 for (int i = 0; i < _sparse.Count; ++i)
                 {
-                    indices[i] = _sparse[i].Key;
-                    values[i] = _sparse[i].Value;
+                    mutation.Indices[i] = _sparse[i].Key;
+                    mutation.Values[i] = _sparse[i].Value;
                 }
-                Contracts.Assert(Utils.IsIncreasing(0, indices, count, length));
-                dst = new VBuffer<Double>(length, count, values, indices);
+                Contracts.Assert(Utils.IsIncreasing(0, mutation.Indices, count, length));
+                dst = mutation.CreateBuffer();
             }
 
             /// <summary>
@@ -3270,7 +3252,8 @@ namespace Microsoft.ML.Trainers.FastTree
             // If there are no trees or no splits, there are no gains.
             if (gainMap.Count == 0)
             {
-                weights = new VBuffer<Float>(numFeatures, 0, weights.Values, weights.Indices);
+                weights = VBufferMutationContext.Create(ref weights, numFeatures, 0)
+                    .CreateBuffer();
                 return;
             }
 

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -120,12 +120,10 @@ namespace Microsoft.ML.Trainers.FastTree
                     var distribution = TrainedEnsemble.GetDistribution(in src, _quantileSampleCount, out weights);
                     var qdist = new QuantileStatistics(distribution, weights);
 
-                    var values = dst.Values;
-                    if (Utils.Size(values) < quantiles.Length)
-                        values = new float[quantiles.Length];
+                    var mutation = VBufferMutationContext.Create(ref dst, quantiles.Length);
                     for (int i = 0; i < quantiles.Length; i++)
-                        values[i] = qdist.GetQuantile((float)quantiles[i]);
-                    dst = new VBuffer<float>(quantiles.Length, values, dst.Indices);
+                        mutation.Values[i] = qdist.GetQuantile((float)quantiles[i]);
+                    dst = mutation.CreateBuffer();
                 };
         }
 

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -120,10 +120,10 @@ namespace Microsoft.ML.Trainers.FastTree
                     var distribution = TrainedEnsemble.GetDistribution(in src, _quantileSampleCount, out weights);
                     var qdist = new QuantileStatistics(distribution, weights);
 
-                    var mutation = VBufferMutationContext.Create(ref dst, quantiles.Length);
+                    var editor = VBufferEditor.Create(ref dst, quantiles.Length);
                     for (int i = 0; i < quantiles.Length; i++)
-                        mutation.Values[i] = qdist.GetQuantile((float)quantiles[i]);
-                    dst = mutation.CreateBuffer();
+                        editor.Values[i] = qdist.GetQuantile((float)quantiles[i]);
+                    dst = editor.Commit();
                 };
         }
 

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -303,14 +303,11 @@ namespace Microsoft.ML.Runtime.Data
                 public void GetTreeValues(ref VBuffer<float> dst)
                 {
                     EnsureCachedPosition();
-                    var vals = dst.Values;
-                    if (Utils.Size(vals) < _numTrees)
-                        vals = new float[_numTrees];
-
+                    var mutation = VBufferMutationContext.Create(ref dst, _numTrees);
                     for (int i = 0; i < _numTrees; i++)
-                        vals[i] = _ensemble.GetLeafValue(i, _leafIds[i]);
+                        mutation.Values[i] = _ensemble.GetLeafValue(i, _leafIds[i]);
 
-                    dst = new VBuffer<float>(_numTrees, vals, dst.Indices);
+                    dst = mutation.CreateBuffer();
                 }
 
                 public void GetLeafIds(ref VBuffer<float> dst)
@@ -484,34 +481,28 @@ namespace Microsoft.ML.Runtime.Data
         {
             var numTrees = _ensemble.TrainedEnsemble.NumTrees;
 
-            var names = dst.Values;
-            if (Utils.Size(names) < numTrees)
-                names = new ReadOnlyMemory<char>[numTrees];
-
+            var mutation = VBufferMutationContext.Create(ref dst, numTrees);
             for (int t = 0; t < numTrees; t++)
-                names[t] = string.Format("Tree{0:000}", t).AsMemory();
+                mutation.Values[t] = string.Format("Tree{0:000}", t).AsMemory();
 
-            dst = new VBuffer<ReadOnlyMemory<char>>(numTrees, names, dst.Indices);
+            dst = mutation.CreateBuffer();
         }
 
         private void GetLeafSlotNames(int col, ref VBuffer<ReadOnlyMemory<char>> dst)
         {
             var numTrees = _ensemble.TrainedEnsemble.NumTrees;
 
-            var names = dst.Values;
-            if (Utils.Size(names) < _totalLeafCount)
-                names = new ReadOnlyMemory<char>[_totalLeafCount];
-
+            var mutation = VBufferMutationContext.Create(ref dst, _totalLeafCount);
             int i = 0;
             int t = 0;
             foreach (var tree in ((ITreeEnsemble)_ensemble).GetTrees())
             {
                 for (int l = 0; l < tree.NumLeaves; l++)
-                    names[i++] = string.Format("Tree{0:000}Leaf{1:000}", t, l).AsMemory();
+                    mutation.Values[i++] = string.Format("Tree{0:000}Leaf{1:000}", t, l).AsMemory();
                 t++;
             }
             _host.Assert(i == _totalLeafCount);
-            dst = new VBuffer<ReadOnlyMemory<char>>(_totalLeafCount, names, dst.Indices);
+            dst = mutation.CreateBuffer();
         }
 
         private void GetPathSlotNames(int col, ref VBuffer<ReadOnlyMemory<char>> dst)
@@ -519,9 +510,7 @@ namespace Microsoft.ML.Runtime.Data
             var numTrees = _ensemble.TrainedEnsemble.NumTrees;
 
             var totalNodeCount = _totalLeafCount - numTrees;
-            var names = dst.Values;
-            if (Utils.Size(names) < totalNodeCount)
-                names = new ReadOnlyMemory<char>[totalNodeCount];
+            var mutation = VBufferMutationContext.Create(ref dst, totalNodeCount);
 
             int i = 0;
             int t = 0;
@@ -529,11 +518,11 @@ namespace Microsoft.ML.Runtime.Data
             {
                 var numLeaves = tree.NumLeaves;
                 for (int l = 0; l < tree.NumLeaves - 1; l++)
-                    names[i++] = string.Format("Tree{0:000}Node{1:000}", t, l).AsMemory();
+                    mutation.Values[i++] = string.Format("Tree{0:000}Node{1:000}", t, l).AsMemory();
                 t++;
             }
             _host.Assert(i == totalNodeCount);
-            dst = new VBuffer<ReadOnlyMemory<char>>(totalNodeCount, names, dst.Indices);
+            dst = mutation.CreateBuffer();
         }
 
         public ISchemaBoundMapper Bind(IHostEnvironment env, RoleMappedSchema schema)

--- a/src/Microsoft.ML.PCA/PcaTransform.cs
+++ b/src/Microsoft.ML.PCA/PcaTransform.cs
@@ -630,17 +630,14 @@ namespace Microsoft.ML.Transforms.Projections
             {
                 ectx.Check(src.Length == transformInfo.Dimension);
 
-                var values = dst.Values;
-                if (Utils.Size(values) < transformInfo.Rank)
-                    values = new float[transformInfo.Rank];
-
+                var mutation = VBufferMutationContext.Create(ref dst, transformInfo.Rank);
                 for (int i = 0; i < transformInfo.Rank; i++)
                 {
-                    values[i] = VectorUtils.DotProductWithOffset(transformInfo.Eigenvectors[i], 0, in src) -
+                    mutation.Values[i] = VectorUtils.DotProductWithOffset(transformInfo.Eigenvectors[i], 0, in src) -
                         (transformInfo.MeanProjected == null ? 0 : transformInfo.MeanProjected[i]);
                 }
 
-                dst = new VBuffer<float>(transformInfo.Rank, values, dst.Indices);
+                dst = mutation.CreateBuffer();
             }
         }
 

--- a/src/Microsoft.ML.PCA/PcaTransform.cs
+++ b/src/Microsoft.ML.PCA/PcaTransform.cs
@@ -630,14 +630,14 @@ namespace Microsoft.ML.Transforms.Projections
             {
                 ectx.Check(src.Length == transformInfo.Dimension);
 
-                var mutation = VBufferMutationContext.Create(ref dst, transformInfo.Rank);
+                var editor = VBufferEditor.Create(ref dst, transformInfo.Rank);
                 for (int i = 0; i < transformInfo.Rank; i++)
                 {
-                    mutation.Values[i] = VectorUtils.DotProductWithOffset(transformInfo.Eigenvectors[i], 0, in src) -
+                    editor.Values[i] = VectorUtils.DotProductWithOffset(transformInfo.Eigenvectors[i], 0, in src) -
                         (transformInfo.MeanProjected == null ? 0 : transformInfo.MeanProjected[i]);
                 }
 
-                dst = mutation.CreateBuffer();
+                dst = editor.Commit();
             }
         }
 

--- a/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
@@ -262,7 +262,7 @@ namespace Microsoft.ML.Runtime.Numeric
             VBuffer<Float> dir = new VBuffer<Float>(x.Length, 1, new Float[] { 1 }, new int[] { 0 });
             for (int n = 0; n < x.Length; n++)
             {
-                VBufferMutationContext.CreateFromBuffer(ref dir).Values[0] = n;
+                VBufferEditor.CreateFromBuffer(ref dir).Values[0] = n;
                 VectorUtils.AddMultInto(in x, Eps, in dir, ref newX);
                 Float rVal = f(in newX, ref newGrad, null);
 
@@ -301,7 +301,7 @@ namespace Microsoft.ML.Runtime.Numeric
             VBuffer<Float> dir = new VBuffer<Float>(x.Length, 1, new Float[] { 1 }, new int[] { 0 });
             foreach (int n in coords)
             {
-                VBufferMutationContext.CreateFromBuffer(ref dir).Values[0] = n;
+                VBufferEditor.CreateFromBuffer(ref dir).Values[0] = n;
                 VectorUtils.AddMultInto(in x, Eps, in dir, ref newX);
                 Float rVal = f(in newX, ref newGrad, null);
 

--- a/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
@@ -101,7 +101,6 @@ namespace Microsoft.ML.Runtime.Numeric
             VBuffer<Float> tempGrad = default(VBuffer<Float>);
             for (int i = from; i < to; ++i)
             {
-                tempGrad = new VBuffer<Float>(0, 0, tempGrad.Values, tempGrad.Indices);
                 _tempVals[chunkIndex] += _func(i, in _input, ref tempGrad);
                 if (_tempGrads[chunkIndex].Length == 0)
                     tempGrad.CopyTo(ref _tempGrads[chunkIndex]);
@@ -263,7 +262,7 @@ namespace Microsoft.ML.Runtime.Numeric
             VBuffer<Float> dir = new VBuffer<Float>(x.Length, 1, new Float[] { 1 }, new int[] { 0 });
             for (int n = 0; n < x.Length; n++)
             {
-                dir.Values[0] = n;
+                VBufferMutationContext.CreateFromBuffer(ref dir).Values[0] = n;
                 VectorUtils.AddMultInto(in x, Eps, in dir, ref newX);
                 Float rVal = f(in newX, ref newGrad, null);
 
@@ -302,7 +301,7 @@ namespace Microsoft.ML.Runtime.Numeric
             VBuffer<Float> dir = new VBuffer<Float>(x.Length, 1, new Float[] { 1 }, new int[] { 0 });
             foreach (int n in coords)
             {
-                dir.Values[0] = n;
+                VBufferMutationContext.CreateFromBuffer(ref dir).Values[0] = n;
                 VectorUtils.AddMultInto(in x, Eps, in dir, ref newX);
                 Float rVal = f(in newX, ref newGrad, null);
 

--- a/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/DifferentiableFunction.cs
@@ -101,6 +101,7 @@ namespace Microsoft.ML.Runtime.Numeric
             VBuffer<Float> tempGrad = default(VBuffer<Float>);
             for (int i = from; i < to; ++i)
             {
+                VBufferUtils.Resize(ref tempGrad, 0, 0);
                 _tempVals[chunkIndex] += _func(i, in _input, ref tempGrad);
                 if (_tempGrads[chunkIndex].Length == 0)
                     tempGrad.CopyTo(ref _tempGrads[chunkIndex]);

--- a/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
@@ -169,7 +169,8 @@ namespace Microsoft.ML.Runtime.Numeric
             for (int n = 0; _maxSteps == 0 || n < _maxSteps; ++n)
             {
                 if (_momentum == 0)
-                    step = new VBuffer<Float>(step.Length, 0, step.Values, step.Indices);
+                    step = VBufferMutationContext.Create(ref step, step.Length, 0)
+                        .CreateBuffer();
                 else
                     VectorUtils.ScaleBy(ref step, _momentum);
 

--- a/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
+++ b/src/Microsoft.ML.StandardLearners/Optimizer/SgdOptimizer.cs
@@ -169,8 +169,7 @@ namespace Microsoft.ML.Runtime.Numeric
             for (int n = 0; _maxSteps == 0 || n < _maxSteps; ++n)
             {
                 if (_momentum == 0)
-                    step = VBufferMutationContext.Create(ref step, step.Length, 0)
-                        .CreateBuffer();
+                    VBufferUtils.Resize(ref step, step.Length, 0);
                 else
                     VectorUtils.ScaleBy(ref step, _momentum);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -329,7 +329,8 @@ namespace Microsoft.ML.Runtime.Learners
                     (in VBuffer<float> x, ref VBuffer<float> grad) =>
                     {
                         // Zero out the gradient by sparsifying.
-                        grad = new VBuffer<float>(grad.Length, 0, grad.Values, grad.Indices);
+                        grad = VBufferMutationContext.Create(ref grad, grad.Length, 0)
+                            .CreateBuffer();
                         EnsureBiases(ref grad);
 
                         if (cursor == null || !cursor.MoveNext())

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -329,8 +329,7 @@ namespace Microsoft.ML.Runtime.Learners
                     (in VBuffer<float> x, ref VBuffer<float> grad) =>
                     {
                         // Zero out the gradient by sparsifying.
-                        grad = VBufferMutationContext.Create(ref grad, grad.Length, 0)
-                            .CreateBuffer();
+                        VBufferUtils.Resize(ref grad, grad.Length, 0);
                         EnsureBiases(ref grad);
 
                         if (cursor == null || !cursor.MoveNext())

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -179,12 +179,13 @@ namespace Microsoft.ML.Runtime.Learners
 
             // Compute deviance: start with loss function.
             float deviance = (float)(2 * loss * WeightSum);
+            var currentWeightsValues = CurrentWeights.GetValues();
 
             if (L2Weight > 0)
             {
                 // Need to subtract L2 regularization loss.
                 // The bias term is not regularized.
-                var regLoss = VectorUtils.NormSquared(CurrentWeights.Values, 1, CurrentWeights.Length - 1) * L2Weight;
+                var regLoss = VectorUtils.NormSquared(currentWeightsValues.Slice(1)) * L2Weight;
                 deviance -= regLoss;
             }
 
@@ -236,9 +237,9 @@ namespace Microsoft.ML.Runtime.Learners
                 weightIndices[0] = 0;
                 weightIndicesInvMap[0] = 0;
                 int j = 1;
-                for (int i = 1; i < CurrentWeights.Length; i++)
+                for (int i = 1; i < currentWeightsValues.Length; i++)
                 {
-                    if (CurrentWeights.Values[i] != 0)
+                    if (currentWeightsValues[i] != 0)
                     {
                         weightIndices[j] = i;
                         weightIndicesInvMap[i] = j++;
@@ -285,7 +286,7 @@ namespace Microsoft.ML.Runtime.Learners
             }
 
             // Initialize the remaining entries.
-            var bias = CurrentWeights.Values[0];
+            var bias = currentWeightsValues[0];
             using (var cursor = cursorFactory.Create())
             {
                 while (cursor.MoveNext())

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -731,12 +731,12 @@ namespace Microsoft.ML.Runtime.Learners
             if (!src.IsDense)
                 weights = DensifyWeights();
 
-            var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
+            var editor = VBufferEditor.Create(ref dst, _numClasses);
             for (int i = 0; i < _biases.Length; i++)
-                mutation.Values[i] = _biases[i] + VectorUtils.DotProduct(in weights[i], in src);
+                editor.Values[i] = _biases[i] + VectorUtils.DotProduct(in weights[i], in src);
 
-            Calibrate(mutation.Values);
-            dst = mutation.CreateBuffer();
+            Calibrate(editor.Values);
+            dst = editor.Commit();
         }
 
         private VBuffer<float>[] DensifyWeights()

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Runtime.Learners
             }
 
             _labelNames = new string[_numClasses];
-            ReadOnlyMemory<char>[] values = labelNames.Values;
+            ReadOnlySpan<ReadOnlyMemory<char>> values = labelNames.GetValues();
 
             // This hashset is used to verify the uniqueness of label names.
             HashSet<string> labelNamesSet = new HashSet<string>();
@@ -204,7 +204,7 @@ namespace Microsoft.ML.Runtime.Learners
                 scores[c] = bias + VectorUtils.DotProductWithOffset(in x, start, in feat);
             }
 
-            float logZ = MathUtils.SoftMax(scores, _numClasses);
+            float logZ = MathUtils.SoftMax(scores.AsSpan(0, _numClasses));
             float datumLoss = logZ;
 
             int lab = (int)label;
@@ -273,7 +273,7 @@ namespace Microsoft.ML.Runtime.Learners
             {
                 // Need to subtract L2 regularization loss.
                 // The bias term is not regularized.
-                var regLoss = VectorUtils.NormSquared(CurrentWeights.Values, BiasCount, CurrentWeights.Length - BiasCount) * L2Weight;
+                var regLoss = VectorUtils.NormSquared(CurrentWeights.GetValues().Slice(BiasCount)) * L2Weight;
                 deviance -= regLoss;
             }
 
@@ -637,11 +637,12 @@ namespace Microsoft.ML.Runtime.Learners
                     int count = 0;
                     foreach (var fw in _weights)
                     {
+                        var fwValues = fw.GetValues();
                         if (fw.IsDense)
                         {
-                            for (int i = 0; i < fw.Length; i++)
+                            for (int i = 0; i < fwValues.Length; i++)
                             {
-                                if (fw.Values[i] != 0)
+                                if (fwValues[i] != 0)
                                 {
                                     ctx.Writer.Write(i);
                                     count++;
@@ -718,27 +719,24 @@ namespace Microsoft.ML.Runtime.Learners
                 {
                     Host.Check(src.Length == _numFeatures);
 
-                    var values = dst.Values;
-                    PredictCore(in src, ref values);
-                    dst = new VBuffer<float>(_numClasses, values, dst.Indices);
+                    PredictCore(in src, ref dst);
                 };
             return (ValueMapper<TSrc, TDst>)(Delegate)del;
         }
 
-        private void PredictCore(in VBuffer<float> src, ref float[] dst)
+        private void PredictCore(in VBuffer<float> src, ref VBuffer<float> dst)
         {
             Host.Check(src.Length == _numFeatures, "src length should equal the number of features");
             var weights = _weights;
             if (!src.IsDense)
                 weights = DensifyWeights();
 
-            if (Utils.Size(dst) < _numClasses)
-                dst = new float[_numClasses];
-
+            var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
             for (int i = 0; i < _biases.Length; i++)
-                dst[i] = _biases[i] + VectorUtils.DotProduct(in weights[i], in src);
+                mutation.Values[i] = _biases[i] + VectorUtils.DotProduct(in weights[i], in src);
 
-            Calibrate(dst);
+            Calibrate(mutation.Values);
+            dst = mutation.CreateBuffer();
         }
 
         private VBuffer<float>[] DensifyWeights()
@@ -768,13 +766,13 @@ namespace Microsoft.ML.Runtime.Learners
             return _weightsDense;
         }
 
-        private void Calibrate(float[] dst)
+        private void Calibrate(Span<float> dst)
         {
-            Host.Assert(Utils.Size(dst) >= _numClasses);
+            Host.Assert(dst.Length >= _numClasses);
 
             // scores are in log-space; convert and fix underflow/overflow
             // TODO:   re-normalize probabilities to account for underflow/overflow?
-            float softmax = MathUtils.SoftMax(dst, _numClasses);
+            float softmax = MathUtils.SoftMax(dst.Slice(0, _numClasses));
             for (int i = 0; i < _numClasses; ++i)
                 dst[i] = MathUtils.ExpSlow(dst[i] - softmax);
         }
@@ -851,7 +849,7 @@ namespace Microsoft.ML.Runtime.Learners
                     "score[" + i.ToString() + "]");
             }
 
-            writer.WriteLine(string.Format("var softmax = MathUtils.SoftMax(scores, {0});", _numClasses));
+            writer.WriteLine(string.Format("var softmax = MathUtils.SoftMax(scores.AsSpan(0, {0}));", _numClasses));
             for (int c = 0; c < _biases.Length; c++)
                 writer.WriteLine("output[{0}] = Math.Exp(scores[{0}] - softmax);", c);
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
@@ -250,8 +250,8 @@ namespace Microsoft.ML.Runtime.Learners
             const Double sqrt2 = 1.41421356237; // Math.Sqrt(2);
 
             bool denseStdError = stats._coeffStdError.Value.IsDense;
-            int[] stdErrorIndices = stats._coeffStdError.Value.Indices;
-            var coeffStdErrorValues = stats._coeffStdError.Value.GetValues();
+            ReadOnlySpan<int> stdErrorIndices = stats._coeffStdError.Value.GetIndices();
+            ReadOnlySpan<float> coeffStdErrorValues = stats._coeffStdError.Value.GetValues();
             for (int i = 1; i < stats.ParametersCount; i++)
             {
                 int wi = denseStdError ? i - 1 : stdErrorIndices[i] - 1;
@@ -272,9 +272,10 @@ namespace Microsoft.ML.Runtime.Learners
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                 {
                     var mutation = VBufferMutationContext.Create(ref dst, statisticsCount);
+                    ReadOnlySpan<int> stdErrorIndices2 = stats._coeffStdError.Value.GetIndices();
                     for (int i = 1; i <= statisticsCount; i++)
                     {
-                        int wi = denseStdError ? i - 1 : stdErrorIndices[i] - 1;
+                        int wi = denseStdError ? i - 1 : stdErrorIndices2[i] - 1;
                         mutation.Values[i - 1] = slotNames.GetItemOrDefault(wi);
                     }
                     dst = mutation.CreateBuffer();
@@ -301,7 +302,7 @@ namespace Microsoft.ML.Runtime.Learners
 
             List<CoefficientStatistics> result = new List<CoefficientStatistics>(_paramCount - 1);
             bool denseStdError = _coeffStdError.Value.IsDense;
-            int[] stdErrorIndices = _coeffStdError.Value.Indices;
+            ReadOnlySpan<int> stdErrorIndices = _coeffStdError.Value.GetIndices();
             Single[] zScores = new Single[_paramCount - 1];
             for (int i = 1; i < _paramCount; i++)
             {

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -467,9 +467,9 @@ namespace Microsoft.ML.Runtime.Learners
                         var tmp = src;
                         Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
 
-                        var mutation = VBufferMutationContext.Create(ref dst, maps.Length);
-                        buffer.CopyTo(mutation.Values);
-                        dst = mutation.CreateBuffer();
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
                     };
             }
 
@@ -542,9 +542,9 @@ namespace Microsoft.ML.Runtime.Learners
                             });
                         Normalize(buffer, maps.Length);
 
-                        var mutation = VBufferMutationContext.Create(ref dst, maps.Length);
-                        buffer.CopyTo(mutation.Values);
-                        dst = mutation.CreateBuffer();
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -457,19 +457,19 @@ namespace Microsoft.ML.Runtime.Learners
                 for (int i = 0; i < Predictors.Length; i++)
                     maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
 
+                var buffer = new float[maps.Length];
                 return
                     (in VBuffer<float> src, ref VBuffer<float> dst) =>
                     {
                         if (InputType.VectorSize > 0)
                             Contracts.Check(src.Length == InputType.VectorSize);
 
-                        var values = dst.Values;
-                        if (Utils.Size(values) < maps.Length)
-                            values = new float[maps.Length];
-
                         var tmp = src;
-                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref values[i]));
-                        dst = new VBuffer<float>(maps.Length, values, dst.Indices);
+                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
+
+                        var mutation = VBufferMutationContext.Create(ref dst, maps.Length);
+                        buffer.CopyTo(mutation.Values);
+                        dst = mutation.CreateBuffer();
                     };
             }
 
@@ -526,25 +526,25 @@ namespace Microsoft.ML.Runtime.Learners
                 for (int i = 0; i < Predictors.Length; i++)
                     maps[i] = _mappers[i].GetMapper<VBuffer<float>, float, float>();
 
+                var buffer = new float[maps.Length];
                 return
                     (in VBuffer<float> src, ref VBuffer<float> dst) =>
                     {
                         if (InputType.VectorSize > 0)
                             Contracts.Check(src.Length == InputType.VectorSize);
 
-                        var values = dst.Values;
-                        if (Utils.Size(values) < maps.Length)
-                            values = new float[maps.Length];
-
                         var tmp = src;
                         Parallel.For(0, maps.Length,
                             i =>
                             {
                                 float score = 0;
-                                maps[i](in tmp, ref score, ref values[i]);
+                                maps[i](in tmp, ref score, ref buffer[i]);
                             });
-                        Normalize(values, maps.Length);
-                        dst = new VBuffer<float>(maps.Length, values, dst.Indices);
+                        Normalize(buffer, maps.Length);
+
+                        var mutation = VBufferMutationContext.Create(ref dst, maps.Length);
+                        buffer.CopyTo(mutation.Values);
+                        dst = mutation.CreateBuffer();
                     };
             }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -356,7 +356,7 @@ namespace Microsoft.ML.Runtime.Learners
             }
         }
 
-        private void ComputeProbabilities(Double[] buffer, ref float[] output)
+        private void ComputeProbabilities(Double[] buffer, Span<float> output)
         {
             // Compute the probabilities and store them in the beginning of buffer. Note that this is safe to do since
             // once we've computed the ith probability, we are totally done with the ith row and all previous rows
@@ -369,8 +369,7 @@ namespace Microsoft.ML.Runtime.Learners
                 sum += value;
             }
 
-            if (Utils.Size(output) < _numClasses)
-                output = new float[_numClasses];
+            Contracts.Assert(output.Length >= _numClasses);
 
             // Normalize.
             if (sum <= 0)
@@ -459,7 +458,6 @@ namespace Microsoft.ML.Runtime.Learners
                     if (InputType.VectorSize > 0)
                         Host.Check(src.Length == InputType.VectorSize);
 
-                    var values = dst.Values;
                     var tmp = src;
                     Parallel.For(0, maps.Length, i =>
                     {
@@ -470,9 +468,10 @@ namespace Microsoft.ML.Runtime.Learners
                     });
 
                     ReconcilePredictions(buffer);
-                    ComputeProbabilities(buffer, ref values);
 
-                    dst = new VBuffer<float>(_numClasses, values, dst.Indices);
+                    var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
+                    ComputeProbabilities(buffer, mutation.Values);
+                    dst = mutation.CreateBuffer();
                 };
             return (ValueMapper<TIn, TOut>)(Delegate)del;
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -469,9 +469,9 @@ namespace Microsoft.ML.Runtime.Learners
 
                     ReconcilePredictions(buffer);
 
-                    var mutation = VBufferMutationContext.Create(ref dst, _numClasses);
-                    ComputeProbabilities(buffer, mutation.Values);
-                    dst = mutation.CreateBuffer();
+                    var editor = VBufferEditor.Create(ref dst, _numClasses);
+                    ComputeProbabilities(buffer, editor.Values);
+                    dst = editor.Commit();
                 };
             return (ValueMapper<TIn, TOut>)(Delegate)del;
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -130,16 +130,18 @@ namespace Microsoft.ML.Trainers.Online
                             numFeatures + 1, numFeatures);
                     }
 
-                    Weights = VBufferUtils.CreateDense<Float>(numFeatures);
+                    var weightValues = new float[numFeatures];
                     for (int i = 0; i < numFeatures; i++)
-                        Weights.Values[i] = Float.Parse(weightStr[i], CultureInfo.InvariantCulture);
+                        weightValues[i] = Float.Parse(weightStr[i], CultureInfo.InvariantCulture);
+                    Weights = new VBuffer<float>(numFeatures, weightValues);
                     Bias = Float.Parse(weightStr[numFeatures], CultureInfo.InvariantCulture);
                 }
                 else if (parent.Args.InitWtsDiameter > 0)
                 {
-                    Weights = VBufferUtils.CreateDense<Float>(numFeatures);
+                    var weightValues = new float[numFeatures];
                     for (int i = 0; i < numFeatures; i++)
-                        Weights.Values[i] = parent.Args.InitWtsDiameter * (parent.Host.Rand.NextSingle() - (Float)0.5);
+                        weightValues[i] = parent.Args.InitWtsDiameter * (parent.Host.Rand.NextSingle() - (Float)0.5);
+                    Weights = new VBuffer<float>(numFeatures, weightValues);
                     Bias = parent.Args.InitWtsDiameter * (parent.Host.Rand.NextSingle() - (Float)0.5);
                 }
                 else if (numFeatures <= 1000)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -787,6 +787,8 @@ namespace Microsoft.ML.Trainers
                         invariant = Loss.ComputeDualUpdateInvariant(featuresNormSquared * lambdaNInv * GetInstanceWeight(cursor));
                     }
 
+                    var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights[0]);
+                    var l1IntermediateWeightsMutation = VBufferMutationContext.CreateFromBuffer(ref l1IntermediateWeights[0]);
                     for (int numTrials = 0; numTrials < maxUpdateTrials; numTrials++)
                     {
                         var dual = duals[idx];
@@ -812,7 +814,7 @@ namespace Microsoft.ML.Trainers
 
                             if (l1ThresholdZero)
                             {
-                                VectorUtils.AddMult(in features, weights[0].Values, primalUpdate);
+                                VectorUtils.AddMult(in features, weightsMutation.Values, primalUpdate);
                                 biasReg[0] += primalUpdate;
                             }
                             else
@@ -831,9 +833,9 @@ namespace Microsoft.ML.Trainers
 
                                 var featureValues = features.GetValues();
                                 if (features.IsDense)
-                                    CpuMathUtils.SdcaL1UpdateDense(primalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                    CpuMathUtils.SdcaL1UpdateDense(primalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeightsMutation.Values, weightsMutation.Values);
                                 else if (featureValues.Length > 0)
-                                    CpuMathUtils.SdcaL1UpdateSparse(primalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeights[0].Values, weights[0].Values);
+                                    CpuMathUtils.SdcaL1UpdateSparse(primalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeightsMutation.Values, weightsMutation.Values);
                             }
 
                             break;
@@ -1836,6 +1838,7 @@ namespace Microsoft.ML.Trainers
                 {
                     using (var cursor = _args.Shuffle ? cursorFactory.Create(rand) : cursorFactory.Create())
                     {
+                        var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights);
                         while (cursor.MoveNext())
                         {
                             VBuffer<float> features = cursor.Features;
@@ -1851,7 +1854,7 @@ namespace Microsoft.ML.Trainers
                             Double rate = ilr / (1 + ilr * l2Weight * (t++));
                             Double step = -derivative * rate;
                             weightScaling *= 1 - rate * l2Weight;
-                            VectorUtils.AddMult(in features, weights.Values, (float)(step / weightScaling));
+                            VectorUtils.AddMult(in features, weightsMutation.Values, (float)(step / weightScaling));
                             bias += (float)step;
                         }
                         if (e == 1)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -788,7 +788,10 @@ namespace Microsoft.ML.Trainers
                     }
 
                     var weightsEditor = VBufferEditor.CreateFromBuffer(ref weights[0]);
-                    var l1IntermediateWeightsEditor = VBufferEditor.CreateFromBuffer(ref l1IntermediateWeights[0]);
+                    var l1IntermediateWeightsEditor =
+                        !l1ThresholdZero ? VBufferEditor.CreateFromBuffer(ref l1IntermediateWeights[0]) :
+                        default;
+
                     for (int numTrials = 0; numTrials < maxUpdateTrials; numTrials++)
                     {
                         var dual = duals[idx];

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -197,6 +197,8 @@ namespace Microsoft.ML.Trainers
                         // Loop trials for compare-and-swap updates of duals.
                         // In general, concurrent update conflict to the same dual variable is rare
                         // if data is shuffled.
+                        var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights[iClass]);
+                        var l1IntermediateWeightsMutation = VBufferMutationContext.CreateFromBuffer(ref l1IntermediateWeights[iClass]);
                         for (int numTrials = 0; numTrials < maxUpdateTrials; numTrials++)
                         {
                             long dualIndex = iClass + dualIndexInitPos;
@@ -223,7 +225,7 @@ namespace Microsoft.ML.Trainers
 
                                 if (l1ThresholdZero)
                                 {
-                                    VectorUtils.AddMult(in features, weights[iClass].Values, -primalUpdate);
+                                    VectorUtils.AddMult(in features, weightsMutation.Values, -primalUpdate);
                                     biasReg[iClass] -= primalUpdate;
                                 }
                                 else
@@ -242,9 +244,9 @@ namespace Microsoft.ML.Trainers
 
                                     var featureValues = features.GetValues();
                                     if (features.IsDense)
-                                        CpuMathUtils.SdcaL1UpdateDense(-primalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                        CpuMathUtils.SdcaL1UpdateDense(-primalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeightsMutation.Values, weightsMutation.Values);
                                     else if (featureValues.Length > 0)
-                                        CpuMathUtils.SdcaL1UpdateSparse(-primalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeights[iClass].Values, weights[iClass].Values);
+                                        CpuMathUtils.SdcaL1UpdateSparse(-primalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeightsMutation.Values, weightsMutation.Values);
                                 }
 
                                 break;
@@ -257,7 +259,8 @@ namespace Microsoft.ML.Trainers
                     biasUnreg[label] += labelAdjustment * lambdaNInv * instanceWeight;
                     if (l1ThresholdZero)
                     {
-                        VectorUtils.AddMult(in features, weights[label].Values, labelPrimalUpdate);
+                        var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights[label]);
+                        VectorUtils.AddMult(in features, weightsMutation.Values, labelPrimalUpdate);
                         biasReg[label] += labelPrimalUpdate;
                     }
                     else
@@ -268,11 +271,13 @@ namespace Microsoft.ML.Trainers
                             ? intermediateBias - Math.Sign(intermediateBias) * l1Threshold
                             : 0;
 
+                        var weightsMutation = VBufferMutationContext.CreateFromBuffer(ref weights[label]);
+                        var l1IntermediateWeightsMutation = VBufferMutationContext.CreateFromBuffer(ref l1IntermediateWeights[label]);
                         var featureValues = features.GetValues();
                         if (features.IsDense)
-                            CpuMathUtils.SdcaL1UpdateDense(labelPrimalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                            CpuMathUtils.SdcaL1UpdateDense(labelPrimalUpdate, featureValues.Length, featureValues, l1Threshold, l1IntermediateWeightsMutation.Values, weightsMutation.Values);
                         else if (featureValues.Length > 0)
-                            CpuMathUtils.SdcaL1UpdateSparse(labelPrimalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeights[label].Values, weights[label].Values);
+                            CpuMathUtils.SdcaL1UpdateSparse(labelPrimalUpdate, featureValues.Length, featureValues, features.GetIndices(), l1Threshold, l1IntermediateWeightsMutation.Values, weightsMutation.Values);
                     }
 
                     rowCount++;
@@ -379,7 +384,7 @@ namespace Microsoft.ML.Trainers
             metrics[(int)MetricKind.BiasUnreg] = biasUnreg[0];
             metrics[(int)MetricKind.BiasReg] = biasReg[0];
             metrics[(int)MetricKind.L1Sparsity] = Args.L1Threshold == 0 ? 1 : weights.Sum(
-                weight => weight.Values.Count(w => w != 0)) / (numClasses * numFeatures);
+                weight => weight.GetValues().Count(w => w != 0)) / (numClasses * numFeatures);
 
             bool converged = dualityGap / newLoss < Args.ConvergenceTolerance;
 

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -194,11 +194,14 @@ namespace Microsoft.ML.Trainers
                         if (iClass == label)
                             continue;
 
+                        var weightsEditor = VBufferEditor.CreateFromBuffer(ref weights[iClass]);
+                        var l1IntermediateWeightsEditor =
+                            !l1ThresholdZero ? VBufferEditor.CreateFromBuffer(ref l1IntermediateWeights[iClass]) :
+                            default;
+
                         // Loop trials for compare-and-swap updates of duals.
                         // In general, concurrent update conflict to the same dual variable is rare
                         // if data is shuffled.
-                        var weightsEditor = VBufferEditor.CreateFromBuffer(ref weights[iClass]);
-                        var l1IntermediateWeightsEditor = VBufferEditor.CreateFromBuffer(ref l1IntermediateWeights[iClass]);
                         for (int numTrials = 0; numTrials < maxUpdateTrials; numTrials++)
                         {
                             long dualIndex = iClass + dualIndexInitPos;

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1436,41 +1436,36 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             var output = result as SsaForecastResult;
 
-            var res = result.PointForecast.Values;
-            if (Utils.Size(res) < horizon)
-                res = new Single[horizon];
+            var resMutation = VBufferMutationContext.Create(ref result.PointForecast, horizon);
 
             int i;
             int j;
             int k;
 
             // Computing the point forecasts
-            res[0] = _nextPrediction;
+            resMutation.Values[0] = _nextPrediction;
             for (i = 1; i < horizon; ++i)
             {
                 k = 0;
-                res[i] = _autoregressionNoiseMean + _observationNoiseMean;
+                resMutation.Values[i] = _autoregressionNoiseMean + _observationNoiseMean;
                 for (j = i; j < _windowSize - 1; ++j, ++k)
-                    res[i] += _state[j] * _alpha[k];
+                    resMutation.Values[i] += _state[j] * _alpha[k];
 
                 for (j = Math.Max(0, i - _windowSize + 1); j < i; ++j, ++k)
-                    res[i] += res[j] * _alpha[k];
+                    resMutation.Values[i] += resMutation.Values[j] * _alpha[k];
             }
 
             // Computing the forecast variances
             if (ShouldComputeForecastIntervals)
             {
-                var sd = output.ForecastStandardDeviation.Values;
-                if (Utils.Size(sd) < horizon)
-                    sd = new Single[horizon];
-
+                var sdMutation = VBufferMutationContext.Create(ref output.ForecastStandardDeviation, horizon);
                 var lastCol = new FixedSizeQueue<Single>(_windowSize - 1);
 
                 for (i = 0; i < _windowSize - 3; ++i)
                     lastCol.AddLast(0);
                 lastCol.AddLast(1);
                 lastCol.AddLast(_alpha[_windowSize - 2]);
-                sd[0] = _autoregressionNoiseVariance + _observationNoiseVariance;
+                sdMutation.Values[0] = _autoregressionNoiseVariance + _observationNoiseVariance;
 
                 for (i = 1; i < horizon; ++i)
                 {
@@ -1479,16 +1474,16 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                         temp += _alpha[j] * lastCol[j];
                     lastCol.AddLast(temp);
 
-                    sd[i] = sd[i - 1] + _autoregressionNoiseVariance * temp * temp;
+                    sdMutation.Values[i] = sdMutation.Values[i - 1] + _autoregressionNoiseVariance * temp * temp;
                 }
 
                 for (i = 0; i < horizon; ++i)
-                    sd[i] = (float)Math.Sqrt(sd[i]);
+                    sdMutation.Values[i] = (float)Math.Sqrt(sdMutation.Values[i]);
 
-                output.ForecastStandardDeviation = new VBuffer<Single>(horizon, sd, output.ForecastStandardDeviation.Indices);
+                output.ForecastStandardDeviation = sdMutation.CreateBuffer();
             }
 
-            result.PointForecast = new VBuffer<Single>(horizon, res, result.PointForecast.Indices);
+            result.PointForecast = resMutation.CreateBuffer();
             output.CanComputeForecastIntervals = ShouldComputeForecastIntervals;
             output.BoundOffset = 0;
         }
@@ -1518,35 +1513,30 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             Contracts.CheckValue(forecast, nameof(forecast));
             Contracts.Check(forecast.CanComputeForecastIntervals, "The forecast intervals cannot be computed for this forecast object.");
 
-            var horizon = Utils.Size(forecast.PointForecast.Values);
-            Contracts.Check(Utils.Size(forecast.ForecastStandardDeviation.Values) >= horizon, "The forecast standard deviation values are not available.");
+            var meanForecast = forecast.PointForecast.GetValues();
+            var horizon = meanForecast.Length;
+            var sdForecast = forecast.ForecastStandardDeviation.GetValues();
+            Contracts.Check(sdForecast.Length >= horizon, "The forecast standard deviation values are not available.");
 
             forecast.ConfidenceLevel = confidenceLevel;
             if (horizon == 0)
                 return;
 
-            var upper = forecast.UpperBound.Values;
-            if (Utils.Size(upper) < horizon)
-                upper = new Single[horizon];
-
-            var lower = forecast.LowerBound.Values;
-            if (Utils.Size(lower) < horizon)
-                lower = new Single[horizon];
+            var upper = VBufferMutationContext.Create(ref forecast.UpperBound, horizon);
+            var lower = VBufferMutationContext.Create(ref forecast.LowerBound, horizon);
 
             var z = ProbabilityFunctions.Probit(0.5 + confidenceLevel / 2.0);
-            var meanForecast = forecast.PointForecast.Values;
-            var sdForecast = forecast.ForecastStandardDeviation.Values;
             double temp;
 
             for (int i = 0; i < horizon; ++i)
             {
                 temp = z * sdForecast[i];
-                upper[i] = (Single)(meanForecast[i] + forecast.BoundOffset + temp);
-                lower[i] = (Single)(meanForecast[i] + forecast.BoundOffset - temp);
+                upper.Values[i] = (Single)(meanForecast[i] + forecast.BoundOffset + temp);
+                lower.Values[i] = (Single)(meanForecast[i] + forecast.BoundOffset - temp);
             }
 
-            forecast.UpperBound = new VBuffer<Single>(horizon, upper, forecast.UpperBound.Indices);
-            forecast.LowerBound = new VBuffer<Single>(horizon, lower, forecast.LowerBound.Indices);
+            forecast.UpperBound = upper.CreateBuffer();
+            forecast.LowerBound = lower.CreateBuffer();
         }
     }
 }

--- a/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
@@ -364,12 +364,12 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             private protected override void SetNaOutput(ref VBuffer<Double> dst)
             {
                 var outputLength = Parent._outputLength;
-                var mutation = VBufferMutationContext.Create(ref dst, outputLength);
+                var editor = VBufferEditor.Create(ref dst, outputLength);
 
                 for (int i = 0; i < outputLength; ++i)
-                    mutation.Values[i] = Double.NaN;
+                    editor.Values[i] = Double.NaN;
 
-                dst = mutation.CreateBuffer();
+                dst = editor.Commit();
             }
 
             private protected override sealed void TransformCore(ref TInput input, FixedSizeQueue<TInput> windowedBuffer, long iteration, ref VBuffer<Double> dst)
@@ -377,7 +377,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                 var outputLength = Parent._outputLength;
                 Host.Assert(outputLength >= 2);
 
-                var result = VBufferMutationContext.Create(ref dst, outputLength);
+                var result = VBufferEditor.Create(ref dst, outputLength);
                 float rawScore = 0;
 
                 for (int i = 0; i < outputLength; ++i)
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                     result.Values[0] = Convert.ToDouble(alert);
                 }
 
-                dst = result.CreateBuffer();
+                dst = result.Commit();
             }
 
             private protected override sealed void InitializeStateCore()

--- a/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
@@ -363,15 +363,13 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             private protected override void SetNaOutput(ref VBuffer<Double> dst)
             {
-                var values = dst.Values;
                 var outputLength = Parent._outputLength;
-                if (Utils.Size(values) < outputLength)
-                    values = new Double[outputLength];
+                var mutation = VBufferMutationContext.Create(ref dst, outputLength);
 
                 for (int i = 0; i < outputLength; ++i)
-                    values[i] = Double.NaN;
+                    mutation.Values[i] = Double.NaN;
 
-                dst = new VBuffer<Double>(Utils.Size(values), values, dst.Indices);
+                dst = mutation.CreateBuffer();
             }
 
             private protected override sealed void TransformCore(ref TInput input, FixedSizeQueue<TInput> windowedBuffer, long iteration, ref VBuffer<Double> dst)
@@ -379,65 +377,62 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                 var outputLength = Parent._outputLength;
                 Host.Assert(outputLength >= 2);
 
-                var result = dst.Values;
-                if (Utils.Size(result) < outputLength)
-                    result = new Double[outputLength];
-
+                var result = VBufferMutationContext.Create(ref dst, outputLength);
                 float rawScore = 0;
 
                 for (int i = 0; i < outputLength; ++i)
-                    result[i] = Double.NaN;
+                    result.Values[i] = Double.NaN;
 
                 // Step 1: Computing the raw anomaly score
-                result[1] = ComputeRawAnomalyScore(ref input, windowedBuffer, iteration);
+                result.Values[1] = ComputeRawAnomalyScore(ref input, windowedBuffer, iteration);
 
-                if (Double.IsNaN(result[1]))
-                    result[0] = 0;
+                if (Double.IsNaN(result.Values[1]))
+                    result.Values[0] = 0;
                 else
                 {
                     if (WindowSize > 0)
                     {
                         // Step 2: Computing the p-value score
-                        rawScore = (float)result[1];
+                        rawScore = (float)result.Values[1];
                         if (Parent.ThresholdScore == AlertingScore.RawScore)
                         {
                             switch (Parent.Side)
                             {
                                 case AnomalySide.Negative:
-                                    rawScore = (float)(-result[1]);
+                                    rawScore = (float)(-result.Values[1]);
                                     break;
 
                                 case AnomalySide.Positive:
                                     break;
 
                                 default:
-                                    rawScore = (float)Math.Abs(result[1]);
+                                    rawScore = (float)Math.Abs(result.Values[1]);
                                     break;
                             }
                         }
                         else
                         {
-                            result[2] = ComputeKernelPValue(rawScore);
+                            result.Values[2] = ComputeKernelPValue(rawScore);
 
                             switch (Parent.Side)
                             {
                                 case AnomalySide.Negative:
-                                    result[2] = 1 - result[2];
+                                    result.Values[2] = 1 - result.Values[2];
                                     break;
 
                                 case AnomalySide.Positive:
                                     break;
 
                                 default:
-                                    result[2] = Math.Min(result[2], 1 - result[2]);
+                                    result.Values[2] = Math.Min(result.Values[2], 1 - result.Values[2]);
                                     break;
                             }
 
                             // Keeping the p-value in the safe range
-                            if (result[2] < MinPValue)
-                                result[2] = MinPValue;
-                            else if (result[2] > MaxPValue)
-                                result[2] = MaxPValue;
+                            if (result.Values[2] < MinPValue)
+                                result.Values[2] = MinPValue;
+                            else if (result.Values[2] > MaxPValue)
+                                result.Values[2] = MaxPValue;
 
                             _rawScoreBuffer.AddLast(rawScore);
 
@@ -448,11 +443,11 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                                 switch (Parent.Martingale)
                                 {
                                     case MartingaleType.Power:
-                                        martingaleUpdate = Parent.LogPowerMartigaleBettingFunc(result[2], Parent.PowerMartingaleEpsilon);
+                                        martingaleUpdate = Parent.LogPowerMartigaleBettingFunc(result.Values[2], Parent.PowerMartingaleEpsilon);
                                         break;
 
                                     case MartingaleType.Mixture:
-                                        martingaleUpdate = Parent.LogMixtureMartigaleBettingFunc(result[2]);
+                                        martingaleUpdate = Parent.LogMixtureMartigaleBettingFunc(result.Values[2]);
                                         break;
                                 }
 
@@ -469,7 +464,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                                     _logMartingaleUpdateBuffer.AddLast(martingaleUpdate);
                                 }
 
-                                result[3] = Math.Exp(_logMartingaleValue);
+                                result.Values[3] = Math.Exp(_logMartingaleValue);
                             }
                         }
                     }
@@ -485,10 +480,10 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                                 alert = rawScore >= Parent.AlertThreshold;
                                 break;
                             case AlertingScore.PValueScore:
-                                alert = result[2] <= Parent.AlertThreshold;
+                                alert = result.Values[2] <= Parent.AlertThreshold;
                                 break;
                             case AlertingScore.MartingaleScore:
-                                alert = (Parent.Martingale != MartingaleType.None) && (result[3] >= Parent.AlertThreshold);
+                                alert = (Parent.Martingale != MartingaleType.None) && (result.Values[3] >= Parent.AlertThreshold);
 
                                 if (alert)
                                 {
@@ -504,10 +499,10 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                         }
                     }
 
-                    result[0] = Convert.ToDouble(alert);
+                    result.Values[0] = Convert.ToDouble(alert);
                 }
 
-                dst = new VBuffer<Double>(outputLength, result, dst.Indices);
+                dst = result.CreateBuffer();
             }
 
             private protected override sealed void InitializeStateCore()

--- a/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
@@ -135,9 +135,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             {
 
                 int size = _parentSliding.WindowSize - _parentSliding._lag + 1;
-                var result = output.Values;
-                if (Utils.Size(result) < size)
-                    result = new TInput[size];
+                var result = VBufferMutationContext.Create(ref output, size);
 
                 TInput value = _parentSliding._nanValue;
                 switch (_parentSliding._begin)
@@ -152,29 +150,27 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                 }
 
                 for (int i = 0; i < size; ++i)
-                    result[i] = value;
-                output = new VBuffer<TInput>(size, result, output.Indices);
+                    result.Values[i] = value;
+                output = result.CreateBuffer();
             }
 
             private protected override void TransformCore(ref TInput input, FixedSizeQueue<TInput> windowedBuffer, long iteration, ref VBuffer<TInput> output)
             {
                 int size = _parentSliding.WindowSize - _parentSliding._lag + 1;
-                var result = output.Values;
-                if (Utils.Size(result) < size)
-                    result = new TInput[size];
+                var result = VBufferMutationContext.Create(ref output, size);
 
                 if (_parentSliding._lag == 0)
                 {
                     for (int i = 0; i < _parentSliding.WindowSize; ++i)
-                        result[i] = windowedBuffer[i];
-                    result[_parentSliding.WindowSize] = input;
+                        result.Values[i] = windowedBuffer[i];
+                    result.Values[_parentSliding.WindowSize] = input;
                 }
                 else
                 {
                     for (int i = 0; i < size; ++i)
-                        result[i] = windowedBuffer[i];
+                        result.Values[i] = windowedBuffer[i];
                 }
-                output = new VBuffer<TInput>(size, result, output.Indices);
+                output = result.CreateBuffer();
             }
 
             private protected override void InitializeStateCore()

--- a/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             {
 
                 int size = _parentSliding.WindowSize - _parentSliding._lag + 1;
-                var result = VBufferMutationContext.Create(ref output, size);
+                var result = VBufferEditor.Create(ref output, size);
 
                 TInput value = _parentSliding._nanValue;
                 switch (_parentSliding._begin)
@@ -151,13 +151,13 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
                 for (int i = 0; i < size; ++i)
                     result.Values[i] = value;
-                output = result.CreateBuffer();
+                output = result.Commit();
             }
 
             private protected override void TransformCore(ref TInput input, FixedSizeQueue<TInput> windowedBuffer, long iteration, ref VBuffer<TInput> output)
             {
                 int size = _parentSliding.WindowSize - _parentSliding._lag + 1;
-                var result = VBufferMutationContext.Create(ref output, size);
+                var result = VBufferEditor.Create(ref output, size);
 
                 if (_parentSliding._lag == 0)
                 {
@@ -170,7 +170,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                     for (int i = 0; i < size; ++i)
                         result.Values[i] = windowedBuffer[i];
                 }
-                output = result.CreateBuffer();
+                output = result.Commit();
             }
 
             private protected override void InitializeStateCore()

--- a/src/Microsoft.ML.Transforms/CountFeatureSelectingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelectingTransformer.cs
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Transforms
                     () =>
                     {
                         getter(ref t);
-                        _buffer.Values[0] = t;
+                        VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = t;
                     };
                 _isDefault = Runtime.Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(type);
                 if (!Runtime.Data.Conversion.Conversions.Instance.TryGetIsNAPredicate<T>(type, out _isMissing))

--- a/src/Microsoft.ML.Transforms/CountFeatureSelectingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelectingTransformer.cs
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Transforms
                     () =>
                     {
                         getter(ref t);
-                        VBufferMutationContext.CreateFromBuffer(ref _buffer).Values[0] = t;
+                        VBufferEditor.CreateFromBuffer(ref _buffer).Values[0] = t;
                     };
                 _isDefault = Runtime.Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(type);
                 if (!Runtime.Data.Conversion.Conversions.Instance.TryGetIsNAPredicate<T>(type, out _isMissing))

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -516,9 +516,9 @@ namespace Microsoft.ML.Transforms
 
                     private void Getter(ref VBuffer<TValue> dst)
                     {
-                        var mutation = VBufferMutationContext.Create(ref dst, _size);
-                        _buffer.AsSpan(0, _size).CopyTo(mutation.Values);
-                        dst = mutation.CreateBuffer();
+                        var editor = VBufferEditor.Create(ref dst, _size);
+                        _buffer.AsSpan(0, _size).CopyTo(editor.Values);
+                        dst = editor.Commit();
                     }
 
                     public override ValueGetter<T> GetGetter<T>(IExceptionContext ctx)

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -516,9 +516,9 @@ namespace Microsoft.ML.Transforms
 
                     private void Getter(ref VBuffer<TValue> dst)
                     {
-                        var values = (Utils.Size(dst.Values) < _size) ? new TValue[_size] : dst.Values;
-                        Array.Copy(_buffer, values, _size);
-                        dst = new VBuffer<TValue>(_size, values, dst.Indices);
+                        var mutation = VBufferMutationContext.Create(ref dst, _size);
+                        _buffer.AsSpan(0, _size).CopyTo(mutation.Values);
+                        dst = mutation.CreateBuffer();
                     }
 
                     public override ValueGetter<T> GetGetter<T>(IExceptionContext ctx)

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -411,7 +411,7 @@ namespace Microsoft.ML.Transforms.Conversions
             Host.AssertValue(_exes[iinfo].SlotMap);
 
             int n = _exes[iinfo].OutputValueCount;
-            var dstMutation = VBufferMutationContext.Create(ref dst, n);
+            var dstEditor = VBufferEditor.Create(ref dst, n);
 
             var srcColumnName = Source.Schema.GetColumnName(Infos[iinfo].Source);
             bool useDefaultSlotNames = !Source.Schema.HasSlotNames(Infos[iinfo].Source, Infos[iinfo].TypeSrc.VectorSize);
@@ -443,10 +443,10 @@ namespace Microsoft.ML.Transforms.Conversions
                         outputSlotName.Append(srcSlotNameValues[inputSlotIndex]);
                 }
 
-                dstMutation.Values[slot] = outputSlotName.ToString().AsMemory();
+                dstEditor.Values[slot] = outputSlotName.ToString().AsMemory();
             }
 
-            dst = dstMutation.CreateBuffer();
+            dst = dstEditor.Commit();
         }
 
         private delegate uint HashDelegate<TSrc>(in TSrc value, uint seed);
@@ -563,7 +563,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         values = denseValues;
                     }
 
-                    var hashes = VBufferMutationContext.Create(ref dst, n);
+                    var hashes = VBufferEditor.Create(ref dst, n);
 
                     for (int i = 0; i < n; i++)
                     {
@@ -580,7 +580,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         hashes.Values[i] = (Hashing.MixHash(hash) & mask) + 1; // +1 to offset from zero, which has special meaning for KeyType
                     }
 
-                    dst = hashes.CreateBuffer();
+                    dst = hashes.Commit();
                 };
         }
 

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -411,9 +411,7 @@ namespace Microsoft.ML.Transforms.Conversions
             Host.AssertValue(_exes[iinfo].SlotMap);
 
             int n = _exes[iinfo].OutputValueCount;
-            var output = dst.Values;
-            if (Utils.Size(output) < n)
-                output = new ReadOnlyMemory<char>[n];
+            var dstMutation = VBufferMutationContext.Create(ref dst, n);
 
             var srcColumnName = Source.Schema.GetColumnName(Infos[iinfo].Source);
             bool useDefaultSlotNames = !Source.Schema.HasSlotNames(Infos[iinfo].Source, Infos[iinfo].TypeSrc.VectorSize);
@@ -427,6 +425,7 @@ namespace Microsoft.ML.Transforms.Conversions
             }
 
             var outputSlotName = new StringBuilder();
+            var srcSlotNameValues = srcSlotNames.GetValues();
             for (int slot = 0; slot < n; slot++)
             {
                 var slotList = _exes[iinfo].SlotMap[slot];
@@ -441,13 +440,13 @@ namespace Microsoft.ML.Transforms.Conversions
                     if (useDefaultSlotNames)
                         outputSlotName.AppendFormat("{0}[{1}]", srcColumnName, inputSlotIndex);
                     else
-                        outputSlotName.Append(srcSlotNames.Values[inputSlotIndex]);
+                        outputSlotName.Append(srcSlotNameValues[inputSlotIndex]);
                 }
 
-                output[slot] = outputSlotName.ToString().AsMemory();
+                dstMutation.Values[slot] = outputSlotName.ToString().AsMemory();
             }
 
-            dst = new VBuffer<ReadOnlyMemory<char>>(n, output, dst.Indices);
+            dst = dstMutation.CreateBuffer();
         }
 
         private delegate uint HashDelegate<TSrc>(in TSrc value, uint seed);
@@ -548,25 +547,23 @@ namespace Microsoft.ML.Transforms.Conversions
                 {
                     getSrc(ref src);
                     Host.Check(src.Length == expectedSrcLength);
-                    TSrc[] values;
+                    ReadOnlySpan<TSrc> values;
 
                     // force-densify the input
                     // REVIEW: this performs poorly if only a fraction of sparse vector is used for hashing.
                     // This scenario was unlikely at the time of writing. Regardless of performance, the hash value
                     // needs to be consistent across equivalent representations - sparse vs dense.
                     if (src.IsDense)
-                        values = src.Values;
+                        values = src.GetValues();
                     else
                     {
                         if (denseValues == null)
                             denseValues = new TSrc[expectedSrcLength];
+                        src.CopyTo(denseValues);
                         values = denseValues;
-                        src.CopyTo(values);
                     }
 
-                    var hashes = dst.Values;
-                    if (Utils.Size(hashes) < n)
-                        hashes = new uint[n];
+                    var hashes = VBufferMutationContext.Create(ref dst, n);
 
                     for (int i = 0; i < n; i++)
                     {
@@ -580,10 +577,10 @@ namespace Microsoft.ML.Transforms.Conversions
                             hash = hashFunction(in values[srcSlot], hash);
                         }
 
-                        hashes[i] = (Hashing.MixHash(hash) & mask) + 1; // +1 to offset from zero, which has special meaning for KeyType
+                        hashes.Values[i] = (Hashing.MixHash(hash) & mask) + 1; // +1 to offset from zero, which has special meaning for KeyType
                     }
 
-                    dst = new VBuffer<uint>(n, hashes, dst.Indices);
+                    dst = hashes.CreateBuffer();
                 };
         }
 
@@ -615,19 +612,19 @@ namespace Microsoft.ML.Transforms.Conversions
                     getSrc(ref src);
                     Host.Check(src.Length == expectedSrcLength);
 
-                    TSrc[] values;
+                    ReadOnlySpan<TSrc> values;
                     // force-densify the input
                     // REVIEW: this performs poorly if only a fraction of sparse vector is used for hashing.
                     // This scenario was unlikely at the time of writing. Regardless of performance, the hash value
                     // needs to be consistent across equivalent representations - sparse vs dense.
                     if (src.IsDense)
-                        values = src.Values;
+                        values = src.GetValues();
                     else
                     {
                         if (denseValues == null)
                             denseValues = new TSrc[expectedSrcLength];
+                        src.CopyTo(denseValues);
                         values = denseValues;
-                        src.CopyTo(values);
                     }
 
                     uint hash = hashSeed;

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -322,7 +322,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 int slotLim = _types[iinfo].VectorSize;
                 Host.Assert(slotLim == (long)typeSrc.VectorSize * _bitsPerKey[iinfo]);
 
-                var mutation = VBufferMutationContext.Create(ref dst, slotLim);
+                var editor = VBufferEditor.Create(ref dst, slotLim);
 
                 var sb = new StringBuilder();
                 int slot = 0;
@@ -343,12 +343,12 @@ namespace Microsoft.ML.Transforms.Conversions
                     {
                         sb.Length = len;
                         sb.AppendMemory(key);
-                        mutation.Values[slot++] = sb.ToString().AsMemory();
+                        editor.Values[slot++] = sb.ToString().AsMemory();
                     }
                 }
                 Host.Assert(slot == slotLim);
 
-                dst = mutation.CreateBuffer();
+                dst = editor.Commit();
             }
 
             protected override Delegate MakeGetter(IRow input, int iinfo, out Action disposer)

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -322,9 +322,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 int slotLim = _types[iinfo].VectorSize;
                 Host.Assert(slotLim == (long)typeSrc.VectorSize * _bitsPerKey[iinfo]);
 
-                var values = dst.Values;
-                if (Utils.Size(values) < slotLim)
-                    values = new ReadOnlyMemory<char>[slotLim];
+                var mutation = VBufferMutationContext.Create(ref dst, slotLim);
 
                 var sb = new StringBuilder();
                 int slot = 0;
@@ -345,12 +343,12 @@ namespace Microsoft.ML.Transforms.Conversions
                     {
                         sb.Length = len;
                         sb.AppendMemory(key);
-                        values[slot++] = sb.ToString().AsMemory();
+                        mutation.Values[slot++] = sb.ToString().AsMemory();
                     }
                 }
                 Host.Assert(slot == slotLim);
 
-                dst = new VBuffer<ReadOnlyMemory<char>>(slotLim, values, dst.Indices);
+                dst = mutation.CreateBuffer();
             }
 
             protected override Delegate MakeGetter(IRow input, int iinfo, out Action disposer)

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -183,17 +183,15 @@ namespace Microsoft.ML.Transforms
             if (size == 0)
                 throw MetadataUtils.ExceptGetMetadata();
 
-            var values = dst.Values;
-            if (Utils.Size(values) < size)
-                values = new ReadOnlyMemory<char>[size];
+            var mutation = VBufferMutationContext.Create(ref dst, size);
 
             var type = Infos[iinfo].TypeSrc;
             if (!type.IsVector)
             {
                 Host.Assert(_types[iinfo].VectorSize == 2);
                 var columnName = Source.Schema.GetColumnName(Infos[iinfo].Source);
-                values[0] = columnName.AsMemory();
-                values[1] = (columnName + IndicatorSuffix).AsMemory();
+                mutation.Values[0] = columnName.AsMemory();
+                mutation.Values[1] = (columnName + IndicatorSuffix).AsMemory();
             }
             else
             {
@@ -230,13 +228,13 @@ namespace Microsoft.ML.Transforms
                     sb.Append(IndicatorSuffix);
                     var str = sb.ToString();
 
-                    values[slot++] = str.AsMemory().Slice(0, len);
-                    values[slot++] = str.AsMemory();
+                    mutation.Values[slot++] = str.AsMemory().Slice(0, len);
+                    mutation.Values[slot++] = str.AsMemory();
                 }
                 Host.Assert(slot == size);
             }
 
-            dst = new VBuffer<ReadOnlyMemory<char>>(size, values, dst.Indices);
+            dst = mutation.CreateBuffer();
         }
 
         protected override Delegate GetGetterCore(IChannel ch, IRow input, int iinfo, out Action disposer)

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -183,15 +183,15 @@ namespace Microsoft.ML.Transforms
             if (size == 0)
                 throw MetadataUtils.ExceptGetMetadata();
 
-            var mutation = VBufferMutationContext.Create(ref dst, size);
+            var editor = VBufferEditor.Create(ref dst, size);
 
             var type = Infos[iinfo].TypeSrc;
             if (!type.IsVector)
             {
                 Host.Assert(_types[iinfo].VectorSize == 2);
                 var columnName = Source.Schema.GetColumnName(Infos[iinfo].Source);
-                mutation.Values[0] = columnName.AsMemory();
-                mutation.Values[1] = (columnName + IndicatorSuffix).AsMemory();
+                editor.Values[0] = columnName.AsMemory();
+                editor.Values[1] = (columnName + IndicatorSuffix).AsMemory();
             }
             else
             {
@@ -228,13 +228,13 @@ namespace Microsoft.ML.Transforms
                     sb.Append(IndicatorSuffix);
                     var str = sb.ToString();
 
-                    mutation.Values[slot++] = str.AsMemory().Slice(0, len);
-                    mutation.Values[slot++] = str.AsMemory();
+                    editor.Values[slot++] = str.AsMemory().Slice(0, len);
+                    editor.Values[slot++] = str.AsMemory();
                 }
                 Host.Assert(slot == size);
             }
 
-            dst = mutation.CreateBuffer();
+            dst = editor.Commit();
         }
 
         protected override Delegate GetGetterCore(IChannel ch, IRow input, int iinfo, out Action disposer)

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -289,13 +289,14 @@ namespace Microsoft.ML.Transforms
             VBufferUtils.Densify<T>(ref src);
             InPredicate<T> defaultPred = Runtime.Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(srcType.ItemType);
             _repIsDefault[iinfo] = new BitArray(srcType.VectorSize);
-            for (int slot = 0; slot < src.Length; slot++)
+            var srcValues = src.GetValues();
+            for (int slot = 0; slot < srcValues.Length; slot++)
             {
-                if (defaultPred(in src.Values[slot]))
+                if (defaultPred(in srcValues[slot]))
                     _repIsDefault[iinfo][slot] = true;
             }
-            T[] valReturn = src.Values;
-            Array.Resize<T>(ref valReturn, srcType.VectorSize);
+            // copy the result array out. Copying is OK because this method is only called on model load.
+            T[] valReturn = srcValues.ToArray();
             Host.Assert(valReturn.Length == src.Length);
             return valReturn;
         }
@@ -737,12 +738,10 @@ namespace Microsoft.ML.Transforms
                 var srcValues = src.GetValues();
                 int srcCount = srcValues.Length;
 
-                var dstValues = dst.Values;
-                var dstIndices = dst.Indices;
-
-                // If the values array is not large enough, allocate sufficient space.
-                // Note: We can't set the max to srcSize as vectors can be of variable lengths.
-                Utils.EnsureSize(ref dstValues, srcCount, keepOld: false);
+                // REVIEW: One thing that changing the code to simply ensure that there are srcCount indices in the arrays
+                // does is over-allocate space if the replacement value is the default value in a dataset with a
+                // signficiant amount of NA values -- is it worth handling allocation of memory for this case?
+                var dstMutation = VBufferMutationContext.Create(ref dst, srcSize, srcCount);
 
                 int iivDst = 0;
                 if (src.IsDense)
@@ -759,7 +758,7 @@ namespace Microsoft.ML.Transforms
                         // the default value, resulting in more than half of the indices being the default value.
                         // In this case, changing the dst vector to be sparse would be more memory efficient -- the current decision
                         // is it is not worth handling this case at the expense of running checks that will almost always not be triggered.
-                        dstValues[ivSrc] = isNA(in srcVal) ? rep : srcVal;
+                        dstMutation.Values[ivSrc] = isNA(in srcVal) ? rep : srcVal;
                     }
                     iivDst = srcCount;
                 }
@@ -768,12 +767,6 @@ namespace Microsoft.ML.Transforms
                     // The source vector is sparse.
                     Host.Assert(srcCount < srcSize);
                     var srcIndices = src.GetIndices();
-
-                    // Allocate more space if necessary.
-                    // REVIEW: One thing that changing the code to simply ensure that there are srcCount indices in the arrays
-                    // does is over-allocate space if the replacement value is the default value in a dataset with a
-                    // signficiant amount of NA values -- is it worth handling allocation of memory for this case?
-                    Utils.EnsureSize(ref dstIndices, srcCount, keepOld: false);
 
                     // Note: ivPrev is only used for asserts.
                     int ivPrev = -1;
@@ -787,21 +780,21 @@ namespace Microsoft.ML.Transforms
 
                         if (!isNA(in srcVal))
                         {
-                            dstValues[iivDst] = srcVal;
-                            dstIndices[iivDst++] = iv;
+                            dstMutation.Values[iivDst] = srcVal;
+                            dstMutation.Indices[iivDst++] = iv;
                         }
                         else if (!repIsDefault)
                         {
                             // Allow for further sparsification.
-                            dstValues[iivDst] = rep;
-                            dstIndices[iivDst++] = iv;
+                            dstMutation.Values[iivDst] = rep;
+                            dstMutation.Indices[iivDst++] = iv;
                         }
                     }
                     Host.Assert(iivDst <= srcCount);
                 }
                 Host.Assert(0 <= iivDst);
                 Host.Assert(repIsDefault || iivDst == srcCount);
-                dst = new VBuffer<T>(srcSize, iivDst, dstValues, dstIndices);
+                dst = dstMutation.CreateBuffer(iivDst);
             }
 
             /// <summary>
@@ -819,11 +812,10 @@ namespace Microsoft.ML.Transforms
                 var srcValues = src.GetValues();
                 int srcCount = srcValues.Length;
 
-                var dstValues = dst.Values;
-                var dstIndices = dst.Indices;
-
-                // If the values array is not large enough, allocate sufficient space.
-                Utils.EnsureSize(ref dstValues, srcCount, srcSize, keepOld: false);
+                // REVIEW: One thing that changing the code to simply ensure that there are srcCount indices in the arrays
+                // does is over-allocate space if the replacement value is the default value in a dataset with a
+                // signficiant amount of NA values -- is it worth handling allocation of memory for this case?
+                var dstMutation = VBufferMutationContext.Create(ref dst, srcSize, srcCount);
 
                 int iivDst = 0;
                 if (src.IsDense)
@@ -840,7 +832,7 @@ namespace Microsoft.ML.Transforms
                         // the default value, resulting in more than half of the indices being the default value.
                         // In this case, changing the dst vector to be sparse would be more memory efficient -- the current decision
                         // is it is not worth handling this case at the expense of running checks that will almost always not be triggered.
-                        dstValues[ivSrc] = isNA(in srcVal) ? rep[ivSrc] : srcVal;
+                        dstMutation.Values[ivSrc] = isNA(in srcVal) ? rep[ivSrc] : srcVal;
                     }
                     iivDst = srcCount;
                 }
@@ -849,12 +841,6 @@ namespace Microsoft.ML.Transforms
                     // The source vector is sparse.
                     Host.Assert(srcCount < srcSize);
                     var srcIndices = src.GetIndices();
-
-                    // Allocate more space if necessary.
-                    // REVIEW: One thing that changing the code to simply ensure that there are srcCount indices in the arrays
-                    // does is over-allocate space if the replacement value is the default value in a dataset with a
-                    // signficiant amount of NA values -- is it worth handling allocation of memory for this case?
-                    Utils.EnsureSize(ref dstIndices, srcCount, srcSize, keepOld: false);
 
                     // Note: ivPrev is only used for asserts.
                     int ivPrev = -1;
@@ -868,20 +854,20 @@ namespace Microsoft.ML.Transforms
 
                         if (!isNA(in srcVal))
                         {
-                            dstValues[iivDst] = srcVal;
-                            dstIndices[iivDst++] = iv;
+                            dstMutation.Values[iivDst] = srcVal;
+                            dstMutation.Indices[iivDst++] = iv;
                         }
                         else if (!repIsDefault[iv])
                         {
                             // Allow for further sparsification.
-                            dstValues[iivDst] = rep[iv];
-                            dstIndices[iivDst++] = iv;
+                            dstMutation.Values[iivDst] = rep[iv];
+                            dstMutation.Indices[iivDst++] = iv;
                         }
                     }
                     Host.Assert(iivDst <= srcCount);
                 }
                 Host.Assert(0 <= iivDst);
-                dst = new VBuffer<T>(srcSize, iivDst, dstValues, dstIndices);
+                dst = dstMutation.CreateBuffer(iivDst);
             }
 
             public void SaveAsOnnx(OnnxContext ctx)

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -291,7 +291,7 @@ namespace Microsoft.ML.Transforms
             private readonly IHost _host;
             private readonly BinFinderBase _binFinder;
             private int _numBins;
-            private int[] _labels;
+            private VBuffer<int> _labels; // always dense
             private int _numLabels;
             private int[][] _contingencyTable;
             private int[] _labelSums;
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Transforms
                     KeyLabelGetter<int> del = GetKeyLabels<int>;
                     var methodInfo = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(labelType.RawType);
                     var parameters = new object[] { trans, labelCol, labelType };
-                    _labels = (int[])methodInfo.Invoke(this, parameters);
+                    _labels = (VBuffer<int>)methodInfo.Invoke(this, parameters);
                     _numLabels = labelType.KeyCount + 1;
 
                     // No need to densify or shift in this case.
@@ -448,29 +448,25 @@ namespace Microsoft.ML.Transforms
                 // Densify and shift labels.
                 VBufferUtils.Densify(ref labels);
                 Contracts.Assert(labels.IsDense);
-                _labels = labels.Values;
-                if (labels.Length < _labels.Length)
-                    Array.Resize(ref _labels, labels.Length);
-                for (int i = 0; i < _labels.Length; i++)
+                var labelsMutation = VBufferMutationContext.CreateFromBuffer(ref labels);
+                for (int i = 0; i < labels.Length; i++)
                 {
-                    _labels[i] -= min;
-                    Contracts.Assert(_labels[i] < _numLabels);
+                    labelsMutation.Values[i] -= min;
+                    Contracts.Assert(labelsMutation.Values[i] < _numLabels);
                 }
+                _labels = labelsMutation.CreateBuffer();
             }
 
-            private delegate int[] KeyLabelGetter<T>(Transposer trans, int labelCol, ColumnType labeColumnType);
+            private delegate VBuffer<int> KeyLabelGetter<T>(Transposer trans, int labelCol, ColumnType labeColumnType);
 
-            private int[] GetKeyLabels<T>(Transposer trans, int labelCol, ColumnType labeColumnType)
+            private VBuffer<int> GetKeyLabels<T>(Transposer trans, int labelCol, ColumnType labelColumnType)
             {
                 var tmp = default(VBuffer<T>);
                 var labels = default(VBuffer<int>);
                 trans.GetSingleSlotValue(labelCol, ref tmp);
-                BinKeys<T>(labeColumnType)(in tmp, ref labels);
+                BinKeys<T>(labelColumnType)(in tmp, ref labels);
                 VBufferUtils.Densify(ref labels);
-                var values = labels.Values;
-                if (labels.Length < values.Length)
-                    Array.Resize(ref values, labels.Length);
-                return values;
+                return labels;
             }
 
             /// <summary>
@@ -609,13 +605,15 @@ namespace Microsoft.ML.Transforms
             /// </summary>
             private void FillTable(in VBuffer<int> features, int offset, int numFeatures)
             {
+                Contracts.Assert(_labels.IsDense);
                 Contracts.Assert(_labels.Length == features.Length);
                 var featureValues = features.GetValues();
+                var labelsValues = _labels.GetValues();
                 if (features.IsDense)
                 {
-                    for (int i = 0; i < _labels.Length; i++)
+                    for (int i = 0; i < labelsValues.Length; i++)
                     {
-                        var label = _labels[i];
+                        var label = labelsValues[i];
                         var feature = featureValues[i] - offset;
                         Contracts.Assert(0 <= label && label < _numLabels);
                         Contracts.Assert(0 <= feature && feature < numFeatures);
@@ -626,9 +624,9 @@ namespace Microsoft.ML.Transforms
 
                 var featureIndices = features.GetIndices();
                 int ii = 0;
-                for (int i = 0; i < _labels.Length; i++)
+                for (int i = 0; i < labelsValues.Length; i++)
                 {
-                    var label = _labels[i];
+                    var label = labelsValues[i];
                     int feature;
                     if (ii == featureIndices.Length || i < featureIndices[ii])
                         feature = -offset;

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -448,13 +448,13 @@ namespace Microsoft.ML.Transforms
                 // Densify and shift labels.
                 VBufferUtils.Densify(ref labels);
                 Contracts.Assert(labels.IsDense);
-                var labelsMutation = VBufferMutationContext.CreateFromBuffer(ref labels);
+                var labelsEditor = VBufferEditor.CreateFromBuffer(ref labels);
                 for (int i = 0; i < labels.Length; i++)
                 {
-                    labelsMutation.Values[i] -= min;
-                    Contracts.Assert(labelsMutation.Values[i] < _numLabels);
+                    labelsEditor.Values[i] -= min;
+                    Contracts.Assert(labelsEditor.Values[i] < _numLabels);
                 }
-                _labels = labelsMutation.CreateBuffer();
+                _labels = labelsEditor.Commit();
             }
 
             private delegate VBuffer<int> KeyLabelGetter<T>(Transposer trans, int labelCol, ColumnType labeColumnType);

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -398,7 +398,8 @@ namespace Microsoft.ML.Transforms
 
         private Delegate MakeGetterVec<T>(int length)
         {
-            return (ValueGetter<VBuffer<T>>)((ref VBuffer<T> value) => value = new VBuffer<T>(length, 0, value.Values, value.Indices));
+            return (ValueGetter<VBuffer<T>>)((ref VBuffer<T> value) =>
+                value = VBufferMutationContext.Create(ref value, length, 0).CreateBuffer());
         }
 
         private sealed class RowCursor : SynchronizedCursorBase<IRowCursor>, IRowCursor
@@ -467,7 +468,8 @@ namespace Microsoft.ML.Transforms
 
             private Delegate MakeGetterVec<T>(int length)
             {
-                return (ValueGetter<VBuffer<T>>)((ref VBuffer<T> value) => value = new VBuffer<T>(length, 0, value.Values, value.Indices));
+                return (ValueGetter<VBuffer<T>>)((ref VBuffer<T> value) =>
+                    value = VBufferMutationContext.Create(ref value, length, 0).CreateBuffer());
             }
         }
 

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -399,7 +399,7 @@ namespace Microsoft.ML.Transforms
         private Delegate MakeGetterVec<T>(int length)
         {
             return (ValueGetter<VBuffer<T>>)((ref VBuffer<T> value) =>
-                value = VBufferMutationContext.Create(ref value, length, 0).CreateBuffer());
+                VBufferUtils.Resize(ref value, length, 0));
         }
 
         private sealed class RowCursor : SynchronizedCursorBase<IRowCursor>, IRowCursor
@@ -469,7 +469,7 @@ namespace Microsoft.ML.Transforms
             private Delegate MakeGetterVec<T>(int length)
             {
                 return (ValueGetter<VBuffer<T>>)((ref VBuffer<T> value) =>
-                    value = VBufferMutationContext.Create(ref value, length, 0).CreateBuffer());
+                    VBufferUtils.Resize(ref value, length, 0));
             }
         }
 

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -580,7 +580,7 @@ namespace Microsoft.ML.Transforms.Projections
                     (ref VBuffer<float> dst) =>
                     {
                         getSrc(ref src);
-                        VBufferMutationContext.CreateFromBuffer(ref oneDimensionalVector).Values[0] = src;
+                        VBufferEditor.CreateFromBuffer(ref oneDimensionalVector).Values[0] = src;
                         TransformFeatures(in oneDimensionalVector, ref dst, _parent._transformInfos[iinfo], featuresAligned, productAligned);
                     };
             }
@@ -620,20 +620,20 @@ namespace Microsoft.ML.Transforms.Projections
                         srcValues.Length, productAligned, transformInfo.NewDim);
                 }
 
-                var dstMutation = VBufferMutationContext.Create(ref dst, newDstLength);
+                var dstEditor = VBufferEditor.Create(ref dst, newDstLength);
                 for (int i = 0; i < transformInfo.NewDim; i++)
                 {
                     var dotProduct = productAligned[i];
                     if (transformInfo.RotationTerms != null)
-                        dstMutation.Values[i] = (float)MathUtils.Cos(dotProduct + transformInfo.RotationTerms[i]) * scale;
+                        dstEditor.Values[i] = (float)MathUtils.Cos(dotProduct + transformInfo.RotationTerms[i]) * scale;
                     else
                     {
-                        dstMutation.Values[2 * i] = (float)MathUtils.Cos(dotProduct) * scale;
-                        dstMutation.Values[2 * i + 1] = (float)MathUtils.Sin(dotProduct) * scale;
+                        dstEditor.Values[2 * i] = (float)MathUtils.Cos(dotProduct) * scale;
+                        dstEditor.Values[2 * i + 1] = (float)MathUtils.Sin(dotProduct) * scale;
                     }
                 }
 
-                dst = dstMutation.CreateBuffer();
+                dst = dstEditor.Commit();
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -580,7 +580,7 @@ namespace Microsoft.ML.Transforms.Projections
                     (ref VBuffer<float> dst) =>
                     {
                         getSrc(ref src);
-                        oneDimensionalVector.Values[0] = src;
+                        VBufferMutationContext.CreateFromBuffer(ref oneDimensionalVector).Values[0] = src;
                         TransformFeatures(in oneDimensionalVector, ref dst, _parent._transformInfos[iinfo], featuresAligned, productAligned);
                     };
             }
@@ -590,24 +590,22 @@ namespace Microsoft.ML.Transforms.Projections
             {
                 Host.Check(src.Length == transformInfo.SrcDim, "column does not have the expected dimensionality.");
 
-                var values = dst.Values;
                 float scale;
+                int newDstLength;
                 if (transformInfo.RotationTerms != null)
                 {
-                    if (Utils.Size(values) < transformInfo.NewDim)
-                        values = new float[transformInfo.NewDim];
+                    newDstLength = transformInfo.NewDim;
                     scale = MathUtils.Sqrt(2.0f / transformInfo.NewDim);
                 }
                 else
                 {
-                    if (Utils.Size(values) < 2 * transformInfo.NewDim)
-                        values = new float[2 * transformInfo.NewDim];
+                    newDstLength = 2 * transformInfo.NewDim;
                     scale = MathUtils.Sqrt(1.0f / transformInfo.NewDim);
                 }
 
                 if (src.IsDense)
                 {
-                    featuresAligned.CopyFrom(src.Values, 0, src.Length);
+                    featuresAligned.CopyFrom(src.GetValues());
                     CpuMathUtils.MatrixTimesSource(false, transformInfo.RndFourierVectors, featuresAligned, productAligned,
                         transformInfo.NewDim);
                 }
@@ -622,20 +620,20 @@ namespace Microsoft.ML.Transforms.Projections
                         srcValues.Length, productAligned, transformInfo.NewDim);
                 }
 
+                var dstMutation = VBufferMutationContext.Create(ref dst, newDstLength);
                 for (int i = 0; i < transformInfo.NewDim; i++)
                 {
                     var dotProduct = productAligned[i];
                     if (transformInfo.RotationTerms != null)
-                        values[i] = (float)MathUtils.Cos(dotProduct + transformInfo.RotationTerms[i]) * scale;
+                        dstMutation.Values[i] = (float)MathUtils.Cos(dotProduct + transformInfo.RotationTerms[i]) * scale;
                     else
                     {
-                        values[2 * i] = (float)MathUtils.Cos(dotProduct) * scale;
-                        values[2 * i + 1] = (float)MathUtils.Sin(dotProduct) * scale;
+                        dstMutation.Values[2 * i] = (float)MathUtils.Cos(dotProduct) * scale;
+                        dstMutation.Values[2 * i + 1] = (float)MathUtils.Sin(dotProduct) * scale;
                     }
                 }
 
-                dst = new VBuffer<float>(transformInfo.RotationTerms == null ? 2 * transformInfo.NewDim : transformInfo.NewDim,
-                    values, dst.Indices);
+                dst = dstMutation.CreateBuffer();
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Transforms.Categorical
 
             protected override void GetMissing(ref VBuffer<TItem> dst)
             {
-                dst = VBufferMutationContext.Create(ref dst, Type.VectorSize, 0).CreateBuffer();
+                VBufferUtils.Resize(ref dst, Type.VectorSize, 0);
             }
 
             protected override void CopyValue(in VBuffer<TItem> src, ref VBuffer<TItem> dst)

--- a/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Transforms.Categorical
 
             protected override void GetMissing(ref VBuffer<TItem> dst)
             {
-                dst = new VBuffer<TItem>(Type.VectorSize, 0, dst.Values, dst.Indices);
+                dst = VBufferMutationContext.Create(ref dst, Type.VectorSize, 0).CreateBuffer();
             }
 
             protected override void CopyValue(in VBuffer<TItem> src, ref VBuffer<TItem> dst)

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -604,7 +604,6 @@ namespace Microsoft.ML.Transforms.Text
                 Host.Check(unigramNames.Length == keyCount);
 
                 var pool = _parent._ngramMaps[iinfo];
-                var values = dst.Values;
 
                 var ngramCount = pool.Count;
                 var dstEditor = VBufferEditor.Create(ref dst, ngramCount);

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -607,8 +607,7 @@ namespace Microsoft.ML.Transforms.Text
                 var values = dst.Values;
 
                 var ngramCount = pool.Count;
-                if (Utils.Size(values) < ngramCount)
-                    Array.Resize(ref values, ngramCount);
+                var dstEditor = VBufferEditor.Create(ref dst, ngramCount);
 
                 StringBuilder sb = new StringBuilder();
                 uint[] ngram = new uint[_parent._transformInfos[iinfo].NgramLength];
@@ -620,10 +619,10 @@ namespace Microsoft.ML.Transforms.Text
                     // Get the unigrams composing the current ngram.
                     ComposeNgramString(ngram, n, sb, keyCount,
                         unigramNames.GetItemOrDefault);
-                    values[slot] = sb.ToString().AsMemory();
+                    dstEditor.Values[slot] = sb.ToString().AsMemory();
                 }
 
-                dst = new VBuffer<ReadOnlyMemory<char>>(ngramCount, values, dst.Indices);
+                dst = dstEditor.Commit();
             }
 
             private delegate void TermGetter(int index, ref ReadOnlyMemory<char> term);
@@ -697,7 +696,7 @@ namespace Microsoft.ML.Transforms.Text
                                     VBufferUtils.Apply(ref dst, (int i, ref float v) => v = (float)(v * _parent._invDocFreqs[iinfo][i]));
                                 }
                                 else
-                                    dst = new VBuffer<float>(0, dst.Values, dst.Indices);
+                                    VBufferUtils.Resize(ref dst, 0);
                             };
                         break;
                     case NgramCountingEstimator.WeightingCriteria.Idf:
@@ -714,7 +713,7 @@ namespace Microsoft.ML.Transforms.Text
                                     VBufferUtils.Apply(ref dst, (int i, ref float v) => v = v >= 1 ? (float)_parent._invDocFreqs[iinfo][i] : 0);
                                 }
                                 else
-                                    dst = new VBuffer<float>(0, dst.Values, dst.Indices);
+                                    VBufferUtils.Resize(ref dst, 0);
                             };
                         break;
                     case NgramCountingEstimator.WeightingCriteria.Tf:
@@ -729,7 +728,7 @@ namespace Microsoft.ML.Transforms.Text
                                     bldr.GetResult(ref dst);
                                 }
                                 else
-                                    dst = new VBuffer<float>(0, dst.Values, dst.Indices);
+                                    VBufferUtils.Resize(ref dst, 0);
                             };
                         break;
                     default:

--- a/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
+++ b/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
@@ -258,10 +258,10 @@ namespace Microsoft.ML.Transforms.Text
                 var keyValuesBoundaries = _keyValuesBoundaries;
                 Host.AssertValue(keyValuesBoundaries);
 
-                var mutation = VBufferMutationContext.Create(ref dst, CharsCount);
+                var editor = VBufferEditor.Create(ref dst, CharsCount);
                 for (int i = 0; i < CharsCount; i++)
-                    mutation.Values[i] = keyValuesStr.AsMemory().Slice(keyValuesBoundaries[i], keyValuesBoundaries[i + 1] - keyValuesBoundaries[i]);
-                dst = mutation.CreateBuffer();
+                    editor.Values[i] = keyValuesStr.AsMemory().Slice(keyValuesBoundaries[i], keyValuesBoundaries[i + 1] - keyValuesBoundaries[i]);
+                dst = editor.Commit();
             }
 
             private void AppendCharRepr(char c, StringBuilder bldr)
@@ -419,21 +419,21 @@ namespace Microsoft.ML.Transforms.Text
                         getSrc(ref src);
 
                         var len = !src.IsEmpty ? (_parent._useMarkerChars ? src.Length + TextMarkersCount : src.Length) : 0;
-                        var mutation = VBufferMutationContext.Create(ref dst, len);
+                        var editor = VBufferEditor.Create(ref dst, len);
                         if (len > 0)
                         {
                             int index = 0;
                             if (_parent._useMarkerChars)
-                                mutation.Values[index++] = TextStartMarker;
+                                editor.Values[index++] = TextStartMarker;
                             var span = src.Span;
                             for (int ich = 0; ich < src.Length; ich++)
-                                mutation.Values[index++] = span[ich];
+                                editor.Values[index++] = span[ich];
                             if (_parent._useMarkerChars)
-                                mutation.Values[index++] = TextEndMarker;
+                                editor.Values[index++] = TextEndMarker;
                             Contracts.Assert(index == len);
                         }
 
-                        dst = mutation.CreateBuffer();
+                        dst = editor.Commit();
                     };
             }
 

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -287,15 +287,13 @@ namespace Microsoft.ML.Transforms.Text
 
                         AddTerms(src, separators, terms);
 
-                        var values = dst.Values;
+                        var mutation = VBufferMutationContext.Create(ref dst, terms.Count);
                         if (terms.Count > 0)
                         {
-                            if (Utils.Size(values) < terms.Count)
-                                values = new ReadOnlyMemory<char>[terms.Count];
-                            terms.CopyTo(values);
+                            terms.CopyTo(mutation.Values);
                         }
 
-                        dst = new VBuffer<ReadOnlyMemory<char>>(terms.Count, values, dst.Indices);
+                        dst = mutation.CreateBuffer();
                     };
             }
 

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -287,13 +287,13 @@ namespace Microsoft.ML.Transforms.Text
 
                         AddTerms(src, separators, terms);
 
-                        var mutation = VBufferMutationContext.Create(ref dst, terms.Count);
+                        var editor = VBufferEditor.Create(ref dst, terms.Count);
                         if (terms.Count > 0)
                         {
-                            terms.CopyTo(mutation.Values);
+                            terms.CopyTo(editor.Values);
                         }
 
-                        dst = mutation.CreateBuffer();
+                        dst = editor.Commit();
                     };
             }
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -496,7 +496,11 @@ namespace Microsoft.ML.Runtime.RunTests
             Assert.True(type is VectorType vecType && vecType.ItemType is TextType && vecType.Size == 10);
             var slotNames = default(VBuffer<ReadOnlyMemory<char>>);
             schema.GetMetadata(MetadataUtils.Kinds.SlotNames, countCol, ref slotNames);
-            Assert.True(slotNames.Values.Select((s, i) => ReadOnlyMemoryUtils.EqualsStr(i.ToString(), s)).All(x => x));
+            var slotNameValues = slotNames.GetValues();
+            for (int i = 0; i < slotNameValues.Length; i++)
+            {
+                Assert.True(ReadOnlyMemoryUtils.EqualsStr(i.ToString(), slotNameValues[i]));
+            }
             using (var curs = confusion.GetRowCursor(col => true))
             {
                 var countGetter = curs.GetGetter<VBuffer<double>>(countCol);
@@ -783,9 +787,10 @@ namespace Microsoft.ML.Runtime.RunTests
                 getter(ref stdev);
                 foldGetter(ref fold);
                 Assert.True(ReadOnlyMemoryUtils.EqualsStr("Standard Deviation", fold));
-                Assert.Equal(2.462, stdev.Values[0], 3);
-                Assert.Equal(2.763, stdev.Values[1], 3);
-                Assert.Equal(3.273, stdev.Values[2], 3);
+                var stdevValues = stdev.GetValues();
+                Assert.Equal(2.462, stdevValues[0], 3);
+                Assert.Equal(2.763, stdevValues[1], 3);
+                Assert.Equal(3.273, stdevValues[2], 3);
 
                 var sumBldr = new BufferBuilder<double>(R8Adder.Instance);
                 sumBldr.Reset(avg.Length, true);
@@ -801,8 +806,11 @@ namespace Microsoft.ML.Runtime.RunTests
                 }
                 var sum = default(VBuffer<double>);
                 sumBldr.GetResult(ref sum);
-                for (int i = 0; i < avg.Length; i++)
-                    Assert.Equal(avg.Values[i], sum.Values[i] / 2);
+
+                var avgValues = avg.GetValues();
+                var sumValues = sum.GetValues();
+                for (int i = 0; i < avgValues.Length; i++)
+                    Assert.Equal(avgValues[i], sumValues[i] / 2);
                 b = cursor.MoveNext();
                 Assert.False(b);
             }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -1483,9 +1483,11 @@ namespace Microsoft.ML.Runtime.RunTests
                 return false;
             v1.CopyToDense(ref dense1);
             v2.CopyToDense(ref dense2);
+            var dense1Values = dense1.GetValues();
+            var dense2Values = dense2.GetValues();
             for (int i = 0; i < dense1.Length; i++)
             {
-                if (!Single.IsNaN(dense1.Values[i]) && !Single.IsNaN(dense2.Values[i]) && dense1.Values[i] != dense2.Values[i])
+                if (!Single.IsNaN(dense1Values[i]) && !Single.IsNaN(dense2Values[i]) && dense1Values[i] != dense2Values[i])
                     return false;
             }
             return true;

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestVectorUtils.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestVectorUtils.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Numeric;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.ML.Runtime.RunTests
+{
+    public class TestVectorUtils
+    {
+        /// <summary>
+        /// Tests SparsifyNormalize works correctly.
+        /// </summary>
+        [Theory]
+        [InlineData(1, true, new[] { 0.8f, 0.9f, 1f }, new[] { 7, 8, 9 })]
+        [InlineData(1, false, new[] { 8f, 9f, 10f }, new[] { 7, 8, 9 })]
+        [InlineData(-4, true, new[] { -0.8f, -0.6f, -0.4f, 0.6f, 0.8f, 1f }, new[] { 0, 1, 2, 7, 8, 9 })]
+        [InlineData(-4, false, new[] { -4f, -3f, -2f, 3f, 4f, 5f }, new[] { 0, 1, 2, 7, 8, 9 })]
+        [InlineData(-10, true, new[] { -1f, -0.9f, -0.8f }, new[] { 0, 1, 2 })]
+        [InlineData(-10, false, new[] { -10f, -9f, -8f }, new[] { 0, 1, 2 })]
+        public void TestSparsifyNormalize(int startRange, bool normalize, float[] expectedValues, int[] expectedIndices)
+        {
+            float[] values = Enumerable.Range(startRange, 10).Select(i => (float)i).ToArray();
+            var a = new VBuffer<float>(10, values);
+
+            VectorUtils.SparsifyNormalize(ref a, 3, 3, normalize);
+
+            Assert.False(a.IsDense);
+            Assert.Equal(10, a.Length);
+            Assert.Equal(expectedIndices, a.GetIndices().ToArray());
+
+            var actualValues = a.GetValues().ToArray();
+            Assert.Equal(expectedValues.Length, actualValues.Length);
+            for (int i = 0; i < expectedValues.Length; i++)
+                Assert.Equal(expectedValues[i], actualValues[i], precision: 6);
+        }
+
+        /// <summary>
+        /// Tests SparsifyNormalize works when asked for all values.
+        /// </summary>
+        [Theory]
+        [InlineData(10, 0)]
+        [InlineData(10, 10)]
+        [InlineData(20, 20)]
+        public void TestSparsifyNormalizeReturnsDense(int top, int bottom)
+        {
+            float[] values = Enumerable.Range(1, 10).Select(i => (float)i).ToArray();
+            var a = new VBuffer<float>(10, values);
+
+            VectorUtils.SparsifyNormalize(ref a, top, bottom, false);
+
+            Assert.True(a.IsDense);
+            Assert.Equal(10, a.Length);
+            Assert.True(a.GetIndices().IsEmpty);
+
+            Assert.Equal(values, a.GetValues().ToArray());
+        }
+    }
+}

--- a/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
@@ -52,8 +52,8 @@ namespace Microsoft.ML.CpuMath.UnitTests
 
             AlignedArray testMatrixAligned1 = new AlignedArray(8 * 8, _vectorAlignment);
             AlignedArray testMatrixAligned2 = new AlignedArray(8 * 16, _vectorAlignment);
-            testMatrixAligned1.CopyFrom(testMatrix1, 0, testMatrix1.Length);
-            testMatrixAligned2.CopyFrom(testMatrix2, 0, testMatrix2.Length);
+            testMatrixAligned1.CopyFrom(testMatrix1);
+            testMatrixAligned2.CopyFrom(testMatrix2);
 
             _testMatrices = new AlignedArray[] { testMatrixAligned1, testMatrixAligned2 };
 
@@ -63,8 +63,8 @@ namespace Microsoft.ML.CpuMath.UnitTests
 
             AlignedArray testSrcVectorAligned1 = new AlignedArray(8, _vectorAlignment);
             AlignedArray testSrcVectorAligned2 = new AlignedArray(16, _vectorAlignment);
-            testSrcVectorAligned1.CopyFrom(testSrcVector1, 0, testSrcVector1.Length);
-            testSrcVectorAligned2.CopyFrom(testSrcVector2, 0, testSrcVector2.Length);
+            testSrcVectorAligned1.CopyFrom(testSrcVector1);
+            testSrcVectorAligned2.CopyFrom(testSrcVector2);
 
             _testSrcVectors = new AlignedArray[] { testSrcVectorAligned1, testSrcVectorAligned2 };
 
@@ -74,8 +74,8 @@ namespace Microsoft.ML.CpuMath.UnitTests
 
             AlignedArray testDstVectorAligned1 = new AlignedArray(8, _vectorAlignment);
             AlignedArray testDstVectorAligned2 = new AlignedArray(16, _vectorAlignment);
-            testDstVectorAligned1.CopyFrom(testDstVector1, 0, testDstVector1.Length);
-            testDstVectorAligned2.CopyFrom(testDstVector2, 0, testDstVector2.Length);
+            testDstVectorAligned1.CopyFrom(testDstVector1);
+            testDstVectorAligned2.CopyFrom(testDstVector2);
 
             _testDstVectors = new AlignedArray[] { testDstVectorAligned1, testDstVectorAligned2 };
         }

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -57,19 +57,21 @@ namespace Microsoft.ML.Scenarios
                 VBuffer<float> c = default;
                 cgetter(ref c);
 
-                Assert.Equal(1.0 * 1.0 + 2.0 * 3.0, c.Values[0]);
-                Assert.Equal(1.0 * 2.0 + 2.0 * 4.0, c.Values[1]);
-                Assert.Equal(3.0 * 1.0 + 4.0 * 3.0, c.Values[2]);
-                Assert.Equal(3.0 * 2.0 + 4.0 * 4.0, c.Values[3]);
+                var cValues = c.GetValues();
+                Assert.Equal(1.0 * 1.0 + 2.0 * 3.0, cValues[0]);
+                Assert.Equal(1.0 * 2.0 + 2.0 * 4.0, cValues[1]);
+                Assert.Equal(3.0 * 1.0 + 4.0 * 3.0, cValues[2]);
+                Assert.Equal(3.0 * 2.0 + 4.0 * 4.0, cValues[3]);
 
                 Assert.True(cursor.MoveNext());
                 c = default;
                 cgetter(ref c);
 
-                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, c.Values[0]);
-                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, c.Values[1]);
-                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, c.Values[2]);
-                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, c.Values[3]);
+                cValues = c.GetValues();
+                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, cValues[0]);
+                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, cValues[1]);
+                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, cValues[2]);
+                Assert.Equal(2.0 * 3.0 + 2.0 * 3.0, cValues[3]);
 
                 Assert.False(cursor.MoveNext());
             }
@@ -214,7 +216,7 @@ namespace Microsoft.ML.Scenarios
             VBuffer<ReadOnlyMemory<char>> inputOps = default;
             schema.GetMetadata(TensorFlowUtils.InputOps, col, ref inputOps);
             Assert.Equal(1, inputOps.Length);
-            Assert.Equal("conv2d/kernel", inputOps.Values[0].ToString());
+            Assert.Equal("conv2d/kernel", inputOps.GetValues()[0].ToString());
 
             Assert.True(schema.TryGetColumnIndex("conv2d/Conv2D", out col));
             type = (VectorType)schema.GetColumnType(col);
@@ -228,8 +230,8 @@ namespace Microsoft.ML.Scenarios
             Assert.NotNull(metadataType);
             schema.GetMetadata(TensorFlowUtils.InputOps, col, ref inputOps);
             Assert.Equal(2, inputOps.Length);
-            Assert.Equal("reshape/Reshape", inputOps.Values[0].ToString());
-            Assert.Equal("conv2d/Conv2D/ReadVariableOp", inputOps.Values[1].ToString());
+            Assert.Equal("reshape/Reshape", inputOps.GetValues()[0].ToString());
+            Assert.Equal("conv2d/Conv2D/ReadVariableOp", inputOps.GetValues()[1].ToString());
 
             Assert.True(schema.TryGetColumnIndex("Softmax", out col));
             type = (VectorType)schema.GetColumnType(col);
@@ -243,7 +245,7 @@ namespace Microsoft.ML.Scenarios
             Assert.NotNull(metadataType);
             schema.GetMetadata(TensorFlowUtils.InputOps, col, ref inputOps);
             Assert.Equal(1, inputOps.Length);
-            Assert.Equal("sequential/dense_1/BiasAdd", inputOps.Values[0].ToString());
+            Assert.Equal("sequential/dense_1/BiasAdd", inputOps.GetValues()[0].ToString());
 
             model_location = "model_matmul/frozen_saved_model.pb";
             schema = TensorFlowUtils.GetModelSchema(env, model_location);
@@ -364,7 +366,7 @@ namespace Microsoft.ML.Scenarios
                     {
                         var trainedBias = default(VBuffer<float>);
                         getter(ref trainedBias);
-                        Assert.NotEqual(trainedBias.Values, new float[] { 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f });
+                        Assert.NotEqual(trainedBias.GetValues().ToArray(), new float[] { 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f });
                     }
                 }
             }

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -245,10 +245,13 @@ namespace Microsoft.ML.Tests
                     aGetter(ref avalue);
                     bGetter(ref bvalue);
                     cGetter(ref cvalue);
-                    Assert.Equal(avalue.Values[0] * bvalue.Values[0] + avalue.Values[1] * bvalue.Values[2], cvalue.Values[0]);
-                    Assert.Equal(avalue.Values[0] * bvalue.Values[1] + avalue.Values[1] * bvalue.Values[3], cvalue.Values[1]);
-                    Assert.Equal(avalue.Values[2] * bvalue.Values[0] + avalue.Values[3] * bvalue.Values[2], cvalue.Values[2]);
-                    Assert.Equal(avalue.Values[2] * bvalue.Values[1] + avalue.Values[3] * bvalue.Values[3], cvalue.Values[3]);
+                    var aValues = avalue.GetValues();
+                    var bValues = bvalue.GetValues();
+                    var cValues = cvalue.GetValues();
+                    Assert.Equal(aValues[0] * bValues[0] + aValues[1] * bValues[2], cValues[0]);
+                    Assert.Equal(aValues[0] * bValues[1] + aValues[1] * bValues[3], cValues[1]);
+                    Assert.Equal(aValues[2] * bValues[0] + aValues[3] * bValues[2], cValues[2]);
+                    Assert.Equal(aValues[2] * bValues[1] + aValues[3] * bValues[3], cValues[3]);
                 }
             }
         }


### PR DESCRIPTION
This completes the redesign work for `VBuffer` by removing `.Values` and `.Indices` public arrays and converts all their usages to the new pattern. This is proposed change (4) in https://github.com/dotnet/machinelearning/issues/608#issuecomment-433185895.

> Change the public T[] Values and public int[] Indices to public ReadOnlySpan<T> GetValues() and public ReadOnlySpan<int> GetIndices().

Fixes #608
