### PR TITLE
Adding support for most learning tasks to PFI

### DIFF
--- a/src/Microsoft.ML.Data/Evaluators/Metrics/ClusteringMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/ClusteringMetrics.cs
@@ -45,5 +45,12 @@ namespace Microsoft.ML.Data
             if (calculateDbi)
                 Dbi = Fetch(ClusteringEvaluator.Dbi);
         }
+
+        internal ClusteringMetrics(double nmi, double avgMinScore, double dbi)
+        {
+            Nmi = nmi;
+            AvgMinScore = avgMinScore;
+            Dbi = dbi;
+        }
     }
 }

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/MultiClassClassifierMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/MultiClassClassifierMetrics.cs
@@ -96,5 +96,18 @@ namespace Microsoft.ML.Data
             PerClassLogLoss = new double[perClassLogLoss.Length];
             perClassLogLoss.CopyTo(PerClassLogLoss);
         }
+
+        internal MultiClassClassifierMetrics(double accuracyMicro, double accuracyMacro, double logLoss, double logLossReduction,
+            int topK, double topKAccuracy, double[] perClassLogLoss)
+        {
+            AccuracyMicro = accuracyMicro;
+            AccuracyMacro = accuracyMacro;
+            LogLoss = logLoss;
+            LogLossReduction = logLossReduction;
+            TopK = topK;
+            TopKAccuracy = topKAccuracy;
+            PerClassLogLoss = new double[perClassLogLoss.Length];
+            perClassLogLoss.CopyTo(PerClassLogLoss, 0);
+        }
     }
 }

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/RankerMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/RankerMetrics.cs
@@ -40,5 +40,13 @@ namespace Microsoft.ML.Data
             Dcg = Fetch(RankerEvaluator.Dcg).GetValues().ToArray();
             Ndcg = Fetch(RankerEvaluator.Ndcg).GetValues().ToArray();
         }
+
+        internal RankerMetrics(double[] dcg, double[] ndcg)
+        {
+            Dcg = new double[dcg.Length];
+            dcg.CopyTo(Dcg, 0);
+            Ndcg = new double[ndcg.Length];
+            ndcg.CopyTo(Ndcg, 0);
+        }
     }
 }

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML
         /// <param name="model">The model to evaluate.</param>
         /// <param name="data">The evaluation data set.</param>
         /// <param name="label">Label column name.</param>
-        /// <param name="features">Feature column names.</param>
+        /// <param name="features">Feature column name.</param>
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
         /// <returns>Array of per-feature 'contributions' to the score.</returns>
@@ -124,7 +124,7 @@ namespace Microsoft.ML
         /// <param name="model">The model to evaluate.</param>
         /// <param name="data">The evaluation data set.</param>
         /// <param name="label">Label column name.</param>
-        /// <param name="features">Feature column names.</param>
+        /// <param name="features">Feature column name.</param>
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
         /// <returns>Array of per-feature 'contributions' to the score.</returns>
@@ -202,7 +202,7 @@ namespace Microsoft.ML
         /// <param name="model">The model to evaluate.</param>
         /// <param name="data">The evaluation data set.</param>
         /// <param name="label">Label column name.</param>
-        /// <param name="features">Feature column names.</param>
+        /// <param name="features">Feature column name.</param>
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
         /// <returns>Array of per-feature 'contributions' to the score.</returns>
@@ -286,7 +286,7 @@ namespace Microsoft.ML
         /// <param name="data">The evaluation data set.</param>
         /// <param name="label">Label column name.</param>
         /// <param name="groupId">GroupId column name</param>
-        /// <param name="features">Feature column names.</param>
+        /// <param name="features">Feature column name.</param>
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
         /// <returns>Array of per-feature 'contributions' to the score.</returns>
@@ -360,7 +360,7 @@ namespace Microsoft.ML
         /// <param name="model">The model to evaluate.</param>
         /// <param name="data">The evaluation data set.</param>
         /// <param name="label">Label column name.</param>
-        /// <param name="features">Feature column names.</param>
+        /// <param name="features">Feature column name.</param>
         /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
         /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
         /// <returns>Array of per-feature 'contributions' to the score.</returns>

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Transforms;
+using System;
 using System.Collections.Immutable;
 
 namespace Microsoft.ML
@@ -26,7 +27,7 @@ namespace Microsoft.ML
         /// <para>
         /// PFI works by taking a labeled dataset, choosing a feature, and permuting the values
         /// for that feature across all the examples, so that each example now has a random value for the feature and
-        /// the original values for all other features. The evalution metric (e.g. AUC or R-squared) is then calculated
+        /// the original values for all other features. The evalution metric (e.g. R-squared) is then calculated
         /// for this modified dataset, and the change in the evaluation metric from the original dataset is computed.
         /// The larger the change in the evaluation metric, the more important the feature is to the model.
         /// PFI works by performing this permutation analysis across all the features of a model, one after another.
@@ -98,7 +99,7 @@ namespace Microsoft.ML
         /// <para>
         /// PFI works by taking a labeled dataset, choosing a feature, and permuting the values
         /// for that feature across all the examples, so that each example now has a random value for the feature and
-        /// the original values for all other features. The evalution metric (e.g. AUC or R-squared) is then calculated
+        /// the original values for all other features. The evalution metric (e.g. AUC) is then calculated
         /// for this modified dataset, and the change in the evaluation metric from the original dataset is computed.
         /// The larger the change in the evaluation metric, the more important the feature is to the model.
         /// PFI works by performing this permutation analysis across all the features of a model, one after another.
@@ -157,6 +158,238 @@ namespace Microsoft.ML
                 negativeRecall: a.NegativeRecall - b.NegativeRecall,
                 f1Score: a.F1Score - b.F1Score,
                 auprc: a.Auprc - b.Auprc);
+        }
+
+        /// <summary>
+        /// Permutation Feature Importance (PFI) for MulticlassClassification
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Permutation feature importance (PFI) is a technique to determine the global importance of features in a trained
+        /// machine learning model. PFI is a simple yet powerful technique motivated by Breiman in his Random Forest paper, section 10
+        /// (Breiman. <a href='https://www.stat.berkeley.edu/~breiman/randomforest2001.pdf'>&quot;Random Forests.&quot;</a> Machine Learning, 2001.)
+        /// The advantage of the PFI method is that it is model agnostic -- it works with any model that can be
+        /// evaluated -- and it can use any dataset, not just the training set, to compute feature importance metrics.
+        /// </para>
+        /// <para>
+        /// PFI works by taking a labeled dataset, choosing a feature, and permuting the values
+        /// for that feature across all the examples, so that each example now has a random value for the feature and
+        /// the original values for all other features. The evalution metric (e.g. micro-accuracy) is then calculated
+        /// for this modified dataset, and the change in the evaluation metric from the original dataset is computed.
+        /// The larger the change in the evaluation metric, the more important the feature is to the model.
+        /// PFI works by performing this permutation analysis across all the features of a model, one after another.
+        /// </para>
+        /// <para>
+        /// In this implementation, PFI computes the change in all possible multiclass classification evaluation metrics for each feature, and an
+        /// <code>ImmutableArray</code> of <code>MultiClassClassifierMetrics</code> objects is returned. See the sample below for an
+        /// example of working with these results to analyze the feature importance of a model.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[PFI](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        /// <param name="ctx">The clustering context.</param>
+        /// <param name="model">The model to evaluate.</param>
+        /// <param name="data">The evaluation data set.</param>
+        /// <param name="label">Label column name.</param>
+        /// <param name="features">Feature column names.</param>
+        /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
+        /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
+        /// <returns>Array of per-feature 'contributions' to the score.</returns>
+        public static ImmutableArray<MultiClassClassifierMetrics>
+            PermutationFeatureImportance(
+                this MulticlassClassificationContext ctx,
+                IPredictionTransformer<IPredictor> model,
+                IDataView data,
+                string label = DefaultColumnNames.Label,
+                string features = DefaultColumnNames.Features,
+                bool useFeatureWeightFilter = false,
+                int? topExamples = null)
+        {
+            return PermutationFeatureImportance<MultiClassClassifierMetrics>.GetImportanceMetricsMatrix(
+                            CatalogUtils.GetEnvironment(ctx),
+                            model,
+                            data,
+                            idv => ctx.Evaluate(idv, label),
+                            MulticlassClassificationDelta,
+                            features,
+                            useFeatureWeightFilter,
+                            topExamples);
+        }
+
+        private static MultiClassClassifierMetrics MulticlassClassificationDelta(
+            MultiClassClassifierMetrics a, MultiClassClassifierMetrics b)
+        {
+            if (a.TopK != b.TopK || a.PerClassLogLoss.Length != b.PerClassLogLoss.Length)
+                throw new ArgumentException($"Can't compare {nameof(MultiClassClassifierMetrics)} with different class counts or TopK.");
+
+            var perClassLogLoss = new double[a.PerClassLogLoss.Length];
+            for (int i = 0; i < perClassLogLoss.Length; i++)
+                perClassLogLoss[i] = a.PerClassLogLoss[i] - b.PerClassLogLoss[i];
+
+            //perClassLogLoss.CopyTo(PerClassLogLoss, 0);
+            return new MultiClassClassifierMetrics(
+                accuracyMicro: a.AccuracyMicro - b.AccuracyMicro,
+                accuracyMacro: a.AccuracyMacro - b.AccuracyMacro,
+                logLoss: a.LogLoss - b.LogLoss,
+                logLossReduction: a.LogLossReduction - b.LogLossReduction,
+                topK: a.TopK,
+                topKAccuracy: a.TopKAccuracy - b.TopKAccuracy,
+                perClassLogLoss: perClassLogLoss
+                );
+        }
+
+        /// <summary>
+        /// Permutation Feature Importance (PFI) for Ranking
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Permutation feature importance (PFI) is a technique to determine the global importance of features in a trained
+        /// machine learning model. PFI is a simple yet powerful technique motivated by Breiman in his Random Forest paper, section 10
+        /// (Breiman. <a href='https://www.stat.berkeley.edu/~breiman/randomforest2001.pdf'>&quot;Random Forests.&quot;</a> Machine Learning, 2001.)
+        /// The advantage of the PFI method is that it is model agnostic -- it works with any model that can be
+        /// evaluated -- and it can use any dataset, not just the training set, to compute feature importance metrics.
+        /// </para>
+        /// <para>
+        /// PFI works by taking a labeled dataset, choosing a feature, and permuting the values
+        /// for that feature across all the examples, so that each example now has a random value for the feature and
+        /// the original values for all other features. The evalution metric (e.g. NDCG) is then calculated
+        /// for this modified dataset, and the change in the evaluation metric from the original dataset is computed.
+        /// The larger the change in the evaluation metric, the more important the feature is to the model.
+        /// PFI works by performing this permutation analysis across all the features of a model, one after another.
+        /// </para>
+        /// <para>
+        /// In this implementation, PFI computes the change in all possible ranking evaluation metrics for each feature, and an
+        /// <code>ImmutableArray</code> of <code>RankingMetrics</code> objects is returned. See the sample below for an
+        /// example of working with these results to analyze the feature importance of a model.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[PFI](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        /// <param name="ctx">The clustering context.</param>
+        /// <param name="model">The model to evaluate.</param>
+        /// <param name="data">The evaluation data set.</param>
+        /// <param name="label">Label column name.</param>
+        /// <param name="groupId">GroupId column name</param>
+        /// <param name="features">Feature column names.</param>
+        /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
+        /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
+        /// <returns>Array of per-feature 'contributions' to the score.</returns>
+        public static ImmutableArray<RankerMetrics>
+            PermutationFeatureImportance(
+                this RankingContext ctx,
+                IPredictionTransformer<IPredictor> model,
+                IDataView data,
+                string label = DefaultColumnNames.Label,
+                string groupId = DefaultColumnNames.GroupId,
+                string features = DefaultColumnNames.Features,
+                bool useFeatureWeightFilter = false,
+                int? topExamples = null)
+        {
+            return PermutationFeatureImportance<RankerMetrics>.GetImportanceMetricsMatrix(
+                            CatalogUtils.GetEnvironment(ctx),
+                            model,
+                            data,
+                            idv => ctx.Evaluate(idv, label, groupId),
+                            RankingDelta,
+                            features,
+                            useFeatureWeightFilter,
+                            topExamples);
+        }
+
+        private static RankerMetrics RankingDelta(
+            RankerMetrics a, RankerMetrics b)
+        {
+            if (a.Dcg.Length!= b.Dcg.Length || a.Ndcg.Length != b.Ndcg.Length)
+                throw new ArgumentException($"Can't compare {nameof(RankerMetrics)} with different DCG/NDCG Lengths.");
+
+            var dcg = new double[a.Dcg.Length];
+            for (int i = 0; i < a.Dcg.Length; i++)
+                dcg[i] = a.Dcg[i] - b.Dcg[i];
+
+            var ndcg = new double[a.Ndcg.Length];
+            for (int i = 0; i < a.Ndcg.Length; i++)
+                ndcg[i] = a.Ndcg[i] - b.Ndcg[i];
+
+            return new RankerMetrics(dcg: dcg, ndcg: ndcg);
+        }
+        /// <summary>
+        /// Permutation Feature Importance (PFI) for Clustering
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Permutation feature importance (PFI) is a technique to determine the global importance of features in a trained
+        /// machine learning model. PFI is a simple yet powerful technique motivated by Breiman in his Random Forest paper, section 10
+        /// (Breiman. <a href='https://www.stat.berkeley.edu/~breiman/randomforest2001.pdf'>&quot;Random Forests.&quot;</a> Machine Learning, 2001.)
+        /// The advantage of the PFI method is that it is model agnostic -- it works with any model that can be
+        /// evaluated -- and it can use any dataset, not just the training set, to compute feature importance metrics.
+        /// </para>
+        /// <para>
+        /// PFI works by taking a labeled dataset, choosing a feature, and permuting the values
+        /// for that feature across all the examples, so that each example now has a random value for the feature and
+        /// the original values for all other features. The evalution metric (e.g. normalized mutual information) is then calculated
+        /// for this modified dataset, and the change in the evaluation metric from the original dataset is computed.
+        /// The larger the change in the evaluation metric, the more important the feature is to the model.
+        /// PFI works by performing this permutation analysis across all the features of a model, one after another.
+        /// </para>
+        /// <para>
+        /// In this implementation, PFI computes the change in all possible clustering evaluation metrics for each feature, and an
+        /// <code>ImmutableArray</code> of <code>ClusteringMetrics</code> objects is returned. See the sample below for an
+        /// example of working with these results to analyze the feature importance of a model.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[PFI](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        /// <param name="ctx">The clustering context.</param>
+        /// <param name="model">The model to evaluate.</param>
+        /// <param name="data">The evaluation data set.</param>
+        /// <param name="label">Label column name.</param>
+        /// <param name="features">Feature column names.</param>
+        /// <param name="useFeatureWeightFilter">Use features weight to pre-filter features.</param>
+        /// <param name="topExamples">Limit the number of examples to evaluate on. null means examples (up to ~ 2 bln) from input will be used.</param>
+        /// <returns>Array of per-feature 'contributions' to the score.</returns>
+        public static ImmutableArray<ClusteringMetrics>
+            PermutationFeatureImportance(
+                this ClusteringContext ctx,
+                IPredictionTransformer<IPredictor> model,
+                IDataView data,
+                string label = DefaultColumnNames.Label,
+                string features = DefaultColumnNames.Features,
+                bool useFeatureWeightFilter = false,
+                int? topExamples = null)
+        {
+            return PermutationFeatureImportance<ClusteringMetrics>.GetImportanceMetricsMatrix(
+                            CatalogUtils.GetEnvironment(ctx),
+                            model,
+                            data,
+                            idv => ctx.Evaluate(idv, label),
+                            ClusteringDelta,
+                            features,
+                            useFeatureWeightFilter,
+                            topExamples);
+        }
+
+        private static ClusteringMetrics ClusteringDelta(
+            ClusteringMetrics a, ClusteringMetrics b)
+        {
+            return new ClusteringMetrics(
+                nmi: a.Nmi - b.Nmi,
+                avgMinScore: a.AvgMinScore- b.AvgMinScore,
+                dbi: a.Dbi - b.Dbi);
         }
     }
 }

--- a/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
+++ b/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Core.Data;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.RunTests;
@@ -19,10 +20,10 @@ namespace Microsoft.ML.Tests
         {
         }
 
+        #region Regression Tests
+
         /// <summary>
-        /// Features: x1, x2, x3, xRand; y = 10*x1 + 20x2 + 5.5x3 + e, xRand- random and Label y is to dependant on xRand.
-        /// Test verifies that xRand has the least importance: L1, L2, RMS and Loss-Fn do not change a lot when xRand is permuted.
-        /// Also test checks that x2 has the biggest importance.
+        /// Test PFI Regression for Dense Features
         /// </summary>
         [Fact]
         public void TestPfiRegressionOnDenseFeatures()
@@ -55,11 +56,7 @@ namespace Microsoft.ML.Tests
         }
 
         /// <summary>
-        /// Features: x1, x2vBuff(sparce vector), x3. 
-        /// y = 10x1 + 10x2vBuff + 30x3 + e.
-        /// Within xBuff feature  2nd slot will be sparse most of the time.
-        /// Test verifies that 2nd slot of xBuff has the least importance: L1, L2, RMS and Loss-Fn do not change a lot when this slot is permuted.
-        /// Also test checks that x2 has the biggest importance.
+        /// Test PFI Regression for Sparse Features
         /// </summary>
         [Fact]
         public void TestPfiRegressionOnSparseFeatures()
@@ -92,6 +89,12 @@ namespace Microsoft.ML.Tests
             Assert.True(MinDeltaIndex(results, m => m.RSquared) == 5);
         }
 
+        #endregion
+
+        #region Binary Classification Tests
+        /// <summary>
+        /// Test PFI Binary Classification for Dense Features
+        /// </summary>
         [Fact]
         public void TestPfiBinaryClassificationOnDenseFeatures()
         {
@@ -127,11 +130,7 @@ namespace Microsoft.ML.Tests
         }
 
         /// <summary>
-        /// Features: x1, x2vBuff(sparce vector), x3. 
-        /// y = 10x1 + 10x2vBuff + 30x3 + e.
-        /// Within xBuff feature  2nd slot will be sparse most of the time.
-        /// Test verifies that 2nd slot of xBuff has the least importance: L1, L2, RMS and Loss-Fn do not change a lot when this slot is permuted.
-        /// Also test checks that x2 has the biggest importance.
+        /// Test PFI Binary Classification for Sparse Features
         /// </summary>
         [Fact]
         public void TestPfiBinaryClassificationOnSparseFeatures()
@@ -168,9 +167,196 @@ namespace Microsoft.ML.Tests
 
             Done();
         }
+        #endregion
 
+        #region Multiclass Classification Tests
+        /// <summary>
+        /// Test PFI Multiclass Classification for Dense Features
+        /// </summary>
+        [Fact]
+        public void TestPfiMulticlassClassificationOnDenseFeatures()
+        {
+            var data = GetDenseDataset(TaskType.MulticlassClassification);
+            var model = ML.MulticlassClassification.Trainers.LogisticRegression().Fit(data);
+            var pfi = ML.MulticlassClassification.PermutationFeatureImportance(model, data);
+
+            // Pfi Indices:
+            // X1: 0
+            // X2Important: 1
+            // X3: 2
+            // X4Rand: 3
+
+            // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
+            Assert.True(MaxDeltaIndex(pfi, m => m.AccuracyMicro) == 3);
+            Assert.True(MinDeltaIndex(pfi, m => m.AccuracyMicro) == 1);
+            Assert.True(MaxDeltaIndex(pfi, m => m.AccuracyMacro) == 3);
+            Assert.True(MinDeltaIndex(pfi, m => m.AccuracyMacro) == 1);
+            Assert.True(MaxDeltaIndex(pfi, m => m.LogLossReduction) == 3);
+            Assert.True(MinDeltaIndex(pfi, m => m.LogLossReduction) == 1);
+
+            // For the following metrics-delta lower is better, so maximum delta means more important feature, and vice versa
+            //  Because they are _negative_, the difference will be positive for worse classifiers.
+            Assert.True(MaxDeltaIndex(pfi, m => m.LogLoss) == 1);
+            Assert.True(MinDeltaIndex(pfi, m => m.LogLoss) == 3);
+            for (int i = 0; i < pfi[0].PerClassLogLoss.Length; i++)
+            {
+                Assert.True(MaxDeltaIndex(pfi, m => m.PerClassLogLoss[i]) == 1);
+                Assert.True(MinDeltaIndex(pfi, m => m.PerClassLogLoss[i]) == 3);
+            }
+
+            Done();
+        }
+
+        /// <summary>
+        /// Test PFI Multiclass Classification for Sparse Features
+        /// </summary>
+        [Fact]
+        public void TestPfiMulticlassClassificationOnSparseFeatures()
+        {
+            var data = GetSparseDataset(TaskType.MulticlassClassification);
+            var model = ML.MulticlassClassification.Trainers.LogisticRegression(advancedSettings: args => { args.MaxIterations = 1000; }).Fit(data);
+            var pfi = ML.MulticlassClassification.PermutationFeatureImportance(model, data);
+
+            // Pfi Indices:
+            // X1: 0
+            // X2VBuffer-Slot-0: 1
+            // X2VBuffer-Slot-1: 2 // Least important
+            // X2VBuffer-Slot-2: 3
+            // X2VBuffer-Slot-3: 4
+            // X3Important: 5 // Most important
+
+            // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
+            Assert.True(MaxDeltaIndex(pfi, m => m.AccuracyMicro) == 2);
+            Assert.True(MinDeltaIndex(pfi, m => m.AccuracyMicro) == 5);
+            Assert.True(MaxDeltaIndex(pfi, m => m.AccuracyMacro) == 2);
+            Assert.True(MinDeltaIndex(pfi, m => m.AccuracyMacro) == 5);
+            Assert.True(MaxDeltaIndex(pfi, m => m.LogLossReduction) == 2);
+            Assert.True(MinDeltaIndex(pfi, m => m.LogLossReduction) == 5);
+
+            // For the following metrics-delta lower is better, so maximum delta means more important feature, and vice versa
+            //  Because they are negative metrics, the _difference_ will be positive for worse classifiers.
+            Assert.True(MaxDeltaIndex(pfi, m => m.LogLoss) == 5);
+            Assert.True(MinDeltaIndex(pfi, m => m.LogLoss) == 2);
+            for (int i = 0; i < pfi[0].PerClassLogLoss.Length; i++)
+            {
+                Assert.True(MaxDeltaIndex(pfi, m => m.PerClassLogLoss[i]) == 5);
+                Assert.True(MinDeltaIndex(pfi, m => m.PerClassLogLoss[i]) == 2);
+            }
+
+            Done();
+        }
+        #endregion
+
+        #region Ranking Tests
+        /// <summary>
+        /// Test PFI Multiclass Classification for Dense Features
+        /// </summary>
+        [Fact]
+        public void TestPfiRankingOnDenseFeatures()
+        {
+            var data = GetDenseDataset(TaskType.Ranking);
+            var model = ML.Ranking.Trainers.FastTree().Fit(data);
+            var pfi = ML.Ranking.PermutationFeatureImportance(model, data);
+
+            // Pfi Indices:
+            // X1: 0 // For Ranking, this column won't result in misorderings
+            // X2Important: 1
+            // X3: 2
+            // X4Rand: 3
+
+            // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
+            for (int i = 0; i < pfi[0].Dcg.Length; i++)
+            {
+                Assert.True(MaxDeltaIndex(pfi, m => m.Dcg[i]) == 0);
+                Assert.True(MinDeltaIndex(pfi, m => m.Dcg[i]) == 1);
+            }
+            for (int i = 0; i < pfi[0].Ndcg.Length; i++)
+            {
+                Assert.True(MaxDeltaIndex(pfi, m => m.Ndcg[i]) == 0);
+                Assert.True(MinDeltaIndex(pfi, m => m.Ndcg[i]) == 1);
+            }
+
+            Done();
+        }
+
+        /// <summary>
+        /// Test PFI Multiclass Classification for Sparse Features
+        /// </summary>
+        [Fact]
+        public void TestPfiRankingOnSparseFeatures()
+        {
+            var data = GetSparseDataset(TaskType.Ranking);
+            var model = ML.Ranking.Trainers.FastTree().Fit(data);
+            var pfi = ML.Ranking.PermutationFeatureImportance(model, data);
+
+            // Pfi Indices:
+            // X1: 0
+            // X2VBuffer-Slot-0: 1
+            // X2VBuffer-Slot-1: 2 // Least important
+            // X2VBuffer-Slot-2: 3
+            // X2VBuffer-Slot-3: 4
+            // X3Important: 5 // Most important
+
+            // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
+            for (int i = 0; i < pfi[0].Dcg.Length; i++)
+            {
+                Assert.True(MaxDeltaIndex(pfi, m => m.Dcg[i]) == 2);
+                Assert.True(MinDeltaIndex(pfi, m => m.Dcg[i]) == 5);
+            }
+            for (int i = 0; i < pfi[0].Ndcg.Length; i++)
+            {
+                Assert.True(MaxDeltaIndex(pfi, m => m.Ndcg[i]) == 2);
+                Assert.True(MinDeltaIndex(pfi, m => m.Ndcg[i]) == 5);
+            }
+
+            Done();
+        }
+        #endregion
+
+        #region Clustering Tests
+        /// <summary>
+        /// Test PFI Clustering for Dense Features
+        /// </summary>
+        [Fact]
+        public void TestPfiClusteringOnDenseFeatures()
+        {
+            var data = GetDenseClusteringDataset();
+
+            var preview = data.Preview();
+
+            var model = ML.Clustering.Trainers.KMeans("Features", clustersCount: 5, 
+                advancedSettings: args =>{ args.NormalizeFeatures = NormalizeOption.No;})
+                .Fit(data);
+            var pfi = ML.Clustering.PermutationFeatureImportance(model, data);
+
+            // Pfi Indices:
+            // X1: 0 -- middling importance for clustering (middling range)
+            // X2Important: 1 -- most important for clustering (largest range)
+            // X3: 2 -- Least important for clustering (smallest range)
+
+            // For the following metrics lower is better, so maximum delta means more important feature, and vice versa
+            Assert.True(MinDeltaIndex(pfi, m => m.AvgMinScore) == 0);
+            Assert.True(MaxDeltaIndex(pfi, m => m.AvgMinScore) == 2);
+
+            // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
+            Assert.True(MinDeltaIndex(pfi, m => m.Nmi) == 2);
+            Assert.True(MaxDeltaIndex(pfi, m => m.Nmi) == 0);
+
+            Done();
+        }
+        #endregion
+
+        #region Helpers
+        /// <summary>
+        /// Features: x1, x2, x3, xRand; y = 10*x1 + 20x2 + 5.5x3 + e, xRand- random and Label y is to dependant on xRand.
+        /// xRand has the least importance: Evaluation metrics do not change a lot when xRand is permuted.
+        /// x2 has the biggest importance.
+        /// </summary>
         private IDataView GetDenseDataset(TaskType task = TaskType.Regression)
         {
+            if (task == TaskType.Clustering)
+                throw new ArgumentException($"TaskType {nameof(TaskType.Clustering)} not supported.");
+
             // Setup synthetic dataset.
             const int numberOfInstances = 1000;
             var rand = new Random(10);
@@ -192,12 +378,16 @@ namespace Microsoft.ML.Tests
                 x4RandArray[i] = x4Rand;
 
                 var noise = rand.Next(50);
+
                 yArray[i] = (float)(10 * x1 + 20 * x2Important + 5.5 * x3 + noise);
             }
 
             // If binary classification, modify the labels
-            if (task == TaskType.BinaryClassification)
-                GetBinaryClassificationScores(yArray);
+            if (task == TaskType.BinaryClassification || 
+                task == TaskType.MulticlassClassification)
+                GetBinaryClassificationLabels(yArray);
+            else if (task == TaskType.Ranking)
+                GetRankingLabels(yArray);
 
             // Create data view.
             var bldr = new ArrayDataViewBuilder(Env);
@@ -206,15 +396,28 @@ namespace Microsoft.ML.Tests
             bldr.AddColumn("X3", NumberType.Float, x3Array);
             bldr.AddColumn("X4Rand", NumberType.Float, x4RandArray);
             bldr.AddColumn("Label", NumberType.Float, yArray);
+            if (task == TaskType.Ranking)
+                bldr.AddColumn("GroupId", NumberType.U4, CreateGroupIds(yArray.Length));
             var srcDV = bldr.GetDataView();
 
             var pipeline = ML.Transforms.Concatenate("Features", "X1", "X2Important", "X3", "X4Rand")
                 .Append(ML.Transforms.Normalize("Features"));
-            var data = pipeline.Fit(srcDV).Transform(srcDV);
 
-            return data;
+            // Create a keytype for Ranking
+            if (task == TaskType.Ranking)
+                return pipeline.Append(ML.Transforms.Conversion.MapValueToKey("GroupId"))
+                    .Fit(srcDV).Transform(srcDV);
+
+            return pipeline.Fit(srcDV).Transform(srcDV);
         }
 
+        /// <summary>
+        /// Features: x1, x2vBuff(sparce vector), x3. 
+        /// y = 10x1 + 10x2vBuff + 30x3 + e.
+        /// Within xBuff feature  2nd slot will be sparse most of the time.
+        /// 2nd slot of xBuff has the least importance: Evaluation metrics do not change a lot when this slot is permuted.
+        /// x2 has the biggest importance.
+        /// </summary>
         private IDataView GetSparseDataset(TaskType task = TaskType.Regression)
         {
             // Setup synthetic dataset.
@@ -257,8 +460,11 @@ namespace Microsoft.ML.Tests
             }
 
             // If binary classification, modify the labels
-            if (task == TaskType.BinaryClassification)
-                GetBinaryClassificationScores(yArray);
+            if (task == TaskType.BinaryClassification ||
+                task == TaskType.MulticlassClassification)
+                GetBinaryClassificationLabels(yArray);
+            else if (task == TaskType.Ranking)
+                GetRankingLabels(yArray);
 
             // Create data view.
             var bldr = new ArrayDataViewBuilder(Env);
@@ -266,13 +472,72 @@ namespace Microsoft.ML.Tests
             bldr.AddColumn("X2VBuffer", NumberType.Float, vbArray);
             bldr.AddColumn("X3Important", NumberType.Float, x3Array);
             bldr.AddColumn("Label", NumberType.Float, yArray);
+            if (task == TaskType.Ranking)
+                bldr.AddColumn("GroupId", NumberType.U4, CreateGroupIds(yArray.Length));
             var srcDV = bldr.GetDataView();
 
             var pipeline = ML.Transforms.Concatenate("Features", "X1", "X2VBuffer", "X3Important")
                 .Append(ML.Transforms.Normalize("Features"));
-            var data = pipeline.Fit(srcDV).Transform(srcDV);
 
-            return data;
+            // Create a keytype for Ranking
+            if (task == TaskType.Ranking)
+                return pipeline.Append(ML.Transforms.Conversion.MapValueToKey("GroupId"))
+                    .Fit(srcDV).Transform(srcDV);
+
+            return pipeline.Fit(srcDV).Transform(srcDV);
+        }
+
+        /// <summary>
+        /// Features: x1, x2, x3, xRand; y = 10*x1 + 20x2 + 5.5x3 + e, xRand- random and Label y is to dependant on xRand.
+        /// xRand has the least importance: Evaluation metrics do not change a lot when xRand is permuted.
+        /// x2 has the biggest importance.
+        /// </summary>
+        private IDataView GetDenseClusteringDataset()
+        {
+            // Define the cluster centers
+            const int clusterCount = 5;
+            float[][] clusterCenters = new float[clusterCount][];
+            for (int i = 0; i < clusterCount; i++)
+            {
+                clusterCenters[i] = new float[3] { i, i, i };
+            }
+
+            // Create rows of data sampled from these clusters
+            const int numberOfInstances = 1000;
+            var rand = new Random(10);
+
+            // The cluster spacing is 1
+            float x1Scale = 0.01f;
+            float x2Scale = 0.1f;
+            float x3Scale = 1f;
+
+            float[] yArray = new float[numberOfInstances];
+            float[] x1Array = new float[numberOfInstances];
+            float[] x2Array = new float[numberOfInstances];
+            float[] x3Array = new float[numberOfInstances];
+
+            for (var i = 0; i < numberOfInstances; i++)
+            {
+                // Assign a cluster
+                var clusterLabel = rand.Next(clusterCount);
+                yArray[i] = clusterLabel;
+
+                x1Array[i] = clusterCenters[clusterLabel][0] + x1Scale * (float)(rand.NextDouble() - 0.5);
+                x2Array[i] = clusterCenters[clusterLabel][1] + x2Scale * (float)(rand.NextDouble() - 0.5);
+                x3Array[i] = clusterCenters[clusterLabel][2] + x3Scale * (float)(rand.NextDouble() - 0.5);
+            }
+
+            // Create data view.
+            var bldr = new ArrayDataViewBuilder(Env);
+            bldr.AddColumn("Label", NumberType.Float, yArray);
+            bldr.AddColumn("X1", NumberType.Float, x1Array);
+            bldr.AddColumn("X2", NumberType.Float, x2Array);
+            bldr.AddColumn("X3", NumberType.Float, x3Array);
+            var srcDV = bldr.GetDataView();
+
+            var pipeline = ML.Transforms.Concatenate("Features", "X1", "X2", "X3");
+
+            return pipeline.Fit(srcDV).Transform(srcDV);
         }
 
         private int MinDeltaIndex<T>(
@@ -291,23 +556,63 @@ namespace Microsoft.ML.Tests
             return metricsDelta.IndexOf(max);
         }
 
-        private void GetBinaryClassificationScores(float[] rawScores)
+        private void GetBinaryClassificationLabels(float[] rawScores)
         {
-            // Compute the average so we can center the response
-            float averageScore = 0.0f;
-            for (int i = 0; i < rawScores.Length; i++)
-                averageScore += rawScores[i];
-            averageScore /= rawScores.Length;
+            float averageScore = GetArrayAverage(rawScores);
 
             // Center the response and then take the sigmoid to generate the classes
             for (int i = 0; i < rawScores.Length; i++)
                 rawScores[i] = MathUtils.Sigmoid(rawScores[i] - averageScore) > 0.5 ? 1 : 0;
         }
 
+        private void GetRankingLabels(float[] rawScores)
+        {
+            var min = MathUtils.Min(rawScores);
+            var max = MathUtils.Max(rawScores);
+
+            for (int i = 0; i < rawScores.Length; i++)
+            {
+                // Bin from [zero,one), then expand out to [0,5) and truncate
+                rawScores[i] = (int)(5 * (rawScores[i] - min) / (max - min));
+                if (rawScores[i] == 5)
+                    rawScores[i] = 4;
+            }
+        }
+
+        private float GetArrayAverage(float[] scores)
+        {
+            // Compute the average so we can center the response
+            float averageScore = 0.0f;
+            for (int i = 0; i < scores.Length; i++)
+                averageScore += scores[i];
+            averageScore /= scores.Length;
+
+            return averageScore;
+        }
+
+        private uint[] CreateGroupIds(int numRows, int rowsPerGroup = 5)
+        {
+            var groupIds = new uint[numRows];
+            // Construct groups of rowsPerGroup using a modulo counter
+            uint group = 0;
+            for (int i = 0; i < groupIds.Length; i++)
+            {
+                if (i % rowsPerGroup == 0)
+                    group++;
+                groupIds[i] = group;
+            }
+
+            return groupIds;
+        }
+
         private enum TaskType
         {
             Regression,
-            BinaryClassification
+            BinaryClassification,
+            MulticlassClassification,
+            Ranking,
+            Clustering
         }
+        #endregion
     }
 }

--- a/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
+++ b/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.RunTests;
@@ -354,8 +355,7 @@ namespace Microsoft.ML.Tests
         /// </summary>
         private IDataView GetDenseDataset(TaskType task = TaskType.Regression)
         {
-            if (task == TaskType.Clustering)
-                throw new ArgumentException($"TaskType {nameof(TaskType.Clustering)} not supported.");
+            Contracts.Assert(task != TaskType.Clustering, $"TaskType {nameof(TaskType.Clustering)} not supported.");
 
             // Setup synthetic dataset.
             const int numberOfInstances = 1000;


### PR DESCRIPTION
This PR adds support to `Permutation Feature Importance` for `Multiclass Classification`, `Ranking`, and `Clustering`.

Fixes #1771
