### PR TITLE
Row now disposable

### DIFF
--- a/src/Microsoft.ML.Api/CustomMappingTransformer.cs
+++ b/src/Microsoft.ML.Api/CustomMappingTransformer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Transforms
                 _typedSrc = TypedCursorable<TSrc>.Create(_host, emptyDataView, false, _parent.InputSchemaDefinition);
             }
 
-            public Delegate[] CreateGetters(Row input, Func<int, bool> activeOutput, out Action disposer)
+            Delegate[] IRowMapper.CreateGetters(Row input, Func<int, bool> activeOutput, out Action disposer)
             {
                 disposer = null;
                 // If no outputs are active, we short-circuit to empty array of getters.
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Transforms
                 return combinedGetter;
             }
 
-            public Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+            Func<int, bool> IRowMapper.GetDependencies(Func<int, bool> activeOutput)
             {
                 if (Enumerable.Range(0, _parent.AddedSchema.Columns.Length).Any(activeOutput))
                 {
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Transforms
                 return col => false;
             }
 
-            public Schema.DetachedColumn[] GetOutputColumns()
+            Schema.DetachedColumn[] IRowMapper.GetOutputColumns()
             {
                 var dstRow = new DataViewConstructionUtils.InputRow<TDst>(_host, _parent.AddedSchema);
                 // All the output columns of dstRow are our outputs.

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ML.Runtime.Api
             return pipe;
         }
 
-        public sealed class InputRow<TRow> : InputRowBase<TRow>, IRowBackedBy<TRow>
+        public sealed class InputRow<TRow> : InputRowBase<TRow>
             where TRow : class
         {
             private TRow _value;

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -416,7 +416,12 @@ namespace Microsoft.ML.Runtime.Api
                 public override long Batch => _toWrap.Batch;
                 public override Schema Schema => _toWrap.Schema;
 
-                public override void Dispose() => _toWrap.Dispose();
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                        _toWrap.Dispose();
+                }
+
                 public override ValueGetter<TValue> GetGetter<TValue>(int col)
                     => _toWrap.GetGetter<TValue>(col);
                 public override ValueGetter<UInt128> GetIdGetter() => _toWrap.GetIdGetter();
@@ -434,8 +439,8 @@ namespace Microsoft.ML.Runtime.Api
 
                 protected readonly DataViewBase<TRow> DataView;
                 protected readonly IChannel Ch;
-
                 private long _position;
+
                 /// <summary>
                 /// Zero-based position of the cursor.
                 /// </summary>
@@ -462,14 +467,14 @@ namespace Microsoft.ML.Runtime.Api
                 /// </summary>
                 protected bool IsGood => State == CursorState.Good;
 
-                public virtual void Dispose()
+                protected sealed override void Dispose(bool disposing)
                 {
-                    if (State != CursorState.Done)
-                    {
-                        Ch.Dispose();
-                        _position = -1;
-                        State = CursorState.Done;
-                    }
+                    if (State == CursorState.Done)
+                        return;
+                    Ch.Dispose();
+                    _position = -1;
+                    base.Dispose(disposing);
+                    State = CursorState.Done;
                 }
 
                 public bool MoveNext()

--- a/src/Microsoft.ML.Api/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Api/StatefulFilterTransform.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Runtime.Api
             _bindings = new ColumnBindings(Schema.Create(newSource.Schema), DataViewConstructionUtils.GetSchemaColumns(_addedSchema));
         }
 
-        public bool CanShuffle { get { return false; } }
+        public bool CanShuffle => false;
 
         Schema IDataView.Schema => OutputSchema;
 
@@ -132,10 +132,7 @@ namespace Microsoft.ML.Runtime.Api
             return new[] { GetRowCursor(predicate, rand) };
         }
 
-        public IDataView Source
-        {
-            get { return _source; }
-        }
+        public IDataView Source => _source;
 
         public IDataTransform ApplyToData(IHostEnvironment env, IDataView newSource)
         {
@@ -158,10 +155,7 @@ namespace Microsoft.ML.Runtime.Api
 
             private bool _disposed;
 
-            public override long Batch
-            {
-                get { return _input.Batch; }
-            }
+            public override long Batch => _input.Batch;
 
             public Cursor(StatefulFilterTransform<TSrc, TDst, TState> parent, RowCursor<TSrc> input, Func<int, bool> predicate)
                 : base(parent.Host)
@@ -196,24 +190,22 @@ namespace Microsoft.ML.Runtime.Api
                 _appendedRow = appendedDataView.GetRowCursor(appendedPredicate);
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                if (!_disposed)
+                if (_disposed)
+                    return;
+                if (disposing)
                 {
-                    var disposableState = _state as IDisposable;
-                    var disposableSrc = _src as IDisposable;
-                    var disposableDst = _dst as IDisposable;
-                    if (disposableState != null)
+                    if (_state is IDisposable disposableState)
                         disposableState.Dispose();
-                    if (disposableSrc != null)
+                    if (_src is IDisposable disposableSrc)
                         disposableSrc.Dispose();
-                    if (disposableDst != null)
+                    if (_dst is IDisposable disposableDst)
                         disposableDst.Dispose();
-
                     _input.Dispose();
-                    base.Dispose();
-                    _disposed = true;
                 }
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public override ValueGetter<UInt128> GetIdGetter()

--- a/src/Microsoft.ML.Api/TypedCursor.cs
+++ b/src/Microsoft.ML.Api/TypedCursor.cs
@@ -496,6 +496,7 @@ namespace Microsoft.ML.Runtime.Api
         private sealed class RowCursorImplementation : RowCursor<TRow>
         {
             private readonly TypedCursor _cursor;
+            private bool _disposed;
 
             public RowCursorImplementation(TypedCursor cursor) => _cursor = cursor;
 
@@ -504,7 +505,15 @@ namespace Microsoft.ML.Runtime.Api
             public override long Batch => _cursor.Batch;
             public override Schema Schema => _cursor.Schema;
 
-            public override void Dispose() { }
+            protected override void Dispose(bool disposing)
+            {
+                if (_disposed)
+                    return;
+                if (disposing)
+                    _cursor.Dispose();
+                _disposed = true;
+                base.Dispose(disposing);
+            }
 
             public override void FillValues(TRow row) => _cursor.FillValues(row);
             public override ValueGetter<TValue> GetGetter<TValue>(int col) => _cursor.GetGetter<TValue>(col);

--- a/src/Microsoft.ML.Api/TypedCursor.cs
+++ b/src/Microsoft.ML.Api/TypedCursor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Runtime.Api
     /// </summary>
     /// <typeparam name="TRow">The user-defined type that is being populated while cursoring.</typeparam>
     [BestFriend]
-    internal interface IRowReadableAs<TRow>
+    internal interface IRowReadableAs<TRow> : IDisposable
         where TRow : class
     {
         /// <summary>
@@ -26,22 +26,6 @@ namespace Microsoft.ML.Runtime.Api
         /// </summary>
         /// <param name="row">The row object. Cannot be null.</param>
         void FillValues(TRow row);
-    }
-
-    /// <summary>
-    /// This interface is an <see cref="Row"/> with 'strongly typed' binding.
-    /// It can accept values of type <typeparamref name="TRow"/> and present the value as a row.
-    /// </summary>
-    /// <typeparam name="TRow">The user-defined type that provides the values while cursoring.</typeparam>
-    internal interface IRowBackedBy<TRow>
-        where TRow : class
-    {
-        /// <summary>
-        /// Accepts the fields of the user-supplied <paramref name="row"/> object and publishes the instance as a row.
-        /// If the row is accessed prior to any object being set, then the data accessors on the row should throw.
-        /// </summary>
-        /// <param name="row">The row object. Cannot be <c>null</c>.</param>
-        void ExtractValues(TRow row);
     }
 
     /// <summary>
@@ -253,36 +237,34 @@ namespace Microsoft.ML.Runtime.Api
             return new TypedCursorable<TRow>(env, data, ignoreMissingColumns, outSchema);
         }
 
-        private abstract class TypedRowBase
+        private abstract class TypedRowBase : WrappingRow
         {
             protected readonly IChannel Ch;
-            private readonly Row _input;
             private readonly Action<TRow>[] _setters;
 
-            public long Batch => _input.Batch;
-
-            public long Position => _input.Position;
-
-            public Schema Schema => _input.Schema;
+            public override Schema Schema => base.Input.Schema;
 
             public TypedRowBase(TypedCursorable<TRow> parent, Row input, string channelMessage)
+                : base(input)
             {
                 Contracts.AssertValue(parent);
                 Contracts.AssertValue(parent._host);
                 Ch = parent._host.Start(channelMessage);
                 Ch.AssertValue(input);
 
-                _input = input;
-
                 int n = parent._pokes.Length;
                 Ch.Assert(n == parent._columns.Length);
                 Ch.Assert(n == parent._columnIndices.Length);
                 _setters = new Action<TRow>[n];
                 for (int i = 0; i < n; i++)
-                    _setters[i] = GenerateSetter(_input, parent._columnIndices[i], parent._columns[i], parent._pokes[i], parent._peeks[i]);
+                    _setters[i] = GenerateSetter(Input, parent._columnIndices[i], parent._columns[i], parent._pokes[i], parent._peeks[i]);
             }
 
-            public ValueGetter<UInt128> GetIdGetter() => _input.GetIdGetter();
+            protected override void DisposeCore(bool disposing)
+            {
+                if (disposing)
+                    Ch.Dispose();
+            }
 
             private Action<TRow> GenerateSetter(Row input, int index, InternalSchemaDefinition.Column column, Delegate poke, Delegate peek)
             {
@@ -292,7 +274,7 @@ namespace Microsoft.ML.Runtime.Api
                 Func<Row, int, Delegate, Delegate, Action<TRow>> del;
                 if (fieldType.IsArray)
                 {
-                    Ch.Assert(colType.IsVector);
+                    Ch.Assert(colType is VectorType);
                     // VBuffer<ReadOnlyMemory<char>> -> String[]
                     if (fieldType.GetElementType() == typeof(string))
                     {
@@ -459,14 +441,14 @@ namespace Microsoft.ML.Runtime.Api
                     setter(row);
             }
 
-            public bool IsColumnActive(int col)
+            public override bool IsColumnActive(int col)
             {
-                return _input.IsColumnActive(col);
+                return Input.IsColumnActive(col);
             }
 
-            public ValueGetter<TValue> GetGetter<TValue>(int col)
+            public override ValueGetter<TValue> GetGetter<TValue>(int col)
             {
-                return _input.GetGetter<TValue>(col);
+                return Input.GetGetter<TValue>(col);
             }
         }
 
@@ -481,6 +463,15 @@ namespace Microsoft.ML.Runtime.Api
         private sealed class RowImplementation : IRowReadableAs<TRow>
         {
             private readonly TypedRow _row;
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+                _row.Dispose();
+                _disposed = true;
+            }
 
             public RowImplementation(TypedRow row) => _row = row;
 
@@ -527,7 +518,6 @@ namespace Microsoft.ML.Runtime.Api
         private sealed class TypedCursor : TypedRowBase
         {
             private readonly RowCursor _input;
-            private bool _disposed;
 
             public TypedCursor(TypedCursorable<TRow> parent, RowCursor input)
                 : base(parent, input, "Cursor")
@@ -542,16 +532,6 @@ namespace Microsoft.ML.Runtime.Api
             }
 
             public CursorState State => _input.State;
-
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    _input.Dispose();
-                    Ch.Dispose();
-                    _disposed = true;
-                }
-            }
 
             public bool MoveNext() => _input.MoveNext();
             public bool MoveMany(long count) => _input.MoveMany(count);

--- a/src/Microsoft.ML.Core/Data/IDataView.cs
+++ b/src/Microsoft.ML.Core/Data/IDataView.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ML.Runtime.Data
     /// A logical row. May be a row of an <see cref="IDataView"/> or a stand-alone row. If/when its contents
     /// change, its <see cref="Position"/> value is changed.
     /// </summary>
-    public abstract class Row
+    public abstract class Row : IDisposable
     {
         /// <summary>
         /// This is incremented when the underlying contents changes, giving clients a way to detect change.
@@ -202,6 +202,25 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         public abstract Schema Schema { get; }
 
+        /// <summary>
+        /// Implementation of dispose. Calls <see cref="Dispose(bool)"/> with <see langword="true"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// The disposable method for the disposable pattern. This default implementation does nothing.
+        /// </summary>
+        /// <param name="disposing">Whether this was called from <see cref="IDisposable.Dispose"/>.
+        /// Subclasses that implement <see cref="object.Finalize"/> should call this method with
+        /// <see langword="false"/>, but I hasten to add that implementing finalizers should be
+        /// avoided if at all possible.</param>.
+        protected virtual void Dispose(bool disposing)
+        {
+        }
     }
 
     /// <summary>
@@ -221,7 +240,7 @@ namespace Microsoft.ML.Runtime.Data
     /// <see cref="CursorState.Done"/>, <see cref="Row.Position"/> is <c>-1</c>. Otherwise,
     /// <see cref="Row.Position"/> >= 0.
     /// </summary>
-    public abstract class RowCursor : Row, IDisposable
+    public abstract class RowCursor : Row
     {
         /// <summary>
         /// Returns the state of the cursor. Before the first call to <see cref="MoveNext"/> or
@@ -252,6 +271,5 @@ namespace Microsoft.ML.Runtime.Data
         /// values from <see cref="Row.GetIdGetter"/>.
         /// </summary>
         public abstract RowCursor GetRootCursor();
-        public abstract void Dispose();
     }
 }

--- a/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
+++ b/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
@@ -104,15 +104,9 @@ namespace Microsoft.ML.Runtime.Data
         /// This method creates a live connection between the input <see cref="Row"/> and the output <see
         /// cref="Row"/>. In particular, when the getters of the output <see cref="Row"/> are invoked, they invoke the
         /// getters of the input row and base the output values on the current values of the input <see cref="Row"/>.
-        /// The output <see cref="Row"/> values are re-computed when requested through the getters.
-        ///
-        /// The optional <paramref name="disposer"/> should be invoked by any user of this row mapping, once it no
-        /// longer needs the <see cref="Row"/>. If no action is needed when the cursor is Disposed, the implementation
-        /// should set <paramref name="disposer"/> to <c>null</c>, otherwise it should be set to a delegate to be
-        /// invoked by the code calling this object. (For example, a wrapping cursor's <see cref="IDisposable.Dispose"/>
-        /// method. It's best for this action to be idempotent - calling it multiple times should be equivalent to
-        /// calling it once.
+        /// The output <see cref="Row"/> values are re-computed when requested through the getters. Also, the returned
+        /// <see cref="Row"/> will dispose <paramref name="input"/> when it is disposed.
         /// </summary>
-        Row GetRow(Row input, Func<int, bool> active, out Action disposer);
+        Row GetRow(Row input, Func<int, bool> active);
     }
 }

--- a/src/Microsoft.ML.Core/Data/LinkedRootCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/LinkedRootCursorBase.cs
@@ -32,12 +32,15 @@ namespace Microsoft.ML.Runtime.Data
             Root = Input.GetRootCursor();
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            if (State != CursorState.Done)
+            if (State == CursorState.Done)
+                return;
+            if (disposing)
             {
                 Input.Dispose();
-                base.Dispose();
+                // The base class should set the state to done under these circumstances.
+                base.Dispose(true);
             }
         }
     }

--- a/src/Microsoft.ML.Core/Data/RootCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/RootCursorBase.cs
@@ -50,14 +50,14 @@ namespace Microsoft.ML.Runtime.Data
             _state = CursorState.NotStarted;
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            if (State != CursorState.Done)
-            {
+            if (State == CursorState.Done)
+                return;
+            if (disposing)
                 Ch.Dispose();
-                _position = -1;
-                _state = CursorState.Done;
-            }
+            _position = -1;
+            _state = CursorState.Done;
         }
 
         public sealed override bool MoveNext()

--- a/src/Microsoft.ML.Core/Data/SchemaBuilder.cs
+++ b/src/Microsoft.ML.Core/Data/SchemaBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Data
         /// <param name="name">The column name.</param>
         /// <param name="type">The column type.</param>
         /// <param name="metadata">The column metadata.</param>
-        public void AddColumn(string name, ColumnType type, Schema.Metadata metadata)
+        public void AddColumn(string name, ColumnType type, Schema.Metadata metadata = null)
         {
             Contracts.CheckNonEmpty(name, nameof(name));
             Contracts.CheckValue(type, nameof(type));

--- a/src/Microsoft.ML.Core/Data/SynchronizedCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/SynchronizedCursorBase.cs
@@ -43,14 +43,17 @@ namespace Microsoft.ML.Runtime.Data
             _root = Input.GetRootCursor();
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            if (!_disposed)
+            if (_disposed)
+                return;
+            if (disposing)
             {
                 Input.Dispose();
                 Ch.Dispose();
-                _disposed = true;
             }
+            base.Dispose(disposing);
+            _disposed = true;
         }
 
         public sealed override bool MoveNext() => _root.MoveNext();

--- a/src/Microsoft.ML.Core/Data/WrappingRow.cs
+++ b/src/Microsoft.ML.Core/Data/WrappingRow.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.ML.Runtime.Data
+{
+    /// <summary>
+    /// Convenient base class for <see cref="Row"/> implementors that wrap a single <see cref="Row"/>
+    /// as their input. The <see cref="Row.Position"/>, <see cref="Row.Batch"/>, and <see cref="Row.GetIdGetter"/>
+    /// are taken from this <see cref="Input"/>.
+    /// </summary>
+    [BestFriend]
+    internal abstract class WrappingRow : Row
+    {
+        private bool _disposed;
+
+        /// <summary>
+        /// The wrapped input row.
+        /// </summary>
+        protected Row Input { get; }
+
+        public sealed override long Batch => Input.Batch;
+        public sealed override long Position => Input.Position;
+        public override ValueGetter<UInt128> GetIdGetter() => Input.GetIdGetter();
+
+        [BestFriend]
+        private protected WrappingRow(Row input)
+        {
+            Contracts.AssertValue(input);
+            Input = input;
+        }
+
+        /// <summary>
+        /// This override of the dispose method by default only calls <see cref="Input"/>'s
+        /// <see cref="IDisposable.Dispose"/> method, but subclasses can enable additional functionality
+        /// via the <see cref="DisposeCore(bool)"/> functionality.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected sealed override void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+            if (disposing)
+                Input.Dispose();
+            DisposeCore(disposing);
+            _disposed = true;
+        }
+
+        /// <summary>
+        /// Called from <see cref="Dispose(bool)"/> with <see langword="true"/> in the case where
+        /// that method has never been called before, and right after <see cref="Input"/> has been
+        /// disposed. The default implementation does nothing.
+        /// </summary>
+        /// <param name="disposing">Whether this was called through the dispose path, as opposed
+        /// to the finalizer path.</param>
+        protected virtual void DisposeCore(bool disposing)
+        {
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Data/WrappingRow.cs
+++ b/src/Microsoft.ML.Core/Data/WrappingRow.cs
@@ -42,9 +42,11 @@ namespace Microsoft.ML.Runtime.Data
         {
             if (_disposed)
                 return;
+            // Since the input was created first, and this instance may depend on it, we should
+            // dispose local resources first before potentially disposing the input row resources.
+            DisposeCore(disposing);
             if (disposing)
                 Input.Dispose();
-            DisposeCore(disposing);
             _disposed = true;
         }
 

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Runtime.Data
             int j = 0;
             for (int i = 0; i < n; i++)
             {
-                for (;;)
+                for (; ; )
                 {
                     string name = string.IsNullOrWhiteSpace(tag) ?
                         string.Format("temp_{0:000}", j) :
@@ -1056,23 +1056,21 @@ namespace Microsoft.ML.Runtime.Data
                     _quitAction = quitAction;
                 }
 
-                public override void Dispose()
+                protected override void Dispose(bool disposing)
                 {
-                    if (!_disposed)
+                    if (_disposed)
+                        return;
+                    if (disposing)
                     {
                         foreach (var pipe in _pipes)
                             pipe.Unset();
-                        _disposed = true;
-                        if (_quitAction != null)
-                            _quitAction();
+                        _quitAction?.Invoke();
                     }
-                    base.Dispose();
+                    _disposed = true;
+                    base.Dispose(disposing);
                 }
 
-                public override ValueGetter<UInt128> GetIdGetter()
-                {
-                    return _idGetter;
-                }
+                public override ValueGetter<UInt128> GetIdGetter() => _idGetter;
 
                 protected override bool MoveNextCore()
                 {
@@ -1203,11 +1201,12 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                if (!_disposed)
+                if (_disposed)
+                    return;
+                if (disposing)
                 {
-                    _disposed = true;
                     _batch = -1;
                     _icursor = -1;
                     _currentCursor = null;
@@ -1215,7 +1214,8 @@ namespace Microsoft.ML.Runtime.Data
                     foreach (var cursor in _cursors)
                         cursor.Dispose();
                 }
-                base.Dispose();
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public override ValueGetter<UInt128> GetIdGetter()

--- a/src/Microsoft.ML.Data/Data/IRowSeekable.cs
+++ b/src/Microsoft.ML.Data/Data/IRowSeekable.cs
@@ -24,10 +24,8 @@ namespace Microsoft.ML.Runtime.Data
     /// For <see cref="RowSeeker"/>, when the state is valid (that is when <see cref="MoveTo(long)"/>
     /// returns <see langword="true"/>), it returns the current row index. Otherwise it's -1.
     /// </summary>
-    public abstract class RowSeeker : Row, IDisposable
+    public abstract class RowSeeker : Row
     {
-        public abstract void Dispose();
-
         /// <summary>
         /// Moves the seeker to a row at a specific row index.
         /// If the row index specified is out of range (less than zero or not less than the

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
@@ -275,16 +275,18 @@ namespace Microsoft.ML.Runtime.Data
 
             public override Schema Schema => _bindings.AsSchema;
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
                 if (_disposed)
                     return;
-
+                if (disposing)
+                {
+                    _ator.Dispose();
+                    _reader.Release();
+                    _stats.Release();
+                }
                 _disposed = true;
-                _ator.Dispose();
-                _reader.Release();
-                _stats.Release();
-                base.Dispose();
+                base.Dispose(disposing);
             }
 
             protected override bool MoveNextCore()

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -824,15 +824,17 @@ namespace Microsoft.ML.Runtime.Data.IO
                     Init(_actives[i]);
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                if (!_disposed)
+                if (_disposed)
+                    return;
+                if (disposing)
                 {
-                    _disposed = true;
                     for (int i = 0; i < _transCursors.Length; ++i)
                         _transCursors[i].Dispose();
-                    base.Dispose();
                 }
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -280,15 +280,16 @@ namespace Microsoft.ML.Runtime.Data
                 return true;
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                if (State != CursorState.Done)
+                if (State == CursorState.Done)
+                    return;
+                if (disposing)
                 {
                     Ch.Dispose();
-                    if (_currentCursor != null)
-                        _currentCursor.Dispose();
-                    base.Dispose();
+                    _currentCursor?.Dispose();
                 }
+                base.Dispose(disposing);
             }
         }
 
@@ -369,15 +370,17 @@ namespace Microsoft.ML.Runtime.Data
                 return true;
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                if (State != CursorState.Done)
+                if (State == CursorState.Done)
+                    return;
+                if (disposing)
                 {
                     Ch.Dispose();
                     foreach (RowCursor c in _cursorSet)
                         c.Dispose();
-                    base.Dispose();
                 }
+                base.Dispose(disposing);
             }
         }
 

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -565,10 +565,6 @@ namespace Microsoft.ML.Data
             public override long Batch => _internal.Batch;
             public override Schema Schema => _internal.Schema;
 
-            public override void Dispose()
-            {
-            }
-
             public override ValueGetter<TValue> GetGetter<TValue>(int col) => _internal.GetGetter<TValue>(col);
             public override ValueGetter<UInt128> GetIdGetter() => _internal.GetIdGetter();
             public override bool IsColumnActive(int col) => _internal.IsColumnActive(col);
@@ -1291,15 +1287,18 @@ namespace Microsoft.ML.Data
                 return _colToActivesIndex[col] >= 0;
             }
 
-            public sealed override void Dispose()
+            protected sealed override void Dispose(bool disposing)
             {
-                if (!_disposed)
+                if (_disposed)
+                    return;
+                if (disposing)
                 {
                     DisposeCore();
                     PositionCore = -1;
                     Ch.Dispose();
-                    _disposed = true;
                 }
+                base.Dispose(disposing);
+                _disposed = true;
             }
 
             public sealed override ValueGetter<TValue> GetGetter<TValue>(int col)

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -43,13 +43,12 @@ namespace Microsoft.ML.Runtime.Data
             return toReturn;
         }
 
-        public Row GetRow(Row input, Func<int, bool> active, out Action disposer)
+        public Row GetRow(Row input, Func<int, bool> active)
         {
             Contracts.CheckValue(input, nameof(input));
             Contracts.CheckValue(active, nameof(active));
             Contracts.CheckParam(input.Schema == InputSchema, nameof(input), "Schema did not match original schema");
 
-            disposer = null;
             if (InnerMappers.Length == 0)
             {
                 bool differentActive = false;
@@ -75,17 +74,7 @@ namespace Microsoft.ML.Runtime.Data
 
             Row result = input;
             for (int i = 0; i < InnerMappers.Length; ++i)
-            {
-                result = InnerMappers[i].GetRow(result, deps[i], out var localDisp);
-                if (localDisp != null)
-                {
-                    if (disposer == null)
-                        disposer = localDisp;
-                    else
-                        disposer = localDisp + disposer;
-                    // We want the last disposer to be called first, so the order of the addition here is important.
-                }
-            }
+                result = InnerMappers[i].GetRow(result, deps[i]);
 
             return result;
         }

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -26,7 +26,8 @@ namespace Microsoft.ML.Runtime.Data
     /// ctor or Create method with <see cref="SignatureLoadRowMapper"/>, along with a corresponding
     /// <see cref="LoadableClassAttribute"/>.
     /// </summary>
-    public interface IRowMapper : ICanSaveModel
+    [BestFriend]
+    internal interface IRowMapper : ICanSaveModel
     {
         /// <summary>
         /// Returns the input columns needed for the requested output columns.
@@ -81,7 +82,8 @@ namespace Microsoft.ML.Runtime.Data
 
         bool ICanSavePfa.CanSavePfa => _mapper is ICanSavePfa pfaMapper ? pfaMapper.CanSavePfa : false;
 
-        public RowToRowMapperTransform(IHostEnvironment env, IDataView input, IRowMapper mapper, Func<Schema, IRowMapper> mapperFactory)
+        [BestFriend]
+        internal RowToRowMapperTransform(IHostEnvironment env, IDataView input, IRowMapper mapper, Func<Schema, IRowMapper> mapperFactory)
             : base(env, RegistrationName, input)
         {
             Contracts.CheckValue(mapper, nameof(mapper));
@@ -91,7 +93,8 @@ namespace Microsoft.ML.Runtime.Data
             _bindings = new ColumnBindings(Schema.Create(input.Schema), mapper.GetOutputColumns());
         }
 
-        public static Schema GetOutputSchema(ISchema inputSchema, IRowMapper mapper)
+        [BestFriend]
+        internal static Schema GetOutputSchema(ISchema inputSchema, IRowMapper mapper)
         {
             Contracts.CheckValue(inputSchema, nameof(inputSchema));
             Contracts.CheckValue(mapper, nameof(mapper));

--- a/src/Microsoft.ML.Data/DataView/SimpleRow.cs
+++ b/src/Microsoft.ML.Data/DataView/SimpleRow.cs
@@ -13,8 +13,8 @@ namespace Microsoft.ML.Runtime.Data
     /// <summary>
     /// An implementation of <see cref="Row"/> that gets its <see cref="Row.Position"/>, <see cref="Row.Batch"/>,
     /// and <see cref="Row.GetIdGetter"/> from an input row. The constructor requires a schema and array of getter
-    /// delegates. A <see langword="null"/> delegate indicates an inactive column. The delegates are assumed to be of the appropriate type
-    /// (this does not validate the type).
+    /// delegates. A <see langword="null"/> delegate indicates an inactive column. The delegates are assumed to be
+    /// of the appropriate type (this does not validate the type).
     /// REVIEW: Should this validate that the delegates are of the appropriate type? It wouldn't be difficult
     /// to do so.
     /// </summary>
@@ -22,17 +22,36 @@ namespace Microsoft.ML.Runtime.Data
     internal sealed class SimpleRow : WrappingRow
     {
         private readonly Delegate[] _getters;
+        private readonly Action _disposer;
 
         public override Schema Schema { get; }
 
-        public SimpleRow(Schema schema, Row input, Delegate[] getters)
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="schema">The schema for the row.</param>
+        /// <param name="input">The row that is being wrapped by this row, where our <see cref="Row.Position"/>,
+        /// <see cref="Row.Batch"/>, <see cref="Row.GetIdGetter"/>.</param>
+        /// <param name="getters">The collection of getter delegates, whose types should map those in a schema.
+        /// If one of these is <see langword="null"/>, the corresponding column is considered inactive.</param>
+        /// <param name="disposer">A method that, if non-null, will be called exactly once during
+        /// <see cref="IDisposable.Dispose"/>, prior to disposing <paramref name="input"/>.</param>
+        public SimpleRow(Schema schema, Row input, Delegate[] getters, Action disposer = null)
             : base(input)
         {
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.CheckValue(input, nameof(input));
-            Contracts.Check(Utils.Size(getters) == schema.ColumnCount);
+            Contracts.Check(Utils.Size(getters) == schema.Count);
+            Contracts.CheckValueOrNull(disposer);
             Schema = schema;
             _getters = getters ?? new Delegate[0];
+            _disposer = disposer;
+        }
+
+        protected override void DisposeCore(bool disposing)
+        {
+            if (disposing)
+                _disposer?.Invoke();
         }
 
         public override ValueGetter<T> GetGetter<T>(int col)

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1086,28 +1086,20 @@ namespace Microsoft.ML.Runtime.Data
                 }
                 #endregion
 
-                private abstract class RowBase<TSplitter> : Row
+                private abstract class RowBase<TSplitter> : WrappingRow
                     where TSplitter : Splitter
                 {
                     protected readonly TSplitter Parent;
-                    protected readonly Row Input;
 
                     public sealed override Schema Schema => Parent.AsSchema;
-                    public sealed override long Position => Input.Position;
-                    public sealed override long Batch => Input.Batch;
 
                     public RowBase(TSplitter parent, Row input)
+                        : base(input)
                     {
                         Contracts.AssertValue(parent);
                         Contracts.AssertValue(input);
                         Contracts.Assert(input.IsColumnActive(parent.SrcCol));
                         Parent = parent;
-                        Input = input;
-                    }
-
-                    public sealed override ValueGetter<UInt128> GetIdGetter()
-                    {
-                        return Input.GetIdGetter();
                     }
                 }
 
@@ -1511,7 +1503,7 @@ namespace Microsoft.ML.Runtime.Data
                 _col = col;
 
                 var builder = new SchemaBuilder();
-                builder.AddColumn(_data.Schema[_col].Name, _type, null);
+                builder.AddColumn(_data.Schema[_col].Name, _type);
                 Schema = builder.GetSchema();
             }
 
@@ -1606,7 +1598,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 _slotCursor = cursor;
                 var builder = new SchemaBuilder();
-                builder.AddColumn("Waffles", cursor.GetSlotType(), null);
+                builder.AddColumn("Waffles", cursor.GetSlotType());
                 Schema = builder.GetSchema();
             }
 

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -110,6 +110,7 @@ namespace Microsoft.ML.Runtime.Data
             private readonly RowCursor[] _cursors;
             private readonly CompositeSchema _compositeSchema;
             private readonly bool[] _isColumnActive;
+            private bool _disposed;
 
             public override long Batch { get { return 0; } }
 
@@ -124,11 +125,17 @@ namespace Microsoft.ML.Runtime.Data
                 _isColumnActive = Utils.BuildArray(_compositeSchema.ColumnCount, predicate);
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                for (int i = _cursors.Length - 1; i >= 0; i--)
-                    _cursors[i].Dispose();
-                base.Dispose();
+                if (_disposed)
+                    return;
+                if (disposing)
+                {
+                    for (int i = _cursors.Length - 1; i >= 0; i--)
+                        _cursors[i].Dispose();
+                }
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public override ValueGetter<UInt128> GetIdGetter()

--- a/src/Microsoft.ML.Data/EntryPoints/TransformModel.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/TransformModel.cs
@@ -236,7 +236,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
             public Schema InputSchema => _rootSchema;
 
-            public Row GetRow(Row input, Func<int, bool> active, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> active)
             {
                 _ectx.Assert(IsCompositeRowToRowMapper(_chain));
                 _ectx.AssertValue(input);
@@ -244,7 +244,6 @@ namespace Microsoft.ML.Runtime.EntryPoints
 
                 _ectx.Check(input.Schema == InputSchema, "Schema of input row must be the same as the schema the mapper is bound to");
 
-                disposer = null;
                 var mappers = new List<IRowToRowMapper>();
                 var actives = new List<Func<int, bool>>();
                 var transform = _chain as IDataTransform;
@@ -262,11 +261,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 actives.Reverse();
                 var row = input;
                 for (int i = 0; i < mappers.Count; i++)
-                {
-                    Action disp;
-                    row = mappers[i].GetRow(row, actives[i], out disp);
-                    disposer += disp;
-                }
+                    row = mappers[i].GetRow(row, actives[i]);
 
                 return row;
             }

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Runtime.Data
             return names;
         }
 
-        protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
+        private protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
         {
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.CheckParam(schema.Label != null, nameof(schema), "Could not find the label column");
@@ -968,7 +968,7 @@ namespace Microsoft.ML.Runtime.Data
             ctx.Writer.WriteBoolByte(_useRaw);
         }
 
-        public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+        private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
         {
             if (_probIndex >= 0)
             {
@@ -981,7 +981,7 @@ namespace Microsoft.ML.Runtime.Data
             return col => activeOutput(AssignedCol) && col == ScoreIndex;
         }
 
-        public override Delegate[] CreateGetters(Row input, Func<int, bool> activeCols, out Action disposer)
+        private protected override Delegate[] CreateGettersCore(Row input, Func<int, bool> activeCols, out Action disposer)
         {
             Host.Assert(LabelIndex >= 0);
             Host.Assert(ScoreIndex >= 0);
@@ -1079,7 +1079,7 @@ namespace Microsoft.ML.Runtime.Data
             return Single.IsNaN(val) ? false : val > _threshold;
         }
 
-        public override Schema.DetachedColumn[] GetOutputColumns()
+        private protected override Schema.DetachedColumn[] GetOutputColumnsCore()
         {
             if (_probIndex >= 0)
             {

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -446,7 +446,8 @@ namespace Microsoft.ML.Runtime.Data
             return new RowToRowMapperTransform(Host, data.Data, mapper, null);
         }
 
-        protected abstract IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema);
+        [BestFriend]
+        private protected abstract IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema);
     }
 
     /// <summary>
@@ -501,10 +502,22 @@ namespace Microsoft.ML.Runtime.Data
             ctx.SaveStringOrNull(LabelCol);
         }
 
-        public abstract Func<int, bool> GetDependencies(Func<int, bool> activeOutput);
+        Func<int, bool> IRowMapper.GetDependencies(Func<int, bool> activeOutput)
+            => GetDependenciesCore(activeOutput);
 
-        public abstract Schema.DetachedColumn[] GetOutputColumns();
+        [BestFriend]
+        private protected abstract Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput);
 
-        public abstract Delegate[] CreateGetters(Row input, Func<int, bool> activeCols, out Action disposer);
+        Schema.DetachedColumn[] IRowMapper.GetOutputColumns()
+            => GetOutputColumnsCore();
+
+        [BestFriend]
+        private protected abstract Schema.DetachedColumn[] GetOutputColumnsCore();
+
+        Delegate[] IRowMapper.CreateGetters(Row input, Func<int, bool> activeCols, out Action disposer)
+            => CreateGettersCore(input, activeCols, out disposer);
+
+        [BestFriend]
+        private protected abstract Delegate[] CreateGettersCore(Row input, Func<int, bool> activeCols, out Action disposer);
     }
 }

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime.Data
         {
         }
 
-        protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
+        private protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
         {
             Host.CheckParam(schema.Label != null, nameof(schema), "Could not find the label column");
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
@@ -436,7 +436,7 @@ namespace Microsoft.ML.Runtime.Data
             base.Save(ctx);
         }
 
-        public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+        private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
         {
             return
                 col =>
@@ -446,7 +446,7 @@ namespace Microsoft.ML.Runtime.Data
                     (col == ScoreIndex || col == LabelIndex);
         }
 
-        public override Schema.DetachedColumn[] GetOutputColumns()
+        private protected override Schema.DetachedColumn[] GetOutputColumnsCore()
         {
             var infos = new Schema.DetachedColumn[5];
             infos[LabelOutput] = new Schema.DetachedColumn(LabelCol, _labelType, _labelMetadata);
@@ -457,7 +457,7 @@ namespace Microsoft.ML.Runtime.Data
             return infos;
         }
 
-        public override Delegate[] CreateGetters(Row input, Func<int, bool> activeCols, out Action disposer)
+        private protected override Delegate[] CreateGettersCore(Row input, Func<int, bool> activeCols, out Action disposer)
         {
             Host.Assert(LabelIndex >= 0);
             Host.Assert(ScoreIndex >= 0);

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Runtime.Data
         {
         }
 
-        protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
+        private protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
         {
             Host.CheckParam(schema.Label != null, nameof(schema), "Schema must contain a label column");
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
@@ -345,13 +345,13 @@ namespace Microsoft.ML.Runtime.Data
                 ctx.SaveNonEmptyString(quantiles[i].ToString());
         }
 
-        public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+        private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
         {
             return
                 col => (activeOutput(L1Col) || activeOutput(L2Col)) && (col == ScoreIndex || col == LabelIndex);
         }
 
-        public override Schema.DetachedColumn[] GetOutputColumns()
+        private protected override Schema.DetachedColumn[] GetOutputColumnsCore()
         {
             var infos = new Schema.DetachedColumn[2];
 
@@ -380,7 +380,7 @@ namespace Microsoft.ML.Runtime.Data
                 };
         }
 
-        public override Delegate[] CreateGetters(Row input, Func<int, bool> activeCols, out Action disposer)
+        private protected override Delegate[] CreateGettersCore(Row input, Func<int, bool> activeCols, out Action disposer)
         {
             Host.Assert(LabelIndex >= 0);
             Host.Assert(ScoreIndex >= 0);

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Runtime.Data
             return new Aggregator(Host, LossFunction, schema.Weight != null, stratName);
         }
 
-        protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
+        private protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
         {
             Contracts.CheckParam(schema.Label != null, nameof(schema), "Could not find the label column");
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
@@ -245,13 +245,13 @@ namespace Microsoft.ML.Runtime.Data
             base.Save(ctx);
         }
 
-        public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+        private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
         {
             return
                 col => (activeOutput(L1Col) || activeOutput(L2Col)) && (col == ScoreIndex || col == LabelIndex);
         }
 
-        public override Schema.DetachedColumn[] GetOutputColumns()
+        private protected override Schema.DetachedColumn[] GetOutputColumnsCore()
         {
             var infos = new Schema.DetachedColumn[2];
             infos[L1Col] = new Schema.DetachedColumn(L1, NumberType.R8, null);
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Runtime.Data
             return infos;
         }
 
-        public override Delegate[] CreateGetters(Row input, Func<int, bool> activeCols, out Action disposer)
+        private protected override Delegate[] CreateGettersCore(Row input, Func<int, bool> activeCols, out Action disposer)
         {
             Host.Assert(LabelIndex >= 0);
             Host.Assert(ScoreIndex >= 0);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -559,7 +559,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 return _predictor.GetInputColumnRoles();
             }
 
-            public Row GetRow(Row input, Func<int, bool> predicate, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> predicate)
             {
                 Func<int, bool> predictorPredicate = col => false;
                 for (int i = 0; i < OutputSchema.ColumnCount; i++)
@@ -570,7 +570,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                         break;
                     }
                 }
-                var predictorRow = _predictor.GetRow(input, predictorPredicate, out disposer);
+                var predictorRow = _predictor.GetRow(input, predictorPredicate);
                 var getters = new Delegate[OutputSchema.ColumnCount];
                 for (int i = 0; i < OutputSchema.ColumnCount - 1; i++)
                 {

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
@@ -353,8 +353,9 @@ namespace Microsoft.ML.Runtime.Data
 
                 if (parent.Stringify)
                 {
-                    _outputSchema = new SimpleSchema(_env,
-                        new KeyValuePair<string, ColumnType>(DefaultColumnNames.FeatureContributions, TextType.Instance));
+                    var builder = new SchemaBuilder();
+                    builder.AddColumn(DefaultColumnNames.FeatureContributions, TextType.Instance, null);
+                    _outputSchema = builder.GetSchema();
                     if (InputSchema.HasSlotNames(InputRoleMappedSchema.Feature.Index, InputRoleMappedSchema.Feature.Type.VectorSize))
                         InputSchema.GetMetadata(MetadataUtils.Kinds.SlotNames, InputRoleMappedSchema.Feature.Index,
                             ref _slotNames);

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
@@ -386,28 +386,28 @@ namespace Microsoft.ML.Runtime.Data
                 return col => false;
             }
 
-            public Row GetOutputRow(Row input, Func<int, bool> predicate, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> active)
             {
                 Contracts.AssertValue(input);
-                Contracts.AssertValue(predicate);
+                Contracts.AssertValue(active);
                 var totalColumnsCount = 1 + _outputGenericSchema.ColumnCount;
                 var getters = new Delegate[totalColumnsCount];
 
-                if (predicate(totalColumnsCount - 1))
+                if (active(totalColumnsCount - 1))
                 {
                     getters[totalColumnsCount - 1] = _parent.Stringify
                         ? _parent.GetTextContributionGetter(input, InputRoleMappedSchema.Feature.Index, _slotNames)
                         : _parent.GetContributionGetter(input, InputRoleMappedSchema.Feature.Index);
                 }
 
-                var genericRow = _genericRowMapper.GetRow(input, GetGenericPredicate(predicate), out disposer);
+                var genericRow = _genericRowMapper.GetRow(input, GetGenericPredicate(active));
                 for (var i = 0; i < _outputGenericSchema.ColumnCount; i++)
                 {
                     if (genericRow.IsColumnActive(i))
                         getters[i] = RowCursorUtils.GetGetterAsDelegate(genericRow, i);
                 }
 
-                return new SimpleRow(OutputSchema, input, getters);
+                return new SimpleRow(OutputSchema, genericRow, getters);
             }
 
             public Func<int, bool> GetGenericPredicate(Func<int, bool> predicate)
@@ -418,11 +418,6 @@ namespace Microsoft.ML.Runtime.Data
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {
                 yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputRoleMappedSchema.Feature.Name);
-            }
-
-            public Row GetRow(Row input, Func<int, bool> active, out Action disposer)
-            {
-                return GetOutputRow(input, active, out disposer);
             }
         }
 

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -307,9 +307,9 @@ namespace Microsoft.ML.Runtime.Data
                     return _mapper.GetInputColumnRoles();
                 }
 
-                public Row GetRow(Row input, Func<int, bool> predicate, out Action disposer)
+                public Row GetRow(Row input, Func<int, bool> predicate)
                 {
-                    var innerRow = _mapper.GetRow(input, predicate, out disposer);
+                    var innerRow = _mapper.GetRow(input, predicate);
                     return new RowImpl(innerRow, OutputSchema);
                 }
 

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -386,38 +386,30 @@ namespace Microsoft.ML.Runtime.Data
                     }
                 }
 
-                private sealed class RowImpl : Row
+                private sealed class RowImpl : WrappingRow
                 {
-                    private readonly Row _row;
                     private readonly Schema _schema;
 
-                    public override long Batch => _row.Batch;
-                    public override long Position => _row.Position;
                     // The schema is of course the only difference from _row.
                     public override Schema Schema => _schema;
 
                     public RowImpl(Row row, Schema schema)
+                        : base(row)
                     {
                         Contracts.AssertValue(row);
                         Contracts.AssertValue(schema);
 
-                        _row = row;
                         _schema = schema;
                     }
 
                     public override bool IsColumnActive(int col)
                     {
-                        return _row.IsColumnActive(col);
+                        return Input.IsColumnActive(col);
                     }
 
                     public override ValueGetter<TValue> GetGetter<TValue>(int col)
                     {
-                        return _row.GetGetter<TValue>(col);
-                    }
-
-                    public override ValueGetter<UInt128> GetIdGetter()
-                    {
-                        return _row.GetIdGetter();
+                        return Input.GetGetter<TValue>(col);
                     }
                 }
             }

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -221,6 +221,7 @@ namespace Microsoft.ML.Runtime.Data
             private readonly bool[] _active;
             private readonly Delegate[] _getters;
             private readonly Action _disposer;
+            private bool _disposed;
 
             public override Schema Schema { get; }
 
@@ -249,10 +250,14 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                _disposer?.Invoke();
-                base.Dispose();
+                if (_disposed)
+                    return;
+                if (disposing)
+                    _disposer?.Invoke();
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public override bool IsColumnActive(int col)

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -155,8 +155,9 @@ namespace Microsoft.ML.Runtime.Data
             Func<int, bool> predicateInput;
             Func<int, bool> predicateMapper;
             GetActive(bindings, active, out predicateInput, out predicateMapper);
-            var output = bindings.RowMapper.GetRow(input, predicateMapper, out disp);
+            var output = bindings.RowMapper.GetRow(input, predicateMapper);
             Func<int, bool> activeInfos = iinfo => active(bindings.MapIinfoToCol(iinfo));
+            disp = output.Dispose;
             return GetGetters(output, activeInfos);
         }
 
@@ -220,7 +221,7 @@ namespace Microsoft.ML.Runtime.Data
             private readonly BindingsBase _bindings;
             private readonly bool[] _active;
             private readonly Delegate[] _getters;
-            private readonly Action _disposer;
+            private readonly Row _output;
             private bool _disposed;
 
             public override Schema Schema { get; }
@@ -237,15 +238,15 @@ namespace Microsoft.ML.Runtime.Data
                 Ch.Assert(active.Length == _bindings.ColumnCount);
                 _active = active;
 
-                var output = _bindings.RowMapper.GetRow(input, predicateMapper, out _disposer);
+                _output = _bindings.RowMapper.GetRow(input, predicateMapper);
                 try
                 {
-                    Ch.Assert(output.Schema == _bindings.RowMapper.OutputSchema);
-                    _getters = parent.GetGetters(output, iinfo => active[_bindings.MapIinfoToCol(iinfo)]);
+                    Ch.Assert(_output.Schema == _bindings.RowMapper.OutputSchema);
+                    _getters = parent.GetGetters(_output, iinfo => active[_bindings.MapIinfoToCol(iinfo)]);
                 }
                 catch (Exception)
                 {
-                    _disposer?.Invoke();
+                    _output.Dispose();
                     throw;
                 }
             }
@@ -255,7 +256,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (_disposed)
                     return;
                 if (disposing)
-                    _disposer?.Invoke();
+                    _output.Dispose();
                 _disposed = true;
                 base.Dispose(disposing);
             }

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -223,7 +223,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public Schema InputSchema => InputRoleMappedSchema.Schema;
 
-            public Row GetRow(Row input, Func<int, bool> predicate, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> predicate)
             {
                 Contracts.AssertValue(input);
                 Contracts.AssertValue(predicate);
@@ -231,7 +231,6 @@ namespace Microsoft.ML.Runtime.Data
                 var getters = new Delegate[1];
                 if (predicate(0))
                     getters[0] = _parent.GetPredictionGetter(input, InputRoleMappedSchema.Feature.Index);
-                disposer = null;
                 return new SimpleRow(OutputSchema, input, getters);
             }
         }
@@ -566,12 +565,11 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            public Row GetRow(Row input, Func<int, bool> predicate, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> predicate)
             {
                 Contracts.AssertValue(input);
                 var active = Utils.BuildArray(OutputSchema.ColumnCount, predicate);
                 var getters = CreateGetters(input, active);
-                disposer = null;
                 return new SimpleRow(OutputSchema, input, getters);
             }
         }

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -393,18 +393,18 @@ namespace Microsoft.ML.Runtime.Data
             return transformer.MakeDataTransform(input);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
+        private protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
 
         /// <summary>
         /// Factory method for SignatureLoadDataTransform.
         /// </summary>
-        public static IDataTransform Create(IHostEnvironment env, ModelLoadContext ctx, IDataView input)
+        private static IDataTransform Create(IHostEnvironment env, ModelLoadContext ctx, IDataView input)
             => new ColumnConcatenatingTransformer(env, ctx).MakeDataTransform(input);
 
         /// <summary>
         /// Factory method for SignatureLoadRowMapper.
         /// </summary>
-        public static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
+        private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => new ColumnConcatenatingTransformer(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
         private sealed class Mapper : MapperBase, ISaveAsOnnx, ISaveAsPfa
@@ -829,7 +829,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+            private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
                 var active = new bool[InputSchema.ColumnCount];
                 for (int i = 0; i < _columns.Length; i++)

--- a/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Transforms
             SaveColumns(ctx);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema inputSchema)
+        private protected override IRowMapper MakeRowMapper(Schema inputSchema)
             => new Mapper(this, inputSchema, ColumnPairs);
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsOnnx

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -579,30 +579,22 @@ namespace Microsoft.ML.Transforms
             }
         }
 
-        private sealed class RowImpl : Row
+        private sealed class RowImpl : WrappingRow
         {
             private readonly Mapper _mapper;
-            private readonly Row _input;
             public RowImpl(Row input, Mapper mapper)
+                : base(input)
             {
                 _mapper = mapper;
-                _input = input;
             }
-
-            public override long Position => _input.Position;
-
-            public override long Batch => _input.Batch;
 
             public override Schema Schema => _mapper.OutputSchema;
 
             public override ValueGetter<TValue> GetGetter<TValue>(int col)
             {
                 int index = _mapper.GetInputIndex(col);
-                return _input.GetGetter<TValue>(index);
+                return Input.GetGetter<TValue>(index);
             }
-
-            public override ValueGetter<UInt128> GetIdGetter()
-                => _input.GetIdGetter();
 
             public override bool IsColumnActive(int col) => true;
         }

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -676,9 +676,8 @@ namespace Microsoft.ML.Transforms
                 return col => active[col];
             }
 
-            public Row GetRow(Row input, Func<int, bool> active, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> active)
             {
-                disposer = null;
                 return new RowImpl(input, _mapper);
             }
 

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
             return true;
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema)
+        private protected override IRowMapper MakeRowMapper(Schema schema)
             => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -319,7 +319,7 @@ namespace Microsoft.ML.Transforms.Conversions
             return ComposeGetterVec(input, iinfo, srcCol, srcType);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         // Factory method for SignatureLoadModel.
         private static HashingTransformer Create(IHostEnvironment env, ModelLoadContext ctx)

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Transforms.Conversions
             SaveColumns(ctx);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
+        private protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsPfa
         {

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -229,7 +229,7 @@ namespace Microsoft.ML.Transforms.Conversions
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsOnnx, ISaveAsPfa
         {

--- a/src/Microsoft.ML.Data/Transforms/NopTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/NopTransform.cs
@@ -133,13 +133,11 @@ namespace Microsoft.ML.Runtime.Data
             return predicate;
         }
 
-        public Row GetRow(Row input, Func<int, bool> active, out Action disposer)
+        public Row GetRow(Row input, Func<int, bool> active)
         {
             Contracts.CheckValue(input, nameof(input));
             Contracts.CheckValue(active, nameof(active));
             Contracts.CheckParam(input.Schema == Source.Schema, nameof(input), "Schema of input row must be the same as the schema the mapper is bound to");
-
-            disposer = null;
             return input;
         }
 

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -478,7 +478,7 @@ namespace Microsoft.ML.Transforms.Normalizers
         public new IDataTransform MakeDataTransform(IDataView input)
             => base.MakeDataTransform(input);
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsOnnx, ISaveAsPfa
         {

--- a/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
             }
 
-            public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+            private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
                 var active = new bool[InputSchema.ColumnCount];
                 foreach (var pair in ColMapNewToOld)

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -495,6 +495,7 @@ namespace Microsoft.ML.Transforms
             private Exception _producerTaskException;
 
             private readonly int[] _colToActivesIndex;
+            private bool _disposed;
 
             public override Schema Schema => _input.Schema;
 
@@ -554,14 +555,17 @@ namespace Microsoft.ML.Transforms
                 _producerTask = LoopProducerWorker();
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                if (_producerTask.Status == TaskStatus.Running)
+                if (_disposed)
+                    return;
+                if (disposing && _producerTask.Status == TaskStatus.Running)
                 {
                     _toProduce.Post(0);
                     _producerTask.Wait();
                 }
-                base.Dispose();
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public static void PostAssert<T>(ITargetBlock<T> target, T item)

--- a/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
@@ -33,7 +33,8 @@ namespace Microsoft.ML.Runtime.Data
             return new RowToRowMapperTransform(Host, new EmptyDataView(Host, inputSchema), MakeRowMapper(inputSchema), MakeRowMapper);
         }
 
-        protected abstract IRowMapper MakeRowMapper(Schema schema);
+        [BestFriend]
+        private protected abstract IRowMapper MakeRowMapper(Schema schema);
 
         public Schema GetOutputSchema(Schema inputSchema)
         {
@@ -67,9 +68,9 @@ namespace Microsoft.ML.Runtime.Data
 
             protected abstract Schema.DetachedColumn[] GetOutputColumnsCore();
 
-            public Schema.DetachedColumn[] GetOutputColumns() => _outputColumns.Value;
+            Schema.DetachedColumn[] IRowMapper.GetOutputColumns() => _outputColumns.Value;
 
-            public Delegate[] CreateGetters(Row input, Func<int, bool> activeOutput, out Action disposer)
+            Delegate[] IRowMapper.CreateGetters(Row input, Func<int, bool> activeOutput, out Action disposer)
             {
                 // REVIEW: it used to be that the mapper's input schema in the constructor was required to be reference-equal to the schema
                 // of the input row.
@@ -100,7 +101,11 @@ namespace Microsoft.ML.Runtime.Data
 
             protected abstract Delegate MakeGetter(Row input, int iinfo, Func<int, bool> activeOutput, out Action disposer);
 
-            public abstract Func<int, bool> GetDependencies(Func<int, bool> activeOutput);
+            Func<int, bool> IRowMapper.GetDependencies(Func<int, bool> activeOutput)
+                => GetDependenciesCore(activeOutput);
+
+            [BestFriend]
+            private protected abstract Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput);
 
             public abstract void Save(ModelSaveContext ctx);
         }

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -188,23 +188,18 @@ namespace Microsoft.ML.Runtime.Data
 
         protected abstract int MapColumnIndex(out bool isSrc, int col);
 
-        private sealed class RowImpl : Row
+        private sealed class RowImpl : WrappingRow
         {
             private readonly Schema _schema;
-            private readonly Row _input;
             private readonly Delegate[] _getters;
 
             private readonly RowToRowMapperTransformBase _parent;
 
-            public override long Batch => _input.Batch;
-
-            public override long Position => _input.Position;
-
             public override Schema Schema => _schema;
 
             public RowImpl(Row input, RowToRowMapperTransformBase parent, Schema schema, Delegate[] getters)
+                : base(input)
             {
-                _input = input;
                 _parent = parent;
                 _schema = schema;
                 _getters = getters;
@@ -215,7 +210,7 @@ namespace Microsoft.ML.Runtime.Data
                 bool isSrc;
                 int index = _parent.MapColumnIndex(out isSrc, col);
                 if (isSrc)
-                    return _input.GetGetter<TValue>(index);
+                    return Input.GetGetter<TValue>(index);
 
                 Contracts.Assert(_getters[index] != null);
                 var fn = _getters[index] as ValueGetter<TValue>;
@@ -224,17 +219,12 @@ namespace Microsoft.ML.Runtime.Data
                 return fn;
             }
 
-            public override ValueGetter<UInt128> GetIdGetter()
-            {
-                return _input.GetIdGetter();
-            }
-
             public override bool IsColumnActive(int col)
             {
                 bool isSrc;
                 int index = _parent.MapColumnIndex(out isSrc, col);
                 if (isSrc)
-                    return _input.IsColumnActive((index));
+                    return Input.IsColumnActive((index));
                 return _getters[index] != null;
             }
         }
@@ -842,7 +832,8 @@ namespace Microsoft.ML.Runtime.Data
             private readonly bool[] _active;
 
             private readonly Delegate[] _getters;
-            private readonly Action[] _disposers;
+            private readonly Action _disposer;
+            private bool _disposed;
 
             public Cursor(IChannelProvider provider, OneToOneTransformBase parent, RowCursor input, bool[] active)
                 : base(provider, input)
@@ -854,30 +845,29 @@ namespace Microsoft.ML.Runtime.Data
                 _active = active;
                 _getters = new Delegate[parent.Infos.Length];
 
-                // Build the delegates.
-                List<Action> disposers = null;
+                // Build the disposing delegate.
+                Action masterDisposer = null;
                 for (int iinfo = 0; iinfo < _getters.Length; iinfo++)
                 {
                     if (!IsColumnActive(parent._bindings.MapIinfoToCol(iinfo)))
                         continue;
-                    Action disposer;
-                    _getters[iinfo] = parent.GetGetterCore(Ch, Input, iinfo, out disposer);
+                    _getters[iinfo] = parent.GetGetterCore(Ch, Input, iinfo, out Action disposer);
                     if (disposer != null)
-                        Utils.Add(ref disposers, disposer);
+                        masterDisposer += disposer;
                 }
-
-                if (Utils.Size(disposers) > 0)
-                    _disposers = disposers.ToArray();
+                _disposer = masterDisposer;
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                if (_disposers != null)
+                if (_disposed)
+                    return;
+                if (disposing)
                 {
-                    foreach (var act in _disposers)
-                        act();
+                    _disposer?.Invoke();
                 }
-                base.Dispose();
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public override Schema Schema => _bindings.AsSchema;

--- a/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
+++ b/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
@@ -360,7 +360,7 @@ namespace Microsoft.ML.Transforms.Conversions
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         internal static bool GetNewType(IExceptionContext ectx, ColumnType srcType, DataKind kind, KeyRange range, out PrimitiveType itemType)
         {

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -713,7 +713,7 @@ namespace Microsoft.ML.Transforms.Conversions
             return _unboundMaps[iinfo];
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema)
+        private protected override IRowMapper MakeRowMapper(Schema schema)
           => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsOnnx, ISaveAsPfa

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -208,11 +208,10 @@ namespace Microsoft.ML.Runtime.Data
                 OutputSchema = Schema.Create(new SchemaImpl(ectx, owner, treeValueType, leafIdType, pathIdType));
             }
 
-            public Row GetRow(Row input, Func<int, bool> predicate, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> predicate)
             {
                 _ectx.CheckValue(input, nameof(input));
                 _ectx.CheckValue(predicate, nameof(predicate));
-                disposer = null;
                 return new SimpleRow(OutputSchema, input, CreateGetters(input, predicate));
             }
 

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -639,7 +639,7 @@ namespace Microsoft.ML.Transforms.Projections
                 int m, int n, float[] a, int lda, float[] s, float[] u, int ldu, float[] vt, int ldvt, float[] superb);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema)
+        private protected override IRowMapper MakeRowMapper(Schema schema)
             => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase

--- a/src/Microsoft.ML.ImageAnalytics/ImageGrayscaleTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageGrayscaleTransform.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                     new float[] {0, 0, 0, 0, 1}
                 });
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         protected override void CheckInputColumn(ISchema inputSchema, int col, int srcCol)
         {

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoaderTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoaderTransform.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                 loaderAssemblyName: typeof(ImageLoaderTransform).Assembly.FullName);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
                 info.Save(ctx);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         protected override void CheckInputColumn(ISchema inputSchema, int col, int srcCol)
         {

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizerTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizerTransform.cs
@@ -285,7 +285,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
             }
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         protected override void CheckInputColumn(ISchema inputSchema, int col, int srcCol)
         {

--- a/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
+++ b/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
@@ -147,8 +147,9 @@ namespace Microsoft.ML.Legacy
                     catch (Exception e)
                     {
                         _pipelineExecutionException = e;
-                        var fakeColumn = new KeyValuePair<string, ColumnType>("Blank", TextType.Instance);
-                        _preview = new EmptyDataView(_environment, Schema.Create(new SimpleSchema(_environment, fakeColumn)));
+                        var builder = new SchemaBuilder();
+                        builder.AddColumn("Blank", TextType.Instance);
+                        _preview = new EmptyDataView(_environment, builder.GetSchema());
                     }
                 }
             }

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Transforms
             foreach (var colName in Outputs)
                 ctx.SaveNonEmptyString(colName);
         }
-        protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
+        private protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
 
         private static int[] AdjustDimensions(OnnxShape shape)
         {
@@ -309,7 +309,7 @@ namespace Microsoft.ML.Transforms
                 return info;
             }
 
-            public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+            private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
                 return col => Enumerable.Range(0, _parent.Outputs.Length).Any(i => activeOutput(i)) && _inputColIndices.Any(i => i == col);
             }

--- a/src/Microsoft.ML.PCA/PcaTransform.cs
+++ b/src/Microsoft.ML.PCA/PcaTransform.cs
@@ -540,7 +540,7 @@ namespace Microsoft.ML.Transforms.Projections
             return y;
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         protected override void CheckInputColumn(ISchema inputSchema, int col, int srcCol)
         {

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -358,15 +358,14 @@ namespace Microsoft.ML.Trainers.Recommender
                 return getters;
             }
 
-            public Row GetRow(Row input, Func<int, bool> predicate, out Action disposer)
+            public Row GetRow(Row input, Func<int, bool> active)
             {
-                var active = Utils.BuildArray(OutputSchema.ColumnCount, predicate);
-                var getters = CreateGetter(input, active);
-                disposer = null;
+                var activeArray = Utils.BuildArray(OutputSchema.ColumnCount, active);
+                var getters = CreateGetter(input, activeArray);
                 return new SimpleRow(OutputSchema, input, getters);
             }
 
-            public ISchemaBindableMapper Bindable { get { return _parent; } }
+            public ISchemaBindableMapper Bindable => _parent;
         }
     }
 

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             }
         }
 
-        public Row GetRow(Row input, Func<int, bool> predicate, out Action action)
+        public Row GetRow(Row input, Func<int, bool> predicate)
         {
             var latentSum = new AlignedArray(_pred.FieldCount * _pred.FieldCount * _pred.LatentDimAligned, 16);
             var featureBuffer = new VBuffer<float>();
@@ -111,7 +111,6 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
                     inputGetters[f] = input.GetGetter<VBuffer<float>>(_inputColumnIndexes[f]);
             }
 
-            action = null;
             var getters = new Delegate[2];
             if (predicate(0))
             {

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -679,7 +679,7 @@ namespace Microsoft.ML.Transforms
             return (tfOutputTypes, outputTypes);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
+        private protected override IRowMapper MakeRowMapper(Schema inputSchema) => new Mapper(this, inputSchema);
 
         public override void Save(ModelSaveContext ctx)
         {
@@ -913,7 +913,7 @@ namespace Microsoft.ML.Transforms
                 }
             }
 
-            public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+            private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
                 return col => Enumerable.Range(0, _parent.Outputs.Length).Any(i => activeOutput(i)) && _inputColIndices.Any(i => i == col);
             }

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -98,16 +98,14 @@ namespace Microsoft.ML.TimeSeries
         {
         }
 
-        internal Row GetStatefulRows(Row input, IRowToRowMapper mapper, Func<int, bool> active,
-            List<StatefulRow> rows, out Action disposer)
+        internal Row GetStatefulRows(Row input, IRowToRowMapper mapper, Func<int, bool> active, List<StatefulRow> rows)
         {
             Contracts.CheckValue(input, nameof(input));
             Contracts.CheckValue(active, nameof(active));
 
-            disposer = null;
             IRowToRowMapper[] innerMappers = new IRowToRowMapper[0];
-            if (mapper is CompositeRowToRowMapper)
-                innerMappers = ((CompositeRowToRowMapper)mapper).InnerMappers;
+            if (mapper is CompositeRowToRowMapper compositeMapper)
+                innerMappers = compositeMapper.InnerMappers;
 
             if (innerMappers.Length == 0)
             {
@@ -122,10 +120,9 @@ namespace Microsoft.ML.TimeSeries
                         throw Contracts.ExceptParam(nameof(input), $"Mapper required column '{input.Schema.GetColumnName(c)}' active but it was not.");
                 }
 
-                var row = mapper.GetRow(input, active, out disposer);
+                var row = mapper.GetRow(input, active);
                 if (row is StatefulRow statefulRow)
                     rows.Add(statefulRow);
-
                 return row;
             }
 
@@ -140,21 +137,10 @@ namespace Microsoft.ML.TimeSeries
             Row result = input;
             for (int i = 0; i < innerMappers.Length; ++i)
             {
-                Action localDisp;
-                result = GetStatefulRows(result, innerMappers[i], deps[i], rows, out localDisp);
+                result = GetStatefulRows(result, innerMappers[i], deps[i], rows);
                 if (result is StatefulRow statefulResult)
                     rows.Add(statefulResult);
-
-                if (localDisp != null)
-                {
-                    if (disposer == null)
-                        disposer = localDisp;
-                    else
-                        disposer = localDisp + disposer;
-                    // We want the last disposer to be called first, so the order of the addition here is important.
-                }
             }
-
             return result;
         }
 
@@ -168,13 +154,14 @@ namespace Microsoft.ML.TimeSeries
             return pinger;
         }
 
-        internal override void PredictionEngineCore(IHostEnvironment env, DataViewConstructionUtils.InputRow<TSrc> inputRow, IRowToRowMapper mapper, bool ignoreMissingColumns,
+        private protected override void PredictionEngineCore(IHostEnvironment env, DataViewConstructionUtils.InputRow<TSrc> inputRow, IRowToRowMapper mapper, bool ignoreMissingColumns,
                  SchemaDefinition inputSchemaDefinition, SchemaDefinition outputSchemaDefinition, out Action disposer, out IRowReadableAs<TDst> outputRow)
         {
             List<StatefulRow> rows = new List<StatefulRow>();
-            Row outputRowLocal = outputRowLocal = GetStatefulRows(inputRow, mapper, col => true, rows, out disposer);
+            Row outputRowLocal = outputRowLocal = GetStatefulRows(inputRow, mapper, col => true, rows);
             var cursorable = TypedCursorable<TDst>.Create(env, new EmptyDataView(env, mapper.OutputSchema), ignoreMissingColumns, outputSchemaDefinition);
             _pinger = CreatePinger(rows);
+            disposer = outputRowLocal.Dispose;
             outputRow = cursorable.GetRow(outputRowLocal);
         }
 

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -478,10 +478,12 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                 return col => false;
             }
 
-            public Row GetRow(Row input, Func<int, bool> active, out Action disposer) =>
-                new RowImpl(_bindings.Schema, input, _mapper.CreateGetters(input, active, out disposer),
-                    _mapper.CreatePinger(input, active, out disposer));
-
+            public Row GetRow(Row input, Func<int, bool> active)
+            {
+                var getters = _mapper.CreateGetters(input, active, out Action disposer);
+                var pingers = _mapper.CreatePinger(input, active, out Action pingerDisposer);
+                return new RowImpl(_bindings.Schema, input, getters, pingers, disposer + pingerDisposer);
+            }
         }
 
         private sealed class RowImpl : StatefulRow
@@ -490,6 +492,8 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             private readonly Row _input;
             private readonly Delegate[] _getters;
             private readonly Action<long> _pinger;
+            private readonly Action _disposer;
+            private bool _disposed;
 
             public override Schema Schema => _schema;
 
@@ -497,7 +501,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             public override long Batch => _input.Batch;
 
-            public RowImpl(Schema schema, Row input, Delegate[] getters, Action<long> pinger)
+            public RowImpl(Schema schema, Row input, Delegate[] getters, Action<long> pinger, Action disposer)
             {
                 Contracts.CheckValue(schema, nameof(schema));
                 Contracts.CheckValue(input, nameof(input));
@@ -506,12 +510,21 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                 _input = input;
                 _getters = getters ?? new Delegate[0];
                 _pinger = pinger;
+                _disposer = disposer;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (_disposed)
+                    return;
+                if (disposing)
+                    _disposer?.Invoke();
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public override ValueGetter<UInt128> GetIdGetter()
-            {
-                return _input.GetIdGetter();
-            }
+                => _input.GetIdGetter();
 
             public override ValueGetter<T> GetGetter<T>(int col)
             {
@@ -745,32 +758,30 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
         Schema IRowToRowMapper.InputSchema => Source.Schema;
 
-        public Row GetRow(Row input, Func<int, bool> active, out Action disposer)
+        public Row GetRow(Row input, Func<int, bool> active)
         {
             Host.CheckValue(input, nameof(input));
             Host.CheckValue(active, nameof(active));
             Host.Check(input.Schema == Source.Schema, "Schema of input row must be the same as the schema the mapper is bound to");
 
-            disposer = null;
             using (var ch = Host.Start("GetEntireRow"))
             {
-                Action disp;
                 var activeArr = new bool[OutputSchema.ColumnCount];
                 for (int i = 0; i < OutputSchema.ColumnCount; i++)
                     activeArr[i] = active(i);
                 var pred = GetActiveOutputColumns(activeArr);
-                var getters = _mapper.CreateGetters(input, pred, out disp);
-                disposer += disp;
-                return new StatefulRow(input, this, OutputSchema, getters,
-                    _mapper.CreatePinger(input, pred, out disp));
+                var getters = _mapper.CreateGetters(input, pred, out Action disp);
+                var pingers = _mapper.CreatePinger(input, pred, out Action pingerDisp);
+                return new StatefulRowImpl(input, this, OutputSchema, getters, pingers, disp + pingerDisp);
             }
         }
 
-        private sealed class StatefulRow : TimeSeries.StatefulRow
+        private sealed class StatefulRowImpl : StatefulRow
         {
             private readonly Row _input;
             private readonly Delegate[] _getters;
             private readonly Action<long> _pinger;
+            private readonly Action _disposer;
 
             private readonly TimeSeriesRowToRowMapperTransform _parent;
 
@@ -780,14 +791,21 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             public override Schema Schema { get; }
 
-            public StatefulRow(Row input, TimeSeriesRowToRowMapperTransform parent,
-                Schema schema, Delegate[] getters, Action<long> pinger)
+            public StatefulRowImpl(Row input, TimeSeriesRowToRowMapperTransform parent,
+                Schema schema, Delegate[] getters, Action<long> pinger, Action disposer)
             {
                 _input = input;
                 _parent = parent;
                 Schema = schema;
                 _getters = getters;
                 _pinger = pinger;
+                _disposer = disposer;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                    _disposer?.Invoke();
             }
 
             public override ValueGetter<TValue> GetGetter<TValue>(int col)

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
         public bool IsRowToRowMapper => false;
 
-        public TState StateRef{ get; set; }
+        public TState StateRef { get; set; }
 
         public int StateRefCount;
 
@@ -825,6 +825,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             private readonly bool[] _active;
             private readonly ColumnBindings _bindings;
             private readonly Action _disposer;
+            private bool _disposed;
 
             public override Schema Schema => _bindings.Schema;
 
@@ -854,19 +855,21 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
                 Ch.AssertValue(_getters);
                 var getter = _getters[index];
-                Ch.Assert(getter != null);
-                var fn = getter as ValueGetter<TValue>;
-                if (fn == null)
-                    throw Ch.Except("Invalid TValue in GetGetter: '{0}'", typeof(TValue));
-                return fn;
+                Ch.AssertValue(getter);
+                if (getter is ValueGetter<TValue> fn)
+                    return fn;
+                throw Ch.Except("Invalid TValue in GetGetter: '{0}'", typeof(TValue));
             }
 
-            public override void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                _disposer?.Invoke();
-                base.Dispose();
+                if (_disposed)
+                    return;
+                if (disposing)
+                    _disposer?.Invoke();
+                _disposed = true;
+                base.Dispose(disposing);
             }
         }
     }
-
 }

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -421,7 +421,7 @@ namespace Microsoft.ML.Transforms.Projections
                 col.Save(ctx);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, Schema.Create(schema));
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, Schema.Create(schema));
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -552,7 +552,7 @@ namespace Microsoft.ML.Transforms
             private readonly GroupKeyColumnChecker[] _groupCheckers;
             private readonly KeepColumnAggregator[] _aggregators;
 
-            public override long Batch { get { return 0; } }
+            public override long Batch => 0;
 
             public override Schema Schema => _parent.OutputSchema;
 
@@ -662,11 +662,19 @@ namespace Microsoft.ML.Transforms
                 return result;
             }
 
-            public override void Dispose()
+            private bool _disposed;
+
+            protected override void Dispose(bool disposing)
             {
-                _leadingCursor.Dispose();
-                _trailingCursor.Dispose();
-                base.Dispose();
+                if (_disposed)
+                    return;
+                if (disposing)
+                {
+                    _leadingCursor.Dispose();
+                    _trailingCursor.Dispose();
+                }
+                _disposed = true;
+                base.Dispose(disposing);
             }
 
             public override ValueGetter<TValue> GetGetter<TValue>(int col)

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Transforms.Conversions
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -140,7 +140,7 @@ namespace Microsoft.ML.Transforms
             SaveColumns(ctx);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
@@ -139,7 +139,7 @@ namespace Microsoft.ML.Transforms
             SaveColumns(ctx);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -493,7 +493,7 @@ namespace Microsoft.ML.Transforms
         }
 
         // Factory method for SignatureLoadModel.
-        public static MissingValueReplacingTransformer Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static MissingValueReplacingTransformer Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             var host = env.Register(LoadName);
@@ -505,11 +505,11 @@ namespace Microsoft.ML.Transforms
         }
 
         // Factory method for SignatureLoadDataTransform.
-        public static IDataTransform Create(IHostEnvironment env, ModelLoadContext ctx, IDataView input)
+        private static IDataTransform Create(IHostEnvironment env, ModelLoadContext ctx, IDataView input)
             => Create(env, ctx).MakeDataTransform(input);
 
         // Factory method for SignatureLoadRowMapper.
-        public static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
+        private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
         private VBuffer<T> CreateVBuffer<T>(T[] array)
@@ -558,7 +558,7 @@ namespace Microsoft.ML.Transforms
             }
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsOnnx
         {

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -498,7 +498,7 @@ namespace Microsoft.ML.Transforms.Projections
                 _transformInfos[i].Save(ctx, string.Format("MatrixGenerator{0}", i));
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -1068,10 +1068,8 @@ namespace Microsoft.ML.Transforms.Text
             return columnMappings;
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema)
-        {
-            return new Mapper(this, schema);
-        }
+        private protected override IRowMapper MakeRowMapper(Schema schema)
+            => new Mapper(this, schema);
     }
 
     /// <include file='doc.xml' path='doc/members/member[@name="LightLDA"]/*' />

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -540,7 +540,7 @@ namespace Microsoft.ML.Transforms.Text
             }
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Transforms.Text
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, Schema.Create(schema));
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, Schema.Create(schema));
 
         private void CheckResources()
         {
@@ -491,7 +491,7 @@ namespace Microsoft.ML.Transforms.Text
                     (_resourcesExist[langVal] ?? (_resourcesExist[langVal] = GetResourceFileStreamOrNull(lang) != null).Value);
             }
 
-            public override Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
+            private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
                 var active = new bool[InputSchema.ColumnCount];
                 foreach (var pair in _colMapNewToOld)
@@ -966,7 +966,7 @@ namespace Microsoft.ML.Transforms.Text
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
            => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, Schema.Create(schema));
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, Schema.Create(schema));
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Transforms.Text
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
+++ b/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Transforms.Text
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase
         {

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Transforms.Text
                 ctx.Writer.Write((uint)_modelKind);
         }
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         protected override void CheckInputColumn(ISchema inputSchema, int col, int srcCol)
         {

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Transforms.Text
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, ISchema inputSchema)
             => Create(env, ctx).MakeRowMapper(Schema.Create(inputSchema));
 
-        protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
+        private protected override IRowMapper MakeRowMapper(Schema schema) => new Mapper(this, schema);
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsPfa
         {

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Benchmarks
             var xf = new HashingTransformer(_env, new[] { info });
             var mapper = xf.GetRowToRowMapper(_inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out int outCol);
-            var outRow = mapper.GetRow(_inRow, c => c == outCol, out var _);
+            var outRow = mapper.GetRow(_inRow, c => c == outCol);
             if (type is VectorType)
                 _vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
             else

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Tests.Transformers
             var xf = new HashingTransformer(Env, new[] { info });
             var mapper = xf.GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out int outCol);
-            var outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            var outRow = mapper.GetRow(inRow, c => c == outCol);
 
             var getter = outRow.GetGetter<uint>(outCol);
             uint result = 0;
@@ -159,7 +159,7 @@ namespace Microsoft.ML.Tests.Transformers
             xf = new HashingTransformer(Env, new[] { info });
             mapper = xf.GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            outRow = mapper.GetRow(inRow, c => c == outCol);
 
             getter = outRow.GetGetter<uint>(outCol);
             getter(ref result);
@@ -177,7 +177,7 @@ namespace Microsoft.ML.Tests.Transformers
             xf = new HashingTransformer(Env, new[] { info });
             mapper = xf.GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            outRow = mapper.GetRow(inRow, c => c == outCol);
 
             var vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
             VBuffer<uint> vecResult = default;
@@ -192,7 +192,7 @@ namespace Microsoft.ML.Tests.Transformers
             xf = new HashingTransformer(Env, new[] { info });
             mapper = xf.GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            outRow = mapper.GetRow(inRow, c => c == outCol);
             vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
             vecGetter(ref vecResult);
 
@@ -211,7 +211,7 @@ namespace Microsoft.ML.Tests.Transformers
             xf = new HashingTransformer(Env, new[] { info });
             mapper = xf.GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            outRow = mapper.GetRow(inRow, c => c == outCol);
             vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
             vecGetter(ref vecResult);
 
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Tests.Transformers
             xf = new HashingTransformer(Env, new[] { info });
             mapper = xf.GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol, out var _);
+            outRow = mapper.GetRow(inRow, c => c == outCol);
             vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
             vecGetter(ref vecResult);
 


### PR DESCRIPTION
Fixes #1824 .

Note that some internal things that instead operate on top of delegates will still have `Action` disposer delegates, but my expectation is that most of those things are (or should be) disposable.

The usual advice about the commits being a useful way to review still apply, though less so than in prior PRs since there are fewer bulk renamings than elsewhere.