### PR TITLE
Allow ML.NET native binaries to work on Windows machines that don't have the VC runtime installed.

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -18,6 +18,9 @@ if(WIN32)
     add_compile_options($<$<CONFIG:Release>:-DNDEBUG>)
     add_compile_options($<$<CONFIG:RelWithDebInfo>:-DNDEBUG>)
     add_compile_options($<$<CONFIG:Debug>:/Od>)
+    add_compile_options($<$<CONFIG:Debug>:/MTd>) # /MT will static link the VC runtime library, so it doesn't need to be installed on the target machine
+    add_compile_options($<$<CONFIG:Release>:/MT>)
+    add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
     add_compile_options(/guard:cf) 
     add_compile_options(/d2Zi+) # make optimized builds debugging easier
     add_compile_options(/nologo) # Suppress Startup Banner
@@ -62,6 +65,8 @@ if(WIN32)
     list(APPEND RESOURCES ${CMAKE_SOURCE_DIR}/../../Tools/NativeVersion.rc)
 else()
     add_compile_options(-Wno-unused-local-typedef)
+    add_compile_options(-fPIC)
+    add_compile_options(-fvisibility=hidden)
     add_definitions(-Werror) # treat warnings as errors
 endif()
 


### PR DESCRIPTION
This allows ML.NET to run on Windows Nano containers.

I also ported 2 Unix compile options we are using in core-setup and corefx that were missed when originally creating the ML.NET native build infrastructure.

Fix #1823
