### PR TITLE
Fix bug in ApplyAt in VBufferUtils

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/VBufferUtils.cs
@@ -405,7 +405,7 @@ namespace Microsoft.ML.Runtime.Internal.Utilities
             // we are modifying in the sparse vector, in which case the vector becomes
             // dense. Then there is no need to do anything with indices.
             bool needIndices = dstValuesCount + 1 < dst.Length;
-            editor = VBufferEditor.Create(ref dst, dst.Length, dstValuesCount + 1);
+            editor = VBufferEditor.Create(ref dst, dst.Length, dstValuesCount + 1, keepOldOnResize: true);
             if (idx != dstValuesCount)
             {
                 // We have to do some sort of shift copy.

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestVBuffer.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestVBuffer.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Internal.Utilities;
+using Xunit;
+
+namespace Microsoft.ML.Core.Tests.UnitTests
+{
+    public sealed class TestVBuffer
+    {
+        [Fact]
+        public void TestApplyAt()
+        {
+            var buffer = new VBuffer<float>(10, 3, new[] { 0.5f, 1.2f, -3.8f }, new[] { 1, 5, 8 });
+            VBufferUtils.ApplyAt(ref buffer, 6, (int slot, ref float value) => { value = value + 1; });
+            Assert.Equal(4, buffer.GetValues().Length);
+            Assert.Equal(1, buffer.GetValues()[2]);
+        }
+    }
+}


### PR DESCRIPTION
When we create the editor, we lose the old values that were in the VBuffer in case it has to be resized.
Fixes #1756 .
