### PR TITLE
Update to use OnnxRuntime library instead of Sonoma

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <GoogleProtobufPackageVersion>3.5.1</GoogleProtobufPackageVersion>
     <LightGBMPackageVersion>2.2.1.1</LightGBMPackageVersion>
-    <MicrosoftMLOnnxRuntimePackageVersion>1.0.0</MicrosoftMLOnnxRuntimePackageVersion>
+    <MicrosoftMLOnnxRuntimePackageVersion>0.1.4</MicrosoftMLOnnxRuntimePackageVersion>
     <MlNetMklDepsPackageVersion>0.0.0.7</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -17,6 +17,7 @@
     <GoogleProtobufPackageVersion>3.5.1</GoogleProtobufPackageVersion>
     <LightGBMPackageVersion>2.2.1.1</LightGBMPackageVersion>
     <MicrosoftMLScoring>1.1.0</MicrosoftMLScoring>
+    <OnnxRuntime>0.1.0-dev002</OnnxRuntime>
     <MlNetMklDepsPackageVersion>0.0.0.7</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -16,8 +16,7 @@
   <PropertyGroup>
     <GoogleProtobufPackageVersion>3.5.1</GoogleProtobufPackageVersion>
     <LightGBMPackageVersion>2.2.1.1</LightGBMPackageVersion>
-    <MicrosoftMLScoring>1.1.0</MicrosoftMLScoring>
-    <OnnxRuntime>0.1.4-dev-48f58fc4</OnnxRuntime>
+    <MicrosoftMLOnnxRuntimePackageVersion>1.0.0</MicrosoftMLOnnxRuntimePackageVersion>
     <MlNetMklDepsPackageVersion>0.0.0.7</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -17,7 +17,7 @@
     <GoogleProtobufPackageVersion>3.5.1</GoogleProtobufPackageVersion>
     <LightGBMPackageVersion>2.2.1.1</LightGBMPackageVersion>
     <MicrosoftMLScoring>1.1.0</MicrosoftMLScoring>
-    <OnnxRuntime>0.1.0-dev002</OnnxRuntime>
+    <OnnxRuntime>0.1.4-dev-48f58fc4</OnnxRuntime>
     <MlNetMklDepsPackageVersion>0.0.0.7</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>

--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <GoogleProtobufPackageVersion>3.5.1</GoogleProtobufPackageVersion>
     <LightGBMPackageVersion>2.2.1.1</LightGBMPackageVersion>
-    <MicrosoftMLOnnxRuntimePackageVersion>0.1.4</MicrosoftMLOnnxRuntimePackageVersion>
+    <MicrosoftMLOnnxRuntimePackageVersion>0.1.5</MicrosoftMLOnnxRuntimePackageVersion>
     <MlNetMklDepsPackageVersion>0.0.0.7</MlNetMklDepsPackageVersion>
     <ParquetDotNetPackageVersion>2.1.3</ParquetDotNetPackageVersion>
     <SystemDrawingCommonPackageVersion>4.5.0</SystemDrawingCommonPackageVersion>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,9 +11,9 @@ using System.IO;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    class Program
+    class OnnxTransformExample
     {
-        static void Main(string[] args)
+        public static void OnnxTransformSample(string[] args)
         {
             // Download the squeeznet image model from ONNX model zoo, version 1.2
             // https://github.com/onnx/models/tree/master/squeezenet
@@ -29,18 +29,16 @@ namespace Microsoft.ML.Samples.Dynamic
             var inputSchema = onnxModel.ModelInfo.InputsInfo[0];
             var inputName = inputSchema.Name;
             var inputShape = inputSchema.Shape;
-            var inputType = inputSchema.Type;
 
             // Deduce image dimensions from inputShape
-            var numChannels = inputShape[1];
-            var imageHeight = inputShape[2];
-            var imageWidth = inputShape[3];
+            var numChannels = (int) inputShape[1];
+            var imageHeight = (int) inputShape[2];
+            var imageWidth =  (int) inputShape[3];
 
             // Similarly, get output node metadata
             var outputSchema = onnxModel.ModelInfo.OutputsInfo[0];
             var outputName = outputSchema.Name;
             var outputShape = outputSchema.Shape;
-            var outputType = outputSchema.Type;
 
             var dataFile = @"test\data\images\images.tsv";
             var imageFolder = Path.GetDirectoryName(dataFile);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -2,120 +2,109 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.ML.Transforms;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.Runtime.Api;
 using Microsoft.ML.Runtime.Data;
-using Microsoft.ML.Runtime.ImageAnalytics;
-using Microsoft.ML;
+using Microsoft.ML.Transforms;
 using System;
-using System.IO;
+using System.Linq;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
     class OnnxTransformExample
     {
-        public static void OnnxTransformSample(string[] args)
+        /// <summary>
+        /// Example use of OnnxEstimator in an ML.NET pipeline
+        /// </summary>
+        public static void OnnxTransformSample()
         {
             // Download the squeeznet image model from ONNX model zoo, version 1.2
             // https://github.com/onnx/models/tree/master/squeezenet
-            var model_location = @"squeezenet\model.onnx";
+            var modelPath = @"squeezenet\model.onnx";
 
-            var env = new MLContext();
+            // Inspect the model's inputs and outputs
+            var session = new InferenceSession(modelPath);
+            var inputInfo = session.InputMetadata.First();
+            var outputInfo = session.OutputMetadata.First();
+            Console.WriteLine($"Input Name is {String.Join(",", inputInfo.Key)}");
+            Console.WriteLine($"Input Dimensions are {String.Join(",", inputInfo.Value.Dimensions)}");
+            Console.WriteLine($"Output Name is {String.Join(",", outputInfo.Key)}");
+            Console.WriteLine($"Output Dimensions are {String.Join(",", outputInfo.Value.Dimensions)}");
+            // Results..
+            // Input Name is data_0
+            // Input Dimensions are 1,3,224,224
+            // Output Name is softmaxout_1
+            // Output Dimensions are 1,1000,1,1
 
-            // Use the utility functions to inspect models inputs, outputs, shape and type
-            // Load the model using the OnnxModel class
-            var onnxModel = new OnnxModel(model_location);
+            // Create ML pipeline to score the data using OnnxScoringEstimator
+            var mlContext = new MLContext();
+            var data = GetTensorData();
+            var idv = mlContext.CreateStreamingDataView(data);
+            var pipeline = new OnnxScoringEstimator(mlContext, modelPath, new[] { inputInfo.Key }, new[] { outputInfo.Key });
 
-            // This model has only 1 input, so inspect 0th index for input node metadata
-            var inputSchema = onnxModel.ModelInfo.InputsInfo[0];
-            var inputName = inputSchema.Name;
-            var inputShape = inputSchema.Shape;
+            // Run the pipeline and get the transformed values
+            var transformedValues = pipeline.Fit(idv).Transform(idv);
 
-            // Deduce image dimensions from inputShape
-            var numChannels = (int) inputShape[1];
-            var imageHeight = (int) inputShape[2];
-            var imageWidth =  (int) inputShape[3];
+            // Retrieve model scores into Prediction class
+            var predictions = transformedValues.AsEnumerable<Prediction>(mlContext, reuseRowObject: false);
 
-            // Similarly, get output node metadata
-            var outputSchema = onnxModel.ModelInfo.OutputsInfo[0];
-            var outputName = outputSchema.Name;
-            var outputShape = outputSchema.Shape;
-
-            var dataFile = @"test\data\images\images.tsv";
-            var imageFolder = Path.GetDirectoryName(dataFile);
-
-            // Use Textloader to load the text file which references the images to load
-            // Preview ...
-            // banana.jpg banana
-            // hotdog.jpg hotdog
-            // tomato.jpg tomato
-            var data = TextLoader.Create(env, new TextLoader.Arguments()
+            // Iterate rows
+            foreach (var prediction in predictions)
             {
-                Column = new[]
+                int numClasses = 0;
+                foreach (var classScore in prediction.softmaxout_1.Take(3))
                 {
-                    new TextLoader.Column("ImagePath", DataKind.TX, 0),
-                    new TextLoader.Column("Name", DataKind.TX, 1),
-                 }
-            }, new MultiFileSource(dataFile));
-
-            // Load the images referenced in the text file
-            var images = ImageLoaderTransform.Create(env, new ImageLoaderTransform.Arguments()
-            {
-                Column = new ImageLoaderTransform.Column[1]
-                {
-                        new ImageLoaderTransform.Column() { Source=  "ImagePath", Name="ImageReal" }
-                },
-                ImageFolder = imageFolder
-            }, data);
-
-            // Resize the images to match model dimensions
-            var cropped = ImageResizerTransform.Create(env, new ImageResizerTransform.Arguments()
-            {
-                Column = new ImageResizerTransform.Column[1]{
-                        new ImageResizerTransform.Column(){ Source = "ImageReal", Name= "ImageCropped", ImageHeight =imageHeight, ImageWidth = imageWidth, Resizing = ImageResizerTransform.ResizingKind.IsoCrop}}
-            }, images);
-
-            // Extract out the RBG pixel values. 
-            // InterleaveArgb = true makes the values RGBRGBRGB. Otherwise it's RRR...GGG...BBB.
-            var pixels = ImagePixelExtractorTransform.Create(env, new ImagePixelExtractorTransform.Arguments()
-            {
-                Column = new ImagePixelExtractorTransform.Column[1]{
-                        new ImagePixelExtractorTransform.Column() {  Source= "ImageCropped", Name = inputName, InterleaveArgb=true}
-                    }
-            }, cropped);
-
-            // Create OnnxTransform, passing in the input and output names the model expects.
-            IDataView trans = OnnxTransform.Create(env, pixels, model_location, new[] { inputName }, new[] { outputName });
-
-            trans.Schema.TryGetColumnIndex(outputName, out int output);
-            using (var cursor = trans.GetRowCursor(col => col == output))
-            {
-                var numRows = 0;
-                var buffer = default(VBuffer<float>);
-                var getter = cursor.GetGetter<VBuffer<float>>(output);
-                // For each image, retrieve the model scores
-                while (cursor.MoveNext())
-                {
-                    int i = 0;
-                    getter(ref buffer);
-                    // print scores for first 3 classes
-                    foreach(var score in buffer.GetValues())
-                    {
-                        Console.WriteLine(String.Format("Example # {0} :Score for class {1} = {2} ",numRows, i, score));
-                        if (++i > 2) break;
-                    }
-                    numRows += 1;
+                    Console.WriteLine($"Class #{numClasses++} score = {classScore}");
                 }
+                Console.WriteLine(new string('-', 10));
             }
+
             // Results look like below...
-            // Example # 0 :Score for class 0 = 1.133263E-06
-            // Example # 0 :Score for class 1 = 1.80478E-07
-            // Example # 0 :Score for class 2 = 1.595297E-07
-            // Example # 1 :Score for class 0 = 1.805106E-05
-            // Example # 1 :Score for class 1 = 1.257452E-05
-            // Example # 1 :Score for class 2 = 2.412128E-06
-            // Example # 2 :Score for class 0 = 1.346096E-06
-            // Example # 2 :Score for class 1 = 1.918751E-07
-            // Example # 2 :Score for class 2 = 7.203341E-08
+            // Class #0 score = 4.544065E-05
+            // Class #1 score = 0.003845858
+            // Class #2 score = 0.0001249467
+            // ----------
+            // Class #0 score = 4.491953E-05
+            // Class #1 score = 0.003848222
+            // Class #2 score = 0.0001245592
+            // ----------
+        }
+
+        /// <summary>
+        /// inputSize is the overall dimensions of the model input tensor.
+        /// </summary>
+        private const int inputSize = 224 * 224 * 3;
+
+        /// <summary>
+        /// A class to hold sample tensor data. Member name should match  
+        /// the inputs that the model expects (in this case, data_0)
+        /// </summary>
+        public class TensorData
+        {
+            [VectorType(inputSize)]
+            public float[] data_0 { get; set; }
+        }
+
+        /// <summary>
+        /// Method to generate sample test data. Returns 2 sample rows.
+        /// </summary>
+        /// <returns></returns>
+        public static TensorData[] GetTensorData()
+        {
+            // This can be any numerical data. Assume image pixel values.
+            var image1 = Enumerable.Range(0, inputSize).Select(x => (float)x / inputSize).ToArray();
+            var image2 = Enumerable.Range(0, inputSize).Select(x => (float)(x + 10000) / inputSize).ToArray();
+            return new TensorData[] { new TensorData() { data_0 = image1 }, new TensorData() { data_0 = image2 } };
+        }
+
+        /// <summary>
+        /// Class to contain the output values from the transformation.
+        /// This model generates a vector of 1000 floats.
+        /// </summary>
+        class Prediction
+        {
+            [VectorType(1000)]
+            public float[] softmaxout_1 { get; set; }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Transforms;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.ImageAnalytics;
+using Microsoft.ML;
+using System;
+using System.IO;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // Download the squeeznet image model from ONNX model zoo, version 1.2
+            // https://github.com/onnx/models/tree/master/squeezenet
+            var model_location = @"squeezenet\model.onnx";
+
+            var env = new MLContext();
+
+            // Use the utility functions to inspect models inputs, outputs, shape and type
+            // Load the model using the OnnxModel class
+            var onnxModel = new OnnxModel(model_location);
+
+            // This model has only 1 input, so inspect 0th index for input node metadata
+            var inputSchema = onnxModel.ModelInfo.InputsInfo[0];
+            var inputName = inputSchema.Name;
+            var inputShape = inputSchema.Shape;
+            var inputType = inputSchema.Type;
+
+            // Deduce image dimensions from inputShape
+            var numChannels = inputShape[1];
+            var imageHeight = inputShape[2];
+            var imageWidth = inputShape[3];
+
+            // Similarly, get output node metadata
+            var outputSchema = onnxModel.ModelInfo.OutputsInfo[0];
+            var outputName = outputSchema.Name;
+            var outputShape = outputSchema.Shape;
+            var outputType = outputSchema.Type;
+
+            var dataFile = @"test\data\images\images.tsv";
+            var imageFolder = Path.GetDirectoryName(dataFile);
+
+            // Use Textloader to load the text file which references the images to load
+            // Preview ...
+            // banana.jpg banana
+            // hotdog.jpg hotdog
+            // tomato.jpg tomato
+            var data = TextLoader.Create(env, new TextLoader.Arguments()
+            {
+                Column = new[]
+                {
+                    new TextLoader.Column("ImagePath", DataKind.TX, 0),
+                    new TextLoader.Column("Name", DataKind.TX, 1),
+                 }
+            }, new MultiFileSource(dataFile));
+
+            // Load the images referenced in the text file
+            var images = ImageLoaderTransform.Create(env, new ImageLoaderTransform.Arguments()
+            {
+                Column = new ImageLoaderTransform.Column[1]
+                {
+                        new ImageLoaderTransform.Column() { Source=  "ImagePath", Name="ImageReal" }
+                },
+                ImageFolder = imageFolder
+            }, data);
+
+            // Resize the images to match model dimensions
+            var cropped = ImageResizerTransform.Create(env, new ImageResizerTransform.Arguments()
+            {
+                Column = new ImageResizerTransform.Column[1]{
+                        new ImageResizerTransform.Column(){ Source = "ImageReal", Name= "ImageCropped", ImageHeight =imageHeight, ImageWidth = imageWidth, Resizing = ImageResizerTransform.ResizingKind.IsoCrop}}
+            }, images);
+
+            // Extract out the RBG pixel values. 
+            // InterleaveArgb = true makes the values RGBRGBRGB. Otherwise it's RRR...GGG...BBB.
+            var pixels = ImagePixelExtractorTransform.Create(env, new ImagePixelExtractorTransform.Arguments()
+            {
+                Column = new ImagePixelExtractorTransform.Column[1]{
+                        new ImagePixelExtractorTransform.Column() {  Source= "ImageCropped", Name = inputName, InterleaveArgb=true}
+                    }
+            }, cropped);
+
+            // Create OnnxTransform, passing in the input and output names the model expects.
+            IDataView trans = OnnxTransform.Create(env, pixels, model_location, new[] { inputName }, new[] { outputName });
+
+            trans.Schema.TryGetColumnIndex(outputName, out int output);
+            using (var cursor = trans.GetRowCursor(col => col == output))
+            {
+                var numRows = 0;
+                var buffer = default(VBuffer<float>);
+                var getter = cursor.GetGetter<VBuffer<float>>(output);
+                // For each image, retrieve the model scores
+                while (cursor.MoveNext())
+                {
+                    int i = 0;
+                    getter(ref buffer);
+                    // print scores for first 3 classes
+                    foreach(var score in buffer.GetValues())
+                    {
+                        Console.WriteLine(String.Format("Example # {0} :Score for class {1} = {2} ",numRows, i, score));
+                        if (++i > 2) break;
+                    }
+                    numRows += 1;
+                }
+            }
+            // Results look like below...
+            // Example # 0 :Score for class 0 = 1.133263E-06
+            // Example # 0 :Score for class 1 = 1.80478E-07
+            // Example # 0 :Score for class 2 = 1.595297E-07
+            // Example # 1 :Score for class 0 = 1.805106E-05
+            // Example # 1 :Score for class 1 = 1.257452E-05
+            // Example # 1 :Score for class 2 = 2.412128E-06
+            // Example # 2 :Score for class 0 = 1.346096E-06
+            // Example # 2 :Score for class 1 = 1.918751E-07
+            // Example # 2 :Score for class 2 = 7.203341E-08
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -13,6 +13,8 @@
     <ProjectReference Include="..\..\..\src\Microsoft.ML.LightGBM\Microsoft.ML.LightGBM.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.ML.Recommender\Microsoft.ML.Recommender.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.ML.TimeSeries\Microsoft.ML.TimeSeries.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.ML.ImageAnalytics\Microsoft.ML.ImageAnalytics.csproj" />
+    <ProjectReference Include="..\..\..\src\/Microsoft.ML.OnnxTransform\Microsoft.ML.OnnxTransform.csproj" />
 
     <NativeAssemblyReference Include="CpuMathNative" />
     <NativeAssemblyReference Include="FastTreeNative" />

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\..\src\Microsoft.ML.Recommender\Microsoft.ML.Recommender.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.ML.TimeSeries\Microsoft.ML.TimeSeries.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.ML.ImageAnalytics\Microsoft.ML.ImageAnalytics.csproj" />
-    <ProjectReference Include="..\..\..\src\/Microsoft.ML.OnnxTransform\Microsoft.ML.OnnxTransform.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.ML.OnnxTransform\Microsoft.ML.OnnxTransform.csproj" />
 
     <NativeAssemblyReference Include="CpuMathNative" />
     <NativeAssemblyReference Include="FastTreeNative" />

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -13,7 +13,6 @@
     <ProjectReference Include="..\..\..\src\Microsoft.ML.LightGBM\Microsoft.ML.LightGBM.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.ML.Recommender\Microsoft.ML.Recommender.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.ML.TimeSeries\Microsoft.ML.TimeSeries.csproj" />
-    <ProjectReference Include="..\..\..\src\Microsoft.ML.ImageAnalytics\Microsoft.ML.ImageAnalytics.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.ML.OnnxTransform\Microsoft.ML.OnnxTransform.csproj" />
 
     <NativeAssemblyReference Include="CpuMathNative" />

--- a/pkg/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.nupkgproj
+++ b/pkg/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.nupkgproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Microsoft.ML/Microsoft.ML.nupkgproj" />
-    <PackageReference Include="Microsoft.ML.Scoring" Version="$(MicrosoftMLScoring)"/>
+    <PackageReference Include="Microsoft.ML.Scoring" Version="$(MicrosoftMLOnnxRuntimePackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/pkg/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.nupkgproj
+++ b/pkg/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.nupkgproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Microsoft.ML/Microsoft.ML.nupkgproj" />
-    <PackageReference Include="Microsoft.ML.Scoring" Version="$(MicrosoftMLOnnxRuntimePackageVersion)"/>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(MicrosoftMLOnnxRuntimePackageVersion)"/>
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.csproj
+++ b/src/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.csproj
@@ -4,14 +4,13 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeInPackage>Microsoft.ML.OnnxTransform</IncludeInPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
-    <!--PackageReference Include="Microsoft.ML.Scoring" Version="$(MicrosoftMLScoring)" /-->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntime)" />
-    <PackageReference Include="System.Numerics.Tensors" Version="0.1.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(MicrosoftMLOnnxRuntimePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.csproj
+++ b/src/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.csproj
@@ -9,7 +9,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
-    <PackageReference Include="Microsoft.ML.Scoring" Version="$(MicrosoftMLScoring)" />
+    <!--PackageReference Include="Microsoft.ML.Scoring" Version="$(MicrosoftMLScoring)" /-->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntime)" />
+    <PackageReference Include="System.Numerics.Tensors" Version="0.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.csproj
+++ b/src/Microsoft.ML.OnnxTransform/Microsoft.ML.OnnxTransform.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeInPackage>Microsoft.ML.OnnxTransform</IncludeInPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Transforms
     /// </summary>
     /// <remarks>
     /// <p>Supports inferencing of models in 1.2 and 1.3 format, using the
-    /// <a href='https://www.nuget.org/packages/Microsoft.ML.Scoring/'>Microsoft.ML.Scoring</a> library
+    /// <a href='https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime/'>Microsoft.ML.OnnxRuntime</a> library
     /// </p>
     /// <p>The inputs and outputs of the onnx models must of of Tensors. Sequence and Maps are not yet supported.</p>
     /// <p>Visit https://github.com/onnx/models to see a list of readily available models to get started with.</p>
@@ -363,10 +363,10 @@ namespace Microsoft.ML.Transforms
                 {
                     UpdateCacheIfNeeded(input.Position, srcNamedValueGetters, activeOutputColNames, outputCache);
                     var namedOnnxValue = outputCache.Outputs[_parent.Outputs[iinfo]];
-                    var editor = VBufferEditor.Create(ref dst, namedOnnxValue.AsTensor<T>().Count());
                     var denseTensor = namedOnnxValue.AsTensor<T>() as System.Numerics.Tensors.DenseTensor<T>;
                     if (denseTensor == null)
                         throw Host.Except($"Output column {namedOnnxValue.Name} doesn't contain a DenseTensor of expected type {typeof(T)}");
+                    var editor = VBufferEditor.Create(ref dst, (int) denseTensor.Length);
                     denseTensor.Buffer.Span.CopyTo(editor.Values);
                     dst = editor.Commit();
                 };

--- a/src/Microsoft.ML.OnnxTransform/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxUtils.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ML.Transforms
     /// It provides API to open a session, score tensors (NamedOnnxValues) and return
     /// the results.
     /// </summary>
-    public sealed class OnnxModel
+    internal sealed class OnnxModel
     {
 
         /// <summary>

--- a/src/Microsoft.ML.OnnxTransform/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Transforms
 
         /// <summary>
         /// OnnxModelInfo contains the data that we should get from
-        /// Sonoma API once that functionality is added.
+        /// OnnxRuntime API once that functionality is added.
         /// </summary>
         public sealed class OnnxModelInfo
         {
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Transforms
 
     internal sealed class OnnxUtils
     {
-        private static Dictionary<System.Type, System.Type> _onnxTypeMap;
+        private static HashSet<System.Type> _onnxTypeMap;
         private static Dictionary<System.Type, DataKind> _typeToKindMap;
 
         /// <summary>
@@ -172,10 +172,10 @@ namespace Microsoft.ML.Transforms
         /// <returns>NamedOnnxValue</returns>
         public static NamedOnnxValue CreateScalarNamedOnnxValue<T>(string name, T data)
         {
-            var typeMap = SystemTypeToOnnxType();
-            if (!typeMap.ContainsKey(typeof(T)))
+            var typeMap = SupportedOnnxRuntimeTypes();
+            if (!typeMap.Contains(typeof(T)))
                 throw new NotImplementedException($"Not implemented type {typeof(T)}");
-            return NamedOnnxValue.CreateFromTensor<T>(name, new DenseTensor<T>(new T[] { data }, new int[] { }));
+            return NamedOnnxValue.CreateFromTensor<T>(name, new DenseTensor<T>(new T[] { data }, new int[] { 0 }));
         }
 
         /// <summary>
@@ -189,8 +189,8 @@ namespace Microsoft.ML.Transforms
         /// <returns>NamedOnnxValue</returns>
         public static NamedOnnxValue CreateNamedOnnxValue<T>(string name, ReadOnlySpan<T> data, OnnxShape shape)
         {
-            var typeMap = SystemTypeToOnnxType();
-            if (!typeMap.ContainsKey(typeof(T)))
+            var typeMap = SupportedOnnxRuntimeTypes();
+            if (!typeMap.Contains(typeof(T)))
                 throw new NotImplementedException($"Not implemented type {typeof(T)}");
             return NamedOnnxValue.CreateFromTensor<T>(name, new DenseTensor<T>(data.ToArray(), shape.Select(x => (int)x).ToArray()));
         }
@@ -230,20 +230,20 @@ namespace Microsoft.ML.Transforms
             return _typeToKindMap;
         }
 
-        internal static Dictionary<System.Type, System.Type> SystemTypeToOnnxType()
+        internal static HashSet<System.Type> SupportedOnnxRuntimeTypes()
         {
             if (_onnxTypeMap == null)
             {
-                _onnxTypeMap = new Dictionary<System.Type, System.Type>
+                _onnxTypeMap = new HashSet<System.Type>
                 {
-                    { typeof(Double) , typeof(Double) },
-                    { typeof(Single) , typeof(Single) },
-                    { typeof(Int16) , typeof(Int16) },
-                    { typeof(Int32) , typeof(Int32) },
-                    { typeof(Int64) , typeof(Int64) },
-                    { typeof(UInt16) , typeof(UInt16) },
-                    { typeof(UInt32) , typeof(UInt32) },
-                    { typeof(UInt64) , typeof(UInt64) }
+                     typeof(Double),
+                     typeof(Single),
+                     typeof(Int16),
+                     typeof(Int32),
+                     typeof(Int64),
+                     typeof(UInt16),
+                     typeof(UInt32),
+                     typeof(UInt64)
                 };
             }
             return _onnxTypeMap;

--- a/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Runtime.Tools;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 using Xunit.Abstractions;
@@ -298,16 +299,10 @@ namespace Microsoft.ML.Tests
                     {
                         getScoresa(ref buffera);
                         getScoresb(ref bufferb);
-                        var suma = 0f;
-                        var sumb = 0f;
-                        foreach (var x in buffera.DenseValues())
-                            suma += x;
-                        foreach (var x in bufferb.DenseValues())
-                            sumb += x;
                         Assert.Equal(5, buffera.Length);
                         Assert.Equal(5, bufferb.Length);
-                        Assert.Equal(0, suma);
-                        Assert.Equal(30, sumb);
+                        Assert.Equal(0, buffera.GetValues().ToArray().Sum());
+                        Assert.Equal(30, bufferb.GetValues().ToArray().Sum());
                     }
                 }
             }

--- a/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
@@ -298,8 +298,16 @@ namespace Microsoft.ML.Tests
                     {
                         getScoresa(ref buffera);
                         getScoresb(ref bufferb);
-                        Console.WriteLine(buffera.GetValues().ToArray());
+                        var suma = 0f;
+                        var sumb = 0f;
+                        foreach (var x in buffera.DenseValues())
+                            suma += x;
+                        foreach (var x in bufferb.DenseValues())
+                            sumb += x;
                         Assert.Equal(5, buffera.Length);
+                        Assert.Equal(5, bufferb.Length);
+                        Assert.Equal(0, suma);
+                        Assert.Equal(30, sumb);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #1272.
Fixes #1228.
Fixes #1514

Replaces the Microsoft.ML.Scoring library with the new Microsoft.ML.OnnxRuntime library.

Upgraded runtime to Onnx 1.3, with isNan operator.

Descriptive error messages instead of SEH exception.

XML documentation for important classes and methods.

Adds a full end-to-end example for users to start with.

