### PR TITLE
Test for Metadata Support In DataView Construction

### DIFF
--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -946,6 +946,7 @@ namespace Microsoft.ML.Runtime.Api
             throw Contracts.ExceptNotImpl("Type '{0}' is not yet supported.", typeT.FullName);
         }
 
+        // We want to use MarshalInvoke instead of adding custom Reflection logic for calling GetGetter<TDst>
         private Delegate GetGetterCore<TDst>()
         {
             return GetGetter<TDst>();

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -946,16 +946,14 @@ namespace Microsoft.ML.Runtime.Api
             throw Contracts.ExceptNotImpl("Type '{0}' is not yet supported.", typeT.FullName);
         }
 
+        private Delegate GetGetterCore<TDst>()
+        {
+            return GetGetter<TDst>();
+        }
+
         internal override Delegate GetGetterDelegate()
         {
-            Type genericClassType = typeof(MetadataInfo<T>);
-            MethodInfo baseMethodInfo = genericClassType.GetMethod("GetGetter");
-
-            Type[] genericArguments = new Type[] { MetadataType.RawType };
-            MethodInfo genericMethodInfo = baseMethodInfo.MakeGenericMethod(genericArguments);
-
-            object classInstance = Activator.CreateInstance(genericClassType, Kind, Value, MetadataType);
-            return genericMethodInfo.Invoke(classInstance, new object[] { }) as Delegate;
+            return Utils.MarshalInvoke(GetGetterCore<int>, MetadataType.RawType);
         }
 
         public class TElement

--- a/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Api/DataViewConstructionUtils.cs
@@ -946,7 +946,17 @@ namespace Microsoft.ML.Runtime.Api
             throw Contracts.ExceptNotImpl("Type '{0}' is not yet supported.", typeT.FullName);
         }
 
-        internal override Delegate GetGetterDelegate() => Utils.MarshalInvoke(GetGetter<int>, MetadataType.RawType);
+        internal override Delegate GetGetterDelegate()
+        {
+            Type genericClassType = typeof(MetadataInfo<T>);
+            MethodInfo baseMethodInfo = genericClassType.GetMethod("GetGetter");
+
+            Type[] genericArguments = new Type[] { MetadataType.RawType };
+            MethodInfo genericMethodInfo = baseMethodInfo.MakeGenericMethod(genericArguments);
+
+            object classInstance = Activator.CreateInstance(genericClassType, Kind, Value, MetadataType);
+            return genericMethodInfo.Invoke(classInstance, new object[] { }) as Delegate;
+        }
 
         public class TElement
         {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -204,13 +204,13 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var kindVBuffer = "Testing VBuffer as metadata.";
             var valueVBuffer = new VBuffer<float>(4, new float[] { 4, 6, 89, 5 });
 
-            var metaFloat = new Microsoft.ML.Runtime.Api.MetadataInfo<float>(kindFloat, valueFloat, coltypeFloat);
-            var metaString = new Microsoft.ML.Runtime.Api.MetadataInfo<string>(kindString, valueString);
+            var metaFloat = new MetadataInfo<float>(kindFloat, valueFloat, coltypeFloat);
+            var metaString = new MetadataInfo<string>(kindString, valueString);
 
             // Add Metadata.
             var labelColumn = autoSchema[0];
             var labelColumnWithMetadata = new SchemaDefinition.Column(mlContext, labelColumn.MemberName, labelColumn.ColumnType,
-                metadataInfos: new Microsoft.ML.Runtime.Api.MetadataInfo[] { metaFloat, metaString });
+                metadataInfos: new MetadataInfo[] { metaFloat, metaString });
 
             var featureColumnWithMetadata = autoSchema[1];
             featureColumnWithMetadata.AddMetadata(kindStringArray, valueStringArray);
@@ -229,16 +229,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             Assert.True(idv.Schema[1].Metadata.Schema.Count == 3);
             Assert.True(idv.Schema[1].Metadata.Schema[0].Name == kindStringArray);
             Assert.True(idv.Schema[1].Metadata.Schema[0].Type.IsVector && idv.Schema[1].Metadata.Schema[0].Type.ItemType.IsText);
-            var thrown = false;
-            try
-            {
-                var schema = idv.Schema[1].Metadata.Schema[kindFloat];
-            }
-            catch
-            {
-                thrown = true;
-            }
-            Assert.True(thrown);
+            Assert.Throws<ArgumentOutOfRangeException>(() => idv.Schema[1].Metadata.Schema[kindFloat]);
 
             float retrievedFloat = 0;
             idv.Schema[0].Metadata.GetValue(kindFloat, ref retrievedFloat);
@@ -261,15 +252,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             idv.Schema[1].Metadata.GetValue(kindVBuffer, ref retrievedVBuffer);
             Assert.True(retrievedVBuffer.Items().SequenceEqual(valueVBuffer.Items()));
 
-            try
-            {
-                idv.Schema[1].Metadata.GetValue(kindFloat, ref retrievedReadOnlyMemoryVBuffer);
-                Assert.True(false, "Throw an error if attribute is applied to a field that is not an IChannel.");
-            }
-            catch (Exception ex)
-            {
-                Assert.True(ex.IsMarked());
-            }
+            var ex = Assert.Throws<InvalidOperationException>(() => idv.Schema[1].Metadata.GetValue(kindFloat, ref retrievedReadOnlyMemoryVBuffer));
+            Assert.True(ex.IsMarked());
         }
 
         private List<BreastCancerExample> ReadBreastCancerExamples()

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -220,8 +220,12 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var mySchema = new SchemaDefinition { labelColumnWithMetadata, featureColumnWithMetadata };
             var idv = mlContext.CreateDataView(data, mySchema);
 
-            Assert.True(idv.Schema[0].Metadata.Schema[kindFloat].Type == coltypeFloat);
-            Assert.True(idv.Schema[0].Metadata.Schema[kindString].Type == TextType.Instance);
+            Assert.True(idv.Schema[0].Metadata.Schema.Count == 2);
+            Assert.True(idv.Schema[0].Metadata.Schema[0].Name == kindFloat);
+            Assert.True(idv.Schema[0].Metadata.Schema[0].Type == coltypeFloat);
+            Assert.True(idv.Schema[0].Metadata.Schema[1].Name == kindString);
+            Assert.True(idv.Schema[0].Metadata.Schema[1].Type == TextType.Instance);
+
             Assert.True(idv.Schema[1].Metadata.Schema.Count == 3);
             Assert.True(idv.Schema[1].Metadata.Schema[0].Name == kindStringArray);
             Assert.True(idv.Schema[1].Metadata.Schema[0].Type.IsVector && idv.Schema[1].Metadata.Schema[0].Type.ItemType.IsText);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -187,90 +187,84 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void MetadataSupportInDataViewConstruction()
         {
             var data = ReadBreastCancerExamples();
-            using (var env = new ConsoleEnvironment(0))
+            var autoSchema = SchemaDefinition.Create(typeof(BreastCancerExample));
+
+            var mlContext = new MLContext(0);
+
+            // Create Metadata.
+            var kindFloat = "Testing float as metadata.";
+            var valueFloat = 10;
+            var coltypeFloat = NumberType.Float;
+            var kindString = "Testing string as metadata.";
+            var valueString = "Strings have value.";
+            var kindStringArray = "Testing string array as metadata.";
+            var valueStringArray = "I really have no idea what these features entail.".Split(' ');
+            var kindFloatArray = "Testing float array as metadata.";
+            var valueFloatArray = new float[] { 1, 17, 7, 19, 25, 0 };
+            var kindVBuffer = "Testing VBuffer as metadata.";
+            var valueVBuffer = new VBuffer<float>(4, new float[] { 4, 6, 89, 5 });
+
+            var metaFloat = new Microsoft.ML.Runtime.Api.MetadataInfo<float>(kindFloat, valueFloat, coltypeFloat);
+            var metaString = new Microsoft.ML.Runtime.Api.MetadataInfo<string>(kindString, valueString);
+
+            // Add Metadata.
+            var labelColumn = autoSchema[0];
+            var labelColumnWithMetadata = new SchemaDefinition.Column(mlContext, labelColumn.MemberName, labelColumn.ColumnType,
+                metadataInfos: new Microsoft.ML.Runtime.Api.MetadataInfo[] { metaFloat, metaString });
+
+            var featureColumnWithMetadata = autoSchema[1];
+            featureColumnWithMetadata.AddMetadata(kindStringArray, valueStringArray);
+            featureColumnWithMetadata.AddMetadata(kindFloatArray, valueFloatArray);
+            featureColumnWithMetadata.AddMetadata(kindVBuffer, valueVBuffer);
+
+            var mySchema = new SchemaDefinition { labelColumnWithMetadata, featureColumnWithMetadata };
+            var idv = mlContext.CreateDataView(data, mySchema);
+
+            Assert.True(idv.Schema[0].Metadata.Schema[kindFloat].Type == coltypeFloat);
+            Assert.True(idv.Schema[0].Metadata.Schema[kindString].Type == TextType.Instance);
+            Assert.True(idv.Schema[1].Metadata.Schema.Count == 3);
+            Assert.True(idv.Schema[1].Metadata.Schema[0].Name == kindStringArray);
+            Assert.True(idv.Schema[1].Metadata.Schema[0].Type.IsVector && idv.Schema[1].Metadata.Schema[0].Type.ItemType.IsText);
+            var thrown = false;
+            try
             {
-                var autoSchema = SchemaDefinition.Create(typeof(BreastCancerExample));
+                var schema = idv.Schema[1].Metadata.Schema[kindFloat];
+            }
+            catch
+            {
+                thrown = true;
+            }
+            Assert.True(thrown);
 
-                // Create Metadata.
-                var kindFloat = "Testing float as metadata.";
-                var valueFloat = 10;
-                var coltypeFloat = NumberType.Float;
-                var kindString = "Testing string as metadata.";
-                var valueString = "Strings have value.";
-                var kindStringArray = "Testing string array as metadata.";
-                var valueStringArray = "I really have no idea what these features entail.".Split(' ');
-                var kindFloatArray = "Testing float array as metadata.";
-                var valueFloatArray = new float[] { 1, 17, 7, 19, 25, 0 };
-                var kindVBuffer = "Testing VBuffer as metadata.";
-                var valueVBuffer = new VBuffer<float>(4, new float[] { 4, 6, 89, 5 });
+            float retrievedFloat = 0;
+            idv.Schema[0].Metadata.GetValue(kindFloat, ref retrievedFloat);
+            Assert.True(Math.Abs(retrievedFloat - valueFloat) < .000001);
 
-                var metaFloat = new Microsoft.ML.Runtime.Api.MetadataInfo<float>(kindFloat, valueFloat, coltypeFloat);
-                var metaString = new Microsoft.ML.Runtime.Api.MetadataInfo<string>(kindString, valueString);
+            ReadOnlyMemory<char> retrievedReadOnlyMemory = new ReadOnlyMemory<char>();
+            idv.Schema[0].Metadata.GetValue(kindString, ref retrievedReadOnlyMemory);
+            Assert.True(retrievedReadOnlyMemory.Span.SequenceEqual(valueString.AsMemory().Span));
 
-                // Add Metadata.
-                var labelColumn = autoSchema[0];
-                var labelColumnWithMetadata = new SchemaDefinition.Column(env, labelColumn.MemberName, labelColumn.ColumnType,
-                    metadataInfos: new Microsoft.ML.Runtime.Api.MetadataInfo[] { metaFloat, metaString });
+            VBuffer<ReadOnlyMemory<char>> retrievedReadOnlyMemoryVBuffer = new VBuffer<ReadOnlyMemory<char>>();
+            idv.Schema[1].Metadata.GetValue(kindStringArray, ref retrievedReadOnlyMemoryVBuffer);
+            Assert.True(retrievedReadOnlyMemoryVBuffer.DenseValues().Select((s, i) => s.ToString() == valueStringArray[i]).All(b => b));
 
-                var featureColumnWithMetadata = autoSchema[1];
-                featureColumnWithMetadata.AddMetadata(kindStringArray, valueStringArray);
-                featureColumnWithMetadata.AddMetadata(kindFloatArray, valueFloatArray);
-                featureColumnWithMetadata.AddMetadata(kindVBuffer, valueVBuffer);
+            VBuffer<float> retrievedFloatVBuffer = new VBuffer<float>(1, new float[] { 2 });
+            idv.Schema[1].Metadata.GetValue(kindFloatArray, ref retrievedFloatVBuffer);
+            VBuffer<float> valueFloatVBuffer = new VBuffer<float>(valueFloatArray.Length, valueFloatArray);
+            Assert.True(retrievedFloatVBuffer.Items().SequenceEqual(valueFloatVBuffer.Items()));
 
-                var mySchema = new SchemaDefinition { labelColumnWithMetadata, featureColumnWithMetadata };
-                var idv = env.CreateDataView(data, mySchema);
+            VBuffer<float> retrievedVBuffer = new VBuffer<float>();
+            idv.Schema[1].Metadata.GetValue(kindVBuffer, ref retrievedVBuffer);
+            Assert.True(retrievedVBuffer.Items().SequenceEqual(valueVBuffer.Items()));
 
-                Assert.True(idv.Schema[0].Metadata.Schema[kindFloat].Type == coltypeFloat);
-                Assert.True(idv.Schema[0].Metadata.Schema[kindString].Type == TextType.Instance);
-
-                Assert.True(idv.Schema[1].Metadata.Schema.Count == 3);
-                Assert.True(idv.Schema[1].Metadata.Schema[0].Name == kindStringArray);
-                Assert.True(idv.Schema[1].Metadata.Schema[0].Type.IsVector && idv.Schema[1].Metadata.Schema[0].Type.ItemType.IsText);
-
-                Assert.Null(idv.Schema.GetMetadataTypeOrNull(kindFloat, 1));
-                Assert.True(idv.Schema[0].Metadata.Schema[kindFloat].Type == coltypeFloat);
-
-                var thrown = false;
-                try
-                {
-                    var schema = idv.Schema[1].Metadata.Schema[kindFloat];
-                }
-                catch
-                {
-                    thrown = true;
-                }
-                Assert.True(thrown);
-
-                float retrievedFloat = 0;
-                idv.Schema[0].Metadata.GetValue(kindFloat, ref retrievedFloat);
-                Assert.True(Math.Abs(retrievedFloat - valueFloat) < .000001);
-
-                ReadOnlyMemory<char> retrievedReadOnlyMemory = new ReadOnlyMemory<char>();
-                idv.Schema[0].Metadata.GetValue(kindString, ref retrievedReadOnlyMemory);
-                Assert.True(retrievedReadOnlyMemory.Span.SequenceEqual(valueString.AsMemory().Span));
-
-                VBuffer<ReadOnlyMemory<char>> retrievedReadOnlyMemoryVBuffer = new VBuffer<ReadOnlyMemory<char>>();
-                idv.Schema[1].Metadata.GetValue(kindStringArray, ref retrievedReadOnlyMemoryVBuffer);
-                Assert.True(retrievedReadOnlyMemoryVBuffer.DenseValues().Select((s, i) => s.ToString() == valueStringArray[i]).All(b => b));
-
-                VBuffer<float> retrievedFloatVBuffer = new VBuffer<float>(1, new float[] { 2 });
-                idv.Schema[1].Metadata.GetValue(kindFloatArray, ref retrievedFloatVBuffer);
-                VBuffer<float> valueFloatVBuffer = new VBuffer<float>(valueFloatArray.Length, valueFloatArray);
-                Assert.True(retrievedFloatVBuffer.Items().SequenceEqual(valueFloatVBuffer.Items()));
-
-                VBuffer<float> retrievedVBuffer = new VBuffer<float>();
-                idv.Schema[1].Metadata.GetValue(kindVBuffer, ref retrievedVBuffer);
-                Assert.True(retrievedVBuffer.Items().SequenceEqual(valueVBuffer.Items()));
-
-                try
-                {
-                    idv.Schema[1].Metadata.GetValue(kindFloat, ref retrievedReadOnlyMemoryVBuffer);
-                    Assert.True(false, "Throw an error if attribute is applied to a field that is not an IChannel.");
-                }
-                catch (Exception ex)
-                {
-                    Assert.True(ex.IsMarked());
-                }
+            try
+            {
+                idv.Schema[1].Metadata.GetValue(kindFloat, ref retrievedReadOnlyMemoryVBuffer);
+                Assert.True(false, "Throw an error if attribute is applied to a field that is not an IChannel.");
+            }
+            catch (Exception ex)
+            {
+                Assert.True(ex.IsMarked());
             }
         }
 


### PR DESCRIPTION
Fixes #1633 

- Inside the `GetGetterDelegate` we were invoking MarshalInvoke with `GetGetter<int>` .  This does not take into consideration  the generic return type `ValueGetter<TDst>`. Subsequently, the validation inside `MarshalInvokeCheckAndCreate` fails.

- As part of the fix, we use reflection to invoke the generic `GetGetter<TDst>` with the appropriate type.