### PR TITLE
Clean up of TextLoader constructor

### DIFF
--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -95,7 +95,7 @@ This is how you can read this data:
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // A boolean column depicting the 'target label'.
         IsOver50K: ctx.LoadBool(0),
         // Three text columns.
@@ -115,7 +115,7 @@ If the schema of the data is not known at compile time, or too cumbersome, you c
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] {
+var reader = mlContext.Data.CreateTextReader(new[] {
         // A boolean column depicting the 'label'.
         new TextLoader.Column("IsOver50K", DataKind.BL, 0),
         // Three text columns.
@@ -153,7 +153,7 @@ This is how you can read this data:
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // A boolean column depicting the 'target label'.
         IsOver50K: ctx.LoadBool(14),
         // Three text columns.
@@ -173,7 +173,7 @@ The code is very similar using the dynamic API:
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] {
+var reader = mlContext.Data.CreateTextReader(new[] {
         // A boolean column depicting the 'label'.
         new TextLoader.Column("IsOver50K", DataKind.BL, 0),
         // Three text columns.
@@ -207,7 +207,7 @@ Reading this file using `TextLoader`:
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // We read the first 11 values as a single float vector.
         FeatureVector: ctx.LoadFloat(0, 10),
         // Separately, read the target variable.
@@ -229,7 +229,7 @@ If the schema of the data is not known at compile time, or too cumbersome, you c
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] {
+var reader = mlContext.Data.CreateTextReader(new[] {
         // We read the first 10 values as a single float vector.
         new TextLoader.Column("FeatureVector", DataKind.R4, new[] {new TextLoader.Range(0, 9)}),
         // Separately, read the target variable.
@@ -298,7 +298,7 @@ Label	Workclass	education	marital-status
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // A boolean column depicting the 'target label'.
         IsOver50K: ctx.LoadBool(0),
         // Three text columns.
@@ -361,7 +361,7 @@ You can also use the dynamic API to create the equivalent of the previous pipeli
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] {
+var reader = mlContext.Data.CreateTextReader(new[] {
         // A boolean column depicting the 'label'.
         new TextLoader.Column("IsOver50K", DataKind.BL, 0),
         // Three text columns.
@@ -422,7 +422,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // We read the first 11 values as a single float vector.
         FeatureVector: ctx.LoadFloat(0, 10),
         // Separately, read the target variable.
@@ -476,7 +476,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] {
+var reader = mlContext.Data.CreateTextReader(new[] {
         // We read the first 11 values as a single float vector.
         new TextLoader.Column("FeatureVector", DataKind.R4, 0, 10),
 
@@ -595,7 +595,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // The four features of the Iris dataset.
         SepalLength: ctx.LoadFloat(0),
         SepalWidth: ctx.LoadFloat(1),
@@ -645,7 +645,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] {
+var reader = mlContext.Data.CreateTextReader(new[] {
         new TextLoader.Column("SepalLength", DataKind.R4, 0),
         new TextLoader.Column("SepalWidth", DataKind.R4, 1),
         new TextLoader.Column("PetalLength", DataKind.R4, 2),
@@ -811,7 +811,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // The four features of the Iris dataset.
         SepalLength: ctx.LoadFloat(0),
         SepalWidth: ctx.LoadFloat(1),
@@ -907,7 +907,7 @@ Here's a snippet of code that demonstrates normalization in learning pipelines. 
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // The four features of the Iris dataset will be grouped together as one Features column.
         Features: ctx.LoadFloat(0, 3),
         // Label: kind of iris.
@@ -942,7 +942,7 @@ You can achieve the same results using the dynamic API.
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] {
+var reader = mlContext.Data.CreateTextReader(new[] {
         // The four features of the Iris dataset will be grouped together as one Features column.
         new TextLoader.Column("Features", DataKind.R4, 0, 3),
         // Label: kind of iris.
@@ -999,7 +999,7 @@ Label	Workclass	education	marital-status	occupation	relationship	ethnicity	sex	n
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         Label: ctx.LoadBool(0),
         // We will load all the categorical features into one vector column of size 8.
         CategoricalFeatures: ctx.LoadText(1, 8),
@@ -1061,7 +1061,7 @@ You can achieve the same results using the dynamic API.
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] 
+var reader = mlContext.Data.CreateTextReader(new[] 
     {
         new TextLoader.Column("Label", DataKind.BL, 0),
         // We will load all the categorical features into one vector column of size 8.
@@ -1144,7 +1144,7 @@ Sentiment   SentimentText
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         IsToxic: ctx.LoadBool(0),
         Message: ctx.LoadText(1)
     ), hasHeader: true);
@@ -1194,7 +1194,7 @@ You can achieve the same results using the dynamic API.
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] 
+var reader = mlContext.Data.CreateTextReader(new[] 
     {
         new TextLoader.Column("IsToxic", DataKind.BL, 0),
         new TextLoader.Column("Message", DataKind.TX, 1),
@@ -1260,7 +1260,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // The four features of the Iris dataset.
         SepalLength: ctx.LoadFloat(0),
         SepalWidth: ctx.LoadFloat(1),
@@ -1316,7 +1316,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new[] 
+var reader = mlContext.Data.CreateTextReader(new[] 
     {
         // We read the first 11 values as a single float vector.
         new TextLoader.Column("SepalLength", DataKind.R4, 0),
@@ -1380,7 +1380,7 @@ var mlContext = new MLContext();
 
 // Read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(ctx => (
+var reader = mlContext.Data.CreateTextReader(ctx => (
         // The four features of the Iris dataset.
         SepalLength: ctx.LoadFloat(0),
         SepalWidth: ctx.LoadFloat(1),

--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -115,9 +115,7 @@ If the schema of the data is not known at compile time, or too cumbersome, you c
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] {
         // A boolean column depicting the 'label'.
         new TextLoader.Column("IsOver50K", DataKind.BL, 0),
         // Three text columns.
@@ -126,8 +124,8 @@ var reader = mlContext.Data.TextReader(new TextLoader.Arguments
         new TextLoader.Column("MaritalStatus", DataKind.TX, 3)
     },
     // First line of the file is a header, not a data row.
-    HasHeader = true
-});
+    hasHeader: true
+);
 
 // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
 var data = reader.Read(dataPath);
@@ -175,19 +173,17 @@ The code is very similar using the dynamic API:
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] {
         // A boolean column depicting the 'label'.
-        new TextLoader.Column("IsOver50k", DataKind.BL, 0),
+        new TextLoader.Column("IsOver50K", DataKind.BL, 0),
         // Three text columns.
         new TextLoader.Column("Workclass", DataKind.TX, 1),
         new TextLoader.Column("Education", DataKind.TX, 2),
         new TextLoader.Column("MaritalStatus", DataKind.TX, 3)
     },
     // First line of the file is a header, not a data row.
-    HasHeader = true
-});
+    hasHeader: true
+);
 
 var data = reader.Read(exampleFile1, exampleFile2);
 ```
@@ -365,19 +361,17 @@ You can also use the dynamic API to create the equivalent of the previous pipeli
 var mlContext = new MLContext();
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] {
         // A boolean column depicting the 'label'.
-        new TextLoader.Column("IsOver50k", DataKind.BL, 0),
+        new TextLoader.Column("IsOver50K", DataKind.BL, 0),
         // Three text columns.
         new TextLoader.Column("Workclass", DataKind.TX, 1),
         new TextLoader.Column("Education", DataKind.TX, 2),
         new TextLoader.Column("MaritalStatus", DataKind.TX, 3)
     },
     // First line of the file is a header, not a data row.
-    HasHeader = true
-});
+    hasHeader: true
+);
 
 // Start creating our processing pipeline. For now, let's just concatenate all the text columns
 // together into one.
@@ -482,9 +476,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] {
         // We read the first 11 values as a single float vector.
         new TextLoader.Column("FeatureVector", DataKind.R4, 0, 10),
 
@@ -492,10 +484,10 @@ var reader = mlContext.Data.TextReader(new TextLoader.Arguments
         new TextLoader.Column("Target", DataKind.R4, 11),
     },
     // First line of the file is a header, not a data row.
-    HasHeader = true,
+    hasHeader: true,
     // Default separator is tab, but we need a semicolon.
-    Separator = ";"
-});
+    separatorChar: ';'
+);
 
 // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
 var trainData = reader.Read(trainDataPath);
@@ -653,9 +645,7 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] {
         new TextLoader.Column("SepalLength", DataKind.R4, 0),
         new TextLoader.Column("SepalWidth", DataKind.R4, 1),
         new TextLoader.Column("PetalLength", DataKind.R4, 2),
@@ -664,8 +654,8 @@ var reader = mlContext.Data.TextReader(new TextLoader.Arguments
         new TextLoader.Column("Label", DataKind.TX, 4),
     },
     // Default separator is tab, but the dataset has comma.
-    Separator = ","
-});
+    separatorChar: ','
+);
 
 // Retrieve the training data.
 var trainData = reader.Read(irisDataPath);
@@ -952,17 +942,15 @@ You can achieve the same results using the dynamic API.
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] {
         // The four features of the Iris dataset will be grouped together as one Features column.
         new TextLoader.Column("Features", DataKind.R4, 0, 3),
         // Label: kind of iris.
         new TextLoader.Column("Label", DataKind.TX, 4),
     },
     // Default separator is tab, but the dataset has comma.
-    Separator = ","
-});
+    separatorChar: ','
+);
 
 // Read the training data.
 var trainData = reader.Read(dataPath);
@@ -1073,9 +1061,8 @@ You can achieve the same results using the dynamic API.
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] 
+    {
         new TextLoader.Column("Label", DataKind.BL, 0),
         // We will load all the categorical features into one vector column of size 8.
         new TextLoader.Column("CategoricalFeatures", DataKind.TX, 1, 8),
@@ -1084,8 +1071,8 @@ var reader = mlContext.Data.TextReader(new TextLoader.Arguments
         // Let's also separately load the 'Workclass' column.
         new TextLoader.Column("Workclass", DataKind.TX, 1),
     },
-    HasHeader = true
-});
+    hasHeader: true
+);
 
 // Read the data.
 var data = reader.Read(dataPath);
@@ -1207,14 +1194,13 @@ You can achieve the same results using the dynamic API.
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] 
+    {
         new TextLoader.Column("IsToxic", DataKind.BL, 0),
         new TextLoader.Column("Message", DataKind.TX, 1),
     },
-    HasHeader = true
-});
+    hasHeader: true
+);
 
 // Read the data.
 var data = reader.Read(dataPath);
@@ -1330,9 +1316,8 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-{
-    Column = new[] {
+var reader = mlContext.Data.TextReader(new[] 
+    {
         // We read the first 11 values as a single float vector.
         new TextLoader.Column("SepalLength", DataKind.R4, 0),
         new TextLoader.Column("SepalWidth", DataKind.R4, 1),
@@ -1342,8 +1327,8 @@ var reader = mlContext.Data.TextReader(new TextLoader.Arguments
         new TextLoader.Column("Label", DataKind.TX, 4),
     },
     // Default separator is tab, but the dataset has comma.
-    Separator = ","
-});
+    separatorChar: ','
+);
 
 // Read the data.
 var data = reader.Read(dataPath);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Step 1: Read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(
+            var reader = mlContext.Data.CreateTextReader(
                 columns: new[]
                     {
                         new TextLoader.Column("MedianHomeValue", DataKind.R4, 0),

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -19,11 +19,8 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Step 1: Read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments()
-                {
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
+            var reader = mlContext.Data.TextReader(
+                columns: new[]
                     {
                         new TextLoader.Column("MedianHomeValue", DataKind.R4, 0),
                         new TextLoader.Column("CrimesPerCapita", DataKind.R4, 1),
@@ -37,8 +34,9 @@ namespace Microsoft.ML.Samples.Dynamic
                         new TextLoader.Column("HighwayDistance", DataKind.R4, 9),
                         new TextLoader.Column("TaxRate", DataKind.R4, 10),
                         new TextLoader.Column("TeacherRatio", DataKind.R4, 11),
-                    }
-                });
+                    }, 
+                hasHeader: true
+            );
             
             // Read the data
             var data = reader.Read(dataFile);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // First, we define the reader: specify the data columns and where to find them in the text file. Notice that we combine entries from
             // all the feature columns into entries of a vector of a single column named "Features".
-            var reader = ml.Data.TextReader(
+            var reader = ml.Data.CreateTextReader(
                 columns: new[]
                     {
                         new TextLoader.Column("Label", DataKind.BL, 0),

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
@@ -31,16 +31,14 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // First, we define the reader: specify the data columns and where to find them in the text file. Notice that we combine entries from
             // all the feature columns into entries of a vector of a single column named "Features".
-            var reader = ml.Data.TextReader(new TextLoader.Arguments()
-            {
-                Separator = "tab",
-                HasHeader = true,
-                Column = new[]
+            var reader = ml.Data.TextReader(
+                columns: new[]
                     {
                         new TextLoader.Column("Label", DataKind.BL, 0),
                         new TextLoader.Column("Features", DataKind.Num, new [] { new TextLoader.Range(1, 9) })
-                    }
-            });
+                    },
+                hasHeader: true
+            );
 
             // Then, we use the reader to read the data as an IDataView.
             var data = reader.Read(dataFilePath);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Step 1: Read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(
+            var reader = mlContext.Data.CreateTextReader(
                 columns: new[]
                     {
                         new TextLoader.Column("MedianHomeValue", DataKind.R4, 0),

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
@@ -19,11 +19,8 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Step 1: Read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments()
-                {
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
+            var reader = mlContext.Data.TextReader(
+                columns: new[]
                     {
                         new TextLoader.Column("MedianHomeValue", DataKind.R4, 0),
                         new TextLoader.Column("CrimesPerCapita", DataKind.R4, 1),
@@ -37,8 +34,9 @@ namespace Microsoft.ML.Samples.Dynamic
                         new TextLoader.Column("HighwayDistance", DataKind.R4, 9),
                         new TextLoader.Column("TaxRate", DataKind.R4, 10),
                         new TextLoader.Column("TeacherRatio", DataKind.R4, 11),
-                    }
-                });
+                    },
+                hasHeader: true
+            );
             
             // Read the data
             var data = reader.Read(dataFile);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // First, we define the reader: specify the data columns and where to find them in the text file.
             // The data file is composed of rows of data, with each row having 11 numerical columns
             // separated by whitespace.
-            var reader = mlContext.Data.TextReader(
+            var reader = mlContext.Data.CreateTextReader(
                 columns: new[]
                     {
                         // Read the first column (indexed by 0) in the data file as an R4 (float)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
@@ -22,11 +22,8 @@ namespace Microsoft.ML.Samples.Dynamic
             // First, we define the reader: specify the data columns and where to find them in the text file.
             // The data file is composed of rows of data, with each row having 11 numerical columns
             // separated by whitespace.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments()
-                {
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
+            var reader = mlContext.Data.TextReader(
+                columns: new[]
                     {
                         // Read the first column (indexed by 0) in the data file as an R4 (float)
                         new TextLoader.Column("MedianHomeValue", DataKind.R4, 0),
@@ -40,9 +37,10 @@ namespace Microsoft.ML.Samples.Dynamic
                         new TextLoader.Column("EmploymentDistance", DataKind.R4, 8),
                         new TextLoader.Column("HighwayDistance", DataKind.R4, 9),
                         new TextLoader.Column("TaxRate", DataKind.R4, 10),
-                        new TextLoader.Column("TeacherRatio", DataKind.R4, 11),
-                    }
-                });
+                        new TextLoader.Column("TeacherRatio", DataKind.R4, 11)
+                    },
+                hasHeader: true
+            );
             
             // Read the data
             var data = reader.Read(dataFile);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SDCA.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SDCA.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Step 1: Read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(
+            var reader = mlContext.Data.CreateTextReader(
                 columns: new[]
                     {
                         new TextLoader.Column("Sentiment", DataKind.BL, 0),

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SDCA.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SDCA.cs
@@ -24,16 +24,14 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Step 1: Read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments()
-                {
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
+            var reader = mlContext.Data.TextReader(
+                columns: new[]
                     {
                         new TextLoader.Column("Sentiment", DataKind.BL, 0),
                         new TextLoader.Column("SentimentText", DataKind.Text, 1)
-                    }
-                });
+                    },
+                hasHeader: true
+            );
             
             // Read the data
             var data = reader.Read(dataFile);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1022,7 +1022,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private static Arguments MakeArgs(Column[] columns, bool hasHeader, char[] separatorChars)
         {
-            separatorChars = separatorChars ?? new[] { '\t' };
+            Contracts.AssertValue(separatorChars);
             var result = new Arguments { Column = columns, HasHeader = hasHeader, SeparatorChars = separatorChars};
             return result;
         }
@@ -1315,6 +1315,12 @@ namespace Microsoft.ML.Runtime.Data
             => (IDataLoader)Create(env, ctx).Read(files);
         internal static IDataLoader Create(IHostEnvironment env, Arguments args, IMultiStreamSource files)
             => (IDataLoader)new TextLoader(env, args, files).Read(files);
+
+        /// <summary>
+        /// Convenience method to create a <see cref="TextLoader"/> and use it to read a specified file.
+        /// </summary>
+        internal static IDataView ReadFile(IHostEnvironment env, Arguments args, IMultiStreamSource fileSource)
+            => new TextLoader(env, args, fileSource).Read(fileSource);
 
         public void Save(ModelSaveContext ctx)
         {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -25,7 +25,6 @@ namespace Microsoft.ML.Runtime.Data
 {
     /// <summary>
     /// Loads a text file into an IDataView. Supports basic mapping from input columns to IDataView columns.
-    /// Should accept any file that TlcTextInstances accepts.
     /// </summary>
     public sealed partial class TextLoader : IDataReader<IMultiStreamSource>, ICanSaveModel
     {
@@ -1009,13 +1008,12 @@ namespace Microsoft.ML.Runtime.Data
         private const string RegistrationName = "TextLoader";
 
         /// <summary>
-        /// Loads a text file into an IDataView. Supports basic mapping from input columns to IDataView columns.
-        /// Should accept any file that TlcTextInstances accepts.
+        /// Loads a text file into an <see cref="IDataView"/>. Supports basic mapping from input columns to IDataView columns.
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChars">Defines the characters used as separators between data points in a row.</param>
+        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
         /// <param name="advancedSettings">A delegate to apply all the advanced arguments to the algorithm.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
         public TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
@@ -1025,6 +1023,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private static Arguments MakeArgs(Column[] columns, bool hasHeader, char[] separatorChars, Action<Arguments> advancedSettings)
         {
+            separatorChars = separatorChars ?? new[] { '\t' };
             var result = new Arguments { Column = columns, HasHeader = hasHeader, SeparatorChars = separatorChars};
             advancedSettings?.Invoke(result);
             return result;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1316,26 +1316,6 @@ namespace Microsoft.ML.Runtime.Data
         internal static IDataLoader Create(IHostEnvironment env, Arguments args, IMultiStreamSource files)
             => (IDataLoader)new TextLoader(env, args, files).Read(files);
 
-        /// <summary>
-        /// Creates a <see cref="TextLoader"/> and uses it to read a specified file.
-        /// </summary>
-        /// <param name="env">The environment to use.</param>
-        /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
-        /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
-        /// <param name="fileSource">Specifies a file from which to read.</param>
-        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Column[] columns, bool hasHeader = false, char separatorChar = '\t')
-            => new TextLoader(env, columns, hasHeader, separatorChar, fileSource).Read(fileSource);
-
-        /// <summary>
-        /// Loads a text file into an <see cref="IDataView"/>. Supports basic mapping from input columns to IDataView columns.
-        /// </summary>
-        /// <param name="env">The environment to use.</param>
-        /// <param name="fileSource">Specifies a file from which to read.</param>
-        /// <param name="args">Defines the settings of the load operation.</param>
-        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Arguments args = null)
-            => new TextLoader(env, args, fileSource).Read(fileSource);
-
         public void Save(ModelSaveContext ctx)
         {
             _host.CheckValue(ctx, nameof(ctx));

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1008,19 +1008,29 @@ namespace Microsoft.ML.Runtime.Data
         private readonly IHost _host;
         private const string RegistrationName = "TextLoader";
 
-        public TextLoader(IHostEnvironment env, Column[] columns, Action<Arguments> advancedSettings, IMultiStreamSource dataSample = null)
-            : this(env, MakeArgs(columns, advancedSettings), dataSample)
+        /// <summary>
+        /// Loads a text file into an IDataView. Supports basic mapping from input columns to IDataView columns.
+        /// Should accept any file that TlcTextInstances accepts.
+        /// </summary>
+        /// <param name="env">The environment to use.</param>
+        /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
+        /// <param name="hasHeader">Whether the file has a header.</param>
+        /// <param name="separatorChars">Defines the characters used as separators between data points in a row.</param>
+        /// <param name="advancedSettings">A delegate to apply all the advanced arguments to the algorithm.</param>
+        /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
+        public TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
+            : this(env, MakeArgs(columns, hasHeader, separatorChars, advancedSettings), dataSample)
         {
         }
 
-        private static Arguments MakeArgs(Column[] columns, Action<Arguments> advancedSettings)
+        private static Arguments MakeArgs(Column[] columns, bool hasHeader, char[] separatorChars, Action<Arguments> advancedSettings)
         {
-            var result = new Arguments { Column = columns };
+            var result = new Arguments { Column = columns, HasHeader = hasHeader, SeparatorChars = separatorChars};
             advancedSettings?.Invoke(result);
             return result;
         }
 
-        public TextLoader(IHostEnvironment env, Arguments args, IMultiStreamSource dataSample = null)
+        internal TextLoader(IHostEnvironment env, Arguments args, IMultiStreamSource dataSample = null)
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(RegistrationName);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1294,7 +1294,7 @@ namespace Microsoft.ML.Runtime.Data
             _parser = new Parser(this);
         }
 
-        public static TextLoader Create(IHostEnvironment env, ModelLoadContext ctx)
+        internal static TextLoader Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             IHost h = env.Register(RegistrationName);
@@ -1306,16 +1306,22 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         // These are legacy constructors needed for ComponentCatalog.
-        public static IDataLoader Create(IHostEnvironment env, ModelLoadContext ctx, IMultiStreamSource files)
+        internal static IDataLoader Create(IHostEnvironment env, ModelLoadContext ctx, IMultiStreamSource files)
             => (IDataLoader)Create(env, ctx).Read(files);
-        public static IDataLoader Create(IHostEnvironment env, Arguments args, IMultiStreamSource files)
+        internal static IDataLoader Create(IHostEnvironment env, Arguments args, IMultiStreamSource files)
             => (IDataLoader)new TextLoader(env, args, files).Read(files);
 
         /// <summary>
-        /// Convenience method to create a <see cref="TextLoader"/> and use it to read a specified file.
+        /// Creates a <see cref="TextLoader"/> and uses it to read a specified file.
         /// </summary>
-        public static IDataView ReadFile(IHostEnvironment env, Arguments args, IMultiStreamSource fileSource)
-            => new TextLoader(env, args, fileSource).Read(fileSource);
+        /// <param name="env">The environment to use.</param>
+        /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
+        /// <param name="hasHeader">Whether the file has a header.</param>
+        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
+        /// <param name="advancedSettings">A delegate to apply all the advanced arguments to the algorithm.</param>
+        /// <param name="fileSource">Specifies a file from which to read.</param>
+        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null)
+            => new TextLoader(env, columns, hasHeader, separatorChars, advancedSettings, fileSource).Read(fileSource);
 
         public void Save(ModelSaveContext ctx)
         {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1013,23 +1013,27 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="env">The environment to use.</param>
         /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
-        /// <param name="advancedSettings">A delegate to apply all the advanced arguments to the algorithm.</param>
+        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
-        public TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
-            : this(env, MakeArgs(columns, hasHeader, separatorChars, advancedSettings), dataSample)
+        public TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null)
+            : this(env, MakeArgs(columns, hasHeader, new[] { separatorChar }), dataSample)
         {
         }
 
-        private static Arguments MakeArgs(Column[] columns, bool hasHeader, char[] separatorChars, Action<Arguments> advancedSettings)
+        private static Arguments MakeArgs(Column[] columns, bool hasHeader, char[] separatorChars)
         {
             separatorChars = separatorChars ?? new[] { '\t' };
             var result = new Arguments { Column = columns, HasHeader = hasHeader, SeparatorChars = separatorChars};
-            advancedSettings?.Invoke(result);
             return result;
         }
 
-        internal TextLoader(IHostEnvironment env, Arguments args, IMultiStreamSource dataSample = null)
+        /// <summary>
+        /// Loads a text file into an <see cref="IDataView"/>. Supports basic mapping from input columns to IDataView columns.
+        /// </summary>
+        /// <param name="env">The environment to use.</param>
+        /// <param name="args">Defines the settings of the load operation.</param>
+        /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
+        public TextLoader(IHostEnvironment env, Arguments args, IMultiStreamSource dataSample = null)
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(RegistrationName);
@@ -1317,11 +1321,19 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="env">The environment to use.</param>
         /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
-        /// <param name="advancedSettings">A delegate to apply all the advanced arguments to the algorithm.</param>
+        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="fileSource">Specifies a file from which to read.</param>
-        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null)
-            => new TextLoader(env, columns, hasHeader, separatorChars, advancedSettings, fileSource).Read(fileSource);
+        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Column[] columns, bool hasHeader = false, char separatorChar = '\t')
+            => new TextLoader(env, columns, hasHeader, separatorChar, fileSource).Read(fileSource);
+
+        /// <summary>
+        /// Loads a text file into an <see cref="IDataView"/>. Supports basic mapping from input columns to IDataView columns.
+        /// </summary>
+        /// <param name="env">The environment to use.</param>
+        /// <param name="fileSource">Specifies a file from which to read.</param>
+        /// <param name="args">Defines the settings of the load operation.</param>
+        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Arguments args)
+            => new TextLoader(env, args, fileSource).Read(fileSource);
 
         public void Save(ModelSaveContext ctx)
         {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1033,11 +1033,12 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="env">The environment to use.</param>
         /// <param name="args">Defines the settings of the load operation.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
-        public TextLoader(IHostEnvironment env, Arguments args, IMultiStreamSource dataSample = null)
+        public TextLoader(IHostEnvironment env, Arguments args = null, IMultiStreamSource dataSample = null)
         {
+            args = args ?? new Arguments();
+
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(RegistrationName);
-
             _host.CheckValue(args, nameof(args));
             _host.CheckValueOrNull(dataSample);
 
@@ -1332,7 +1333,7 @@ namespace Microsoft.ML.Runtime.Data
         /// <param name="env">The environment to use.</param>
         /// <param name="fileSource">Specifies a file from which to read.</param>
         /// <param name="args">Defines the settings of the load operation.</param>
-        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Arguments args)
+        public static IDataView ReadFile(IHostEnvironment env, IMultiStreamSource fileSource, Arguments args = null)
             => new TextLoader(env, args, fileSource).Read(fileSource);
 
         public void Save(ModelSaveContext ctx)

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ML
         /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">The optional location of a data sample.</param>
-        public static TextLoader TextReader(this DataOperations catalog,
+        public static TextLoader CreateTextReader(this DataOperations catalog,
             Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null)
             => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample);
 
@@ -31,7 +31,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The catalog.</param>
         /// <param name="args">Defines the settings of the load operation.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
-        public static TextLoader TextReader(this DataOperations catalog, Arguments args, IMultiStreamSource dataSample = null)
+        public static TextLoader CreateTextReader(this DataOperations catalog, Arguments args, IMultiStreamSource dataSample = null)
             => new TextLoader(CatalogUtils.GetEnvironment(catalog), args, dataSample);
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The catalog.</param>
         /// <param name="path">Specifies a file from which to read.</param>
         /// <param name="args">Defines the settings of the load operation.</param>
-        public static IDataView ReadFromTextFile(this DataOperations catalog, string path, Arguments args)
+        public static IDataView ReadFromTextFile(this DataOperations catalog, string path, Arguments args = null)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -14,17 +14,25 @@ namespace Microsoft.ML
     public static class TextLoaderSaverCatalog
     {
         /// <summary>
-        /// Create a text reader.
+        /// Create a text reader <see cref="TextLoader"/>.
         /// </summary>
         /// <param name="catalog">The catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
-        /// <param name="advancedSettings">The delegate to set additional settings.</param>
+        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">The optional location of a data sample.</param>
         public static TextLoader TextReader(this DataOperations catalog,
-            Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChars, advancedSettings, dataSample);
+            Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null)
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample);
+
+        /// <summary>
+        /// Create a text reader <see cref="TextLoader"/>.
+        /// </summary>
+        /// <param name="catalog">The catalog.</param>
+        /// <param name="args">Defines the settings of the load operation.</param>
+        /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
+        public static TextLoader TextReader(this DataOperations catalog, Arguments args, IMultiStreamSource dataSample = null)
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), args, dataSample);
 
         /// <summary>
         /// Read a data view from a text file using <see cref="TextLoader"/>.
@@ -32,12 +40,11 @@ namespace Microsoft.ML
         /// <param name="catalog">The catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
-        /// <param name="advancedSettings">The delegate to set additional settings.</param>
+        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="path">The path to the file.</param>
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile(this DataOperations catalog,
-            string path, Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null)
+            string path, Column[] columns, bool hasHeader = false, char separatorChar = '\t')
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 
@@ -45,7 +52,25 @@ namespace Microsoft.ML
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            var reader = new TextLoader(env, columns, hasHeader, separatorChars, advancedSettings, dataSample: null);
+            var reader = new TextLoader(env, columns, hasHeader, separatorChar, dataSample: null);
+            return reader.Read(new MultiFileSource(path));
+        }
+
+        /// <summary>
+        /// Read a data view from a text file using <see cref="TextLoader"/>.
+        /// </summary>
+        /// <param name="catalog">The catalog.</param>
+        /// <param name="path">Specifies a file from which to read.</param>
+        /// <param name="args">Defines the settings of the load operation.</param>
+        public static IDataView ReadFromTextFile(this DataOperations catalog, string path, Arguments args)
+        {
+            Contracts.CheckNonEmpty(path, nameof(path));
+
+            var env = catalog.GetEnvironment();
+
+            // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
+            // Therefore, we are going to disallow data sample.
+            var reader = new TextLoader(env, args, dataSample: null);
             return reader.Read(new MultiFileSource(path));
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -5,13 +5,8 @@
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Data.IO;
-using Microsoft.ML.Runtime.Internal.Utilities;
-using Microsoft.ML.StaticPipe;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using static Microsoft.ML.Runtime.Data.TextLoader;
 
 namespace Microsoft.ML
@@ -36,8 +31,8 @@ namespace Microsoft.ML
         /// <param name="advancedSettings">The delegate to set additional settings.</param>
         /// <param name="dataSample">The optional location of a data sample.</param>
         public static TextLoader TextReader(this DataOperations catalog,
-            TextLoader.Column[] columns, Action<TextLoader.Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, advancedSettings, dataSample);
+            TextLoader.Column[] columns, Action<Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, advancedSettings: advancedSettings, dataSample: dataSample);
 
         /// <summary>
         /// Read a data view from a text file using <see cref="TextLoader"/>.
@@ -48,7 +43,7 @@ namespace Microsoft.ML
         /// <param name="path">The path to the file</param>
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile(this DataOperations catalog,
-            TextLoader.Column[] columns, string path, Action<TextLoader.Arguments> advancedSettings = null)
+            TextLoader.Column[] columns, string path, Action<Arguments> advancedSettings = null)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 
@@ -56,7 +51,7 @@ namespace Microsoft.ML
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            var reader = new TextLoader(env, columns, advancedSettings, dataSample: null);
+            var reader = new TextLoader(env, columns, advancedSettings: advancedSettings, dataSample: null);
             return reader.Read(new MultiFileSource(path));
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -67,11 +67,9 @@ namespace Microsoft.ML
             Contracts.CheckNonEmpty(path, nameof(path));
 
             var env = catalog.GetEnvironment();
+            var source = new MultiFileSource(path);
 
-            // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
-            // Therefore, we are going to disallow data sample.
-            var reader = new TextLoader(env, args, dataSample: null);
-            return reader.Read(new MultiFileSource(path));
+            return new TextLoader(env, args, source).Read(source);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
+        /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">The optional location of a data sample.</param>
         public static TextLoader TextReader(this DataOperations catalog,
             Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null)
@@ -40,7 +40,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
+        /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="path">The path to the file.</param>
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile(this DataOperations catalog,

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -17,33 +17,27 @@ namespace Microsoft.ML
         /// Create a text reader.
         /// </summary>
         /// <param name="catalog">The catalog.</param>
-        /// <param name="args">The arguments to text reader, describing the data schema.</param>
-        /// <param name="dataSample">The optional location of a data sample.</param>
-        public static TextLoader TextReader(this DataOperations catalog,
-            TextLoader.Arguments args, IMultiStreamSource dataSample = null)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), args, dataSample);
-
-        /// <summary>
-        /// Create a text reader.
-        /// </summary>
-        /// <param name="catalog">The catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
+        /// <param name="hasHeader">Whether the file has a header.</param>
+        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
         /// <param name="advancedSettings">The delegate to set additional settings.</param>
         /// <param name="dataSample">The optional location of a data sample.</param>
         public static TextLoader TextReader(this DataOperations catalog,
-            TextLoader.Column[] columns, Action<Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, advancedSettings: advancedSettings, dataSample: dataSample);
+            Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null, IMultiStreamSource dataSample = null)
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChars, advancedSettings, dataSample);
 
         /// <summary>
         /// Read a data view from a text file using <see cref="TextLoader"/>.
         /// </summary>
         /// <param name="catalog">The catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
-        /// <param name="advancedSettings">The delegate to set additional settings</param>
-        /// <param name="path">The path to the file</param>
+        /// <param name="hasHeader">Whether the file has a header.</param>
+        /// <param name="separatorChars">Defines the characters used as separators between data points in a row. By default the tab character is taken as separator.</param>
+        /// <param name="advancedSettings">The delegate to set additional settings.</param>
+        /// <param name="path">The path to the file.</param>
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile(this DataOperations catalog,
-            TextLoader.Column[] columns, string path, Action<Arguments> advancedSettings = null)
+            string path, Column[] columns, bool hasHeader = false, char[] separatorChars = null, Action<Arguments> advancedSettings = null)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 
@@ -51,7 +45,7 @@ namespace Microsoft.ML
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            var reader = new TextLoader(env, columns, advancedSettings: advancedSettings, dataSample: null);
+            var reader = new TextLoader(env, columns, hasHeader, separatorChars, advancedSettings, dataSample: null);
             return reader.Read(new MultiFileSource(path));
         }
 

--- a/src/Microsoft.ML.Data/StaticPipe/DataLoadSaveOperationsExtensions.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/DataLoadSaveOperationsExtensions.cs
@@ -4,14 +4,7 @@
 
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
-using Microsoft.ML.Runtime.Data.IO;
-using Microsoft.ML.Runtime.Internal.Utilities;
-using Microsoft.ML.StaticPipe;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using static Microsoft.ML.Runtime.Data.TextLoader;
 
 namespace Microsoft.ML.StaticPipe
@@ -40,10 +33,10 @@ namespace Microsoft.ML.StaticPipe
         /// <param name="allowSparse">Whether the input may include sparse representations.</param>
         /// <param name="trimWhitspace">Remove trailing whitespace from lines.</param>
         /// <returns>A configured statically-typed reader for text files.</returns>
-        public static DataReader<IMultiStreamSource, TShape> TextReader<[IsShape] TShape>(
+        public static DataReader<IMultiStreamSource, TShape> CreateTextReader<[IsShape] TShape>(
             this DataOperations catalog, Func<Context, TShape> func, IMultiStreamSource files = null,
             bool hasHeader = false, char separator = '\t', bool allowQuoting = true, bool allowSparse = true,
             bool trimWhitspace = false)
-         => TextLoader.CreateReader(catalog.Environment, func, files, hasHeader, separator, allowQuoting, allowSparse, trimWhitspace);
+         => CreateReader(catalog.Environment, func, files, hasHeader, separator, allowQuoting, allowSparse, trimWhitspace);
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -483,9 +483,10 @@ namespace Microsoft.ML.Transforms.Conversions
                             "{0} should not be specified when default loader is TextLoader. Ignoring {0}={1}",
                             nameof(Arguments.TermsColumn), src);
                     }
-                    termData = TextLoader.ReadFile(env, fileSource,
-                        columns: new[] { new TextLoader.Column("Term", DataKind.TX, 0) }
-                        );
+                    termData = new TextLoader(env,
+                        columns: new[] { new TextLoader.Column("Term", DataKind.TX, 0) },
+                        dataSample: fileSource)
+                        .Read(fileSource);
                     src = "Term";
                     autoConvert = true;
                 }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -483,13 +483,9 @@ namespace Microsoft.ML.Transforms.Conversions
                             "{0} should not be specified when default loader is TextLoader. Ignoring {0}={1}",
                             nameof(Arguments.TermsColumn), src);
                     }
-                    termData = TextLoader.ReadFile(env,
-                        new TextLoader.Arguments()
-                        {
-                            Separator = "tab",
-                            Column = new[] { new TextLoader.Column("Term", DataKind.TX, 0) }
-                        },
-                        fileSource);
+                    termData = TextLoader.ReadFile(env, fileSource,
+                        columns: new[] { new TextLoader.Column("Term", DataKind.TX, 0) }
+                        );
                     src = "Term";
                     autoConvert = true;
                 }

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -283,8 +283,7 @@ namespace Microsoft.ML.Runtime.Model
             {
                 // REVIEW: Should really validate the schema here, and consider
                 // ignoring this stream if it isn't as expected.
-                var loader = TextLoader.ReadFile(env, new TextLoader.Arguments(),
-                    new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile));
+                var loader = TextLoader.ReadFile(env, new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile), null);
 
                 using (var cursor = loader.GetRowCursor(c => true))
                 {

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Runtime.Model
             {
                 // REVIEW: Should really validate the schema here, and consider
                 // ignoring this stream if it isn't as expected.
-                var loader = TextLoader.ReadFile(env, new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile), null);
+                var loader = TextLoader.ReadFile(env, new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile), new TextLoader.Arguments());
 
                 using (var cursor = loader.GetRowCursor(c => true))
                 {

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -283,7 +283,8 @@ namespace Microsoft.ML.Runtime.Model
             {
                 // REVIEW: Should really validate the schema here, and consider
                 // ignoring this stream if it isn't as expected.
-                var loader = TextLoader.ReadFile(env, new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile));
+                var loader = new TextLoader(env, dataSample: new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile))
+                    .Read(new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile));
 
                 using (var cursor = loader.GetRowCursor(c => true))
                 {

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -283,8 +283,8 @@ namespace Microsoft.ML.Runtime.Model
             {
                 // REVIEW: Should really validate the schema here, and consider
                 // ignoring this stream if it isn't as expected.
-                var loader = new TextLoader(env, dataSample: new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile))
-                    .Read(new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile));
+                var repoStreamWrapper = new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile);
+                var loader = new TextLoader(env, dataSample: repoStreamWrapper).Read(repoStreamWrapper);
 
                 using (var cursor = loader.GetRowCursor(c => true))
                 {

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Runtime.Model
             {
                 // REVIEW: Should really validate the schema here, and consider
                 // ignoring this stream if it isn't as expected.
-                var loader = TextLoader.ReadFile(env, new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile), new TextLoader.Arguments());
+                var loader = TextLoader.ReadFile(env, new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile));
 
                 using (var cursor = loader.GetRowCursor(c => true))
                 {

--- a/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
@@ -361,11 +361,14 @@ namespace Microsoft.ML.Transforms.Categorical
             ulong max = ulong.MinValue;
             try
             {
-                var data = TextLoader.ReadFile(host, new MultiFileSource(filename), new[]
+                var data = new TextLoader(host, new[]
                     {
                         new TextLoader.Column("Term", DataKind.TX, 0),
                         new TextLoader.Column("Value", DataKind.TX, 1)
-                    });
+                    },
+                    dataSample: new MultiFileSource(filename)
+                ).Read(new MultiFileSource(filename));
+
                 using (var cursor = data.GetRowCursor(c => true))
                 {
                     var getTerm = cursor.GetGetter<ReadOnlyMemory<char>>(0);

--- a/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
@@ -361,13 +361,14 @@ namespace Microsoft.ML.Transforms.Categorical
             ulong max = ulong.MinValue;
             try
             {
+                var file = new MultiFileSource(filename);
                 var data = new TextLoader(host, new[]
                     {
                         new TextLoader.Column("Term", DataKind.TX, 0),
                         new TextLoader.Column("Value", DataKind.TX, 1)
                     },
-                    dataSample: new MultiFileSource(filename)
-                ).Read(new MultiFileSource(filename));
+                    dataSample: file
+                ).Read(file);
 
                 using (var cursor = data.GetRowCursor(c => true))
                 {

--- a/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
@@ -361,9 +361,6 @@ namespace Microsoft.ML.Transforms.Categorical
             ulong max = ulong.MinValue;
             try
             {
-                var txtArgs = new TextLoader.Arguments();
-                bool parsed = CmdParser.ParseArguments(host, "col=Term:TX:0 col=Value:TX:1", txtArgs);
-                host.Assert(parsed);
                 var data = TextLoader.ReadFile(host, new MultiFileSource(filename), new[]
                     {
                         new TextLoader.Column("Term", DataKind.TX, 0),

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -722,17 +722,13 @@ namespace Microsoft.ML.Transforms.Text
                 {
                     if (stopwordsCol == null)
                         stopwordsCol = "Stopwords";
-                    dataLoader = TextLoader.Create(
+                    dataLoader = new TextLoader(
                         Host,
-                        new TextLoader.Arguments()
+                        columns: new[]
                         {
-                            Separator = "tab",
-                            Column = new[]
-                            {
-                                new TextLoader.Column(stopwordsCol, DataKind.TX, 0)
-                            }
+                            new TextLoader.Column(stopwordsCol, DataKind.TX, 0)
                         },
-                        fileSource);
+                        dataSample: fileSource).Read(fileSource) as IDataLoader;
                 }
                 ch.AssertNonEmpty(stopwordsCol);
             }

--- a/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
+++ b/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Benchmarks
             var ml = new MLContext(seed: 1);
             // Pipeline
 
-            var input = ml.Data.ReadFromTextFile(new[] {
+            var input = ml.Data.ReadFromTextFile(_dataPath, new[] {
                             new TextLoader.Column("Label", DataKind.R4, 0),
                             new TextLoader.Column("CatFeatures", DataKind.TX,
                                 new [] {
@@ -28,11 +28,7 @@ namespace Microsoft.ML.Benchmarks
                                 new [] {
                                     new TextLoader.Range() { Min = 9, Max = 14 },
                                 }),
-            }, _dataPath, s =>
-            {
-                s.HasHeader = true;
-                s.Separator = "\t";
-            });
+            }, hasHeader: true);
 
             var estimatorPipeline = ml.Transforms.Categorical.OneHotEncoding("CatFeatures")
                 .Append(ml.Transforms.Normalize("NumFeatures"))

--- a/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
+++ b/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ML.Benchmarks
                             new TextLoader.Column("Label", DataKind.BL, 0),
                             new TextLoader.Column("Features", DataKind.R4, new[] { new TextLoader.Range(1, 9) })
                         }, 
-                        false
+                        hasHeader: false
                     );
 
             IDataView data = reader.Read(_breastCancerDataPath);

--- a/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
+++ b/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
@@ -38,19 +38,16 @@ namespace Microsoft.ML.Benchmarks
 
             var env = new MLContext(seed: 1, conc: 1);
             var reader = new TextLoader(env,
-                new TextLoader.Arguments()
-                {
-                    Separator = "\t",
-                    HasHeader = true,
-                    Column = new[]
+                    columns: new[]
                     {
                             new TextLoader.Column("Label", DataKind.R4, 0),
                             new TextLoader.Column("SepalLength", DataKind.R4, 1),
                             new TextLoader.Column("SepalWidth", DataKind.R4, 2),
                             new TextLoader.Column("PetalLength", DataKind.R4, 3),
                             new TextLoader.Column("PetalWidth", DataKind.R4, 4),
-                    }
-                });
+                    },
+                    hasHeader: true
+                );
 
             IDataView data = reader.Read(_irisDataPath);
 
@@ -73,17 +70,13 @@ namespace Microsoft.ML.Benchmarks
             string _sentimentDataPath = Program.GetInvariantCultureDataPath("wikipedia-detox-250-line-data.tsv");
 
             var env = new MLContext(seed: 1, conc: 1);
-            var reader = new TextLoader(env,
-                    new TextLoader.Arguments()
-                    {
-                        Separator = "\t",
-                        HasHeader = true,
-                        Column = new[]
+            var reader = new TextLoader(env, columns: new[]
                         {
                             new TextLoader.Column("Label", DataKind.BL, 0),
                             new TextLoader.Column("SentimentText", DataKind.Text, 1)
-                        }
-                    });
+                        },
+                        hasHeader: true                        
+                    );
 
             IDataView data = reader.Read(_sentimentDataPath);
 
@@ -106,17 +99,13 @@ namespace Microsoft.ML.Benchmarks
             string _breastCancerDataPath = Program.GetInvariantCultureDataPath("breast-cancer.txt");
 
             var env = new MLContext(seed: 1, conc: 1);
-            var reader = new TextLoader(env,
-                    new TextLoader.Arguments()
-                    {
-                        Separator = "\t",
-                        HasHeader = false,
-                        Column = new[]
+            var reader = new TextLoader(env, columns: new[]
                         {
                             new TextLoader.Column("Label", DataKind.BL, 0),
                             new TextLoader.Column("Features", DataKind.R4, new[] { new TextLoader.Range(1, 9) })
-                        }
-                    });
+                        }, 
+                        false
+                    );
 
             IDataView data = reader.Read(_breastCancerDataPath);
 

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -64,30 +64,26 @@ namespace Microsoft.ML.Benchmarks
         {
             var env = new MLContext(seed: 1);
             // Pipeline
-            var loader = TextLoader.ReadFile(env,
-                new TextLoader.Arguments()
+            var loader = TextLoader.ReadFile(env, new MultiFileSource(_sentimentDataPath),
+                columns: new[]
                 {
-                    AllowQuoting = false,
-                    AllowSparse = false,
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
+                    new TextLoader.Column()
                     {
-                            new TextLoader.Column()
-                            {
-                                Name = "Label",
-                                Source = new [] { new TextLoader.Range() { Min=0, Max=0} },
-                                Type = DataKind.Num
-                            },
+                        Name = "Label",
+                        Source = new [] { new TextLoader.Range() { Min=0, Max=0} },
+                        Type = DataKind.Num
+                    },
 
-                            new TextLoader.Column()
-                            {
-                                Name = "SentimentText",
-                                Source = new [] { new TextLoader.Range() { Min=1, Max=1} },
-                                Type = DataKind.Text
-                            }
+                    new TextLoader.Column()
+                    {
+                        Name = "SentimentText",
+                        Source = new [] { new TextLoader.Range() { Min=1, Max=1} },
+                        Type = DataKind.Text
                     }
-                }, new MultiFileSource(_sentimentDataPath));
+                },
+                hasHeader: true,
+                advancedSettings: s => { s.AllowQuoting = false; s.AllowSparse = false; }
+                );
 
             var text = TextFeaturizingEstimator.Create(env,
                 new TextFeaturizingEstimator.Arguments()

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Benchmarks
         {
             var env = new MLContext(seed: 1);
             // Pipeline
-            var arguemnts = new TextLoader.Arguments()
+            var arguments = new TextLoader.Arguments()
             {
                 Column = new TextLoader.Column[]
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Benchmarks
                 AllowQuoting = false,
                 AllowSparse = false
             };
-            var loader = TextLoader.ReadFile(env, new MultiFileSource(_sentimentDataPath), arguemnts);
+            var loader = TextLoader.ReadFile(env, new MultiFileSource(_sentimentDataPath), arguments);
 
             var text = TextFeaturizingEstimator.Create(env,
                 new TextFeaturizingEstimator.Arguments()

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Benchmarks
                 AllowQuoting = false,
                 AllowSparse = false
             };
-            var loader = TextLoader.ReadFile(env, new MultiFileSource(_sentimentDataPath), arguments);
+            var loader = env.Data.ReadFromTextFile(_sentimentDataPath, arguments);
 
             var text = TextFeaturizingEstimator.Create(env,
                 new TextFeaturizingEstimator.Arguments()

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -64,26 +64,29 @@ namespace Microsoft.ML.Benchmarks
         {
             var env = new MLContext(seed: 1);
             // Pipeline
-            var loader = TextLoader.ReadFile(env, new MultiFileSource(_sentimentDataPath),
-                columns: new[]
+            var arguemnts = new TextLoader.Arguments()
+            {
+                Column = new TextLoader.Column[]
                 {
                     new TextLoader.Column()
                     {
                         Name = "Label",
-                        Source = new [] { new TextLoader.Range() { Min=0, Max=0} },
+                        Source = new[] { new TextLoader.Range() { Min = 0, Max = 0 } },
                         Type = DataKind.Num
                     },
 
                     new TextLoader.Column()
                     {
                         Name = "SentimentText",
-                        Source = new [] { new TextLoader.Range() { Min=1, Max=1} },
+                        Source = new[] { new TextLoader.Range() { Min = 1, Max = 1 } },
                         Type = DataKind.Text
                     }
                 },
-                hasHeader: true,
-                advancedSettings: s => { s.AllowQuoting = false; s.AllowSparse = false; }
-                );
+                HasHeader = true,
+                AllowQuoting = false,
+                AllowSparse = false
+            };
+            var loader = TextLoader.ReadFile(env, new MultiFileSource(_sentimentDataPath), arguemnts);
 
             var text = TextFeaturizingEstimator.Create(env,
                 new TextFeaturizingEstimator.Arguments()

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -606,7 +606,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
 
             var fastTrees = new IPredictorModel[3];
             for (int i = 0; i < 3; i++)
@@ -628,7 +628,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombinerWithCategoricalSplits()
         {
             var dataPath = GetDataPath("adult.tiny.with-schema.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
 
             var cat = new OneHotEncodingEstimator(Env, "Categories", "Features").Fit(dataView).Transform(dataView);
             var fastTrees = new IPredictorModel[3];
@@ -729,7 +729,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
 
             var predictors = new IPredictorModel[]
             {
@@ -775,7 +775,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestMultiClassEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
 
             var predictors = new IPredictorModel[]
             {

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -606,7 +606,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
 
             var fastTrees = new IPredictorModel[3];
             for (int i = 0; i < 3; i++)
@@ -628,7 +628,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombinerWithCategoricalSplits()
         {
             var dataPath = GetDataPath("adult.tiny.with-schema.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
 
             var cat = new OneHotEncodingEstimator(Env, "Categories", "Features").Fit(dataView).Transform(dataView);
             var fastTrees = new IPredictorModel[3];
@@ -729,7 +729,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
 
             var predictors = new IPredictorModel[]
             {
@@ -775,7 +775,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestMultiClassEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), new TextLoader.Arguments());
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
 
             var predictors = new IPredictorModel[]
             {

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -606,7 +606,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.Create(Env, new TextLoader.Arguments(), new MultiFileSource(dataPath));
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
 
             var fastTrees = new IPredictorModel[3];
             for (int i = 0; i < 3; i++)
@@ -628,7 +628,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombinerWithCategoricalSplits()
         {
             var dataPath = GetDataPath("adult.tiny.with-schema.txt");
-            var dataView = TextLoader.Create(Env, new TextLoader.Arguments(), new MultiFileSource(dataPath));
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
 
             var cat = new OneHotEncodingEstimator(Env, "Categories", "Features").Fit(dataView).Transform(dataView);
             var fastTrees = new IPredictorModel[3];
@@ -729,7 +729,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.Create(Env, new TextLoader.Arguments(), new MultiFileSource(dataPath));
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
 
             var predictors = new IPredictorModel[]
             {
@@ -775,7 +775,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestMultiClassEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.Create(Env, new TextLoader.Arguments(), new MultiFileSource(dataPath));
+            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath), null);
 
             var predictors = new IPredictorModel[]
             {

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -606,12 +606,12 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
+            var dataView = ML.Data.ReadFromTextFile(dataPath);
 
             var fastTrees = new IPredictorModel[3];
             for (int i = 0; i < 3; i++)
             {
-                fastTrees[i] = FastTree.TrainBinary(Env, new FastTreeBinaryClassificationTrainer.Arguments
+                fastTrees[i] = FastTree.TrainBinary(ML, new FastTreeBinaryClassificationTrainer.Arguments
                 {
                     FeatureColumn = "Features",
                     NumTrees = 5,
@@ -628,13 +628,13 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestTreeEnsembleCombinerWithCategoricalSplits()
         {
             var dataPath = GetDataPath("adult.tiny.with-schema.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
+            var dataView = ML.Data.ReadFromTextFile(dataPath);
 
-            var cat = new OneHotEncodingEstimator(Env, "Categories", "Features").Fit(dataView).Transform(dataView);
+            var cat = new OneHotEncodingEstimator(ML, "Categories", "Features").Fit(dataView).Transform(dataView);
             var fastTrees = new IPredictorModel[3];
             for (int i = 0; i < 3; i++)
             {
-                fastTrees[i] = FastTree.TrainBinary(Env, new FastTreeBinaryClassificationTrainer.Arguments
+                fastTrees[i] = FastTree.TrainBinary(ML, new FastTreeBinaryClassificationTrainer.Arguments
                 {
                     FeatureColumn = "Features",
                     NumTrees = 5,
@@ -729,11 +729,11 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
+            var dataView = ML.Data.ReadFromTextFile(dataPath);
 
             var predictors = new IPredictorModel[]
             {
-                FastTree.TrainBinary(Env, new FastTreeBinaryClassificationTrainer.Arguments
+                FastTree.TrainBinary(ML, new FastTreeBinaryClassificationTrainer.Arguments
                 {
                     FeatureColumn = "Features",
                     NumTrees = 5,
@@ -741,7 +741,7 @@ namespace Microsoft.ML.Runtime.RunTests
                     LabelColumn = DefaultColumnNames.Label,
                     TrainingData = dataView
                 }).PredictorModel,
-                AveragedPerceptronTrainer.TrainBinary(Env, new AveragedPerceptronTrainer.Arguments()
+                AveragedPerceptronTrainer.TrainBinary(ML, new AveragedPerceptronTrainer.Arguments()
                 {
                     FeatureColumn = "Features",
                     LabelColumn = DefaultColumnNames.Label,
@@ -749,7 +749,7 @@ namespace Microsoft.ML.Runtime.RunTests
                     TrainingData = dataView,
                     NormalizeFeatures = NormalizeOption.No
                 }).PredictorModel,
-                LogisticRegression.TrainBinary(Env, new LogisticRegression.Arguments()
+                LogisticRegression.TrainBinary(ML, new LogisticRegression.Arguments()
                 {
                     FeatureColumn = "Features",
                     LabelColumn = DefaultColumnNames.Label,
@@ -757,7 +757,7 @@ namespace Microsoft.ML.Runtime.RunTests
                     TrainingData = dataView,
                     NormalizeFeatures = NormalizeOption.No
                 }).PredictorModel,
-                LogisticRegression.TrainBinary(Env, new LogisticRegression.Arguments()
+                LogisticRegression.TrainBinary(ML, new LogisticRegression.Arguments()
                 {
                     FeatureColumn = "Features",
                     LabelColumn = DefaultColumnNames.Label,
@@ -775,7 +775,7 @@ namespace Microsoft.ML.Runtime.RunTests
         public void TestMultiClassEnsembleCombiner()
         {
             var dataPath = GetDataPath("breast-cancer.txt");
-            var dataView = TextLoader.ReadFile(Env, new MultiFileSource(dataPath));
+            var dataView = ML.Data.ReadFromTextFile(dataPath);
 
             var predictors = new IPredictorModel[]
             {

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -882,7 +882,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                + "1 1 2 4 15";
             var dataSource = new BytesStreamSource(content);
 
-            var text = ml.Data.TextReader(ctx => (
+            var text = ml.Data.CreateTextReader(ctx => (
                label: ctx.LoadBool(0),
                text: ctx.LoadText(1),
                numericFeatures: ctx.LoadDouble(2, null)), // If fit correctly, this ought to be equivalent to max of 4, that is, length of 3.

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -976,7 +976,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Read data file. The file contains 3 columns, label (float value), matrixColumnIndex (unsigned integer key), and matrixRowIndex (unsigned integer key).
             // More specifically, LoadKey(1, 0, 19) means that the matrixColumnIndex column is read from the 2nd (indexed by 1) column in the data file and as
             // a key type (stored as 32-bit unsigned integer) ranged from 0 to 19 (aka the training matrix has 20 columns).
-            var reader = mlContext.Data.TextReader(ctx => (label: ctx.LoadFloat(0), matrixColumnIndex: ctx.LoadKey(1, 0, 19), matrixRowIndex: ctx.LoadKey(2, 0, 39)), hasHeader: true);
+            var reader = mlContext.Data.CreateTextReader(ctx => (label: ctx.LoadFloat(0), matrixColumnIndex: ctx.LoadKey(1, 0, 19), matrixRowIndex: ctx.LoadKey(2, 0, 39)), hasHeader: true);
 
             // The parameter that will be into the onFit method below. The obtained predictor will be assigned to this variable
             // so that we will be able to touch it.

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             // Note that we don't pass in "args", but pass in a default args so we test
             // the auto-schema parsing.
-            var loadedData = TextLoader.ReadFile(env, new TextLoader.Arguments(), new MultiFileSource(pathData));
+            var loadedData = TextLoader.ReadFile(env, new MultiFileSource(pathData), null);
             if (!CheckMetadataTypes(loadedData.Schema))
                 Failed();
 

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             // Note that we don't pass in "args", but pass in a default args so we test
             // the auto-schema parsing.
-            var loadedData = TextLoader.ReadFile(env, new MultiFileSource(pathData), new TextLoader.Arguments());
+            var loadedData = TextLoader.ReadFile(env, new MultiFileSource(pathData));
             if (!CheckMetadataTypes(loadedData.Schema))
                 Failed();
 

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             // Note that we don't pass in "args", but pass in a default args so we test
             // the auto-schema parsing.
-            var loadedData = TextLoader.ReadFile(env, new MultiFileSource(pathData));
+            var loadedData = ML.Data.ReadFromTextFile(pathData);
             if (!CheckMetadataTypes(loadedData.Schema))
                 Failed();
 

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             // Note that we don't pass in "args", but pass in a default args so we test
             // the auto-schema parsing.
-            var loadedData = TextLoader.ReadFile(env, new MultiFileSource(pathData), null);
+            var loadedData = TextLoader.ReadFile(env, new MultiFileSource(pathData), new TextLoader.Arguments());
             if (!CheckMetadataTypes(loadedData.Schema))
                 Failed();
 

--- a/test/Microsoft.ML.TestFramework/ModelHelper.cs
+++ b/test/Microsoft.ML.TestFramework/ModelHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.TestFramework
 #pragma warning disable 612, 618
     public static class ModelHelper
     {
-        private static IHostEnvironment s_environment = new MLContext(seed: 1);
+        private static MLContext s_environment = new MLContext(seed: 1);
         private static ITransformModel s_housePriceModel;
 
         public static void WriteKcHousePriceModel(string dataPath, string outputModelPath)
@@ -41,7 +41,7 @@ namespace Microsoft.ML.TestFramework
 
         public static IDataView GetKcHouseDataView(string dataPath)
         {
-            return Runtime.Data.TextLoader.ReadFile(s_environment, new MultiFileSource(dataPath), 
+            return s_environment.Data.ReadFromTextFile(dataPath, 
                 columns: new[]
                 {
                     new Runtime.Data.TextLoader.Column("Id", Runtime.Data.DataKind.TX, 0),

--- a/test/Microsoft.ML.TestFramework/ModelHelper.cs
+++ b/test/Microsoft.ML.TestFramework/ModelHelper.cs
@@ -41,17 +41,34 @@ namespace Microsoft.ML.TestFramework
 
         public static IDataView GetKcHouseDataView(string dataPath)
         {
-            var dataSchema = "col=Id:TX:0 col=Date:TX:1 col=Label:R4:2 col=Bedrooms:R4:3 " +
-                "col=Bathrooms:R4:4 col=SqftLiving:R4:5 col=SqftLot:R4:6 col=Floors:R4:7 " +
-                "col=Waterfront:R4:8 col=View:R4:9 col=Condition:R4:10 col=Grade:R4:11 " +
-                "col=SqftAbove:R4:12 col=SqftBasement:R4:13 col=YearBuilt:R4:14 " +
-                "col=YearRenovated:R4:15 col=Zipcode:R4:16 col=Lat:R4:17 col=Long:R4:18 " +
-                "col=SqftLiving15:R4:19 col=SqftLot15:R4:20 header+ sep=,";
-
-            var txtArgs = new Runtime.Data.TextLoader.Arguments();
-            bool parsed = CmdParser.ParseArguments(s_environment, dataSchema, txtArgs);
-            s_environment.Assert(parsed);
-            return Runtime.Data.TextLoader.ReadFile(s_environment, txtArgs, new MultiFileSource(dataPath));
+            return Runtime.Data.TextLoader.ReadFile(s_environment, new MultiFileSource(dataPath), 
+                columns: new[]
+                {
+                    new Runtime.Data.TextLoader.Column("Id", Runtime.Data.DataKind.TX, 0),
+                    new Runtime.Data.TextLoader.Column("Date", Runtime.Data.DataKind.TX, 1),
+                    new Runtime.Data.TextLoader.Column("Label", Runtime.Data.DataKind.R4, 2),
+                    new Runtime.Data.TextLoader.Column("BedRooms", Runtime.Data.DataKind.R4, 3),
+                    new Runtime.Data.TextLoader.Column("BathRooms", Runtime.Data.DataKind.R4, 4),
+                    new Runtime.Data.TextLoader.Column("SqftLiving", Runtime.Data.DataKind.R4, 5),
+                    new Runtime.Data.TextLoader.Column("SqftLot", Runtime.Data.DataKind.R4, 6),
+                    new Runtime.Data.TextLoader.Column("Floors", Runtime.Data.DataKind.R4, 7),
+                    new Runtime.Data.TextLoader.Column("WaterFront", Runtime.Data.DataKind.R4, 8),
+                    new Runtime.Data.TextLoader.Column("View", Runtime.Data.DataKind.R4, 9),
+                    new Runtime.Data.TextLoader.Column("Condition", Runtime.Data.DataKind.R4, 10),
+                    new Runtime.Data.TextLoader.Column("Grade", Runtime.Data.DataKind.R4, 11),
+                    new Runtime.Data.TextLoader.Column("SqftAbove", Runtime.Data.DataKind.R4, 12),
+                    new Runtime.Data.TextLoader.Column("SqftBasement", Runtime.Data.DataKind.R4, 13),
+                    new Runtime.Data.TextLoader.Column("YearBuilt", Runtime.Data.DataKind.R4, 14),
+                    new Runtime.Data.TextLoader.Column("YearRenovated", Runtime.Data.DataKind.R4, 15),
+                    new Runtime.Data.TextLoader.Column("Zipcode", Runtime.Data.DataKind.R4, 16),
+                    new Runtime.Data.TextLoader.Column("Lat", Runtime.Data.DataKind.R4, 17),
+                    new Runtime.Data.TextLoader.Column("Long", Runtime.Data.DataKind.R4, 18),
+                    new Runtime.Data.TextLoader.Column("SqftLiving15", Runtime.Data.DataKind.R4, 19),
+                    new Runtime.Data.TextLoader.Column("SqftLot15", Runtime.Data.DataKind.R4, 20)
+                }, 
+                hasHeader: true,
+                separatorChars: new[] { ',' }
+            );
         }
 
         private static ITransformModel CreateKcHousePricePredictorModel(string dataPath)

--- a/test/Microsoft.ML.TestFramework/ModelHelper.cs
+++ b/test/Microsoft.ML.TestFramework/ModelHelper.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.TestFramework
                     new Runtime.Data.TextLoader.Column("SqftLot15", Runtime.Data.DataKind.R4, 20)
                 }, 
                 hasHeader: true,
-                separatorChars: new[] { ',' }
+                separatorChar: ','
             );
         }
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/ApiScenariosTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/ApiScenariosTests.cs
@@ -64,11 +64,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 };
         }
 
-        private static char[] MakeIrisSeparator()
-        {
-            return new[] { ',' };
-        }
-
         private static TextLoader.Column[] MakeSentimentColumns()
         {
             return new[]

--- a/test/Microsoft.ML.Tests/Scenarios/Api/ApiScenariosTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/ApiScenariosTests.cs
@@ -52,34 +52,30 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             public float Score;
         }
 
-        private static TextLoader.Arguments MakeIrisTextLoaderArgs()
+        private static TextLoader.Column[] MakeIrisColumns()
         {
-            return new TextLoader.Arguments()
-            {
-                Separator = "comma",
-                Column = new[]
+            return new[]
                 {
                     new TextLoader.Column("SepalLength", DataKind.R4, 0),
                     new TextLoader.Column("SepalWidth", DataKind.R4, 1),
                     new TextLoader.Column("PetalLength", DataKind.R4, 2),
                     new TextLoader.Column("PetalWidth",DataKind.R4, 3),
                     new TextLoader.Column("Label", DataKind.Text, 4)
-                }
-            };
+                };
         }
 
-        private static TextLoader.Arguments MakeSentimentTextLoaderArgs()
+        private static char[] MakeIrisSeparator()
         {
-            return new TextLoader.Arguments()
-            {
-                Separator = "tab",
-                HasHeader = true,
-                Column = new[]
+            return new[] { ',' };
+        }
+
+        private static TextLoader.Column[] MakeSentimentColumns()
+        {
+            return new[]
                 {
                     new TextLoader.Column("Label", DataKind.BL, 0),
                     new TextLoader.Column("SentimentText", DataKind.Text, 1)
-                }
-            };
+                };
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Create the reader: define the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     // A boolean column depicting the 'target label'.
                     IsOver50K: ctx.LoadBool(0),
                     // Three text columns.
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     // We read the first 11 values as a single float vector.
                     FeatureVector: ctx.LoadFloat(0, 10),
                     // Separately, read the target variable.
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     // The four features of the Iris dataset.
                     SepalLength: ctx.LoadFloat(0),
                     SepalWidth: ctx.LoadFloat(1),
@@ -256,7 +256,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     // The four features of the Iris dataset.
                     SepalLength: ctx.LoadFloat(0),
                     SepalWidth: ctx.LoadFloat(1),
@@ -328,7 +328,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     // The four features of the Iris dataset will be grouped together as one Features column.
                     Features: ctx.LoadFloat(0, 3),
                     // Label: kind of iris.
@@ -444,7 +444,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     IsToxic: ctx.LoadBool(0),
                     Message: ctx.LoadText(1)
                 ), hasHeader: true);
@@ -506,7 +506,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     Label: ctx.LoadBool(0),
                     // We will load all the categorical features into one vector column of size 8.
                     CategoricalFeatures: ctx.LoadText(1, 8),
@@ -573,7 +573,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     // The four features of the Iris dataset.
                     SepalLength: ctx.LoadFloat(0),
                     SepalWidth: ctx.LoadFloat(1),
@@ -633,7 +633,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(ctx => (
+            var reader = mlContext.Data.CreateTextReader(ctx => (
                     // The four features of the Iris dataset.
                     SepalLength: ctx.LoadFloat(0),
                     SepalWidth: ctx.LoadFloat(1),

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -41,9 +41,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Create the reader: define the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Column = new[] {
+            var reader = mlContext.Data.TextReader(new[] {
                     // A boolean column depicting the 'label'.
                     new TextLoader.Column("IsOver50K", DataKind.BL, 0),
                     // Three text columns.
@@ -52,8 +50,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("MaritalStatus", DataKind.TX, 3)
                 },
                 // First line of the file is a header, not a data row.
-                HasHeader = true
-            });
+                hasHeader: true
+            );
 
             // Start creating our processing pipeline. For now, let's just concatenate all the text columns
             // together into one.
@@ -93,9 +91,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Column = new[] {
+            var reader = mlContext.Data.TextReader(new[] {
                     // We read the first 11 values as a single float vector.
                     new TextLoader.Column("FeatureVector", DataKind.R4, 0, 10),
 
@@ -103,10 +99,10 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Target", DataKind.R4, 11),
                 },
                 // First line of the file is a header, not a data row.
-                HasHeader = true,
+                true,
                 // Default separator is tab, but we need a semicolon.
-                Separator = ";"
-            });
+                new[] { ';' }
+            );
 
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var trainData = reader.Read(trainDataPath);
@@ -171,9 +167,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Column = new[] {
+            var reader = mlContext.Data.TextReader(new[] {
                     new TextLoader.Column("SepalLength", DataKind.R4, 0),
                     new TextLoader.Column("SepalWidth", DataKind.R4, 1),
                     new TextLoader.Column("PetalLength", DataKind.R4, 2),
@@ -182,8 +176,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Label", DataKind.TX, 4),
                 },
                 // Default separator is tab, but the dataset has comma.
-                Separator = ","
-            });
+                separatorChars: new[] { ',' }
+            );
 
             // Retrieve the training data.
             var trainData = reader.Read(irisDataPath);
@@ -240,17 +234,15 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Column = new[] {
+            var reader = mlContext.Data.TextReader(new[] {
                     // The four features of the Iris dataset will be grouped together as one Features column.
                     new TextLoader.Column("Features", DataKind.R4, 0, 3),
                     // Label: kind of iris.
                     new TextLoader.Column("Label", DataKind.TX, 4),
                 },
                 // Default separator is tab, but the dataset has comma.
-                Separator = ","
-            });
+                separatorChars: new[] { ',' }
+            );
 
             // Read the training data.
             var trainData = reader.Read(dataPath);
@@ -303,14 +295,13 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Column = new[] {
+            var reader = mlContext.Data.TextReader(new[] 
+                {
                     new TextLoader.Column("IsToxic", DataKind.BL, 0),
                     new TextLoader.Column("Message", DataKind.TX, 1),
                 },
-                HasHeader = true
-            });
+                true
+            );
 
             // Read the data.
             var data = reader.Read(dataPath);
@@ -371,9 +362,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Column = new[] {
+            var reader = mlContext.Data.TextReader(new[] 
+                {
                     new TextLoader.Column("Label", DataKind.BL, 0),
                     // We will load all the categorical features into one vector column of size 8.
                     new TextLoader.Column("CategoricalFeatures", DataKind.TX, 1, 8),
@@ -382,8 +372,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     // Let's also separately load the 'Workclass' column.
                     new TextLoader.Column("Workclass", DataKind.TX, 1),
                 },
-                HasHeader = true
-            });
+                true
+            );
 
             // Read the data.
             var data = reader.Read(dataPath);
@@ -436,9 +426,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Column = new[] {
+            var reader = mlContext.Data.TextReader(new[] 
+                {
                     // We read the first 11 values as a single float vector.
                     new TextLoader.Column("SepalLength", DataKind.R4, 0),
                     new TextLoader.Column("SepalWidth", DataKind.R4, 1),
@@ -448,8 +437,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Label", DataKind.TX, 4),
                 },
                 // Default separator is tab, but the dataset has comma.
-                Separator = ","
-            });
+                separatorChars: new[] { ',' }
+            );
 
             // Read the data.
             var data = reader.Read(dataPath);
@@ -505,7 +494,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Target", DataKind.R4, 10)
                 },
                 // Default separator is tab, but we need a comma.
-                s => s.Separator = ",");
+                separatorChars: new[] { ',' });
 
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var data = reader.Read(dataPath);
@@ -527,11 +516,11 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         public void CustomTransformer()
         {
             var mlContext = new MLContext();
-            var data = mlContext.Data.ReadFromTextFile(new[]
+            var data = mlContext.Data.ReadFromTextFile(GetDataPath("adult.tiny.with-schema.txt"), new[]
             {
                 new TextLoader.Column("Income", DataKind.R4, 10),
                 new TextLoader.Column("Features", DataKind.R4, 12, 14)
-            }, GetDataPath("adult.tiny.with-schema.txt"), s => { s.Separator = "\t"; s.HasHeader = true; });
+            }, true);
 
             PrepareData(mlContext, data);
             TrainModel(mlContext, data);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Create the reader: define the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] {
+            var reader = mlContext.Data.CreateTextReader(new[] {
                     // A boolean column depicting the 'label'.
                     new TextLoader.Column("IsOver50K", DataKind.BL, 0),
                     // Three text columns.
@@ -91,7 +91,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] {
+            var reader = mlContext.Data.CreateTextReader(new[] {
                     // We read the first 11 values as a single float vector.
                     new TextLoader.Column("FeatureVector", DataKind.R4, 0, 10),
 
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] {
+            var reader = mlContext.Data.CreateTextReader(new[] {
                     new TextLoader.Column("SepalLength", DataKind.R4, 0),
                     new TextLoader.Column("SepalWidth", DataKind.R4, 1),
                     new TextLoader.Column("PetalLength", DataKind.R4, 2),
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] {
+            var reader = mlContext.Data.CreateTextReader(new[] {
                     // The four features of the Iris dataset will be grouped together as one Features column.
                     new TextLoader.Column("Features", DataKind.R4, 0, 3),
                     // Label: kind of iris.
@@ -295,7 +295,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] 
+            var reader = mlContext.Data.CreateTextReader(new[] 
                 {
                     new TextLoader.Column("IsToxic", DataKind.BL, 0),
                     new TextLoader.Column("Message", DataKind.TX, 1),
@@ -362,7 +362,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] 
+            var reader = mlContext.Data.CreateTextReader(new[] 
                 {
                     new TextLoader.Column("Label", DataKind.BL, 0),
                     // We will load all the categorical features into one vector column of size 8.
@@ -426,7 +426,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Step one: read the data as an IDataView.
             // First, we define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] 
+            var reader = mlContext.Data.CreateTextReader(new[] 
                 {
                     // We read the first 11 values as a single float vector.
                     new TextLoader.Column("SepalLength", DataKind.R4, 0),
@@ -487,7 +487,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Create the reader: define the data columns and where to find them in the text file.
-            var reader = mlContext.Data.TextReader(new[] {
+            var reader = mlContext.Data.CreateTextReader(new[] {
 	                // We read the first 10 values as a single float vector.
                     new TextLoader.Column("FeatureVector", DataKind.R4, new[] {new TextLoader.Range(0, 9)}),
                     // Separately, read the target variable.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -99,9 +99,9 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Target", DataKind.R4, 11),
                 },
                 // First line of the file is a header, not a data row.
-                true,
+                hasHeader: true,
                 // Default separator is tab, but we need a semicolon.
-                new[] { ';' }
+                separatorChar: ';'
             );
 
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
@@ -176,7 +176,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Label", DataKind.TX, 4),
                 },
                 // Default separator is tab, but the dataset has comma.
-                separatorChars: new[] { ',' }
+                separatorChar: ','
             );
 
             // Retrieve the training data.
@@ -241,7 +241,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Label", DataKind.TX, 4),
                 },
                 // Default separator is tab, but the dataset has comma.
-                separatorChars: new[] { ',' }
+                separatorChar: ','
             );
 
             // Read the training data.
@@ -300,7 +300,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("IsToxic", DataKind.BL, 0),
                     new TextLoader.Column("Message", DataKind.TX, 1),
                 },
-                true
+                hasHeader: true
             );
 
             // Read the data.
@@ -372,7 +372,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     // Let's also separately load the 'Workclass' column.
                     new TextLoader.Column("Workclass", DataKind.TX, 1),
                 },
-                true
+                hasHeader: true
             );
 
             // Read the data.
@@ -437,7 +437,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Label", DataKind.TX, 4),
                 },
                 // Default separator is tab, but the dataset has comma.
-                separatorChars: new[] { ',' }
+                separatorChar: ','
             );
 
             // Read the data.
@@ -494,7 +494,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                     new TextLoader.Column("Target", DataKind.R4, 10)
                 },
                 // Default separator is tab, but we need a comma.
-                separatorChars: new[] { ',' });
+                separatorChar: ',' );
 
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var data = reader.Read(dataPath);
@@ -520,7 +520,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             {
                 new TextLoader.Column("Income", DataKind.R4, 10),
                 new TextLoader.Column("Features", DataKind.R4, 12, 14)
-            }, true);
+            }, hasHeader: true);
 
             PrepareData(mlContext, data);
             TrainModel(mlContext, data);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/CrossValidation.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/CrossValidation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
 
-            var data = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
+            var data = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")
                     .Append(ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: (s) => { s.ConvergenceTolerance = 1f; s.NumThreads = 1; }));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/CrossValidation.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/CrossValidation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
 
-            var data = ml.Data.TextReader(MakeSentimentColumns(), true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
+            var data = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")
                     .Append(ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: (s) => { s.ConvergenceTolerance = 1f; s.NumThreads = 1; }));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/CrossValidation.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/CrossValidation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
 
-            var data = ml.Data.TextReader(MakeSentimentTextLoaderArgs()).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
+            var data = ml.Data.TextReader(MakeSentimentColumns(), true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")
                     .Append(ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: (s) => { s.ConvergenceTolerance = 1f; s.NumThreads = 1; }));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var ml = new MLContext();
 
-            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChars: MakeIrisSeparator())
+            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChar: ',')
                     .Read(dataPath);
 
             var pipeline = new ColumnConcatenatingEstimator (ml, "Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.MakePredictionFunction<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChars: MakeIrisSeparator());
+            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChar: ',');
             var testData = testLoader.AsEnumerable<IrisData>(ml, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var ml = new MLContext();
 
-            var data = ml.Data.TextReader(MakeIrisTextLoaderArgs())
+            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChars: MakeIrisSeparator())
                     .Read(dataPath);
 
             var pipeline = new ColumnConcatenatingEstimator (ml, "Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.MakePredictionFunction<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = TextLoader.ReadFile(ml, MakeIrisTextLoaderArgs(), new MultiFileSource(dataPath));
+            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChars: MakeIrisSeparator());
             var testData = testLoader.AsEnumerable<IrisData>(ml, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var ml = new MLContext();
 
-            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChar: ',')
+            var data = ml.Data.CreateTextReader(MakeIrisColumns(), separatorChar: ',')
                     .Read(dataPath);
 
             var pipeline = new ColumnConcatenatingEstimator (ml, "Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.MakePredictionFunction<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChar: ',');
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, MakeIrisColumns(), separatorChar: ',');
             var testData = testLoader.AsEnumerable<IrisData>(ml, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Evaluation.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Evaluation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var ml = new MLContext(seed: 1, conc: 1);
 
             // Pipeline.
-            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), true)
+            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features"))
                 .Append(ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: s => s.NumThreads = 1));
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Evaluation.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Evaluation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var ml = new MLContext(seed: 1, conc: 1);
 
             // Pipeline.
-            var pipeline = ml.Data.TextReader(MakeSentimentTextLoaderArgs())
+            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features"))
                 .Append(ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: s => s.NumThreads = 1));
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Evaluation.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Evaluation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var ml = new MLContext(seed: 1, conc: 1);
 
             // Pipeline.
-            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
+            var pipeline = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features"))
                 .Append(ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: s => s.NumThreads = 1));
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
 
             var ml = new MLContext();
-            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChars: MakeIrisSeparator())
+            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChar: ',')
                 .Read(dataPath);
 
             Action<IrisData, IrisData> action = (i, j) =>
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.MakePredictionFunction<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChars: MakeIrisSeparator());
+            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChar: ',');
             var testData = testLoader.AsEnumerable<IrisData>(ml, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
 
             var ml = new MLContext();
-            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChar: ',')
+            var data = ml.Data.CreateTextReader(MakeIrisColumns(), separatorChar: ',')
                 .Read(dataPath);
 
             Action<IrisData, IrisData> action = (i, j) =>
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.MakePredictionFunction<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChar: ',');
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, MakeIrisColumns(), separatorChar: ',');
             var testData = testLoader.AsEnumerable<IrisData>(ml, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
 
             var ml = new MLContext();
-            var data = ml.Data.TextReader(MakeIrisTextLoaderArgs())
+            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChars: MakeIrisSeparator())
                 .Read(dataPath);
 
             Action<IrisData, IrisData> action = (i, j) =>
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.MakePredictionFunction<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = TextLoader.ReadFile(ml, MakeIrisTextLoaderArgs(), new MultiFileSource(dataPath));
+            var testLoader = TextLoader.ReadFile(ml, new MultiFileSource(dataPath), MakeIrisColumns(), separatorChars: MakeIrisSeparator());
             var testData = testLoader.AsEnumerable<IrisData>(ml, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/FileBasedSavingOfData.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/FileBasedSavingOfData.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var ml = new MLContext(seed: 1, conc: 1);
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));
-            var trainData = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
+            var trainData = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features"))
                 .Fit(src).Read(src);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/FileBasedSavingOfData.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/FileBasedSavingOfData.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var ml = new MLContext(seed: 1, conc: 1);
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));
-            var trainData = ml.Data.TextReader(MakeSentimentTextLoaderArgs())
+            var trainData = ml.Data.TextReader(MakeSentimentColumns(), true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features"))
                 .Fit(src).Read(src);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/FileBasedSavingOfData.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/FileBasedSavingOfData.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var ml = new MLContext(seed: 1, conc: 1);
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));
-            var trainData = ml.Data.TextReader(MakeSentimentColumns(), true)
+            var trainData = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features"))
                 .Fit(src).Read(src);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_IntrospectiveTraining()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var data = ml.Data.TextReader(MakeSentimentTextLoaderArgs())
+            var data = ml.Data.TextReader(MakeSentimentColumns(), true)
                 .Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_IntrospectiveTraining()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var data = ml.Data.TextReader(MakeSentimentColumns(), true)
+            var data = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
                 .Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_IntrospectiveTraining()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var data = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
+            var data = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true)
                 .Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_Metacomponents()
         {
             var ml = new MLContext();
-            var data = ml.Data.TextReader(MakeIrisTextLoaderArgs())
+            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChars: MakeIrisSeparator())
                 .Read(GetDataPath(TestDatasets.irisData.trainFilename));
 
             var sdcaTrainer = ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: (s) => { s.MaxIterations = 100; s.Shuffle = true; s.NumThreads = 1; });

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_Metacomponents()
         {
             var ml = new MLContext();
-            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChar: ',')
+            var data = ml.Data.CreateTextReader(MakeIrisColumns(), separatorChar: ',')
                 .Read(GetDataPath(TestDatasets.irisData.trainFilename));
 
             var sdcaTrainer = ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: (s) => { s.MaxIterations = 100; s.Shuffle = true; s.NumThreads = 1; });

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_Metacomponents()
         {
             var ml = new MLContext();
-            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChars: MakeIrisSeparator())
+            var data = ml.Data.TextReader(MakeIrisColumns(), separatorChar: ',')
                 .Read(GetDataPath(TestDatasets.irisData.trainFilename));
 
             var sdcaTrainer = ml.BinaryClassification.Trainers.StochasticDualCoordinateAscent("Label", "Features", advancedSettings: (s) => { s.MaxIterations = 100; s.Shuffle = true; s.NumThreads = 1; });

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         void New_MultithreadedPrediction()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentTextLoaderArgs());
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
             var data = reader.Read(new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename)));
 
             // Pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         void New_MultithreadedPrediction()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
+            var reader = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true);
             var data = reader.Read(new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename)));
 
             // Pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         void New_MultithreadedPrediction()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
             var data = reader.Read(new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename)));
 
             // Pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/ReconfigurablePrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/ReconfigurablePrediction.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_ReconfigurablePrediction()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var dataReader = ml.Data.TextReader(MakeSentimentTextLoaderArgs());
+            var dataReader = ml.Data.TextReader(MakeSentimentColumns(), true);
 
             var data = dataReader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             var testData = dataReader.Read(GetDataPath(TestDatasets.Sentiment.testFilename));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/ReconfigurablePrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/ReconfigurablePrediction.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_ReconfigurablePrediction()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var dataReader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
+            var dataReader = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true);
 
             var data = dataReader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             var testData = dataReader.Read(GetDataPath(TestDatasets.Sentiment.testFilename));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/ReconfigurablePrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/ReconfigurablePrediction.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_ReconfigurablePrediction()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var dataReader = ml.Data.TextReader(MakeSentimentColumns(), true);
+            var dataReader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
 
             var data = dataReader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             var testData = dataReader.Read(GetDataPath(TestDatasets.Sentiment.testFilename));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_SimpleTrainAndPredict()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
+            var reader = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true);
             var data = reader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_SimpleTrainAndPredict()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentTextLoaderArgs());
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
             var data = reader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_SimpleTrainAndPredict()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
             var data = reader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features")

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_TrainSaveModelAndPredict()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentTextLoaderArgs());
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
             var data = reader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             // Pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_TrainSaveModelAndPredict()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
             var data = reader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             // Pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void New_TrainSaveModelAndPredict()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
+            var reader = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true);
             var data = reader.Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             // Pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var ml = new MLContext(seed: 1, conc: 1);
 
-            var data = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
+            var data = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features");

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var ml = new MLContext(seed: 1, conc: 1);
 
-            var data = ml.Data.TextReader(MakeSentimentColumns(), true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
+            var data = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features");

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var ml = new MLContext(seed: 1, conc: 1);
 
-            var data = ml.Data.TextReader(MakeSentimentTextLoaderArgs()).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
+            var data = ml.Data.TextReader(MakeSentimentColumns(), true).Read(GetDataPath(TestDatasets.Sentiment.trainFilename));
 
             // Pipeline.
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features");

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithValidationSet.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithValidationSet.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
             // Pipeline.
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features");
 
             // Train the pipeline, prepare train and validation set.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithValidationSet.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithValidationSet.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
             // Pipeline.
-            var reader = ml.Data.TextReader(MakeSentimentTextLoaderArgs());
+            var reader = ml.Data.TextReader(MakeSentimentColumns(), true);
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features");
 
             // Train the pipeline, prepare train and validation set.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithValidationSet.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithValidationSet.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
             // Pipeline.
-            var reader = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true);
+            var reader = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true);
             var pipeline = ml.Transforms.Text.FeaturizeText("SentimentText", "Features");
 
             // Train the pipeline, prepare train and validation set.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         void New_Visibility()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
+            var pipeline = ml.Data.CreateTextReader(MakeSentimentColumns(), hasHeader: true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features", s => s.OutputTokens = true));
 
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         void New_Visibility()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var pipeline = ml.Data.TextReader(MakeSentimentTextLoaderArgs())
+            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features", s => s.OutputTokens = true));
 
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         void New_Visibility()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), true)
+            var pipeline = ml.Data.TextReader(MakeSentimentColumns(), hasHeader: true)
                 .Append(ml.Transforms.Text.FeaturizeText("SentimentText", "Features", s => s.OutputTokens = true));
 
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -26,10 +26,7 @@ namespace Microsoft.ML.Scenarios
         {
             var mlContext = new MLContext(seed: 1, conc: 1);
 
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments()
-            {
-                HasHeader = false,
-                Column = new[]
+            var reader = mlContext.Data.TextReader(columns: new[]
                 {
                     new TextLoader.Column("Label", DataKind.R4, 0),
                     new TextLoader.Column("SepalLength", DataKind.R4, 1),
@@ -37,7 +34,7 @@ namespace Microsoft.ML.Scenarios
                     new TextLoader.Column("PetalLength", DataKind.R4, 3),
                     new TextLoader.Column("PetalWidth", DataKind.R4, 4)
                 }
-            });
+            );
 
             var pipe = mlContext.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(mlContext.Transforms.Normalize("Features"))

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Scenarios
         {
             var mlContext = new MLContext(seed: 1, conc: 1);
 
-            var reader = mlContext.Data.TextReader(columns: new[]
+            var reader = mlContext.Data.CreateTextReader(columns: new[]
                 {
                     new TextLoader.Column("Label", DataKind.R4, 0),
                     new TextLoader.Column("SepalLength", DataKind.R4, 1),

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
@@ -25,17 +25,14 @@ namespace Microsoft.ML.Scenarios
 
             var env = new MLContext(seed: 1, conc: 1);
             // Pipeline
-            var loader = TextLoader.ReadFile(env,
-                new TextLoader.Arguments()
+            var loader = TextLoader.ReadFile(env, new MultiFileSource(dataPath),
+                columns: new[]
                 {
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
-                    {
-                        new TextLoader.Column("Label", DataKind.Num, 0),
-                        new TextLoader.Column("SentimentText", DataKind.Text, 1)
-                    }
-                }, new MultiFileSource(dataPath));
+                    new TextLoader.Column("Label", DataKind.Num, 0),
+                    new TextLoader.Column("SentimentText", DataKind.Text, 1)
+                },
+                hasHeader: true
+            );
 
             var trans = TextFeaturizingEstimator.Create(env, new TextFeaturizingEstimator.Arguments()
             {
@@ -86,17 +83,14 @@ namespace Microsoft.ML.Scenarios
 
             var env = new MLContext(seed: 1, conc: 1);
             // Pipeline
-            var loader = TextLoader.ReadFile(env,
-                new TextLoader.Arguments()
+            var loader = TextLoader.ReadFile(env, new MultiFileSource(dataPath),
+                columns: new[]
                 {
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
-                    {
-                        new TextLoader.Column("Label", DataKind.Num, 0),
-                        new TextLoader.Column("SentimentText", DataKind.Text, 1)
-                    }
-                }, new MultiFileSource(dataPath));
+                    new TextLoader.Column("Label", DataKind.Num, 0),
+                    new TextLoader.Column("SentimentText", DataKind.Text, 1)
+                },
+                hasHeader: true 
+            );
 
             var text = TextFeaturizingEstimator.Create(env, new TextFeaturizingEstimator.Arguments()
             {

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Scenarios
 
             var env = new MLContext(seed: 1, conc: 1);
             // Pipeline
-            var loader = TextLoader.ReadFile(env, new MultiFileSource(dataPath),
+            var loader = env.Data.ReadFromTextFile(dataPath,
                 columns: new[]
                 {
                     new TextLoader.Column("Label", DataKind.Num, 0),
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Scenarios
 
             var env = new MLContext(seed: 1, conc: 1);
             // Pipeline
-            var loader = TextLoader.ReadFile(env, new MultiFileSource(dataPath),
+            var loader = env.Data.ReadFromTextFile(dataPath,
                 columns: new[]
                 {
                     new TextLoader.Column("Label", DataKind.Num, 0),

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -258,17 +258,14 @@ namespace Microsoft.ML.Scenarios
         {
             var mlContext = new MLContext(seed: 1, conc: 1);
             var reader = mlContext.Data.TextReader(
-                new TextLoader.Arguments()
-                {
-                    Separator = "tab",
-                    HasHeader = true,
-                    Column = new[]
+                    columns: new[]
                     {
                         new TextLoader.Column("Label", DataKind.U4 , new [] { new TextLoader.Range(0) }, new KeyRange(0, 9)),
                         new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
 
-                    }
-                });
+                    },
+                    hasHeader: true
+                );
 
             var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
             var testData = reader.Read(GetDataPath(TestDatasets.mnistOneClass.testFilename));
@@ -303,17 +300,12 @@ namespace Microsoft.ML.Scenarios
             try
             {
                 var mlContext = new MLContext(seed: 1, conc: 1);
-                var reader = mlContext.Data.TextReader(
-                    new TextLoader.Arguments
-                    {
-                        Separator = "tab",
-                        HasHeader = false,
-                        Column = new[]
+                var reader = mlContext.Data.TextReader(columns: new[]
                         {
                             new TextLoader.Column("Label", DataKind.I8, 0),
                             new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
                         }
-                    });
+                    );
 
                 var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
                 var testData = reader.Read(GetDataPath(TestDatasets.mnistOneClass.testFilename));
@@ -398,17 +390,13 @@ namespace Microsoft.ML.Scenarios
             {
                 var mlContext = new MLContext(seed: 1, conc: 1);
 
-                var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-                {
-                    Separator = "tab",
-                    HasHeader = false,
-                    Column = new[]
+                var reader = mlContext.Data.TextReader(new[]
                     {
                         new TextLoader.Column("Label", DataKind.U4, new []{ new TextLoader.Range(0) }, new KeyRange(0, 9)),
                         new TextLoader.Column("TfLabel", DataKind.I8, 0),
                         new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
                     }
-                });
+                );
 
                 var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
                 var testData = reader.Read(GetDataPath(TestDatasets.mnistOneClass.testFilename));
@@ -491,16 +479,13 @@ namespace Microsoft.ML.Scenarios
             // of predicted label of a single in-memory example.
 
             var mlContext = new MLContext(seed: 1, conc: 1);
-            var reader = mlContext.Data.TextReader(new TextLoader.Arguments
-            {
-                Separator = "tab",
-                HasHeader = true,
-                Column = new[]
+            var reader = mlContext.Data.TextReader(columns: new[]
                 {
                     new TextLoader.Column("Label", DataKind.U4 , new [] { new TextLoader.Range(0) }, new KeyRange(0, 9)),
                     new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
-                }
-            });
+                },
+                hasHeader: true
+            );
 
             var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
             var testData = reader.Read(GetDataPath(TestDatasets.mnistOneClass.testFilename));
@@ -625,14 +610,13 @@ namespace Microsoft.ML.Scenarios
 
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
-            var data = TextLoader.Create(mlContext, new TextLoader.Arguments()
-            {
-                Column = new[]
-                {
+            var data = TextLoader.ReadFile(mlContext, new MultiFileSource(dataFile),
+                    columns: new[]
+                    {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
                         new TextLoader.Column("Name", DataKind.TX, 1),
-                    }
-            }, new MultiFileSource(dataFile));
+                    } 
+                );
 
             var pipeEstimator = new ImageLoadingEstimator(mlContext, imageFolder, ("ImagePath", "ImageReal"))
                 .Append(new ImageResizingEstimator(mlContext, "ImageReal", "ImageCropped", imageWidth, imageHeight))
@@ -673,14 +657,12 @@ namespace Microsoft.ML.Scenarios
 
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
-            var data = TextLoader.Create(mlContext, new TextLoader.Arguments()
-            {
-                Column = new[]
+            var data = TextLoader.ReadFile(mlContext, new MultiFileSource(dataFile), columns: new[]
                 {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
                         new TextLoader.Column("Name", DataKind.TX, 1),
-                    }
-            }, new MultiFileSource(dataFile));
+                }
+            );
             var images = ImageLoaderTransform.Create(mlContext, new ImageLoaderTransform.Arguments()
             {
                 Column = new ImageLoaderTransform.Column[1]
@@ -732,14 +714,13 @@ namespace Microsoft.ML.Scenarios
             var imageWidth = 28;
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
-            var data = TextLoader.Create(mlContext, new TextLoader.Arguments()
-            {
-                Column = new[]
+            var data = TextLoader.ReadFile(mlContext, new MultiFileSource(dataFile), 
+                columns: new[]
                 {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
                         new TextLoader.Column("Name", DataKind.TX, 1),
-                    }
-            }, new MultiFileSource(dataFile));
+                }
+            );
             var images = ImageLoaderTransform.Create(mlContext, new ImageLoaderTransform.Arguments()
             {
                 Column = new ImageLoaderTransform.Column[1]

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Scenarios
         public void TensorFlowTransformMNISTConvTest()
         {
             var mlContext = new MLContext(seed: 1, conc: 1);
-            var reader = mlContext.Data.TextReader(
+            var reader = mlContext.Data.CreateTextReader(
                     columns: new[]
                     {
                         new TextLoader.Column("Label", DataKind.U4 , new [] { new TextLoader.Range(0) }, new KeyRange(0, 9)),
@@ -300,7 +300,7 @@ namespace Microsoft.ML.Scenarios
             try
             {
                 var mlContext = new MLContext(seed: 1, conc: 1);
-                var reader = mlContext.Data.TextReader(columns: new[]
+                var reader = mlContext.Data.CreateTextReader(columns: new[]
                         {
                             new TextLoader.Column("Label", DataKind.I8, 0),
                             new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
@@ -390,7 +390,7 @@ namespace Microsoft.ML.Scenarios
             {
                 var mlContext = new MLContext(seed: 1, conc: 1);
 
-                var reader = mlContext.Data.TextReader(new[]
+                var reader = mlContext.Data.CreateTextReader(new[]
                     {
                         new TextLoader.Column("Label", DataKind.U4, new []{ new TextLoader.Range(0) }, new KeyRange(0, 9)),
                         new TextLoader.Column("TfLabel", DataKind.I8, 0),
@@ -479,7 +479,7 @@ namespace Microsoft.ML.Scenarios
             // of predicted label of a single in-memory example.
 
             var mlContext = new MLContext(seed: 1, conc: 1);
-            var reader = mlContext.Data.TextReader(columns: new[]
+            var reader = mlContext.Data.CreateTextReader(columns: new[]
                 {
                     new TextLoader.Column("Label", DataKind.U4 , new [] { new TextLoader.Range(0) }, new KeyRange(0, 9)),
                     new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
@@ -610,7 +610,7 @@ namespace Microsoft.ML.Scenarios
 
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
-            var data = TextLoader.ReadFile(mlContext, new MultiFileSource(dataFile),
+            var data = mlContext.Data.ReadFromTextFile(dataFile,
                     columns: new[]
                     {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
@@ -657,7 +657,7 @@ namespace Microsoft.ML.Scenarios
 
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
-            var data = TextLoader.ReadFile(mlContext, new MultiFileSource(dataFile), columns: new[]
+            var data = mlContext.Data.ReadFromTextFile(dataFile, columns: new[]
                 {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
                         new TextLoader.Column("Name", DataKind.TX, 1),
@@ -714,7 +714,7 @@ namespace Microsoft.ML.Scenarios
             var imageWidth = 28;
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
-            var data = TextLoader.ReadFile(mlContext, new MultiFileSource(dataFile), 
+            var data = mlContext.Data.ReadFromTextFile(dataFile, 
                 columns: new[]
                 {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Tests.Transformers
             var loader = ML.Data.TextReader(new[] {
                     new TextLoader.Column("Float1", DataKind.R4, 9),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(9), new TextLoader.Range(10), new TextLoader.Range(11), new TextLoader.Range(12) })
-            }, s => { s.Separator = "\t"; s.HasHeader = true; });
+            }, hasHeader: true);
 
             var data = loader.Read(source);
 
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new TextLoader.Column("Float1", DataKind.R4, 0),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(0), new TextLoader.Range(2), new TextLoader.Range(4), new TextLoader.Range(10) }),
                     new TextLoader.Column("Text1", DataKind.Text, 0)
-            }, s => { s.Separator = ","; s.HasHeader = true; });
+            }, hasHeader: true, separatorChars: new[] { ',' });
 
             var data = loader.Read(source);
 

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new TextLoader.Column("Float1", DataKind.R4, 0),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(0), new TextLoader.Range(2), new TextLoader.Range(4), new TextLoader.Range(10) }),
                     new TextLoader.Column("Text1", DataKind.Text, 0)
-            }, hasHeader: true, separatorChars: new[] { ',' });
+            }, hasHeader: true, separatorChar: ',' );
 
             var data = loader.Read(source);
 

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Tests.Transformers
         {
             string dataPath = GetDataPath("adult.tiny.with-schema.txt");
             var source = new MultiFileSource(dataPath);
-            var loader = ML.Data.TextReader(new[] {
+            var loader = ML.Data.CreateTextReader(new[] {
                     new TextLoader.Column("Float1", DataKind.R4, 9),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(9), new TextLoader.Range(10), new TextLoader.Range(11), new TextLoader.Range(12) })
             }, hasHeader: true);
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Tests.Transformers
         {
             string dataPath = GetDataPath("adult.test");
             var source = new MultiFileSource(dataPath);
-            var loader = ML.Data.TextReader(new[] {
+            var loader = ML.Data.CreateTextReader(new[] {
                     new TextLoader.Column("Float1", DataKind.R4, 0),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(0), new TextLoader.Range(2), new TextLoader.Range(4), new TextLoader.Range(10) }),
                     new TextLoader.Column("Text1", DataKind.Text, 0)


### PR DESCRIPTION
Fixes #1611.

1. Hid the constructor of `TextLoader` that takes Arguments, and exposed `HasHeader` and `SeparatorChars` as non-advanced parameters. 
2. Made Create methods internal and modified the code accordingly. 
3. Added comments for the public facing constructor that was retained.