### PR TITLE
Public API for Tree predictors

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FastTreeRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FastTreeRegression.cs
@@ -27,22 +27,26 @@ namespace Microsoft.ML.Samples.Dynamic
             // 34   1       0-5yrs      2         4         2             4  ...
             // 35   1       6-11yrs     1         3         32            5  ...
 
-            // A pipeline for concatenating the parity and induced columns together in the Features column and training a FastTreeRegression model on them.
+            // A pipeline for concatenating the Parity and Induced columns together in the Features column.
+            // We will train a FastTreeRegression model with 1 tree on these two columns to predict Age.
             string outputColumnName = "Features";
             var pipeline = ml.Transforms.Concatenate(outputColumnName, new[] { "Parity", "Induced" })
-                .Append(ml.Regression.Trainers.FastTree(labelColumn: "Age", featureColumn: outputColumnName, numTrees: 2, numLeaves: 2, minDatapointsInLeaves: 1));
+                .Append(ml.Regression.Trainers.FastTree(labelColumn: "Age", featureColumn: outputColumnName, numTrees: 1, numLeaves: 2, minDatapointsInLeaves: 1));
 
             var model = pipeline.Fit(trainData);
 
             // Get the trained model parameters.
             var modelParams = model.LastTransformer.Model;
 
-            // Get the leaf and the leaf value for a row of data with Parity = 1, Induced = 1 in the first tree.
+            // Let's see where an example with Parity = 1 and Induced = 1 would end up in the single trained tree.
             var testRow = new VBuffer<float>(2, new[] { 1.0f, 1.0f });
+            // Use the path object to pass to GetLeaf, which will populate path with the IDs of th nodes from root to leaf.
             List<int> path = default;
-            var leaf = modelParams.GetLeaf(0, in testRow, ref path);
-            var leafValue = modelParams.GetLeafValue(0, leaf);
-            Console.WriteLine("The leaf value in tree 0 is: " + leafValue);                        
+            // Get the ID of the leaf this example ends up in tree 0.
+            var leafID = modelParams.GetLeaf(0, in testRow, ref path);
+            // Get the leaf value for this leaf ID in tree 0.
+            var leafValue = modelParams.GetLeafValue(0, leafID);
+            Console.WriteLine("The leaf value in tree 0 is: " + leafValue);
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FastTreeRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FastTreeRegression.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.ML.Runtime.Api;
+using Microsoft.ML.Runtime.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    public class FastTreeRegressionExample
+    {
+        public static void FastTreeRegression()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Get a small dataset as an IEnumerable and convert it to an IDataView.
+            var data = SamplesUtils.DatasetUtils.GetInfertData();
+            var trainData = ml.CreateStreamingDataView(data);
+
+            // Preview of the data.
+            //
+            // Age  Case  Education  Induced     Parity  PooledStratum  RowNum  ...
+            // 26   1       0-5yrs      1         6         3             1  ...
+            // 42   1       0-5yrs      1         1         1             2  ...
+            // 39   1       0-5yrs      2         6         4             3  ...
+            // 34   1       0-5yrs      2         4         2             4  ...
+            // 35   1       6-11yrs     1         3         32            5  ...
+
+            // A pipeline for concatenating the parity and induced columns together in the Features column and training a FastTreeRegression model on them.
+            string outputColumnName = "Features";
+            var pipeline = ml.Transforms.Concatenate(outputColumnName, new[] { "Parity", "Induced" })
+                .Append(ml.Regression.Trainers.FastTree(labelColumn: "Age", featureColumn: outputColumnName, numTrees: 2, numLeaves: 2, minDatapointsInLeaves: 1));
+
+            var model = pipeline.Fit(trainData);
+
+            // Get the trained model parameters.
+            var modelParams = model.LastTransformer.Model;
+
+            // Get the leaf and the leaf value for a row of data with Parity = 1, Induced = 1 in the first tree.
+            var testRow = new VBuffer<float>(2, new[] { 1.0f, 1.0f });
+            List<int> path = default;
+            var leaf = modelParams.GetLeaf(0, in testRow, ref path);
+            var leafValue = modelParams.GetLeafValue(0, leaf);
+            Console.WriteLine("The leaf value in tree 0 is: " + leafValue);                        
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Samples.Static
             var data = reader.Read(dataFile);
 
             // The predictor that gets produced out of training
-            FastTreeRegressionPredictor pred = null;
+            FastTreeRegressionModelParameters pred = null;
 
             // Create the estimator
             var learningPipeline = reader.MakeNewEstimator()

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Samples.Static
             var (trainData, testData) = mlContext.Regression.TrainTestSplit(data, testFraction: 0.1);
 
             // The predictor that gets produced out of training
-            LightGbmRegressionPredictor pred = null;
+            LightGbmRegressionModelParameters pred = null;
 
             // Create the estimator
             var learningPipeline = reader.MakeNewEstimator()

--- a/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
+++ b/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
@@ -38,7 +38,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// Predictor that can specialize for quantile regression. It will produce a <see cref="ISchemaBindableMapper"/>, given
     /// an array of quantiles.
     /// </summary>
-    public interface IQuantileRegressionPredictor
+    [BestFriend]
+    internal interface IQuantileRegressionPredictor
     {
         ISchemaBindableMapper CreateMapper(Double[] quantiles);
     }
@@ -59,7 +60,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     }
 
     // REVIEW: How should this quantile stuff work?
-    public interface IQuantileValueMapper
+    [BestFriend]
+    internal interface IQuantileValueMapper
     {
         ValueMapper<VBuffer<Float>, VBuffer<Float>> GetMapper(Float[] quantiles);
     }
@@ -183,7 +185,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// Interface for mapping input values to corresponding feature contributions.
     /// This interface is commonly implemented by predictors.
     /// </summary>
-    public interface IFeatureContributionMapper : IPredictor
+    [BestFriend]
+    internal interface IFeatureContributionMapper : IPredictor
     {
         /// <summary>
         /// Get a delegate for mapping Contributions to Features.

--- a/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
+++ b/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
@@ -101,7 +101,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// <summary>
     /// Predictors that can output themselves in the Bing ini format.
     /// </summary>
-    public interface ICanSaveInIniFormat
+    [BestFriend]
+    internal interface ICanSaveInIniFormat
     {
         void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null);
     }
@@ -109,7 +110,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// <summary>
     /// Predictors that can output Summary.
     /// </summary>
-    public interface ICanSaveSummary
+    [BestFriend]
+    internal interface ICanSaveSummary
     {
         void SaveSummary(TextWriter writer, RoleMappedSchema schema);
     }
@@ -119,7 +121,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// The content of value 'object' can be any type such as integer, float, string or an array of them.
     /// It is up the caller to check and decide how to consume the values.
     /// </summary>
-    public interface ICanGetSummaryInKeyValuePairs
+    [BestFriend]
+    internal interface ICanGetSummaryInKeyValuePairs
     {
         /// <summary>
         /// Gets model summary including model statistics (if exists) in key value pairs.
@@ -127,7 +130,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
         IList<KeyValuePair<string, object>> GetSummaryInKeyValuePairs(RoleMappedSchema schema);
     }
 
-    public interface ICanGetSummaryAsIRow
+    [BestFriend]
+    internal interface ICanGetSummaryAsIRow
     {
         Row GetSummaryIRowOrNull(RoleMappedSchema schema);
 
@@ -142,7 +146,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// <summary>
     /// Predictors that can output themselves in C#/C++ code.
     /// </summary>
-    public interface ICanSaveInSourceCode
+    [BestFriend]
+    internal interface ICanSaveInSourceCode
     {
         void SaveAsCode(TextWriter writer, RoleMappedSchema schema);
     }

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             return (ValueMapper<TIn, TOut, TDist>)(Delegate)del;
         }
 
-        public ValueMapper<TSrc, VBuffer<Float>> GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize)
+        ValueMapper<TSrc, VBuffer<Float>> IFeatureContributionMapper.GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize)
         {
             // REVIEW: checking this a bit too late.
             Host.Check(_featureContribution != null, "Predictor does not implement IFeatureContributionMapper");
@@ -682,7 +682,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             return new Bound(Host, this, schema);
         }
 
-        public ValueMapper<TSrc, VBuffer<float>> GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize)
+        ValueMapper<TSrc, VBuffer<float>> IFeatureContributionMapper.GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize)
         {
             // REVIEW: checking this a bit too late.
             Host.Check(_featureContribution != null, "Predictor does not implement " + nameof(IFeatureContributionMapper));

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -221,9 +221,9 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
         private readonly IValueMapper _mapper;
         private readonly IFeatureContributionMapper _featureContribution;
 
-        public ColumnType InputType => _mapper.InputType;
-        public ColumnType OutputType => _mapper.OutputType;
-        public ColumnType DistType => NumberType.Float;
+        ColumnType IValueMapper.InputType => _mapper.InputType;
+        ColumnType IValueMapper.OutputType => _mapper.OutputType;
+        ColumnType IValueMapperDist.DistType => NumberType.Float;
         bool ICanSavePfa.CanSavePfa => (_mapper as ICanSavePfa)?.CanSavePfa == true;
         bool ICanSaveOnnx.CanSaveOnnx(OnnxContext ctx) => (_mapper as ICanSaveOnnx)?.CanSaveOnnx(ctx) == true;
 
@@ -239,16 +239,16 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             _featureContribution = predictor as IFeatureContributionMapper;
         }
 
-        public ValueMapper<TIn, TOut> GetMapper<TIn, TOut>()
+        ValueMapper<TIn, TOut> IValueMapper.GetMapper<TIn, TOut>()
         {
             return _mapper.GetMapper<TIn, TOut>();
         }
 
-        public ValueMapper<TIn, TOut, TDist> GetMapper<TIn, TOut, TDist>()
+        ValueMapper<TIn, TOut, TDist> IValueMapperDist.GetMapper<TIn, TOut, TDist>()
         {
             Host.Check(typeof(TOut) == typeof(Float));
             Host.Check(typeof(TDist) == typeof(Float));
-            var map = GetMapper<TIn, Float>();
+            var map = ((IValueMapper)this).GetMapper<TIn, Float>();
             ValueMapper<TIn, Float, Float> del =
                 (in TIn src, ref Float score, ref Float prob) =>
                 {

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             Calibrator = calibrator;
         }
 
-        public void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null)
+        void ICanSaveInIniFormat.SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator)
         {
             Host.Check(calibrator == null, "Too many calibrators.");
             var saver = SubPredictor as ICanSaveInIniFormat;
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 saver.SaveAsText(writer, schema);
         }
 
-        public void SaveAsCode(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
         {
             // REVIEW: What about the calibrator?
             var saver = SubPredictor as ICanSaveInSourceCode;
@@ -175,7 +175,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 saver.SaveAsCode(writer, schema);
         }
 
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             // REVIEW: What about the calibrator?
             var saver = SubPredictor as ICanSaveSummary;
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
         }
 
         ///<inheritdoc/>
-        public IList<KeyValuePair<string, object>> GetSummaryInKeyValuePairs(RoleMappedSchema schema)
+        IList<KeyValuePair<string, object>> ICanGetSummaryInKeyValuePairs.GetSummaryInKeyValuePairs(RoleMappedSchema schema)
         {
             // REVIEW: What about the calibrator?
             var saver = SubPredictor as ICanGetSummaryInKeyValuePairs;

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Runtime.Data
                 };
         }
 
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             var summarySaver = Predictor as ICanSaveSummary;
             if (summarySaver == null)

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -557,7 +557,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
         public abstract ISchemaBoundMapper Bind(IHostEnvironment env, RoleMappedSchema schema);
 
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             for (int i = 0; i < PredictorModels.Length; i++)
             {
@@ -688,7 +688,7 @@ namespace Microsoft.ML.Runtime.Ensemble
         ///       - If neither of those interfaces are implemented then the value is a string containing the name of the type of model.
         /// </summary>
         /// <returns></returns>
-        public IList<KeyValuePair<string, object>> GetSummaryInKeyValuePairs(RoleMappedSchema schema)
+        IList<KeyValuePair<string, object>> ICanGetSummaryInKeyValuePairs.GetSummaryInKeyValuePairs(RoleMappedSchema schema)
         {
             Host.CheckValueOrNull(schema);
 

--- a/src/Microsoft.ML.Ensemble/Trainer/EnsemblePredictorBase.cs
+++ b/src/Microsoft.ML.Ensemble/Trainer/EnsemblePredictorBase.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ML.Runtime.Ensemble
         /// <summary>
         /// Saves the model summary
         /// </summary>
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             for (int i = 0; i < Models.Length; i++)
             {

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -2839,7 +2839,7 @@ namespace Microsoft.ML.Trainers.FastTree
         bool ICanSavePfa.CanSavePfa => true;
         bool ICanSaveOnnx.CanSaveOnnx(OnnxContext ctx) => true;
 
-        protected TreeEnsembleModelParameters(IHostEnvironment env, string name, TreeEnsemble trainedEnsemble, int numFeatures, string innerArgs)
+        public TreeEnsembleModelParameters(IHostEnvironment env, string name, TreeEnsemble trainedEnsemble, int numFeatures, string innerArgs)
             : base(env, name)
         {
             Host.CheckValue(trainedEnsemble, nameof(trainedEnsemble));

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -2794,7 +2794,7 @@ namespace Microsoft.ML.Trainers.FastTree
         }
     }
 
-    public abstract class FastTreePredictionWrapper :
+    public abstract class TreeEnsembleModelParameters :
         PredictorBase<Float>,
         IValueMapper,
         ICanSaveInTextFormat,
@@ -2839,7 +2839,7 @@ namespace Microsoft.ML.Trainers.FastTree
         bool ICanSavePfa.CanSavePfa => true;
         bool ICanSaveOnnx.CanSaveOnnx(OnnxContext ctx) => true;
 
-        protected FastTreePredictionWrapper(IHostEnvironment env, string name, TreeEnsemble trainedEnsemble, int numFeatures, string innerArgs)
+        protected TreeEnsembleModelParameters(IHostEnvironment env, string name, TreeEnsemble trainedEnsemble, int numFeatures, string innerArgs)
             : base(env, name)
         {
             Host.CheckValue(trainedEnsemble, nameof(trainedEnsemble));
@@ -2860,7 +2860,7 @@ namespace Microsoft.ML.Trainers.FastTree
             OutputType = NumberType.Float;
         }
 
-        protected FastTreePredictionWrapper(IHostEnvironment env, string name, ModelLoadContext ctx, VersionInfo ver)
+        protected TreeEnsembleModelParameters(IHostEnvironment env, string name, ModelLoadContext ctx, VersionInfo ver)
             : base(env, name, ctx)
         {
             // *** Binary format ***
@@ -2933,7 +2933,7 @@ namespace Microsoft.ML.Trainers.FastTree
             dst = (Float)TrainedEnsemble.GetOutput(in src);
         }
 
-        public ValueMapper<TSrc, VBuffer<Float>> GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize)
+        ValueMapper<TSrc, VBuffer<Float>> IFeatureContributionMapper.GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize)
         {
             Host.Check(typeof(TSrc) == typeof(VBuffer<Float>));
             Host.Check(typeof(TDst) == typeof(VBuffer<Float>));

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -2811,7 +2811,8 @@ namespace Microsoft.ML.Trainers.FastTree
         ISingleCanSaveOnnx
     {
         //The below two properties are necessary for tree Visualizer
-        public TreeEnsemble TrainedEnsemble { get; }
+        [BestFriend]
+        internal TreeEnsemble TrainedEnsemble { get; }
         int ITreeEnsemble.NumTrees => TrainedEnsemble.NumTrees;
 
         // Inner args is used only for documentation purposes when saving comments to INI files.

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -2963,7 +2963,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// <summary>
         /// write out a C# representation of the ensemble
         /// </summary>
-        public void SaveAsCode(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValueOrNull(schema);
             SaveEnsembleAsCode(writer, schema);
@@ -2976,13 +2976,13 @@ namespace Microsoft.ML.Trainers.FastTree
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValueOrNull(schema);
-            SaveAsIni(writer, schema);
+            ((ICanSaveInIniFormat)this).SaveAsIni(writer, schema);
         }
 
         /// <summary>
         /// Output the INI model to a given writer
         /// </summary>
-        public void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null)
+        void ICanSaveInIniFormat.SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
@@ -3156,12 +3156,12 @@ namespace Microsoft.ML.Trainers.FastTree
             return true;
         }
 
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             writer.WriteLine();
             writer.WriteLine("Per-feature gain summary for the boosted tree ensemble:");
 
-            foreach (var pair in GetSummaryInKeyValuePairs(schema))
+            foreach (var pair in ((ICanGetSummaryInKeyValuePairs)this).GetSummaryInKeyValuePairs(schema))
             {
                 Host.Assert(pair.Value is Double);
                 writer.WriteLine("\t{0}\t{1}", pair.Key, (Double)pair.Value);
@@ -3187,7 +3187,7 @@ namespace Microsoft.ML.Trainers.FastTree
         }
 
         ///<inheritdoc/>
-        public IList<KeyValuePair<string, object>> GetSummaryInKeyValuePairs(RoleMappedSchema schema)
+        IList<KeyValuePair<string, object>> ICanGetSummaryInKeyValuePairs.GetSummaryInKeyValuePairs(RoleMappedSchema schema)
         {
             List<KeyValuePair<string, object>> results = new List<KeyValuePair<string, object>>();
 
@@ -3309,7 +3309,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return TrainedEnsemble.GetTreeAt(treeId).GetLeaf(in features, ref path);
         }
 
-        public Row GetSummaryIRowOrNull(RoleMappedSchema schema)
+        Row ICanGetSummaryAsIRow.GetSummaryIRowOrNull(RoleMappedSchema schema)
         {
             var names = default(VBuffer<ReadOnlyMemory<char>>);
             MetadataUtils.GetSlotNames(schema, RoleMappedSchema.ColumnRole.Feature, NumFeatures, ref names);
@@ -3324,7 +3324,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return MetadataUtils.MetadataAsRow(builder.GetMetadata());
         }
 
-        public Row GetStatsIRowOrNull(RoleMappedSchema schema)
+        Row ICanGetSummaryAsIRow.GetStatsIRowOrNull(RoleMappedSchema schema)
         {
             return null;
         }

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -36,17 +36,17 @@ using System.Linq;
     "fastrank",
     "fastrankwrapper")]
 
-[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(FastTreeBinaryPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(FastTreeBinaryModelParameters), null, typeof(SignatureLoadModel),
     "FastTree Binary Executor",
-    FastTreeBinaryPredictor.LoaderSignature)]
+    FastTreeBinaryModelParameters.LoaderSignature)]
 
 namespace Microsoft.ML.Trainers.FastTree
 {
-    public sealed class FastTreeBinaryPredictor :
-        FastTreePredictionWrapper
+    public sealed class FastTreeBinaryModelParameters :
+        TreeEnsembleModelParameters
     {
-        public const string LoaderSignature = "FastTreeBinaryExec";
-        public const string RegistrationName = "FastTreeBinaryPredictor";
+        internal const string LoaderSignature = "FastTreeBinaryExec";
+        internal const string RegistrationName = "FastTreeBinaryPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 verReadableCur: 0x00010005,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(FastTreeBinaryPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(FastTreeBinaryModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
@@ -69,12 +69,12 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
-        internal FastTreeBinaryPredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        internal FastTreeBinaryModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private FastTreeBinaryPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private FastTreeBinaryModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -85,12 +85,12 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            var predictor = new FastTreeBinaryPredictor(env, ctx);
+            var predictor = new FastTreeBinaryModelParameters(env, ctx);
             ICalibrator calibrator;
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
@@ -177,7 +177,7 @@ namespace Microsoft.ML.Trainers.FastTree
             // output probabilities when transformed using a scaled logistic function,
             // so transform the scores using that.
 
-            var pred = new FastTreeBinaryPredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
+            var pred = new FastTreeBinaryModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
             // FastTree's binary classification boosting framework's natural probabilistic interpretation
             // is explained in "From RankNet to LambdaRank to LambdaMART: An Overview" by Chris Burges.
             // The correctness of this scaling depends upon the gradient calculation in

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
-        internal FastTreeBinaryModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public FastTreeBinaryModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -108,7 +108,7 @@ namespace Microsoft.ML.Trainers.FastTree
         /// <summary>
         /// The LoadName for the assembly containing the trainer.
         /// </summary>
-        public const string LoadNameValue = "FastTreeBinaryClassification";
+        internal const string LoadNameValue = "FastTreeBinaryClassification";
         internal const string UserNameValue = "FastTree (Boosted Trees) Classification";
         internal const string Summary = "Uses a logit-boost boosted tree learner to perform binary classification.";
         internal const string ShortName = "ftc";

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -1130,7 +1130,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
-        internal FastTreerankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public FastTreerankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -33,9 +33,9 @@ using System.Text;
     "frrank",
     "btrank")]
 
-[assembly: LoadableClass(typeof(FastTreeRankingPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(FastTreerankingModelParameters), null, typeof(SignatureLoadModel),
     "FastTree Ranking Executor",
-    FastTreeRankingPredictor.LoaderSignature)]
+    FastTreerankingModelParameters.LoaderSignature)]
 
 [assembly: LoadableClass(typeof(void), typeof(FastTree), null, typeof(SignatureEntryPointModule), "FastTree")]
 
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Trainers.FastTree
 {
     /// <include file='doc.xml' path='doc/members/member[@name="FastTree"]/*' />
     public sealed partial class FastTreeRankingTrainer
-        : BoostingFastTreeTrainerBase<FastTreeRankingTrainer.Arguments, RankingPredictionTransformer<FastTreeRankingPredictor>, FastTreeRankingPredictor>
+        : BoostingFastTreeTrainerBase<FastTreeRankingTrainer.Arguments, RankingPredictionTransformer<FastTreerankingModelParameters>, FastTreerankingModelParameters>
     {
         internal const string LoadNameValue = "FastTreeRanking";
         internal const string UserNameValue = "FastTree (Boosted Trees) Ranking";
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return GetLabelGains().Length - 1;
         }
 
-        private protected override FastTreeRankingPredictor TrainModelCore(TrainContext context)
+        private protected override FastTreerankingModelParameters TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -126,7 +126,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 TrainCore(ch);
                 FeatureCount = trainData.Schema.Feature.Type.ValueCount;
             }
-            return new FastTreeRankingPredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
+            return new FastTreerankingModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 
         private Double[] GetLabelGains()
@@ -454,10 +454,10 @@ namespace Microsoft.ML.Trainers.FastTree
             return headerBuilder.ToString();
         }
 
-        protected override RankingPredictionTransformer<FastTreeRankingPredictor> MakeTransformer(FastTreeRankingPredictor model, Schema trainSchema)
-        => new RankingPredictionTransformer<FastTreeRankingPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RankingPredictionTransformer<FastTreerankingModelParameters> MakeTransformer(FastTreerankingModelParameters model, Schema trainSchema)
+        => new RankingPredictionTransformer<FastTreerankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RankingPredictionTransformer<FastTreeRankingPredictor> Train(IDataView trainData, IDataView validationData = null)
+        public RankingPredictionTransformer<FastTreerankingModelParameters> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
@@ -1104,10 +1104,10 @@ namespace Microsoft.ML.Trainers.FastTree
         }
     }
 
-    public sealed class FastTreeRankingPredictor : FastTreePredictionWrapper
+    public sealed class FastTreerankingModelParameters : TreeEnsembleModelParameters
     {
-        public const string LoaderSignature = "FastTreeRankerExec";
-        public const string RegistrationName = "FastTreeRankingPredictor";
+        internal const string LoaderSignature = "FastTreeRankerExec";
+        internal const string RegistrationName = "FastTreeRankingPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -1121,7 +1121,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 verReadableCur: 0x00010004,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(FastTreeRankingPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(FastTreerankingModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
@@ -1130,12 +1130,12 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
-        internal FastTreeRankingPredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        internal FastTreerankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private FastTreeRankingPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private FastTreerankingModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -1146,9 +1146,9 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public static FastTreeRankingPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static FastTreerankingModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
-            return new FastTreeRankingPredictor(env, ctx);
+            return new FastTreerankingModelParameters(env, ctx);
         }
 
         public override PredictionKind PredictionKind => PredictionKind.Ranking;

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -33,9 +33,9 @@ using System.Text;
     "frrank",
     "btrank")]
 
-[assembly: LoadableClass(typeof(FastTreerankingModelParameters), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(FastTreeRankingModelParameters), null, typeof(SignatureLoadModel),
     "FastTree Ranking Executor",
-    FastTreerankingModelParameters.LoaderSignature)]
+    FastTreeRankingModelParameters.LoaderSignature)]
 
 [assembly: LoadableClass(typeof(void), typeof(FastTree), null, typeof(SignatureEntryPointModule), "FastTree")]
 
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Trainers.FastTree
 {
     /// <include file='doc.xml' path='doc/members/member[@name="FastTree"]/*' />
     public sealed partial class FastTreeRankingTrainer
-        : BoostingFastTreeTrainerBase<FastTreeRankingTrainer.Arguments, RankingPredictionTransformer<FastTreerankingModelParameters>, FastTreerankingModelParameters>
+        : BoostingFastTreeTrainerBase<FastTreeRankingTrainer.Arguments, RankingPredictionTransformer<FastTreeRankingModelParameters>, FastTreeRankingModelParameters>
     {
         internal const string LoadNameValue = "FastTreeRanking";
         internal const string UserNameValue = "FastTree (Boosted Trees) Ranking";
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Trainers.FastTree
             return GetLabelGains().Length - 1;
         }
 
-        private protected override FastTreerankingModelParameters TrainModelCore(TrainContext context)
+        private protected override FastTreeRankingModelParameters TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -126,7 +126,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 TrainCore(ch);
                 FeatureCount = trainData.Schema.Feature.Type.ValueCount;
             }
-            return new FastTreerankingModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
+            return new FastTreeRankingModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 
         private Double[] GetLabelGains()
@@ -454,10 +454,10 @@ namespace Microsoft.ML.Trainers.FastTree
             return headerBuilder.ToString();
         }
 
-        protected override RankingPredictionTransformer<FastTreerankingModelParameters> MakeTransformer(FastTreerankingModelParameters model, Schema trainSchema)
-        => new RankingPredictionTransformer<FastTreerankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RankingPredictionTransformer<FastTreeRankingModelParameters> MakeTransformer(FastTreeRankingModelParameters model, Schema trainSchema)
+        => new RankingPredictionTransformer<FastTreeRankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RankingPredictionTransformer<FastTreerankingModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        public RankingPredictionTransformer<FastTreeRankingModelParameters> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
@@ -1104,7 +1104,7 @@ namespace Microsoft.ML.Trainers.FastTree
         }
     }
 
-    public sealed class FastTreerankingModelParameters : TreeEnsembleModelParameters
+    public sealed class FastTreeRankingModelParameters : TreeEnsembleModelParameters
     {
         internal const string LoaderSignature = "FastTreeRankerExec";
         internal const string RegistrationName = "FastTreeRankingPredictor";
@@ -1121,7 +1121,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 verReadableCur: 0x00010004,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(FastTreerankingModelParameters).Assembly.FullName);
+                loaderAssemblyName: typeof(FastTreeRankingModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
@@ -1130,12 +1130,12 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
-        public FastTreerankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public FastTreeRankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private FastTreerankingModelParameters(IHostEnvironment env, ModelLoadContext ctx)
+        private FastTreeRankingModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -1146,9 +1146,9 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        private static FastTreerankingModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static FastTreeRankingModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
-            return new FastTreerankingModelParameters(env, ctx);
+            return new FastTreeRankingModelParameters(env, ctx);
         }
 
         public override PredictionKind PredictionKind => PredictionKind.Ranking;

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -28,15 +28,15 @@ using System.Text;
     "frr",
     "btr")]
 
-[assembly: LoadableClass(typeof(FastTreeRegressionPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(FastTreeRegressionModelParameters), null, typeof(SignatureLoadModel),
     "FastTree Regression Executor",
-    FastTreeRegressionPredictor.LoaderSignature)]
+    FastTreeRegressionModelParameters.LoaderSignature)]
 
 namespace Microsoft.ML.Trainers.FastTree
 {
     /// <include file='doc.xml' path='doc/members/member[@name="FastTree"]/*' />
     public sealed partial class FastTreeRegressionTrainer
-        : BoostingFastTreeTrainerBase<FastTreeRegressionTrainer.Arguments, RegressionPredictionTransformer<FastTreeRegressionPredictor>, FastTreeRegressionPredictor>
+        : BoostingFastTreeTrainerBase<FastTreeRegressionTrainer.Arguments, RegressionPredictionTransformer<FastTreeRegressionModelParameters>, FastTreeRegressionModelParameters>
     {
         public const string LoadNameValue = "FastTreeRegression";
         internal const string UserNameValue = "FastTree (Boosted Trees) Regression";
@@ -85,7 +85,7 @@ namespace Microsoft.ML.Trainers.FastTree
         {
         }
 
-        private protected override FastTreeRegressionPredictor TrainModelCore(TrainContext context)
+        private protected override FastTreeRegressionModelParameters TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -101,7 +101,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 ConvertData(trainData);
                 TrainCore(ch);
             }
-            return new FastTreeRegressionPredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
+            return new FastTreeRegressionModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 
         protected override void CheckArgs(IChannel ch)
@@ -164,10 +164,10 @@ namespace Microsoft.ML.Trainers.FastTree
             return new RegressionTest(ConstructScoreTracker(TrainSet));
         }
 
-        protected override RegressionPredictionTransformer<FastTreeRegressionPredictor> MakeTransformer(FastTreeRegressionPredictor model, Schema trainSchema)
-            => new RegressionPredictionTransformer<FastTreeRegressionPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RegressionPredictionTransformer<FastTreeRegressionModelParameters> MakeTransformer(FastTreeRegressionModelParameters model, Schema trainSchema)
+            => new RegressionPredictionTransformer<FastTreeRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<FastTreeRegressionPredictor> Train(IDataView trainData, IDataView validationData = null)
+        public RegressionPredictionTransformer<FastTreeRegressionModelParameters> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
@@ -441,10 +441,10 @@ namespace Microsoft.ML.Trainers.FastTree
         }
     }
 
-    public sealed class FastTreeRegressionPredictor : FastTreePredictionWrapper
+    public sealed class FastTreeRegressionModelParameters : TreeEnsembleModelParameters
     {
-        public const string LoaderSignature = "FastTreeRegressionExec";
-        public const string RegistrationName = "FastTreeRegressionPredictor";
+        internal const string LoaderSignature = "FastTreeRegressionExec";
+        internal const string RegistrationName = "FastTreeRegressionPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -458,7 +458,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 verReadableCur: 0x00010004,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(FastTreeRegressionPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(FastTreeRegressionModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
@@ -467,12 +467,12 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
-        internal FastTreeRegressionPredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        internal FastTreeRegressionModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private FastTreeRegressionPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private FastTreeRegressionModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -483,12 +483,12 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public static FastTreeRegressionPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static FastTreeRegressionModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            return new FastTreeRegressionPredictor(env, ctx);
+            return new FastTreeRegressionModelParameters(env, ctx);
         }
 
         public override PredictionKind PredictionKind => PredictionKind.Regression;

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -467,7 +467,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
 
-        internal FastTreeRegressionModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public FastTreeRegressionModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -23,9 +23,9 @@ using System.Text;
     FastTreeTweedieTrainer.LoadNameValue,
     FastTreeTweedieTrainer.ShortName)]
 
-[assembly: LoadableClass(typeof(FastTreeTweediePredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(FastTreeTweedieModelParameters), null, typeof(SignatureLoadModel),
     "FastTree Tweedie Regression Executor",
-    FastTreeTweediePredictor.LoaderSignature)]
+    FastTreeTweedieModelParameters.LoaderSignature)]
 
 namespace Microsoft.ML.Trainers.FastTree
 {
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Trainers.FastTree
     // https://arxiv.org/pdf/1508.06378.pdf
     /// <include file='doc.xml' path='doc/members/member[@name="FastTreeTweedieRegression"]/*' />
     public sealed partial class FastTreeTweedieTrainer
-         : BoostingFastTreeTrainerBase<FastTreeTweedieTrainer.Arguments, RegressionPredictionTransformer<FastTreeTweediePredictor>, FastTreeTweediePredictor>
+         : BoostingFastTreeTrainerBase<FastTreeTweedieTrainer.Arguments, RegressionPredictionTransformer<FastTreeTweedieModelParameters>, FastTreeTweedieModelParameters>
     {
         internal const string LoadNameValue = "FastTreeTweedieRegression";
         internal const string UserNameValue = "FastTree (Boosted Trees) Tweedie Regression";
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Initialize();
         }
 
-        private protected override FastTreeTweediePredictor TrainModelCore(TrainContext context)
+        private protected override FastTreeTweedieModelParameters TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -104,7 +104,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 ConvertData(trainData);
                 TrainCore(ch);
             }
-            return new FastTreeTweediePredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
+            return new FastTreeTweedieModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 
         protected override void CheckArgs(IChannel ch)
@@ -316,10 +316,10 @@ namespace Microsoft.ML.Trainers.FastTree
             PrintTestGraph(ch);
         }
 
-        protected override RegressionPredictionTransformer<FastTreeTweediePredictor> MakeTransformer(FastTreeTweediePredictor model, Schema trainSchema)
-         => new RegressionPredictionTransformer<FastTreeTweediePredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RegressionPredictionTransformer<FastTreeTweedieModelParameters> MakeTransformer(FastTreeTweedieModelParameters model, Schema trainSchema)
+         => new RegressionPredictionTransformer<FastTreeTweedieModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<FastTreeTweediePredictor> Train(IDataView trainData, IDataView validationData = null)
+        public RegressionPredictionTransformer<FastTreeTweedieModelParameters> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
@@ -446,10 +446,10 @@ namespace Microsoft.ML.Trainers.FastTree
         }
     }
 
-    public sealed class FastTreeTweediePredictor : FastTreePredictionWrapper
+    public sealed class FastTreeTweedieModelParameters : TreeEnsembleModelParameters
     {
-        public const string LoaderSignature = "FastTreeTweedieExec";
-        public const string RegistrationName = "FastTreeTweediePredictor";
+        internal const string LoaderSignature = "FastTreeTweedieExec";
+        internal const string RegistrationName = "FastTreeTweediePredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -461,7 +461,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 verReadableCur: 0x00010002,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(FastTreeTweediePredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(FastTreeTweedieModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010001;
@@ -470,12 +470,12 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010003;
 
-        internal FastTreeTweediePredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        internal FastTreeTweedieModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private FastTreeTweediePredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private FastTreeTweedieModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -486,12 +486,12 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public static FastTreeTweediePredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static FastTreeTweedieModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            return new FastTreeTweediePredictor(env, ctx);
+            return new FastTreeTweedieModelParameters(env, ctx);
         }
 
         protected override void Map(in VBuffer<float> src, ref float dst)

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -470,7 +470,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         protected override uint VerCategoricalSplitSerialized => 0x00010003;
 
-        internal FastTreeTweedieModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public FastTreeTweedieModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -1043,7 +1043,7 @@ namespace Microsoft.ML.Trainers.FastTree
             }
         }
 
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             ((ICanSaveInTextFormat)this).SaveAsText(writer, schema);
         }

--- a/src/Microsoft.ML.FastTree/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.FastTree/Properties/AssemblyInfo.cs
@@ -6,6 +6,8 @@ using System.Runtime.CompilerServices;
 using Microsoft.ML;
 
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Core.Tests" + PublicKey.TestValue)]
+
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.LightGBM" + PublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Sweeper" + PublicKey.Value)]
 
 [assembly: WantsToBeBestFriends]

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -25,9 +25,9 @@ using System.Linq;
     FastForestClassification.ShortName,
     "ffc")]
 
-[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(FastForestClassificationPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(FastForestClassificationModelParameters), null, typeof(SignatureLoadModel),
     "FastForest Binary Executor",
-    FastForestClassificationPredictor.LoaderSignature)]
+    FastForestClassificationModelParameters.LoaderSignature)]
 
 [assembly: LoadableClass(typeof(void), typeof(FastForest), null, typeof(SignatureEntryPointModule), "FastForest")]
 
@@ -46,11 +46,11 @@ namespace Microsoft.ML.Trainers.FastTree
         }
     }
 
-    public sealed class FastForestClassificationPredictor :
-        FastTreePredictionWrapper
+    public sealed class FastForestClassificationModelParameters :
+        TreeEnsembleModelParameters
     {
-        public const string LoaderSignature = "FastForestBinaryExec";
-        public const string RegistrationName = "FastForestClassificationPredictor";
+        internal const string LoaderSignature = "FastForestBinaryExec";
+        internal const string RegistrationName = "FastForestClassificationPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 verReadableCur: 0x00010005,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(FastForestClassificationPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(FastForestClassificationModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010003;
@@ -79,11 +79,11 @@ namespace Microsoft.ML.Trainers.FastTree
         /// </summary>
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        public FastForestClassificationPredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public FastForestClassificationModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         { }
 
-        private FastForestClassificationPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private FastForestClassificationModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -94,12 +94,12 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            var predictor = new FastForestClassificationPredictor(env, ctx);
+            var predictor = new FastForestClassificationModelParameters(env, ctx);
             ICalibrator calibrator;
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
@@ -192,7 +192,7 @@ namespace Microsoft.ML.Trainers.FastTree
             // calibrator, transform the scores using that.
 
             // REVIEW: Need a way to signal the outside world that we prefer simple sigmoid?
-            return new FastForestClassificationPredictor(Host, TrainedEnsemble, FeatureCount, InnerArgs);
+            return new FastForestClassificationModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }
 
         protected override ObjectiveFunctionBase ConstructObjFunc(IChannel ch)

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                     predictor = calibrated.SubPredictor;
                     paramA = -(calibrated.Calibrator as PlattCalibrator).ParamA;
                 }
-                var tree = predictor as FastTreePredictionWrapper;
+                var tree = predictor as TreeEnsembleModelParameters;
                 if (tree == null)
                     throw _host.Except("Model is not a tree ensemble");
                 foreach (var t in tree.TrainedEnsemble.Trees)
@@ -99,14 +99,14 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             {
                 case PredictionKind.BinaryClassification:
                     if (!binaryClassifier)
-                        return new FastTreeBinaryPredictor(_host, ensemble, featureCount, null);
+                        return new FastTreeBinaryModelParameters(_host, ensemble, featureCount, null);
 
                     var cali = new PlattCalibrator(_host, -1, 0);
-                    return new FeatureWeightsCalibratedPredictor(_host, new FastTreeBinaryPredictor(_host, ensemble, featureCount, null), cali);
+                    return new FeatureWeightsCalibratedPredictor(_host, new FastTreeBinaryModelParameters(_host, ensemble, featureCount, null), cali);
                 case PredictionKind.Regression:
-                    return new FastTreeRegressionPredictor(_host, ensemble, featureCount, null);
+                    return new FastTreeRegressionModelParameters(_host, ensemble, featureCount, null);
                 case PredictionKind.Ranking:
-                    return new FastTreeRankingPredictor(_host, ensemble, featureCount, null);
+                    return new FastTreerankingModelParameters(_host, ensemble, featureCount, null);
                 default:
                     _host.Assert(false);
                     throw _host.ExceptNotSupp();

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                 case PredictionKind.Regression:
                     return new FastTreeRegressionModelParameters(_host, ensemble, featureCount, null);
                 case PredictionKind.Ranking:
-                    return new FastTreerankingModelParameters(_host, ensemble, featureCount, null);
+                    return new FastTreeRankingModelParameters(_host, ensemble, featureCount, null);
                 default:
                     _host.Assert(false);
                     throw _host.ExceptNotSupp();

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 private readonly IExceptionContext _ectx;
                 private readonly Row _input;
-                private readonly FastTreePredictionWrapper _ensemble;
+                private readonly TreeEnsembleModelParameters _ensemble;
                 private readonly int _numTrees;
                 private readonly int _numLeaves;
 
@@ -276,7 +276,7 @@ namespace Microsoft.ML.Runtime.Data
                 private long _cachedLeafBuilderPosition;
                 private long _cachedPathBuilderPosition;
 
-                public State(IExceptionContext ectx, Row input, FastTreePredictionWrapper ensemble, int numLeaves, int featureIndex)
+                public State(IExceptionContext ectx, Row input, TreeEnsembleModelParameters ensemble, int numLeaves, int featureIndex)
                 {
                     Contracts.AssertValue(ectx);
                     _ectx = ectx;
@@ -422,7 +422,7 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         private readonly IHost _host;
-        private readonly FastTreePredictionWrapper _ensemble;
+        private readonly TreeEnsembleModelParameters _ensemble;
         private readonly int _totalLeafCount;
 
         public TreeEnsembleFeaturizerBindableMapper(IHostEnvironment env, Arguments args, IPredictor predictor)
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Runtime.Data
 
             if (predictor is CalibratedPredictorBase)
                 predictor = ((CalibratedPredictorBase)predictor).SubPredictor;
-            _ensemble = predictor as FastTreePredictionWrapper;
+            _ensemble = predictor as TreeEnsembleModelParameters;
             _host.Check(_ensemble != null, "Predictor in model file does not have compatible type");
 
             _totalLeafCount = CountLeaves(_ensemble);
@@ -449,7 +449,7 @@ namespace Microsoft.ML.Runtime.Data
             // *** Binary format ***
             // ensemble
 
-            ctx.LoadModel<FastTreePredictionWrapper, SignatureLoadModel>(env, out _ensemble, "Ensemble");
+            ctx.LoadModel<TreeEnsembleModelParameters, SignatureLoadModel>(env, out _ensemble, "Ensemble");
             _totalLeafCount = CountLeaves(_ensemble);
         }
 
@@ -466,7 +466,7 @@ namespace Microsoft.ML.Runtime.Data
             ctx.SaveModel(_ensemble, "Ensemble");
         }
 
-        private static int CountLeaves(FastTreePredictionWrapper ensemble)
+        private static int CountLeaves(TreeEnsembleModelParameters ensemble)
         {
             Contracts.AssertValue(ensemble);
 
@@ -644,7 +644,7 @@ namespace Microsoft.ML.Runtime.Data
                     // Make sure that the given predictor has the correct number of input features.
                     if (predictor is CalibratedPredictorBase)
                         predictor = ((CalibratedPredictorBase)predictor).SubPredictor;
-                    // Predictor should be a FastTreePredictionWrapper, which implements IValueMapper, so this should
+                    // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                     // be non-null.
                     var vm = predictor as IValueMapper;
                     ch.CheckUserArg(vm != null, nameof(args.TrainedModelFile), "Predictor in model file does not have compatible type");
@@ -708,7 +708,7 @@ namespace Microsoft.ML.Runtime.Data
                 // Make sure that the given predictor has the correct number of input features.
                 if (predictor is CalibratedPredictorBase)
                     predictor = ((CalibratedPredictorBase)predictor).SubPredictor;
-                // Predictor should be a FastTreePredictionWrapper, which implements IValueMapper, so this should
+                // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                 // be non-null.
                 var vm = predictor as IValueMapper;
                 ch.CheckUserArg(vm != null, nameof(args.PredictorModel), "Predictor does not have compatible type");

--- a/src/Microsoft.ML.FastTree/TreeTrainersStatic.cs
+++ b/src/Microsoft.ML.FastTree/TreeTrainersStatic.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ML.StaticPipe
             int minDatapointsInLeaves = Defaults.MinDocumentsInLeaves,
             double learningRate = Defaults.LearningRates,
             Action<FastTreeRankingTrainer.Arguments> advancedSettings = null,
-            Action<FastTreerankingModelParameters> onFit = null)
+            Action<FastTreeRankingModelParameters> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, numTrees, minDatapointsInLeaves, learningRate, advancedSettings, onFit);
 

--- a/src/Microsoft.ML.FastTree/TreeTrainersStatic.cs
+++ b/src/Microsoft.ML.FastTree/TreeTrainersStatic.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.StaticPipe
             int minDatapointsInLeaves = Defaults.MinDocumentsInLeaves,
             double learningRate = Defaults.LearningRates,
             Action<FastTreeRegressionTrainer.Arguments> advancedSettings = null,
-            Action<FastTreeRegressionPredictor> onFit = null)
+            Action<FastTreeRegressionModelParameters> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, numTrees, minDatapointsInLeaves, learningRate, advancedSettings, onFit);
 
@@ -144,7 +144,7 @@ namespace Microsoft.ML.StaticPipe
             int minDatapointsInLeaves = Defaults.MinDocumentsInLeaves,
             double learningRate = Defaults.LearningRates,
             Action<FastTreeRankingTrainer.Arguments> advancedSettings = null,
-            Action<FastTreeRankingPredictor> onFit = null)
+            Action<FastTreerankingModelParameters> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, numTrees, minDatapointsInLeaves, learningRate, advancedSettings, onFit);
 

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -738,7 +738,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             return new OlsLinearRegressionPredictor(env, ctx);
         }
 
-        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             var names = default(VBuffer<ReadOnlyMemory<char>>);
             MetadataUtils.GetSlotNames(schema, RoleMappedSchema.ColumnRole.Feature, Weight.Length, ref names);

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -738,7 +738,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             return new OlsLinearRegressionPredictor(env, ctx);
         }
 
-        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             var names = default(VBuffer<ReadOnlyMemory<char>>);
             MetadataUtils.GetSlotNames(schema, RoleMappedSchema.ColumnRole.Feature, Weight.Length, ref names);

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -738,7 +738,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             return new OlsLinearRegressionPredictor(env, ctx);
         }
 
-        public override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             var names = default(VBuffer<ReadOnlyMemory<char>>);
             MetadataUtils.GetSlotNames(schema, RoleMappedSchema.ColumnRole.Feature, Weight.Length, ref names);

--- a/src/Microsoft.ML.Legacy/AssemblyRegistration.cs
+++ b/src/Microsoft.ML.Legacy/AssemblyRegistration.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Runtime
 
             _ = typeof(TextLoader).Assembly; // ML.Data
             //_ = typeof(EnsemblePredictor).Assembly); // ML.Ensemble BUG https://github.com/dotnet/machinelearning/issues/1078 Ensemble isn't in a NuGet package
-            _ = typeof(FastTreeBinaryPredictor).Assembly; // ML.FastTree
+            _ = typeof(FastTreeBinaryModelParameters).Assembly; // ML.FastTree
             _ = typeof(KMeansModelParameters).Assembly; // ML.KMeansClustering
             _ = typeof(Maml).Assembly; // ML.Maml
             _ = typeof(PcaPredictor).Assembly; // ML.PCA

--- a/src/Microsoft.ML.Legacy/CSharpApi.cs
+++ b/src/Microsoft.ML.Legacy/CSharpApi.cs
@@ -401,6 +401,20 @@ namespace Microsoft.ML
             }
 
             [Obsolete]
+            public Microsoft.ML.Legacy.Models.PipelineSweeper.Output Add(Microsoft.ML.Legacy.Models.PipelineSweeper input)
+            {
+                var output = new Microsoft.ML.Legacy.Models.PipelineSweeper.Output();
+                Add(input, output);
+                return output;
+            }
+
+            [Obsolete]
+            public void Add(Microsoft.ML.Legacy.Models.PipelineSweeper input, Microsoft.ML.Legacy.Models.PipelineSweeper.Output output)
+            {
+                _jsonNodes.Add(Serialize("Models.PipelineSweeper", input, output));
+            }
+
+            [Obsolete]
             public Microsoft.ML.Legacy.Models.PlattCalibrator.Output Add(Microsoft.ML.Legacy.Models.PlattCalibrator input)
             {
                 var output = new Microsoft.ML.Legacy.Models.PlattCalibrator.Output();
@@ -496,6 +510,20 @@ namespace Microsoft.ML
             public void Add(Microsoft.ML.Legacy.Models.Summarizer input, Microsoft.ML.Legacy.Models.Summarizer.Output output)
             {
                 _jsonNodes.Add(Serialize("Models.Summarizer", input, output));
+            }
+
+            [Obsolete]
+            public Microsoft.ML.Legacy.Models.SweepResultExtractor.Output Add(Microsoft.ML.Legacy.Models.SweepResultExtractor input)
+            {
+                var output = new Microsoft.ML.Legacy.Models.SweepResultExtractor.Output();
+                Add(input, output);
+                return output;
+            }
+
+            [Obsolete]
+            public void Add(Microsoft.ML.Legacy.Models.SweepResultExtractor input, Microsoft.ML.Legacy.Models.SweepResultExtractor.Output output)
+            {
+                _jsonNodes.Add(Serialize("Models.SweepResultExtractor", input, output));
             }
 
             [Obsolete]
@@ -4097,6 +4125,120 @@ namespace Microsoft.ML
     {
 
         /// <summary>
+        /// AutoML pipeline sweeping optimzation macro.
+        /// </summary>
+        [Obsolete]
+        public sealed partial class PipelineSweeper
+        {
+
+
+            /// <summary>
+            /// The data to be used for training.
+            /// </summary>
+            [Obsolete]
+            public Var<Microsoft.ML.Runtime.Data.IDataView> TrainingData { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
+
+            /// <summary>
+            /// The data to be used for testing.
+            /// </summary>
+            [Obsolete]
+            public Var<Microsoft.ML.Runtime.Data.IDataView> TestingData { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
+
+            /// <summary>
+            /// The arguments for creating an AutoMlState component.
+            /// </summary>
+            [JsonConverter(typeof(ComponentSerializer))]
+            [Obsolete]
+            public AutoMlStateBase StateArguments { get; set; }
+
+            /// <summary>
+            /// The stateful object conducting of the autoML search.
+            /// </summary>
+            [Obsolete]
+            public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
+
+            /// <summary>
+            /// Number of candidate pipelines to retrieve each round.
+            /// </summary>
+            [Obsolete]
+            public int BatchSize { get; set; }
+
+            /// <summary>
+            /// Output datasets from previous iteration of sweep.
+            /// </summary>
+            [Obsolete]
+            public ArrayVar<Microsoft.ML.Runtime.Data.IDataView> CandidateOutputs { get; set; } = new ArrayVar<Microsoft.ML.Runtime.Data.IDataView>();
+
+            /// <summary>
+            /// Column(s) to use as Role 'Label'
+            /// </summary>
+            [Obsolete]
+            public string[] LabelColumns { get; set; }
+
+            /// <summary>
+            /// Column(s) to use as Role 'Group'
+            /// </summary>
+            [Obsolete]
+            public string[] GroupColumns { get; set; }
+
+            /// <summary>
+            /// Column(s) to use as Role 'Weight'
+            /// </summary>
+            [Obsolete]
+            public string[] WeightColumns { get; set; }
+
+            /// <summary>
+            /// Column(s) to use as Role 'Name'
+            /// </summary>
+            [Obsolete]
+            public string[] NameColumns { get; set; }
+
+            /// <summary>
+            /// Column(s) to use as Role 'NumericFeature'
+            /// </summary>
+            [Obsolete]
+            public string[] NumericFeatureColumns { get; set; }
+
+            /// <summary>
+            /// Column(s) to use as Role 'CategoricalFeature'
+            /// </summary>
+            [Obsolete]
+            public string[] CategoricalFeatureColumns { get; set; }
+
+            /// <summary>
+            /// Column(s) to use as Role 'TextFeature'
+            /// </summary>
+            [Obsolete]
+            public string[] TextFeatureColumns { get; set; }
+
+            /// <summary>
+            /// Column(s) to use as Role 'ImagePath'
+            /// </summary>
+            [Obsolete]
+            public string[] ImagePathColumns { get; set; }
+
+
+            [Obsolete]
+            public sealed class Output
+            {
+                /// <summary>
+                /// Stateful autoML object, keeps track of where the search in progress.
+                /// </summary>
+                public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
+
+                /// <summary>
+                /// Results of the sweep, including pipelines (as graph strings), IDs, and metric values.
+                /// </summary>
+                public Var<Microsoft.ML.Runtime.Data.IDataView> Results { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
+
+            }
+        }
+    }
+
+    namespace Legacy.Models
+    {
+
+        /// <summary>
         /// Apply a Platt calibrator to an input model
         /// </summary>
         [Obsolete]
@@ -4523,6 +4665,41 @@ namespace Microsoft.ML
                 /// The training set statistics. Note that this output can be null.
                 /// </summary>
                 public Var<Microsoft.ML.Runtime.Data.IDataView> Stats { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
+
+            }
+        }
+    }
+
+    namespace Legacy.Models
+    {
+
+        /// <summary>
+        /// Extracts the sweep result.
+        /// </summary>
+        [Obsolete]
+        public sealed partial class SweepResultExtractor
+        {
+
+
+            /// <summary>
+            /// The stateful object conducting of the autoML search.
+            /// </summary>
+            [Obsolete]
+            public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
+
+
+            [Obsolete]
+            public sealed class Output
+            {
+                /// <summary>
+                /// Stateful autoML object, keeps track of where the search in progress.
+                /// </summary>
+                public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
+
+                /// <summary>
+                /// Results of the sweep, including pipelines (as graph strings), IDs, and metric values.
+                /// </summary>
+                public Var<Microsoft.ML.Runtime.Data.IDataView> Results { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
 
             }
         }
@@ -20213,6 +20390,150 @@ namespace Microsoft.ML
     namespace Runtime
     {
         [Obsolete]
+        public abstract class AutoMlEngine : ComponentKind {}
+
+
+
+        /// <summary>
+        /// AutoML engine that returns learners with default settings.
+        /// </summary>
+        [Obsolete]
+        public sealed class DefaultsAutoMlEngine : AutoMlEngine
+        {
+            [Obsolete]
+            internal override string ComponentName => "Defaults";
+        }
+
+
+
+        /// <summary>
+        /// AutoML engine that consists of distinct, hierarchical stages of operation.
+        /// </summary>
+        [Obsolete]
+        public sealed class RocketAutoMlEngine : AutoMlEngine
+        {
+            /// <summary>
+            /// Number of learners to retain for second stage.
+            /// </summary>
+            [Obsolete]
+            public int TopKLearners { get; set; } = 2;
+
+            /// <summary>
+            /// Number of trials for retained second stage learners.
+            /// </summary>
+            [Obsolete]
+            public int SecondRoundTrialsPerLearner { get; set; } = 5;
+
+            /// <summary>
+            /// Use random initialization only.
+            /// </summary>
+            [Obsolete]
+            public bool RandomInitialization { get; set; } = false;
+
+            /// <summary>
+            /// Number of initilization pipelines, used for random initialization only.
+            /// </summary>
+            [Obsolete]
+            public int NumInitializationPipelines { get; set; } = 20;
+
+            [Obsolete]
+            internal override string ComponentName => "Rocket";
+        }
+
+
+
+        /// <summary>
+        /// AutoML engine using uniform random sampling.
+        /// </summary>
+        [Obsolete]
+        public sealed class UniformRandomAutoMlEngine : AutoMlEngine
+        {
+            [Obsolete]
+            internal override string ComponentName => "UniformRandom";
+        }
+
+        [Obsolete]
+        public abstract class AutoMlStateBase : ComponentKind {}
+
+        [Obsolete]
+        public enum PipelineSweeperSupportedMetricsMetrics
+        {
+            Auc = 0,
+            AccuracyMicro = 1,
+            AccuracyMacro = 2,
+            L1 = 3,
+            L2 = 4,
+            F1 = 5,
+            AuPrc = 6,
+            TopKAccuracy = 7,
+            Rms = 8,
+            LossFn = 9,
+            RSquared = 10,
+            LogLoss = 11,
+            LogLossReduction = 12,
+            Ndcg = 13,
+            Dcg = 14,
+            PositivePrecision = 15,
+            PositiveRecall = 16,
+            NegativePrecision = 17,
+            NegativeRecall = 18,
+            DrAtK = 19,
+            DrAtPFpr = 20,
+            DrAtNumPos = 21,
+            NumAnomalies = 22,
+            ThreshAtK = 23,
+            ThreshAtP = 24,
+            ThreshAtNumPos = 25,
+            Nmi = 26,
+            AvgMinScore = 27,
+            Dbi = 28
+        }
+
+
+
+        /// <summary>
+        /// State of an AutoML search and search space.
+        /// </summary>
+        [Obsolete]
+        public sealed class AutoMlStateAutoMlStateBase : AutoMlStateBase
+        {
+            /// <summary>
+            /// Supported metric for evaluator.
+            /// </summary>
+            [Obsolete]
+            public PipelineSweeperSupportedMetricsMetrics Metric { get; set; } = PipelineSweeperSupportedMetricsMetrics.Auc;
+
+            /// <summary>
+            /// AutoML engine (pipeline optimizer) that generates next candidates.
+            /// </summary>
+            [JsonConverter(typeof(ComponentSerializer))]
+            [Obsolete]
+            public AutoMlEngine Engine { get; set; }
+
+            /// <summary>
+            /// Kind of trainer for task, such as binary classification trainer, multiclass trainer, etc.
+            /// </summary>
+            [Obsolete]
+            public Microsoft.ML.Legacy.Models.MacroUtilsTrainerKinds TrainerKind { get; set; } = Microsoft.ML.Legacy.Models.MacroUtilsTrainerKinds.SignatureBinaryClassifierTrainer;
+
+            /// <summary>
+            /// Arguments for creating terminator, which determines when to stop search.
+            /// </summary>
+            [JsonConverter(typeof(ComponentSerializer))]
+            [Obsolete]
+            public SearchTerminator TerminatorArgs { get; set; }
+
+            /// <summary>
+            /// Learner set to sweep over (if available).
+            /// </summary>
+            [Obsolete]
+            public string[] RequestedLearners { get; set; }
+
+            [Obsolete]
+            internal override string ComponentName => "AutoMlState";
+        }
+
+        [Obsolete]
         public abstract class BoosterParameterFunction : ComponentKind {}
 
 
@@ -23311,6 +23632,27 @@ namespace Microsoft.ML
         {
             [Obsolete]
             internal override string ComponentName => "SquaredLoss";
+        }
+
+        [Obsolete]
+        public abstract class SearchTerminator : ComponentKind {}
+
+
+
+        /// <summary>
+        /// Terminators a sweep based on total number of iterations.
+        /// </summary>
+        [Obsolete]
+        public sealed class IterationLimitedSearchTerminator : SearchTerminator
+        {
+            /// <summary>
+            /// Total number of iterations.
+            /// </summary>
+            [Obsolete]
+            public int FinalHistoryLength { get; set; }
+
+            [Obsolete]
+            internal override string ComponentName => "IterationLimited";
         }
 
         [Obsolete]

--- a/src/Microsoft.ML.Legacy/CSharpApi.cs
+++ b/src/Microsoft.ML.Legacy/CSharpApi.cs
@@ -401,20 +401,6 @@ namespace Microsoft.ML
             }
 
             [Obsolete]
-            public Microsoft.ML.Legacy.Models.PipelineSweeper.Output Add(Microsoft.ML.Legacy.Models.PipelineSweeper input)
-            {
-                var output = new Microsoft.ML.Legacy.Models.PipelineSweeper.Output();
-                Add(input, output);
-                return output;
-            }
-
-            [Obsolete]
-            public void Add(Microsoft.ML.Legacy.Models.PipelineSweeper input, Microsoft.ML.Legacy.Models.PipelineSweeper.Output output)
-            {
-                _jsonNodes.Add(Serialize("Models.PipelineSweeper", input, output));
-            }
-
-            [Obsolete]
             public Microsoft.ML.Legacy.Models.PlattCalibrator.Output Add(Microsoft.ML.Legacy.Models.PlattCalibrator input)
             {
                 var output = new Microsoft.ML.Legacy.Models.PlattCalibrator.Output();
@@ -510,20 +496,6 @@ namespace Microsoft.ML
             public void Add(Microsoft.ML.Legacy.Models.Summarizer input, Microsoft.ML.Legacy.Models.Summarizer.Output output)
             {
                 _jsonNodes.Add(Serialize("Models.Summarizer", input, output));
-            }
-
-            [Obsolete]
-            public Microsoft.ML.Legacy.Models.SweepResultExtractor.Output Add(Microsoft.ML.Legacy.Models.SweepResultExtractor input)
-            {
-                var output = new Microsoft.ML.Legacy.Models.SweepResultExtractor.Output();
-                Add(input, output);
-                return output;
-            }
-
-            [Obsolete]
-            public void Add(Microsoft.ML.Legacy.Models.SweepResultExtractor input, Microsoft.ML.Legacy.Models.SweepResultExtractor.Output output)
-            {
-                _jsonNodes.Add(Serialize("Models.SweepResultExtractor", input, output));
             }
 
             [Obsolete]
@@ -4125,120 +4097,6 @@ namespace Microsoft.ML
     {
 
         /// <summary>
-        /// AutoML pipeline sweeping optimzation macro.
-        /// </summary>
-        [Obsolete]
-        public sealed partial class PipelineSweeper
-        {
-
-
-            /// <summary>
-            /// The data to be used for training.
-            /// </summary>
-            [Obsolete]
-            public Var<Microsoft.ML.Runtime.Data.IDataView> TrainingData { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
-
-            /// <summary>
-            /// The data to be used for testing.
-            /// </summary>
-            [Obsolete]
-            public Var<Microsoft.ML.Runtime.Data.IDataView> TestingData { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
-
-            /// <summary>
-            /// The arguments for creating an AutoMlState component.
-            /// </summary>
-            [JsonConverter(typeof(ComponentSerializer))]
-            [Obsolete]
-            public AutoMlStateBase StateArguments { get; set; }
-
-            /// <summary>
-            /// The stateful object conducting of the autoML search.
-            /// </summary>
-            [Obsolete]
-            public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
-
-            /// <summary>
-            /// Number of candidate pipelines to retrieve each round.
-            /// </summary>
-            [Obsolete]
-            public int BatchSize { get; set; }
-
-            /// <summary>
-            /// Output datasets from previous iteration of sweep.
-            /// </summary>
-            [Obsolete]
-            public ArrayVar<Microsoft.ML.Runtime.Data.IDataView> CandidateOutputs { get; set; } = new ArrayVar<Microsoft.ML.Runtime.Data.IDataView>();
-
-            /// <summary>
-            /// Column(s) to use as Role 'Label'
-            /// </summary>
-            [Obsolete]
-            public string[] LabelColumns { get; set; }
-
-            /// <summary>
-            /// Column(s) to use as Role 'Group'
-            /// </summary>
-            [Obsolete]
-            public string[] GroupColumns { get; set; }
-
-            /// <summary>
-            /// Column(s) to use as Role 'Weight'
-            /// </summary>
-            [Obsolete]
-            public string[] WeightColumns { get; set; }
-
-            /// <summary>
-            /// Column(s) to use as Role 'Name'
-            /// </summary>
-            [Obsolete]
-            public string[] NameColumns { get; set; }
-
-            /// <summary>
-            /// Column(s) to use as Role 'NumericFeature'
-            /// </summary>
-            [Obsolete]
-            public string[] NumericFeatureColumns { get; set; }
-
-            /// <summary>
-            /// Column(s) to use as Role 'CategoricalFeature'
-            /// </summary>
-            [Obsolete]
-            public string[] CategoricalFeatureColumns { get; set; }
-
-            /// <summary>
-            /// Column(s) to use as Role 'TextFeature'
-            /// </summary>
-            [Obsolete]
-            public string[] TextFeatureColumns { get; set; }
-
-            /// <summary>
-            /// Column(s) to use as Role 'ImagePath'
-            /// </summary>
-            [Obsolete]
-            public string[] ImagePathColumns { get; set; }
-
-
-            [Obsolete]
-            public sealed class Output
-            {
-                /// <summary>
-                /// Stateful autoML object, keeps track of where the search in progress.
-                /// </summary>
-                public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
-
-                /// <summary>
-                /// Results of the sweep, including pipelines (as graph strings), IDs, and metric values.
-                /// </summary>
-                public Var<Microsoft.ML.Runtime.Data.IDataView> Results { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
-
-            }
-        }
-    }
-
-    namespace Legacy.Models
-    {
-
-        /// <summary>
         /// Apply a Platt calibrator to an input model
         /// </summary>
         [Obsolete]
@@ -4665,41 +4523,6 @@ namespace Microsoft.ML
                 /// The training set statistics. Note that this output can be null.
                 /// </summary>
                 public Var<Microsoft.ML.Runtime.Data.IDataView> Stats { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
-
-            }
-        }
-    }
-
-    namespace Legacy.Models
-    {
-
-        /// <summary>
-        /// Extracts the sweep result.
-        /// </summary>
-        [Obsolete]
-        public sealed partial class SweepResultExtractor
-        {
-
-
-            /// <summary>
-            /// The stateful object conducting of the autoML search.
-            /// </summary>
-            [Obsolete]
-            public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
-
-
-            [Obsolete]
-            public sealed class Output
-            {
-                /// <summary>
-                /// Stateful autoML object, keeps track of where the search in progress.
-                /// </summary>
-                public Var<Microsoft.ML.Runtime.EntryPoints.IMlState> State { get; set; } = new Var<Microsoft.ML.Runtime.EntryPoints.IMlState>();
-
-                /// <summary>
-                /// Results of the sweep, including pipelines (as graph strings), IDs, and metric values.
-                /// </summary>
-                public Var<Microsoft.ML.Runtime.Data.IDataView> Results { get; set; } = new Var<Microsoft.ML.Runtime.Data.IDataView>();
 
             }
         }
@@ -20390,150 +20213,6 @@ namespace Microsoft.ML
     namespace Runtime
     {
         [Obsolete]
-        public abstract class AutoMlEngine : ComponentKind {}
-
-
-
-        /// <summary>
-        /// AutoML engine that returns learners with default settings.
-        /// </summary>
-        [Obsolete]
-        public sealed class DefaultsAutoMlEngine : AutoMlEngine
-        {
-            [Obsolete]
-            internal override string ComponentName => "Defaults";
-        }
-
-
-
-        /// <summary>
-        /// AutoML engine that consists of distinct, hierarchical stages of operation.
-        /// </summary>
-        [Obsolete]
-        public sealed class RocketAutoMlEngine : AutoMlEngine
-        {
-            /// <summary>
-            /// Number of learners to retain for second stage.
-            /// </summary>
-            [Obsolete]
-            public int TopKLearners { get; set; } = 2;
-
-            /// <summary>
-            /// Number of trials for retained second stage learners.
-            /// </summary>
-            [Obsolete]
-            public int SecondRoundTrialsPerLearner { get; set; } = 5;
-
-            /// <summary>
-            /// Use random initialization only.
-            /// </summary>
-            [Obsolete]
-            public bool RandomInitialization { get; set; } = false;
-
-            /// <summary>
-            /// Number of initilization pipelines, used for random initialization only.
-            /// </summary>
-            [Obsolete]
-            public int NumInitializationPipelines { get; set; } = 20;
-
-            [Obsolete]
-            internal override string ComponentName => "Rocket";
-        }
-
-
-
-        /// <summary>
-        /// AutoML engine using uniform random sampling.
-        /// </summary>
-        [Obsolete]
-        public sealed class UniformRandomAutoMlEngine : AutoMlEngine
-        {
-            [Obsolete]
-            internal override string ComponentName => "UniformRandom";
-        }
-
-        [Obsolete]
-        public abstract class AutoMlStateBase : ComponentKind {}
-
-        [Obsolete]
-        public enum PipelineSweeperSupportedMetricsMetrics
-        {
-            Auc = 0,
-            AccuracyMicro = 1,
-            AccuracyMacro = 2,
-            L1 = 3,
-            L2 = 4,
-            F1 = 5,
-            AuPrc = 6,
-            TopKAccuracy = 7,
-            Rms = 8,
-            LossFn = 9,
-            RSquared = 10,
-            LogLoss = 11,
-            LogLossReduction = 12,
-            Ndcg = 13,
-            Dcg = 14,
-            PositivePrecision = 15,
-            PositiveRecall = 16,
-            NegativePrecision = 17,
-            NegativeRecall = 18,
-            DrAtK = 19,
-            DrAtPFpr = 20,
-            DrAtNumPos = 21,
-            NumAnomalies = 22,
-            ThreshAtK = 23,
-            ThreshAtP = 24,
-            ThreshAtNumPos = 25,
-            Nmi = 26,
-            AvgMinScore = 27,
-            Dbi = 28
-        }
-
-
-
-        /// <summary>
-        /// State of an AutoML search and search space.
-        /// </summary>
-        [Obsolete]
-        public sealed class AutoMlStateAutoMlStateBase : AutoMlStateBase
-        {
-            /// <summary>
-            /// Supported metric for evaluator.
-            /// </summary>
-            [Obsolete]
-            public PipelineSweeperSupportedMetricsMetrics Metric { get; set; } = PipelineSweeperSupportedMetricsMetrics.Auc;
-
-            /// <summary>
-            /// AutoML engine (pipeline optimizer) that generates next candidates.
-            /// </summary>
-            [JsonConverter(typeof(ComponentSerializer))]
-            [Obsolete]
-            public AutoMlEngine Engine { get; set; }
-
-            /// <summary>
-            /// Kind of trainer for task, such as binary classification trainer, multiclass trainer, etc.
-            /// </summary>
-            [Obsolete]
-            public Microsoft.ML.Legacy.Models.MacroUtilsTrainerKinds TrainerKind { get; set; } = Microsoft.ML.Legacy.Models.MacroUtilsTrainerKinds.SignatureBinaryClassifierTrainer;
-
-            /// <summary>
-            /// Arguments for creating terminator, which determines when to stop search.
-            /// </summary>
-            [JsonConverter(typeof(ComponentSerializer))]
-            [Obsolete]
-            public SearchTerminator TerminatorArgs { get; set; }
-
-            /// <summary>
-            /// Learner set to sweep over (if available).
-            /// </summary>
-            [Obsolete]
-            public string[] RequestedLearners { get; set; }
-
-            [Obsolete]
-            internal override string ComponentName => "AutoMlState";
-        }
-
-        [Obsolete]
         public abstract class BoosterParameterFunction : ComponentKind {}
 
 
@@ -23632,27 +23311,6 @@ namespace Microsoft.ML
         {
             [Obsolete]
             internal override string ComponentName => "SquaredLoss";
-        }
-
-        [Obsolete]
-        public abstract class SearchTerminator : ComponentKind {}
-
-
-
-        /// <summary>
-        /// Terminators a sweep based on total number of iterations.
-        /// </summary>
-        [Obsolete]
-        public sealed class IterationLimitedSearchTerminator : SearchTerminator
-        {
-            /// <summary>
-            /// Total number of iterations.
-            /// </summary>
-            [Obsolete]
-            public int FinalHistoryLength { get; set; }
-
-            [Obsolete]
-            internal override string ComponentName => "IterationLimited";
         }
 
         [Obsolete]

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        internal LightGbmBinaryModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public LightGbmBinaryModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -20,16 +20,16 @@ using System;
     new[] { typeof(SignatureBinaryClassifierTrainer), typeof(SignatureTrainer), typeof(SignatureTreeEnsembleTrainer) },
     LightGbmBinaryTrainer.UserName, LightGbmBinaryTrainer.LoadNameValue, LightGbmBinaryTrainer.ShortName, DocName = "trainer/LightGBM.md")]
 
-[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(LightGbmBinaryPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(LightGbmBinaryModelParameters), null, typeof(SignatureLoadModel),
     "LightGBM Binary Executor",
-    LightGbmBinaryPredictor.LoaderSignature)]
+    LightGbmBinaryModelParameters.LoaderSignature)]
 
 [assembly: LoadableClass(typeof(void), typeof(LightGbm), null, typeof(SignatureEntryPointModule), "LightGBM")]
 
 namespace Microsoft.ML.Runtime.LightGBM
 {
     /// <include file='doc.xml' path='doc/members/member[@name="LightGBM"]/*' />
-    public sealed class LightGbmBinaryPredictor : FastTreePredictionWrapper
+    public sealed class LightGbmBinaryModelParameters : TreeEnsembleModelParameters
     {
         internal const string LoaderSignature = "LightGBMBinaryExec";
         internal const string RegistrationName = "LightGBMBinaryPredictor";
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime.LightGBM
                 verReadableCur: 0x00010004,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(LightGbmBinaryPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(LightGbmBinaryModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
@@ -55,12 +55,12 @@ namespace Microsoft.ML.Runtime.LightGBM
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        internal LightGbmBinaryPredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        internal LightGbmBinaryModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private LightGbmBinaryPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private LightGbmBinaryModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -71,12 +71,12 @@ namespace Microsoft.ML.Runtime.LightGBM
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            var predictor = new LightGbmBinaryPredictor(env, ctx);
+            var predictor = new LightGbmBinaryModelParameters(env, ctx);
             ICalibrator calibrator;
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);
-            var pred = new LightGbmBinaryPredictor(Host, TrainedEnsemble, FeatureCount, innerArgs);
+            var pred = new LightGbmBinaryModelParameters(Host, TrainedEnsemble, FeatureCount, innerArgs);
             var cali = new PlattCalibrator(Host, -0.5, 0);
             return new FeatureWeightsCalibratedPredictor(Host, pred, cali);
         }

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -82,9 +82,9 @@ namespace Microsoft.ML.Runtime.LightGBM
             return res;
         }
 
-        private LightGbmBinaryPredictor CreateBinaryPredictor(int classID, string innerArgs)
+        private LightGbmBinaryModelParameters CreateBinaryPredictor(int classID, string innerArgs)
         {
-            return new LightGbmBinaryPredictor(Host, GetBinaryEnsemble(classID), FeatureCount, innerArgs);
+            return new LightGbmBinaryModelParameters(Host, GetBinaryEnsemble(classID), FeatureCount, innerArgs);
         }
 
         private protected override OvaPredictor CreatePredictor()

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
         public override PredictionKind PredictionKind => PredictionKind.Ranking;
 
-        internal LightGbmRankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public LightGbmRankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -18,17 +18,17 @@ using System;
     new[] { typeof(SignatureRankerTrainer), typeof(SignatureTrainer), typeof(SignatureTreeEnsembleTrainer) },
     "LightGBM Ranking", LightGbmRankingTrainer.LoadNameValue, LightGbmRankingTrainer.ShortName, DocName = "trainer/LightGBM.md")]
 
-[assembly: LoadableClass(typeof(LightGbmRankingPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(LightGbmRankingModelParameters), null, typeof(SignatureLoadModel),
     "LightGBM Ranking Executor",
-    LightGbmRankingPredictor.LoaderSignature)]
+    LightGbmRankingModelParameters.LoaderSignature)]
 
 namespace Microsoft.ML.Runtime.LightGBM
 {
 
-    public sealed class LightGbmRankingPredictor : FastTreePredictionWrapper
+    public sealed class LightGbmRankingModelParameters : TreeEnsembleModelParameters
     {
-        public const string LoaderSignature = "LightGBMRankerExec";
-        public const string RegistrationName = "LightGBMRankingPredictor";
+        internal const string LoaderSignature = "LightGBMRankerExec";
+        internal const string RegistrationName = "LightGBMRankingPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Runtime.LightGBM
                 verReadableCur: 0x00010004,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(LightGbmRankingPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(LightGbmRankingModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
@@ -51,12 +51,12 @@ namespace Microsoft.ML.Runtime.LightGBM
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
         public override PredictionKind PredictionKind => PredictionKind.Ranking;
 
-        internal LightGbmRankingPredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        internal LightGbmRankingModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private LightGbmRankingPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private LightGbmRankingModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -67,14 +67,14 @@ namespace Microsoft.ML.Runtime.LightGBM
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        private static LightGbmRankingPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static LightGbmRankingModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
-            return new LightGbmRankingPredictor(env, ctx);
+            return new LightGbmRankingModelParameters(env, ctx);
         }
     }
 
     /// <include file='doc.xml' path='doc/members/member[@name="LightGBM"]/*' />
-    public sealed class LightGbmRankingTrainer : LightGbmTrainerBase<float, RankingPredictionTransformer<LightGbmRankingPredictor>, LightGbmRankingPredictor>
+    public sealed class LightGbmRankingTrainer : LightGbmTrainerBase<float, RankingPredictionTransformer<LightGbmRankingModelParameters>, LightGbmRankingModelParameters>
     {
         public const string UserName = "LightGBM Ranking";
         public const string LoadNameValue = "LightGBMRanking";
@@ -151,11 +151,11 @@ namespace Microsoft.ML.Runtime.LightGBM
                 error();
         }
 
-        private protected override LightGbmRankingPredictor CreatePredictor()
+        private protected override LightGbmRankingModelParameters CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);
-            return new LightGbmRankingPredictor(Host, TrainedEnsemble, FeatureCount, innerArgs);
+            return new LightGbmRankingModelParameters(Host, TrainedEnsemble, FeatureCount, innerArgs);
         }
 
         protected override void CheckAndUpdateParametersBeforeTraining(IChannel ch, RoleMappedData data, float[] labels, int[] groups)
@@ -178,10 +178,10 @@ namespace Microsoft.ML.Runtime.LightGBM
             };
         }
 
-        protected override RankingPredictionTransformer<LightGbmRankingPredictor> MakeTransformer(LightGbmRankingPredictor model, Schema trainSchema)
-         => new RankingPredictionTransformer<LightGbmRankingPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RankingPredictionTransformer<LightGbmRankingModelParameters> MakeTransformer(LightGbmRankingModelParameters model, Schema trainSchema)
+         => new RankingPredictionTransformer<LightGbmRankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RankingPredictionTransformer<LightGbmRankingPredictor> Train(IDataView trainData, IDataView validationData = null)
+        public RankingPredictionTransformer<LightGbmRankingModelParameters> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        internal LightGbmRegressionModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        public LightGbmRegressionModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -18,17 +18,17 @@ using System;
     new[] { typeof(SignatureRegressorTrainer), typeof(SignatureTrainer), typeof(SignatureTreeEnsembleTrainer) },
     LightGbmRegressorTrainer.UserNameValue, LightGbmRegressorTrainer.LoadNameValue, LightGbmRegressorTrainer.ShortName, DocName = "trainer/LightGBM.md")]
 
-[assembly: LoadableClass(typeof(LightGbmRegressionPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(LightGbmRegressionModelParameters), null, typeof(SignatureLoadModel),
     "LightGBM Regression Executor",
-    LightGbmRegressionPredictor.LoaderSignature)]
+    LightGbmRegressionModelParameters.LoaderSignature)]
 
 namespace Microsoft.ML.Runtime.LightGBM
 {
     /// <include file='doc.xml' path='doc/members/member[@name="LightGBM"]/*' />
-    public sealed class LightGbmRegressionPredictor : FastTreePredictionWrapper
+    public sealed class LightGbmRegressionModelParameters : TreeEnsembleModelParameters
     {
-        public const string LoaderSignature = "LightGBMRegressionExec";
-        public const string RegistrationName = "LightGBMRegressionPredictor";
+        internal const string LoaderSignature = "LightGBMRegressionExec";
+        internal const string RegistrationName = "LightGBMRegressionPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Runtime.LightGBM
                 verReadableCur: 0x00010004,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(LightGbmRegressionPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(LightGbmRegressionModelParameters).Assembly.FullName);
         }
 
         protected override uint VerNumFeaturesSerialized => 0x00010002;
@@ -51,12 +51,12 @@ namespace Microsoft.ML.Runtime.LightGBM
         protected override uint VerCategoricalSplitSerialized => 0x00010005;
         public override PredictionKind PredictionKind => PredictionKind.Regression;
 
-        internal LightGbmRegressionPredictor(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
+        internal LightGbmRegressionModelParameters(IHostEnvironment env, TreeEnsemble trainedEnsemble, int featureCount, string innerArgs)
             : base(env, RegistrationName, trainedEnsemble, featureCount, innerArgs)
         {
         }
 
-        private LightGbmRegressionPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private LightGbmRegressionModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx, GetVersionInfo())
         {
         }
@@ -67,17 +67,17 @@ namespace Microsoft.ML.Runtime.LightGBM
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public static LightGbmRegressionPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static LightGbmRegressionModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            return new LightGbmRegressionPredictor(env, ctx);
+            return new LightGbmRegressionModelParameters(env, ctx);
         }
     }
 
     /// <include file='doc.xml' path='doc/members/member[@name="LightGBM"]/*' />
-    public sealed class LightGbmRegressorTrainer : LightGbmTrainerBase<float, RegressionPredictionTransformer<LightGbmRegressionPredictor>, LightGbmRegressionPredictor>
+    public sealed class LightGbmRegressorTrainer : LightGbmTrainerBase<float, RegressionPredictionTransformer<LightGbmRegressionModelParameters>, LightGbmRegressionModelParameters>
     {
         internal const string Summary = "LightGBM Regression";
         internal const string LoadNameValue = "LightGBMRegression";
@@ -119,12 +119,12 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
         }
 
-        private protected override LightGbmRegressionPredictor CreatePredictor()
+        private protected override LightGbmRegressionModelParameters CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null,
                 "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);
-            return new LightGbmRegressionPredictor(Host, TrainedEnsemble, FeatureCount, innerArgs);
+            return new LightGbmRegressionModelParameters(Host, TrainedEnsemble, FeatureCount, innerArgs);
         }
 
         protected override void CheckDataValid(IChannel ch, RoleMappedData data)
@@ -155,10 +155,10 @@ namespace Microsoft.ML.Runtime.LightGBM
             };
         }
 
-        protected override RegressionPredictionTransformer<LightGbmRegressionPredictor> MakeTransformer(LightGbmRegressionPredictor model, Schema trainSchema)
-            => new RegressionPredictionTransformer<LightGbmRegressionPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RegressionPredictionTransformer<LightGbmRegressionModelParameters> MakeTransformer(LightGbmRegressionModelParameters model, Schema trainSchema)
+            => new RegressionPredictionTransformer<LightGbmRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<LightGbmRegressionPredictor> Train(IDataView trainData, IDataView validationData = null)
+        public RegressionPredictionTransformer<LightGbmRegressionModelParameters> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmStatic.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmStatic.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.StaticPipe
             double? learningRate = null,
             int numBoostRound = LightGbmArguments.Defaults.NumBoostRound,
             Action<LightGbmArguments> advancedSettings = null,
-            Action<LightGbmRegressionPredictor> onFit = null)
+            Action<LightGbmRegressionModelParameters> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, minDataPerLeaf, learningRate, numBoostRound, advancedSettings, onFit);
 
@@ -144,7 +144,7 @@ namespace Microsoft.ML.StaticPipe
             double? learningRate = null,
             int numBoostRound = LightGbmArguments.Defaults.NumBoostRound,
             Action<LightGbmArguments> advancedSettings = null,
-            Action<LightGbmRankingPredictor> onFit = null)
+            Action<LightGbmRankingModelParameters> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, minDataPerLeaf, learningRate, numBoostRound, advancedSettings, onFit);
             Contracts.CheckValue(groupId, nameof(groupId));

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -498,7 +498,7 @@ namespace Microsoft.ML.Trainers.PCA
             return new PcaPredictor(env, ctx);
         }
 
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             ((ICanSaveInTextFormat)this).SaveAsText(writer, schema);
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
@@ -354,7 +354,7 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         [BestFriend]
-        private protected abstract void SaveSummary(TextWriter writer, RoleMappedSchema schema);
+        internal abstract void SaveSummary(TextWriter writer, RoleMappedSchema schema);
 
         void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema) => SaveSummary(writer, schema);
 
@@ -499,7 +499,7 @@ namespace Microsoft.ML.Runtime.Learners
             return new LinearBinaryPredictor(Host, in weights, bias);
         }
 
-        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
 
@@ -629,7 +629,7 @@ namespace Microsoft.ML.Runtime.Learners
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
@@ -710,7 +710,7 @@ namespace Microsoft.ML.Runtime.Learners
             return MathUtils.ExpSlow(base.Score(in src));
         }
 
-        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
@@ -344,7 +344,7 @@ namespace Microsoft.ML.Runtime.Learners
             SaveSummary(writer, schema);
         }
 
-        public void SaveAsCode(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
@@ -353,9 +353,13 @@ namespace Microsoft.ML.Runtime.Learners
             LinearPredictorUtils.SaveAsCode(writer, in weights, Bias, schema);
         }
 
-        public abstract void SaveSummary(TextWriter writer, RoleMappedSchema schema);
+        [BestFriend]
+        private protected abstract void SaveSummary(TextWriter writer, RoleMappedSchema schema);
 
-        public virtual Row GetSummaryIRowOrNull(RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema) => SaveSummary(writer, schema);
+
+        [BestFriend]
+        private protected virtual Row GetSummaryIRowOrNull(RoleMappedSchema schema)
         {
             var names = default(VBuffer<ReadOnlyMemory<char>>);
             MetadataUtils.GetSlotNames(schema, RoleMappedSchema.ColumnRole.Feature, Weight.Length, ref names);
@@ -368,9 +372,17 @@ namespace Microsoft.ML.Runtime.Learners
             return MetadataUtils.MetadataAsRow(builder.GetMetadata());
         }
 
-        public virtual Row GetStatsIRowOrNull(RoleMappedSchema schema) => null;
+        Row ICanGetSummaryAsIRow.GetSummaryIRowOrNull(RoleMappedSchema schema) => GetSummaryIRowOrNull(schema);
 
-        public abstract void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null);
+        [BestFriend]
+        private protected virtual Row GetStatsIRowOrNull(RoleMappedSchema schema) => null;
+
+        Row ICanGetSummaryAsIRow.GetStatsIRowOrNull(RoleMappedSchema schema) => GetStatsIRowOrNull(schema);
+
+        [BestFriend]
+        private protected abstract void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null);
+
+        void ICanSaveInIniFormat.SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator) => SaveAsIni(writer, schema, calibrator);
 
         public virtual void GetFeatureWeights(ref VBuffer<Float> weights)
         {
@@ -487,7 +499,7 @@ namespace Microsoft.ML.Runtime.Learners
             return new LinearBinaryPredictor(Host, in weights, bias);
         }
 
-        public override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
 
@@ -500,7 +512,7 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         ///<inheritdoc/>
-        public IList<KeyValuePair<string, object>> GetSummaryInKeyValuePairs(RoleMappedSchema schema)
+        IList<KeyValuePair<string, object>> ICanGetSummaryInKeyValuePairs.GetSummaryInKeyValuePairs(RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
 
@@ -511,7 +523,7 @@ namespace Microsoft.ML.Runtime.Learners
             return results;
         }
 
-        public override Row GetStatsIRowOrNull(RoleMappedSchema schema)
+        private protected override Row GetStatsIRowOrNull(RoleMappedSchema schema)
         {
             if (_stats == null)
                 return null;
@@ -521,7 +533,7 @@ namespace Microsoft.ML.Runtime.Learners
             return MetadataUtils.MetadataAsRow(meta);
         }
 
-        public override void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null)
+        private protected override void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
@@ -553,7 +565,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Output the INI model to a given writer
         /// </summary>
-        public override void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator)
+        private protected override void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator)
         {
             if (calibrator != null)
                 throw Host.ExceptNotImpl("Saving calibrators is not implemented yet.");
@@ -617,7 +629,7 @@ namespace Microsoft.ML.Runtime.Learners
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        public override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
@@ -640,7 +652,7 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         ///<inheritdoc/>
-        public IList<KeyValuePair<string, object>> GetSummaryInKeyValuePairs(RoleMappedSchema schema)
+        IList<KeyValuePair<string, object>> ICanGetSummaryInKeyValuePairs.GetSummaryInKeyValuePairs(RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
 
@@ -698,7 +710,7 @@ namespace Microsoft.ML.Runtime.Learners
             return MathUtils.ExpSlow(base.Score(in src));
         }
 
-        public override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
@@ -354,11 +354,10 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         [BestFriend]
-        internal abstract void SaveSummary(TextWriter writer, RoleMappedSchema schema);
+        private protected abstract void SaveSummary(TextWriter writer, RoleMappedSchema schema);
 
         void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema) => SaveSummary(writer, schema);
 
-        [BestFriend]
         private protected virtual Row GetSummaryIRowOrNull(RoleMappedSchema schema)
         {
             var names = default(VBuffer<ReadOnlyMemory<char>>);
@@ -374,12 +373,10 @@ namespace Microsoft.ML.Runtime.Learners
 
         Row ICanGetSummaryAsIRow.GetSummaryIRowOrNull(RoleMappedSchema schema) => GetSummaryIRowOrNull(schema);
 
-        [BestFriend]
         private protected virtual Row GetStatsIRowOrNull(RoleMappedSchema schema) => null;
 
         Row ICanGetSummaryAsIRow.GetStatsIRowOrNull(RoleMappedSchema schema) => GetStatsIRowOrNull(schema);
 
-        [BestFriend]
         private protected abstract void SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator = null);
 
         void ICanSaveInIniFormat.SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator) => SaveAsIni(writer, schema, calibrator);
@@ -499,7 +496,7 @@ namespace Microsoft.ML.Runtime.Learners
             return new LinearBinaryPredictor(Host, in weights, bias);
         }
 
-        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
 
@@ -629,7 +626,7 @@ namespace Microsoft.ML.Runtime.Learners
             ctx.SetVersionInfo(GetVersionInfo());
         }
 
-        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
@@ -710,7 +707,7 @@ namespace Microsoft.ML.Runtime.Learners
             return MathUtils.ExpSlow(base.Score(in src));
         }
 
-        internal override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearPredictor.cs
@@ -389,7 +389,7 @@ namespace Microsoft.ML.Runtime.Learners
             Weight.CopyTo(ref weights);
         }
 
-        public ValueMapper<TSrc, VBuffer<Float>> GetFeatureContributionMapper<TSrc, TDstContributions>(int top, int bottom, bool normalize)
+        ValueMapper<TSrc, VBuffer<Float>> IFeatureContributionMapper.GetFeatureContributionMapper<TSrc, TDstContributions>(int top, int bottom, bool normalize)
         {
             Contracts.Check(typeof(TSrc) == typeof(VBuffer<Float>));
             Contracts.Check(typeof(TDstContributions) == typeof(VBuffer<Float>));

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -781,7 +781,7 @@ namespace Microsoft.ML.Runtime.Learners
         {
             writer.WriteLine(nameof(MulticlassLogisticRegression) + " bias and non-zero weights");
 
-            foreach (var namedValues in GetSummaryInKeyValuePairs(schema))
+            foreach (var namedValues in ((ICanGetSummaryInKeyValuePairs)this).GetSummaryInKeyValuePairs(schema))
             {
                 Host.Assert(namedValues.Value is float);
                 writer.WriteLine("\t{0}\t{1}", namedValues.Key, (float)namedValues.Value);
@@ -792,7 +792,7 @@ namespace Microsoft.ML.Runtime.Learners
         }
 
         ///<inheritdoc/>
-        public IList<KeyValuePair<string, object>> GetSummaryInKeyValuePairs(RoleMappedSchema schema)
+        IList<KeyValuePair<string, object>> ICanGetSummaryInKeyValuePairs.GetSummaryInKeyValuePairs(RoleMappedSchema schema)
         {
             Host.CheckValueOrNull(schema);
 
@@ -832,7 +832,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Output the text model to a given writer
         /// </summary>
-        public void SaveAsCode(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValueOrNull(schema);
@@ -851,7 +851,7 @@ namespace Microsoft.ML.Runtime.Learners
                 writer.WriteLine("output[{0}] = Math.Exp(scores[{0}] - softmax);", c);
         }
 
-        public void SaveSummary(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveSummary.SaveSummary(TextWriter writer, RoleMappedSchema schema)
         {
             ((ICanSaveInTextFormat)this).SaveAsText(writer, schema);
         }
@@ -985,12 +985,12 @@ namespace Microsoft.ML.Runtime.Learners
             return bldr.GetDataView();
         }
 
-        public Row GetSummaryIRowOrNull(RoleMappedSchema schema)
+        Row ICanGetSummaryAsIRow.GetSummaryIRowOrNull(RoleMappedSchema schema)
         {
             return null;
         }
 
-        public Row GetStatsIRowOrNull(RoleMappedSchema schema)
+        Row ICanGetSummaryAsIRow.GetStatsIRowOrNull(RoleMappedSchema schema)
         {
             if (_stats == null)
                 return null;

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -365,7 +365,7 @@ namespace Microsoft.ML.Trainers
             return (ValueMapper<TIn, TOut>)(Delegate)_impl.GetMapper();
         }
 
-        public void SaveAsCode(TextWriter writer, RoleMappedSchema schema)
+        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
         {
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -129,9 +129,11 @@ namespace Microsoft.ML.Trainers
         private readonly Random _random;
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
-        public ColumnType InputType { get; }
-        public ColumnType OutputType => NumberType.Float;
-        public ColumnType DistType => NumberType.Float;
+
+        private readonly ColumnType _inputType;
+        ColumnType IValueMapper.InputType => _inputType;
+        ColumnType IValueMapper.OutputType => NumberType.Float;
+        ColumnType IValueMapperDist.DistType => NumberType.Float;
 
         public RandomPredictor(IHostEnvironment env, int seed)
             : base(env, LoaderSignature)
@@ -141,7 +143,7 @@ namespace Microsoft.ML.Trainers
             _instanceLock = new object();
             _random = RandomUtils.Create(_seed);
 
-            InputType = new VectorType(NumberType.Float);
+            _inputType = new VectorType(NumberType.Float);
         }
 
         /// <summary>
@@ -158,10 +160,10 @@ namespace Microsoft.ML.Trainers
             _instanceLock = new object();
             _random = RandomUtils.Create(_seed);
 
-            InputType = new VectorType(NumberType.Float);
+            _inputType = new VectorType(NumberType.Float);
         }
 
-        public static RandomPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static RandomPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
@@ -184,7 +186,7 @@ namespace Microsoft.ML.Trainers
             ctx.Writer.Write(_seed);
         }
 
-        public ValueMapper<TIn, TOut> GetMapper<TIn, TOut>()
+        ValueMapper<TIn, TOut> IValueMapper.GetMapper<TIn, TOut>()
         {
             Contracts.Check(typeof(TIn) == typeof(VBuffer<float>));
             Contracts.Check(typeof(TOut) == typeof(float));
@@ -193,7 +195,7 @@ namespace Microsoft.ML.Trainers
             return (ValueMapper<TIn, TOut>)(Delegate)del;
         }
 
-        public ValueMapper<TIn, TOut, TDist> GetMapper<TIn, TOut, TDist>()
+        ValueMapper<TIn, TOut, TDist> IValueMapperDist.GetMapper<TIn, TOut, TDist>()
         {
             Contracts.Check(typeof(TIn) == typeof(VBuffer<float>));
             Contracts.Check(typeof(TOut) == typeof(float));
@@ -371,7 +373,7 @@ namespace Microsoft.ML.Trainers
             _prob = prob;
             _raw = 2 * _prob - 1;       // This could be other functions -- logodds for instance
 
-            InputType = new VectorType(NumberType.Float);
+            _inputType = new VectorType(NumberType.Float);
         }
 
         private PriorPredictor(IHostEnvironment env, ModelLoadContext ctx)
@@ -385,7 +387,7 @@ namespace Microsoft.ML.Trainers
 
             _raw = 2 * _prob - 1;
 
-            InputType = new VectorType(NumberType.Float);
+            _inputType = new VectorType(NumberType.Float);
         }
 
         public static PriorPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
@@ -410,11 +412,13 @@ namespace Microsoft.ML.Trainers
 
         public override PredictionKind PredictionKind
         { get { return PredictionKind.BinaryClassification; } }
-        public ColumnType InputType { get; }
-        public ColumnType OutputType => NumberType.Float;
-        public ColumnType DistType => NumberType.Float;
 
-        public ValueMapper<TIn, TOut> GetMapper<TIn, TOut>()
+        private readonly ColumnType _inputType;
+        ColumnType IValueMapper.InputType => _inputType;
+        ColumnType IValueMapper.OutputType => NumberType.Float;
+        ColumnType IValueMapperDist.DistType => NumberType.Float;
+
+        ValueMapper<TIn, TOut> IValueMapper.GetMapper<TIn, TOut>()
         {
             Contracts.Check(typeof(TIn) == typeof(VBuffer<float>));
             Contracts.Check(typeof(TOut) == typeof(float));
@@ -423,7 +427,7 @@ namespace Microsoft.ML.Trainers
             return (ValueMapper<TIn, TOut>)(Delegate)del;
         }
 
-        public ValueMapper<TIn, TOut, TDist> GetMapper<TIn, TOut, TDist>()
+        ValueMapper<TIn, TOut, TDist> IValueMapperDist.GetMapper<TIn, TOut, TDist>()
         {
             Contracts.Check(typeof(TIn) == typeof(VBuffer<float>));
             Contracts.Check(typeof(TOut) == typeof(float));

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Trainers
         IValueMapperDist,
         ICanSaveModel
     {
-        public const string LoaderSignature = "RandomPredictor";
+        internal const string LoaderSignature = "RandomPredictor";
         private static VersionInfo GetVersionInfo()
         {
             return new VersionInfo(

--- a/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
@@ -106,13 +106,13 @@ namespace Microsoft.ML.Runtime.Sweeper
             }
 
             // Fit Random Forest Model on previous run data.
-            FastForestRegressionPredictor forestPredictor = FitModel(viableRuns);
+            FastForestRegressionModelParameters forestPredictor = FitModel(viableRuns);
 
             // Using acquisition function and current best, get candidate configuration(s).
             return GenerateCandidateConfigurations(numOfCandidates, viableRuns, forestPredictor);
         }
 
-        private FastForestRegressionPredictor FitModel(IEnumerable<IRunResult> previousRuns)
+        private FastForestRegressionModelParameters FitModel(IEnumerable<IRunResult> previousRuns)
         {
             Single[] targets = new Single[previousRuns.Count()];
             Single[][] features = new Single[previousRuns.Count()][];
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Runtime.Sweeper
         /// <param name="previousRuns">History of previously evaluated points, with their emprical performance values.</param>
         /// <param name="forest">Trained random forest ensemble. Used in evaluating the candidates.</param>
         /// <returns>An array of ParamaterSets which are the candidate configurations to sweep.</returns>
-        private ParameterSet[] GenerateCandidateConfigurations(int numOfCandidates, IEnumerable<IRunResult> previousRuns, FastForestRegressionPredictor forest)
+        private ParameterSet[] GenerateCandidateConfigurations(int numOfCandidates, IEnumerable<IRunResult> previousRuns, FastForestRegressionModelParameters forest)
         {
             // Get k best previous runs ParameterSets.
             ParameterSet[] bestKParamSets = GetKBestConfigurations(previousRuns, forest, _args.LocalSearchParentCount);
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Runtime.Sweeper
         /// <param name="numOfCandidates">Number of candidate configurations returned by the method (top K).</param>
         /// <param name="previousRuns">Historical run results.</param>
         /// <returns>Array of parameter sets, which will then be evaluated.</returns>
-        private ParameterSet[] GreedyPlusRandomSearch(ParameterSet[] parents, FastForestRegressionPredictor forest, int numOfCandidates, IEnumerable<IRunResult> previousRuns)
+        private ParameterSet[] GreedyPlusRandomSearch(ParameterSet[] parents, FastForestRegressionModelParameters forest, int numOfCandidates, IEnumerable<IRunResult> previousRuns)
         {
             // REVIEW: The IsMetricMaximizing flag affects the comparator, so that
             // performing Max() should get the best, regardless of if it is maximizing or
@@ -231,7 +231,7 @@ namespace Microsoft.ML.Runtime.Sweeper
         /// <param name="bestVal">Best performance seen thus far.</param>
         /// <param name="epsilon">Threshold for when to stop the local search.</param>
         /// <returns></returns>
-        private Tuple<double, ParameterSet> LocalSearch(ParameterSet parent, FastForestRegressionPredictor forest, double bestVal, double epsilon)
+        private Tuple<double, ParameterSet> LocalSearch(ParameterSet parent, FastForestRegressionModelParameters forest, double bestVal, double epsilon)
         {
             try
             {
@@ -332,7 +332,7 @@ namespace Microsoft.ML.Runtime.Sweeper
         /// <param name="forest">Trained forest predictor, used for filtering configs.</param>
         /// <param name="configs">Parameter configurations.</param>
         /// <returns>2D array where rows correspond to configurations, and columns to the predicted leaf values.</returns>
-        private double[][] GetForestRegressionLeafValues(FastForestRegressionPredictor forest, ParameterSet[] configs)
+        private double[][] GetForestRegressionLeafValues(FastForestRegressionModelParameters forest, ParameterSet[] configs)
         {
             List<double[]> datasetLeafValues = new List<double[]>();
             var e = forest.TrainedEnsemble;
@@ -369,14 +369,14 @@ namespace Microsoft.ML.Runtime.Sweeper
             return meansAndStdDevs;
         }
 
-        private double[] EvaluateConfigurationsByEI(FastForestRegressionPredictor forest, double bestVal, ParameterSet[] configs)
+        private double[] EvaluateConfigurationsByEI(FastForestRegressionModelParameters forest, double bestVal, ParameterSet[] configs)
         {
             double[][] leafPredictions = GetForestRegressionLeafValues(forest, configs);
             double[][] forestStatistics = ComputeForestStats(leafPredictions);
             return ComputeEIs(bestVal, forestStatistics);
         }
 
-        private ParameterSet[] GetKBestConfigurations(IEnumerable<IRunResult> previousRuns, FastForestRegressionPredictor forest, int k = 10)
+        private ParameterSet[] GetKBestConfigurations(IEnumerable<IRunResult> previousRuns, FastForestRegressionModelParameters forest, int k = 10)
         {
             // NOTE: Should we change this to rank according to EI (using forest), instead of observed performance?
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -347,7 +347,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private (IEnumerable<string> epListContents, JObject manifest) BuildManifests()
         {
-            Env.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryPredictor).Assembly);
+            Env.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryModelParameters).Assembly);
             Env.ComponentCatalog.RegisterAssembly(typeof(TensorFlowTransform).Assembly);
             Env.ComponentCatalog.RegisterAssembly(typeof(ImageLoaderTransform).Assembly);
             Env.ComponentCatalog.RegisterAssembly(typeof(SymSgdClassificationTrainer).Assembly);
@@ -1952,14 +1952,14 @@ namespace Microsoft.ML.Runtime.RunTests
         [ConditionalFact(typeof(Environment), nameof(Environment.Is64BitProcess))] // LightGBM is 64-bit only
         public void EntryPointLightGbmBinary()
         {
-            Env.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryPredictor).Assembly);
+            Env.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryModelParameters).Assembly);
             TestEntryPointRoutine("breast-cancer.txt", "Trainers.LightGbmBinaryClassifier");
         }
 
         [ConditionalFact(typeof(Environment), nameof(Environment.Is64BitProcess))] // LightGBM is 64-bit only
         public void EntryPointLightGbmMultiClass()
         {
-            Env.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryPredictor).Assembly);
+            Env.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryModelParameters).Assembly);
             TestEntryPointRoutine(GetDataPath(@"iris.txt"), "Trainers.LightGbmClassifier");
         }
 

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             base.InitializeEnvironment(environment);
 
-            environment.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryPredictor).Assembly);
+            environment.ComponentCatalog.RegisterAssembly(typeof(LightGbmBinaryModelParameters).Assembly);
             environment.ComponentCatalog.RegisterAssembly(typeof(SymSgdClassificationTrainer).Assembly);
         }
 

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -770,7 +770,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(0), features: c.LoadFloat(9, 14), groupId: c.LoadText(1)),
                 separator: '\t', hasHeader: true);
 
-            FastTreerankingModelParameters pred = null;
+            FastTreeRankingModelParameters pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, r.features, groupId: r.groupId.ToKey()))

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -423,7 +423,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10)),
                 separator: ';', hasHeader: true);
 
-            FastTreeRegressionPredictor pred = null;
+            FastTreeRegressionModelParameters pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, score: ctx.Trainers.FastTree(r.label, r.features,
@@ -505,7 +505,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10)),
                 separator: ';', hasHeader: true);
 
-            LightGbmRegressionPredictor pred = null;
+            LightGbmRegressionModelParameters pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, score: ctx.Trainers.LightGbm(r.label, r.features,
@@ -770,7 +770,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(0), features: c.LoadFloat(9, 14), groupId: c.LoadText(1)),
                 separator: '\t', hasHeader: true);
 
-            FastTreeRankingPredictor pred = null;
+            FastTreerankingModelParameters pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, r.features, groupId: r.groupId.ToKey()))
@@ -811,7 +811,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(0), features: c.LoadFloat(9, 14), groupId: c.LoadText(1)),
                 separator: '\t', hasHeader: true);
 
-            LightGbmRankingPredictor pred = null;
+            LightGbmRankingModelParameters pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, r.features, groupId: r.groupId.ToKey()))

--- a/test/Microsoft.ML.TestFramework/EnvironmentExtensions.cs
+++ b/test/Microsoft.ML.TestFramework/EnvironmentExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.TestFramework
             env.ComponentCatalog.RegisterAssembly(typeof(TextLoader).Assembly); // ML.Data
             env.ComponentCatalog.RegisterAssembly(typeof(LinearPredictor).Assembly); // ML.StandardLearners
             env.ComponentCatalog.RegisterAssembly(typeof(OneHotEncodingTransformer).Assembly); // ML.Transforms
-            env.ComponentCatalog.RegisterAssembly(typeof(FastTreeBinaryPredictor).Assembly); // ML.FastTree
+            env.ComponentCatalog.RegisterAssembly(typeof(FastTreeBinaryModelParameters).Assembly); // ML.FastTree
             env.ComponentCatalog.RegisterAssembly(typeof(EnsemblePredictor).Assembly); // ML.Ensemble
             env.ComponentCatalog.RegisterAssembly(typeof(KMeansModelParameters).Assembly); // ML.KMeansClustering
             env.ComponentCatalog.RegisterAssembly(typeof(PcaPredictor).Assembly); // ML.PCA

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/SentimentPredictionTests.cs
@@ -8,6 +8,7 @@ using Microsoft.ML.Runtime.Api;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Trainers.FastTree;
 using Microsoft.ML.Runtime.Internal.Calibration;
+using Microsoft.ML.Runtime.Internal.Internallearn;
 using Microsoft.ML.Transforms.Text;
 using System.Linq;
 using Xunit;
@@ -74,7 +75,7 @@ namespace Microsoft.ML.Scenarios
             Assert.True(predictions.ElementAt(1).Sentiment);
 
             // Get feature importance based on feature gain during training
-            var summary = ((FeatureWeightsCalibratedPredictor)pred).GetSummaryInKeyValuePairs(trainRoles.Schema);
+            var summary = ((ICanGetSummaryInKeyValuePairs)pred).GetSummaryInKeyValuePairs(trainRoles.Schema);
             Assert.Equal(1.0, (double)summary[0].Value, 1);
         }
 
@@ -148,7 +149,7 @@ namespace Microsoft.ML.Scenarios
             Assert.True(predictions.ElementAt(1).Sentiment);
 
             // Get feature importance based on feature gain during training
-            var summary = ((FeatureWeightsCalibratedPredictor)pred).GetSummaryInKeyValuePairs(trainRoles.Schema);
+            var summary = ((ICanGetSummaryInKeyValuePairs)pred).GetSummaryInKeyValuePairs(trainRoles.Schema);
             Assert.Equal(1.0, (double)summary[0].Value, 1);
         }
 


### PR DESCRIPTION
Fix #1701 

Internalized and explicitly implemented the following interfaces implemented by `FastTreePredictionWrapper`:
- `ICanSaveInIniFormat`
- `ICanSaveInSourceCode`
- `ICanSaveSummary`
- `ICanSaveSummaryInKeyValuePairs`
- `ICanGetSummaryAsIRow`
- `IFeatureContributionMapper`
- `IQuantileValueMapper`
- `IQuantileRegressionPredictor`
- `IValueMapperDist`

Renamed `FastTreePredictionWrapper` to `TreeEnsembleModelParameters` and descendants to `XYZModelParameters`. Reduced public surface of `TreeEnsembleModelParameters` and descendants.

Added public constructors for `TreeEnsembleModelParameters` and descendants.

Added a sample showing `FastTreeRegressionModelParameters` operations.