### PR TITLE
Public API for Linear Predictors

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Samples.Dynamic
             }
         }
 
-        private static float[] GetLinearModelWeights(LinearRegressionPredictor linearModel)
+        private static float[] GetLinearModelWeights(LinearRegressionModelParameters linearModel)
         {
             var weights = new VBuffer<float>();
             linearModel.GetFeatureWeights(ref weights);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SDCARegression.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.ML.Runtime.Api;
-using Microsoft.ML.Runtime.Data;
+﻿using Microsoft.ML.Data;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.ML.Samples.Dynamic
@@ -39,7 +37,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var modelParams = model.LastTransformer.Model;
             // Inspect the bias and model weights.
             Console.WriteLine("The bias term is: " + modelParams.Bias);
-            Console.WriteLine("The feature weights are: " + string.Join(", ", modelParams.Weights2.ToArray()));
+            Console.WriteLine("The feature weights are: " + string.Join(", ", modelParams.Weights.ToArray()));
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SDCARegression.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.ML.Runtime.Api;
+using Microsoft.ML.Runtime.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    public class SDCARegressionExample
+    {
+        public static void SDCARegression()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Get a small dataset as an IEnumerable and convert it to an IDataView.
+            var data = SamplesUtils.DatasetUtils.GetInfertData();
+            var trainData = ml.CreateStreamingDataView(data);
+
+            // Preview of the data.
+            //
+            // Age  Case  Education  Induced     Parity  PooledStratum  RowNum  ...
+            // 26   1       0-5yrs      1         6         3             1  ...
+            // 42   1       0-5yrs      1         1         1             2  ...
+            // 39   1       0-5yrs      2         6         4             3  ...
+            // 34   1       0-5yrs      2         4         2             4  ...
+            // 35   1       6-11yrs     1         3         32            5  ...
+
+            // A pipeline for concatenating the Parity and Induced columns together in the Features column.
+            // We will train a FastTreeRegression model with 1 tree on these two columns to predict Age.
+            string outputColumnName = "Features";
+            var pipeline = ml.Transforms.Concatenate(outputColumnName, new[] { "Parity", "Induced" })
+                .Append(ml.Regression.Trainers.StochasticDualCoordinateAscent(labelColumn: "Age", featureColumn: outputColumnName, maxIterations:2));
+
+            var model = pipeline.Fit(trainData);
+
+            // Get the trained model parameters.
+            var modelParams = model.LastTransformer.Model;
+            // Inspect the bias and model weights.
+            Console.WriteLine("The bias term is: " + modelParams.Bias);
+            Console.WriteLine("The feature weights are: " + string.Join(", ", modelParams.Weights2.ToArray()));
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Samples.Static
             var (trainData, testData) = mlContext.Regression.TrainTestSplit(data, testFraction: 0.1);
 
             // The predictor that gets produced out of training
-            LinearRegressionPredictor pred = null;
+            LinearRegressionModelParameters pred = null;
 
             // Create the estimator
             var learningPipeline = reader.MakeNewEstimator()

--- a/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
+++ b/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
@@ -21,7 +21,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// <summary>
     /// A generic interface for models that can average parameters from multiple instance of self
     /// </summary>
-    public interface IParameterMixer
+    [BestFriend]
+    internal interface IParameterMixer
     {
         IParameterMixer CombineParameters(IList<IParameterMixer> models);
     }
@@ -29,7 +30,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// <summary>
     /// A generic interface for models that can average parameters from multiple instance of self
     /// </summary>
-    public interface IParameterMixer<TOutput>
+    [BestFriend]
+    internal interface IParameterMixer<TOutput>
     {
         IParameterMixer<TOutput> CombineParameters(IList<IParameterMixer<TOutput>> models);
     }
@@ -48,7 +50,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// A generic interface for probability distributions
     /// </summary>
     /// <typeparam name="TResult">Type of statistics result</typeparam>
-    public interface IDistribution<out TResult>
+    [BestFriend]
+    internal interface IDistribution<out TResult>
     {
         TResult Minimum { get; }
 
@@ -70,7 +73,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     /// Interface for quantile distribution
     /// </summary>
     /// <typeparam name="TResult">Type of statistics result</typeparam>
-    public interface IQuantileDistribution<TResult> : IDistribution<TResult>, ISampleableDistribution<TResult>
+    [BestFriend]
+    internal interface IQuantileDistribution<TResult> : IDistribution<TResult>, ISampleableDistribution<TResult>
     {
         TResult Median { get; }
 
@@ -81,7 +85,8 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
         TResult GetQuantile(Float p);
     }
 
-    public interface ISampleableDistribution<TResult> : IDistribution<TResult>
+    [BestFriend]
+    internal interface ISampleableDistribution<TResult> : IDistribution<TResult>
     {
         /// <summary>
         /// Returns Support sample for the distribution.

--- a/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
+++ b/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Float = System.Single;
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -66,7 +64,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
     [BestFriend]
     internal interface IQuantileValueMapper
     {
-        ValueMapper<VBuffer<Float>, VBuffer<Float>> GetMapper(Float[] quantiles);
+        ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper(float[] quantiles);
     }
 
     /// <summary>
@@ -82,7 +80,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
         /// Returns an estimate of the p-th quantile, the data value where proportionately p of the data has value
         /// less than or equal to the returned value.
         /// </summary>
-        TResult GetQuantile(Float p);
+        TResult GetQuantile(float p);
     }
 
     [BestFriend]
@@ -176,7 +174,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
         /// The larger the absolute value of a weights, the more informative/important the feature.
         /// A weights of zero signifies that the feature is not used by the model.
         /// </summary>
-        void GetFeatureWeights(ref VBuffer<Float> weights);
+        void GetFeatureWeights(ref VBuffer<float> weights);
     }
 
     /// <summary>
@@ -201,7 +199,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
         /// For trees we will not have negative contributions, so bottom param will be ignored.
         /// If normalization is requested that resulting values will be normalized to [-1, 1].
         /// </summary>
-        ValueMapper<TSrc, VBuffer<Float>> GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize);
+        ValueMapper<TSrc, VBuffer<float>> GetFeatureContributionMapper<TSrc, TDst>(int top, int bottom, bool normalize);
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -494,7 +494,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             _featureWeights.GetFeatureWeights(ref weights);
         }
 
-        public IParameterMixer<Float> CombineParameters(IList<IParameterMixer<Float>> models)
+        IParameterMixer<Float> IParameterMixer<Float>.CombineParameters(IList<IParameterMixer<Float>> models)
         {
             var predictors = models.Select(
                 m =>
@@ -1466,7 +1466,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             return string.Format("Platt calibrator parameters: A={0}, B={1}", ParamA, ParamB);
         }
 
-        public IParameterMixer CombineParameters(IList<IParameterMixer> calibrators)
+        IParameterMixer IParameterMixer.CombineParameters(IList<IParameterMixer> calibrators)
         {
             Double a = 0;
             Double b = 0;

--- a/src/Microsoft.ML.FastTree/QuantileStatistics.cs
+++ b/src/Microsoft.ML.FastTree/QuantileStatistics.cs
@@ -2,56 +2,54 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Float = System.Single;
-
 using System;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Internal.Internallearn;
 
 namespace Microsoft.ML.Runtime
 {
-    public sealed class QuantileStatistics : IQuantileDistribution<Float>
+    public sealed class QuantileStatistics : IQuantileDistribution<float>
     {
-        private readonly Float[] _data;
-        private readonly Float[] _weights;
+        private readonly float[] _data;
+        private readonly float[] _weights;
 
         //This holds the cumulative sum of _weights to search the rank easily by binary search.
-        private Float[] _weightedSums;
+        private float[] _weightedSums;
         private SummaryStatistics _summaryStatistics;
 
-        Float IDistribution<Float>.Minimum
+        float IDistribution<float>.Minimum
         {
             get
             {
                 if (_data.Length == 0)
-                    return Float.NaN;
+                    return float.NaN;
 
                 return _data[0];
             }
         }
 
-        Float IDistribution<Float>.Maximum
+        float IDistribution<float>.Maximum
         {
             get
             {
                 if (_data.Length == 0)
-                    return Float.NaN;
+                    return float.NaN;
 
                 return _data[_data.Length - 1];
             }
         }
 
-        Float IQuantileDistribution<Float>.Median { get { return ((IQuantileDistribution<Float>)this).GetQuantile(0.5F); } }
+        float IQuantileDistribution<float>.Median { get { return ((IQuantileDistribution<float>)this).GetQuantile(0.5F); } }
 
-        Float IDistribution<Float>.Mean { get { return (Float)SummaryStatistics.Mean; } }
+        float IDistribution<float>.Mean { get { return (float)SummaryStatistics.Mean; } }
 
-        Float IDistribution<Float>.StandardDeviation { get { return (Float)SummaryStatistics.SampleStdDev; } }
+        float IDistribution<float>.StandardDeviation { get { return (float)SummaryStatistics.SampleStdDev; } }
 
         /// <summary>
         /// data array will be modified because of sorting if it is not already sorted yet and this class owns the data.
         /// Modifying the data outside will lead to erroneous output by this class
         /// </summary>
-        public QuantileStatistics(Float[] data, Float[] weights = null, bool isSorted = false)
+        public QuantileStatistics(float[] data, float[] weights = null, bool isSorted = false)
         {
             Contracts.CheckValue(data, nameof(data));
             Contracts.Check(weights == null || weights.Length == data.Length, "weights");
@@ -69,19 +67,19 @@ namespace Microsoft.ML.Runtime
         /// There are many ways to estimate quantile. This implementations is based on R-8, SciPy-(1/3,1/3)
         /// https://en.wikipedia.org/wiki/Quantile#Estimating_the_quantiles_of_a_population
         /// </summary>
-        Float IQuantileDistribution<Float>.GetQuantile(Float p)
+        float IQuantileDistribution<float>.GetQuantile(float p)
         {
             Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Probablity argument for Quantile function should be between 0 to 1 inclusive");
 
             if (_data.Length == 0)
-                return Float.NaN;
+                return float.NaN;
 
             if (p == 0 || _data.Length == 1)
                 return _data[0];
             if (p == 1)
                 return _data[_data.Length - 1];
 
-            Float h = GetRank(p);
+            float h = GetRank(p);
 
             if (h <= 1)
                 return _data[0];
@@ -90,12 +88,12 @@ namespace Microsoft.ML.Runtime
                 return _data[_data.Length - 1];
 
             var hf = (int)h;
-            return (Float)(_data[hf - 1] + (h - hf) * (_data[hf] - _data[hf - 1]));
+            return (float)(_data[hf - 1] + (h - hf) * (_data[hf] - _data[hf - 1]));
         }
 
-        Float[] ISampleableDistribution<Float>.GetSupportSample(out Float[] weights)
+        float[] ISampleableDistribution<float>.GetSupportSample(out float[] weights)
         {
-            var result = new Float[_data.Length];
+            var result = new float[_data.Length];
             Array.Copy(_data, result, _data.Length);
             if (_weights == null)
             {
@@ -103,25 +101,25 @@ namespace Microsoft.ML.Runtime
             }
             else
             {
-                weights = new Float[_data.Length];
+                weights = new float[_data.Length];
                 Array.Copy(_weights, weights, _weights.Length);
             }
 
             return result;
         }
 
-        private Float GetRank(Float p)
+        private float GetRank(float p)
         {
-            const Float oneThird = (Float)1 / 3;
+            const float oneThird = (float)1 / 3;
 
             // holds length of the _data array if the weights is null or holds the sum of weights
-            Float weightedLength = _data.Length;
+            float weightedLength = _data.Length;
 
             if (_weights != null)
             {
                 if (_weightedSums == null)
                 {
-                    _weightedSums = new Float[_weights.Length];
+                    _weightedSums = new float[_weights.Length];
                     _weightedSums[0] = _weights[0];
                     for (int i = 1; i < _weights.Length; i++)
                         _weightedSums[i] = _weights[i] + _weightedSums[i - 1];

--- a/src/Microsoft.ML.FastTree/QuantileStatistics.cs
+++ b/src/Microsoft.ML.FastTree/QuantileStatistics.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.Runtime
         private Float[] _weightedSums;
         private SummaryStatistics _summaryStatistics;
 
-        public Float Minimum
+        Float IDistribution<Float>.Minimum
         {
             get
             {
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Runtime
             }
         }
 
-        public Float Maximum
+        Float IDistribution<Float>.Maximum
         {
             get
             {
@@ -41,11 +41,11 @@ namespace Microsoft.ML.Runtime
             }
         }
 
-        public Float Median { get { return GetQuantile(0.5F); } }
+        Float IQuantileDistribution<Float>.Median { get { return ((IQuantileDistribution<Float>)this).GetQuantile(0.5F); } }
 
-        public Float Mean { get { return (Float)SummaryStatistics.Mean; } }
+        Float IDistribution<Float>.Mean { get { return (Float)SummaryStatistics.Mean; } }
 
-        public Float StandardDeviation { get { return (Float)SummaryStatistics.SampleStdDev; } }
+        Float IDistribution<Float>.StandardDeviation { get { return (Float)SummaryStatistics.SampleStdDev; } }
 
         /// <summary>
         /// data array will be modified because of sorting if it is not already sorted yet and this class owns the data.
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Runtime
         /// There are many ways to estimate quantile. This implementations is based on R-8, SciPy-(1/3,1/3)
         /// https://en.wikipedia.org/wiki/Quantile#Estimating_the_quantiles_of_a_population
         /// </summary>
-        public Float GetQuantile(Float p)
+        Float IQuantileDistribution<Float>.GetQuantile(Float p)
         {
             Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Probablity argument for Quantile function should be between 0 to 1 inclusive");
 
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Runtime
             return (Float)(_data[hf - 1] + (h - hf) * (_data[hf] - _data[hf - 1]));
         }
 
-        public Float[] GetSupportSample(out Float[] weights)
+        Float[] ISampleableDistribution<Float>.GetSupportSample(out Float[] weights)
         {
             var result = new Float[_data.Length];
             Array.Copy(_data, result, _data.Length);

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -119,7 +119,7 @@ namespace Microsoft.ML.Trainers.FastTree
                     // REVIEW: Should make this more efficient - it repeatedly allocates too much stuff.
                     float[] weights = null;
                     var distribution = TrainedEnsemble.GetDistribution(in src, _quantileSampleCount, out weights);
-                    var qdist = new QuantileStatistics(distribution, weights);
+                    IQuantileDistribution<float> qdist = new QuantileStatistics(distribution, weights);
 
                     var editor = VBufferEditor.Create(ref dst, quantiles.Length);
                     for (int i = 0; i < quantiles.Length; i++)

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -293,7 +293,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             {
                 // We would expect the solution to the problem to be exact in this case.
                 ch.Info("Number of examples equals number of parameters, solution is exact but no statistics can be derived");
-                return new OlsLinearRegressionModelParameters(Host, in weights, bias, null, null, null, 1, float.NaN);
+                return new OlsLinearRegressionModelParameters(Host, in weights, bias);
             }
 
             Double rss = 0; // residual sum of squares
@@ -329,7 +329,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             // Also we can't estimate it, unless we can estimate the variance, which requires more examples than
             // parameters.
             if (!_perParameterSignificance || m >= n)
-                return new OlsLinearRegressionModelParameters(Host, in weights, bias, null, null, null, rSquared, rSquaredAdjusted);
+                return new OlsLinearRegressionModelParameters(Host, in weights, bias, rSquared: rSquared, rSquaredAdjusted: rSquaredAdjusted);
 
             ch.Assert(!Double.IsNaN(rSquaredAdjusted));
             var standardErrors = new Double[m];

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -26,16 +26,16 @@ using System.Security;
     OlsLinearRegressionTrainer.LoadNameValue,
     OlsLinearRegressionTrainer.ShortName)]
 
-[assembly: LoadableClass(typeof(OlsLinearRegressionPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(OlsLinearRegressionModelParameters), null, typeof(SignatureLoadModel),
     "OLS Linear Regression Executor",
-    OlsLinearRegressionPredictor.LoaderSignature)]
+    OlsLinearRegressionModelParameters.LoaderSignature)]
 
 [assembly: LoadableClass(typeof(void), typeof(OlsLinearRegressionTrainer), null, typeof(SignatureEntryPointModule), OlsLinearRegressionTrainer.LoadNameValue)]
 
 namespace Microsoft.ML.Trainers.HalLearners
 {
     /// <include file='doc.xml' path='doc/members/member[@name="OLS"]/*' />
-    public sealed class OlsLinearRegressionTrainer : TrainerEstimatorBase<RegressionPredictionTransformer<OlsLinearRegressionPredictor>, OlsLinearRegressionPredictor>
+    public sealed class OlsLinearRegressionTrainer : TrainerEstimatorBase<RegressionPredictionTransformer<OlsLinearRegressionModelParameters>, OlsLinearRegressionModelParameters>
     {
         public sealed class Arguments : LearnerInputBaseWithWeight
         {
@@ -111,10 +111,10 @@ namespace Microsoft.ML.Trainers.HalLearners
             return args;
         }
 
-        protected override RegressionPredictionTransformer<OlsLinearRegressionPredictor> MakeTransformer(OlsLinearRegressionPredictor model, Schema trainSchema)
-             => new RegressionPredictionTransformer<OlsLinearRegressionPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RegressionPredictionTransformer<OlsLinearRegressionModelParameters> MakeTransformer(OlsLinearRegressionModelParameters model, Schema trainSchema)
+             => new RegressionPredictionTransformer<OlsLinearRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<OlsLinearRegressionPredictor> Train(IDataView trainData, IPredictor initialPredictor = null)
+        public RegressionPredictionTransformer<OlsLinearRegressionModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Trainers.HalLearners
         private static Double ProbClamp(Double p)
             => Math.Max(0, Math.Min(p, 1));
 
-        private protected override OlsLinearRegressionPredictor TrainModelCore(TrainContext context)
+        private protected override OlsLinearRegressionModelParameters TrainModelCore(TrainContext context)
         {
             using (var ch = Host.Start("Training"))
             {
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             }
         }
 
-        private OlsLinearRegressionPredictor TrainCore(IChannel ch, FloatLabelCursor.Factory cursorFactory, int featureCount)
+        private OlsLinearRegressionModelParameters TrainCore(IChannel ch, FloatLabelCursor.Factory cursorFactory, int featureCount)
         {
             Host.AssertValue(ch);
             ch.AssertValue(cursorFactory);
@@ -293,14 +293,14 @@ namespace Microsoft.ML.Trainers.HalLearners
             {
                 // We would expect the solution to the problem to be exact in this case.
                 ch.Info("Number of examples equals number of parameters, solution is exact but no statistics can be derived");
-                return new OlsLinearRegressionPredictor(Host, in weights, bias, null, null, null, 1, float.NaN);
+                return new OlsLinearRegressionModelParameters(Host, in weights, bias, null, null, null, 1, float.NaN);
             }
 
             Double rss = 0; // residual sum of squares
             Double tss = 0; // total sum of squares
             using (var cursor = cursorFactory.Create())
             {
-                IValueMapper lrPredictor = new LinearRegressionPredictor(Host, in weights, bias);
+                IValueMapper lrPredictor = new LinearRegressionModelParameters(Host, in weights, bias);
                 var lrMap = lrPredictor.GetMapper<VBuffer<float>, float>();
                 float yh = default;
                 while (cursor.MoveNext())
@@ -329,7 +329,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             // Also we can't estimate it, unless we can estimate the variance, which requires more examples than
             // parameters.
             if (!_perParameterSignificance || m >= n)
-                return new OlsLinearRegressionPredictor(Host, in weights, bias, null, null, null, rSquared, rSquaredAdjusted);
+                return new OlsLinearRegressionModelParameters(Host, in weights, bias, null, null, null, rSquared, rSquaredAdjusted);
 
             ch.Assert(!Double.IsNaN(rSquaredAdjusted));
             var standardErrors = new Double[m];
@@ -376,7 +376,7 @@ namespace Microsoft.ML.Trainers.HalLearners
                 ch.Check(0 <= pValues[i] && pValues[i] <= 1, "p-Value calculated outside expected [0,1] range");
             }
 
-            return new OlsLinearRegressionPredictor(Host, in weights, bias, standardErrors, tValues, pValues, rSquared, rSquaredAdjusted);
+            return new OlsLinearRegressionModelParameters(Host, in weights, bias, standardErrors, tValues, pValues, rSquared, rSquaredAdjusted);
         }
 
         internal static class Mkl
@@ -536,10 +536,10 @@ namespace Microsoft.ML.Trainers.HalLearners
     /// <summary>
     /// A linear predictor for which per parameter significance statistics are available.
     /// </summary>
-    public sealed class OlsLinearRegressionPredictor : RegressionPredictor
+    public sealed class OlsLinearRegressionModelParameters : RegressionModelParameters
     {
-        public const string LoaderSignature = "OlsLinearRegressionExec";
-        public const string RegistrationName = "OlsLinearRegressionPredictor";
+        internal const string LoaderSignature = "OlsLinearRegressionExec";
+        internal const string RegistrationName = "OlsLinearRegressionPredictor";
 
         /// <summary>
         /// Version information to be saved in binary format
@@ -552,7 +552,7 @@ namespace Microsoft.ML.Trainers.HalLearners
                 verReadableCur: 0x00010001,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(OlsLinearRegressionPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(OlsLinearRegressionModelParameters).Assembly.FullName);
         }
 
         // The following will be null iff RSquaredAdjusted is NaN.
@@ -610,7 +610,7 @@ namespace Microsoft.ML.Trainers.HalLearners
         public IReadOnlyCollection<Double> PValues
         { get { return _pValues.AsReadOnly(); } }
 
-        internal OlsLinearRegressionPredictor(IHostEnvironment env, in VBuffer<float> weights, float bias,
+        public OlsLinearRegressionModelParameters(IHostEnvironment env, in VBuffer<float> weights, float bias,
             Double[] standardErrors, Double[] tValues, Double[] pValues, Double rSquared, Double rSquaredAdjusted)
             : base(env, RegistrationName, in weights, bias)
         {
@@ -647,7 +647,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             _rSquaredAdjusted = rSquaredAdjusted;
         }
 
-        private OlsLinearRegressionPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private OlsLinearRegressionModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx)
         {
             // *** Binary format ***
@@ -731,12 +731,12 @@ namespace Microsoft.ML.Trainers.HalLearners
             Contracts.CheckDecode(0 <= p && p <= 1);
         }
 
-        public static OlsLinearRegressionPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static OlsLinearRegressionModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            return new OlsLinearRegressionPredictor(env, ctx);
+            return new OlsLinearRegressionModelParameters(env, ctx);
         }
 
         private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -565,16 +565,14 @@ namespace Microsoft.ML.Trainers.HalLearners
         /// <summary>
         /// The coefficient of determination.
         /// </summary>
-        public Double RSquared
-        { get { return _rSquared; } }
+        public Double RSquared => _rSquared;
 
         /// <summary>
         /// The adjusted coefficient of determination. It is only possible to produce
         /// an adjusted R-squared if there are more examples than parameters in the model
         /// plus one. If this condition is not met, this value will be <c>NaN</c>.
         /// </summary>
-        public Double RSquaredAdjusted
-        { get { return _rSquaredAdjusted; } }
+        public Double RSquaredAdjusted => _rSquaredAdjusted;
 
         /// <summary>
         /// Whether the model has per parameter statistics. This is false iff
@@ -585,33 +583,29 @@ namespace Microsoft.ML.Trainers.HalLearners
         /// <see cref="OlsLinearRegressionTrainer.Arguments.PerParameterSignificance"/>
         /// to false.
         /// </summary>
-        public bool HasStatistics
-        { get { return _standardErrors != null; } }
+        public bool HasStatistics => _standardErrors != null;
 
         /// <summary>
         /// The standard error per model parameter, where the first corresponds to the bias,
         /// and all subsequent correspond to each weight in turn. This is <c>null</c> if and
         /// only if <see cref="HasStatistics"/> is <c>false</c>.
         /// </summary>
-        public IReadOnlyCollection<Double> StandardErrors
-        { get { return _standardErrors.AsReadOnly(); } }
+        public IReadOnlyCollection<Double> StandardErrors => _standardErrors.AsReadOnly();
 
         /// <summary>
         /// t-Statistic values corresponding to each of the model standard errors. This is
         /// <c>null</c> if and only if <see cref="HasStatistics"/> is <c>false</c>.
         /// </summary>
-        public IReadOnlyCollection<Double> TValues
-        { get { return _tValues.AsReadOnly(); } }
+        public IReadOnlyCollection<Double> TValues => _tValues.AsReadOnly();
 
         /// <summary>
         /// p-values corresponding to each of the model standard errors. This is <c>null</c>
         /// if and only if <see cref="HasStatistics"/> is <c>false</c>.
         /// </summary>
-        public IReadOnlyCollection<Double> PValues
-        { get { return _pValues.AsReadOnly(); } }
+        public IReadOnlyCollection<Double> PValues => _pValues.AsReadOnly();
 
         public OlsLinearRegressionModelParameters(IHostEnvironment env, in VBuffer<float> weights, float bias,
-            Double[] standardErrors, Double[] tValues, Double[] pValues, Double rSquared, Double rSquaredAdjusted)
+            Double[] standardErrors = null, Double[] tValues = null, Double[] pValues = null, Double rSquared = 1, Double rSquaredAdjusted = float.NaN)
             : base(env, RegistrationName, in weights, bias)
         {
             Contracts.AssertValueOrNull(standardErrors);

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -141,8 +141,8 @@ namespace Microsoft.ML.Trainers.SymSgd
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearPredictor;
-                linInitPred = linInitPred ?? initPred as LinearPredictor;
+                var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearModelParameters;
+                linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");
                 return TrainCore(ch, preparedData, linInitPred, weightSetCount);
@@ -195,7 +195,7 @@ namespace Microsoft.ML.Trainers.SymSgd
             VBuffer<float> maybeSparseWeights = default;
             VBufferUtils.CreateMaybeSparseCopy(in weights, ref maybeSparseWeights,
                 Conversions.Instance.GetIsDefaultPredicate<float>(NumberType.R4));
-            var predictor = new LinearBinaryPredictor(Host, in maybeSparseWeights, bias);
+            var predictor = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias);
             return new ParameterMixingCalibratedPredictor(Host, predictor, new PlattCalibrator(Host, -1, 0));
         }
 
@@ -635,7 +635,7 @@ namespace Microsoft.ML.Trainers.SymSgd
             }
         }
 
-        private TPredictor TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor, int weightSetCount)
+        private TPredictor TrainCore(IChannel ch, RoleMappedData data, LinearModelParameters predictor, int weightSetCount)
         {
             int numFeatures = data.Schema.Feature.Type.VectorSize;
             var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight);

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
@@ -2,13 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Float = System.Single;
-
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Calibration;
@@ -20,26 +14,31 @@ using Microsoft.ML.Runtime.Model.Onnx;
 using Microsoft.ML.Runtime.Model.Pfa;
 using Microsoft.ML.Runtime.Numeric;
 using Newtonsoft.Json.Linq;
-using Microsoft.ML.Data;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Float = System.Single;
 
 // This is for deserialization from a model repository.
-[assembly: LoadableClass(typeof(IPredictorProducing<Float>), typeof(LinearBinaryPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(IPredictorProducing<Float>), typeof(LinearBinaryModelParameters), null, typeof(SignatureLoadModel),
     "Linear Binary Executor",
-    LinearBinaryPredictor.LoaderSignature)]
+    LinearBinaryModelParameters.LoaderSignature)]
 
 // This is for deserialization from a model repository.
-[assembly: LoadableClass(typeof(LinearRegressionPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(LinearRegressionModelParameters), null, typeof(SignatureLoadModel),
     "Linear Regression Executor",
-    LinearRegressionPredictor.LoaderSignature)]
+    LinearRegressionModelParameters.LoaderSignature)]
 
 // This is for deserialization from a model repository.
-[assembly: LoadableClass(typeof(PoissonRegressionPredictor), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(PoissonRegressionModelParameters), null, typeof(SignatureLoadModel),
     "Poisson Regression Executor",
-    PoissonRegressionPredictor.LoaderSignature)]
+    PoissonRegressionModelParameters.LoaderSignature)]
 
 namespace Microsoft.ML.Runtime.Learners
 {
-    public abstract class LinearPredictor : PredictorBase<Float>,
+    public abstract class LinearModelParameters : PredictorBase<Float>,
         IValueMapper,
         ICanSaveInIniFormat,
         ICanSaveInTextFormat,
@@ -60,7 +59,7 @@ namespace Microsoft.ML.Runtime.Learners
 
         private sealed class WeightsCollection : IReadOnlyList<Float>
         {
-            private readonly LinearPredictor _pred;
+            private readonly LinearModelParameters _pred;
 
             public int Count => _pred.Weight.Length;
 
@@ -75,7 +74,7 @@ namespace Microsoft.ML.Runtime.Learners
                 }
             }
 
-            public WeightsCollection(LinearPredictor pred)
+            public WeightsCollection(LinearModelParameters pred)
             {
                 Contracts.AssertValue(pred);
                 _pred = pred;
@@ -112,7 +111,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="weights">The weights for the linear predictor. Note that this
         /// will take ownership of the <see cref="VBuffer{T}"/>.</param>
         /// <param name="bias">The bias added to every output score.</param>
-        internal LinearPredictor(IHostEnvironment env, string name, in VBuffer<Float> weights, Float bias)
+        public LinearModelParameters(IHostEnvironment env, string name, in VBuffer<Float> weights, Float bias)
             : base(env, name)
         {
             Host.CheckParam(FloatUtils.IsFinite(weights.GetValues()), nameof(weights), "Cannot initialize linear predictor with non-finite weights");
@@ -128,7 +127,7 @@ namespace Microsoft.ML.Runtime.Learners
                 _weightsDenseLock = new object();
         }
 
-        protected LinearPredictor(IHostEnvironment env, string name, ModelLoadContext ctx)
+        protected LinearModelParameters(IHostEnvironment env, string name, ModelLoadContext ctx)
             : base(env, name, ctx)
         {
             // *** Binary format ***
@@ -311,12 +310,12 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-        protected void CombineParameters(IList<IParameterMixer<Float>> models, out VBuffer<Float> weights, out Float bias)
+        internal void CombineParameters(IList<IParameterMixer<Float>> models, out VBuffer<Float> weights, out Float bias)
         {
             Type type = GetType();
 
             Contracts.Check(type == models[0].GetType(), "Submodel for parameter mixer has the wrong type");
-            var first = (LinearPredictor)models[0];
+            var first = (LinearModelParameters)models[0];
 
             weights = default(VBuffer<Float>);
             first.Weight.CopyTo(ref weights);
@@ -327,7 +326,7 @@ namespace Microsoft.ML.Runtime.Learners
                 var m = models[i];
                 Contracts.Check(type == m.GetType(), "Submodel for parameter mixer has the wrong type");
 
-                var sub = (LinearPredictor)m;
+                var sub = (LinearModelParameters)m;
                 var subweights = sub.Weight;
                 VectorUtils.Add(in subweights, ref weights);
                 bias += sub.Bias;
@@ -400,12 +399,12 @@ namespace Microsoft.ML.Runtime.Learners
         }
     }
 
-    public sealed partial class LinearBinaryPredictor : LinearPredictor,
+    public sealed partial class LinearBinaryModelParameters : LinearModelParameters,
         ICanGetSummaryInKeyValuePairs,
         IParameterMixer<Float>
     {
-        public const string LoaderSignature = "Linear2CExec";
-        public const string RegistrationName = "LinearBinaryPredictor";
+        internal const string LoaderSignature = "Linear2CExec";
+        internal const string RegistrationName = "LinearBinaryPredictor";
 
         private const string ModelStatsSubModelFilename = "ModelStats";
         private readonly LinearModelStatistics _stats;
@@ -422,7 +421,7 @@ namespace Microsoft.ML.Runtime.Learners
                 verReadableCur: 0x00020001,
                 verWeCanReadBack: 0x00020001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(LinearBinaryPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(LinearBinaryModelParameters).Assembly.FullName);
         }
 
         /// <summary>
@@ -433,14 +432,14 @@ namespace Microsoft.ML.Runtime.Learners
         /// will take ownership of the <see cref="VBuffer{T}"/>.</param>
         /// <param name="bias">The bias added to every output score.</param>
         /// <param name="stats"></param>
-        public LinearBinaryPredictor(IHostEnvironment env, in VBuffer<Float> weights, Float bias, LinearModelStatistics stats = null)
+        public LinearBinaryModelParameters(IHostEnvironment env, in VBuffer<Float> weights, Float bias, LinearModelStatistics stats = null)
             : base(env, RegistrationName, in weights, bias)
         {
             Contracts.AssertValueOrNull(stats);
             _stats = stats;
         }
 
-        private LinearBinaryPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private LinearBinaryModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx)
         {
             // For model version earlier than 0x00020001, there is no model statisitcs.
@@ -454,12 +453,12 @@ namespace Microsoft.ML.Runtime.Learners
             ctx.LoadModelOrNull<LinearModelStatistics, SignatureLoadModel>(Host, out _stats, ModelStatsSubModelFilename);
         }
 
-        public static IPredictorProducing<Float> Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static IPredictorProducing<Float> Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            var predictor = new LinearBinaryPredictor(env, ctx);
+            var predictor = new LinearBinaryModelParameters(env, ctx);
             ICalibrator calibrator;
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
@@ -488,12 +487,12 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-        public IParameterMixer<Float> CombineParameters(IList<IParameterMixer<Float>> models)
+        IParameterMixer<Float> IParameterMixer<Float>.CombineParameters(IList<IParameterMixer<Float>> models)
         {
             VBuffer<Float> weights;
             Float bias;
             CombineParameters(models, out weights, out bias);
-            return new LinearBinaryPredictor(Host, in weights, bias);
+            return new LinearBinaryModelParameters(Host, in weights, bias);
         }
 
         private protected override void SaveSummary(TextWriter writer, RoleMappedSchema schema)
@@ -542,14 +541,14 @@ namespace Microsoft.ML.Runtime.Learners
         }
     }
 
-    public abstract class RegressionPredictor : LinearPredictor
+    public abstract class RegressionModelParameters : LinearModelParameters
     {
-        protected RegressionPredictor(IHostEnvironment env, string name, in VBuffer<Float> weights, Float bias)
+        public RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<Float> weights, Float bias)
             : base(env, name, in weights, bias)
         {
         }
 
-        protected RegressionPredictor(IHostEnvironment env, string name, ModelLoadContext ctx)
+        protected RegressionModelParameters(IHostEnvironment env, string name, ModelLoadContext ctx)
             : base(env, name, ctx)
         {
         }
@@ -576,12 +575,12 @@ namespace Microsoft.ML.Runtime.Learners
         }
     }
 
-    public sealed class LinearRegressionPredictor : RegressionPredictor,
+    public sealed class LinearRegressionModelParameters : RegressionModelParameters,
         IParameterMixer<Float>,
         ICanGetSummaryInKeyValuePairs
     {
-        public const string LoaderSignature = "LinearRegressionExec";
-        public const string RegistrationName = "LinearRegressionPredictor";
+        internal const string LoaderSignature = "LinearRegressionExec";
+        internal const string RegistrationName = "LinearRegressionPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -592,7 +591,7 @@ namespace Microsoft.ML.Runtime.Learners
                 verReadableCur: 0x00020001,
                 verWeCanReadBack: 0x00020001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(LinearRegressionPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(LinearRegressionModelParameters).Assembly.FullName);
         }
 
         /// <summary>
@@ -602,22 +601,22 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="weights">The weights for the linear predictor. Note that this
         /// will take ownership of the <see cref="VBuffer{T}"/>.</param>
         /// <param name="bias">The bias added to every output score.</param>
-        public LinearRegressionPredictor(IHostEnvironment env, in VBuffer<Float> weights, Float bias)
+        public LinearRegressionModelParameters(IHostEnvironment env, in VBuffer<Float> weights, Float bias)
             : base(env, RegistrationName, in weights, bias)
         {
         }
 
-        private LinearRegressionPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private LinearRegressionModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx)
         {
         }
 
-        public static LinearRegressionPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static LinearRegressionModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            return new LinearRegressionPredictor(env, ctx);
+            return new LinearRegressionModelParameters(env, ctx);
         }
 
         private protected override void SaveCore(ModelSaveContext ctx)
@@ -640,12 +639,12 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-        public IParameterMixer<Float> CombineParameters(IList<IParameterMixer<Float>> models)
+        IParameterMixer<Float> IParameterMixer<Float>.CombineParameters(IList<IParameterMixer<Float>> models)
         {
             VBuffer<Float> weights;
             Float bias;
             CombineParameters(models, out weights, out bias);
-            return new LinearRegressionPredictor(Host, in weights, bias);
+            return new LinearRegressionModelParameters(Host, in weights, bias);
         }
 
         ///<inheritdoc/>
@@ -661,10 +660,10 @@ namespace Microsoft.ML.Runtime.Learners
         }
     }
 
-    public sealed class PoissonRegressionPredictor : RegressionPredictor, IParameterMixer<Float>
+    public sealed class PoissonRegressionModelParameters : RegressionModelParameters, IParameterMixer<Float>
     {
-        public const string LoaderSignature = "PoissonRegressionExec";
-        public const string RegistrationName = "PoissonRegressionPredictor";
+        internal const string LoaderSignature = "PoissonRegressionExec";
+        internal const string RegistrationName = "PoissonRegressionPredictor";
 
         private static VersionInfo GetVersionInfo()
         {
@@ -675,25 +674,25 @@ namespace Microsoft.ML.Runtime.Learners
                 verReadableCur: 0x00020001,
                 verWeCanReadBack: 0x00020001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(PoissonRegressionPredictor).Assembly.FullName);
+                loaderAssemblyName: typeof(PoissonRegressionModelParameters).Assembly.FullName);
         }
 
-        internal PoissonRegressionPredictor(IHostEnvironment env, in VBuffer<Float> weights, Float bias)
+        public PoissonRegressionModelParameters(IHostEnvironment env, in VBuffer<Float> weights, Float bias)
             : base(env, RegistrationName, in weights, bias)
         {
         }
 
-        private PoissonRegressionPredictor(IHostEnvironment env, ModelLoadContext ctx)
+        private PoissonRegressionModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, RegistrationName, ctx)
         {
         }
 
-        public static PoissonRegressionPredictor Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static PoissonRegressionModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            return new PoissonRegressionPredictor(env, ctx);
+            return new PoissonRegressionModelParameters(env, ctx);
         }
 
         private protected override void SaveCore(ModelSaveContext ctx)
@@ -721,12 +720,12 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-        public IParameterMixer<Float> CombineParameters(IList<IParameterMixer<Float>> models)
+        IParameterMixer<Float> IParameterMixer<Float>.CombineParameters(IList<IParameterMixer<Float>> models)
         {
             VBuffer<Float> weights;
             Float bias;
             CombineParameters(models, out weights, out bias);
-            return new PoissonRegressionPredictor(Host, in weights, bias);
+            return new PoissonRegressionModelParameters(Host, in weights, bias);
         }
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
@@ -19,16 +19,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
 
 // This is for deserialization from a model repository.
 [assembly: LoadableClass(typeof(IPredictorProducing<float>), typeof(LinearBinaryModelParameters), null, typeof(SignatureLoadModel),
-=======
-using Float = System.Single;
-
-// This is for deserialization from a model repository.
-[assembly: LoadableClass(typeof(IPredictorProducing<Float>), typeof(LinearBinaryModelParameters), null, typeof(SignatureLoadModel),
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
     "Linear Binary Executor",
     LinearBinaryModelParameters.LoaderSignature)]
 
@@ -44,11 +37,7 @@ using Float = System.Single;
 
 namespace Microsoft.ML.Runtime.Learners
 {
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
     public abstract class LinearModelParameters : PredictorBase<float>,
-=======
-    public abstract class LinearModelParameters : PredictorBase<Float>,
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         IValueMapper,
         ICanSaveInIniFormat,
         ICanSaveInTextFormat,
@@ -121,11 +110,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="weights">The weights for the linear predictor. Note that this
         /// will take ownership of the <see cref="VBuffer{T}"/>.</param>
         /// <param name="bias">The bias added to every output score.</param>
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         public LinearModelParameters(IHostEnvironment env, string name, in VBuffer<float> weights, float bias)
-=======
-        public LinearModelParameters(IHostEnvironment env, string name, in VBuffer<Float> weights, Float bias)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
             : base(env, name)
         {
             Host.CheckParam(FloatUtils.IsFinite(weights.GetValues()), nameof(weights), "Cannot initialize linear predictor with non-finite weights");
@@ -324,11 +309,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         internal void CombineParameters(IList<IParameterMixer<float>> models, out VBuffer<float> weights, out float bias)
-=======
-        internal void CombineParameters(IList<IParameterMixer<Float>> models, out VBuffer<Float> weights, out Float bias)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         {
             Type type = GetType();
 
@@ -450,11 +431,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// will take ownership of the <see cref="VBuffer{T}"/>.</param>
         /// <param name="bias">The bias added to every output score.</param>
         /// <param name="stats"></param>
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         public LinearBinaryModelParameters(IHostEnvironment env, in VBuffer<float> weights, float bias, LinearModelStatistics stats = null)
-=======
-        public LinearBinaryModelParameters(IHostEnvironment env, in VBuffer<Float> weights, Float bias, LinearModelStatistics stats = null)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
             : base(env, RegistrationName, in weights, bias)
         {
             Contracts.AssertValueOrNull(stats);
@@ -475,11 +452,7 @@ namespace Microsoft.ML.Runtime.Learners
             ctx.LoadModelOrNull<LinearModelStatistics, SignatureLoadModel>(Host, out _stats, ModelStatsSubModelFilename);
         }
 
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         private static IPredictorProducing<float> Create(IHostEnvironment env, ModelLoadContext ctx)
-=======
-        private static IPredictorProducing<Float> Create(IHostEnvironment env, ModelLoadContext ctx)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
@@ -513,11 +486,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         IParameterMixer<float> IParameterMixer<float>.CombineParameters(IList<IParameterMixer<float>> models)
-=======
-        IParameterMixer<Float> IParameterMixer<Float>.CombineParameters(IList<IParameterMixer<Float>> models)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         {
             VBuffer<float> weights;
             float bias;
@@ -573,11 +542,7 @@ namespace Microsoft.ML.Runtime.Learners
 
     public abstract class RegressionModelParameters : LinearModelParameters
     {
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
-        public RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<float> weights, float bias)
-=======
-        public RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<Float> weights, Float bias)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+       public RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<float> weights, float bias)
             : base(env, name, in weights, bias)
         {
         }
@@ -610,11 +575,7 @@ namespace Microsoft.ML.Runtime.Learners
     }
 
     public sealed class LinearRegressionModelParameters : RegressionModelParameters,
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         IParameterMixer<float>,
-=======
-        IParameterMixer<Float>,
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         ICanGetSummaryInKeyValuePairs
     {
         internal const string LoaderSignature = "LinearRegressionExec";
@@ -639,11 +600,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <param name="weights">The weights for the linear predictor. Note that this
         /// will take ownership of the <see cref="VBuffer{T}"/>.</param>
         /// <param name="bias">The bias added to every output score.</param>
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         public LinearRegressionModelParameters(IHostEnvironment env, in VBuffer<float> weights, float bias)
-=======
-        public LinearRegressionModelParameters(IHostEnvironment env, in VBuffer<Float> weights, Float bias)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
             : base(env, RegistrationName, in weights, bias)
         {
         }
@@ -681,11 +638,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         IParameterMixer<float> IParameterMixer<float>.CombineParameters(IList<IParameterMixer<float>> models)
-=======
-        IParameterMixer<Float> IParameterMixer<Float>.CombineParameters(IList<IParameterMixer<Float>> models)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         {
             VBuffer<float> weights;
             float bias;
@@ -706,11 +659,7 @@ namespace Microsoft.ML.Runtime.Learners
         }
     }
 
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
     public sealed class PoissonRegressionModelParameters : RegressionModelParameters, IParameterMixer<float>
-=======
-    public sealed class PoissonRegressionModelParameters : RegressionModelParameters, IParameterMixer<Float>
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
     {
         internal const string LoaderSignature = "PoissonRegressionExec";
         internal const string RegistrationName = "PoissonRegressionPredictor";
@@ -727,11 +676,7 @@ namespace Microsoft.ML.Runtime.Learners
                 loaderAssemblyName: typeof(PoissonRegressionModelParameters).Assembly.FullName);
         }
 
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         public PoissonRegressionModelParameters(IHostEnvironment env, in VBuffer<float> weights, float bias)
-=======
-        public PoissonRegressionModelParameters(IHostEnvironment env, in VBuffer<Float> weights, Float bias)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
             : base(env, RegistrationName, in weights, bias)
         {
         }
@@ -774,11 +719,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Combine a bunch of models into one by averaging parameters
         /// </summary>
-<<<<<<< HEAD:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         IParameterMixer<float> IParameterMixer<float>.CombineParameters(IList<IParameterMixer<float>> models)
-=======
-        IParameterMixer<Float> IParameterMixer<Float>.CombineParameters(IList<IParameterMixer<Float>> models)
->>>>>>> 6ce0779f9b8d0a886177c851811663b195cc421e:src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
         {
             VBuffer<float> weights;
             float bias;

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsStatic.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.StaticPipe
             int memorySize = Arguments.Defaults.MemorySize,
             bool enoforceNoNegativity = Arguments.Defaults.EnforceNonNegativity,
             Action<Arguments> advancedSettings = null,
-            Action<PoissonRegressionPredictor> onFit = null)
+            Action<PoissonRegressionModelParameters> onFit = null)
         {
             LbfgsStaticUtils.ValidateParams(label, features, weights, l1Weight, l2Weight, optimizationTolerance, memorySize, enoforceNoNegativity, advancedSettings, onFit);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -384,7 +384,7 @@ namespace Microsoft.ML.Runtime.Learners
         {
             Contracts.AssertValue(srcPredictor);
 
-            var pred = srcPredictor.SubPredictor as LinearBinaryPredictor;
+            var pred = srcPredictor.SubPredictor as LinearBinaryModelParameters;
             Contracts.AssertValue(pred);
             return InitializeWeights(pred.Weights2, new[] { pred.Bias });
         }
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Runtime.Learners
             CurrentWeights.GetItemOrDefault(0, ref bias);
             CurrentWeights.CopyTo(ref weights, 1, CurrentWeights.Length - 1);
             return new ParameterMixingCalibratedPredictor(Host,
-                new LinearBinaryPredictor(Host, in weights, bias, _stats),
+                new LinearBinaryModelParameters(Host, in weights, bias, _stats),
                 new PlattCalibrator(Host, -1, 0));
         }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -386,7 +386,7 @@ namespace Microsoft.ML.Runtime.Learners
 
             var pred = srcPredictor.SubPredictor as LinearBinaryModelParameters;
             Contracts.AssertValue(pred);
-            return InitializeWeights(pred.Weights2, new[] { pred.Bias });
+            return InitializeWeights(pred.Weights, new[] { pred.Bias });
         }
 
         protected override ParameterMixingCalibratedPredictor CreatePredictor()

--- a/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
@@ -291,7 +291,7 @@ namespace Microsoft.ML.Runtime.Learners
             if (!_coeffStdError.HasValue)
                 return new List<CoefficientStatistics>();
 
-            var weights = parent.Weights2 as IReadOnlyList<Single>;
+            var weights = parent.Weights as IReadOnlyList<Single>;
             _env.Assert(_paramCount == 1 || weights != null);
             _env.Assert(_coeffStdError.Value.Length == weights.Count + 1);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Runtime.Learners
                 };
         }
 
-        private List<CoefficientStatistics> GetUnorderedCoefficientStatistics(LinearBinaryPredictor parent, RoleMappedSchema schema)
+        private List<CoefficientStatistics> GetUnorderedCoefficientStatistics(LinearBinaryModelParameters parent, RoleMappedSchema schema)
         {
             Contracts.AssertValue(_env);
             _env.CheckValue(parent, nameof(parent));
@@ -324,7 +324,7 @@ namespace Microsoft.ML.Runtime.Learners
         /// <summary>
         /// Gets the coefficient statistics as an object.
         /// </summary>
-        public CoefficientStatistics[] GetCoefficientStatistics(LinearBinaryPredictor parent, RoleMappedSchema schema, int paramCountCap)
+        public CoefficientStatistics[] GetCoefficientStatistics(LinearBinaryModelParameters parent, RoleMappedSchema schema, int paramCountCap)
         {
             Contracts.AssertValue(_env);
             _env.CheckValue(parent, nameof(parent));
@@ -345,7 +345,7 @@ namespace Microsoft.ML.Runtime.Learners
             return order.Prepend(new[] { new CoefficientStatistics("(Bias)", bias, stdError, zScore, pValue) }).ToArray();
         }
 
-        public void SaveText(TextWriter writer, LinearBinaryPredictor parent, RoleMappedSchema schema, int paramCountCap)
+        public void SaveText(TextWriter writer, LinearBinaryModelParameters parent, RoleMappedSchema schema, int paramCountCap)
         {
             Contracts.AssertValue(_env);
             _env.CheckValue(writer, nameof(writer));
@@ -383,7 +383,7 @@ namespace Microsoft.ML.Runtime.Learners
             writer.WriteLine("Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1");
         }
 
-        public void SaveSummaryInKeyValuePairs(LinearBinaryPredictor parent,
+        public void SaveSummaryInKeyValuePairs(LinearBinaryModelParameters parent,
             RoleMappedSchema schema, int paramCountCap, List<KeyValuePair<string, object>> resultCollection)
         {
             Contracts.AssertValue(_env);
@@ -409,7 +409,7 @@ namespace Microsoft.ML.Runtime.Learners
             }
         }
 
-        internal Schema.Metadata MakeStatisticsMetadata(LinearBinaryPredictor parent, RoleMappedSchema schema, in VBuffer<ReadOnlyMemory<char>> names)
+        internal Schema.Metadata MakeStatisticsMetadata(LinearBinaryModelParameters parent, RoleMappedSchema schema, in VBuffer<ReadOnlyMemory<char>> names)
         {
             _env.AssertValueOrNull(parent);
             _env.AssertValue(schema);

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedLinear.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Trainers.Online
             private readonly AveragedLinearArguments _args;
             private readonly IScalarOutputLoss _loss;
 
-            private protected AveragedTrainStateBase(IChannel ch, int numFeatures, LinearPredictor predictor, AveragedLinearTrainer<TTransformer, TModel> parent)
+            private protected AveragedTrainStateBase(IChannel ch, int numFeatures, LinearModelParameters predictor, AveragedLinearTrainer<TTransformer, TModel> parent)
                 : base(ch, numFeatures, predictor, parent)
             {
                 // Do the other initializations by setting the setters as if user had set them

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Trainers.Online
     //     - Feature normalization. By default, rescaling between min and max values for every feature
     //     - Prediction calibration to produce probabilities. Off by default, if on, uses exponential (aka Platt) calibration.
     /// <include file='doc.xml' path='doc/members/member[@name="AP"]/*' />
-    public sealed class AveragedPerceptronTrainer : AveragedLinearTrainer<BinaryPredictionTransformer<LinearBinaryPredictor>, LinearBinaryPredictor>
+    public sealed class AveragedPerceptronTrainer : AveragedLinearTrainer<BinaryPredictionTransformer<LinearBinaryModelParameters>, LinearBinaryModelParameters>
     {
         public const string LoadNameValue = "AveragedPerceptron";
         internal const string UserNameValue = "Averaged Perceptron";
@@ -56,12 +56,12 @@ namespace Microsoft.ML.Trainers.Online
 
         private sealed class TrainState : AveragedTrainStateBase
         {
-            public TrainState(IChannel ch, int numFeatures, LinearPredictor predictor, AveragedPerceptronTrainer parent)
+            public TrainState(IChannel ch, int numFeatures, LinearModelParameters predictor, AveragedPerceptronTrainer parent)
                 : base(ch, numFeatures, predictor, parent)
             {
             }
 
-            public override LinearBinaryPredictor CreatePredictor()
+            public override LinearBinaryModelParameters CreatePredictor()
             {
                 Contracts.Assert(WeightsScale == 1);
 
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Trainers.Online
                     bias = TotalBias / (float)NumWeightUpdates;
                 }
 
-                return new LinearBinaryPredictor(ParentHost, in weights, bias);
+                return new LinearBinaryModelParameters(ParentHost, in weights, bias);
             }
         }
 
@@ -175,15 +175,15 @@ namespace Microsoft.ML.Trainers.Online
                 error();
         }
 
-        private protected override TrainStateBase MakeState(IChannel ch, int numFeatures, LinearPredictor predictor)
+        private protected override TrainStateBase MakeState(IChannel ch, int numFeatures, LinearModelParameters predictor)
         {
             return new TrainState(ch, numFeatures, predictor, this);
         }
 
-        protected override BinaryPredictionTransformer<LinearBinaryPredictor> MakeTransformer(LinearBinaryPredictor model, Schema trainSchema)
-        => new BinaryPredictionTransformer<LinearBinaryPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<LinearBinaryModelParameters> MakeTransformer(LinearBinaryModelParameters model, Schema trainSchema)
+        => new BinaryPredictionTransformer<LinearBinaryModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<LinearBinaryPredictor> Train(IDataView trainData, IPredictor initialPredictor = null)
+        public BinaryPredictionTransformer<LinearBinaryModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         [TlcModule.EntryPoint(Name = "Trainers.AveragedPerceptronBinaryClassifier",

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Trainers.Online
     /// <summary>
     /// Linear SVM that implements PEGASOS for training. See: http://ttic.uchicago.edu/~shai/papers/ShalevSiSr07.pdf
     /// </summary>
-    public sealed class LinearSvm : OnlineLinearTrainer<BinaryPredictionTransformer<LinearBinaryPredictor>, LinearBinaryPredictor>
+    public sealed class LinearSvm : OnlineLinearTrainer<BinaryPredictionTransformer<LinearBinaryModelParameters>, LinearBinaryModelParameters>
     {
         internal const string LoadNameValue = "LinearSVM";
         internal const string ShortName = "svm";
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Trainers.Online
             private readonly bool _performProjection;
             private readonly float _lambda;
 
-            public TrainState(IChannel ch, int numFeatures, LinearPredictor predictor, LinearSvm parent)
+            public TrainState(IChannel ch, int numFeatures, LinearModelParameters predictor, LinearSvm parent)
                 : base(ch, numFeatures, predictor, parent)
             {
                 _batchSize = parent.Args.BatchSize;
@@ -212,11 +212,11 @@ namespace Microsoft.ML.Trainers.Online
             public override Float Margin(in VBuffer<Float> feat)
                 => Bias + VectorUtils.DotProduct(in feat, in Weights) * WeightsScale;
 
-            public override LinearBinaryPredictor CreatePredictor()
+            public override LinearBinaryModelParameters CreatePredictor()
             {
                 Contracts.Assert(WeightsScale == 1);
                 // below should be `in Weights`, but can't because of https://github.com/dotnet/roslyn/issues/29371
-                return new LinearBinaryPredictor(ParentHost, Weights, Bias);
+                return new LinearBinaryModelParameters(ParentHost, Weights, Bias);
             }
         }
 
@@ -274,7 +274,7 @@ namespace Microsoft.ML.Trainers.Online
             data.CheckBinaryLabel();
         }
 
-        private protected override TrainStateBase MakeState(IChannel ch, int numFeatures, LinearPredictor predictor)
+        private protected override TrainStateBase MakeState(IChannel ch, int numFeatures, LinearModelParameters predictor)
         {
             return new TrainState(ch, numFeatures, predictor, this);
         }
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Trainers.Online
                 calibrator: input.Calibrator, maxCalibrationExamples: input.MaxCalibrationExamples);
         }
 
-        protected override BinaryPredictionTransformer<LinearBinaryPredictor> MakeTransformer(LinearBinaryPredictor model, Schema trainSchema)
-        => new BinaryPredictionTransformer<LinearBinaryPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<LinearBinaryModelParameters> MakeTransformer(LinearBinaryModelParameters model, Schema trainSchema)
+        => new BinaryPredictionTransformer<LinearBinaryModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Trainers.Online
 {
 
     /// <include file='doc.xml' path='doc/members/member[@name="OGD"]/*' />
-    public sealed class OnlineGradientDescentTrainer : AveragedLinearTrainer<RegressionPredictionTransformer<LinearRegressionPredictor>, LinearRegressionPredictor>
+    public sealed class OnlineGradientDescentTrainer : AveragedLinearTrainer<RegressionPredictionTransformer<LinearRegressionModelParameters>, LinearRegressionModelParameters>
     {
         internal const string LoadNameValue = "OnlineGradientDescent";
         internal const string UserNameValue = "Stochastic Gradient Descent (Regression)";
@@ -62,12 +62,12 @@ namespace Microsoft.ML.Trainers.Online
 
         private sealed class TrainState : AveragedTrainStateBase
         {
-            public TrainState(IChannel ch, int numFeatures, LinearPredictor predictor, OnlineGradientDescentTrainer parent)
+            public TrainState(IChannel ch, int numFeatures, LinearModelParameters predictor, OnlineGradientDescentTrainer parent)
                 : base(ch, numFeatures, predictor, parent)
             {
             }
 
-            public override LinearRegressionPredictor CreatePredictor()
+            public override LinearRegressionModelParameters CreatePredictor()
             {
                 Contracts.Assert(WeightsScale == 1);
                 VBuffer<float> weights = default;
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Trainers.Online
                     VectorUtils.ScaleBy(ref weights, 1 / (float)NumWeightUpdates);
                     bias = TotalBias / (float)NumWeightUpdates;
                 }
-                return new LinearRegressionPredictor(ParentHost, in weights, bias);
+                return new LinearRegressionModelParameters(ParentHost, in weights, bias);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Trainers.Online
             data.CheckRegressionLabel();
         }
 
-        private protected override TrainStateBase MakeState(IChannel ch, int numFeatures, LinearPredictor predictor)
+        private protected override TrainStateBase MakeState(IChannel ch, int numFeatures, LinearModelParameters predictor)
         {
             return new TrainState(ch, numFeatures, predictor, this);
         }
@@ -181,10 +181,10 @@ namespace Microsoft.ML.Trainers.Online
                 () => LearnerEntryPointsUtils.FindColumn(host, input.TrainingData.Schema, input.LabelColumn));
         }
 
-        protected override RegressionPredictionTransformer<LinearRegressionPredictor> MakeTransformer(LinearRegressionPredictor model, Schema trainSchema)
-        => new RegressionPredictionTransformer<LinearRegressionPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RegressionPredictionTransformer<LinearRegressionModelParameters> MakeTransformer(LinearRegressionModelParameters model, Schema trainSchema)
+        => new RegressionPredictionTransformer<LinearRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<LinearRegressionPredictor> Train(IDataView trainData, IPredictor initialPredictor = null)
+        public RegressionPredictionTransformer<LinearRegressionModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLearnerStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLearnerStatic.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.StaticPipe
                 float l2RegularizerWeight = AveragedLinearArguments.AveragedDefaultArgs.L2RegularizerWeight,
                 int numIterations = AveragedLinearArguments.AveragedDefaultArgs.NumIterations,
                 Action<AveragedPerceptronTrainer.Arguments> advancedSettings = null,
-                Action<LinearBinaryPredictor> onFit = null
+                Action<LinearBinaryModelParameters> onFit = null
             )
         {
             OnlineLinearStaticUtils.CheckUserParams(label, features, weights, learningRate, l2RegularizerWeight, numIterations, onFit, advancedSettings);
@@ -116,7 +116,7 @@ namespace Microsoft.ML.StaticPipe
             float l2RegularizerWeight = OnlineGradientDescentTrainer.Arguments.OgdDefaultArgs.L2RegularizerWeight,
             int numIterations = OnlineLinearArguments.OnlineDefaultArgs.NumIterations,
             Action<AveragedLinearArguments> advancedSettings = null,
-            Action<LinearRegressionPredictor> onFit = null)
+            Action<LinearRegressionModelParameters> onFit = null)
         {
             OnlineLinearStaticUtils.CheckUserParams(label, features, weights, learningRate, l2RegularizerWeight, numIterations, onFit, advancedSettings);
             Contracts.CheckValueOrNull(lossFunction);

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Trainers.Online
 
         /// <summary>
         /// An object to hold the mutable updatable state for the online linear trainers. Specific algorithms should subclass
-        /// this, and return the instance via <see cref="MakeState(IChannel, int, LinearPredictor)"/>.
+        /// this, and return the instance via <see cref="MakeState(IChannel, int, LinearModelParameters)"/>.
         /// </summary>
         private protected abstract class TrainStateBase
         {
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Trainers.Online
 
             protected readonly IHost ParentHost;
 
-            protected TrainStateBase(IChannel ch, int numFeatures, LinearPredictor predictor, OnlineLinearTrainer<TTransformer, TModel> parent)
+            protected TrainStateBase(IChannel ch, int numFeatures, LinearModelParameters predictor, OnlineLinearTrainer<TTransformer, TModel> parent)
             {
                 Contracts.CheckValue(ch, nameof(ch));
                 ch.Check(numFeatures > 0, "Cannot train with zero features!");
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Trainers.Online
         {
             Host.CheckValue(context, nameof(context));
             var initPredictor = context.InitialPredictor;
-            var initLinearPred = initPredictor as LinearPredictor ?? (initPredictor as CalibratedPredictorBase)?.SubPredictor as LinearPredictor;
+            var initLinearPred = initPredictor as LinearModelParameters ?? (initPredictor as CalibratedPredictorBase)?.SubPredictor as LinearModelParameters;
             Host.CheckParam(initPredictor == null || initLinearPred != null, nameof(context), "Not a linear predictor.");
             var data = context.TrainingSet;
 
@@ -316,6 +316,6 @@ namespace Microsoft.ML.Trainers.Online
             }
         }
 
-        private protected abstract TrainStateBase MakeState(IChannel ch, int numFeatures, LinearPredictor predictor);
+        private protected abstract TrainStateBase MakeState(IChannel ch, int numFeatures, LinearModelParameters predictor);
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -15,7 +15,6 @@ using Microsoft.ML.Runtime.Numeric;
 using Microsoft.ML.Runtime.Training;
 using System;
 using System.Globalization;
-using Float = System.Single;
 
 namespace Microsoft.ML.Trainers.Online
 {
@@ -34,7 +33,7 @@ namespace Microsoft.ML.Trainers.Online
         [Argument(ArgumentType.AtMostOnce, HelpText = "Init weights diameter", ShortName = "initwts", SortOrder = 140)]
         [TGUI(Label = "Initial Weights Scale", SuggestedSweeps = "0,0.1,0.5,1")]
         [TlcModule.SweepableFloatParamAttribute("InitWtsDiameter", 0.0f, 1.0f, numSteps: 5)]
-        public Float InitWtsDiameter = 0;
+        public float InitWtsDiameter = 0;
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "Whether to shuffle for each training iteration", ShortName = "shuf")]
         [TlcModule.SweepableDiscreteParamAttribute("Shuffle", new object[] { false, true })]
@@ -70,7 +69,7 @@ namespace Microsoft.ML.Trainers.Online
             public int Iteration;
 
             /// <summary>
-            /// The number of examples in the current iteration. Incremented by <see cref="ProcessDataInstance(IChannel, in VBuffer{Float}, Float, Float)"/>,
+            /// The number of examples in the current iteration. Incremented by <see cref="ProcessDataInstance(IChannel, in VBuffer{float}, float, float)"/>,
             /// and reset by <see cref="BeginIteration(IChannel)"/>.
             /// </summary>
             public long NumIterExamples;
@@ -84,17 +83,17 @@ namespace Microsoft.ML.Trainers.Online
             /// Current weights. The weights vector is considered to be scaled by <see cref="WeightsScale"/>. Storing this separately
             /// allows us to avoid the overhead of an explicit scaling, which some algorithms will attempt to do on each example's update.
             /// </summary>
-            public VBuffer<Float> Weights;
+            public VBuffer<float> Weights;
 
             /// <summary>
             /// The implicit scaling factor for <see cref="Weights"/>. Note that this does not affect <see cref="Bias"/>.
             /// </summary>
-            public Float WeightsScale;
+            public float WeightsScale;
 
             /// <summary>
             /// The intercept term.
             /// </summary>
-            public Float Bias;
+            public float Bias;
 
             protected readonly IHost ParentHost;
 
@@ -132,22 +131,22 @@ namespace Microsoft.ML.Trainers.Online
 
                     var weightValues = new float[numFeatures];
                     for (int i = 0; i < numFeatures; i++)
-                        weightValues[i] = Float.Parse(weightStr[i], CultureInfo.InvariantCulture);
+                        weightValues[i] = float.Parse(weightStr[i], CultureInfo.InvariantCulture);
                     Weights = new VBuffer<float>(numFeatures, weightValues);
-                    Bias = Float.Parse(weightStr[numFeatures], CultureInfo.InvariantCulture);
+                    Bias = float.Parse(weightStr[numFeatures], CultureInfo.InvariantCulture);
                 }
                 else if (parent.Args.InitWtsDiameter > 0)
                 {
                     var weightValues = new float[numFeatures];
                     for (int i = 0; i < numFeatures; i++)
-                        weightValues[i] = parent.Args.InitWtsDiameter * (parent.Host.Rand.NextSingle() - (Float)0.5);
+                        weightValues[i] = parent.Args.InitWtsDiameter * (parent.Host.Rand.NextSingle() - (float)0.5);
                     Weights = new VBuffer<float>(numFeatures, weightValues);
-                    Bias = parent.Args.InitWtsDiameter * (parent.Host.Rand.NextSingle() - (Float)0.5);
+                    Bias = parent.Args.InitWtsDiameter * (parent.Host.Rand.NextSingle() - (float)0.5);
                 }
                 else if (numFeatures <= 1000)
-                    Weights = VBufferUtils.CreateDense<Float>(numFeatures);
+                    Weights = VBufferUtils.CreateDense<float>(numFeatures);
                 else
-                    Weights = VBufferUtils.CreateEmpty<Float>(numFeatures);
+                    Weights = VBufferUtils.CreateEmpty<float>(numFeatures);
                 WeightsScale = 1;
             }
 
@@ -170,7 +169,7 @@ namespace Microsoft.ML.Trainers.Online
             /// </summary>
             public void ScaleWeightsIfNeeded()
             {
-                Float absWeightsScale = Math.Abs(WeightsScale);
+                float absWeightsScale = Math.Abs(WeightsScale);
                 if (absWeightsScale < _minWeightScale || absWeightsScale > _maxWeightScale)
                     ScaleWeights();
             }
@@ -202,7 +201,7 @@ namespace Microsoft.ML.Trainers.Online
             /// <summary>
             /// This should be overridden by derived classes. This implementation simply increments <see cref="NumIterExamples"/>.
             /// </summary>
-            public virtual void ProcessDataInstance(IChannel ch, in VBuffer<Float> feat, Float label, Float weight)
+            public virtual void ProcessDataInstance(IChannel ch, in VBuffer<float> feat, float label, float weight)
             {
                 ch.Assert(FloatUtils.IsFinite(feat.GetValues()));
                 ++NumIterExamples;
@@ -211,23 +210,23 @@ namespace Microsoft.ML.Trainers.Online
             /// <summary>
             /// Return the raw margin from the decision hyperplane
             /// </summary>
-            public Float CurrentMargin(in VBuffer<Float> feat)
+            public float CurrentMargin(in VBuffer<float> feat)
                 => Bias + VectorUtils.DotProduct(in feat, in Weights) * WeightsScale;
 
             /// <summary>
-            /// The default implementation just calls <see cref="CurrentMargin(in VBuffer{Float})"/>.
+            /// The default implementation just calls <see cref="CurrentMargin(in VBuffer{float})"/>.
             /// </summary>
             /// <param name="feat"></param>
             /// <returns></returns>
-            public virtual Float Margin(in VBuffer<Float> feat)
+            public virtual float Margin(in VBuffer<float> feat)
                 => CurrentMargin(in feat);
 
             public abstract TModel CreatePredictor();
         }
 
         // Our tolerance for the error induced by the weight scale may depend on our precision.
-        private const Float _maxWeightScale = 1 << 10; // Exponent ranges 127 to -128, tolerate 10 being cut off that.
-        private const Float _minWeightScale = 1 / _maxWeightScale;
+        private const float _maxWeightScale = 1 << 10; // Exponent ranges 127 to -128, tolerate 10 being cut off that.
+        private const float _minWeightScale = 1 / _maxWeightScale;
 
         protected const string UserErrorPositive = "must be positive";
         protected const string UserErrorNonNegative = "must be non-negative";
@@ -273,7 +272,7 @@ namespace Microsoft.ML.Trainers.Online
                 TrainCore(ch, data, state);
 
                 ch.Assert(state.WeightsScale == 1);
-                Float maxNorm = Math.Max(VectorUtils.MaxNorm(in state.Weights), Math.Abs(state.Bias));
+                float maxNorm = Math.Max(VectorUtils.MaxNorm(in state.Weights), Math.Abs(state.Bias));
                 ch.Check(FloatUtils.IsFinite(maxNorm),
                     "The weights/bias contain invalid values (NaN or Infinite). Potential causes: high learning rates, no normalization, high initial weights, etc.");
                 return state.CreatePredictor();

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ML.Trainers
         protected override VBuffer<float> InitializeWeightsFromPredictor(PoissonRegressionModelParameters srcPredictor)
         {
             Contracts.AssertValue(srcPredictor);
-            return InitializeWeights(srcPredictor.Weights2, new[] { srcPredictor.Bias });
+            return InitializeWeights(srcPredictor.Weights, new[] { srcPredictor.Bias });
         }
 
         protected override void PreTrainingProcessInstance(float label, in VBuffer<float> feat, float weight)

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -28,7 +28,7 @@ using System;
 namespace Microsoft.ML.Trainers
 {
     /// <include file='doc.xml' path='doc/members/member[@name="PoissonRegression"]/*' />
-    public sealed class PoissonRegression : LbfgsTrainerBase<PoissonRegression.Arguments, RegressionPredictionTransformer<PoissonRegressionPredictor>, PoissonRegressionPredictor>
+    public sealed class PoissonRegression : LbfgsTrainerBase<PoissonRegression.Arguments, RegressionPredictionTransformer<PoissonRegressionModelParameters>, PoissonRegressionModelParameters>
     {
         internal const string LoadNameValue = "PoissonRegression";
         internal const string UserNameValue = "Poisson Regression";
@@ -95,13 +95,13 @@ namespace Microsoft.ML.Trainers
             };
         }
 
-        protected override RegressionPredictionTransformer<PoissonRegressionPredictor> MakeTransformer(PoissonRegressionPredictor model, Schema trainSchema)
-            => new RegressionPredictionTransformer<PoissonRegressionPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RegressionPredictionTransformer<PoissonRegressionModelParameters> MakeTransformer(PoissonRegressionModelParameters model, Schema trainSchema)
+            => new RegressionPredictionTransformer<PoissonRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<PoissonRegressionPredictor> Train(IDataView trainData, IPredictor initialPredictor = null)
+        public RegressionPredictionTransformer<PoissonRegressionModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
-        protected override VBuffer<float> InitializeWeightsFromPredictor(PoissonRegressionPredictor srcPredictor)
+        protected override VBuffer<float> InitializeWeightsFromPredictor(PoissonRegressionModelParameters srcPredictor)
         {
             Contracts.AssertValue(srcPredictor);
             return InitializeWeights(srcPredictor.Weights2, new[] { srcPredictor.Bias });
@@ -153,13 +153,13 @@ namespace Microsoft.ML.Trainers
             return -(y * dot - lambda) * weight;
         }
 
-        protected override PoissonRegressionPredictor CreatePredictor()
+        protected override PoissonRegressionModelParameters CreatePredictor()
         {
             VBuffer<float> weights = default(VBuffer<float>);
             CurrentWeights.CopyTo(ref weights, 1, CurrentWeights.Length - 1);
             float bias = 0;
             CurrentWeights.GetItemOrDefault(0, ref bias);
-            return new PoissonRegressionPredictor(Host, in weights, bias);
+            return new PoissonRegressionModelParameters(Host, in weights, bias);
         }
 
         protected override void ComputeTrainingStatistics(IChannel ch, FloatLabelCursor.Factory factory, float loss, int numParams)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
@@ -15,7 +15,6 @@ using Microsoft.ML.Runtime.Learners;
 using Microsoft.ML.Runtime.Training;
 using Microsoft.ML.Trainers;
 using System;
-using Float = System.Single;
 
 [assembly: LoadableClass(SdcaRegressionTrainer.Summary, typeof(SdcaRegressionTrainer), typeof(SdcaRegressionTrainer.Arguments),
     new[] { typeof(SignatureRegressorTrainer), typeof(SignatureTrainer), typeof(SignatureFeatureScorerTrainer) },
@@ -100,20 +99,20 @@ namespace Microsoft.ML.Trainers
         {
         }
 
-        protected override LinearRegressionModelParameters CreatePredictor(VBuffer<Float>[] weights, Float[] bias)
+        protected override LinearRegressionModelParameters CreatePredictor(VBuffer<float>[] weights, float[] bias)
         {
             Host.CheckParam(Utils.Size(weights) == 1, nameof(weights));
             Host.CheckParam(Utils.Size(bias) == 1, nameof(bias));
             Host.CheckParam(weights[0].Length > 0, nameof(weights));
 
-            VBuffer<Float> maybeSparseWeights = default;
+            VBuffer<float> maybeSparseWeights = default;
             // below should be `in weights[0]`, but can't because of https://github.com/dotnet/roslyn/issues/29371
             VBufferUtils.CreateMaybeSparseCopy(weights[0], ref maybeSparseWeights,
-                Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
+                Conversions.Instance.GetIsDefaultPredicate<float>(NumberType.Float));
             return new LinearRegressionModelParameters(Host, in maybeSparseWeights, bias[0]);
         }
 
-        protected override Float GetInstanceWeight(FloatLabelCursor cursor)
+        protected override float GetInstanceWeight(FloatLabelCursor cursor)
         {
             return cursor.Weight;
         }
@@ -137,13 +136,13 @@ namespace Microsoft.ML.Trainers
         }
 
         // Using a different logic for default L2 parameter in regression.
-        protected override Float TuneDefaultL2(IChannel ch, int maxIterations, long rowCount, int numThreads)
+        protected override float TuneDefaultL2(IChannel ch, int maxIterations, long rowCount, int numThreads)
         {
             Contracts.AssertValue(ch);
             Contracts.Assert(maxIterations > 0);
             Contracts.Assert(rowCount > 0);
             Contracts.Assert(numThreads > 0);
-            Float l2;
+            float l2;
 
             if (rowCount > 10000)
                 l2 = 1e-04f;

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaRegression.cs
@@ -26,7 +26,7 @@ using Float = System.Single;
 namespace Microsoft.ML.Trainers
 {
     /// <include file='doc.xml' path='doc/members/member[@name="SDCA"]/*' />
-    public sealed class SdcaRegressionTrainer : SdcaTrainerBase<SdcaRegressionTrainer.Arguments, RegressionPredictionTransformer<LinearRegressionPredictor>, LinearRegressionPredictor>
+    public sealed class SdcaRegressionTrainer : SdcaTrainerBase<SdcaRegressionTrainer.Arguments, RegressionPredictionTransformer<LinearRegressionModelParameters>, LinearRegressionModelParameters>
     {
         internal const string LoadNameValue = "SDCAR";
         internal const string UserNameValue = "Fast Linear Regression (SA-SDCA)";
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Trainers
         {
         }
 
-        protected override LinearRegressionPredictor CreatePredictor(VBuffer<Float>[] weights, Float[] bias)
+        protected override LinearRegressionModelParameters CreatePredictor(VBuffer<Float>[] weights, Float[] bias)
         {
             Host.CheckParam(Utils.Size(weights) == 1, nameof(weights));
             Host.CheckParam(Utils.Size(bias) == 1, nameof(bias));
@@ -110,7 +110,7 @@ namespace Microsoft.ML.Trainers
             // below should be `in weights[0]`, but can't because of https://github.com/dotnet/roslyn/issues/29371
             VBufferUtils.CreateMaybeSparseCopy(weights[0], ref maybeSparseWeights,
                 Conversions.Instance.GetIsDefaultPredicate<Float>(NumberType.Float));
-            return new LinearRegressionPredictor(Host, in maybeSparseWeights, bias[0]);
+            return new LinearRegressionModelParameters(Host, in maybeSparseWeights, bias[0]);
         }
 
         protected override Float GetInstanceWeight(FloatLabelCursor cursor)
@@ -164,8 +164,8 @@ namespace Microsoft.ML.Trainers
             };
         }
 
-        protected override RegressionPredictionTransformer<LinearRegressionPredictor> MakeTransformer(LinearRegressionPredictor model, Schema trainSchema)
-            => new RegressionPredictionTransformer<LinearRegressionPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override RegressionPredictionTransformer<LinearRegressionModelParameters> MakeTransformer(LinearRegressionModelParameters model, Schema trainSchema)
+            => new RegressionPredictionTransformer<LinearRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
     }
 
     /// <summary>

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaStatic.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.StaticPipe
             int? maxIterations = null,
             ISupportSdcaRegressionLoss loss = null,
             Action<SdcaRegressionTrainer.Arguments> advancedSettings = null,
-            Action<LinearRegressionPredictor> onFit = null)
+            Action<LinearRegressionModelParameters> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -109,7 +109,7 @@ namespace Microsoft.ML.StaticPipe
                     float? l1Threshold = null,
                     int? maxIterations = null,
                     Action<SdcaBinaryTrainer.Arguments> advancedSettings = null,
-                    Action<LinearBinaryPredictor, ParameterMixingCalibratedPredictor> onFit = null)
+                    Action<LinearBinaryModelParameters, ParameterMixingCalibratedPredictor> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -131,7 +131,7 @@ namespace Microsoft.ML.StaticPipe
                             // Under the default log-loss we assume a calibrated predictor.
                             var model = trans.Model;
                             var cali = (ParameterMixingCalibratedPredictor)model;
-                            var pred = (LinearBinaryPredictor)cali.SubPredictor;
+                            var pred = (LinearBinaryModelParameters)cali.SubPredictor;
                             onFit(pred, cali);
                         });
                     }
@@ -165,7 +165,7 @@ namespace Microsoft.ML.StaticPipe
         /// result in any way; it is only a way for the caller to be informed about what was learnt.</param>
         /// <returns>The set of output columns including in order the predicted binary classification score (which will range
         /// from negative to positive infinity), and the predicted label.</returns>
-        /// <seealso cref="Sdca(BinaryClassificationContext.BinaryClassificationTrainers, Scalar{bool}, Vector{float}, Scalar{float}, float?, float?, int?, Action{SdcaBinaryTrainer.Arguments}, Action{LinearBinaryPredictor, ParameterMixingCalibratedPredictor})"/>
+        /// <seealso cref="Sdca(BinaryClassificationContext.BinaryClassificationTrainers, Scalar{bool}, Vector{float}, Scalar{float}, float?, float?, int?, Action{SdcaBinaryTrainer.Arguments}, Action{LinearBinaryModelParameters, ParameterMixingCalibratedPredictor})"/>
         public static (Scalar<float> score, Scalar<bool> predictedLabel) Sdca(
                 this BinaryClassificationContext.BinaryClassificationTrainers ctx,
                 Scalar<bool> label, Vector<float> features,
@@ -175,7 +175,7 @@ namespace Microsoft.ML.StaticPipe
                 float? l1Threshold = null,
                 int? maxIterations = null,
                 Action<SdcaBinaryTrainer.Arguments> advancedSettings = null,
-                Action<LinearBinaryPredictor> onFit = null
+                Action<LinearBinaryModelParameters> onFit = null
             )
         {
             Contracts.CheckValue(label, nameof(label));
@@ -200,9 +200,9 @@ namespace Microsoft.ML.StaticPipe
                         {
                             var model = trans.Model;
                             if (model is ParameterMixingCalibratedPredictor cali)
-                                onFit((LinearBinaryPredictor)cali.SubPredictor);
+                                onFit((LinearBinaryModelParameters)cali.SubPredictor);
                             else
-                                onFit((LinearBinaryPredictor)model);
+                                onFit((LinearBinaryModelParameters)model);
                         });
                     }
                     return trainer;

--- a/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
@@ -35,8 +35,8 @@ namespace Microsoft.ML.Runtime.Learners
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearPredictor;
-                linInitPred = linInitPred ?? initPred as LinearPredictor;
+                var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearModelParameters;
+                linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");
                 return TrainCore(ch, preparedData, linInitPred, weightSetCount);
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Runtime.Learners
             return examplesToFeedTrain;
         }
 
-        protected abstract TModel TrainCore(IChannel ch, RoleMappedData data, LinearPredictor predictor, int weightSetCount);
+        protected abstract TModel TrainCore(IChannel ch, RoleMappedData data, LinearModelParameters predictor, int weightSetCount);
 
         protected abstract void CheckLabel(RoleMappedData examples, out int weightSetCount);
     }

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
             // 11 input features, so we ought to have 11 weights.
-            Assert.Equal(11, pred.Weights2.Count);
+            Assert.Equal(11, pred.Weights.Count);
 
             var data = model.Read(dataSource);
 
@@ -131,7 +131,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.NotNull(pred);
             Assert.NotNull(cali);
             // 9 input features, so we ought to have 9 weights.
-            Assert.Equal(9, pred.Weights2.Count);
+            Assert.Equal(9, pred.Weights.Count);
 
             var data = model.Read(dataSource);
 
@@ -177,7 +177,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
             // 9 input features, so we ought to have 9 weights.
-            Assert.Equal(9, pred.Weights2.Count);
+            Assert.Equal(9, pred.Weights.Count);
 
             var data = model.Read(dataSource);
 
@@ -218,7 +218,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
             // 9 input features, so we ought to have 9 weights.
-            Assert.Equal(9, pred.Weights2.Count);
+            Assert.Equal(9, pred.Weights.Count);
 
             var data = model.Read(dataSource);
 
@@ -254,7 +254,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
             // 9 input features, so we ought to have 9 weights.
-            Assert.Equal(9, pred.Weights2.Count);
+            Assert.Equal(9, pred.Weights.Count);
 
             var data = model.Read(dataSource);
 

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10)),
                 separator: ';', hasHeader: true);
 
-            LinearRegressionPredictor pred = null;
+            LinearRegressionModelParameters pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, score: ctx.Trainers.Sdca(r.label, r.features, maxIterations: 2,
@@ -114,7 +114,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoader.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            LinearBinaryPredictor pred = null;
+            LinearBinaryModelParameters pred = null;
             ParameterMixingCalibratedPredictor cali = null;
 
             var est = reader.MakeNewEstimator()
@@ -160,7 +160,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoader.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            LinearBinaryPredictor pred = null;
+            LinearBinaryModelParameters pred = null;
 
             var loss = new HingeLoss(1);
 
@@ -204,7 +204,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoader.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            LinearBinaryPredictor pred = null;
+            LinearBinaryModelParameters pred = null;
 
             var loss = new HingeLoss(1);
 
@@ -240,7 +240,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoader.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            LinearBinaryPredictor pred = null;
+            LinearBinaryModelParameters pred = null;
 
             var loss = new HingeLoss(1);
 
@@ -547,7 +547,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10)),
                 separator: ';', hasHeader: true);
 
-            PoissonRegressionPredictor pred = null;
+            PoissonRegressionModelParameters pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, score: ctx.Trainers.PoissonRegression(r.label, r.features,
@@ -673,7 +673,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadFloat(11), features: c.LoadFloat(0, 10)),
                 separator: ';', hasHeader: true);
 
-            LinearRegressionPredictor pred = null;
+            LinearRegressionModelParameters pred = null;
 
             var loss = new SquaredLoss();
 

--- a/test/Microsoft.ML.TestFramework/EnvironmentExtensions.cs
+++ b/test/Microsoft.ML.TestFramework/EnvironmentExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.TestFramework
             where TEnvironment : IHostEnvironment
         {
             env.ComponentCatalog.RegisterAssembly(typeof(TextLoader).Assembly); // ML.Data
-            env.ComponentCatalog.RegisterAssembly(typeof(LinearPredictor).Assembly); // ML.StandardLearners
+            env.ComponentCatalog.RegisterAssembly(typeof(LinearModelParameters).Assembly); // ML.StandardLearners
             env.ComponentCatalog.RegisterAssembly(typeof(OneHotEncodingTransformer).Assembly); // ML.Transforms
             env.ComponentCatalog.RegisterAssembly(typeof(FastTreeBinaryModelParameters).Assembly); // ML.FastTree
             env.ComponentCatalog.RegisterAssembly(typeof(EnsemblePredictor).Assembly); // ML.Ensemble

--- a/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             pipe = pipe.Append(new LogisticRegression(Env, "Label", "Features", advancedSettings: s => { s.ShowTrainingStats = true; }));
             var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor>>;
 
-            var linearModel = transformerChain.LastTransformer.Model.SubPredictor as LinearBinaryPredictor;
+            var linearModel = transformerChain.LastTransformer.Model.SubPredictor as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;
             LinearModelStatistics.TryGetBiasStatistics(stats, 2, out float stdError, out float zScore, out float pValue);
 
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor>>;
 
-            var linearModel = transformerChain.LastTransformer.Model.SubPredictor as LinearBinaryPredictor;
+            var linearModel = transformerChain.LastTransformer.Model.SubPredictor as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;
             LinearModelStatistics.TryGetBiasStatistics(stats, 2, out float stdError, out float zScore, out float pValue);
 


### PR DESCRIPTION
Fixes #1702 

Rename linear predictors to `XyzModelParameters`, reduce public surface, add a sample, internalize and explicitly implement the following interfaces:
- `IParameterMixer`
- `IParameterMixer<TOutput>`
- `IDistribution<out TResult>`
- `IQuantileDistribution<TResult>`
- `ISampleableDistribution<TResult>`

I have not renamed the namespaces, after discussion with @TomFinley during the course of fixing #1699. We will revisit namespace rename at a later time.