### PR TITLE
Contracts.Assert statements valid for Debug-Intrinsics

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,6 @@
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <Configurations>Debug;Release;Debug-Intrinsics;Release-Intrinsics</Configurations>
-    <DefineConstants>$(DefineContants);DEBUG</DefineConstants>
     <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <NativeTargetArchitecture Condition="'$(NativeTargetArchitecture)' == ''">$(TargetArchitecture)</NativeTargetArchitecture>
@@ -114,6 +113,7 @@
   <!-- Taken from https://github.com/dotnet/sdk/blob/073c98b92c81066c6c2e17c3674adbb6e833409a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L41-L47 -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug-Intrinsics'">
     <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>$(DefineContants);DEBUG</DefineConstants>
     <Optimize>false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release-Intrinsics'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <Configurations>Debug;Release;Debug-Intrinsics;Release-Intrinsics</Configurations>
+    <DefineConstants>$(DefineContants);DEBUG</DefineConstants>
     <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <NativeTargetArchitecture Condition="'$(NativeTargetArchitecture)' == ''">$(TargetArchitecture)</NativeTargetArchitecture>

--- a/src/Microsoft.ML.CpuMath/AssemblyInfo.cs
+++ b/src/Microsoft.ML.CpuMath/AssemblyInfo.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.ML;
 
 [assembly: InternalsVisibleTo("Microsoft.ML.CpuMath.UnitTests.netstandard" + PublicKey.TestValue)]
+[assembly: InternalsVisibleTo("Microsoft.ML.CpuMath.UnitTests.netcoreapp" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo("Microsoft.ML.Data" + PublicKey.Value)]
 [assembly: InternalsVisibleTo("Microsoft.ML.FastTree" + PublicKey.Value)]
 [assembly: InternalsVisibleTo("Microsoft.ML.HalLearners" + PublicKey.Value)]

--- a/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
@@ -153,8 +153,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         // Multiply matrix times vector into vector.
         public static unsafe void MatMul(AlignedArray mat, AlignedArray src, AlignedArray dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Size == dst.Size);
-
             MatMul(mat.Items, src.Items, dst.Items, crow, ccol);
         }
 
@@ -162,7 +160,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.Assert(crow % 4 == 0);
             Contracts.Assert(ccol % 4 == 0);
-            Contracts.Assert(src.Length == dst.Length);
 
             fixed (float* psrc = &MemoryMarshal.GetReference(src))
             fixed (float* pdst = &MemoryMarshal.GetReference(dst))
@@ -310,8 +307,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static unsafe void MatMulP(AlignedArray mat, ReadOnlySpan<int> rgposSrc, AlignedArray src,
                                 int posMin, int iposMin, int iposEnd, AlignedArray dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Size == dst.Size);
-
             MatMulP(mat.Items, rgposSrc, src.Items, posMin, iposMin, iposEnd, dst.Items, crow, ccol);
         }
 
@@ -320,7 +315,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.Assert(crow % 8 == 0);
             Contracts.Assert(ccol % 8 == 0);
-            Contracts.Assert(src.Length == dst.Length);
 
             // REVIEW: For extremely sparse inputs, interchanging the loops would
             // likely be more efficient.
@@ -474,8 +468,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
         public static unsafe void MatMulTran(AlignedArray mat, AlignedArray src, AlignedArray dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Size == dst.Size);
-
             MatMulTran(mat.Items, src.Items, dst.Items, crow, ccol);
         }
 
@@ -483,7 +475,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.Assert(crow % 4 == 0);
             Contracts.Assert(ccol % 4 == 0);
-            Contracts.Assert(src.Length == dst.Length);
 
             fixed (float* psrc = &MemoryMarshal.GetReference(src))
             fixed (float* pdst = &MemoryMarshal.GetReference(dst))

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -91,7 +91,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static void MatrixTimesSource(AlignedArray matrix, ReadOnlySpan<int> rgposSrc, AlignedArray sourceValues,
             int posMin, int iposMin, int iposLimit, AlignedArray destination, int stride)
         {
-            Contracts.AssertValue(rgposSrc);
             Contracts.Assert(iposMin >= 0);
             Contracts.Assert(iposMin <= iposLimit);
             Contracts.Assert(iposLimit <= rgposSrc.Length);

--- a/src/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.csproj
+++ b/src/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.csproj
@@ -22,6 +22,9 @@
     <Compile Remove="AvxIntrinsics.cs" />
 
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -117,8 +117,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         // Multiply matrix times vector into vector.
         public static unsafe void MatMul(AlignedArray mat, AlignedArray src, AlignedArray dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Size == dst.Size);
-
             MatMul(mat.Items, src.Items, dst.Items, crow, ccol);
         }
 
@@ -126,7 +124,6 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         {
             Contracts.Assert(crow % 4 == 0);
             Contracts.Assert(ccol % 4 == 0);
-            Contracts.Assert(src.Length == dst.Length);
 
             fixed (float* psrc = &MemoryMarshal.GetReference(src))
             fixed (float* pdst = &MemoryMarshal.GetReference(dst))
@@ -282,15 +279,12 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
         public static unsafe void MatMulP(AlignedArray mat, ReadOnlySpan<int> rgposSrc, AlignedArray src,
                                 int posMin, int iposMin, int iposEnd, AlignedArray dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Size == dst.Size);
-
             MatMulP(mat.Items, rgposSrc, src.Items, posMin, iposMin, iposEnd, dst.Items, crow, ccol);
         }
 
         public static unsafe void MatMulP(ReadOnlySpan<float> mat, ReadOnlySpan<int> rgposSrc, ReadOnlySpan<float> src,
                                         int posMin, int iposMin, int iposEnd, Span<float> dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Length == dst.Length);
             Contracts.Assert(crow % 4 == 0);
             Contracts.Assert(ccol % 4 == 0);
 
@@ -449,14 +443,11 @@ namespace Microsoft.ML.Runtime.Internal.CpuMath
 
         public static unsafe void MatMulTran(AlignedArray mat, AlignedArray src, AlignedArray dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Size == dst.Size);
-
             MatMulTran(mat.Items, src.Items, dst.Items, crow, ccol);
         }
 
         public static unsafe void MatMulTran(ReadOnlySpan<float> mat, ReadOnlySpan<float> src, Span<float> dst, int crow, int ccol)
         {
-            Contracts.Assert(src.Length == dst.Length);
             Contracts.Assert(crow % 4 == 0);
             Contracts.Assert(ccol % 4 == 0);
 


### PR DESCRIPTION
Debuger is currently skipping the Contracts.Assert statements without validating them. for Debug-Intrinsics.

After the change
- If the debugger is attached and the condition is false then the debugger will  break
- If the debugger is not attached, the test will get aborted
