### PR TITLE
Remove ISchema in FakeSchema

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
@@ -6,27 +6,26 @@ using Microsoft.ML.Core.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.ML.Data.DataLoadSave
 {
-
     /// <summary>
     /// A fake schema that is manufactured out of a SchemaShape.
     /// It will pretend that all vector sizes are equal to 10, all key value counts are equal to 10,
     /// and all values are defaults (for metadata).
     /// </summary>
-    internal sealed class FakeSchema : ISchema
+    internal sealed class FakeSchemaFactory
     {
         private const int AllVectorSizes = 10;
         private const int AllKeySizes = 10;
-
         private readonly IHostEnvironment _env;
         private readonly SchemaShape _shape;
         private readonly Dictionary<string, int> _colMap;
 
-        public FakeSchema(IHostEnvironment env, SchemaShape inputShape)
+        public FakeSchemaFactory(IHostEnvironment env, SchemaShape inputShape)
         {
             _env = env;
             _shape = inputShape;
@@ -34,22 +33,24 @@ namespace Microsoft.ML.Data.DataLoadSave
                 .ToDictionary(idx => _shape[idx].Name, idx => idx);
         }
 
-        public int ColumnCount => _shape.Count;
-
-        public string GetColumnName(int col)
+        public Schema Make()
         {
-            _env.Check(0 <= col && col < ColumnCount);
-            return _shape[col].Name;
-        }
+            var builder = new SchemaBuilder();
 
-        public ColumnType GetColumnType(int col)
-        {
-            _env.Check(0 <= col && col < ColumnCount);
-            var inputCol = _shape[col];
-            return MakeColumnType(inputCol);
+            for (int i = 0; i < _shape.Count; ++i)
+            {
+                var metaBuilder = new MetadataBuilder();
+                var partialMetadata = _shape[i].Metadata;
+                for (int j = 0; j < partialMetadata.Count; ++j)
+                {
+                    var metaColumnType = MakeColumnType(partialMetadata[i]);
+                    var del = GetMetadataGetter(metaColumnType);
+                    metaBuilder.Add(partialMetadata[j].Name, metaColumnType, del);
+                }
+                builder.AddColumn(_shape[i].Name, MakeColumnType(_shape[i]));
+            }
+            return builder.GetSchema();
         }
-
-        public bool TryGetColumnIndex(string name, out int col) => _colMap.TryGetValue(name, out col);
 
         private static ColumnType MakeColumnType(SchemaShape.Column inputCol)
         {
@@ -63,48 +64,25 @@ namespace Microsoft.ML.Data.DataLoadSave
             return curType;
         }
 
-        public void GetMetadata<TValue>(string kind, int col, ref TValue value)
+        private Delegate GetMetadataGetter(ColumnType colType)
         {
-            _env.Check(0 <= col && col < ColumnCount);
-            var inputCol = _shape[col];
-            var metaShape = inputCol.Metadata;
-            if (metaShape == null || !metaShape.TryFindColumn(kind, out var metaColumn))
-                throw _env.ExceptGetMetadata();
-
-            var colType = MakeColumnType(metaColumn);
-            _env.Check(colType.RawType.Equals(typeof(TValue)));
-
             if (colType.IsVector)
-            {
-                // This as an atypical use of VBuffer: we create it in GetMetadataVec, and then pass through
-                // via boxing to be returned out of this method. This is intentional.
-                value = (TValue)Utils.MarshalInvoke(GetMetadataVec<int>, colType.ItemType.RawType);
-            }
+                return Utils.MarshalInvoke(GetDefaultVectorGetter<int>, colType.ItemType.RawType);
             else
-                value = default;
+                return Utils.MarshalInvoke(GetDefaultGetter<int>, colType.RawType);
         }
 
-        private object GetMetadataVec<TItem>() => new VBuffer<TItem>(AllVectorSizes, 0, null, null);
-
-        public ColumnType GetMetadataTypeOrNull(string kind, int col)
+        private Delegate GetDefaultVectorGetter<TValue>()
         {
-            _env.Check(0 <= col && col < ColumnCount);
-            var inputCol = _shape[col];
-            var metaShape = inputCol.Metadata;
-            if (metaShape == null || !metaShape.TryFindColumn(kind, out var metaColumn))
-                return null;
-            return MakeColumnType(metaColumn);
+            ValueGetter<VBuffer<TValue>> getter = (ref VBuffer<TValue> value) => value = new VBuffer<TValue>(AllVectorSizes, 0, null, null);
+            return getter;
         }
 
-        public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
+        private Delegate GetDefaultGetter<TValue>()
         {
-            _env.Check(0 <= col && col < ColumnCount);
-            var inputCol = _shape[col];
-            var metaShape = inputCol.Metadata;
-            if (metaShape == null)
-                return Enumerable.Empty<KeyValuePair<string, ColumnType>>();
-
-            return metaShape.Select(c => new KeyValuePair<string, ColumnType>(c.Name, MakeColumnType(c)));
+            ValueGetter<TValue> getter = (ref TValue value) => value = default;
+            return getter;
         }
+
     }
 }

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
 
-            var fakeSchema = new FakeSchemaFactory(Host, inputSchema).Make();
+            var fakeSchema = FakeSchemaFactory.Create(inputSchema);
             var transformer = Fit(new EmptyDataView(Host, fakeSchema));
             return SchemaShape.Create(transformer.GetOutputSchema(fakeSchema));
         }
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Runtime.Data
         public override SchemaShape GetOutputSchema(SchemaShape inputSchema)
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
-            var fakeSchema = new FakeSchemaFactory(Host, inputSchema).Make();
+            var fakeSchema = FakeSchemaFactory.Create(inputSchema);
             return SchemaShape.Create(Transformer.GetOutputSchema(fakeSchema));
         }
     }

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
 
-            var fakeSchema = Schema.Create(new FakeSchema(Host, inputSchema));
+            var fakeSchema = new FakeSchemaFactory(Host, inputSchema).Make();
             var transformer = Fit(new EmptyDataView(Host, fakeSchema));
             return SchemaShape.Create(transformer.GetOutputSchema(fakeSchema));
         }
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Runtime.Data
         public override SchemaShape GetOutputSchema(SchemaShape inputSchema)
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
-            var fakeSchema = Schema.Create(new FakeSchema(Host, inputSchema));
+            var fakeSchema = new FakeSchemaFactory(Host, inputSchema).Make();
             return SchemaShape.Create(Transformer.GetOutputSchema(fakeSchema));
         }
     }


### PR DESCRIPTION
`FakeSchema` is not longer an `ISchema` and renamed to `FakeSchemaFactory`. It's a part of #1501.