### PR TITLE
Adding XML Documentation for Generalized Additive Models

### DIFF
--- a/src/Microsoft.ML.FastTree/GamClassification.cs
+++ b/src/Microsoft.ML.FastTree/GamClassification.cs
@@ -23,9 +23,9 @@ using System.Threading.Tasks;
     BinaryClassificationGamTrainer.LoadNameValue,
     BinaryClassificationGamTrainer.ShortName, DocName = "trainer/GAM.md")]
 
-[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(BinaryClassGamPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(BinaryClassificationGamPredictor), null, typeof(SignatureLoadModel),
     "GAM Binary Class Predictor",
-    BinaryClassGamPredictor.LoaderSignature)]
+    BinaryClassificationGamPredictor.LoaderSignature)]
 
 namespace Microsoft.ML.Trainers.FastTree
 {
@@ -108,7 +108,7 @@ namespace Microsoft.ML.Trainers.FastTree
         private protected override IPredictorProducing<float> TrainModelCore(TrainContext context)
         {
             TrainBase(context);
-            var predictor = new BinaryClassGamPredictor(Host, InputLength, TrainSet,
+            var predictor = new BinaryClassificationGamPredictor(Host, InputLength, TrainSet,
                 MeanEffect, BinEffects, FeatureMap);
             var calibrator = new PlattCalibrator(Host, -1.0 * _sigmoidParameter, 0);
             return new CalibratedPredictor(Host, predictor, calibrator);
@@ -154,16 +154,16 @@ namespace Microsoft.ML.Trainers.FastTree
         }
     }
 
-    public class BinaryClassGamPredictor : GamPredictorBase, IPredictorProducing<float>
+    public class BinaryClassificationGamPredictor : GamPredictorBase, IPredictorProducing<float>
     {
         public const string LoaderSignature = "BinaryClassGamPredictor";
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        public BinaryClassGamPredictor(IHostEnvironment env, int inputLength, Dataset trainset,
+        public BinaryClassificationGamPredictor(IHostEnvironment env, int inputLength, Dataset trainset,
             double meanEffect, double[][] binEffects, int[] featureMap)
             : base(env, LoaderSignature, inputLength, trainset, meanEffect, binEffects, featureMap) { }
 
-        private BinaryClassGamPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private BinaryClassificationGamPredictor(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, LoaderSignature, ctx) { }
 
         public static VersionInfo GetVersionInfo()
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 verReadableCur: 0x00010001,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(BinaryClassGamPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(BinaryClassificationGamPredictor).Assembly.FullName);
         }
 
         public static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Trainers.FastTree
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
 
-            var predictor = new BinaryClassGamPredictor(env, ctx);
+            var predictor = new BinaryClassificationGamPredictor(env, ctx);
             ICalibrator calibrator;
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -38,20 +38,20 @@ namespace Microsoft.ML.Trainers.FastTree
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Generalized Additive Models, or GAMs, model the data as an
-    /// independent set of feature responses similar to a linear model. For each feature, the GAM trainer
-    /// learns a function, known as a shape function, that outputs a response as a function
-    /// of the feature value. (In contrast, a linear model fits a linear response (e.g. a line) to each feature).
-    /// To score an example, the output of each shape function is added up and the total value is the
-    /// output of the model (hence the name Generalized Additive Models).
+    /// Generalized Additive Models, or GAMs, model the data as a set of linearly independent features
+    /// similar to a linear model. For each feature, the GAM trainer learns a non-linear function,
+    /// called a "shape function", that computes the response as a function of the feature's value.
+    /// (In contrast, a linear model fits a linear response (e.g. a line) to each feature.)
+    /// To score an example, the outputs of all the shape functions are summed and the score is the total value.
     /// </para>
     /// <para>
     /// This GAM trainer is implemented using shallow gradient boosted trees (e.g. tree stumps) to learn nonparametric
     /// shape functions, and is based on the method described in Lou, Caruana, and Gehrke.
-    /// <a href='http://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf'>"Intelligible Models for Classification and Regression."</a> KDD’12, Beijing, China. 2012.
+    /// <a href='http://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf'>"Intelligible Models for Classification and Regression."</a> KDD'12, Beijing, China. 2012.
     /// After training, an intercept is added to represent the average prediction over the training set,
     /// and the shape functions are normalized to represent the deviation from the average prediction. This results
     /// in models that are easily interpreted simply by inspecting the intercept and the shape functions.
+    /// See the sample below for an example of how to train a GAM model and inspect and interpret the results.
     /// </para>
     /// </remarks>
     /// <example>

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -34,7 +34,24 @@ namespace Microsoft.ML.Trainers.FastTree
     using SplitInfo = LeastSquaresRegressionTreeLearner.SplitInfo;
 
     /// <summary>
-    /// Generalized Additive Model Learner.
+    /// Generalized Additive Model Trainer. Generalized Additive Models, or GAMs, model the data as an
+    /// independent set of feature responses similar to a linear model. For each feature, the GAM trainer
+    /// learns a nonparametric function, known as a shape function, that outputs a response as a function
+    /// of the feature value. (In contrast, a linear model fits a linear response (e.g. a line) to each feature).
+    /// To score an example, the output of each shape function is added up and the total value is the
+    /// output of the model (hence the name Generalized Additive Models).
+    /// This GAM trainer is implemented using shallow gradient boosted trees (e.g. tree stumps) to learn the
+    /// shape functions, and is based on the method described in Lou, Caruana, and Gehrke.
+    /// "Intelligible Models for Classification and Regression." KDD’12, Beijing, China. 2012.
+    /// After training, an intercept is added to represent the average prediction over the training set,
+    /// and the shape functions are normalized to represent the deviation from this average prediction.
+    /// <example>
+    /// <format type="text/markdown">
+    /// <![CDATA[
+    /// [!code-csharp[MF](~/../docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs)]
+    /// ]]>
+    /// </format>
+    /// </example>
     /// </summary>
     public abstract partial class GamTrainerBase<TArgs, TTransformer, TPredictor> : TrainerEstimatorBase<TTransformer, TPredictor>
         where TTransformer: ISingleFeaturePredictionTransformer<TPredictor>

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -34,25 +34,33 @@ namespace Microsoft.ML.Trainers.FastTree
     using SplitInfo = LeastSquaresRegressionTreeLearner.SplitInfo;
 
     /// <summary>
-    /// Generalized Additive Model Trainer. Generalized Additive Models, or GAMs, model the data as an
+    /// Generalized Additive Model Trainer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Generalized Additive Models, or GAMs, model the data as an
     /// independent set of feature responses similar to a linear model. For each feature, the GAM trainer
-    /// learns a nonparametric function, known as a shape function, that outputs a response as a function
+    /// learns a function, known as a shape function, that outputs a response as a function
     /// of the feature value. (In contrast, a linear model fits a linear response (e.g. a line) to each feature).
     /// To score an example, the output of each shape function is added up and the total value is the
     /// output of the model (hence the name Generalized Additive Models).
-    /// This GAM trainer is implemented using shallow gradient boosted trees (e.g. tree stumps) to learn the
+    /// </para>
+    /// <para>
+    /// This GAM trainer is implemented using shallow gradient boosted trees (e.g. tree stumps) to learn nonparametric
     /// shape functions, and is based on the method described in Lou, Caruana, and Gehrke.
-    /// "Intelligible Models for Classification and Regression." KDD’12, Beijing, China. 2012.
+    /// <a href='http://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf'>"Intelligible Models for Classification and Regression."</a> KDD’12, Beijing, China. 2012.
     /// After training, an intercept is added to represent the average prediction over the training set,
-    /// and the shape functions are normalized to represent the deviation from this average prediction.
+    /// and the shape functions are normalized to represent the deviation from the average prediction. This results
+    /// in models that are easily interpreted simply by inspecting the intercept and the shape functions.
+    /// </para>
+    /// </remarks>
     /// <example>
     /// <format type="text/markdown">
     /// <![CDATA[
-    /// [!code-csharp[MF](~/../docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs)]
+    /// [!code-csharp[GAM](~/../docs/samples/doc/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs)]
     /// ]]>
     /// </format>
     /// </example>
-    /// </summary>
     public abstract partial class GamTrainerBase<TArgs, TTransformer, TPredictor> : TrainerEstimatorBase<TTransformer, TPredictor>
         where TTransformer: ISingleFeaturePredictionTransformer<TPredictor>
         where TArgs : GamTrainerBase<TArgs, TTransformer, TPredictor>.ArgumentsBase, new()

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Trainers.FastTree
     /// <para>
     /// This GAM trainer is implemented using shallow gradient boosted trees (e.g. tree stumps) to learn nonparametric
     /// shape functions, and is based on the method described in Lou, Caruana, and Gehrke.
-    /// <a href='http://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf'>"Intelligible Models for Classification and Regression."</a> KDD'12, Beijing, China. 2012.
+    /// <a href='http://www.cs.cornell.edu/~yinlou/papers/lou-kdd12.pdf'>&quot;Intelligible Models for Classification and Regression.&quot;</a> KDD&apos;12, Beijing, China. 2012.
     /// After training, an intercept is added to represent the average prediction over the training set,
     /// and the shape functions are normalized to represent the deviation from the average prediction. This results
     /// in models that are easily interpreted simply by inspecting the intercept and the shape functions.

--- a/src/Microsoft.ML.FastTree/TreeTrainersCatalog.cs
+++ b/src/Microsoft.ML.FastTree/TreeTrainersCatalog.cs
@@ -98,7 +98,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Predict a target using a decision tree regression model trained with the <see cref="FastTreeRegressionTrainer"/>.
+        /// Predict a target using generalized additive models trained with the <see cref="BinaryClassificationGamTrainer"/>.
         /// </summary>
         /// <param name="ctx">The <see cref="BinaryClassificationContext"/>.</param>
         /// <param name="labelColumn">The labelColumn column.</param>
@@ -123,7 +123,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Predict a target using a decision tree binary classification model trained with the <see cref="RegressionGamTrainer"/>.
+        /// Predict a target using generalized additive models trained with the <see cref="RegressionGamTrainer"/>.
         /// </summary>
         /// <param name="ctx">The <see cref="RegressionContext"/>.</param>
         /// <param name="labelColumn">The labelColumn column.</param>


### PR DESCRIPTION
This PR updates the XML Docs for GAMs with more information about the learner and points to the new samples being added to the repository.

This also fixes the name of the binary classification trainer.

Fixes #1730 