### PR TITLE
Tolerance added for rff tests

### DIFF
--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -1164,12 +1164,10 @@ namespace Microsoft.ML.Runtime.RunTests
             return FloatUtils.GetBits(x) == FloatUtils.GetBits(y) || CompareNumbersWithTolerance(x, y, null, 3);
         }
 
-        private const float SingleEps = 1e-6f;
-
-        private static bool EqualWithEpsSingle(float x, float y)
+        private bool EqualWithEpsSingle(float x, float y)
         {
             // bitwise comparison is needed because Abs(Inf-Inf) and Abs(NaN-NaN) are not 0s.
-            return FloatUtils.GetBits(x) == FloatUtils.GetBits(y) || Math.Abs(x - y) < SingleEps;
+            return FloatUtils.GetBits(x) == FloatUtils.GetBits(y) || CompareNumbersWithTolerance(x, y, null, 3);
         }
 
         protected Func<bool> GetComparerOne<T>(Row r1, Row r2, int col, Func<T, T, bool> fn)

--- a/test/Microsoft.ML.Tests/Transformers/RffTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/RffTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Tests.Transformers
             public int A;
         }
 
-        [ConditionalFact(typeof(BaseTestBaseline), nameof(BaseTestBaseline.LessThanNetCore30OrNotNetCore))] // netcore3.0 output differs from Baseline
+        [Fact]
         public void RffWorkout()
         {
             Random rand = new Random();


### PR DESCRIPTION
Fixes #1825

Rff is using the new cpumathalgorithm for matrix multiplication
So sometimes there is difference in last few decimal places(due to different number of multiplications) from the original baseline so adding tolerance corrects the error.
