### PR TITLE
Internalizing MetadataUtils

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/MatrixFactorization.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/MatrixFactorization.cs
@@ -1,5 +1,4 @@
 using Microsoft.ML.Data;
-using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.ML.Core/Data/IEstimator.cs
+++ b/src/Microsoft.ML.Core/Data/IEstimator.cs
@@ -173,7 +173,7 @@ namespace Microsoft.ML.Core.Data
 
             for (int iCol = 0; iCol < schema.Count; iCol++)
             {
-                if (!schema.IsHidden(iCol))
+                if (!schema[iCol].IsHidden)
                 {
                     // First create the metadata.
                     var mCols = new List<Column>();

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -229,7 +229,7 @@ namespace Microsoft.ML.Runtime.Data
                 var cols = kvp.Value;
 #if DEBUG
                 foreach (var info in cols)
-                    Contracts.Assert(!schema.IsHidden(info.Index), "How did a hidden column sneak in?");
+                    Contracts.Assert(!schema[info.Index].IsHidden, "How did a hidden column sneak in?");
 #endif
                 if (cols.Count == 1)
                 {

--- a/src/Microsoft.ML.Data/Commands/SaveDataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/SaveDataCommand.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ML.Runtime.Data
             var cols = new List<int>();
             for (int i = 0; i < data.Schema.Count; i++)
             {
-                if (!Args.KeepHidden && data.Schema.IsHidden(i))
+                if (!Args.KeepHidden && data.Schema[i].IsHidden)
                     continue;
                 var type = data.Schema.GetColumnType(i);
                 if (saver.IsColumnSavable(type))
@@ -205,7 +205,7 @@ namespace Microsoft.ML.Runtime.Data
             var cols = new List<int>();
             for (int i = 0; i < view.Schema.ColumnCount; i++)
             {
-                if (!keepHidden && view.Schema.IsHidden(i))
+                if (!keepHidden && view.Schema[i].IsHidden)
                     continue;
                 var type = view.Schema.GetColumnType(i);
                 if (saver.IsColumnSavable(type))

--- a/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
@@ -181,7 +181,7 @@ namespace Microsoft.ML.Runtime.Data
             var cols = new List<int>();
             for (int i = 0; i < loader.Schema.Count; i++)
             {
-                if (!Args.KeepHidden && loader.Schema.IsHidden(i))
+                if (!Args.KeepHidden && loader.Schema[i].IsHidden)
                     continue;
                 if (!(outputAllColumns || ShouldAddColumn(loader.Schema, i, maxScoreId, outputNamesAndLabels)))
                     continue;

--- a/src/Microsoft.ML.Data/Commands/TrainCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TrainCommand.cs
@@ -462,7 +462,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 if (autoNorm != NormalizeOption.Yes)
                 {
-                    if (!trainer.Info.NeedNormalization || schema.IsNormalized(featCol))
+                    if (!trainer.Info.NeedNormalization || schema[featCol].IsNormalized())
                     {
                         ch.Info("Not adding a normalizer.");
                         return false;

--- a/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data.Conversion;
 using Microsoft.ML.Runtime.Model;
 

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -11,6 +11,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
@@ -191,7 +192,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
 
             VBuffer<ReadOnlyMemory<char>> slotNames = default;
             int len = schema.Feature.Type.ValueCount;
-            if (schema.Schema.HasSlotNames(schema.Feature.Index, len))
+            if (schema.Schema[schema.Feature.Index].HasSlotNames(len))
                 schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, schema.Feature.Index, ref slotNames);
             else
                 slotNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(len);

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -4,18 +4,15 @@
 
 #pragma warning disable 420 // volatile with Interlocked.CompareExchange
 
-using Float = System.Single;
-
+using Microsoft.ML.Data;
+using Microsoft.ML.Runtime.Data;
+using Microsoft.ML.Runtime.Internal.Utilities;
+using Microsoft.ML.Runtime.Model;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.ML.Data;
-using Microsoft.ML.Runtime;
-using Microsoft.ML.Runtime.Data;
-using Microsoft.ML.Runtime.Internal.Utilities;
-using Microsoft.ML.Runtime.Model;
 
 namespace Microsoft.ML.Runtime.Internal.Internallearn
 {

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Calibration;
 using Microsoft.ML.Runtime.Internal.Internallearn;
@@ -126,7 +127,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             {
                 labelType = trainRms.Label.Type;
                 if (labelType.IsKey &&
-                    trainRms.Schema.HasKeyValues(trainRms.Label.Index, labelType.KeyCount))
+                    trainRms.Schema[trainRms.Label.Index].HasKeyValues(labelType.KeyCount))
                 {
                     VBuffer<ReadOnlyMemory<char>> keyValues = default;
                     trainRms.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, trainRms.Label.Index,

--- a/src/Microsoft.ML.Data/EntryPoints/ScoreColumnSelector.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/ScoreColumnSelector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             List<int> indices = new List<int>();
             for (int i = 0; i < view.Schema.ColumnCount; i++)
             {
-                if (view.Schema.IsHidden(i))
+                if (view.Schema[i].IsHidden)
                     continue;
                 if (!ShouldAddColumn(view.Schema, i, input.ExtraColumns, maxScoreId))
                     continue;
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     var copyCols = new List<(string Source, string Name)>();
                     for (int i = 0; i < input.Data.Schema.ColumnCount; i++)
                     {
-                        if (input.Data.Schema.IsHidden(i))
+                        if (input.Data.Schema[i].IsHidden)
                             continue;
                         if (!ShouldAddColumn(input.Data.Schema, i, null, maxScoreId))
                             continue;

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.ML.Data;
 
 [assembly: LoadableClass(typeof(AnomalyDetectionEvaluator), typeof(AnomalyDetectionEvaluator), typeof(AnomalyDetectionEvaluator.Arguments), typeof(SignatureEvaluator),
     "Anomaly Detection Evaluator", AnomalyDetectionEvaluator.LoadName, "AnomalyDetection", "Anomaly")]

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
@@ -12,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.ML.Data;
 
 [assembly: LoadableClass(typeof(AnomalyDetectionEvaluator), typeof(AnomalyDetectionEvaluator), typeof(AnomalyDetectionEvaluator.Arguments), typeof(SignatureEvaluator),
     "Anomaly Detection Evaluator", AnomalyDetectionEvaluator.LoadName, "AnomalyDetection", "Anomaly")]

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -1183,7 +1183,7 @@ namespace Microsoft.ML.Runtime.Data
             var probInfo = EvaluateUtils.GetOptAuxScoreColumnInfo(Host, schema.Schema, _probCol, nameof(Arguments.ProbabilityColumn),
                 scoreInfo.Index, MetadataUtils.Const.ScoreValueKind.Probability, t => t == NumberType.Float);
             if (probInfo != null)
-                cols = cols.Prepend(RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probInfo.Name));
+                cols = MetadataUtils.Prepend(cols, RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probInfo.Name));
             return cols;
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Transforms;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Runtime.Data
 {
@@ -111,7 +112,7 @@ namespace Microsoft.ML.Runtime.Data
                 : StratCols.Select(col => RoleMappedSchema.CreatePair(Strat, col));
 
             if (needName && schema.Name != null)
-                roles = roles.Prepend(RoleMappedSchema.ColumnRole.Name.Bind(schema.Name.Name));
+                roles = MetadataUtils.Prepend(roles, RoleMappedSchema.ColumnRole.Name.Bind(schema.Name.Name));
 
             return roles.Concat(GetInputColumnRolesCore(schema));
         }

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Transforms;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Runtime.Data
 {

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -575,7 +575,7 @@ namespace Microsoft.ML.Runtime.Data
             _numClasses = scoreInfo.Type.VectorSize;
             _types = new ColumnType[4];
 
-            if (schema.HasSlotNames(ScoreIndex, _numClasses))
+            if (schema[(int) ScoreIndex].HasSlotNames(_numClasses))
             {
                 var classNames = default(VBuffer<ReadOnlyMemory<char>>);
                 schema.GetMetadata(MetadataUtils.Kinds.SlotNames, ScoreIndex, ref classNames);
@@ -926,7 +926,7 @@ namespace Microsoft.ML.Runtime.Data
                     // Find the old per-class log-loss column and drop it.
                     for (int col = 0; col < idv.Schema.ColumnCount; col++)
                     {
-                        if (idv.Schema.IsHidden(col) &&
+                        if (idv.Schema[col].IsHidden &&
                             idv.Schema.GetColumnName(col).Equals(MultiClassClassifierEvaluator.PerClassLogLoss))
                         {
                             idv = new ChooseColumnsByIndexTransform(Host,
@@ -1001,7 +1001,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!perInst.Schema.TryGetColumnIndex(schema.Label.Name, out int labelCol))
                 throw Host.Except("Could not find column '{0}'", schema.Label.Name);
             var labelType = perInst.Schema.GetColumnType(labelCol);
-            if (labelType is KeyType keyType && (!perInst.Schema.HasKeyValues(labelCol, keyType.KeyCount) || labelType.RawKind != DataKind.U4))
+            if (labelType is KeyType keyType && (!(bool) perInst.Schema[labelCol].HasKeyValues(keyType.KeyCount) || labelType.RawKind != DataKind.U4))
             {
                 perInst = LambdaColumnMapper.Create(Host, "ConvertToDouble", perInst, schema.Label.Name,
                     schema.Label.Name, perInst.Schema.GetColumnType(labelCol), NumberType.R8,

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -697,7 +697,7 @@ namespace Microsoft.ML.Runtime.Data
                 int labelCount = 0;
                 for (int i = 0; i < fold.Schema.ColumnCount; i++)
                 {
-                    if (fold.Schema.IsHidden(i) || (needWeighted && i == isWeightedCol) ||
+                    if (fold.Schema[i].IsHidden || (needWeighted && i == isWeightedCol) ||
                         (hasStrats && (i == stratCol || i == stratVal)))
                     {
                         continue;

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluatorBase.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Internal.Utilities;
 

--- a/src/Microsoft.ML.Data/Model/Pfa/BoundPfaContext.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/BoundPfaContext.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             var fieldNames = new HashSet<string>();
             for (int c = 0; c < schema.ColumnCount; ++c)
             {
-                if (schema.IsHidden(c))
+                if (schema[c].IsHidden)
                     continue;
                 string name = schema.GetColumnName(c);
                 if (toDrop.Contains(name))

--- a/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
@@ -186,7 +186,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             var toExport = new List<string>();
             for (int i = 0; i < end.Schema.ColumnCount; ++i)
             {
-                if (end.Schema.IsHidden(i))
+                if (end.Schema[i].IsHidden)
                     continue;
                 var name = end.Schema.GetColumnName(i);
                 if (_outputsToDrop.Contains(name))

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -2,18 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Float = System.Single;
-
-using System;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
-using Microsoft.ML.Runtime.Model;
 using Microsoft.ML.Runtime.Internal.Utilities;
+using Microsoft.ML.Runtime.Model;
 using Microsoft.ML.Runtime.Model.Onnx;
-using Newtonsoft.Json.Linq;
 using Microsoft.ML.Runtime.Model.Pfa;
-using System.Collections.Generic;
-using Microsoft.ML.Data;
+using Newtonsoft.Json.Linq;
+using System;
+
+using Float = System.Single;
 
 [assembly: LoadableClass(typeof(BinaryClassifierScorer), typeof(BinaryClassifierScorer.Arguments), typeof(SignatureDataScorer),
     "Binary Classifier Scorer", "BinaryClassifierScorer", "BinaryClassifier", "Binary",

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Runtime.Model.Onnx;
 using Newtonsoft.Json.Linq;
 using Microsoft.ML.Runtime.Model.Pfa;
 using System.Collections.Generic;
+using Microsoft.ML.Data;
 
 [assembly: LoadableClass(typeof(BinaryClassifierScorer), typeof(BinaryClassifierScorer.Arguments), typeof(SignatureDataScorer),
     "Binary Classifier Scorer", "BinaryClassifierScorer", "BinaryClassifier", "Binary",

--- a/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
@@ -5,6 +5,7 @@
 using Float = System.Single;
 
 using System;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
@@ -356,9 +356,8 @@ namespace Microsoft.ML.Runtime.Data
                     var builder = new SchemaBuilder();
                     builder.AddColumn(DefaultColumnNames.FeatureContributions, TextType.Instance, null);
                     _outputSchema = builder.GetSchema();
-                    if (InputSchema.HasSlotNames(InputRoleMappedSchema.Feature.Index, InputRoleMappedSchema.Feature.Type.VectorSize))
-                        InputSchema.GetMetadata(MetadataUtils.Kinds.SlotNames, InputRoleMappedSchema.Feature.Index,
-                            ref _slotNames);
+                    if (InputSchema[InputRoleMappedSchema.Feature.Index].HasSlotNames(InputRoleMappedSchema.Feature.Type.VectorSize))
+                        InputSchema.GetMetadata(MetadataUtils.Kinds.SlotNames, InputRoleMappedSchema.Feature.Index, ref _slotNames);
                     else
                         _slotNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(InputRoleMappedSchema.Feature.Type.VectorSize);
                 }
@@ -443,7 +442,7 @@ namespace Microsoft.ML.Runtime.Data
                 _parentSchema = parentSchema;
                 _featureCol = featureCol;
                 _featureVectorSize = _parentSchema.GetColumnType(_featureCol).VectorSize;
-                _hasSlotNames = _parentSchema.HasSlotNames(_featureCol, _featureVectorSize);
+                _hasSlotNames = _parentSchema[_featureCol].HasSlotNames(_featureVectorSize);
 
                 _names = new string[] { columnName };
                 _types = new ColumnType[] { columnType };

--- a/src/Microsoft.ML.Data/Scorers/QuantileRegressionScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/QuantileRegressionScorer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;

--- a/src/Microsoft.ML.Data/Scorers/ScoreMapperSchema.cs
+++ b/src/Microsoft.ML.Data/Scorers/ScoreMapperSchema.cs
@@ -5,6 +5,7 @@
 using Float = System.Single;
 using System.Collections.Generic;
 using System;
+using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Runtime.Data
 {

--- a/src/Microsoft.ML.Data/Scorers/ScoreMapperSchema.cs
+++ b/src/Microsoft.ML.Data/Scorers/ScoreMapperSchema.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Float = System.Single;
-using System.Collections.Generic;
-using System;
 using Microsoft.ML.Data;
+using System;
+using System.Collections.Generic;
 
 namespace Microsoft.ML.Runtime.Data
 {

--- a/src/Microsoft.ML.Data/StaticPipe/PipelineColumn.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/PipelineColumn.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.StaticPipe.Runtime;

--- a/src/Microsoft.ML.Data/StaticPipe/SchemaAssertionContext.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/SchemaAssertionContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data;
 
 namespace Microsoft.ML.StaticPipe.Runtime

--- a/src/Microsoft.ML.Data/Training/TrainerUtils.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerUtils.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Runtime.Training
             var col = data.Schema.Feature;
             if (col == null)
                 throw Contracts.ExceptParam(nameof(data), "Training data must specify a feature column.");
-            Contracts.Assert(!data.Schema.Schema.IsHidden(col.Index));
+            Contracts.Assert(!data.Schema.Schema[col.Index].IsHidden);
             if (!col.Type.IsKnownSizeVector || col.Type.ItemType != NumberType.Float)
                 throw Contracts.ExceptParam(nameof(data), "Training feature column '{0}' must be a known-size vector of R4, but has type: {1}.", col.Name, col.Type);
         }
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Runtime.Training
             // If the above function is generalized, this needs to be as well.
             Contracts.AssertValue(data);
             Contracts.Assert(data.Schema.Feature != null);
-            Contracts.Assert(!data.Schema.Schema.IsHidden(data.Schema.Feature.Index));
+            Contracts.Assert(!data.Schema.Schema[data.Schema.Feature.Index].IsHidden);
             Contracts.Assert(data.Schema.Feature.Type.IsKnownSizeVector);
             Contracts.Assert(data.Schema.Feature.Type.ItemType == NumberType.Float);
             length = data.Schema.Feature.Type.VectorSize;
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Runtime.Training
             var col = data.Schema.Label;
             if (col == null)
                 throw Contracts.ExceptParam(nameof(data), "Training data must specify a label column.");
-            Contracts.Assert(!data.Schema.Schema.IsHidden(col.Index));
+            Contracts.Assert(!data.Schema.Schema[col.Index].IsHidden);
             if (!col.Type.IsBool && col.Type != NumberType.R4 && col.Type != NumberType.R8 && col.Type.KeyCount != 2)
             {
                 if (col.Type.IsKey)
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Runtime.Training
             var col = data.Schema.Label;
             if (col == null)
                 throw Contracts.ExceptParam(nameof(data), "Training data must specify a label column.");
-            Contracts.Assert(!data.Schema.Schema.IsHidden(col.Index));
+            Contracts.Assert(!data.Schema.Schema[col.Index].IsHidden);
             if (col.Type != NumberType.R4 && col.Type != NumberType.R8)
             {
                 throw Contracts.ExceptParam(nameof(data),
@@ -136,7 +136,7 @@ namespace Microsoft.ML.Runtime.Training
             var col = data.Schema.Label;
             if (col == null)
                 throw Contracts.ExceptParam(nameof(data), "Training data must specify a label column.");
-            Contracts.Assert(!data.Schema.Schema.IsHidden(col.Index));
+            Contracts.Assert(!data.Schema.Schema[col.Index].IsHidden);
             if (col.Type.KeyCount > 0)
             {
                 count = col.Type.KeyCount;
@@ -182,7 +182,7 @@ namespace Microsoft.ML.Runtime.Training
             var col = data.Schema.Label;
             if (col == null)
                 throw Contracts.ExceptParam(nameof(data), "Training data must specify a label column.");
-            Contracts.Assert(!data.Schema.Schema.IsHidden(col.Index));
+            Contracts.Assert(!data.Schema.Schema[col.Index].IsHidden);
             if (!col.Type.IsKnownSizeVector || col.Type.ItemType != NumberType.Float)
                 throw Contracts.ExceptParam(nameof(data), "Training label column '{0}' must be a known-size vector of R4, but has type: {1}.", col.Name, col.Type);
         }
@@ -194,7 +194,7 @@ namespace Microsoft.ML.Runtime.Training
             var col = data.Schema.Weight;
             if (col == null)
                 return;
-            Contracts.Assert(!data.Schema.Schema.IsHidden(col.Index));
+            Contracts.Assert(!data.Schema.Schema[col.Index].IsHidden);
             if (col.Type != NumberType.R4 && col.Type != NumberType.R8)
                 throw Contracts.ExceptParam(nameof(data), "Training weight column '{0}' must be of floating point numeric type, but has type: {1}.", col.Name, col.Type);
         }
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Runtime.Training
             var col = data.Schema.Group;
             if (col == null)
                 return;
-            Contracts.Assert(!data.Schema.Schema.IsHidden(col.Index));
+            Contracts.Assert(!data.Schema.Schema[col.Index].IsHidden);
             if (col.Type.IsKey)
                 return;
             throw Contracts.ExceptParam(nameof(data), "Training group column '{0}' type is invalid: {1}. Must be Key type.", col.Name, col.Type);

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -474,7 +474,7 @@ namespace Microsoft.ML.Runtime.Data
                     else
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", srcName, itemType.ToString(), curType.ToString());
 
-                    if (isNormalized && !inputSchema.IsNormalized(srcCol))
+                    if (isNormalized && !inputSchema[srcCol].IsNormalized())
                         isNormalized = false;
 
                     if (MetadataUtils.TryGetCategoricalFeatureIndices(inputSchema, srcCol, out int[] typeCat))
@@ -484,7 +484,7 @@ namespace Microsoft.ML.Runtime.Data
                         hasCategoricals = true;
                     }
 
-                    if (!hasSlotNames && !curType.IsVector || inputSchema.HasSlotNames(srcCol, curType.VectorSize))
+                    if (!hasSlotNames && !curType.IsVector || inputSchema[srcCol].HasSlotNames(curType.VectorSize))
                         hasSlotNames = true;
                 }
 

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -525,7 +525,7 @@ namespace Microsoft.ML.Transforms
                     var columnDict = new Dictionary<string, List<int>>();
                     for (int colIdx = 0; colIdx < inputSchema.ColumnCount; ++colIdx)
                     {
-                        if (!keepHidden && inputSchema.IsHidden(colIdx))
+                        if (!keepHidden && inputSchema[colIdx].IsHidden)
                             continue;
 
                         var columnName = inputSchema[colIdx].Name;

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -517,7 +517,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                 {
                     Host.Assert(typeSrc.IsKnownSizeVector);
                     var dstLength = slotDropper.DstLength;
-                    var hasSlotNames = input.HasSlotNames(_cols[iinfo], _srcTypes[iinfo].VectorSize);
+                    var hasSlotNames = input[_cols[iinfo]].HasSlotNames(_srcTypes[iinfo].VectorSize);
                     type = new VectorType((PrimitiveType)typeSrc.ItemType, Math.Max(dstLength, 1));
                     suppressed = dstLength == 0;
                 }
@@ -821,7 +821,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                     if (_srcTypes[iinfo].IsVector && _srcTypes[iinfo].IsKnownSizeVector)
                     {
                         var dstLength = _slotDropper[iinfo].DstLength;
-                        var hasSlotNames = InputSchema.HasSlotNames(_cols[iinfo], _srcTypes[iinfo].VectorSize);
+                        var hasSlotNames = InputSchema[_cols[iinfo]].HasSlotNames(_srcTypes[iinfo].VectorSize);
                         var type = new VectorType((PrimitiveType)_srcTypes[iinfo].ItemType, Math.Max(dstLength, 1));
 
                         if (hasSlotNames && dstLength > 0)

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime.Data
 
             bool identity;
             // Second choice: if key, utilize the KeyValues metadata for that key, if it has one and is text.
-            if (schema.HasKeyValues(col, keyType.KeyCount))
+            if (schema[col].HasKeyValues(keyType.KeyCount))
             {
                 // REVIEW: Non-textual KeyValues are certainly possible. Should we handle them?
                 // Get the key names.

--- a/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
@@ -11,7 +12,6 @@ using Microsoft.ML.Transforms;
 using System;
 using System.Text;
 using System.Threading;
-using Microsoft.ML.Data;
 using Float = System.Single;
 
 [assembly: LoadableClass(LabelConvertTransform.Summary, typeof(LabelConvertTransform), typeof(LabelConvertTransform.Arguments), typeof(SignatureDataTransform),

--- a/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
@@ -11,6 +11,7 @@ using Microsoft.ML.Transforms;
 using System;
 using System.Text;
 using System.Threading;
+using Microsoft.ML.Data;
 using Float = System.Single;
 
 [assembly: LoadableClass(LabelConvertTransform.Summary, typeof(LabelConvertTransform), typeof(LabelConvertTransform.Arguments), typeof(SignatureDataTransform),

--- a/src/Microsoft.ML.Data/Transforms/NormalizeUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeUtils.cs
@@ -76,16 +76,16 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         /// <param name="schema">The role-mapped schema to query</param>
         /// <returns>Returns null if <paramref name="schema"/> does not have <see cref="RoleMappedSchema.Feature"/>
-        /// defined, and otherwise returns a Boolean value as returned from <see cref="MetadataUtils.IsNormalized(Schema, int)"/>
+        /// defined, and otherwise returns a Boolean value as returned from <see cref="MetadataUtils.IsNormalized(Schema.Column)"/>
         /// on that feature column</returns>
-        /// <seealso cref="MetadataUtils.IsNormalized(Schema, int)"/>
+        /// <seealso cref="MetadataUtils.IsNormalized(Schema.Column)"/>
         public static bool? FeaturesAreNormalized(this RoleMappedSchema schema)
         {
             // REVIEW: The role mapped data has the ability to have multiple columns fill the role of features, which is
             // useful in some trainers that are nonetheless parameteric and can therefore benefit from normalization.
             Contracts.CheckValue(schema, nameof(schema));
             var featInfo = schema.Feature;
-            return featInfo == null ? default(bool?) : schema.Schema.IsNormalized(featInfo.Index);
+            return featInfo == null ? default(bool?) : schema.Schema[featInfo.Index].IsNormalized();
         }
     }
 
@@ -154,7 +154,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 if (!schema.TryGetColumnIndex(column.Source, out int col))
                     throw env.ExceptUserArg(nameof(input.Column), $"Column '{column.Source}' does not exist.");
-                if (!schema.IsNormalized(col))
+                if (!schema[col].IsNormalized())
                     columnsToNormalize.Add(column);
             }
 

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -418,7 +418,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     inputCols = new HashSet<string>();
                     for (int j = 0; j < inputSchema.ColumnCount; j++)
                     {
-                        if (inputSchema.IsHidden(j))
+                        if (inputSchema[j].IsHidden)
                             continue;
                         inputCols.Add(inputSchema.GetColumnName(j));
                     }
@@ -429,7 +429,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     int nonHiddenCols = 0;
                     for (int j = 0; j < inputSchema.ColumnCount; j++)
                     {
-                        if (inputSchema.IsHidden(j))
+                        if (inputSchema[j].IsHidden)
                             continue;
                         var name = inputSchema.GetColumnName(j);
                         if (!inputCols.Contains(name))

--- a/src/Microsoft.ML.EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML.EntryPoints/CrossValidationMacro.cs
@@ -470,7 +470,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     // Find the old Count column and drop it.
                     for (int col = 0; col < idv.Schema.ColumnCount; col++)
                     {
-                        if (idv.Schema.IsHidden(col) &&
+                        if (idv.Schema[col].IsHidden &&
                             idv.Schema.GetColumnName(col).Equals(MetricKinds.ColumnNames.Count))
                         {
                             input.ConfusionMatrix[i] = new ChooseColumnsByIndexTransform(env,

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.ML.Data;
 
 [assembly: LoadableClass(typeof(void), typeof(FeatureCombiner), null, typeof(SignatureEntryPointModule), "FeatureCombiner")]
 

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -2,18 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Utilities;
-using Microsoft.ML.Transforms.Categorical;
 using Microsoft.ML.Transforms.Conversions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.ML.Data;
 
 [assembly: LoadableClass(typeof(void), typeof(FeatureCombiner), null, typeof(SignatureEntryPointModule), "FeatureCombiner")]
 

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Microsoft.ML.Data;
 using Timer = Microsoft.ML.Trainers.FastTree.Internal.Timer;
 
 [assembly: LoadableClass(typeof(GamPredictorBase.VisualizationCommand), typeof(GamPredictorBase.VisualizationCommand.Arguments), typeof(SignatureCommand),
@@ -1120,7 +1121,7 @@ namespace Microsoft.ML.Trainers.FastTree
                     ch.Check(schema.Feature.Type.ValueCount == _pred._inputLength);
 
                     int len = schema.Feature.Type.ValueCount;
-                    if (schema.Schema.HasSlotNames(schema.Feature.Index, len))
+                    if (schema.Schema[schema.Feature.Index].HasSlotNames(len))
                         schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, schema.Feature.Index, ref _featNames);
                     else
                         _featNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(len);

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -3,25 +3,25 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Command;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.EntryPoints;
-using Microsoft.ML.Trainers.FastTree;
-using Microsoft.ML.Trainers.FastTree.Internal;
 using Microsoft.ML.Runtime.Internal.Calibration;
 using Microsoft.ML.Runtime.Internal.CpuMath;
 using Microsoft.ML.Runtime.Internal.Internallearn;
 using Microsoft.ML.Runtime.Internal.Utilities;
 using Microsoft.ML.Runtime.Model;
 using Microsoft.ML.Runtime.Training;
+using Microsoft.ML.Trainers.FastTree;
+using Microsoft.ML.Trainers.FastTree.Internal;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using Microsoft.ML.Data;
 using Timer = Microsoft.ML.Trainers.FastTree.Internal.Timer;
 
 [assembly: LoadableClass(typeof(GamPredictorBase.VisualizationCommand), typeof(GamPredictorBase.VisualizationCommand.Arguments), typeof(SignatureCommand),

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Trainers.FastTree.Internal
 {
@@ -417,7 +418,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
             Contracts.Assert(feat.Type.ValueCount > 0);
 
             var sch = schema.Schema;
-            if (sch.HasSlotNames(feat.Index, feat.Type.ValueCount))
+            if (sch[feat.Index].HasSlotNames(feat.Type.ValueCount))
                 sch.GetMetadata(MetadataUtils.Kinds.SlotNames, feat.Index, ref _names);
             else
                 _names = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(feat.Type.ValueCount);

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
@@ -14,7 +15,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Trainers.FastTree.Internal
 {

--- a/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
+++ b/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Legacy
                 if (dataView.Schema.GetColumnType(colIndex).IsVector)
                 {
                     var n = dataView.Schema.GetColumnType(colIndex).VectorSize;
-                    if (dataView.Schema.HasSlotNames(colIndex, n))
+                    if (dataView.Schema[colIndex].HasSlotNames(n))
                     {
                         var slots = default(VBuffer<ReadOnlyMemory<char>>);
                         dataView.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colIndex, ref slots);

--- a/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
+++ b/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Runtime.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Legacy.Models
 {

--- a/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
+++ b/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Legacy.Models
 {

--- a/src/Microsoft.ML.Legacy/PredictionModel.cs
+++ b/src/Microsoft.ML.Legacy/PredictionModel.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Legacy
                 return false;
 
             int expectedLabelCount = schema.GetColumnType(colIndex).ValueCount;
-            if (!schema.HasSlotNames(colIndex, expectedLabelCount))
+            if (!schema[colIndex].HasSlotNames(expectedLabelCount))
                 return false;
 
             VBuffer<ReadOnlyMemory<char>> labels = default;

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.Runtime.Internal.Utilities;
@@ -10,7 +11,6 @@ using Microsoft.ML.Runtime.Training;
 using Microsoft.ML.Trainers.FastTree.Internal;
 using System;
 using System.Collections.Generic;
-using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Runtime.LightGBM
 {

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Runtime.Training;
 using Microsoft.ML.Trainers.FastTree.Internal;
 using System;
 using System.Collections.Generic;
+using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Runtime.LightGBM
 {

--- a/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
+++ b/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
@@ -232,7 +232,7 @@ namespace Microsoft.ML.Runtime.Model.Onnx
             //Add graph outputs.
             for (int i = 0; i < end.Schema.ColumnCount; ++i)
             {
-                if (end.Schema.IsHidden(i))
+                if (end.Schema[i].IsHidden)
                     continue;
 
                 var idataviewColumnName = end.Schema.GetColumnName(i);

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
@@ -16,7 +17,6 @@ using Microsoft.ML.Trainers.Recommender;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ML.Data;
 
 [assembly: LoadableClass(MatrixFactorizationTrainer.Summary, typeof(MatrixFactorizationTrainer), typeof(MatrixFactorizationTrainer.Arguments),
     new Type[] { typeof(SignatureTrainer), typeof(SignatureMatrixRecommendingTrainer) },

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -16,6 +16,7 @@ using Microsoft.ML.Trainers.Recommender;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML.Data;
 
 [assembly: LoadableClass(MatrixFactorizationTrainer.Summary, typeof(MatrixFactorizationTrainer), typeof(MatrixFactorizationTrainer.Arguments),
     new Type[] { typeof(SignatureTrainer), typeof(SignatureMatrixRecommendingTrainer) },

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
@@ -14,7 +15,6 @@ using Microsoft.ML.Runtime.Training;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ML.Data;
 
 [assembly: LoadableClass(FieldAwareFactorizationMachineTrainer.Summary, typeof(FieldAwareFactorizationMachineTrainer),
     typeof(FieldAwareFactorizationMachineTrainer.Arguments), new[] { typeof(SignatureBinaryClassifierTrainer), typeof(SignatureTrainer) }

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -14,6 +14,7 @@ using Microsoft.ML.Runtime.Training;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML.Data;
 
 [assembly: LoadableClass(FieldAwareFactorizationMachineTrainer.Summary, typeof(FieldAwareFactorizationMachineTrainer),
     typeof(FieldAwareFactorizationMachineTrainer.Arguments), new[] { typeof(SignatureBinaryClassifierTrainer), typeof(SignatureTrainer) }
@@ -301,7 +302,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
                 var col = featureColumns[f];
                 if (col == null)
                     throw ch.ExceptParam(nameof(data), "Empty feature column not allowed");
-                Host.Assert(!data.Schema.Schema.IsHidden(col.Index));
+                Host.Assert(!data.Schema.Schema[col.Index].IsHidden);
                 if (!(col.Type is VectorType vectorType) ||
                     !vectorType.IsKnownSizeVector ||
                     vectorType.ItemType != NumberType.Float)

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearPredictorUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearPredictorUtils.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.IO;
 using System.Text.RegularExpressions;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Calibration;
 using Microsoft.ML.Runtime.Internal.Utilities;

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Runtime.Learners
             var schema = cursorFactory.Data.Data.Schema;
             var featureLength = CurrentWeights.Length - BiasCount;
             var namesSpans = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(featureLength);
-            if (schema.HasSlotNames(featureColIdx, featureLength))
+            if (schema[featureColIdx].HasSlotNames(featureLength))
                 schema.GetMetadata(MetadataUtils.Kinds.SlotNames, featureColIdx, ref namesSpans);
             Host.Assert(namesSpans.Length == featureLength);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Data.Conversion;
@@ -12,7 +13,6 @@ using Microsoft.ML.Runtime.Training;
 using Microsoft.ML.Trainers.Online;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Runtime.Learners
 {

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -12,6 +12,7 @@ using Microsoft.ML.Runtime.Training;
 using Microsoft.ML.Trainers.Online;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Runtime.Learners
 {

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -146,7 +146,7 @@ namespace Microsoft.ML.Trainers
         private IDataView MapLabels(RoleMappedData data, int cls)
         {
             var lab = data.Schema.Label;
-            Host.Assert(!data.Schema.Schema.IsHidden(lab.Index));
+            Host.Assert(!data.Schema.Schema[lab.Index].IsHidden);
             Host.Assert(lab.Type.KeyCount > 0 || lab.Type == NumberType.R4 || lab.Type == NumberType.R8);
 
             if (lab.Type.KeyCount > 0)

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -145,7 +145,7 @@ namespace Microsoft.ML.Trainers
         private IDataView MapLabels(RoleMappedData data, int cls1, int cls2)
         {
             var lab = data.Schema.Label;
-            Host.Assert(!data.Schema.Schema.IsHidden(lab.Index));
+            Host.Assert(!data.Schema.Schema[lab.Index].IsHidden);
             Host.Assert(lab.Type.KeyCount > 0 || lab.Type == NumberType.R4 || lab.Type == NumberType.R8);
 
             if (lab.Type.KeyCount > 0)

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Runtime.Training;
 using Microsoft.ML.Trainers;
 using System;
 using System.Linq;
+using Microsoft.ML.Data;
 
 [assembly: LoadableClass(RandomTrainer.Summary, typeof(RandomTrainer), typeof(RandomTrainer.Arguments),
     new[] { typeof(SignatureBinaryClassifierTrainer), typeof(SignatureTrainer) },

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -3,17 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Core.Data;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Internallearn;
 using Microsoft.ML.Runtime.Internal.Utilities;
-using Microsoft.ML.Runtime.Learners;
 using Microsoft.ML.Runtime.Model;
 using Microsoft.ML.Runtime.Training;
 using Microsoft.ML.Trainers;
 using System;
 using System.Linq;
-using Microsoft.ML.Data;
 
 [assembly: LoadableClass(RandomTrainer.Summary, typeof(RandomTrainer), typeof(RandomTrainer.Arguments),
     new[] { typeof(SignatureBinaryClassifierTrainer), typeof(SignatureTrainer) },

--- a/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
@@ -9,10 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Transforms.TensorFlow
 {

--- a/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Transforms.TensorFlow
 {

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+using Microsoft.ML.Data;
 using Float = System.Single;
 
 [assembly: LoadableClass(HashJoiningTransform.Summary, typeof(HashJoiningTransform), typeof(HashJoiningTransform.Arguments), typeof(SignatureDataTransform),
@@ -414,7 +415,7 @@ namespace Microsoft.ML.Transforms.Conversions
             var dstEditor = VBufferEditor.Create(ref dst, n);
 
             var srcColumnName = Source.Schema.GetColumnName(Infos[iinfo].Source);
-            bool useDefaultSlotNames = !Source.Schema.HasSlotNames(Infos[iinfo].Source, Infos[iinfo].TypeSrc.VectorSize);
+            bool useDefaultSlotNames = !Source.Schema[Infos[iinfo].Source].HasSlotNames(Infos[iinfo].TypeSrc.VectorSize);
             VBuffer<ReadOnlyMemory<char>> srcSlotNames = default;
             if (!useDefaultSlotNames)
             {

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;
@@ -14,7 +15,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
-using Microsoft.ML.Data;
 using Float = System.Single;
 
 [assembly: LoadableClass(HashJoiningTransform.Summary, typeof(HashJoiningTransform), typeof(HashJoiningTransform.Arguments), typeof(SignatureDataTransform),

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -6,6 +6,7 @@ using Float = System.Single;
 
 using System;
 using System.Text;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data;

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Transforms
                 data.Schema.TryGetColumnIndex(features, out int featuresColumnIndex);
 
                 ch.Info("Number of slots: " + numSlots);
-                if (data.Schema.HasSlotNames(featuresColumnIndex, numSlots))
+                if (data.Schema[featuresColumnIndex].HasSlotNames(numSlots))
                     data.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, featuresColumnIndex, ref slotNames);
 
                 if (slotNames.Length != numSlots)

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -945,7 +945,7 @@ namespace Microsoft.ML.Transforms.Text
                 numVocabs[i] = 0;
 
                 VBuffer<ReadOnlyMemory<char>> dst = default;
-                if (inputSchema.HasSlotNames(srcCol, srcColType.ValueCount))
+                if (inputSchema[srcCol].HasSlotNames(srcColType.ValueCount))
                     inputSchema.GetMetadata(MetadataUtils.Kinds.SlotNames, srcCol, ref dst);
                 else
                     dst = default(VBuffer<ReadOnlyMemory<char>>);

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -582,7 +582,7 @@ namespace Microsoft.ML.Transforms.Text
 
             private void AddMetadata(int iinfo, MetadataBuilder builder)
             {
-                if (InputSchema.HasKeyValues(_srcCols[iinfo], _srcTypes[iinfo].ItemType.KeyCount))
+                if (InputSchema[_srcCols[iinfo]].HasKeyValues(_srcTypes[iinfo].ItemType.KeyCount))
                 {
                     ValueGetter<VBuffer<ReadOnlyMemory<char>>> getter = (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                     {
@@ -599,7 +599,7 @@ namespace Microsoft.ML.Transforms.Text
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
 
                 var keyCount = _srcTypes[iinfo].ItemType.KeyCount;
-                Host.Assert(InputSchema.HasKeyValues(_srcCols[iinfo], keyCount));
+                Host.Assert(InputSchema[_srcCols[iinfo]].HasKeyValues(keyCount));
 
                 var unigramNames = new VBuffer<ReadOnlyMemory<char>>();
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Transforms;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML.Data;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
 using Microsoft.ML.Legacy.Data;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.EntryPoints;
 using Microsoft.ML.TestFramework;
-using Microsoft.ML.Transforms;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.ML.Data;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -381,9 +381,9 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.True(schema.TryGetColumnIndex("features", out int featCol));
             Assert.True(schema.TryGetColumnIndex("bin", out int binCol));
             Assert.True(schema.TryGetColumnIndex("mm", out int mmCol));
-            Assert.False(schema.IsNormalized(featCol));
-            Assert.True(schema.IsNormalized(binCol));
-            Assert.True(schema.IsNormalized(mmCol));
+            Assert.False(schema[featCol].IsNormalized());
+            Assert.True(schema[binCol].IsNormalized());
+            Assert.True(schema[mmCol].IsNormalized());
         }
 
         [Fact]

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Runtime.RunTests
             for (int c = 0; c < schema.ColumnCount; ++c)
             {
                 ColumnType type = schema.GetColumnType(c);
-                if (saver.IsColumnSavable(type) && (hidden || !schema.IsHidden(c)))
+                if (saver.IsColumnSavable(type) && (hidden || !schema[c].IsHidden))
                     savable.Add(c);
             }
 

--- a/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.ML.Tests.Transformers
             var result = newpipe.Fit(dataView).Transform(dataView);
             Assert.True(result.Schema.TryGetColumnIndex("NAA", out var col));
             // Check that the column is normalized.
-            Assert.True(result.Schema.IsNormalized(col));
+            Assert.True(result.Schema[col].IsNormalized());
             // Check that slot names metadata was correctly created.
             var value = new VBuffer<ReadOnlyMemory<char>>();
             var type = result.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, col);


### PR DESCRIPTION
Contributes to #1500 

Moved most of MetadataUtils to internal, except some public methods to access common metadata.
Removed some methods that are now trivial.
