### PR TITLE
Prevent DNNImageModels from being downloaded on all machines

### DIFF
--- a/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
+++ b/src/Redist/Microsoft.ML.DnnImageFeaturizer.ModelRedist/Microsoft.ML.DnnImageFeaturizer.ModelRedist.proj
@@ -102,11 +102,11 @@
   </Target>
 
   <Target Name="CopyDnnModelFiles"
+          Condition="'$(SkipRIDAgnosticAssets)' != 'true'"
           Inputs="@(ModelFileCopy)" Outputs="@(ModelFileCopy->'%(TargetPath)')"
           DependsOnTargets="DownloadDnnModelFiles">
     <Message Importance="High" Text="Copying external model files... @(ModelFileCopy->'%(TargetPath)')" />
     <Copy SourceFiles="@(ModelFileCopy)"
-          Condition="'$(SkipRIDAgnosticAssets)' != 'true'"
           DestinationFiles="@(ModelFileCopy->'%(TargetPath)')" />
   </Target>
 


### PR DESCRIPTION
Moves the check location to prevent download from happening on unnecessary machines during the official build. Fixes #1841 
