### PR TITLE
Remove ISchema in FeatureContributionCalculationTransform

### DIFF
--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
@@ -364,9 +364,9 @@ namespace Microsoft.ML.Runtime.Data
                 }
                 else
                 {
-                    _outputSchema = Schema.Create(new FeatureContributionSchema(_env, DefaultColumnNames.FeatureContributions,
-                        new VectorType(NumberType.R4, schema.Feature.Type as VectorType),
-                        InputSchema, InputRoleMappedSchema.Feature.Index));
+                    var builder = new SchemaBuilder();
+                    builder.AddColumn(DefaultColumnNames.FeatureContributions , new VectorType(NumberType.R4, schema.Feature.Type as VectorType));
+                    _outputSchema = builder.GetSchema();
                 }
 
                 _outputGenericSchema = _genericRowMapper.OutputSchema;
@@ -418,78 +418,6 @@ namespace Microsoft.ML.Runtime.Data
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {
                 yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputRoleMappedSchema.Feature.Name);
-            }
-        }
-
-        private sealed class FeatureContributionSchema : ISchema
-        {
-            private readonly Schema _parentSchema;
-            private readonly IExceptionContext _ectx;
-            private readonly string[] _names;
-            private readonly ColumnType[] _types;
-            private readonly Dictionary<string, int> _columnNameMap;
-            private readonly int _featureCol;
-            private readonly int _featureVectorSize;
-            private readonly bool _hasSlotNames;
-
-            public int ColumnCount => _types.Length;
-
-            public FeatureContributionSchema(IExceptionContext ectx, string columnName, ColumnType columnType, Schema parentSchema, int featureCol)
-            {
-                Contracts.CheckValueOrNull(ectx);
-                Contracts.CheckValue(parentSchema, nameof(parentSchema));
-                _ectx = ectx;
-                _ectx.CheckNonEmpty(columnName, nameof(columnName));
-                _parentSchema = parentSchema;
-                _featureCol = featureCol;
-                _featureVectorSize = _parentSchema.GetColumnType(_featureCol).VectorSize;
-                _hasSlotNames = _parentSchema.HasSlotNames(_featureCol, _featureVectorSize);
-
-                _names = new string[] { columnName };
-                _types = new ColumnType[] { columnType };
-                _columnNameMap = new Dictionary<string, int>() { { columnName, 0 } };
-            }
-
-            public bool TryGetColumnIndex(string name, out int col)
-            {
-                return _columnNameMap.TryGetValue(name, out col);
-            }
-
-            public string GetColumnName(int col)
-            {
-                _ectx.CheckParam(0 <= col && col < ColumnCount, nameof(col));
-                return _names[col];
-            }
-
-            public ColumnType GetColumnType(int col)
-            {
-                _ectx.CheckParam(0 <= col && col < ColumnCount, nameof(col));
-                return _types[col];
-            }
-
-            public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
-            {
-                _ectx.CheckParam(col == 0, nameof(col));
-                if (_hasSlotNames)
-                    yield return MetadataUtils.GetSlotNamesPair(_featureVectorSize);
-            }
-
-            public ColumnType GetMetadataTypeOrNull(string kind, int col)
-            {
-                _ectx.CheckNonEmpty(kind, nameof(kind));
-                _ectx.CheckParam(col == 0, nameof(col));
-                if (_hasSlotNames)
-                    return MetadataUtils.GetNamesType(_featureVectorSize);
-                return null;
-            }
-
-            public void GetMetadata<TValue>(string kind, int col, ref TValue value)
-            {
-                _ectx.CheckParam(col == 0, nameof(col));
-                if (kind == MetadataUtils.Kinds.SlotNames && _hasSlotNames)
-                    _parentSchema.GetMetadata(kind, _featureCol, ref value);
-                else
-                    throw MetadataUtils.ExceptGetMetadata();
             }
         }
     }


### PR DESCRIPTION
As title. It's a part of #1501. This change is not difficult because the output schema only contains one column, which is per feature contribution.