### PR TITLE
Add fixes to prevent potential build failures due to redist copying

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -24,7 +24,7 @@ phases:
     container: LinuxContainer
   steps:
   # Only build native assets to avoid conflicts.
-  - script: ./build.sh -buildNative -$(BuildConfig)
+  - script: ./build.sh -buildNative -$(BuildConfig) -skipRIDAgnosticAssets
     displayName: Build
 
   - task: PublishBuildArtifacts@1
@@ -49,7 +49,7 @@ phases:
     - agent.os -equals Darwin
   steps:
   # Only build native assets to avoid conflicts.
-  - script: ./build.sh -buildNative -$(BuildConfig)
+  - script: ./build.sh -buildNative -$(BuildConfig) -skipRIDAgnosticAssets
     displayName: Build
 
   - task: PublishBuildArtifacts@1
@@ -89,7 +89,7 @@ phases:
     condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
   # Only build native assets to avoid conflicts.
-  - script: ./build.cmd -buildNative -$(BuildConfig) -buildArch=x86
+  - script: ./build.cmd -buildNative -$(BuildConfig) -buildArch=x86 -skipRIDAgnosticAssets
     displayName: Build
   
   - task: MSBuild@1

--- a/config.json
+++ b/config.json
@@ -30,6 +30,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "SkipRIDAgnosticAssets": {
+      "description": "Prevents RID agnostic assets in redist from being built.",
+      "valueType": "property",
+      "values": [],
+      "defaultValue": ""
+    },
     "MsBuildLogging": {
       "description": "MsBuild logging options.",
       "valueType": "passThrough",

--- a/config.json
+++ b/config.json
@@ -118,6 +118,12 @@
             "BuildNative": "default"
           }
         },
+        "skipRIDAgnosticAssets": {
+          "description": "Avoid building RID agnostic assets in redist.",
+          "settings": {
+            "SkipRIDAgnosticAssets": "default"
+          }
+        },
         "buildPackages": {
           "description": "Builds the NuGet packages.",
           "settings": {

--- a/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+++ b/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
@@ -106,11 +106,11 @@
           DependsOnTargets="DownloadDnnModelFiles">
     <Message Importance="High" Text="Copying external model files... @(ModelFileCopy->'%(TargetPath)')" />
     <Copy SourceFiles="@(ModelFileCopy)"
+          Condition="'$(SkipRIDAgnosticAssets)' == ''"
           DestinationFiles="@(ModelFileCopy->'%(TargetPath)')" />
   </Target>
 
   <Target Name="Build"
-          Condition="'$(SkipRIDAgnosticAssets)' == ''"
           DependsOnTargets="CopyDnnModelFiles" />
 
 </Project>

--- a/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+++ b/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
@@ -110,6 +110,7 @@
   </Target>
 
   <Target Name="Build"
+          Condition="'$(SkipRIDAgnosticAssets)' == ''"
           DependsOnTargets="CopyDnnModelFiles" />
 
 </Project>

--- a/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+++ b/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
@@ -106,7 +106,7 @@
           DependsOnTargets="DownloadDnnModelFiles">
     <Message Importance="High" Text="Copying external model files... @(ModelFileCopy->'%(TargetPath)')" />
     <Copy SourceFiles="@(ModelFileCopy)"
-          Condition="'$(SkipRIDAgnosticAssets)' == ''"
+          Condition="'$(SkipRIDAgnosticAssets)' != 'true'"
           DestinationFiles="@(ModelFileCopy->'%(TargetPath)')" />
   </Target>
 


### PR DESCRIPTION
Adds a new build script flag that allows specifying that certain RID agnostic files inside redist should not be built/executed. This is used to prevent the DNNImageFeaturizer models from being copied on each leg causing possible build failures. Instead, the copying only happens on Windows x64. Fixes #1775 