### PR TITLE
[RIP] ISchema

### DIFF
--- a/src/Microsoft.ML.Core/Data/IDataView.cs
+++ b/src/Microsoft.ML.Core/Data/IDataView.cs
@@ -8,59 +8,6 @@ using System.Collections.Generic;
 namespace Microsoft.ML.Data
 {
     /// <summary>
-    /// Legacy interface for schema information.
-    /// Please avoid implementing this interface, use <see cref="Schema"/>.
-    /// </summary>
-    [BestFriend]
-    internal interface ISchema
-    {
-        /// <summary>
-        /// Number of columns.
-        /// </summary>
-        int ColumnCount { get; }
-
-        /// <summary>
-        /// If there is a column with the given name, set col to its index and return true.
-        /// Otherwise, return false. The expectation is that if there are multiple columns
-        /// with the same name, the greatest index is returned.
-        /// </summary>
-        bool TryGetColumnIndex(string name, out int col);
-
-        /// <summary>
-        /// Get the name of the given column index. Column names must be non-empty and non-null,
-        /// but multiple columns may have the same name.
-        /// </summary>
-        string GetColumnName(int col);
-
-        /// <summary>
-        /// Get the type of the given column index. This must be non-null.
-        /// </summary>
-        ColumnType GetColumnType(int col);
-
-        /// <summary>
-        /// Produces the metadata kinds and associated types supported by the given column.
-        /// If there is no metadata the returned enumerable should be non-null, but empty.
-        /// The string key values are unique, non-empty, non-null strings. The type should
-        /// be non-null.
-        /// </summary>
-        IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col);
-
-        /// <summary>
-        /// If the given column has metadata of the indicated kind, this returns the type of the metadata.
-        /// Otherwise, it returns null.
-        /// </summary>
-        ColumnType GetMetadataTypeOrNull(string kind, int col);
-
-        /// <summary>
-        /// Fetches the indicated metadata for the indicated column.
-        /// This should only be called if a corresponding call to GetMetadataTypeOrNull
-        /// returned non-null. And the TValue type should be compatible with the type
-        /// returned by that call. Otherwise, this should throw an exception.
-        /// </summary>
-        void GetMetadata<TValue>(string kind, int col, ref TValue value);
-    }
-
-    /// <summary>
     /// The input and output of Query Operators (Transforms). This is the fundamental data pipeline
     /// type, comparable to <see cref="IEnumerable{T}"/> for LINQ.
     /// </summary>

--- a/src/Microsoft.ML.Core/Data/Schema.cs
+++ b/src/Microsoft.ML.Core/Data/Schema.cs
@@ -264,38 +264,6 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Manufacture an instance of <see cref="Schema"/> out of any <see cref="ISchema"/>.
-        /// </summary>
-        [BestFriend]
-        internal static Schema Create(ISchema inputSchema)
-        {
-            Contracts.CheckValue(inputSchema, nameof(inputSchema));
-
-            var builder = new SchemaBuilder();
-            for (int i = 0; i < inputSchema.ColumnCount; i++)
-            {
-                var meta = new MetadataBuilder();
-                foreach (var kvp in inputSchema.GetMetadataTypes(i))
-                {
-                    var getter = Utils.MarshalInvoke(GetMetadataGetterDelegate<int>, kvp.Value.RawType, inputSchema, i, kvp.Key);
-                    meta.Add(kvp.Key, kvp.Value, getter);
-                }
-                builder.AddColumn(inputSchema.GetColumnName(i), inputSchema.GetColumnType(i), meta.GetMetadata());
-            }
-
-            return builder.GetSchema();
-        }
-
-        private static Delegate GetMetadataGetterDelegate<TValue>(ISchema schema, int col, string kind)
-        {
-            // REVIEW: We are facing a choice here: cache 'value' and get rid of 'schema' reference altogether,
-            // or retain the reference but be more memory efficient. This code should not stick around for too long
-            // anyway, so let's not sweat too much, and opt for the latter.
-            ValueGetter<TValue> getter = (ref TValue value) => schema.GetMetadata(kind, col, ref value);
-            return getter;
-        }
-
-        /// <summary>
         /// Legacy method to get the column index.
         /// DO NOT USE: use <see cref="GetColumnOrNull"/> instead.
         /// </summary>

--- a/src/Microsoft.ML.TensorFlow/TensorFlowModelInfo.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlowModelInfo.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Transforms
         }
 
         /// <summary>
-        /// Get <see cref="ISchema"/> for complete model. Every node in the TensorFlow model will be included in the <see cref="ISchema"/> object.
+        /// Get <see cref="Schema"/> for complete model. Every node in the TensorFlow model will be included in the <see cref="Schema"/> object.
         /// </summary>
         internal Schema GetModelSchema()
         {
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Transforms
         }
 
         /// <summary>
-        /// Get <see cref="ISchema"/> for only those nodes which are marked "Placeholder" in the TensorFlow model.
+        /// Get <see cref="Schema"/> for only those nodes which are marked "Placeholder" in the TensorFlow model.
         /// This method is convenient for exploring the model input(s) in case TensorFlow graph is very large.
         /// </summary>
         public Schema GetInputSchema()


### PR DESCRIPTION
Fixes #1501. Waiting for #2111 to be merged.

[Update] This PR will be splitted into small pieces!

- [x] Replace `ISchema` with `Schema` in all cases without writing extra code
- [x] Remove `ITransposeSchema` because it's a `ISchema`
- [x] Remove the uses of `ISchema` in ColumnBindingsBase
- [x] Remove the uses of `ISchema` in `internal sealed class CompositeSchema : ISchema` in `machinelearning\src\Microsoft.ML.Data\DataView\CompositeSchema.cs`
- [x] Remove the uses of `ISchema` in `internal sealed class FakeSchema : ISchema` in `machinelearning\src\Microsoft.ML.Data\DataLoadSave\FakeSchema.cs`
- [x] Remove the uses of `ISchema` in `private abstract class NoMetadataSchema : ISchema` in 	`machinelearning\src\Microsoft.ML.Data\DataView\Transposer.cs`
- [x] Remove the uses of `ISchema` in `private sealed class Bindings : ISchema` in `machinelearning\src\Microsoft.ML.Data\Dirty\ChooseColumnsByIndexTransform.cs`
- [x] Remove the uses of `ISchema` in `private sealed class Bindings : ISchema` in `machinelearning\src\Microsoft.ML.Data\DataLoadSave\Text\TextLoader.cs`
- [x] Remove the uses of `ISchema` in `private sealed class FeatureContributionSchema : ISchema` in `machinelearning\src\Microsoft.ML.Data\Scorers\FeatureContributionCalculationTransform.cs`
- [x] Remove the uses of `ISchema` in `private sealed class FeatureNameCollectionSchema : ISchema` in `machinelearning\src\Microsoft.ML.Data\Depricated\Instances\HeaderSchema.cs`
- [x] Remove the uses of `ISchema` in `private sealed class SchemaImpl : ISchema` in `machinelearning\src\Microsoft.ML.Data\Scorers\MultiClassClassifierScorer.cs`
- [x] Remove the uses of `ISchema` in `private sealed class SchemaImpl : ISchema` in `machinelearning\src\Microsoft.ML.Data\DataLoadSave\Binary\BinaryLoader.cs`
- [x] Remove the uses of `ISchema` in `public abstract class ScoreMapperSchemaBase : ISchema` in `machinelearning\src\Microsoft.ML.Data\Scorers\ScoreMapperSchema.cs`
- [x] Remove the uses of `ISchema` in `private sealed class GroupSchema : ISchema` in `machinelearning\src\Microsoft.ML.Transforms\GroupTransform.cs`
- [x] Remove the uses of `ISchema` in `private sealed class SchemaImpl : ISchema` in 	`machinelearning\src\Microsoft.ML.Transforms\UngroupTransform.cs`
- [x] Remove the uses of `ISchema` in `public abstract class SimpleSchemaBase : ISchem` in `machinelearning\src\Microsoft.ML.Data\DataView\SimpleRow.cs`











