### PR TITLE
Loading the label for binary classfication as BL instead of R4

### DIFF
--- a/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
+++ b/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.Benchmarks
             // Pipeline
 
             var input = ml.Data.ReadFromTextFile(_dataPath, new[] {
-                            new TextLoader.Column("Label", DataKind.R4, 0),
+                            new TextLoader.Column("Label", DataKind.BL, 0),
                             new TextLoader.Column("CatFeatures", DataKind.TX,
                                 new [] {
                                     new TextLoader.Range() { Min = 1, Max = 8 },


### PR DESCRIPTION
Kmeans Benchmark was broken because Binary classfiers expected the label column to be binary but we were loading it as R4

