### PR TITLE
Making Schema implement ISchema explicitly

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -85,7 +85,7 @@ namespace Microsoft.ML.Samples.Dynamic
                 var value = row.Features[featureOfInterest];
                 var contribution = row.FeatureContributions[featureOfInterest];
                 var percentContribution = 100 * contribution / row.Score;
-                var name = data.Schema.GetColumnName(featureOfInterest + 1);
+                var name = data.Schema[(int) (featureOfInterest + 1)].Name;
                 var weight = weights.GetValues()[featureOfInterest];
 
                 Console.WriteLine("{0:0.00}\t{1:0.00}\t{2}\t{3:0.00}\t{4:0.00}\t{5:0.00}\t{6:0.00}",

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
@@ -48,8 +48,8 @@ namespace Microsoft.ML.Samples.Dynamic
             // and use a small number of bins to make it easy to visualize in the console window.
             // For real appplications, it is recommended to start with the default number of bins.
             var labelName = "MedianHomeValue";
-            var featureNames = data.Schema.GetColumns()
-                .Select(tuple => tuple.column.Name) // Get the column names
+            var featureNames = data.Schema
+                .Select(column => column.Name) // Get the column names
                 .Where(name => name != labelName) // Drop the Label
                 .ToArray();
             var pipeline = mlContext.Transforms.Concatenate("Features", featureNames)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance.cs
@@ -71,8 +71,8 @@ namespace Microsoft.ML.Samples.Dynamic
             // Now let's look at which features are most important to the model overall
             // First, we have to prepare the data:
             // Get the feature names as an IEnumerable
-            var featureNames = data.Schema.GetColumns()
-                .Select(tuple => tuple.column.Name) // Get the column names
+            var featureNames = data.Schema
+                .Select(column => column.Name) // Get the column names
                 .Where(name => name != labelName) // Drop the Label
                 .ToArray();
 

--- a/src/Microsoft.ML.Core/Data/IEstimator.cs
+++ b/src/Microsoft.ML.Core/Data/IEstimator.cs
@@ -184,8 +184,8 @@ namespace Microsoft.ML.Core.Data
                     }
                     var metadata = mCols.Count > 0 ? new SchemaShape(mCols) : _empty;
                     // Next create the single column.
-                    GetColumnTypeShape(schema.GetColumnType(iCol), out var vecKind, out var itemType, out var isKey);
-                    cols.Add(new Column(schema.GetColumnName(iCol), vecKind, itemType, isKey, metadata));
+                    GetColumnTypeShape(schema[iCol].Type, out var vecKind, out var itemType, out var isKey);
+                    cols.Add(new Column(schema[iCol].Name, vecKind, itemType, isKey, metadata));
                 }
             }
             return new SchemaShape(cols);

--- a/src/Microsoft.ML.Core/Data/IEstimator.cs
+++ b/src/Microsoft.ML.Core/Data/IEstimator.cs
@@ -177,10 +177,10 @@ namespace Microsoft.ML.Core.Data
                 {
                     // First create the metadata.
                     var mCols = new List<Column>();
-                    foreach (var metaNameType in schema.GetMetadataTypes(iCol))
+                    foreach (var metaColumn in schema[iCol].Metadata.Schema)
                     {
-                        GetColumnTypeShape(metaNameType.Value, out var mVecKind, out var mItemType, out var mIsKey);
-                        mCols.Add(new Column(metaNameType.Key, mVecKind, mItemType, mIsKey));
+                        GetColumnTypeShape(metaColumn.Type, out var mVecKind, out var mItemType, out var mIsKey);
+                        mCols.Add(new Column(metaColumn.Name, mVecKind, mItemType, mIsKey));
                     }
                     var metadata = mCols.Count > 0 ? new SchemaShape(mCols) : _empty;
                     // Next create the single column.

--- a/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
+++ b/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Runtime.Data
 
         /// <summary>
         /// Given a predicate specifying which columns are needed, return a predicate indicating which input columns are
-        /// needed. The domain of the function is defined over the indices of the columns of <see cref="Schema.ColumnCount"/>
+        /// needed. The domain of the function is defined over the indices of the columns of <see cref="Schema.Count"/>
         /// for <see cref="InputSchema"/>.
         /// </summary>
         Func<int, bool> GetDependencies(Func<int, bool> predicate);

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -447,7 +447,7 @@ namespace Microsoft.ML.Data
 
             bool isValid = false;
             categoricalFeatures = null;
-            if (!(schema.GetColumnType(colIndex) is VectorType vecType && vecType.Size > 0))
+            if (!(schema[colIndex].Type is VectorType vecType && vecType.Size > 0))
                 return isValid;
 
             var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.CategoricalSlotRanges, colIndex);

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Data
                 if (filterFunc != null && !filterFunc(schema, col))
                     continue;
                 uint value = 0;
-                schema.GetMetadata(metadataKind, col, ref value);
+                schema[col].Metadata.GetValue(metadataKind, ref value);
                 if (max < value)
                 {
                     max = value;
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Data
                 if (columnType != null && columnType.IsKey && columnType.RawKind == DataKind.U4)
                 {
                     uint val = 0;
-                    schema.GetMetadata(metadataKind, col, ref val);
+                    schema[col].Metadata.GetValue(metadataKind, ref val);
                     if (val == value)
                         yield return col;
                 }
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Data
                 if (columnType != null && columnType.IsText)
                 {
                     ReadOnlyMemory<char> val = default;
-                    schema.GetMetadata(metadataKind, col, ref val);
+                    schema[col].Metadata.GetValue(metadataKind, ref val);
                     if (ReadOnlyMemoryUtils.EqualsStr(value, val))
                         yield return col;
                 }
@@ -338,7 +338,7 @@ namespace Microsoft.ML.Data
                 VBufferUtils.Resize(ref slotNames, vectorSize, 0);
             }
             else
-                schema.Schema.GetMetadata(Kinds.SlotNames, list[0].Index, ref slotNames);
+                schema.Schema[list[0].Index].Metadata.GetValue(Kinds.SlotNames, ref slotNames);
         }
 
         [BestFriend]
@@ -454,7 +454,7 @@ namespace Microsoft.ML.Data
             if (type?.RawType == typeof(VBuffer<int>))
             {
                 VBuffer<int> catIndices = default(VBuffer<int>);
-                schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colIndex, ref catIndices);
+                schema[colIndex].Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref catIndices);
                 VBufferUtils.Densify(ref catIndices);
                 int columnSlotsCount = vecType.Size;
                 if (catIndices.Length > 0 && catIndices.Length % 2 == 0 && catIndices.Length <= columnSlotsCount * 2)

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -239,7 +239,7 @@ namespace Microsoft.ML.Data
             colMax = -1;
             for (int col = 0; col < schema.Count; col++)
             {
-                var columnType = schema.GetMetadataTypeOrNull(metadataKind, col);
+                var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
                 if (columnType == null || !columnType.IsKey || columnType.RawKind != DataKind.U4)
                     continue;
                 if (filterFunc != null && !filterFunc(schema, col))
@@ -264,7 +264,7 @@ namespace Microsoft.ML.Data
         {
             for (int col = 0; col < schema.Count; col++)
             {
-                var columnType = schema.GetMetadataTypeOrNull(metadataKind, col);
+                var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
                 if (columnType != null && columnType.IsKey && columnType.RawKind == DataKind.U4)
                 {
                     uint val = 0;
@@ -284,7 +284,7 @@ namespace Microsoft.ML.Data
         {
             for (int col = 0; col < schema.Count; col++)
             {
-                var columnType = schema.GetMetadataTypeOrNull(metadataKind, col);
+                var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
                 if (columnType != null && columnType.IsText)
                 {
                     ReadOnlyMemory<char> val = default;
@@ -450,7 +450,7 @@ namespace Microsoft.ML.Data
             if (!(schema[colIndex].Type is VectorType vecType && vecType.Size > 0))
                 return isValid;
 
-            var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.CategoricalSlotRanges, colIndex);
+            var type = schema[colIndex].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.CategoricalSlotRanges)?.Type;
             if (type?.RawType == typeof(VBuffer<int>))
             {
                 VBuffer<int> catIndices = default(VBuffer<int>);

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -65,9 +65,9 @@ namespace Microsoft.ML.Runtime.Data
         public static ColumnInfo CreateFromIndex(Schema schema, int index)
         {
             Contracts.CheckValue(schema, nameof(schema));
-            Contracts.CheckParam(0 <= index && index < schema.ColumnCount, nameof(index));
+            Contracts.CheckParam(0 <= index && index < schema.Count, nameof(index));
 
-            return new ColumnInfo(schema.GetColumnName(index), index, schema.GetColumnType(index));
+            return new ColumnInfo(schema[index].Name, index, schema[index].Type);
         }
     }
 

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!schema.TryGetColumnIndex(name, out int index))
                 return false;
 
-            colInfo = new ColumnInfo(name, index, schema.GetColumnType(index));
+            colInfo = new ColumnInfo(name, index, schema[index].Type);
             return true;
         }
 

--- a/src/Microsoft.ML.Core/Data/Schema.cs
+++ b/src/Microsoft.ML.Core/Data/Schema.cs
@@ -300,6 +300,17 @@ namespace Microsoft.ML.Data
             return getter;
         }
 
+        /// <summary>
+        /// Legacy method to get the column index.
+        /// DO NOT USE: use <see cref="GetColumnOrNull"/> instead.
+        /// </summary>
+        [BestFriend]
+        internal bool TryGetColumnIndex(string name, out int col)
+        {
+            col = GetColumnOrNull(name)?.Index ?? -1;
+            return col >= 0;
+        }
+
         #region Legacy schema API to be removed
         /// <summary>
         /// Number of columns in the schema.
@@ -316,15 +327,10 @@ namespace Microsoft.ML.Data
         ColumnType ISchema.GetMetadataTypeOrNull(string kind, int col)
             => this[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
 
-        public void GetMetadata<TValue>(string kind, int col, ref TValue value)
-        {
-            var meta = this[col].Metadata;
-            if (meta == null)
-                throw MetadataUtils.ExceptGetMetadata();
-            meta.GetValue(kind, ref value);
-        }
+        void ISchema.GetMetadata<TValue>(string kind, int col, ref TValue value)
+            => this[col].Metadata.GetValue(kind, ref value);
 
-        public bool TryGetColumnIndex(string name, out int col)
+        bool ISchema.TryGetColumnIndex(string name, out int col)
         {
             col = GetColumnOrNull(name)?.Index ?? -1;
             return col >= 0;

--- a/src/Microsoft.ML.Core/Data/Schema.cs
+++ b/src/Microsoft.ML.Core/Data/Schema.cs
@@ -30,11 +30,6 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Number of columns in the schema.
         /// </summary>
-        public int ColumnCount => _columns.Length;
-
-        /// <summary>
-        /// Number of columns in the schema.
-        /// </summary>
         public int Count => _columns.Length;
 
         /// <summary>
@@ -249,7 +244,7 @@ namespace Microsoft.ML.Data
                 GetGetter<TValue>(column.Value.Index)(ref value);
             }
 
-            public override string ToString() => string.Join(", ", Schema.GetColumns().Select(x => x.column.Name));
+            public override string ToString() => string.Join(", ", Schema.Select(x => x.Name));
 
         }
 
@@ -269,11 +264,6 @@ namespace Microsoft.ML.Data
                 _nameMap[_columns[i].Name] = i;
             }
         }
-
-        /// <summary>
-        /// Get all non-hidden columns as pairs of (index, <see cref="Column"/>).
-        /// </summary>
-        public IEnumerable<(int index, Column column)> GetColumns() => _nameMap.Values.Select(idx => (idx, _columns[idx]));
 
         /// <summary>
         /// Manufacture an instance of <see cref="Schema"/> out of any <see cref="ISchema"/>.
@@ -311,6 +301,11 @@ namespace Microsoft.ML.Data
         }
 
         #region Legacy schema API to be removed
+        /// <summary>
+        /// Number of columns in the schema.
+        /// </summary>
+        int ISchema.ColumnCount => _columns.Length;
+
         public string GetColumnName(int col) => this[col].Name;
 
         public ColumnType GetColumnType(int col) => this[col].Type;
@@ -320,7 +315,7 @@ namespace Microsoft.ML.Data
             var meta = this[col].Metadata;
             if (meta == null)
                 return Enumerable.Empty<KeyValuePair<string, ColumnType>>();
-            return meta.Schema.GetColumns().Select(c => new KeyValuePair<string, ColumnType>(c.column.Name, c.column.Type));
+            return meta.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
         }
 
         public ColumnType GetMetadataTypeOrNull(string kind, int col)

--- a/src/Microsoft.ML.Core/Data/Schema.cs
+++ b/src/Microsoft.ML.Core/Data/Schema.cs
@@ -310,23 +310,11 @@ namespace Microsoft.ML.Data
 
         ColumnType ISchema.GetColumnType(int col) => this[col].Type;
 
-        public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
-        {
-            var meta = this[col].Metadata;
-            if (meta == null)
-                return Enumerable.Empty<KeyValuePair<string, ColumnType>>();
-            return meta.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
-        }
+        IEnumerable<KeyValuePair<string, ColumnType>> ISchema.GetMetadataTypes(int col)
+            => this[col].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
 
-        public ColumnType GetMetadataTypeOrNull(string kind, int col)
-        {
-            var meta = this[col].Metadata;
-            if (meta == null)
-                return null;
-            if (meta.Schema.TryGetColumnIndex(kind, out int metaCol))
-                return meta.Schema[metaCol].Type;
-            return null;
-        }
+        ColumnType ISchema.GetMetadataTypeOrNull(string kind, int col)
+            => this[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
 
         public void GetMetadata<TValue>(string kind, int col, ref TValue value)
         {

--- a/src/Microsoft.ML.Core/Data/Schema.cs
+++ b/src/Microsoft.ML.Core/Data/Schema.cs
@@ -306,9 +306,9 @@ namespace Microsoft.ML.Data
         /// </summary>
         int ISchema.ColumnCount => _columns.Length;
 
-        public string GetColumnName(int col) => this[col].Name;
+        string ISchema.GetColumnName(int col) => this[col].Name;
 
-        public ColumnType GetColumnType(int col) => this[col].Type;
+        ColumnType ISchema.GetColumnType(int col) => this[col].Type;
 
         public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
         {

--- a/src/Microsoft.ML.Core/Data/SchemaDebuggerProxy.cs
+++ b/src/Microsoft.ML.Core/Data/SchemaDebuggerProxy.cs
@@ -39,10 +39,10 @@ namespace Microsoft.ML.Data
         private static List<KeyValuePair<string, object>> BuildValues(Schema.Metadata metadata)
         {
             var result = new List<KeyValuePair<string, object>>();
-            foreach ((var index, var column) in metadata.Schema.GetColumns())
+            foreach (var column in metadata.Schema)
             {
                 var name = column.Name;
-                var value = Utils.MarshalInvoke(GetValue<int>, column.Type.RawType, metadata, index);
+                var value = Utils.MarshalInvoke(GetValue<int>, column.Type.RawType, metadata, column.Index);
                 result.Add(new KeyValuePair<string, object>(name, value));
             }
             return result;

--- a/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/CrossValidationCommand.cs
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (group != null && schema.TryGetColumnIndex(group, out index))
                 {
                     // Check if group column key type with known cardinality.
-                    var type = schema.GetColumnType(index);
+                    var type = schema[index].Type;
                     if (type.KeyCount > 0)
                         stratificationColumn = group;
                 }
@@ -322,7 +322,7 @@ namespace Microsoft.ML.Runtime.Data
                 int col;
                 if (!input.Schema.TryGetColumnIndex(stratificationColumn, out col))
                     throw ch.ExceptUserArg(nameof(Arguments.StratificationColumn), "Column '{0}' does not exist", stratificationColumn);
-                var type = input.Schema.GetColumnType(col);
+                var type = input.Schema[col].Type;
                 if (!RangeFilter.IsValidRangeFilterColumnType(ch, type))
                 {
                     ch.Info("Hashing the stratification column");

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -165,8 +165,8 @@ namespace Microsoft.ML.Runtime.Data
                         {
                             for (int currentIndex = 0; currentIndex < cursor.Schema.Count; currentIndex++)
                             {
-                                var nameOfMetric = "TLC_" + cursor.Schema.GetColumnName(currentIndex);
-                                var type = cursor.Schema.GetColumnType(currentIndex);
+                                var nameOfMetric = "TLC_" + cursor.Schema[currentIndex].Name;
+                                var type = cursor.Schema[currentIndex].Type;
                                 if (type.IsNumber)
                                 {
                                     var getter = RowCursorUtils.GetGetterAs<double>(NumberType.R8, cursor, currentIndex);

--- a/src/Microsoft.ML.Data/Commands/SaveDataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/SaveDataCommand.cs
@@ -146,11 +146,11 @@ namespace Microsoft.ML.Runtime.Data
             {
                 if (!Args.KeepHidden && data.Schema[i].IsHidden)
                     continue;
-                var type = data.Schema.GetColumnType(i);
+                var type = data.Schema[i].Type;
                 if (saver.IsColumnSavable(type))
                     cols.Add(i);
                 else
-                    ch.Info(MessageSensitivity.Schema, "The column '{0}' will not be written as it has unsavable column type.", data.Schema.GetColumnName(i));
+                    ch.Info(MessageSensitivity.Schema, "The column '{0}' will not be written as it has unsavable column type.", data.Schema[i].Name);
             }
             Host.NotSensitive().Check(cols.Count > 0, "No valid columns to save");
 
@@ -207,11 +207,11 @@ namespace Microsoft.ML.Runtime.Data
             {
                 if (!keepHidden && view.Schema[i].IsHidden)
                     continue;
-                var type = view.Schema.GetColumnType(i);
+                var type = view.Schema[i].Type;
                 if (saver.IsColumnSavable(type))
                     cols.Add(i);
                 else
-                    ch.Info(MessageSensitivity.Schema, "The column '{0}' will not be written as it has unsavable column type.", view.Schema.GetColumnName(i));
+                    ch.Info(MessageSensitivity.Schema, "The column '{0}' will not be written as it has unsavable column type.", view.Schema[i].Name);
             }
 
             ch.Check(cols.Count > 0, "No valid columns to save");

--- a/src/Microsoft.ML.Data/Commands/SaveDataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/SaveDataCommand.cs
@@ -203,7 +203,7 @@ namespace Microsoft.ML.Runtime.Data
             ch.CheckValue(stream, nameof(stream));
 
             var cols = new List<int>();
-            for (int i = 0; i < view.Schema.ColumnCount; i++)
+            for (int i = 0; i < view.Schema.Count; i++)
             {
                 if (!keepHidden && view.Schema[i].IsHidden)
                     continue;

--- a/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ScoreCommand.cs
@@ -185,13 +185,13 @@ namespace Microsoft.ML.Runtime.Data
                     continue;
                 if (!(outputAllColumns || ShouldAddColumn(loader.Schema, i, maxScoreId, outputNamesAndLabels)))
                     continue;
-                var type = loader.Schema.GetColumnType(i);
+                var type = loader.Schema[i].Type;
                 if (writer.IsColumnSavable(type))
                     cols.Add(i);
                 else
                 {
                     ch.Warning("The column '{0}' will not be written as it has unsavable column type.",
-                        loader.Schema.GetColumnName(i));
+                        loader.Schema[i].Name);
                 }
             }
 
@@ -217,7 +217,7 @@ namespace Microsoft.ML.Runtime.Data
             }
             if (outputNamesAndLabels)
             {
-                switch (schema.GetColumnName(i))
+                switch (schema[i].Name)
                 {
                     case "Label":
                     case "Name":
@@ -227,7 +227,7 @@ namespace Microsoft.ML.Runtime.Data
                         break;
                 }
             }
-            if (Args.OutputColumn != null && Array.FindIndex(Args.OutputColumn, schema.GetColumnName(i).Equals) >= 0)
+            if (Args.OutputColumn != null && Array.FindIndex(Args.OutputColumn, schema[i].Name.Equals) >= 0)
                 return true;
             return false;
         }

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Runtime.Data
                 return;
             }
 #endif
-            int colLim = schema.ColumnCount;
+            int colLim = schema.Count;
 
             var itw = new IndentedTextWriter(writer, "  ");
             itw.WriteLine("{0} columns:", colLim);
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(itw);
             Contracts.AssertValue(schema);
-            Contracts.Assert(0 <= col && col < schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < schema.Count);
 
             using (itw.Nest())
             {
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(itw);
             Contracts.AssertValue(schema);
-            Contracts.Assert(0 <= col && col < schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < schema.Count);
             Contracts.AssertNonEmpty(kind);
             Contracts.AssertValue(type);
             Contracts.Assert(!type.IsVector);
@@ -230,7 +230,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(itw);
             Contracts.AssertValue(schema);
-            Contracts.Assert(0 <= col && col < schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < schema.Count);
             Contracts.AssertNonEmpty(kind);
             Contracts.AssertValue(type);
             Contracts.Assert(!type.IsVector);
@@ -250,7 +250,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(itw);
             Contracts.AssertValue(schema);
-            Contracts.Assert(0 <= col && col < schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < schema.Count);
             Contracts.AssertNonEmpty(kind);
             Contracts.AssertValue(type);
             Contracts.Assert(type.IsVector);
@@ -270,7 +270,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(itw);
             Contracts.AssertValue(schema);
-            Contracts.Assert(0 <= col && col < schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < schema.Count);
             Contracts.AssertNonEmpty(kind);
             Contracts.AssertValue(type);
             Contracts.Assert(type.IsVector);

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -136,8 +136,8 @@ namespace Microsoft.ML.Runtime.Data
                 var names = default(VBuffer<ReadOnlyMemory<char>>);
                 for (int col = 0; col < colLim; col++)
                 {
-                    var name = schema.GetColumnName(col);
-                    var type = schema.GetColumnType(col);
+                    var name = schema[col].Name;
+                    var type = schema[col].Type;
                     var slotType = tschema == null ? null : tschema.GetSlotType(col);
                     itw.WriteLine("{0}: {1}{2}", name, type, slotType == null ? "" : " (T)");
 

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Runtime.Data
                     if (!type.IsKnownSizeVector)
                         continue;
                     ColumnType typeNames;
-                    if ((typeNames = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, col)) == null)
+                    if ((typeNames = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type) == null)
                         continue;
                     if (typeNames.VectorSize != type.VectorSize || !typeNames.ItemType.IsText)
                     {
@@ -188,18 +188,16 @@ namespace Microsoft.ML.Runtime.Data
 
             using (itw.Nest())
             {
-                foreach (var kvp in schema.GetMetadataTypes(col).OrderBy(p => p.Key))
+                foreach (var metaColumn in schema[col].Metadata.Schema.OrderBy(mcol => mcol.Name))
                 {
-                    Contracts.AssertNonEmpty(kvp.Key);
-                    Contracts.AssertValue(kvp.Value);
-                    var type = kvp.Value;
-                    itw.Write("Metadata '{0}': {1}", kvp.Key, type);
+                    var type = metaColumn.Type;
+                    itw.Write("Metadata '{0}': {1}", metaColumn.Name, type);
                     if (showVals)
                     {
                         if (!type.IsVector)
-                            ShowMetadataValue(itw, schema, col, kvp.Key, type);
+                            ShowMetadataValue(itw, schema, col, metaColumn.Name, type);
                         else
-                            ShowMetadataValueVec(itw, schema, col, kvp.Key, type);
+                            ShowMetadataValueVec(itw, schema, col, metaColumn.Name, type);
                     }
                     itw.WriteLine();
                 }

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Runtime.Data
                         Contracts.Assert(false, "Unexpected slot names type");
                         continue;
                     }
-                    schema.GetMetadata(MetadataUtils.Kinds.SlotNames, col, ref names);
+                    schema[col].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref names);
                     if (names.Length != type.VectorSize)
                     {
                         Contracts.Assert(false, "Unexpected length of slot names vector");
@@ -238,7 +238,7 @@ namespace Microsoft.ML.Runtime.Data
 
             var value = default(T);
             var sb = default(StringBuilder);
-            schema.GetMetadata(kind, col, ref value);
+            schema[col].Metadata.GetValue(kind, ref value);
             conv(in value, ref sb);
 
             itw.Write(": '{0}'", sb);
@@ -277,7 +277,7 @@ namespace Microsoft.ML.Runtime.Data
             var conv = Conversions.Instance.GetStringConversion<T>(type.ItemType);
 
             var value = default(VBuffer<T>);
-            schema.GetMetadata(kind, col, ref value);
+            schema[col].Metadata.GetValue(kind, ref value);
 
             itw.Write(": Length={0}, Count={0}", value.Length, value.GetValues().Length);
 

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 if (!predicate(col))
                     continue;
-                var type = schema.GetColumnType(col);
+                var type = schema[col].Type;
                 if (!IsCachable(type))
                     return false;
             }
@@ -348,7 +348,7 @@ namespace Microsoft.ML.Runtime.Data
                     for (int i = 0; i < activeToCol.Length; ++i)
                     {
                         int c = activeToCol[i];
-                        ColumnType type = schema.GetColumnType(c);
+                        ColumnType type = schema[c].Type;
                         var pool = GetPool(type, ourPools, c);
                         outPipes[i] = OutPipe.Create(type, pool);
                     }
@@ -540,7 +540,7 @@ namespace Microsoft.ML.Runtime.Data
                     ch.Assert(0 <= activeToCol[c] && activeToCol[c] < _schema.Count);
                     ch.Assert(c == 0 || activeToCol[c - 1] < activeToCol[c]);
                     ch.Assert(input.IsColumnActive(activeToCol[c]));
-                    var type = input.Schema.GetColumnType(activeToCol[c]);
+                    var type = input.Schema[activeToCol[c]].Type;
                     ch.Assert(type.IsCachable());
                     arguments[1] = activeToCol[c];
                     var inPipe = inPipes[c] =
@@ -1233,21 +1233,21 @@ namespace Microsoft.ML.Runtime.Data
 
             private Delegate CreateGetter(int col)
             {
-                var methInfo = _methInfo.MakeGenericMethod(Schema.GetColumnType(col).RawType);
+                var methInfo = _methInfo.MakeGenericMethod(Schema[col].Type.RawType);
                 return (Delegate)methInfo.Invoke(this, new object[] { col });
             }
 
             private Delegate CreateGetter<T>(int col)
             {
                 ValueGetter<T>[] getters = new ValueGetter<T>[_cursors.Length];
-                var type = Schema.GetColumnType(col);
+                var type = Schema[col].Type;
                 for (int i = 0; i < _cursors.Length; ++i)
                 {
                     var cursor = _cursors[i];
                     Ch.AssertValue(cursor);
                     Ch.Assert(col < cursor.Schema.Count);
                     Ch.Assert(cursor.IsColumnActive(col));
-                    Ch.Assert(type.Equals(cursor.Schema.GetColumnType(col)));
+                    Ch.Assert(type.Equals(cursor.Schema[col].Type));
                     getters[i] = _cursors[i].GetGetter<T>(col);
                 }
                 ValueGetter<T> mine =
@@ -1314,7 +1314,7 @@ namespace Microsoft.ML.Runtime.Data
                 ValueGetter<ReadOnlyMemory<char>> getter;
                 var srcColIndex = colIndices[i];
 
-                var colType = cursor.Schema.GetColumnType(srcColIndex);
+                var colType = cursor.Schema[srcColIndex].Type;
                 if (colType.IsVector)
                 {
                     getter = Utils.MarshalInvoke(GetVectorFlatteningGetter<int>, colType.ItemType.RawType,

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Runtime.Data
         public static Delegate GetGetterAsDelegate(Row row, int col)
         {
             Contracts.CheckValue(row, nameof(row));
-            Contracts.CheckParam(0 <= col && col < row.Schema.ColumnCount, nameof(col));
+            Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             Func<Row, int, Delegate> getGetter = GetGetterAsDelegateCore<int>;
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(typeDst, nameof(typeDst));
             Contracts.CheckParam(typeDst.IsPrimitive, nameof(typeDst));
             Contracts.CheckValue(row, nameof(row));
-            Contracts.CheckParam(0 <= col && col < row.Schema.ColumnCount, nameof(col));
+            Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema.GetColumnType(col);
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckParam(typeDst.IsPrimitive, nameof(typeDst));
             Contracts.CheckParam(typeDst.RawType == typeof(TDst), nameof(typeDst));
             Contracts.CheckValue(row, nameof(row));
-            Contracts.CheckParam(0 <= col && col < row.Schema.ColumnCount, nameof(col));
+            Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema.GetColumnType(col);
@@ -115,7 +115,7 @@ namespace Microsoft.ML.Runtime.Data
         public static ValueGetter<StringBuilder> GetGetterAsStringBuilder(Row row, int col)
         {
             Contracts.CheckValue(row, nameof(row));
-            Contracts.CheckParam(0 <= col && col < row.Schema.ColumnCount, nameof(col));
+            Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema.GetColumnType(col);
@@ -148,7 +148,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.CheckValue(typeDst, nameof(typeDst));
             Contracts.CheckValue(row, nameof(row));
-            Contracts.CheckParam(0 <= col && col < row.Schema.ColumnCount, nameof(col));
+            Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema.GetColumnType(col);
@@ -168,7 +168,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(typeDst, nameof(typeDst));
             Contracts.CheckParam(typeDst.RawType == typeof(TDst), nameof(typeDst));
             Contracts.CheckValue(row, nameof(row));
-            Contracts.CheckParam(0 <= col && col < row.Schema.ColumnCount, nameof(col));
+            Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema.GetColumnType(col);
@@ -297,7 +297,7 @@ namespace Microsoft.ML.Runtime.Data
         public static Func<bool> GetIsNewGroupDelegate(Row cursor, int col)
         {
             Contracts.CheckValue(cursor, nameof(cursor));
-            Contracts.Check(0 <= col && col < cursor.Schema.ColumnCount);
+            Contracts.Check(0 <= col && col < cursor.Schema.Count);
             ColumnType type = cursor.Schema.GetColumnType(col);
             Contracts.Check(type.IsKey);
             return Utils.MarshalInvoke(GetIsNewGroupDelegateCore<int>, type.RawType, cursor, col);
@@ -485,7 +485,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(row, nameof(row));
-            env.CheckParam(Enumerable.Range(0, row.Schema.ColumnCount).All(c => row.IsColumnActive(c)), nameof(row), "Some columns were inactive");
+            env.CheckParam(Enumerable.Range(0, row.Schema.Count).All(c => row.IsColumnActive(c)), nameof(row), "Some columns were inactive");
             return new OneRowDataView(env, row);
         }
 
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.AssertValue(env);
                 _host = env.Register("OneRowDataView");
                 _host.AssertValue(row);
-                _host.Assert(Enumerable.Range(0, row.Schema.ColumnCount).All(c => row.IsColumnActive(c)));
+                _host.Assert(Enumerable.Range(0, row.Schema.Count).All(c => row.IsColumnActive(c)));
 
                 _row = row;
             }
@@ -511,7 +511,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 _host.CheckValue(needCol, nameof(needCol));
                 _host.CheckValueOrNull(rand);
-                bool[] active = Utils.BuildArray(Schema.ColumnCount, needCol);
+                bool[] active = Utils.BuildArray(Schema.Count, needCol);
                 return new Cursor(_host, this, active);
             }
 
@@ -541,7 +541,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     Ch.AssertValue(parent);
                     Ch.AssertValue(active);
-                    Ch.Assert(active.Length == parent.Schema.ColumnCount);
+                    Ch.Assert(active.Length == parent.Schema.Count);
                     _parent = parent;
                     _active = active;
                 }
@@ -553,7 +553,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 public override ValueGetter<TValue> GetGetter<TValue>(int col)
                 {
-                    Ch.CheckParam(0 <= col && col < Schema.ColumnCount, nameof(col));
+                    Ch.CheckParam(0 <= col && col < Schema.Count, nameof(col));
                     Ch.CheckParam(IsColumnActive(col), nameof(col), "Requested column is not active");
                     var getter = _parent._row.GetGetter<TValue>(col);
                     return
@@ -566,7 +566,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 public override bool IsColumnActive(int col)
                 {
-                    Ch.CheckParam(0 <= col && col < Schema.ColumnCount, nameof(col));
+                    Ch.CheckParam(0 <= col && col < Schema.Count, nameof(col));
                     // We present the "illusion" that this column is not active, even though it must be
                     // in the input row.
                     Ch.Assert(_parent._row.IsColumnActive(col));

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             Func<Row, int, Delegate> getGetter = GetGetterAsDelegateCore<int>;
-            return Utils.MarshalInvoke(getGetter, row.Schema.GetColumnType(col).RawType, row, col);
+            return Utils.MarshalInvoke(getGetter, row.Schema[col].Type.RawType, row, col);
         }
 
         private static Delegate GetGetterAsDelegateCore<TValue>(Row row, int col)
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
-            var typeSrc = row.Schema.GetColumnType(col);
+            var typeSrc = row.Schema[col].Type;
             Contracts.Check(typeSrc.IsPrimitive, "Source column type must be primitive");
 
             Func<ColumnType, ColumnType, Row, int, ValueGetter<int>> del = GetGetterAsCore<int, int>;
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
-            var typeSrc = row.Schema.GetColumnType(col);
+            var typeSrc = row.Schema[col].Type;
             Contracts.Check(typeSrc.IsPrimitive, "Source column type must be primitive");
 
             Func<ColumnType, ColumnType, Row, int, ValueGetter<TDst>> del = GetGetterAsCore<int, TDst>;
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
-            var typeSrc = row.Schema.GetColumnType(col);
+            var typeSrc = row.Schema[col].Type;
             Contracts.Check(typeSrc.IsPrimitive, "Source column type must be primitive");
             return Utils.MarshalInvoke(GetGetterAsStringBuilderCore<int>, typeSrc.RawType, typeSrc, row, col);
         }
@@ -151,7 +151,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
-            var typeSrc = row.Schema.GetColumnType(col);
+            var typeSrc = row.Schema[col].Type;
             Contracts.Check(typeSrc.IsVector, "Source column type must be vector");
 
             Func<VectorType, PrimitiveType, GetterFactory, ValueGetter<VBuffer<int>>> del = GetVecGetterAsCore<int, int>;
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
-            var typeSrc = row.Schema.GetColumnType(col);
+            var typeSrc = row.Schema[col].Type;
             Contracts.Check(typeSrc.IsVector, "Source column type must be vector");
 
             Func<VectorType, PrimitiveType, GetterFactory, ValueGetter<VBuffer<TDst>>> del = GetVecGetterAsCore<int, TDst>;
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.CheckValue(cursor, nameof(cursor));
             Contracts.Check(0 <= col && col < cursor.Schema.Count);
-            ColumnType type = cursor.Schema.GetColumnType(col);
+            ColumnType type = cursor.Schema[col].Type;
             Contracts.Check(type.IsKey);
             return Utils.MarshalInvoke(GetIsNewGroupDelegateCore<int>, type.RawType, cursor, col);
         }
@@ -368,7 +368,7 @@ namespace Microsoft.ML.Runtime.Data
 
         public static ValueGetter<Single> GetLabelGetter(Row cursor, int labelIndex)
         {
-            var type = cursor.Schema.GetColumnType(labelIndex);
+            var type = cursor.Schema[labelIndex].Type;
 
             if (type == NumberType.R4)
                 return cursor.GetGetter<Single>(labelIndex);
@@ -390,7 +390,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private static ValueGetter<Single> GetLabelGetterNotFloat(Row cursor, int labelIndex)
         {
-            var type = cursor.Schema.GetColumnType(labelIndex);
+            var type = cursor.Schema[labelIndex].Type;
 
             Contracts.Assert(type != NumberType.R4 && type != NumberType.R8);
 

--- a/src/Microsoft.ML.Data/DataDebuggerPreview.cs
+++ b/src/Microsoft.ML.Data/DataDebuggerPreview.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Data
             Contracts.CheckParam(maxRows >= 0, nameof(maxRows));
             Schema = data.Schema;
 
-            int n = data.Schema.ColumnCount;
+            int n = data.Schema.Count;
 
             var rows = new List<RowInfo>();
             var columns = new List<object>[n];

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -1016,7 +1016,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             var saver = new BinarySaver(env, saverArgs);
 
             var cols = Enumerable.Range(0, schema.Count)
-                .Select(x => new { col = x, isSavable = saver.IsColumnSavable(schema.GetColumnType(x)) });
+                .Select(x => new { col = x, isSavable = saver.IsColumnSavable(schema[x].Type) });
             int[] toSave = cols.Where(x => x.isSavable).Select(x => x.col).ToArray();
             unsavableColIndices = cols.Where(x => !x.isSavable).Select(x => x.col).ToArray();
             ctx.SaveBinaryStream("Schema.idv", w => saver.SaveData(w.BaseStream, noRows, toSave));

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -355,7 +355,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             }
             IValueCodec<T> codec = (IValueCodec<T>)generalCodec;
             T value = default(T);
-            schema.GetMetadata(kind, col, ref value);
+            schema[col].Metadata.GetValue(kind, ref value);
 
             // Metadatas will often be pretty small, so that compression makes no sense.
             // We try both a compressed and uncompressed version of metadata and

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Runtime.Data.IO
         {
             _host.AssertValue(writer);
             _host.AssertValue(schema);
-            _host.Assert(0 <= col && col < schema.ColumnCount);
+            _host.Assert(0 <= col && col < schema.Count);
 
             int count = 0;
             WriteMetadataCoreDelegate del = WriteMetadataCore<int>;

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -280,7 +280,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 _host.Check(!string.IsNullOrEmpty(pair.Key), "Metadata with null or empty kind detected, disallowed");
                 _host.Check(pair.Value != null, "Metadata with null type detected, disallowed");
                 if (!kinds.Add(pair.Key))
-                    throw _host.Except("Metadata with duplicate kind '{0}' encountered, disallowed", pair.Key, schema.GetColumnName(col));
+                    throw _host.Except("Metadata with duplicate kind '{0}' encountered, disallowed", pair.Key, schema[col].Name);
                 args[3] = pair.Key;
                 args[4] = pair.Value;
                 IValueCodec codec = (IValueCodec)methInfo.MakeGenericMethod(pair.Value.RawType).Invoke(this, args);
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 {
                     // Nothing was written.
                     ch.Warning("Could not get codec for type {0}, dropping column '{1}' index {2} metadata kind '{3}'",
-                        pair.Value, schema.GetColumnName(col), col, pair.Key);
+                        pair.Value, schema[col].Name, col, pair.Key);
                     continue;
                 }
                 offsets.Add(writer.BaseStream.Position);
@@ -509,7 +509,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                                 // long: Offset to the start of the lookup table
                                 // long: Offset to the start of the metadata TOC entries, or 0 if this has no metadata
 
-                                string name = sourceSchema.GetColumnName(active.SourceIndex);
+                                string name = sourceSchema[active.SourceIndex].Name;
                                 writer.Write(name);
                                 int nameLen = Encoding.UTF8.GetByteCount(name);
                                 expectedPosition += Utils.Leb128IntLength((uint)nameLen) + nameLen;
@@ -720,10 +720,10 @@ namespace Microsoft.ML.Runtime.Data.IO
 
             for (int c = 0; c < colIndices.Length; ++c)
             {
-                ColumnType type = schema.GetColumnType(colIndices[c]);
+                ColumnType type = schema[colIndices[c]].Type;
                 IValueCodec codec;
                 if (!_factory.TryGetCodec(type, out codec))
-                    throw _host.Except("Could not get codec for requested column {0} of type {1}", schema.GetColumnName(c), type);
+                    throw _host.Except("Could not get codec for requested column {0} of type {1}", schema[c].Name, type);
                 _host.Assert(type.Equals(codec.Type));
                 activeSourceColumns[c] = new ColumnCodec(colIndices[c], codec);
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -589,7 +589,7 @@ namespace Microsoft.ML.Runtime.Data
             if (TransposeSchema?.GetSlotType(col) == null)
             {
                 throw _host.ExceptParam(nameof(col), "Bad call to GetSlotCursor on untransposable column '{0}'",
-                    Schema.GetColumnName(col));
+                    Schema[col].Name);
             }
             _host.AssertValue(_tview);
             return _tview.GetSlotCursor(col);

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -585,7 +585,7 @@ namespace Microsoft.ML.Runtime.Data
 
         public SlotCursor GetSlotCursor(int col)
         {
-            _host.CheckParam(0 <= col && col < Schema.ColumnCount, nameof(col));
+            _host.CheckParam(0 <= col && col < Schema.Count, nameof(col));
             if (TransposeSchema?.GetSlotType(col) == null)
             {
                 throw _host.ExceptParam(nameof(col), "Bad call to GetSlotCursor on untransposable column '{0}'",

--- a/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
@@ -638,12 +638,12 @@ namespace Microsoft.ML.Runtime.Data
 
             private bool SchemasMatch(Schema schema1, Schema schema2)
             {
-                if (schema1.ColumnCount != schema2.ColumnCount)
+                if (schema1.Count != schema2.Count)
                 {
                     return false;
                 }
 
-                int colLim = schema1.ColumnCount;
+                int colLim = schema1.Count;
                 for (int col = 0; col < colLim; col++)
                 {
                     var type1 = schema1.GetColumnType(col);

--- a/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
@@ -526,7 +526,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     if (_subActive[i])
                     {
-                        var type = _subCursor.Schema.GetColumnType(i);
+                        var type = _subCursor.Schema[i].Type;
                         _subGetters[i] = MarshalGetter(_subCursor.GetGetter<int>, type.RawType, i);
                     }
                 }
@@ -561,7 +561,7 @@ namespace Microsoft.ML.Runtime.Data
                         continue;
                     }
 
-                    var type = Schema.GetColumnType(i);
+                    var type = Schema[i].Type;
 
                     // Use sub-cursor for all sub-columns.
                     if (IsSubColumn(i))
@@ -646,8 +646,8 @@ namespace Microsoft.ML.Runtime.Data
                 int colLim = schema1.Count;
                 for (int col = 0; col < colLim; col++)
                 {
-                    var type1 = schema1.GetColumnType(col);
-                    var type2 = schema2.GetColumnType(col);
+                    var type1 = schema1[col].Type;
+                    var type2 = schema2[col].Type;
                     if (!type1.Equals(type2))
                     {
                         return false;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 _getSrc = cursor.GetGetter<VBuffer<T>>(source);
                 ColumnType typeNames;
                 if (type.IsKnownSizeVector &&
-                    (typeNames = cursor.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, source)) != null &&
+                    (typeNames = cursor.Schema[source].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type) != null &&
                     typeNames.VectorSize == type.VectorSize && typeNames.ItemType.IsText)
                 {
                     cursor.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, source, ref _slotNames);
@@ -408,7 +408,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                     }
                     if (!type.IsKnownSizeVector)
                         continue;
-                    var typeNames = data.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, cols[i]);
+                    var typeNames = data.Schema[cols[i]].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
                     if (typeNames != null && typeNames.VectorSize == type.VectorSize && typeNames.ItemType.IsText)
                         hasHeader = true;
                 }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -385,7 +385,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             ch.AssertNonEmpty(cols);
 
             // Determine the active columns and whether there is header information.
-            bool[] active = new bool[data.Schema.ColumnCount];
+            bool[] active = new bool[data.Schema.Count];
             for (int i = 0; i < cols.Length; i++)
             {
                 ch.Check(0 <= cols[i] && cols[i] < active.Length);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                     (typeNames = cursor.Schema[source].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type) != null &&
                     typeNames.VectorSize == type.VectorSize && typeNames.ItemType.IsText)
                 {
-                    cursor.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, source, ref _slotNames);
+                    cursor.Schema[source].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref _slotNames);
                     Contracts.Check(_slotNames.Length == typeNames.VectorSize, "Unexpected slot names length");
                 }
                 _slotCount = type.VectorSize;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             {
                 Contracts.AssertValue(cursor);
 
-                ColumnType type = cursor.Schema.GetColumnType(col);
+                ColumnType type = cursor.Schema[col].Type;
                 Type writePipeType;
                 if (type.IsVector)
                     writePipeType = typeof(VecValueWriter<>).MakeGenericType(type.ItemType.RawType);
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 : base(type, source, sep)
             {
                 _getSrc = cursor.GetGetter<T>(source);
-                _columnName = cursor.Schema.GetColumnName(source);
+                _columnName = cursor.Schema[source].Name;
             }
 
             public override void WriteData(Action<StringBuilder, int> appendItem, out int length)
@@ -389,7 +389,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             for (int i = 0; i < cols.Length; i++)
             {
                 ch.Check(0 <= cols[i] && cols[i] < active.Length);
-                ch.Check(data.Schema.GetColumnType(cols[i]).ItemType.RawKind != 0);
+                ch.Check(data.Schema[cols[i]].Type.ItemType.RawKind != 0);
                 active[cols[i]] = true;
             }
 
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 {
                     if (hasHeader)
                         continue;
-                    var type = data.Schema.GetColumnType(cols[i]);
+                    var type = data.Schema[cols[i]].Type;
                     if (!type.IsVector)
                     {
                         hasHeader = true;
@@ -463,8 +463,8 @@ namespace Microsoft.ML.Runtime.Data.IO
             for (int i = 0; i < pipes.Length; i++)
             {
                 int src = pipes[i].Source;
-                string name = schema.GetColumnName(src);
-                var type = schema.GetColumnType(src);
+                string name = schema[src].Name;
+                var type = schema[src].Type;
 
                 var column = GetColumn(name, type, index);
                 sb.Append(" col=");

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                     Host.CheckDecode(rowCount == 0 || _parent._header.RowCount == rowCount);
 
                     var schema = view.Schema;
-                    Host.CheckDecode(schema.ColumnCount == _parent._header.ColumnCount);
+                    Host.CheckDecode(schema.Count == _parent._header.ColumnCount);
                 }
             }
 
@@ -270,7 +270,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 {
                     // The correctness of this relies upon the schema entry being read first.
                     Host.AssertValue(parent._schemaEntry);
-                    Host.Assert(0 <= col && col < parent.Schema.ColumnCount);
+                    Host.Assert(0 <= col && col < parent.Schema.Count);
                     _col = col;
 
                     // Either we have to have data, or the parent has to have explicit row data.
@@ -293,7 +293,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                     Host.AssertValue(view);
                     // This must have precisely one column, of type vector.
                     var schema = view.Schema;
-                    Host.CheckDecode(schema.ColumnCount == 1);
+                    Host.CheckDecode(schema.Count == 1);
                     var ttype = schema.GetColumnType(0);
                     Host.CheckDecode(ttype.IsVector);
                     // We have no way to encode a type of zero length vectors per se in the case
@@ -470,7 +470,7 @@ namespace Microsoft.ML.Runtime.Data.IO
 
             _header = new Header()
             {
-                ColumnCount = schemaView.Schema.ColumnCount
+                ColumnCount = schemaView.Schema.Count
             };
             _schemaEntry = new SubIdvEntry.SchemaSubIdv(this, schemaView);
             _host.Assert(_schemaEntry.GetViewOrNull() == schemaView);
@@ -551,8 +551,8 @@ namespace Microsoft.ML.Runtime.Data.IO
             var saver = new BinarySaver(env, saverArgs);
 
             // We load our schema from what amounts to a binary loader, so all columns should likewise be savable.
-            env.Assert(Enumerable.Range(0, schema.ColumnCount).All(c => saver.IsColumnSavable(schema.GetColumnType(c))));
-            ctx.SaveBinaryStream("Schema.idv", w => saver.SaveData(w.BaseStream, noRows, Utils.GetIdentityPermutation(schema.ColumnCount)));
+            env.Assert(Enumerable.Range(0, schema.Count).All(c => saver.IsColumnSavable(schema.GetColumnType(c))));
+            ctx.SaveBinaryStream("Schema.idv", w => saver.SaveData(w.BaseStream, noRows, Utils.GetIdentityPermutation(schema.Count)));
         }
 
         private unsafe Header InitHeader(BinaryReader reader)
@@ -614,7 +614,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             private readonly TransposeLoader _parent;
             private Schema Schema { get { return _parent.Schema; } }
             private IHost Host { get { return _parent._host; } }
-            public int ColumnCount { get { return Schema.ColumnCount; } }
+            public int ColumnCount { get { return Schema.Count; } }
 
             public SchemaImpl(TransposeLoader parent)
             {
@@ -781,7 +781,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                         var view = _entries[col].GetViewOrNull();
                         // Since we don't have row-wise data, this view must exist.
                         _host.AssertValue(view);
-                        _host.Assert(view.Schema.ColumnCount == 1);
+                        _host.Assert(view.Schema.Count == 1);
                         var trans = _colTransposers[col] = Transposer.Create(_host, view, false, new int[] { 0 });
                         _host.Assert(trans.TransposeSchema.ColumnCount == 1);
                         _host.Assert(trans.TransposeSchema.GetSlotType(0).ValueCount == Schema.GetColumnType(col).ValueCount);
@@ -842,7 +842,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             /// </summary>
             private void Init(int col)
             {
-                Ch.Assert(0 <= col && col < Schema.ColumnCount);
+                Ch.Assert(0 <= col && col < Schema.Count);
                 Ch.Assert(_colToActivesIndex[col] >= 0);
                 var type = Schema.GetColumnType(col);
                 Ch.Assert(_parent.TransposeSchema.GetSlotType(col).ValueCount == _parent._header.RowCount);

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -650,7 +650,7 @@ namespace Microsoft.ML.Runtime.Data.IO
 
             public void GetMetadata<TValue>(string kind, int col, ref TValue value)
             {
-                Schema.GetMetadata<TValue>(kind, col, ref value);
+                Schema[col].Metadata.GetValue(kind, ref value);
             }
 
             public VectorType GetSlotType(int col)

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -640,12 +640,12 @@ namespace Microsoft.ML.Runtime.Data.IO
 
             public ColumnType GetMetadataTypeOrNull(string kind, int col)
             {
-                return Schema.GetMetadataTypeOrNull(kind, col);
+                return Schema[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
             }
 
             public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
             {
-                return Schema.GetMetadataTypes(col);
+                return Schema[col].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
             }
 
             public void GetMetadata<TValue>(string kind, int col, ref TValue value)

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
@@ -148,7 +148,7 @@ namespace Microsoft.ML.Runtime.Data.IO
             string msg = _writeRowData ? "row-wise data, schema, and metadata" : "schema and metadata";
             viewAction(msg, subdata);
             foreach (var col in cols)
-                viewAction(data.Schema.GetColumnName(col), new TransposerUtils.SlotDataView(_host, data, col));
+                viewAction(data.Schema[col].Name, new TransposerUtils.SlotDataView(_host, data, col));
 
             // Wrote out the dataview. Write out the table offset.
             using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Runtime.Data.IO
                 {
                     using (var substream = new SubsetStream(stream))
                     {
-                        _internalSaver.SaveData(substream, view, Utils.GetIdentityPermutation(view.Schema.ColumnCount));
+                        _internalSaver.SaveData(substream, view, Utils.GetIdentityPermutation(view.Schema.Count));
                         substream.Seek(0, SeekOrigin.End);
                         ch.Info("Wrote {0} data view in {1} bytes", name, substream.Length);
                     }

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -109,10 +109,10 @@ namespace Microsoft.ML.Runtime.Data
             const string errMsg = "Inconsistent schema: all source dataviews must have identical column names, sizes, and item types.";
 
             int startingSchemaIndex = _schema == _sources[0].Schema ? 1 : 0;
-            int colCount = _schema.ColumnCount;
+            int colCount = _schema.Count;
 
             // Check if the column counts are identical.
-            _host.Check(_sources.All(source => source.Schema.ColumnCount == colCount), errMsg);
+            _host.Check(_sources.All(source => source.Schema.Count == colCount), errMsg);
 
             for (int c = 0; c < colCount; c++)
             {
@@ -175,7 +175,7 @@ namespace Microsoft.ML.Runtime.Data
                 Sources = parent._sources;
                 Ch.AssertNonEmpty(Sources);
                 Schema = parent._schema;
-                Getters = new Delegate[Schema.ColumnCount];
+                Getters = new Delegate[Schema.Count];
             }
 
             protected Delegate CreateGetter(int col)
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public sealed override bool IsColumnActive(int col)
             {
-                Ch.Check(0 <= col && col < Schema.ColumnCount, "Column index is out of range");
+                Ch.Check(0 <= col && col < Schema.Count, "Column index is out of range");
                 return Getters[col] != null;
             }
         }

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -122,8 +122,8 @@ namespace Microsoft.ML.Runtime.Data
                 for (int i = startingSchemaIndex; i < _sources.Length; i++)
                 {
                     var schema = _sources[i].Schema;
-                    _host.Check(schema.GetColumnName(c) == name, errMsg);
-                    _host.Check(schema.GetColumnType(c).SameSizeAndItemType(type), errMsg);
+                    _host.Check(schema[c].Name == name, errMsg);
+                    _host.Check(schema[c].Type.SameSizeAndItemType(type), errMsg);
                 }
             }
         }

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -261,15 +261,15 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     Ch.AssertValue(view);
                     Ch.AssertValueOrNull(rand);
-                    Ch.Assert(view.Schema.ColumnCount >= 0);
+                    Ch.Assert(view.Schema.Count >= 0);
 
                     _view = view;
-                    _active = new BitArray(view.Schema.ColumnCount);
+                    _active = new BitArray(view.Schema.Count);
                     if (predicate == null)
                         _active.SetAll(true);
                     else
                     {
-                        for (int i = 0; i < view.Schema.ColumnCount; ++i)
+                        for (int i = 0; i < view.Schema.Count; ++i)
                             _active[i] = predicate(i);
                     }
                     if (rand != null)
@@ -300,13 +300,13 @@ namespace Microsoft.ML.Runtime.Data
 
                 public override bool IsColumnActive(int col)
                 {
-                    Ch.Check(0 <= col & col < Schema.ColumnCount);
+                    Ch.Check(0 <= col & col < Schema.Count);
                     return _active[col];
                 }
 
                 public override ValueGetter<TValue> GetGetter<TValue>(int col)
                 {
-                    Ch.Check(0 <= col & col < Schema.ColumnCount);
+                    Ch.Check(0 <= col & col < Schema.Count);
                     Ch.Check(_active[col], "column is not active");
                     var column = _view._columns[col] as Column<TValue>;
                     if (column == null)

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Data
 
             _cacheLock = new object();
             _cacheFillerThreads = new ConcurrentBag<Thread>();
-            _caches = new ColumnCache[_subsetInput.Schema.ColumnCount];
+            _caches = new ColumnCache[_subsetInput.Schema.Count];
 
             if (Utils.Size(prefetch) > 0)
                 KickoffFiller(prefetch);
@@ -124,13 +124,13 @@ namespace Microsoft.ML.Data
                 Array.Copy(prefetch, tmp, prefetch.Length);
                 Array.Sort(tmp);
                 prefetch = tmp;
-                if (prefetch.Length > 0 && (prefetch[0] < 0 || prefetch[prefetch.Length - 1] >= schema.ColumnCount))
+                if (prefetch.Length > 0 && (prefetch[0] < 0 || prefetch[prefetch.Length - 1] >= schema.Count))
                     throw env.Except("Prefetch array had column indices out of range");
             }
             int ip = 0;
             inputToSubset = null;
 
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
             {
                 var type = schema.GetColumnType(c);
                 env.Assert(ip == prefetch.Length || c <= prefetch[ip]);
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Data
                 {
                     if (inputToSubset == null)
                     {
-                        inputToSubset = new int[schema.ColumnCount];
+                        inputToSubset = new int[schema.Count];
                         for (int cc = 0; cc < c; ++cc)
                             inputToSubset[cc] = cc;
                     }
@@ -182,10 +182,10 @@ namespace Microsoft.ML.Data
         /// if this was cachable, or else -1 if the column was not cachable</returns>
         public int MapInputToCacheColumnIndex(int inputIndex)
         {
-            int inputIndexLim = _inputToSubsetColIndex == null ? _subsetInput.Schema.ColumnCount : _inputToSubsetColIndex.Length;
+            int inputIndexLim = _inputToSubsetColIndex == null ? _subsetInput.Schema.Count : _inputToSubsetColIndex.Length;
             _host.CheckParam(0 <= inputIndex && inputIndex < inputIndexLim, nameof(inputIndex), "Input column index not in range");
             var result = _inputToSubsetColIndex == null ? inputIndex : _inputToSubsetColIndex[inputIndex];
-            _host.Assert(-1 <= result && result < _subsetInput.Schema.ColumnCount);
+            _host.Assert(-1 <= result && result < _subsetInput.Schema.Count);
             return result;
         }
 
@@ -704,7 +704,7 @@ namespace Microsoft.ML.Data
                 Contracts.AssertValue(pred);
                 _parent = parent;
 
-                int[] actives = Enumerable.Range(0, _parent.Schema.ColumnCount).Where(pred).ToArray();
+                int[] actives = Enumerable.Range(0, _parent.Schema.Count).Where(pred).ToArray();
                 // Kick off the thread to fill in any requested columns.
                 _parent.KickoffFiller(actives);
 
@@ -1263,7 +1263,7 @@ namespace Microsoft.ML.Data
                 PositionCore = -1;
 
                 // Set up the mapping from active columns.
-                int colLim = Schema.ColumnCount;
+                int colLim = Schema.Count;
                 int[] actives;
                 Utils.BuildSubsetMaps(colLim, predicate, out actives, out _colToActivesIndex);
                 // Construct the getters. Simultaneously collect whatever "waiters"
@@ -1378,7 +1378,7 @@ namespace Microsoft.ML.Data
                 Contracts.AssertValue(parent);
                 var host = parent._host;
                 host.AssertValue(input);
-                host.Assert(0 <= srcCol & srcCol < input.Schema.ColumnCount);
+                host.Assert(0 <= srcCol & srcCol < input.Schema.Count);
                 host.Assert(input.IsColumnActive(srcCol));
 
                 var type = input.Schema.GetColumnType(srcCol);
@@ -1563,7 +1563,7 @@ namespace Microsoft.ML.Data
                 : base(parent._host, waiter)
             {
                 Contracts.AssertValue(input);
-                Contracts.Assert(0 <= srcCol & srcCol < input.Schema.ColumnCount);
+                Contracts.Assert(0 <= srcCol & srcCol < input.Schema.Count);
                 Contracts.Assert(input.Schema.GetColumnType(srcCol).RawType == typeof(T));
             }
 

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Data
 
             for (int c = 0; c < schema.Count; ++c)
             {
-                var type = schema.GetColumnType(c);
+                var type = schema[c].Type;
                 env.Assert(ip == prefetch.Length || c <= prefetch[ip]);
                 if (!type.IsCachable())
                 {
@@ -149,7 +149,7 @@ namespace Microsoft.ML.Data
                     {
                         throw env.Except(
                             "Asked to prefetch column '{0}' into cache, but it is of unhandled type '{1}'",
-                            schema.GetColumnName(c), type);
+                            schema[c].Name, type);
                     }
                 }
                 else
@@ -1315,14 +1315,14 @@ namespace Microsoft.ML.Data
             {
                 Ch.Assert(0 <= col && col < _colToActivesIndex.Length);
                 Ch.Assert(_colToActivesIndex[col] >= 0);
-                return Utils.MarshalInvoke(CreateGetterDelegate<int>, Schema.GetColumnType(col).RawType, col);
+                return Utils.MarshalInvoke(CreateGetterDelegate<int>, Schema[col].Type.RawType, col);
             }
 
             private Delegate CreateGetterDelegate<TValue>(int col)
             {
                 Ch.Assert(0 <= col && col < _colToActivesIndex.Length);
                 Ch.Assert(_colToActivesIndex[col] >= 0);
-                Ch.Assert(Schema.GetColumnType(col).RawType == typeof(TValue));
+                Ch.Assert(Schema[col].Type.RawType == typeof(TValue));
 
                 var cache = (ColumnCache<TValue>)Parent._caches[col];
                 return CreateGetterDelegateCore(cache);
@@ -1381,7 +1381,7 @@ namespace Microsoft.ML.Data
                 host.Assert(0 <= srcCol & srcCol < input.Schema.Count);
                 host.Assert(input.IsColumnActive(srcCol));
 
-                var type = input.Schema.GetColumnType(srcCol);
+                var type = input.Schema[srcCol].Type;
                 Type pipeType;
                 if (type.IsVector)
                     pipeType = typeof(ImplVec<>).MakeGenericType(type.ItemType.RawType);
@@ -1444,7 +1444,7 @@ namespace Microsoft.ML.Data
                 public ImplVec(CacheDataView parent, RowCursor input, int srcCol, OrderedWaiter waiter)
                     : base(parent, input, srcCol, waiter)
                 {
-                    var type = input.Schema.GetColumnType(srcCol);
+                    var type = input.Schema[srcCol].Type;
                     Ctx.Assert(type.IsVector);
                     _uniformLength = type.VectorSize;
                     _indices = new BigArray<int>();
@@ -1564,7 +1564,7 @@ namespace Microsoft.ML.Data
             {
                 Contracts.AssertValue(input);
                 Contracts.Assert(0 <= srcCol & srcCol < input.Schema.Count);
-                Contracts.Assert(input.Schema.GetColumnType(srcCol).RawType == typeof(T));
+                Contracts.Assert(input.Schema[srcCol].Type.RawType == typeof(T));
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Runtime.Data
             if (InnerMappers.Length == 0)
             {
                 bool differentActive = false;
-                for (int c = 0; c < input.Schema.ColumnCount; ++c)
+                for (int c = 0; c < input.Schema.Count; ++c)
                 {
                     bool wantsActive = active(c);
                     bool isActive = input.IsColumnActive(c);

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Runtime.Data
                     differentActive |= wantsActive != isActive;
 
                     if (wantsActive && !isActive)
-                        throw Contracts.ExceptParam(nameof(input), $"Mapper required column '{input.Schema.GetColumnName(c)}' active but it was not.");
+                        throw Contracts.ExceptParam(nameof(input), $"Mapper required column '{input.Schema[c].Name}' active but it was not.");
                 }
                 return input;
             }

--- a/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
 
@@ -105,13 +106,13 @@ namespace Microsoft.ML.Runtime.Data
         public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
         {
             GetColumnSource(col, out int dv, out int srcCol);
-            return _sources[dv].GetMetadataTypes(srcCol);
+            return _sources[dv][srcCol].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
         }
 
         public ColumnType GetMetadataTypeOrNull(string kind, int col)
         {
             GetColumnSource(col, out int dv, out int srcCol);
-            return _sources[dv].GetMetadataTypeOrNull(kind, srcCol);
+            return _sources[dv][srcCol].Metadata.Schema.GetColumnOrNull(kind)?.Type;
         }
 
         public void GetMetadata<TValue>(string kind, int col, ref TValue value)

--- a/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Runtime.Data
             for (int i = 0; i < sources.Length; i++)
             {
                 var schema = sources[i];
-                _cumulativeColCounts[i + 1] = _cumulativeColCounts[i] + schema.ColumnCount;
+                _cumulativeColCounts[i + 1] = _cumulativeColCounts[i] + schema.Count;
             }
             AsSchema = Schema.Create(this);
         }
@@ -72,7 +72,7 @@ namespace Microsoft.ML.Runtime.Data
                 srcIndex--;
             Contracts.Assert(0 <= srcIndex && srcIndex < _cumulativeColCounts.Length);
             srcCol = col - _cumulativeColCounts[srcIndex];
-            Contracts.Assert(0 <= srcCol && srcCol < _sources[srcIndex].ColumnCount);
+            Contracts.Assert(0 <= srcCol && srcCol < _sources[srcIndex].Count);
         }
 
         public bool TryGetColumnIndex(string name, out int col)

--- a/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Runtime.Data
         public void GetMetadata<TValue>(string kind, int col, ref TValue value)
         {
             GetColumnSource(col, out int dv, out int srcCol);
-            _sources[dv].GetMetadata(kind, srcCol, ref value);
+            _sources[dv][srcCol].Metadata.GetValue(kind, ref value);
         }
     }
 }

--- a/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeSchema.cs
@@ -93,13 +93,13 @@ namespace Microsoft.ML.Runtime.Data
         public string GetColumnName(int col)
         {
             GetColumnSource(col, out int dv, out int srcCol);
-            return _sources[dv].GetColumnName(srcCol);
+            return _sources[dv][srcCol].Name;
         }
 
         public ColumnType GetColumnType(int col)
         {
             GetColumnSource(col, out int dv, out int srcCol);
-            return _sources[dv].GetColumnType(srcCol);
+            return _sources[dv][srcCol].Type;
         }
 
         public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Runtime.Data
                 Schema = schema;
                 _getters = new Delegate[_colCount];
                 for (int c = 0; c < _colCount; c++)
-                    _getters[c] = predicate(c) ? CreateGetter(schema.GetColumnType(c), schemaDef.Columns[c], peeks[c]) : null;
+                    _getters[c] = predicate(c) ? CreateGetter(schema[c].Type, schemaDef.Columns[c], peeks[c]) : null;
             }
 
             //private Delegate CreateGetter(SchemaProxy schema, int index, Delegate peek)

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -148,10 +148,10 @@ namespace Microsoft.ML.Runtime.Data
                 Host.AssertValue(schemaDef);
                 Host.AssertValue(peeks);
                 Host.AssertValue(predicate);
-                Host.Assert(schema.ColumnCount == schemaDef.Columns.Length);
-                Host.Assert(schema.ColumnCount == peeks.Length);
+                Host.Assert(schema.Count == schemaDef.Columns.Length);
+                Host.Assert(schema.Count == peeks.Length);
 
-                _colCount = schema.ColumnCount;
+                _colCount = schema.Count;
                 Schema = schema;
                 _getters = new Delegate[_colCount];
                 for (int c = 0; c < _colCount; c++)

--- a/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Runtime.Data
                 Ch.AssertValue(schema);
                 Ch.AssertValue(needCol);
                 Schema = schema;
-                _active = Utils.BuildArray(Schema.ColumnCount, needCol);
+                _active = Utils.BuildArray(Schema.Count, needCol);
             }
 
             public override ValueGetter<RowId> GetIdGetter()

--- a/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaColumnMapper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime.Data
             bool tmp = input.Schema.TryGetColumnIndex(src, out int colSrc);
             if (!tmp)
                 throw env.ExceptParam(nameof(src), "The input data doesn't have a column named '{0}'", src);
-            var typeOrig = input.Schema.GetColumnType(colSrc);
+            var typeOrig = input.Schema[colSrc].Type;
 
             // REVIEW: Ideally this should support vector-type conversion. It currently doesn't.
             bool ident;

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Runtime.Data
             bool tmp = input.Schema.TryGetColumnIndex(src, out colSrc);
             if (!tmp)
                 throw env.ExceptParam(nameof(src), "The input data doesn't have a column named '{0}'", src);
-            var typeOrig = input.Schema.GetColumnType(colSrc);
+            var typeOrig = input.Schema[colSrc].Type;
 
             // REVIEW: Ideally this should support vector-type conversion. It currently doesn't.
             bool ident;

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 Host.AssertValue(pred);
                 Host.Assert(conv != null | typeof(T1) == typeof(T2));
-                Host.Assert(0 <= colSrc & colSrc < Source.Schema.ColumnCount);
+                Host.Assert(0 <= colSrc & colSrc < Source.Schema.Count);
 
                 _colSrc = colSrc;
                 _pred = pred;
@@ -138,8 +138,8 @@ namespace Microsoft.ML.Runtime.Data
             private Func<int, bool> GetActive(Func<int, bool> predicate, out bool[] active)
             {
                 Host.AssertValue(predicate);
-                active = new bool[Source.Schema.ColumnCount];
-                bool[] activeInput = new bool[Source.Schema.ColumnCount];
+                active = new bool[Source.Schema.Count];
+                bool[] activeInput = new bool[Source.Schema.Count];
                 for (int i = 0; i < active.Length; i++)
                     activeInput[i] = active[i] = predicate(i);
                 activeInput[_colSrc] = true;

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -142,12 +142,12 @@ namespace Microsoft.ML.Runtime.Data
         /// </summary>
         private bool[] GetActive(Func<int, bool> predicate, out Func<int, bool> predicateInput)
         {
-            int n = _bindings.Schema.ColumnCount;
+            int n = _bindings.Schema.Count;
             var active = Utils.BuildArray(n, predicate);
             Contracts.Assert(active.Length == n);
 
             var activeInput = _bindings.GetActiveInput(predicate);
-            Contracts.Assert(activeInput.Length == _bindings.InputSchema.ColumnCount);
+            Contracts.Assert(activeInput.Length == _bindings.InputSchema.Count);
 
             // Get a predicate that determines which outputs are active.
             var predicateOut = GetActiveOutputColumns(active);
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Runtime.Data
         private Func<int, bool> GetActiveOutputColumns(bool[] active)
         {
             Contracts.AssertValue(active);
-            Contracts.Assert(active.Length == _bindings.Schema.ColumnCount);
+            Contracts.Assert(active.Length == _bindings.Schema.Count);
 
             return
                 col =>
@@ -248,8 +248,8 @@ namespace Microsoft.ML.Runtime.Data
 
             using (var ch = Host.Start("GetEntireRow"))
             {
-                var activeArr = new bool[OutputSchema.ColumnCount];
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                var activeArr = new bool[OutputSchema.Count];
+                for (int i = 0; i < OutputSchema.Count; i++)
                     activeArr[i] = active(i);
                 var pred = GetActiveOutputColumns(activeArr);
                 var getters = _mapper.CreateGetters(input, pred, out Action disp);
@@ -355,7 +355,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public override bool IsColumnActive(int col)
             {
-                Ch.Check(0 <= col && col < _bindings.Schema.ColumnCount);
+                Ch.Check(0 <= col && col < _bindings.Schema.Count);
                 return _active[col];
             }
 

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -342,7 +342,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public void GetMetadata<TValue>(string kind, int col, ref TValue value)
             {
-                InputSchema.GetMetadata(kind, col, ref value);
+                InputSchema[col].Metadata.GetValue(kind, ref value);
             }
 
             public VectorType GetSlotType(int col)
@@ -1677,7 +1677,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public void GetMetadata<TValue>(string kind, int col, ref TValue value)
             {
-                _schema.GetMetadata(kind, col, ref value);
+                _schema[col].Metadata.GetValue(kind, ref value);
             }
         }
     }

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Runtime.Data
             _cols = new ColumnInfo[columns.Length];
             var schema = _view.Schema;
             _nameToICol = new Dictionary<string, int>();
-            _inputToTransposed = Utils.CreateArray(schema.ColumnCount, -1);
+            _inputToTransposed = Utils.CreateArray(schema.Count, -1);
             for (int c = 0; c < columns.Length; ++c)
             {
                 _nameToICol[(_cols[c] = ColumnInfo.CreateFromIndex(schema, columns[c])).Name] = c;
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 var slicer = new DataViewSlicer(_host, view, columns);
                 var slicerSchema = slicer.Schema;
-                ch.Assert(Enumerable.Range(0, slicerSchema.ColumnCount).All(c => saver.IsColumnSavable(slicerSchema.GetColumnType(c))));
+                ch.Assert(Enumerable.Range(0, slicerSchema.Count).All(c => saver.IsColumnSavable(slicerSchema.GetColumnType(c))));
                 _splitLim = new int[_cols.Length];
                 List<int> toSave = new List<int>();
                 int offset = 0;
@@ -223,8 +223,8 @@ namespace Microsoft.ML.Runtime.Data
             var schema = view.Schema;
             for (int c = 0; c < columns.Length; ++c)
             {
-                if (!(0 <= columns[c] && columns[c] < schema.ColumnCount))
-                    throw host.ExceptParam(nameof(columns), "Column index {0} illegal for data with {1} column", columns[c], schema.ColumnCount);
+                if (!(0 <= columns[c] && columns[c] < schema.Count))
+                    throw host.ExceptParam(nameof(columns), "Column index {0} illegal for data with {1} column", columns[c], schema.Count);
             }
             return columns;
         }
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public Schema AsSchema { get; }
 
-            public int ColumnCount { get { return InputSchema.ColumnCount; } }
+            public int ColumnCount { get { return InputSchema.Count; } }
 
             public SchemaImpl(Transposer parent)
             {
@@ -367,7 +367,7 @@ namespace Microsoft.ML.Runtime.Data
             protected SlotCursor(Transposer parent, int col)
                 : base(parent._host)
             {
-                Ch.Assert(0 <= col && col < parent.Schema.ColumnCount);
+                Ch.Assert(0 <= col && col < parent.Schema.Count);
                 _parent = parent;
                 _col = col;
             }
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Runtime.Data
             public SlotCursorOne(Transposer parent, int col)
                 : base(parent, col)
             {
-                Ch.Assert(0 <= col && col < parent.Schema.ColumnCount);
+                Ch.Assert(0 <= col && col < parent.Schema.Count);
                 int iinfo = parent._inputToTransposed[col];
                 Ch.Assert(iinfo >= 0);
                 int smin = iinfo == 0 ? 0 : parent._splitLim[iinfo - 1];
@@ -896,7 +896,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     var splitter = _splitters[i];
                     // Don't activate input source columns if none of the resulting columns were selected.
-                    bool isActive = pred == null || Enumerable.Range(offset, splitter.AsSchema.ColumnCount).Any(c => pred(c));
+                    bool isActive = pred == null || Enumerable.Range(offset, splitter.AsSchema.Count).Any(c => pred(c));
                     if (isActive)
                     {
                         activeSplitters[i] = isActive;
@@ -1005,7 +1005,7 @@ namespace Microsoft.ML.Runtime.Data
                 protected Splitter(IDataView view, int col)
                 {
                     Contracts.AssertValue(view);
-                    Contracts.Assert(0 <= col && col < view.Schema.ColumnCount);
+                    Contracts.Assert(0 <= col && col < view.Schema.Count);
                     _view = view;
                     _col = col;
                 }
@@ -1383,7 +1383,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 public override bool IsColumnActive(int col)
                 {
-                    Ch.Check(0 <= col && col < Schema.ColumnCount, "col");
+                    Ch.Check(0 <= col && col < Schema.Count, "col");
                     int splitInd;
                     int splitCol;
                     _slicer.OutputColumnToSplitterIndices(col, out splitInd, out splitCol);
@@ -1411,7 +1411,7 @@ namespace Microsoft.ML.Runtime.Data
         public static void GetSingleSlotValue<T>(this ITransposeDataView view, int col, ref VBuffer<T> dst)
         {
             Contracts.CheckValue(view, nameof(view));
-            Contracts.CheckParam(0 <= col && col < view.Schema.ColumnCount, nameof(col));
+            Contracts.CheckParam(0 <= col && col < view.Schema.Count, nameof(col));
             using (var cursor = view.GetSlotCursor(col))
             {
                 var getter = cursor.GetGetter<T>();
@@ -1496,7 +1496,7 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.CheckValue(env, nameof(env));
                 _host = env.Register("SlotDataView");
                 _host.CheckValue(data, nameof(data));
-                _host.CheckParam(0 <= col && col < data.Schema.ColumnCount, nameof(col));
+                _host.CheckParam(0 <= col && col < data.Schema.Count, nameof(col));
                 _type = data.TransposeSchema.GetSlotType(col);
                 _host.AssertValue(_type);
 
@@ -1636,7 +1636,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             private readonly Schema _schema;
 
-            public int ColumnCount { get { return _schema.ColumnCount; } }
+            public int ColumnCount { get { return _schema.Count; } }
 
             public SimpleTransposeSchema(Schema schema)
             {

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -332,12 +332,12 @@ namespace Microsoft.ML.Runtime.Data
 
             public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
             {
-                return InputSchema.GetMetadataTypes(col);
+                return InputSchema[col].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
             }
 
             public ColumnType GetMetadataTypeOrNull(string kind, int col)
             {
-                return InputSchema.GetMetadataTypeOrNull(kind, col);
+                return InputSchema[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
             }
 
             public void GetMetadata<TValue>(string kind, int col, ref TValue value)
@@ -1667,12 +1667,12 @@ namespace Microsoft.ML.Runtime.Data
 
             public IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypes(int col)
             {
-                return _schema.GetMetadataTypes(col);
+                return _schema[col].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
             }
 
             public ColumnType GetMetadataTypeOrNull(string kind, int col)
             {
-                return _schema.GetMetadataTypeOrNull(kind, col);
+                return _schema[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
             }
 
             public void GetMetadata<TValue>(string kind, int col, ref TValue value)

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Data
                         continue;
                     throw _host.Except("Column '{0}' not found in the data view", col.ColumnName);
                 }
-                var realColType = _data.Schema.GetColumnType(colIndex);
+                var realColType = _data.Schema[colIndex].Type;
                 if (!IsCompatibleType(realColType, col.MemberInfo))
                 {
                     throw _host.Except(
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Data
 
             private Action<TRow> GenerateSetter(Row input, int index, InternalSchemaDefinition.Column column, Delegate poke, Delegate peek)
             {
-                var colType = input.Schema.GetColumnType(index);
+                var colType = input.Schema[index].Type;
                 var fieldType = column.OutputType;
                 var genericType = fieldType;
                 Func<Row, int, Delegate, Delegate, Action<TRow>> del;

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -190,7 +190,7 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
             VBuffer<ReadOnlyMemory<char>> slotNames = default;
             int len = schema.Feature.Type.ValueCount;
             if (schema.Schema[schema.Feature.Index].HasSlotNames(len))
-                schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, schema.Feature.Index, ref slotNames);
+                schema.Schema[schema.Feature.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slotNames);
             else
                 slotNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(len);
             var slotNameValues = slotNames.GetValues();

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -85,7 +85,7 @@ namespace Microsoft.ML.Runtime.Data
                 // Compute the mapping, <see cref="_sources"/>, from output column index to input column index.
                 if (drop)
                     // Drop columns indexed by args.Index
-                    sources = Enumerable.Range(0, sourceSchema.ColumnCount).Except(selectedColumnIndexes).ToArray();
+                    sources = Enumerable.Range(0, sourceSchema.Count).Except(selectedColumnIndexes).ToArray();
                 else
                     // Keep columns indexed by args.Index
                     sources = selectedColumnIndexes;
@@ -108,8 +108,8 @@ namespace Microsoft.ML.Runtime.Data
                     var selectedIndex = _sources[i];
 
                     // The dropped/kept columns are determined by user-specified arguments, so we throw if a bad configuration is provided.
-                    string fmt = string.Format("Column index {0} invalid for input with {1} columns", selectedIndex, _sourceSchema.ColumnCount);
-                    Contracts.Check(selectedIndex < _sourceSchema.ColumnCount, fmt);
+                    string fmt = string.Format("Column index {0} invalid for input with {1} columns", selectedIndex, _sourceSchema.Count);
+                    Contracts.Check(selectedIndex < _sourceSchema.Count, fmt);
 
                     // Copy the selected column into output schema.
                     var selectedColumn = _sourceSchema[selectedIndex];
@@ -151,13 +151,13 @@ namespace Microsoft.ML.Runtime.Data
 
             internal bool[] GetActive(Func<int, bool> predicate)
             {
-                return Utils.BuildArray(OutputSchema.ColumnCount, predicate);
+                return Utils.BuildArray(OutputSchema.Count, predicate);
             }
 
             internal Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
                 Contracts.AssertValue(predicate);
-                var active = new bool[_sourceSchema.ColumnCount];
+                var active = new bool[_sourceSchema.Count];
                 for (int i = 0; i < _sources.Length; i++)
                 {
                     if (predicate(i))
@@ -279,7 +279,7 @@ namespace Microsoft.ML.Runtime.Data
                 : base(provider, input)
             {
                 Ch.AssertValue(bindings);
-                Ch.Assert(active == null || active.Length == bindings.OutputSchema.ColumnCount);
+                Ch.Assert(active == null || active.Length == bindings.OutputSchema.Count);
 
                 _bindings = bindings;
                 _active = active;
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public override bool IsColumnActive(int col)
             {
-                Ch.Check(0 <= col && col < _bindings.OutputSchema.ColumnCount);
+                Ch.Check(0 <= col && col < _bindings.OutputSchema.Count);
                 return _active == null || _active[col];
             }
 

--- a/src/Microsoft.ML.Data/EntryPoints/Cache.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/Cache.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     var schema = input.Data.Schema;
 
                     var cols = new List<int>();
-                    for (int i = 0; i < schema.ColumnCount; i++)
+                    for (int i = 0; i < schema.Count; i++)
                     {
                         var type = schema.GetColumnType(i);
                         if (saver.IsColumnSavable(type))

--- a/src/Microsoft.ML.Data/EntryPoints/Cache.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/Cache.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     var cols = new List<int>();
                     for (int i = 0; i < schema.Count; i++)
                     {
-                        var type = schema.GetColumnType(i);
+                        var type = schema[i].Type;
                         if (saver.IsColumnSavable(type))
                             cols.Add(i);
                     }

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -130,8 +130,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     trainRms.Schema[trainRms.Label.Index].HasKeyValues(labelType.KeyCount))
                 {
                     VBuffer<ReadOnlyMemory<char>> keyValues = default;
-                    trainRms.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, trainRms.Label.Index,
-                        ref keyValues);
+                    trainRms.Schema[trainRms.Label.Index].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keyValues);
                     return keyValues.DenseValues().Select(v => v.ToString()).ToArray();
                 }
             }

--- a/src/Microsoft.ML.Data/EntryPoints/ScoreColumnSelector.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/ScoreColumnSelector.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             {
                 return true;
             }
-            var columnName = schema.GetColumnName(i);
+            var columnName = schema[i].Name;
             if (extraColumns != null && Array.FindIndex(extraColumns, columnName.Equals) >= 0)
                 return true;
             return false;
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                         {
                             continue;
                         }
-                        var source = input.Data.Schema.GetColumnName(i);
+                        var source = input.Data.Schema[i].Name;
                         var name = source + "." + positiveClass;
                         copyCols.Add((source, name));
                     }

--- a/src/Microsoft.ML.Data/EntryPoints/ScoreColumnSelector.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/ScoreColumnSelector.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var view = input.Data;
             var maxScoreId = view.Schema.GetMaxMetadataKind(out int colMax, MetadataUtils.Kinds.ScoreColumnSetId);
             List<int> indices = new List<int>();
-            for (int i = 0; i < view.Schema.ColumnCount; i++)
+            for (int i = 0; i < view.Schema.Count; i++)
             {
                 if (view.Schema[i].IsHidden)
                     continue;
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     int colMax;
                     var maxScoreId = input.Data.Schema.GetMaxMetadataKind(out colMax, MetadataUtils.Kinds.ScoreColumnSetId);
                     var copyCols = new List<(string Source, string Name)>();
-                    for (int i = 0; i < input.Data.Schema.ColumnCount; i++)
+                    for (int i = 0; i < input.Data.Schema.Count; i++)
                     {
                         if (input.Data.Schema[i].IsHidden)
                             continue;

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -686,7 +686,7 @@ namespace Microsoft.ML.Runtime.Data
                 ValueGetter<uint> stratGetter = null;
                 if (hasStrat)
                 {
-                    var type = cursor.Schema.GetColumnType(stratCol);
+                    var type = cursor.Schema[stratCol].Type;
                     stratGetter = RowCursorUtils.GetGetterAs<uint>(type, cursor, stratCol);
                 }
                 bool foundRow = false;

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Runtime.Data
                 (type = schema.Schema[schema.Label.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type) != null &&
                 type.ItemType.IsKnownSizeVector && type.ItemType.IsText)
             {
-                schema.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, schema.Label.Index, ref labelNames);
+                schema.Schema[schema.Label.Index].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref labelNames);
             }
             else
                 labelNames = new VBuffer<ReadOnlyMemory<char>>(2, new[] { "positive".AsMemory(), "negative".AsMemory() });

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -1097,18 +1097,18 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertValueOrNull(_probCol);
             Host.AssertNonEmpty(LabelCol);
 
-            var t = schema.GetColumnType(LabelIndex);
+            var t = schema[(int) LabelIndex].Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.KeyCount != 2)
                 throw Host.Except("Label column '{0}' has type '{1}' but must be R4, R8, BL or a 2-value key", LabelCol, t);
 
-            t = schema.GetColumnType(ScoreIndex);
+            t = schema[ScoreIndex].Type;
             if (t.IsVector || t.ItemType != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type '{1}' but must be R4", ScoreCol, t);
 
             if (_probIndex >= 0)
             {
                 Host.Assert(!string.IsNullOrEmpty(_probCol));
-                t = schema.GetColumnType(_probIndex);
+                t = schema[_probIndex].Type;
                 if (t.IsVector || t.ItemType != NumberType.Float)
                     throw Host.Except("Probability column '{0}' has type '{1}' but must be R4", _probCol, t);
             }

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -175,7 +175,7 @@ namespace Microsoft.ML.Runtime.Data
             ColumnType type;
             var labelNames = default(VBuffer<ReadOnlyMemory<char>>);
             if (schema.Label.Type.IsKey &&
-                (type = schema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, schema.Label.Index)) != null &&
+                (type = schema.Schema[schema.Label.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type) != null &&
                 type.ItemType.IsKnownSizeVector && type.ItemType.IsText)
             {
                 schema.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, schema.Label.Index, ref labelNames);

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -751,7 +751,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Host.AssertNonEmpty(ScoreCol);
 
-            var type = schema.GetColumnType(ScoreIndex);
+            var type = schema[(int) ScoreIndex].Type;
             if (!type.IsKnownSizeVector || type.ItemType != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type {1}, but must be a float vector of known-size", ScoreCol, type);
         }
@@ -835,14 +835,14 @@ namespace Microsoft.ML.Runtime.Data
             // Wrap with a DropSlots transform to pick only the first _numTopClusters slots.
             if (perInst.Schema.TryGetColumnIndex(ClusteringPerInstanceEvaluator.SortedClusters, out int index))
             {
-                var type = perInst.Schema.GetColumnType(index);
+                var type = perInst.Schema[index].Type;
                 if (_numTopClusters < type.VectorSize)
                     perInst = new SlotsDroppingTransformer(Host, ClusteringPerInstanceEvaluator.SortedClusters, min: _numTopClusters).Transform(perInst);
             }
 
             if (perInst.Schema.TryGetColumnIndex(ClusteringPerInstanceEvaluator.SortedClusterScores, out index))
             {
-                var type = perInst.Schema.GetColumnType(index);
+                var type = perInst.Schema[index].Type;
                 if (_numTopClusters < type.VectorSize)
                     perInst = new SlotsDroppingTransformer(Host, ClusteringPerInstanceEvaluator.SortedClusterScores, min: _numTopClusters).Transform(perInst);
             }

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Runtime.Data
         // Lambda used as validator/filter in calls to GetMaxMetadataKind.
         private static bool CheckScoreColumnKindIsKnown(Schema schema, int col)
         {
-            var columnType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnKind, col);
+            var columnType = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
             if (columnType == null || !columnType.IsText)
                 return false;
             ReadOnlyMemory<char> tmp = default;
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Runtime.Data
         // Lambda used as validator/filter in calls to GetMaxMetadataKind.
         private static bool CheckScoreColumnKind(Schema schema, int col)
         {
-            var columnType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnKind, col);
+            var columnType = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
             return columnType != null && columnType.IsText;
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.ML.Runtime.Data
             }
 
             // Get the score column set id from colScore.
-            var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnSetId, colScore);
+            var type = schema[colScore].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnSetId)?.Type;
             if (type == null || !type.IsKey || type.RawKind != DataKind.U4)
             {
                 // scoreCol is not part of a score column set, so can't determine an aux column.
@@ -217,7 +217,7 @@ namespace Microsoft.ML.Runtime.Data
             ectx.CheckParam(0 <= col && col < schema.Count, nameof(col));
             ectx.CheckNonEmpty(kind, nameof(kind));
 
-            var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnKind, col);
+            var type = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
             if (type == null || !type.IsText)
                 return false;
             var tmp = default(ReadOnlyMemory<char>);
@@ -347,7 +347,7 @@ namespace Microsoft.ML.Runtime.Data
                             // followed by the slot name if it exists, or "Label_i" if it doesn't.
                             VBuffer<ReadOnlyMemory<char>> names = default;
                             var size = schema[i].Type.VectorSize;
-                            var slotNamesType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, i);
+                            var slotNamesType = schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
                             if (slotNamesType != null && slotNamesType.VectorSize == size && slotNamesType.ItemType.IsText)
                                 schema.GetMetadata(MetadataUtils.Kinds.SlotNames, i, ref names);
                             else
@@ -563,7 +563,7 @@ namespace Microsoft.ML.Runtime.Data
                     throw Contracts.Except($"Schema number {i} does not contain column '{columnName}'");
 
                 var type = schema[indices[i]].Type;
-                var keyValueType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, indices[i]);
+                var keyValueType = schema[indices[i]].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                 if (type.IsVector != isVec)
                     throw Contracts.Except($"Column '{columnName}' in schema number {i} does not have the correct type");
                 if (keyValueType == null || keyValueType.ItemType.RawType != typeof(T))
@@ -856,7 +856,7 @@ namespace Microsoft.ML.Runtime.Data
                     else if (dvNumber == 0 && name == labelColName)
                     {
                         // The label column can be a key. Reconcile the key values, and wrap with a KeyToValue transform.
-                        labelColKeyValuesType = dv.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, i);
+                        labelColKeyValuesType = dv.Schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                     }
                     else if (dvNumber == 0 && dv.Schema[i].HasKeyValues(type.KeyCount))
                         firstDvKeyWithNamesColumns.Add(name);
@@ -1015,7 +1015,7 @@ namespace Microsoft.ML.Runtime.Data
 
                     vBufferGetters[i] = row.GetGetter<VBuffer<double>>(i);
                     metricCount += type.VectorSize;
-                    var slotNamesType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, i);
+                    var slotNamesType = schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
                     if (slotNamesType != null && slotNamesType.VectorSize == type.VectorSize && slotNamesType.ItemType.IsText)
                         schema.GetMetadata(MetadataUtils.Kinds.SlotNames, i, ref names);
                     else
@@ -1215,7 +1215,7 @@ namespace Microsoft.ML.Runtime.Data
                 var name = schema[i].Name;
                 if (i == stratCol)
                 {
-                    var keyValuesType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, i);
+                    var keyValuesType = schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                     if (keyValuesType == null || !keyValuesType.ItemType.IsText ||
                         keyValuesType.VectorSize != type.KeyCount)
                     {
@@ -1344,7 +1344,7 @@ namespace Microsoft.ML.Runtime.Data
             // Get the class names.
             int countCol;
             host.Check(confusionDataView.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.Count, out countCol), "Did not find the count column");
-            var type = confusionDataView.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, countCol);
+            var type = confusionDataView.Schema[countCol].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
             host.Check(type != null && type.IsKnownSizeVector && type.ItemType.IsText, "The Count column does not have a text vector metadata of kind SlotNames.");
 
             var labelNames = default(VBuffer<ReadOnlyMemory<char>>);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -166,7 +166,7 @@ namespace Microsoft.ML.Runtime.Data
             ectx.CheckValue(schema, nameof(schema));
             ectx.CheckValueOrNull(name);
             ectx.CheckNonEmpty(argName, nameof(argName));
-            ectx.CheckParam(0 <= colScore && colScore < schema.ColumnCount, nameof(colScore));
+            ectx.CheckParam(0 <= colScore && colScore < schema.Count, nameof(colScore));
             ectx.CheckNonEmpty(valueKind, nameof(valueKind));
 
             if (!string.IsNullOrWhiteSpace(name))
@@ -214,7 +214,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.CheckValueOrNull(ectx);
             ectx.CheckValue(schema, nameof(schema));
-            ectx.CheckParam(0 <= col && col < schema.ColumnCount, nameof(col));
+            ectx.CheckParam(0 <= col && col < schema.Count, nameof(col));
             ectx.CheckNonEmpty(kind, nameof(kind));
 
             var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnKind, col);
@@ -293,11 +293,11 @@ namespace Microsoft.ML.Runtime.Data
                     stratColGetter = (ref uint dst) => dst = 0;
 
                 // We currently have only double valued or vector of double valued metrics.
-                var colCount = schema.ColumnCount;
+                var colCount = schema.Count;
                 var getters = new ValueGetter<double>[colCount];
                 var vBufferGetters = getVectorMetrics ? new ValueGetter<VBuffer<double>>[colCount] : null;
 
-                for (int i = 0; i < schema.ColumnCount; i++)
+                for (int i = 0; i < schema.Count; i++)
                 {
                     if (schema[i].IsHidden || hasWeighted && i == isWeightedCol ||
                         hasStrats && (i == stratCol || i == stratVal))
@@ -393,9 +393,9 @@ namespace Microsoft.ML.Runtime.Data
             // We use the first column in the data view as an input column to the LambdaColumnMapper,
             // because it must have an input.
             int inputCol = 0;
-            while (inputCol < input.Schema.ColumnCount && input.Schema[inputCol].IsHidden)
+            while (inputCol < input.Schema.Count && input.Schema[inputCol].IsHidden)
                 inputCol++;
-            env.Assert(inputCol < input.Schema.ColumnCount);
+            env.Assert(inputCol < input.Schema.Count);
 
             var inputColName = input.Schema.GetColumnName(0);
             var inputColType = input.Schema.GetColumnType(0);
@@ -435,9 +435,9 @@ namespace Microsoft.ML.Runtime.Data
             // We use the first column in the data view as an input column to the LambdaColumnMapper,
             // because it must have an input.
             int inputCol = 0;
-            while (inputCol < input.Schema.ColumnCount && input.Schema[inputCol].IsHidden)
+            while (inputCol < input.Schema.Count && input.Schema[inputCol].IsHidden)
                 inputCol++;
-            env.Assert(inputCol < input.Schema.ColumnCount);
+            env.Assert(inputCol < input.Schema.Count);
 
             var inputColName = input.Schema.GetColumnName(inputCol);
             var inputColType = input.Schema.GetColumnType(inputCol);
@@ -815,7 +815,7 @@ namespace Microsoft.ML.Runtime.Data
             foreach (var dv in foldDataViews)
             {
                 var hidden = new List<int>();
-                for (int i = 0; i < dv.Schema.ColumnCount; i++)
+                for (int i = 0; i < dv.Schema.Count; i++)
                 {
                     if (dv.Schema[i].IsHidden)
                     {
@@ -935,7 +935,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private static IEnumerable<int> FindHiddenColumns(Schema schema, string colName)
         {
-            for (int i = 0; i < schema.ColumnCount; i++)
+            for (int i = 0; i < schema.Count; i++)
             {
                 if (schema[i].IsHidden && schema.GetColumnName(i) == colName)
                     yield return i;
@@ -984,15 +984,15 @@ namespace Microsoft.ML.Runtime.Data
         {
             ch.AssertValue(schema);
             ch.AssertValue(row);
-            ch.Assert(Utils.Size(getters) == schema.ColumnCount);
-            ch.Assert(Utils.Size(vBufferGetters) == schema.ColumnCount);
+            ch.Assert(Utils.Size(getters) == schema.Count);
+            ch.Assert(Utils.Size(vBufferGetters) == schema.Count);
 
             // Get the names of the metrics. For R8 valued columns the metric name is the column name. For R8 vector valued columns
             // the names of the metrics are the column name, followed by the slot name if it exists, or "Label_i" if it doesn't.
             VBuffer<ReadOnlyMemory<char>> names = default;
             int metricCount = 0;
             var metricNames = new List<string>();
-            for (int i = 0; i < schema.ColumnCount; i++)
+            for (int i = 0; i < schema.Count; i++)
             {
                 if (schema[i].IsHidden || ignoreCol(i))
                     continue;
@@ -1078,7 +1078,7 @@ namespace Microsoft.ML.Runtime.Data
             foldCol = hasFoldCol ? fcol : -1;
 
             // We currently have only double valued or vector of double valued metrics.
-            int colCount = data.Schema.ColumnCount;
+            int colCount = data.Schema.Count;
             var getters = new ValueGetter<double>[colCount];
             var vBufferGetters = new ValueGetter<VBuffer<double>>[colCount];
             int numResults = 0;
@@ -1200,7 +1200,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(env);
 
-            int colCount = schema.ColumnCount;
+            int colCount = schema.Count;
 
             var dvBldr = new ArrayDataViewBuilder(env);
             var weightedDvBldr = isWeightedCol >= 0 ? new ArrayDataViewBuilder(env) : null;

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -924,7 +924,7 @@ namespace Microsoft.ML.Runtime.Data
                     var idv = views[i];
 
                     // Find the old per-class log-loss column and drop it.
-                    for (int col = 0; col < idv.Schema.ColumnCount; col++)
+                    for (int col = 0; col < idv.Schema.Count; col++)
                     {
                         if (idv.Schema[col].IsHidden &&
                             idv.Schema.GetColumnName(col).Equals(MultiClassClassifierEvaluator.PerClassLogLoss))

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Runtime.Data
             var labelNames = default(VBuffer<ReadOnlyMemory<char>>);
             if (mdType != null && mdType.IsKnownSizeVector && mdType.ItemType.IsText)
             {
-                schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, scoreInfo.Index, ref labelNames);
+                schema.Schema[scoreInfo.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref labelNames);
                 names = new ReadOnlyMemory<char>[labelNames.Length];
                 labelNames.CopyTo(names);
             }
@@ -578,7 +578,7 @@ namespace Microsoft.ML.Runtime.Data
             if (schema[(int) ScoreIndex].HasSlotNames(_numClasses))
             {
                 var classNames = default(VBuffer<ReadOnlyMemory<char>>);
-                schema.GetMetadata(MetadataUtils.Kinds.SlotNames, ScoreIndex, ref classNames);
+                schema[(int) ScoreIndex].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref classNames);
                 _classNames = new ReadOnlyMemory<char>[_numClasses];
                 classNames.CopyTo(_classNames);
             }

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Runtime.Data
             ReadOnlyMemory<char>[] names;
             // Get the label names from the score column if they exist, or use the default names.
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
-            var mdType = schema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, scoreInfo.Index);
+            var mdType = schema.Schema[scoreInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
             var labelNames = default(VBuffer<ReadOnlyMemory<char>>);
             if (mdType != null && mdType.IsKnownSizeVector && mdType.ItemType.IsText)
             {

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -813,10 +813,10 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertNonEmpty(ScoreCol);
             Host.AssertNonEmpty(LabelCol);
 
-            var t = schema.GetColumnType(ScoreIndex);
+            var t = schema[(int) ScoreIndex].Type;
             if (t.VectorSize < 2 || t.ItemType != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type '{1}' but must be a vector of two or more items of type R4", ScoreCol, t);
-            t = schema.GetColumnType(LabelIndex);
+            t = schema[LabelIndex].Type;
             if (t != NumberType.Float && t.KeyCount <= 0)
                 throw Host.Except("Label column '{0}' has type '{1}' but must be a float or a known-cardinality key", LabelCol, t);
         }
@@ -927,7 +927,7 @@ namespace Microsoft.ML.Runtime.Data
                     for (int col = 0; col < idv.Schema.Count; col++)
                     {
                         if (idv.Schema[col].IsHidden &&
-                            idv.Schema.GetColumnName(col).Equals(MultiClassClassifierEvaluator.PerClassLogLoss))
+                            idv.Schema[col].Name.Equals(MultiClassClassifierEvaluator.PerClassLogLoss))
                         {
                             idv = new ChooseColumnsByIndexTransform(Host,
                                 new ChooseColumnsByIndexTransform.Arguments() { Drop = true, Index = new[] { col } }, idv);
@@ -1000,18 +1000,18 @@ namespace Microsoft.ML.Runtime.Data
             // text file, since if there are different key counts the columns cannot be appended.
             if (!perInst.Schema.TryGetColumnIndex(schema.Label.Name, out int labelCol))
                 throw Host.Except("Could not find column '{0}'", schema.Label.Name);
-            var labelType = perInst.Schema.GetColumnType(labelCol);
+            var labelType = perInst.Schema[labelCol].Type;
             if (labelType is KeyType keyType && (!(bool) perInst.Schema[labelCol].HasKeyValues(keyType.KeyCount) || labelType.RawKind != DataKind.U4))
             {
                 perInst = LambdaColumnMapper.Create(Host, "ConvertToDouble", perInst, schema.Label.Name,
-                    schema.Label.Name, perInst.Schema.GetColumnType(labelCol), NumberType.R8,
+                    schema.Label.Name, perInst.Schema[labelCol].Type, NumberType.R8,
                     (in uint src, ref double dst) => dst = src == 0 ? double.NaN : src - 1 + (double)keyType.Min);
             }
 
             var perInstSchema = perInst.Schema;
             if (perInstSchema.TryGetColumnIndex(MultiClassPerInstanceEvaluator.SortedClasses, out int sortedClassesIndex))
             {
-                var type = perInstSchema.GetColumnType(sortedClassesIndex);
+                var type = perInstSchema[sortedClassesIndex].Type;
                 // Wrap with a DropSlots transform to pick only the first _numTopClasses slots.
                 if (_numTopClasses < type.VectorSize)
                     perInst = new SlotsDroppingTransformer(Host, MultiClassPerInstanceEvaluator.SortedClasses, min: _numTopClasses).Transform(perInst);
@@ -1020,7 +1020,7 @@ namespace Microsoft.ML.Runtime.Data
             // Wrap with a DropSlots transform to pick only the first _numTopClasses slots.
             if (perInst.Schema.TryGetColumnIndex(MultiClassPerInstanceEvaluator.SortedScores, out int sortedScoresIndex))
             {
-                var type = perInst.Schema.GetColumnType(sortedScoresIndex);
+                var type = perInst.Schema[sortedScoresIndex].Type;
                 if (_numTopClasses < type.VectorSize)
                    perInst = new SlotsDroppingTransformer(Host, MultiClassPerInstanceEvaluator.SortedScores, min: _numTopClasses).Transform(perInst);
             }

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -596,7 +596,7 @@ namespace Microsoft.ML.Runtime.Data
             if (type != null && type.IsText)
             {
                 return
-                    (ref VBuffer<ReadOnlyMemory<char>> dst) => schema.GetMetadata(MetadataUtils.Kinds.SlotNames, column, ref dst);
+                    (ref VBuffer<ReadOnlyMemory<char>> dst) => schema[column].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref dst);
             }
             return
                 (ref VBuffer<ReadOnlyMemory<char>> dst) =>

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -546,7 +546,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertNonEmpty(ScoreCol);
             Host.AssertNonEmpty(LabelCol);
 
-            var t = schema.GetColumnType(LabelIndex);
+            var t = schema[(int) LabelIndex].Type;
             if (!t.IsKnownSizeVector || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
                 throw Host.Except("Label column '{0}' has type '{1}' but must be a known-size vector of R4 or R8", LabelCol, t);
             labelType = new VectorType((PrimitiveType)t.ItemType, t.VectorSize);
@@ -555,7 +555,7 @@ namespace Microsoft.ML.Runtime.Data
             builder.AddSlotNames(t.VectorSize, CreateSlotNamesGetter(schema, LabelIndex, labelType.VectorSize, "True"));
             labelMetadata = builder.GetMetadata();
 
-            t = schema.GetColumnType(ScoreIndex);
+            t = schema[ScoreIndex].Type;
             if (t.VectorSize == 0 || t.ItemType != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type '{1}' but must be a known length vector of type R4", ScoreCol, t);
             scoreType = new VectorType((PrimitiveType)t.ItemType, t.VectorSize);
@@ -688,7 +688,7 @@ namespace Microsoft.ML.Runtime.Data
                 ValueGetter<uint> stratGetter;
                 if (hasStrats)
                 {
-                    var type = cursor.Schema.GetColumnType(stratCol);
+                    var type = cursor.Schema[stratCol].Type;
                     stratGetter = RowCursorUtils.GetGetterAs<uint>(type, cursor, stratCol);
                 }
                 else
@@ -703,7 +703,7 @@ namespace Microsoft.ML.Runtime.Data
                         continue;
                     }
 
-                    var type = fold.Schema.GetColumnType(i);
+                    var type = fold.Schema[i].Type;
                     if (type.IsKnownSizeVector && type.ItemType == NumberType.R8)
                     {
                         vBufferGetters[i] = cursor.GetGetter<VBuffer<double>>(i);
@@ -752,7 +752,7 @@ namespace Microsoft.ML.Runtime.Data
                             vBufferGetters[i](ref metricVals);
                             ch.Assert(metricVals.Length == labelCount);
 
-                            sb.AppendFormat("{0}{1,12}:", isWeighted ? "Weighted " : "", fold.Schema.GetColumnName(i));
+                            sb.AppendFormat("{0}{1,12}:", isWeighted ? "Weighted " : "", fold.Schema[i].Name);
                             foreach (var metric in metricVals.Items(all: true))
                                 sb.AppendFormat(" {0,20:G20}", metric.Value);
                             sb.AppendLine();

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -592,7 +592,7 @@ namespace Microsoft.ML.Runtime.Data
 
         private ValueGetter<VBuffer<ReadOnlyMemory<char>>> CreateSlotNamesGetter(Schema schema, int column, int length, string prefix)
         {
-            var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, column);
+            var type = schema[column].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
             if (type != null && type.IsText)
             {
                 return

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -673,7 +673,7 @@ namespace Microsoft.ML.Runtime.Data
             bool hasStratVals = fold.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratVal, out stratVal);
             ch.Assert(hasStrats == hasStratVals);
 
-            var colCount = fold.Schema.ColumnCount;
+            var colCount = fold.Schema.Count;
             var vBufferGetters = new ValueGetter<VBuffer<double>>[colCount];
 
             using (var cursor = fold.GetRowCursor(col => true))
@@ -695,7 +695,7 @@ namespace Microsoft.ML.Runtime.Data
                     stratGetter = (ref uint dst) => dst = 0;
 
                 int labelCount = 0;
-                for (int i = 0; i < fold.Schema.ColumnCount; i++)
+                for (int i = 0; i < fold.Schema.Count; i++)
                 {
                     if (fold.Schema[i].IsHidden || (needWeighted && i == isWeightedCol) ||
                         (hasStrats && (i == stratCol || i == stratVal)))

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.CheckParam(schema.Label != null, nameof(schema), "Schema must contain a label column");
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             int scoreSize = scoreInfo.Type.VectorSize;
-            var type = schema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, scoreInfo.Index);
+            var type = schema.Schema[scoreInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
             Host.Check(type != null && type.IsKnownSizeVector && type.ItemType.IsText, "Quantile regression score column must have slot names");
             var quantiles = default(VBuffer<ReadOnlyMemory<char>>);
             schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, scoreInfo.Index, ref quantiles);
@@ -74,9 +74,9 @@ namespace Microsoft.ML.Runtime.Data
             var t = scoreInfo.Type;
             Host.Assert(t.VectorSize > 0 && (t.ItemType == NumberType.R4 || t.ItemType == NumberType.R8));
             var slotNames = default(VBuffer<ReadOnlyMemory<char>>);
-            t = schema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, scoreInfo.Index);
+            t = schema.Schema[scoreInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
             if (t != null && t.VectorSize == scoreInfo.Type.VectorSize && t.ItemType.IsText)
-                schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, scoreInfo.Index, ref slotNames);
+                schema.Schema[scoreInfo.Index].GetSlotNames(ref slotNames);
             return new Aggregator(Host, LossFunction, schema.Weight != null, scoreInfo.Type.VectorSize, in slotNames, stratName);
         }
 
@@ -447,7 +447,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertNonEmpty(ScoreCol);
             Host.AssertNonEmpty(LabelCol);
 
-            var t = schema[(int) LabelIndex].Type;
+            var t = schema[(int)LabelIndex].Type;
             if (t != NumberType.R4)
                 throw Host.Except("Label column '{0}' has type '{1}' but must be R4", LabelCol, t);
 

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -447,11 +447,11 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertNonEmpty(ScoreCol);
             Host.AssertNonEmpty(LabelCol);
 
-            var t = schema.GetColumnType(LabelIndex);
+            var t = schema[(int) LabelIndex].Type;
             if (t != NumberType.R4)
                 throw Host.Except("Label column '{0}' has type '{1}' but must be R4", LabelCol, t);
 
-            t = schema.GetColumnType(ScoreIndex);
+            t = schema[ScoreIndex].Type;
             if (t.VectorSize == 0 || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
             {
                 throw Host.Except(
@@ -515,10 +515,10 @@ namespace Microsoft.ML.Runtime.Data
             IDataView output = data;
             for (int i = 0; i < data.Schema.Count; i++)
             {
-                var type = data.Schema.GetColumnType(i);
+                var type = data.Schema[i].Type;
                 if (type.IsKnownSizeVector && type.ItemType == NumberType.R8)
                 {
-                    var name = data.Schema.GetColumnName(i);
+                    var name = data.Schema[i].Name;
                     var index = _index ?? type.VectorSize / 2;
                     output = LambdaColumnMapper.Create(Host, "Quantile Regression", output, name, name, type, NumberType.R8,
                         (in VBuffer<Double> src, ref Double dst) => dst = src.GetItemOrDefault(index));

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime.Data
             var type = schema.Schema[scoreInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
             Host.Check(type != null && type.IsKnownSizeVector && type.ItemType.IsText, "Quantile regression score column must have slot names");
             var quantiles = default(VBuffer<ReadOnlyMemory<char>>);
-            schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, scoreInfo.Index, ref quantiles);
+            schema.Schema[scoreInfo.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref quantiles);
             Host.Assert(quantiles.IsDense && quantiles.Length == scoreSize);
 
             return new QuantileRegressionPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, schema.Label.Name, scoreSize, quantiles);

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -513,7 +513,7 @@ namespace Microsoft.ML.Runtime.Data
         private IDataView ExtractRelevantIndex(IDataView data)
         {
             IDataView output = data;
-            for (int i = 0; i < data.Schema.ColumnCount; i++)
+            for (int i = 0; i < data.Schema.Count; i++)
             {
                 var type = data.Schema.GetColumnType(i);
                 if (type.IsKnownSizeVector && type.ItemType == NumberType.R8)

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -318,11 +318,11 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertNonEmpty(ScoreCol);
             Host.AssertNonEmpty(LabelCol);
 
-            var t = schema.GetColumnType(LabelIndex);
+            var t = schema[(int) LabelIndex].Type;
             if (t != NumberType.R4)
                 throw Host.Except("Label column '{0}' has type '{1}' but must be R4", LabelCol, t);
 
-            t = schema.GetColumnType(ScoreIndex);
+            t = schema[ScoreIndex].Type;
             if (t.IsVector || t.ItemType != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type '{1}' but must be R4", ScoreCol, t);
         }

--- a/src/Microsoft.ML.Data/Model/Pfa/BoundPfaContext.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/BoundPfaContext.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             recordType["name"] = "DataInput";
             var fields = new JArray();
             var fieldNames = new HashSet<string>();
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
             {
                 if (schema[c].IsHidden)
                     continue;
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
         private JToken PfaTypeOrNullForColumn(Schema schema, int col)
         {
             _host.AssertValue(schema);
-            _host.Assert(0 <= col && col < schema.ColumnCount);
+            _host.Assert(0 <= col && col < schema.Count);
 
             ColumnType type = schema.GetColumnType(col);
             return T.PfaTypeOrNullForColumnType(type);

--- a/src/Microsoft.ML.Data/Model/Pfa/BoundPfaContext.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/BoundPfaContext.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             {
                 if (schema[c].IsHidden)
                     continue;
-                string name = schema.GetColumnName(c);
+                string name = schema[c].Name;
                 if (toDrop.Contains(name))
                     continue;
                 JToken pfaType = PfaTypeOrNullForColumn(schema, c);
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             _host.AssertValue(schema);
             _host.Assert(0 <= col && col < schema.Count);
 
-            ColumnType type = schema.GetColumnType(col);
+            ColumnType type = schema[col].Type;
             return T.PfaTypeOrNullForColumnType(type);
         }
 

--- a/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             {
                 if (end.Schema[i].IsHidden)
                     continue;
-                var name = end.Schema.GetColumnName(i);
+                var name = end.Schema[i].Name;
                 if (_outputsToDrop.Contains(name))
                     continue;
                 if (!ctx.IsInput(name) || _keepInput)

--- a/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/SavePfaCommand.cs
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Runtime.Model.Pfa
             }
 
             var toExport = new List<string>();
-            for (int i = 0; i < end.Schema.ColumnCount; ++i)
+            for (int i = 0; i < end.Schema.Count; ++i)
             {
                 if (end.Schema[i].IsHidden)
                     continue;

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -534,7 +534,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 env.Check(_predictor != null, "Predictor is not a row-to-row mapper");
                 if (!_predictor.OutputSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out _scoreCol))
                     throw env.Except("Predictor does not output a score");
-                var scoreType = _predictor.OutputSchema.GetColumnType(_scoreCol);
+                var scoreType = _predictor.OutputSchema[_scoreCol].Type;
                 env.Check(!scoreType.IsVector && scoreType.IsNumber);
                 OutputSchema = Schema.Create(new BinaryClassifierSchema());
             }
@@ -569,7 +569,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 var getters = new Delegate[OutputSchema.Count];
                 for (int i = 0; i < OutputSchema.Count - 1; i++)
                 {
-                    var type = predictorRow.Schema.GetColumnType(i);
+                    var type = predictorRow.Schema[i].Type;
                     if (!predicate(i))
                         continue;
                     getters[i] = Utils.MarshalInvoke(GetPredictorGetter<int>, type.RawType, predictorRow, i);
@@ -733,7 +733,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                 ch.Info("Not training a calibrator because the predictor does not output a score column.");
                 return false;
             }
-            var type = outputSchema.GetColumnType(scoreCol);
+            var type = outputSchema[scoreCol].Type;
             if (type != NumberType.Float)
             {
                 ch.Info("Not training a calibrator because the predictor output is {0}, but expected to be {1}.", type, NumberType.R4);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -541,7 +541,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                         return _predictor.GetDependencies(col => true);
@@ -557,7 +557,7 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
             public Row GetRow(Row input, Func<int, bool> predicate)
             {
                 Func<int, bool> predictorPredicate = col => false;
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                     {
@@ -566,16 +566,16 @@ namespace Microsoft.ML.Runtime.Internal.Calibration
                     }
                 }
                 var predictorRow = _predictor.GetRow(input, predictorPredicate);
-                var getters = new Delegate[OutputSchema.ColumnCount];
-                for (int i = 0; i < OutputSchema.ColumnCount - 1; i++)
+                var getters = new Delegate[OutputSchema.Count];
+                for (int i = 0; i < OutputSchema.Count - 1; i++)
                 {
                     var type = predictorRow.Schema.GetColumnType(i);
                     if (!predicate(i))
                         continue;
                     getters[i] = Utils.MarshalInvoke(GetPredictorGetter<int>, type.RawType, predictorRow, i);
                 }
-                if (predicate(OutputSchema.ColumnCount - 1))
-                    getters[OutputSchema.ColumnCount - 1] = GetProbGetter(predictorRow);
+                if (predicate(OutputSchema.Count - 1))
+                    getters[OutputSchema.Count - 1] = GetProbGetter(predictorRow);
                 return new SimpleRow(OutputSchema, predictorRow, getters);
             }
 

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Runtime.Data
 
             if (trainSchema?.Label == null)
                 return mapper; // We don't even have a label identified in a training schema.
-            var keyType = trainSchema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, trainSchema.Label.Index);
+            var keyType = trainSchema.Schema[trainSchema.Label.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             if (keyType == null || !CanWrap(mapper, keyType))
                 return mapper;
 
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Runtime.Data
             int scoreIdx;
             if (!mapper.OutputSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIdx))
                 return false; // The mapper doesn't even publish a score column to attach the metadata to.
-            if (mapper.OutputSchema.GetMetadataTypeOrNull(MetadataUtils.Kinds.TrainingLabelValues, scoreIdx) != null)
+            if (mapper.OutputSchema[scoreIdx].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.TrainingLabelValues)?.Type != null)
                 return false; // The mapper publishes a score column, and already produces its own slot names.
 
             return labelNameType.IsVector && labelNameType.VectorSize == 2;
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Runtime.Data
             env.Assert(mapper is ISchemaBoundRowMapper);
 
             // Key values from the training schema label, will map to slot names of the score output.
-            var type = trainSchema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, trainSchema.Label.Index);
+            var type = trainSchema.Schema[trainSchema.Label.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             env.AssertValue(type);
             env.Assert(type.IsVector);
 

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -119,8 +119,7 @@ namespace Microsoft.ML.Runtime.Data
             ValueGetter<VBuffer<T>> getter =
                 (ref VBuffer<T> value) =>
                 {
-                    trainSchema.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues,
-                        trainSchema.Label.Index, ref value);
+                    trainSchema.Schema[trainSchema.Label.Index].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref value);
                 };
 
             return MultiClassClassifierScorer.LabelNameBindableMapper.CreateBound<T>(env, (ISchemaBoundRowMapper)mapper, type as VectorType, getter, MetadataUtils.Kinds.TrainingLabelValues, CanWrap);

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 Contracts.CheckValue(input, nameof(input));
                 Contracts.Check(0 <= colSrc && colSrc < input.Schema.Count);
-                var typeSrc = input.Schema.GetColumnType(colSrc);
+                var typeSrc = input.Schema[colSrc].Type;
 
                 Func<Row, int, VBuffer<ReadOnlyMemory<char>>, ValueGetter<ReadOnlyMemory<char>>> del = GetTextValueGetter<int>;
                 var meth = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(typeSrc.RawType);
@@ -230,7 +230,7 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.CheckValue(input, nameof(input));
                 Contracts.Check(0 <= colSrc && colSrc < input.Schema.Count);
 
-                var typeSrc = input.Schema.GetColumnType(colSrc);
+                var typeSrc = input.Schema[colSrc].Type;
                 Func<Row, int, ValueGetter<VBuffer<float>>> del = GetValueGetter<int>;
 
                 // REVIEW: Assuming Feature contributions will be VBuffer<float>.
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Runtime.Data
                 _ectx.CheckNonEmpty(columnName, nameof(columnName));
                 _parentSchema = parentSchema;
                 _featureCol = featureCol;
-                _featureVectorSize = _parentSchema.GetColumnType(_featureCol).VectorSize;
+                _featureVectorSize = _parentSchema[_featureCol].Type.VectorSize;
                 _hasSlotNames = _parentSchema[_featureCol].HasSlotNames(_featureVectorSize);
 
                 _names = new string[] { columnName };

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
@@ -357,7 +357,7 @@ namespace Microsoft.ML.Runtime.Data
                     builder.AddColumn(DefaultColumnNames.FeatureContributions, TextType.Instance, null);
                     _outputSchema = builder.GetSchema();
                     if (InputSchema[InputRoleMappedSchema.Feature.Index].HasSlotNames(InputRoleMappedSchema.Feature.Type.VectorSize))
-                        InputSchema.GetMetadata(MetadataUtils.Kinds.SlotNames, InputRoleMappedSchema.Feature.Index, ref _slotNames);
+                        InputSchema[InputRoleMappedSchema.Feature.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref _slotNames);
                     else
                         _slotNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(InputRoleMappedSchema.Feature.Type.VectorSize);
                 }
@@ -486,7 +486,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 _ectx.CheckParam(col == 0, nameof(col));
                 if (kind == MetadataUtils.Kinds.SlotNames && _hasSlotNames)
-                    _parentSchema.GetMetadata(kind, _featureCol, ref value);
+                    _parentSchema[_featureCol].Metadata.GetValue(kind, ref value);
                 else
                     throw MetadataUtils.ExceptGetMetadata();
             }

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculationTransform.cs
@@ -217,7 +217,7 @@ namespace Microsoft.ML.Runtime.Data
             public Delegate GetTextContributionGetter(Row input, int colSrc, VBuffer<ReadOnlyMemory<char>> slotNames)
             {
                 Contracts.CheckValue(input, nameof(input));
-                Contracts.Check(0 <= colSrc && colSrc < input.Schema.ColumnCount);
+                Contracts.Check(0 <= colSrc && colSrc < input.Schema.Count);
                 var typeSrc = input.Schema.GetColumnType(colSrc);
 
                 Func<Row, int, VBuffer<ReadOnlyMemory<char>>, ValueGetter<ReadOnlyMemory<char>>> del = GetTextValueGetter<int>;
@@ -228,7 +228,7 @@ namespace Microsoft.ML.Runtime.Data
             public Delegate GetContributionGetter(Row input, int colSrc)
             {
                 Contracts.CheckValue(input, nameof(input));
-                Contracts.Check(0 <= colSrc && colSrc < input.Schema.ColumnCount);
+                Contracts.Check(0 <= colSrc && colSrc < input.Schema.Count);
 
                 var typeSrc = input.Schema.GetColumnType(colSrc);
                 Func<Row, int, ValueGetter<VBuffer<float>>> del = GetValueGetter<int>;
@@ -377,7 +377,7 @@ namespace Microsoft.ML.Runtime.Data
             /// </summary>
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                         return col => col == InputRoleMappedSchema.Feature.Index;
@@ -389,7 +389,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 Contracts.AssertValue(input);
                 Contracts.AssertValue(active);
-                var totalColumnsCount = 1 + _outputGenericSchema.ColumnCount;
+                var totalColumnsCount = 1 + _outputGenericSchema.Count;
                 var getters = new Delegate[totalColumnsCount];
 
                 if (active(totalColumnsCount - 1))
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Runtime.Data
                 }
 
                 var genericRow = _genericRowMapper.GetRow(input, GetGenericPredicate(active));
-                for (var i = 0; i < _outputGenericSchema.ColumnCount; i++)
+                for (var i = 0; i < _outputGenericSchema.Count; i++)
                 {
                     if (genericRow.IsColumnActive(i))
                         getters[i] = RowCursorUtils.GetGetterAsDelegate(genericRow, i);

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -430,8 +430,7 @@ namespace Microsoft.ML.Runtime.Data
             ValueGetter<VBuffer<T>> getter =
                 (ref VBuffer<T> value) =>
                 {
-                    trainSchema.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues,
-                        trainSchema.Label.Index, ref value);
+                    trainSchema.Schema[trainSchema.Label.Index].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref value);
                 };
 
             return LabelNameBindableMapper.CreateBound<T>(env, (ISchemaBoundRowMapper)mapper, type as VectorType, getter, MetadataUtils.Kinds.SlotNames, CanWrap);

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Runtime.Data
                     var builder = new SchemaBuilder();
                     // Sequentially add columns so that the order of them is not changed comparing with the schema in the mapper
                     // that computes score column.
-                    for (int i = 0; i < partialSchema.ColumnCount; ++i)
+                    for (int i = 0; i < partialSchema.Count; ++i)
                     {
                         var meta = new MetadataBuilder();
                         if (i == scoreColumnIndex)

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -373,7 +373,7 @@ namespace Microsoft.ML.Runtime.Data
 
             if (trainSchema == null || trainSchema.Label == null)
                 return mapper; // We don't even have a label identified in a training schema.
-            var keyType = trainSchema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, trainSchema.Label.Index);
+            var keyType = trainSchema.Schema[trainSchema.Label.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             if (keyType == null || !CanWrap(mapper, keyType))
                 return mapper;
 
@@ -406,7 +406,7 @@ namespace Microsoft.ML.Runtime.Data
             int scoreIdx;
             if (!outSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIdx))
                 return false; // The mapper doesn't even publish a score column to attach the metadata to.
-            if (outSchema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, scoreIdx) != null)
+            if (outSchema[scoreIdx].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type != null)
                 return false; // The mapper publishes a score column, and already produces its own slot names.
             var scoreType = outSchema[scoreIdx].Type;
 
@@ -422,7 +422,7 @@ namespace Microsoft.ML.Runtime.Data
             env.Assert(mapper is ISchemaBoundRowMapper);
 
             // Key values from the training schema label, will map to slot names of the score output.
-            var type = trainSchema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, trainSchema.Label.Index);
+            var type = trainSchema.Schema[trainSchema.Label.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             env.AssertValue(type);
             env.Assert(type.IsVector);
 

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -408,7 +408,7 @@ namespace Microsoft.ML.Runtime.Data
                 return false; // The mapper doesn't even publish a score column to attach the metadata to.
             if (outSchema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, scoreIdx) != null)
                 return false; // The mapper publishes a score column, and already produces its own slot names.
-            var scoreType = outSchema.GetColumnType(scoreIdx);
+            var scoreType = outSchema[scoreIdx].Type;
 
             // Check that the type is vector, and is of compatible size with the score output.
             return labelNameType.IsVector && labelNameType.VectorSize == scoreType.VectorSize;

--- a/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Runtime.Data
                 env.AssertValue(input);
                 env.AssertValue(bindable);
 
-                string scoreCol = RowMapper.OutputSchema.GetColumnName(ScoreColumnIndex);
+                string scoreCol = RowMapper.OutputSchema[ScoreColumnIndex].Name;
                 var schema = new RoleMappedSchema(input, RowMapper.GetInputColumnRoles());
 
                 // Checks compatibility of the predictor input types.
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Runtime.Data
                 int scoreColIndex;
                 env.CheckDecode(mapper.OutputSchema.TryGetColumnIndex(scoreCol, out scoreColIndex));
 
-                var scoreType = mapper.OutputSchema.GetColumnType(scoreColIndex);
+                var scoreType = mapper.OutputSchema[scoreColIndex].Type;
                 env.CheckDecode(outputTypeMatches(scoreType));
                 var predColType = getPredColType(scoreType, rowMapper);
 
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Runtime.Data
                 // int: id of the column used for deriving the predicted label column
                 SaveBase(ctx);
                 ctx.SaveNonEmptyString(ScoreColumnKind);
-                ctx.SaveNonEmptyString(RowMapper.OutputSchema.GetColumnName(ScoreColumnIndex));
+                ctx.SaveNonEmptyString(RowMapper.OutputSchema[ScoreColumnIndex].Name);
             }
 
             protected override ColumnType GetColumnTypeCore(int iinfo)
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Runtime.Data
                     {
                         var sch = _predColMetadata.Schema;
                         for (int i = 0; i < sch.Count; ++i)
-                            yield return new KeyValuePair<string, ColumnType>(sch.GetColumnName(i), sch.GetColumnType(i));
+                            yield return new KeyValuePair<string, ColumnType>(sch[i].Name, sch[i].Type);
                     }
                 }
                 foreach (var pair in base.GetMetadataTypesCore(iinfo))
@@ -215,7 +215,7 @@ namespace Microsoft.ML.Runtime.Data
                 {
                     int mcol;
                     if (_predColMetadata.Schema.TryGetColumnIndex(kind, out mcol))
-                        return _predColMetadata.Schema.GetColumnType(mcol);
+                        return _predColMetadata.Schema[mcol].Type;
                 }
                 return base.GetMetadataTypeCore(kind, iinfo);
             }
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Runtime.Data
             if (!mapper.OutputSchema.TryGetColumnIndex(scoreColName, out scoreColIndex))
                 throw Host.ExceptParam(nameof(scoreColName), "mapper does not contain a column '{0}'", scoreColName);
 
-            var scoreType = mapper.OutputSchema.GetColumnType(scoreColIndex);
+            var scoreType = mapper.OutputSchema[scoreColIndex].Type;
             Host.Check(outputTypeMatches(scoreType), "Unexpected predictor output type");
             var predColType = getPredColType(scoreType, rowMapper);
 

--- a/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Runtime.Data
             private static Schema.Metadata KeyValueMetadataFromMetadata<T>(Schema.Metadata meta, Schema.Column metaCol)
             {
                 Contracts.AssertValue(meta);
-                Contracts.Assert(0 <= metaCol.Index && metaCol.Index < meta.Schema.ColumnCount);
+                Contracts.Assert(0 <= metaCol.Index && metaCol.Index < meta.Schema.Count);
                 Contracts.Assert(metaCol.Type.RawType == typeof(T));
                 var getter = meta.GetGetter<T>(metaCol.Index);
                 var builder = new MetadataBuilder();
@@ -192,7 +192,7 @@ namespace Microsoft.ML.Runtime.Data
                     if (_predColMetadata != null)
                     {
                         var sch = _predColMetadata.Schema;
-                        for (int i = 0; i < sch.ColumnCount; ++i)
+                        for (int i = 0; i < sch.Count; ++i)
                             yield return new KeyValuePair<string, ColumnType>(sch.GetColumnName(i), sch.GetColumnType(i));
                     }
                 }
@@ -406,7 +406,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.AssertValue(output);
             Host.AssertValue(predicate);
             Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
-            Host.Assert(Bindings.InfoCount == output.Schema.ColumnCount + 1);
+            Host.Assert(Bindings.InfoCount == output.Schema.Count + 1);
 
             var getters = new Delegate[Bindings.InfoCount];
 

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Runtime.Data
             else if (!trainSchema.TryGetColumnIndex(featureColumn, out int col))
                 throw Host.ExceptSchemaMismatch(nameof(featureColumn), RoleMappedSchema.ColumnRole.Feature.Value, featureColumn);
             else
-                FeatureColumnType = trainSchema.GetColumnType(col);
+                FeatureColumnType = trainSchema[col].Type;
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, model);
         }
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Runtime.Data
             else if (!TrainSchema.TryGetColumnIndex(FeatureColumn, out int col))
                 throw Host.ExceptSchemaMismatch(nameof(FeatureColumn), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumn);
             else
-                FeatureColumnType = TrainSchema.GetColumnType(col);
+                FeatureColumnType = TrainSchema[col].Type;
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, Model);
         }
@@ -206,8 +206,8 @@ namespace Microsoft.ML.Runtime.Data
             {
                 if (!inputSchema.TryGetColumnIndex(FeatureColumn, out int col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumn, FeatureColumnType.ToString(), null);
-                if (!inputSchema.GetColumnType(col).Equals(FeatureColumnType))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumn, FeatureColumnType.ToString(), inputSchema.GetColumnType(col).ToString());
+                if (!inputSchema[col].Type.Equals(FeatureColumnType))
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumn, FeatureColumnType.ToString(), inputSchema[col].Type.ToString());
             }
 
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -196,7 +196,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.Assert(0 <= col && col < row.Schema.Count);
             Contracts.Assert(row.IsColumnActive(col));
 
-            var type = row.Schema.GetColumnType(col);
+            var type = row.Schema[col].Type;
             Func<Row, int, ValueGetter<int>> del = GetGetterFromRow<int>;
             var meth = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(type.RawType);
             return (Delegate)meth.Invoke(null, new object[] { row, col });
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Runtime.Data
             for (int i = 0; i < namesDerived.Length; i++)
                 res[dst++] = namesDerived[i] + suffix;
             for (int i = 0; i < schema.Count; i++)
-                res[dst++] = schema.GetColumnName(i) + suffix;
+                res[dst++] = schema[i].Name + suffix;
             Contracts.Assert(dst == count);
             return res;
         }
@@ -406,7 +406,7 @@ namespace Microsoft.ML.Runtime.Data
         protected override ColumnType GetColumnTypeCore(int iinfo)
         {
             Contracts.Assert(DerivedColumnCount <= iinfo && iinfo < InfoCount);
-            return Mapper.OutputSchema.GetColumnType(iinfo - DerivedColumnCount);
+            return Mapper.OutputSchema[iinfo - DerivedColumnCount].Type;
         }
 
         protected override IEnumerable<KeyValuePair<string, ColumnType>> GetMetadataTypesCore(int iinfo)

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -181,7 +181,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.AssertValue(row);
             Contracts.AssertValue(predicate);
 
-            var getters = new Delegate[row.Schema.ColumnCount];
+            var getters = new Delegate[row.Schema.Count];
             for (int col = 0; col < getters.Length; col++)
             {
                 if (predicate(col))
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Runtime.Data
         protected static Delegate GetGetterFromRow(Row row, int col)
         {
             Contracts.AssertValue(row);
-            Contracts.Assert(0 <= col && col < row.Schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < row.Schema.Count);
             Contracts.Assert(row.IsColumnActive(col));
 
             var type = row.Schema.GetColumnType(col);
@@ -205,7 +205,7 @@ namespace Microsoft.ML.Runtime.Data
         protected static ValueGetter<T> GetGetterFromRow<T>(Row output, int col)
         {
             Contracts.AssertValue(output);
-            Contracts.Assert(0 <= col && col < output.Schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < output.Schema.Count);
             Contracts.Assert(output.IsColumnActive(col));
             return output.GetGetter<T>(col);
         }
@@ -344,12 +344,12 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.AssertValue(namesDerived);
 
             var schema = mapper.OutputSchema;
-            int count = namesDerived.Length + schema.ColumnCount;
+            int count = namesDerived.Length + schema.Count;
             var res = new string[count];
             int dst = 0;
             for (int i = 0; i < namesDerived.Length; i++)
                 res[dst++] = namesDerived[i] + suffix;
-            for (int i = 0; i < schema.ColumnCount; i++)
+            for (int i = 0; i < schema.Count; i++)
                 res[dst++] = schema.GetColumnName(i) + suffix;
             Contracts.Assert(dst == count);
             return res;
@@ -458,8 +458,8 @@ namespace Microsoft.ML.Runtime.Data
             return
                 col =>
                 {
-                    Contracts.Assert(0 <= col && col < Mapper.OutputSchema.ColumnCount);
-                    return 0 <= col && col < Mapper.OutputSchema.ColumnCount &&
+                    Contracts.Assert(0 <= col && col < Mapper.OutputSchema.Count);
+                    return 0 <= col && col < Mapper.OutputSchema.Count &&
                         active[MapIinfoToCol(col + DerivedColumnCount)];
                 };
         }

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Runtime.Data
                 default:
                     if (iinfo < DerivedColumnCount)
                         throw MetadataUtils.ExceptGetMetadata();
-                    Mapper.OutputSchema.GetMetadata<TValue>(kind, iinfo - DerivedColumnCount, ref value);
+                    Mapper.OutputSchema[iinfo - DerivedColumnCount].Metadata.GetValue(kind, ref value);
                     break;
             }
         }

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -416,7 +416,7 @@ namespace Microsoft.ML.Runtime.Data
             yield return MetadataUtils.ScoreColumnSetIdType.GetPair(MetadataUtils.Kinds.ScoreColumnSetId);
             if (iinfo < DerivedColumnCount)
                 yield break;
-            foreach (var pair in Mapper.OutputSchema.GetMetadataTypes(iinfo - DerivedColumnCount))
+            foreach (var pair in Mapper.OutputSchema[iinfo - DerivedColumnCount].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type)))
                 yield return pair;
         }
 
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Runtime.Data
                 return MetadataUtils.ScoreColumnSetIdType;
             if (iinfo < DerivedColumnCount)
                 return null;
-            return Mapper.OutputSchema.GetMetadataTypeOrNull(kind, iinfo - DerivedColumnCount);
+            return Mapper.OutputSchema[iinfo - DerivedColumnCount].Metadata.Schema.GetColumnOrNull(kind)?.Type;
         }
 
         protected override void GetMetadataCore<TValue>(string kind, int iinfo, ref TValue value)

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Runtime.Data
         protected virtual Delegate GetPredictionGetter(Row input, int colSrc)
         {
             Contracts.AssertValue(input);
-            Contracts.Assert(0 <= colSrc && colSrc < input.Schema.ColumnCount);
+            Contracts.Assert(0 <= colSrc && colSrc < input.Schema.Count);
 
             var typeSrc = input.Schema.GetColumnType(colSrc);
             Func<Row, int, ValueGetter<int>> del = GetValueGetter<int, int>;
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.AssertValue(schema);
                 Contracts.AssertValue(parent);
                 Contracts.AssertValue(schema.Feature);
-                Contracts.Assert(outputSchema.ColumnCount == 1);
+                Contracts.Assert(outputSchema.Count == 1);
 
                 _parent = parent;
                 InputRoleMappedSchema = schema;
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                         return col => col == InputRoleMappedSchema.Feature.Index;
@@ -496,7 +496,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i) && InputRoleMappedSchema.Feature != null)
                         return col => col == InputRoleMappedSchema.Feature.Index;
@@ -568,7 +568,7 @@ namespace Microsoft.ML.Runtime.Data
             public Row GetRow(Row input, Func<int, bool> predicate)
             {
                 Contracts.AssertValue(input);
-                var active = Utils.BuildArray(OutputSchema.ColumnCount, predicate);
+                var active = Utils.BuildArray(OutputSchema.Count, predicate);
                 var getters = CreateGetters(input, active);
                 return new SimpleRow(OutputSchema, input, getters);
             }
@@ -658,7 +658,7 @@ namespace Microsoft.ML.Runtime.Data
         protected override Delegate GetPredictionGetter(Row input, int colSrc)
         {
             Contracts.AssertValue(input);
-            Contracts.Assert(0 <= colSrc && colSrc < input.Schema.ColumnCount);
+            Contracts.Assert(0 <= colSrc && colSrc < input.Schema.Count);
 
             var typeSrc = input.Schema.GetColumnType(colSrc);
             Contracts.Assert(typeSrc.IsVector && typeSrc.ItemType == NumberType.Float);

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -149,7 +149,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.AssertValue(input);
             Contracts.Assert(0 <= colSrc && colSrc < input.Schema.Count);
 
-            var typeSrc = input.Schema.GetColumnType(colSrc);
+            var typeSrc = input.Schema[colSrc].Type;
             Func<Row, int, ValueGetter<int>> del = GetValueGetter<int, int>;
             var meth = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(typeSrc.RawType, ScoreType.RawType);
             return (Delegate)meth.Invoke(this, new object[] { input, colSrc });
@@ -660,7 +660,7 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.AssertValue(input);
             Contracts.Assert(0 <= colSrc && colSrc < input.Schema.Count);
 
-            var typeSrc = input.Schema.GetColumnType(colSrc);
+            var typeSrc = input.Schema[colSrc].Type;
             Contracts.Assert(typeSrc.IsVector && typeSrc.ItemType == NumberType.Float);
             Contracts.Assert(ValueMapper == null ||
                 typeSrc.VectorSize == ValueMapper.InputType.VectorSize || ValueMapper.InputType.VectorSize == 0);

--- a/src/Microsoft.ML.Data/StaticPipe/DataView.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/DataView.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ML.StaticPipe
         public DataView<TShape> Cache()
         {
             // Generate all column indexes in the source data.
-            var prefetched = Enumerable.Range(0, AsDynamic.Schema.ColumnCount).ToArray();
+            var prefetched = Enumerable.Range(0, AsDynamic.Schema.Count).ToArray();
             // Create a cached version of the source data by caching all columns.
             return new DataView<TShape>(Env, new CacheDataView(Env, AsDynamic, prefetched), Shape);
         }

--- a/src/Microsoft.ML.Data/StaticPipe/StaticSchemaShape.cs
+++ b/src/Microsoft.ML.Data/StaticPipe/StaticSchemaShape.cs
@@ -251,7 +251,7 @@ namespace Microsoft.ML.StaticPipe.Runtime
                     var meta = col.Metadata;
                     if (meta.Schema.TryGetColumnIndex(MetadataUtils.Kinds.IsNormalized, out int normcol))
                     {
-                        var normtype = meta.Schema.GetColumnType(normcol);
+                        var normtype = meta.Schema[normcol].Type;
                         if (normtype == BoolType.Instance)
                         {
                             bool val = default;

--- a/src/Microsoft.ML.Data/TrainContext.cs
+++ b/src/Microsoft.ML.Data/TrainContext.cs
@@ -139,7 +139,7 @@ namespace Microsoft.ML
                 if (!data.Schema.TryGetColumnIndex(stratificationColumn, out int stratCol))
                     throw Host.ExceptSchemaMismatch(nameof(stratificationColumn), "stratification", stratificationColumn);
 
-                var type = data.Schema.GetColumnType(stratCol);
+                var type = data.Schema[stratCol].Type;
                 if (!RangeFilter.IsValidRangeFilterColumnType(Host, type))
                 {
                     // Hash the stratification column.

--- a/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
@@ -839,7 +839,7 @@ namespace Microsoft.ML.Runtime.Data
                     if (!input.TryGetColumnIndex(src[j], out srcIndices[j]))
                         throw Contracts.ExceptUserArg(standardColumnArgName, "Source column '{0}' not found", src[j]);
 #pragma warning restore MSML_ContractsNameUsesNameof
-                    srcTypes[j] = input.GetColumnType(srcIndices[j]);
+                    srcTypes[j] = input[srcIndices[j]].Type;
                     var size = srcTypes[j].ValueCount;
                     srcSize = size == 0 ? null : checked(srcSize + size);
                 }
@@ -941,7 +941,7 @@ namespace Microsoft.ML.Runtime.Data
                         string src = ctx.LoadNonEmptyString();
                         if (!input.TryGetColumnIndex(src, out indices[j]))
                             throw Contracts.Except("Source column '{0}' is required but not found", src);
-                        srcTypes[j] = input.GetColumnType(indices[j]);
+                        srcTypes[j] = input[indices[j]].Type;
                         var size = srcTypes[j].ValueCount;
                         srcSize = size == 0 ? null : checked(srcSize + size);
                     }
@@ -952,7 +952,7 @@ namespace Microsoft.ML.Runtime.Data
                         if (reason != null)
                         {
                             throw Contracts.Except("Source columns '{0}' have invalid types: {1}. Source types: '{2}'.",
-                                string.Join(", ", indices.Select(k => input.GetColumnName(k))),
+                                string.Join(", ", indices.Select(k => input[k].Name)),
                                 reason,
                                 string.Join(", ", srcTypes.Select(type => type.ToString())));
                         }

--- a/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
@@ -679,7 +679,7 @@ namespace Microsoft.ML.Runtime.Data
             // Construct the indices.
             var indices = new List<int>();
             var namesUsed = new HashSet<string>();
-            for (int i = 0; i < input.ColumnCount; i++)
+            for (int i = 0; i < input.Count; i++)
             {
                 namesUsed.Add(input[i].Name);
                 indices.Add(i);
@@ -707,7 +707,7 @@ namespace Microsoft.ML.Runtime.Data
                     }
                 }
             }
-            Contracts.Assert(indices.Count == addedColumns.Length + input.ColumnCount);
+            Contracts.Assert(indices.Count == addedColumns.Length + input.Count);
 
             // Create the output schema.
             var schemaColumns = indices.Select(idx => idx >= 0 ? new Schema.DetachedColumn(input[idx]) : addedColumns[~idx]);
@@ -749,7 +749,7 @@ namespace Microsoft.ML.Runtime.Data
             }
             else
             {
-                Contracts.Assert(index < InputSchema.ColumnCount);
+                Contracts.Assert(index < InputSchema.Count);
                 isSrcColumn = true;
             }
             return index;
@@ -764,11 +764,11 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(predicate);
 
-            var active = new bool[InputSchema.ColumnCount];
+            var active = new bool[InputSchema.Count];
             for (int dst = 0; dst < _colMap.Length; dst++)
             {
                 int src = _colMap[dst];
-                Contracts.Assert(-AddedColumnIndices.Count <= src && src < InputSchema.ColumnCount);
+                Contracts.Assert(-AddedColumnIndices.Count <= src && src < InputSchema.Count);
                 if (src >= 0 && predicate(dst))
                     active[src] = true;
             }

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -457,7 +457,7 @@ namespace Microsoft.ML.Runtime.Data
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", srcName);
                     sources[i] = srcCol;
 
-                    var curType = inputSchema.GetColumnType(srcCol);
+                    var curType = inputSchema[srcCol].Type;
                     if (itemType == null)
                     {
                         itemType = curType.ItemType;
@@ -691,7 +691,7 @@ namespace Microsoft.ML.Runtime.Data
                                 if (type.VectorSize != 0 && type.VectorSize != tmpBufs[i].Length)
                                 {
                                     throw Contracts.Except("Column '{0}': expected {1} slots, but got {2}",
-                                        input.Schema.GetColumnName(SrcIndices[i]), type.VectorSize, tmpBufs[i].Length)
+                                        input.Schema[SrcIndices[i]].Name, type.VectorSize, tmpBufs[i].Length)
                                         .MarkSensitive(MessageSensitivity.Schema);
                                 }
                                 dstLength = checked(dstLength + tmpBufs[i].Length);

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -831,7 +831,7 @@ namespace Microsoft.ML.Runtime.Data
 
             private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
-                var active = new bool[InputSchema.ColumnCount];
+                var active = new bool[InputSchema.Count];
                 for (int i = 0; i < _columns.Length; i++)
                 {
                     if (activeOutput(i))

--- a/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
@@ -185,7 +185,7 @@ namespace Microsoft.ML.Transforms
                     => input.GetGetter<T>(index);
 
                 input.Schema.TryGetColumnIndex(_columns[iinfo].Source, out int colIndex);
-                var type = input.Schema.GetColumnType(colIndex);
+                var type = input.Schema[colIndex].Type;
                 return Utils.MarshalInvoke(MakeGetter<int>, type.RawType, input, colIndex);
             }
 
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Transforms
                 {
                     var srcVariableName = ctx.GetVariableName(column.Source);
                     _schema.TryGetColumnIndex(column.Source, out int colIndex);
-                    var dstVariableName = ctx.AddIntermediateVariable(_schema.GetColumnType(colIndex), column.Name);
+                    var dstVariableName = ctx.AddIntermediateVariable(_schema[colIndex].Type, column.Name);
                     var node = ctx.CreateNode(opType, srcVariableName, dstVariableName, ctx.GetNodeName(opType));
                     node.AddAttribute("type", LoaderSignature);
                 }

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -442,7 +442,7 @@ namespace Microsoft.ML.Transforms
         public Schema GetOutputSchema(Schema inputSchema)
         {
             _host.CheckValue(inputSchema, nameof(inputSchema));
-            if (!IgnoreMissing && !IsSchemaValid(inputSchema.GetColumns().Select(x => x.column.Name),
+            if (!IgnoreMissing && !IsSchemaValid(inputSchema.Select(x => x.Name),
                                                                 SelectColumns, out IEnumerable<string> invalidColumns))
             {
                 throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", string.Join(",", invalidColumns));
@@ -454,7 +454,7 @@ namespace Microsoft.ML.Transforms
         public IRowToRowMapper GetRowToRowMapper(Schema inputSchema)
         {
             _host.CheckValue(inputSchema, nameof(inputSchema));
-            if (!IgnoreMissing && !IsSchemaValid(inputSchema.GetColumns().Select(x => x.column.Name),
+            if (!IgnoreMissing && !IsSchemaValid(inputSchema.Select(x => x.Name),
                                                     SelectColumns, out IEnumerable<string> invalidColumns))
             {
                 throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", string.Join(",", invalidColumns));
@@ -468,7 +468,7 @@ namespace Microsoft.ML.Transforms
         public IDataView Transform(IDataView input)
         {
             _host.CheckValue(input, nameof(input));
-            if (!IgnoreMissing && !IsSchemaValid(input.Schema.GetColumns().Select(x => x.column.Name),
+            if (!IgnoreMissing && !IsSchemaValid(input.Schema.Select(x => x.Name),
                                                     SelectColumns, out IEnumerable<string> invalidColumns))
             {
                 throw _host.ExceptSchemaMismatch(nameof(input), "input", string.Join(",", invalidColumns));
@@ -511,7 +511,7 @@ namespace Microsoft.ML.Transforms
                 Schema inputSchema)
             {
                 var outputToInputMapping = new List<int>();
-                var columnCount = inputSchema.ColumnCount;
+                var columnCount = inputSchema.Count;
 
                 if (keepColumns)
                 {
@@ -523,7 +523,7 @@ namespace Microsoft.ML.Transforms
                     // column name-> list of column indices. This dictionary is used for
                     // building the final mapping.
                     var columnDict = new Dictionary<string, List<int>>();
-                    for (int colIdx = 0; colIdx < inputSchema.ColumnCount; ++colIdx)
+                    for (int colIdx = 0; colIdx < inputSchema.Count; ++colIdx)
                     {
                         if (!keepHidden && inputSchema[colIdx].IsHidden)
                             continue;
@@ -559,7 +559,7 @@ namespace Microsoft.ML.Transforms
                     // given an input of ABC and dropping column B will result in AC.
                     // In drop mode, we drop all columns with the specified names and keep all the rest,
                     // ignoring the keepHidden argument.
-                    for(int colIdx = 0; colIdx < inputSchema.ColumnCount; colIdx++)
+                    for(int colIdx = 0; colIdx < inputSchema.Count; colIdx++)
                     {
                         if (selectedColumns.Contains(inputSchema[colIdx].Name))
                             continue;
@@ -635,7 +635,7 @@ namespace Microsoft.ML.Transforms
                 var inputRowCursor = Source.GetRowCursor(inputPred, rand);
 
                 // Build the active state for the output
-                var active = Utils.BuildArray(_mapper.OutputSchema.ColumnCount, needCol);
+                var active = Utils.BuildArray(_mapper.OutputSchema.Count, needCol);
                 return new Cursor(_host, _mapper, inputRowCursor, active);
             }
 
@@ -649,7 +649,7 @@ namespace Microsoft.ML.Transforms
                 var inputs = Source.GetRowCursorSet(out consolidator, inputPred, n, rand);
 
                 // Build out the acitve state for the output
-                var active = Utils.BuildArray(_mapper.OutputSchema.ColumnCount, needCol);
+                var active = Utils.BuildArray(_mapper.OutputSchema.Count, needCol);
                 _host.AssertNonEmpty(inputs);
 
                 // No need to split if this is given 1 input cursor.
@@ -665,8 +665,8 @@ namespace Microsoft.ML.Transforms
 
             public Func<int, bool> GetDependencies(Func<int, bool> activeOutput)
             {
-                var active = new bool[_mapper.InputSchema.ColumnCount];
-                var columnCount = _mapper.OutputSchema.ColumnCount;
+                var active = new bool[_mapper.InputSchema.Count];
+                var columnCount = _mapper.OutputSchema.Count;
                 for (int colIdx = 0; colIdx < columnCount; ++colIdx)
                 {
                     if (activeOutput(colIdx))

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -463,7 +463,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                 {
                     if (!InputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out _cols[i]))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].input);
-                    _srcTypes[i] = inputSchema.GetColumnType(_cols[i]);
+                    _srcTypes[i] = inputSchema[_cols[i]].Type;
                     if (!IsValidColumnType(_srcTypes[i].ItemType))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].input);
                     _slotDropper[i] = new SlotDropper(_srcTypes[i].ValueCount, _parent.SlotsMin[i], _parent.SlotsMax[i]);

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -528,7 +528,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
 
                 var names = default(VBuffer<ReadOnlyMemory<char>>);
-                InputSchema.GetMetadata(MetadataUtils.Kinds.SlotNames, _cols[iinfo], ref names);
+                InputSchema[_cols[iinfo]].GetSlotNames(ref names);
                 _slotDropper[iinfo].DropSlots(ref names, ref dst);
             }
 

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -717,7 +717,7 @@ namespace Microsoft.ML.Transforms.Conversions
         {
             Contracts.Assert(Utils.IsPowerOfTwo(mask + 1));
             Contracts.AssertValue(input);
-            Contracts.Assert(0 <= srcCol && srcCol < input.Schema.ColumnCount);
+            Contracts.Assert(0 <= srcCol && srcCol < input.Schema.Count);
             Contracts.Assert(input.Schema.GetColumnType(srcCol).RawType == typeof(T));
 
             var srcGetter = input.GetGetter<T>(srcCol);

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             if (!HashingEstimator.IsColumnTypeValid(type))
                 throw Host.ExceptParam(nameof(inputSchema), HashingEstimator.ExpectedColumnType);
         }
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Transforms.Conversions
             var keyCount = column.HashBits < 31 ? 1 << column.HashBits : 0;
             inputSchema.TryGetColumnIndex(column.Input, out int srcCol);
             var itemType = new KeyType(DataKind.U4, 0, keyCount, keyCount > 0);
-            var srcType = inputSchema.GetColumnType(srcCol);
+            var srcType = inputSchema[srcCol].Type;
             if (!srcType.IsVector)
                 return itemType;
             else
@@ -316,7 +316,7 @@ namespace Microsoft.ML.Transforms.Conversions
             Host.Assert(0 <= iinfo && iinfo < _columns.Length);
             disposer = null;
             input.Schema.TryGetColumnIndex(_columns[iinfo].Input, out int srcCol);
-            var srcType = input.Schema.GetColumnType(srcCol);
+            var srcType = input.Schema[srcCol].Type;
             if (!srcType.IsVector)
                 return ComposeGetterOne(input, iinfo, srcCol, srcType);
             return ComposeGetterVec(input, iinfo, srcCol, srcType);
@@ -718,7 +718,7 @@ namespace Microsoft.ML.Transforms.Conversions
             Contracts.Assert(Utils.IsPowerOfTwo(mask + 1));
             Contracts.AssertValue(input);
             Contracts.Assert(0 <= srcCol && srcCol < input.Schema.Count);
-            Contracts.Assert(input.Schema.GetColumnType(srcCol).RawType == typeof(T));
+            Contracts.Assert(input.Schema[srcCol].Type.RawType == typeof(T));
 
             var srcGetter = input.GetGetter<T>(srcCol);
             T src = default;
@@ -934,7 +934,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 Row = row;
                 row.Schema.TryGetColumnIndex(ex.Input, out int srcCol);
                 _srcCol = srcCol;
-                _srcType = row.Schema.GetColumnType(srcCol);
+                _srcType = row.Schema[srcCol].Type;
                 _ex = ex;
                 // If this is a vector and ordered, then we must include the slot as part of the representation.
                 _includeSlot = _srcType.IsVector && _ex.Ordered;
@@ -952,7 +952,7 @@ namespace Microsoft.ML.Transforms.Conversions
             public static InvertHashHelper Create(Row row, ColumnInfo ex, int invertHashMaxCount, Delegate dstGetter)
             {
                 row.Schema.TryGetColumnIndex(ex.Input, out int srcCol);
-                ColumnType typeSrc = row.Schema.GetColumnType(srcCol);
+                ColumnType typeSrc = row.Schema[srcCol].Type;
                 Type t = typeSrc.IsVector ? (ex.Ordered ? typeof(ImplVecOrdered<>) : typeof(ImplVec<>)) : typeof(ImplOne<>);
                 t = t.MakeGenericType(typeSrc.ItemType.RawType);
                 var consTypes = new Type[] { typeof(Row), typeof(ColumnInfo), typeof(int), typeof(Delegate) };

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Runtime.Data
         {
             Contracts.AssertValue(schema);
             Contracts.Assert(0 <= col && col < schema.Count);
-            var type = schema.GetColumnType(col).ItemType;
+            var type = schema[col].Type.ItemType;
             Contracts.Assert(type.RawType == typeof(T));
             var conv = Conversion.Conversions.Instance;
 

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Runtime.Data
                 // REVIEW: Non-textual KeyValues are certainly possible. Should we handle them?
                 // Get the key names.
                 VBuffer<ReadOnlyMemory<char>> keyValues = default;
-                schema.GetMetadata(MetadataUtils.Kinds.KeyValues, col, ref keyValues);
+                schema[col].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keyValues);
                 ReadOnlyMemory<char> value = default;
 
                 // REVIEW: We could optimize for identity, but it's probably not worthwhile.

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Runtime.Data
         public static ValueMapper<T, StringBuilder> GetSimpleMapper<T>(Schema schema, int col)
         {
             Contracts.AssertValue(schema);
-            Contracts.Assert(0 <= col && col < schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < schema.Count);
             var type = schema.GetColumnType(col).ItemType;
             Contracts.Assert(type.RawType == typeof(T));
             var conv = Conversion.Conversions.Instance;

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -229,7 +229,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     // Construct kvMaps.
                     Contracts.Assert(types[iinfo] == null);
                     var typeSrc = schema[ColMapNewToOld[iinfo]].Type;
-                    var typeVals = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, ColMapNewToOld[iinfo]);
+                    var typeVals = schema[ColMapNewToOld[iinfo]].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                     Host.Check(typeVals != null, "Metadata KeyValues does not exist");
                     Host.Check(typeVals.VectorSize == typeSrc.ItemType.KeyCount, "KeyValues metadata size does not match column type key count");
                     if (!(typeSrc is VectorType vectorType))

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -228,7 +228,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 {
                     // Construct kvMaps.
                     Contracts.Assert(types[iinfo] == null);
-                    var typeSrc = schema.GetColumnType(ColMapNewToOld[iinfo]);
+                    var typeSrc = schema[ColMapNewToOld[iinfo]].Type;
                     var typeVals = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, ColMapNewToOld[iinfo]);
                     Host.Check(typeVals != null, "Metadata KeyValues does not exist");
                     Host.Check(typeVals.VectorSize == typeSrc.ItemType.KeyCount, "KeyValues metadata size does not match column type key count");

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             string reason = TestIsKey(type);
             if (reason != null)
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, reason, type.ToString());
@@ -282,7 +282,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 {
                     if (!inputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out int colSrc))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].input);
-                    var type = inputSchema.GetColumnType(colSrc);
+                    var type = inputSchema[colSrc].Type;
                     _parent.CheckInputColumn(inputSchema, i, colSrc);
                     infos[i] = new ColInfo(_parent.ColumnPairs[i].output, _parent.ColumnPairs[i].input, type);
                 }

--- a/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Transforms
 
             disposer = null;
             int col = Infos[iinfo].Source;
-            var typeSrc = input.Schema.GetColumnType(col);
+            var typeSrc = input.Schema[col].Type;
             Contracts.Assert(RowCursorUtils.TestGetLabelGetter(typeSrc) == null);
             return RowCursorUtils.GetLabelGetter(input, col);
         }

--- a/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
+++ b/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Runtime.Data
 
             if (info.SchemaSrc == null || info.FilterSrc != null && !info.FilterSrc(kind, index))
                 throw ectx.ExceptGetMetadata();
-            info.SchemaSrc.GetMetadata(kind, info.IndexSrc, ref value);
+            info.SchemaSrc[info.IndexSrc].Metadata.GetValue(kind, ref value);
         }
     }
 

--- a/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
+++ b/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Runtime.Data
             Func<string, int, bool> filterSrc = null)
         {
             Contracts.Check(!_sealed, "MetadataDispatcher sealed");
-            Contracts.Check(schemaSrc == null || (0 <= indexSrc && indexSrc < schemaSrc.ColumnCount), "indexSrc out of range");
+            Contracts.Check(schemaSrc == null || (0 <= indexSrc && indexSrc < schemaSrc.Count), "indexSrc out of range");
             Contracts.Check(filterSrc == null || schemaSrc != null, "filterSrc should be null if schemaSrc is null");
             return new ColInfo(schemaSrc, indexSrc, filterSrc);
         }

--- a/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
+++ b/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
@@ -236,7 +236,7 @@ namespace Microsoft.ML.Runtime.Data
                 yield break;
 
             // Pass through from base, with filtering.
-            foreach (var kvp in info.SchemaSrc.GetMetadataTypes(info.IndexSrc))
+            foreach (var kvp in info.SchemaSrc[info.IndexSrc].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type)))
             {
                 if (kinds != null && kinds.Contains(kvp.Key))
                     continue;
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Runtime.Data
                 return null;
             if (info.FilterSrc != null && !info.FilterSrc(kind, index))
                 return null;
-            return info.SchemaSrc.GetMetadataTypeOrNull(kind, info.IndexSrc);
+            return info.SchemaSrc[info.IndexSrc].Metadata.Schema.GetColumnOrNull(kind)?.Type;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -236,8 +236,8 @@ namespace Microsoft.ML.Transforms
         private Func<int, bool> GetActive(Func<int, bool> predicate, out bool[] active)
         {
             Host.AssertValue(predicate);
-            active = new bool[Source.Schema.ColumnCount];
-            bool[] activeInput = new bool[Source.Schema.ColumnCount];
+            active = new bool[Source.Schema.Count];
+            bool[] activeInput = new bool[Source.Schema.Count];
             for (int i = 0; i < active.Length; i++)
                 activeInput[i] = active[i] = predicate(i);
             for (int i = 0; i < _infos.Length; i++)

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Transforms
                 if (_srcIndexToInfoIndex.ContainsKey(index))
                     throw Host.ExceptUserArg(nameof(args.Column), "Source column '{0}' specified multiple times", src);
 
-                var type = schema.GetColumnType(index);
+                var type = schema[index].Type;
                 if (!TestType(type))
                     throw Host.ExceptUserArg(nameof(args.Column), $"Column '{src}' has type {type} which does not support missing values, so we cannot filter on them", src);
 
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Transforms
                 if (_srcIndexToInfoIndex.ContainsKey(index))
                     throw Host.Except("Source column '{0}' specified multiple times", src);
 
-                var type = schema.GetColumnType(index);
+                var type = schema[index].Type;
                 if (!TestType(type))
                     throw Host.Except($"Column '{src}' has type {type} which does not support missing values, so we cannot filter on them", src);
 
@@ -180,7 +180,7 @@ namespace Microsoft.ML.Transforms
             Host.Assert(_infos.Length > 0);
             ctx.Writer.Write(_infos.Length);
             foreach (var info in _infos)
-                ctx.SaveNonEmptyString(Source.Schema.GetColumnName(info.Index));
+                ctx.SaveNonEmptyString(Source.Schema[info.Index].Name);
         }
 
         private static bool TestType(ColumnType type)

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
@@ -746,7 +746,7 @@ namespace Microsoft.ML.Transforms.Normalizers
             private ValueGetter<int> GetLabelGetter(Row row, int col, out int labelCardinality)
             {
                 // The label column type is checked as part of args validation.
-                var type = row.Schema.GetColumnType(col);
+                var type = row.Schema[col].Type;
                 Host.Assert(type.IsKey || type.IsNumber);
 
                 if (type.IsKey)
@@ -849,7 +849,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 : base(host, lim, labelColId, dataRow)
             {
                 _colValueGetter = dataRow.GetGetter<VBuffer<TFloat>>(valueColId);
-                var valueColType = dataRow.Schema.GetColumnType(valueColId);
+                var valueColType = dataRow.Schema[valueColId].Type;
                 Host.Assert(valueColType.IsKnownSizeVector);
                 ColumnSlotCount = valueColType.ValueCount;
 
@@ -1062,7 +1062,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 // checking for label column
                 host.CheckUserArg(!string.IsNullOrWhiteSpace(args.LabelColumn), nameof(args.LabelColumn), "Must specify the label column name");
                 int labelColumnId = GetLabelColumnId(host, cursor.Schema, args.LabelColumn);
-                var labelColumnType = cursor.Schema.GetColumnType(labelColumnId);
+                var labelColumnType = cursor.Schema[labelColumnId].Type;
                 if (labelColumnType.IsKey)
                     host.CheckUserArg(labelColumnType.KeyCount > 0, nameof(args.LabelColumn), "Label column must have a known cardinality");
                 else

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -368,7 +368,7 @@ namespace Microsoft.ML.Transforms.Normalizers
             env.CheckValue(data, nameof(data));
             env.CheckValue(columns, nameof(columns));
 
-            bool[] activeInput = new bool[data.Schema.ColumnCount];
+            bool[] activeInput = new bool[data.Schema.Count];
 
             var srcCols = new int[columns.Length];
             var srcTypes = new ColumnType[columns.Length];

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -378,7 +378,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 bool success = data.Schema.TryGetColumnIndex(info.Input, out srcCols[i]);
                 if (!success)
                     throw env.ExceptSchemaMismatch(nameof(data), "input", info.Input);
-                srcTypes[i] = data.Schema.GetColumnType(srcCols[i]);
+                srcTypes[i] = data.Schema[srcCols[i]].Type;
                 activeInput[srcCols[i]] = true;
 
                 var supervisedBinColumn = info as NormalizingEstimator.SupervisedBinningColumn;
@@ -505,7 +505,7 @@ namespace Microsoft.ML.Transforms.Normalizers
         {
             const string expectedType = "scalar or known-size vector of R4";
 
-            var colType = inputSchema.GetColumnType(srcCol);
+            var colType = inputSchema[srcCol].Type;
             if (colType.IsVector && !colType.IsKnownSizeVector)
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, expectedType, "variable-size vector");
             if (!colType.ItemType.Equals(NumberType.R4) && !colType.ItemType.Equals(NumberType.R8))

--- a/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Runtime.Data
 
             private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
-                var active = new bool[InputSchema.ColumnCount];
+                var active = new bool[InputSchema.Count];
                 foreach (var pair in ColMapNewToOld)
                     if (activeOutput(pair.Key))
                         active[pair.Value] = true;

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -246,8 +246,8 @@ namespace Microsoft.ML.Transforms
         private Func<int, bool> GetActive(Func<int, bool> predicate, out bool[] active)
         {
             Host.AssertValue(predicate);
-            active = new bool[Source.Schema.ColumnCount];
-            bool[] activeInput = new bool[Source.Schema.ColumnCount];
+            active = new bool[Source.Schema.Count];
+            bool[] activeInput = new bool[Source.Schema.Count];
             for (int i = 0; i < active.Length; i++)
                 activeInput[i] = active[i] = predicate(i);
             activeInput[_index] = true;
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Transforms
 
             public override ValueGetter<TValue> GetGetter<TValue>(int col)
             {
-                Ch.Check(0 <= col && col < Schema.ColumnCount);
+                Ch.Check(0 <= col && col < Schema.Count);
                 Ch.Check(IsColumnActive(col));
 
                 if (col != Parent._index)

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Transforms
 
             using (var ch = Host.Start("Checking parameters"))
             {
-                _type = schema.GetColumnType(_index);
+                _type = schema[_index].Type;
                 if (!IsValidRangeFilterColumnType(ch, _type))
                     throw ch.ExceptUserArg(nameof(args.Column), "Column '{0}' does not have compatible type", args.Column);
                 if (_type.IsKey)
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Transforms
             if (!schema.TryGetColumnIndex(column, out _index))
                 throw Host.Except("column", "Source column '{0}' not found", column);
 
-            _type = schema.GetColumnType(_index);
+            _type = schema[_index].Type;
             if (_type != NumberType.R4 && _type != NumberType.R8 && _type.KeyCount == 0)
                 throw Host.Except("column", "Column '{0}' does not have compatible type", column);
 
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Transforms
             // byte: includeMin
             // byte: includeMax
             ctx.Writer.Write(sizeof(Float));
-            ctx.SaveNonEmptyString(Source.Schema.GetColumnName(_index));
+            ctx.SaveNonEmptyString(Source.Schema[_index].Name);
             Host.Assert(_min < _max);
             ctx.Writer.Write(_min);
             ctx.Writer.Write(_max);

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -191,7 +191,7 @@ namespace Microsoft.ML.Transforms
         {
             List<int> columnsToDrop = null;
             var schema = data.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
             {
                 var type = schema.GetColumnType(c);
                 if (!type.IsCachable())
@@ -211,7 +211,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         internal static bool CanShuffleAll(Schema schema)
         {
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
             {
                 var type = schema.GetColumnType(c);
                 if (!type.IsCachable())
@@ -518,7 +518,7 @@ namespace Microsoft.ML.Transforms
 
                 _pipeIndices = Utils.GetIdentityPermutation(_poolRows - 1 + _bufferDepth * _blockSize);
 
-                int colLim = Schema.ColumnCount;
+                int colLim = Schema.Count;
                 int numActive = 0;
                 _colToActivesIndex = new int[colLim];
                 for (int c = 0; c < colLim; ++c)

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Transforms
             var schema = data.Schema;
             for (int c = 0; c < schema.Count; ++c)
             {
-                var type = schema.GetColumnType(c);
+                var type = schema[c].Type;
                 if (!type.IsCachable())
                     Utils.Add(ref columnsToDrop, c);
             }
@@ -213,7 +213,7 @@ namespace Microsoft.ML.Transforms
         {
             for (int c = 0; c < schema.Count; ++c)
             {
-                var type = schema.GetColumnType(c);
+                var type = schema[c].Type;
                 if (!type.IsCachable())
                     return false;
             }
@@ -531,7 +531,7 @@ namespace Microsoft.ML.Transforms
                     if (ia < 0)
                         continue;
                     _pipes[ia] = ShufflePipe.Create(_pipeIndices.Length,
-                        input.Schema.GetColumnType(c), RowCursorUtils.GetGetterAsDelegate(input, c));
+                        input.Schema[c].Type, RowCursorUtils.GetGetterAsDelegate(input, c));
                     _getters[ia] = CreateGetterDelegate(c);
                 }
                 var idPipe = _pipes[numActive + (int)ExtraIndex.Id] = ShufflePipe.Create(_pipeIndices.Length, NumberType.UG, input.GetIdGetter());
@@ -682,14 +682,14 @@ namespace Microsoft.ML.Transforms
                 Ch.Assert(0 <= col && col < _colToActivesIndex.Length);
                 Ch.Assert(_colToActivesIndex[col] >= 0);
                 Func<int, Delegate> createDel = CreateGetterDelegate<int>;
-                return Utils.MarshalInvoke(createDel, Schema.GetColumnType(col).RawType, col);
+                return Utils.MarshalInvoke(createDel, Schema[col].Type.RawType, col);
             }
 
             private Delegate CreateGetterDelegate<TValue>(int col)
             {
                 Ch.Assert(0 <= col && col < _colToActivesIndex.Length);
                 Ch.Assert(_colToActivesIndex[col] >= 0);
-                Ch.Assert(Schema.GetColumnType(col).RawType == typeof(TValue));
+                Ch.Assert(Schema[col].Type.RawType == typeof(TValue));
                 return CreateGetterDelegate<TValue>(_pipes[_colToActivesIndex[col]]);
             }
 

--- a/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.ML.Transforms
             Host.AssertValueOrNull(rand);
 
             var input = Source.GetRowCursor(predicate);
-            var activeColumns = Utils.BuildArray(OutputSchema.ColumnCount, predicate);
+            var activeColumns = Utils.BuildArray(OutputSchema.Count, predicate);
             return new Cursor(Host, input, OutputSchema, activeColumns, _skip, _take);
         }
 

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -322,7 +322,7 @@ namespace Microsoft.ML.Runtime.Data
                     if (!input.TryGetColumnIndex(item.Source, out colSrc))
                         throw host.ExceptUserArg(nameof(OneToOneColumn.Source), "Source column '{0}' not found", item.Source);
 
-                    var type = input.GetColumnType(colSrc);
+                    var type = input[colSrc].Type;
                     if (testType != null)
                     {
                         string reason = testType(type);
@@ -371,7 +371,7 @@ namespace Microsoft.ML.Runtime.Data
                     int colSrc;
                     if (!input.TryGetColumnIndex(src, out colSrc))
                         throw host.Except("Source column '{0}' is required but not found", src);
-                    var type = input.GetColumnType(colSrc);
+                    var type = input[colSrc].Type;
                     if (testType != null)
                     {
                         string reason = testType(type);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -277,7 +277,7 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 if (!inputSchema.TryGetColumnIndex(ColumnPairs[i].input, out int colSrc))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[i].input);
-                var type = inputSchema.GetColumnType(colSrc);
+                var type = inputSchema[colSrc].Type;
                 string reason = TestIsKnownDataKind(type);
                 if (reason != null)
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[i].input, reason, type.ToString());
@@ -477,7 +477,7 @@ namespace Microsoft.ML.Transforms.Conversions
             int colSrc;
             if (!termData.Schema.TryGetColumnIndex(src, out colSrc))
                 throw ch.ExceptUserArg(nameof(termsColumn), "Unknown column '{0}'", src);
-            var typeSrc = termData.Schema.GetColumnType(colSrc);
+            var typeSrc = termData.Schema[colSrc].Type;
             if (!autoConvert && !typeSrc.Equals(bldr.ItemType))
                 throw ch.ExceptUserArg(nameof(termsColumn), "Must be of type '{0}' but was '{1}'", bldr.ItemType, typeSrc);
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -1088,7 +1088,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         return;
 
                     _schema.TryGetColumnIndex(_infos[_iinfo].Source, out int srcCol);
-                    ColumnType srcMetaType = _schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, srcCol);
+                    ColumnType srcMetaType = _schema[srcCol].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                     if (srcMetaType == null || srcMetaType.VectorSize != TypedMap.ItemType.KeyCount ||
                         TypedMap.ItemType.KeyCount == 0 || !Utils.MarshalInvoke(AddMetadataCore<int>, srcMetaType.ItemType.RawType, srcMetaType.ItemType, builder))
                     {
@@ -1168,7 +1168,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         return;
 
                     _schema.TryGetColumnIndex(_infos[_iinfo].Source, out int srcCol);
-                    ColumnType srcMetaType = _schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, srcCol);
+                    ColumnType srcMetaType = _schema[srcCol].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                     if (srcMetaType == null || srcMetaType.VectorSize != TypedMap.ItemType.KeyCount ||
                         TypedMap.ItemType.KeyCount == 0 || !Utils.MarshalInvoke(WriteTextTermsCore<int>, srcMetaType.ItemType.RawType, ((VectorType)srcMetaType).ItemType, writer))
                     {

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 Contracts.Assert(count > 0);
                 Contracts.AssertValue(bldr);
 
-                var type = schema.GetColumnType(col);
+                var type = schema[col].Type;
                 Contracts.Assert(autoConvert || bldr.ItemType == type.ItemType);
                 // Auto conversion should only be possible when the type is text.
                 Contracts.Assert(type.IsText || !autoConvert);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -284,7 +284,7 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 Contracts.AssertValue(row);
                 var schema = row.Schema;
-                Contracts.Assert(0 <= col && col < schema.ColumnCount);
+                Contracts.Assert(0 <= col && col < schema.Count);
                 Contracts.Assert(count > 0);
                 Contracts.AssertValue(bldr);
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -1117,7 +1117,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         (ref VBuffer<TMeta> dst) =>
                         {
                             VBuffer<TMeta> srcMeta = default(VBuffer<TMeta>);
-                            _schema.GetMetadata(MetadataUtils.Kinds.KeyValues, srcCol, ref srcMeta);
+                            _schema[srcCol].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref srcMeta);
                             _host.Assert(srcMeta.Length == srcType.Count);
 
                             VBuffer<T> keyVals = default(VBuffer<T>);
@@ -1193,7 +1193,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     _schema.TryGetColumnIndex(_infos[_iinfo].Source, out int srcCol);
 
                     VBuffer<TMeta> srcMeta = default(VBuffer<TMeta>);
-                    _schema.GetMetadata(MetadataUtils.Kinds.KeyValues, srcCol, ref srcMeta);
+                    _schema[srcCol].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref srcMeta);
                     if (srcMeta.Length != srcType.Count)
                         return false;
 

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Data
         private static IEnumerable<T> GetColumnDirect<T>(IDataView data, int col)
         {
             Contracts.AssertValue(data);
-            Contracts.Assert(0 <= col && col < data.Schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < data.Schema.Count);
 
             using (var cursor = data.GetRowCursor(col.Equals))
             {
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Data
         private static IEnumerable<TOut> GetColumnConvert<TOut, TData>(IDataView data, int col, Func<TData, TOut> convert)
         {
             Contracts.AssertValue(data);
-            Contracts.Assert(0 <= col && col < data.Schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < data.Schema.Count);
 
             using (var cursor = data.GetRowCursor(col.Equals))
             {
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Data
         private static IEnumerable<T[]> GetColumnArrayDirect<T>(IDataView data, int col)
         {
             Contracts.AssertValue(data);
-            Contracts.Assert(0 <= col && col < data.Schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < data.Schema.Count);
 
             using (var cursor = data.GetRowCursor(col.Equals))
             {
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Data
         private static IEnumerable<TOut[]> GetColumnArrayConvert<TOut, TData>(IDataView data, int col, Func<TData, TOut> convert)
         {
             Contracts.AssertValue(data);
-            Contracts.Assert(0 <= col && col < data.Schema.ColumnCount);
+            Contracts.Assert(0 <= col && col < data.Schema.Count);
 
             using (var cursor = data.GetRowCursor(col.Equals))
             {

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Data
             //     - If this is the same type, we can map directly.
             //     - Otherwise, we need a conversion delegate.
 
-            var colType = data.Schema.GetColumnType(col);
+            var colType = data.Schema[col].Type;
             if (colType.RawType == typeof(T))
             {
                 // Direct mapping is possible.

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -247,7 +247,7 @@ namespace Microsoft.ML.Runtime.Model
                 // ever go ahead and do something so stupid as that.
                 var saver = new TextSaver(env, new TextSaver.Arguments() { Dense = true, Silent = true });
                 var view = builder.GetDataView();
-                saver.SaveData(entry.Stream, view, Utils.GetIdentityPermutation(view.Schema.ColumnCount));
+                saver.SaveData(entry.Stream, view, Utils.GetIdentityPermutation(view.Schema.Count));
             }
         }
 

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Runtime.Ensemble
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                         return col => _inputColIndices.Contains(col);
@@ -416,7 +416,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 if (inputCols == null)
                 {
                     inputCols = new HashSet<string>();
-                    for (int j = 0; j < inputSchema.ColumnCount; j++)
+                    for (int j = 0; j < inputSchema.Count; j++)
                     {
                         if (inputSchema[j].IsHidden)
                             continue;
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 else
                 {
                     int nonHiddenCols = 0;
-                    for (int j = 0; j < inputSchema.ColumnCount; j++)
+                    for (int j = 0; j < inputSchema.Count; j++)
                     {
                         if (inputSchema[j].IsHidden)
                             continue;

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -642,7 +642,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             env.Assert(keyValuesType.ItemType.RawType == typeof(T));
             env.AssertNonEmpty(models);
             var labelNames = default(VBuffer<T>);
-            schema.GetMetadata(MetadataUtils.Kinds.KeyValues, labelIndex, ref labelNames);
+            schema[labelIndex].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref labelNames);
             var classCount = labelNames.Length;
 
             var curLabelNames = default(VBuffer<T>);
@@ -662,7 +662,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 var mdType = rmd.Schema.Schema[labelInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                 if (!mdType.Equals(keyValuesType))
                     throw env.Except("Label column of model {0} has different key value type than model 0", i);
-                rmd.Schema.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, labelInfo.Index, ref curLabelNames);
+                rmd.Schema.Schema[labelInfo.Index].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref curLabelNames);
                 if (!AreEqual(in labelNames, in curLabelNames))
                     throw env.Except("Label of model {0} has different values than model 0", i);
             }

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -420,7 +420,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     {
                         if (inputSchema[j].IsHidden)
                             continue;
-                        inputCols.Add(inputSchema.GetColumnName(j));
+                        inputCols.Add(inputSchema[j].Name);
                     }
                     _inputCols = inputCols.ToArray();
                 }
@@ -431,7 +431,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                     {
                         if (inputSchema[j].IsHidden)
                             continue;
-                        var name = inputSchema.GetColumnName(j);
+                        var name = inputSchema[j].Name;
                         if (!inputCols.Contains(name))
                             throw Host.Except("Inconsistent schemas: Some schemas do not contain the column '{0}'", name);
                         nonHiddenCols++;
@@ -592,7 +592,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             if (labelInfo == null)
                 throw env.Except("Training schema for model 0 does not have a label column");
 
-            var labelType = rmd.Schema.Schema.GetColumnType(rmd.Schema.Label.Index);
+            var labelType = rmd.Schema.Schema[rmd.Schema.Label.Index].Type;
             if (!labelType.IsKey)
                 return CheckNonKeyLabelColumnCore(env, pred, models, isBinary, labelType);
 
@@ -655,7 +655,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 if (labelInfo == null)
                     throw env.Except("Training schema for model {0} does not have a label column", i);
 
-                var curLabelType = rmd.Schema.Schema.GetColumnType(rmd.Schema.Label.Index) as KeyType;
+                var curLabelType = rmd.Schema.Schema[rmd.Schema.Label.Index].Type as KeyType;
                 if (!labelType.Equals(curLabelType))
                     throw env.Except("Label column of model {0} has different type than model 0", i);
 

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -599,7 +599,7 @@ namespace Microsoft.ML.Runtime.Ensemble
             if (isBinary && labelType.KeyCount != 2)
                 throw env.Except("Label is not binary");
             var schema = rmd.Schema.Schema;
-            var mdType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, labelInfo.Index);
+            var mdType = schema[labelInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             if (mdType == null || !mdType.IsKnownSizeVector)
                 throw env.Except("Label column of type key must have a vector of key values metadata");
 
@@ -659,7 +659,7 @@ namespace Microsoft.ML.Runtime.Ensemble
                 if (!labelType.Equals(curLabelType))
                     throw env.Except("Label column of model {0} has different type than model 0", i);
 
-                var mdType = rmd.Schema.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, labelInfo.Index);
+                var mdType = rmd.Schema.Schema[labelInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                 if (!mdType.Equals(keyValuesType))
                     throw env.Except("Label column of model {0} has different key value type than model 0", i);
                 rmd.Schema.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, labelInfo.Index, ref curLabelNames);

--- a/src/Microsoft.ML.EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML.EntryPoints/CrossValidationMacro.cs
@@ -468,7 +468,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                 {
                     var idv = input.ConfusionMatrix[i];
                     // Find the old Count column and drop it.
-                    for (int col = 0; col < idv.Schema.ColumnCount; col++)
+                    for (int col = 0; col < idv.Schema.Count; col++)
                     {
                         if (idv.Schema[col].IsHidden &&
                             idv.Schema.GetColumnName(col).Equals(MetricKinds.ColumnNames.Count))

--- a/src/Microsoft.ML.EntryPoints/CrossValidationMacro.cs
+++ b/src/Microsoft.ML.EntryPoints/CrossValidationMacro.cs
@@ -471,7 +471,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
                     for (int col = 0; col < idv.Schema.Count; col++)
                     {
                         if (idv.Schema[col].IsHidden &&
-                            idv.Schema.GetColumnName(col).Equals(MetricKinds.ColumnNames.Count))
+                            idv.Schema[col].Name.Equals(MetricKinds.ColumnNames.Count))
                         {
                             input.ConfusionMatrix[i] = new ChooseColumnsByIndexTransform(env,
                                 new ChooseColumnsByIndexTransform.Arguments() { Drop = true, Index = new[] { col } }, idv);

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -120,7 +120,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             var schema = data.Schema;
             if (!schema.TryGetColumnIndex(colName, out col))
                 return null;
-            var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, col);
+            var type = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             if (type == null || !type.IsKnownSizeVector || !type.ItemType.IsText)
                 return null;
             var metadata = default(VBuffer<ReadOnlyMemory<char>>);

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             if (type == null || !type.IsKnownSizeVector || !type.ItemType.IsText)
                 return null;
             var metadata = default(VBuffer<ReadOnlyMemory<char>>);
-            schema.GetMetadata(MetadataUtils.Kinds.KeyValues, col, ref metadata);
+            schema[col].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref metadata);
             if (!metadata.IsDense)
                 return null;
             var sb = new StringBuilder();

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -235,7 +235,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             int labelCol;
             if (!input.Data.Schema.TryGetColumnIndex(input.LabelColumn, out labelCol))
                 throw host.Except($"Column '{input.LabelColumn}' not found.");
-            var labelType = input.Data.Schema.GetColumnType(labelCol);
+            var labelType = input.Data.Schema[labelCol].Type;
             if (labelType.IsKey || labelType.IsBool)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
@@ -270,7 +270,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             int predictedLabelCol;
             if (!input.Data.Schema.TryGetColumnIndex(input.PredictedLabelColumn, out predictedLabelCol))
                 throw host.Except($"Column '{input.PredictedLabelColumn}' not found.");
-            var predictedLabelType = input.Data.Schema.GetColumnType(predictedLabelCol);
+            var predictedLabelType = input.Data.Schema[predictedLabelCol].Type;
             if (predictedLabelType.IsNumber || predictedLabelType.IsBool)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             int labelCol;
             if (!input.Data.Schema.TryGetColumnIndex(input.LabelColumn, out labelCol))
                 throw host.Except($"Column '{input.LabelColumn}' not found.");
-            var labelType = input.Data.Schema.GetColumnType(labelCol);
+            var labelType = input.Data.Schema[labelCol].Type;
             if (labelType == NumberType.R4 || !labelType.IsNumber)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -1122,7 +1122,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
                     int len = schema.Feature.Type.ValueCount;
                     if (schema.Schema[schema.Feature.Index].HasSlotNames(len))
-                        schema.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, schema.Feature.Index, ref _featNames);
+                        schema.Schema[schema.Feature.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref _featNames);
                     else
                         _featNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(len);
 

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
@@ -419,7 +419,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
 
             var sch = schema.Schema;
             if (sch[feat.Index].HasSlotNames(feat.Type.ValueCount))
-                sch.GetMetadata(MetadataUtils.Kinds.SlotNames, feat.Index, ref _names);
+                sch[feat.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref _names);
             else
                 _names = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(feat.Type.ValueCount);
 #if !CORECLR

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -780,7 +780,7 @@ namespace Microsoft.ML.Runtime.Data
             int col;
             if (!input.Schema.TryGetColumnIndex(labelName, out col))
                 throw ch.Except("Label column '{0}' not found.", labelName);
-            ColumnType labelType = input.Schema.GetColumnType(col);
+            ColumnType labelType = input.Schema[col].Type;
             if (!labelType.IsKey)
             {
                 if (labelPermutationSeed != 0)

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Runtime.Data
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                         return col => col == InputRoleMappedSchema.Feature.Index;

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -312,7 +312,7 @@ namespace Microsoft.ML.Transforms.Projections
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var inType = inputSchema.GetColumnType(srcCol);
+            var inType = inputSchema[srcCol].Type;
             var reason = TestColumn(inType);
             if (reason != null)
                 throw Host.ExceptParam(nameof(inputSchema), reason);
@@ -383,7 +383,7 @@ namespace Microsoft.ML.Transforms.Projections
             {
                 if (!inputSchema.TryGetColumnIndex(columns[i].Input, out cols[i]))
                     throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].Input);
-                srcTypes[i] = inputSchema.GetColumnType(cols[i]);
+                srcTypes[i] = inputSchema[cols[i]].Type;
                 var reason = TestColumn(srcTypes[i]);
                 if (reason != null)
                     throw env.ExceptParam(nameof(inputData.Schema), reason);
@@ -659,7 +659,7 @@ namespace Microsoft.ML.Transforms.Projections
                 {
                     if (!InputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out _cols[i]))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].input);
-                    _srcTypes[i] = inputSchema.GetColumnType(_cols[i]);
+                    _srcTypes[i] = inputSchema[_cols[i]].Type;
                     ValidateModel(Host, _parent._models[i], _srcTypes[i]);
                     if (_parent._columns[i].SaveInv)
                         ValidateModel(Host, _parent._invModels[i], _srcTypes[i]);

--- a/src/Microsoft.ML.ImageAnalytics/ImageGrayscaleTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageGrayscaleTransform.cs
@@ -156,8 +156,8 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            if (!(inputSchema.GetColumnType(srcCol) is ImageType))
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, "image", inputSchema.GetColumnType(srcCol).ToString());
+            if (!(inputSchema[srcCol].Type is ImageType))
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, "image", inputSchema[srcCol].Type.ToString());
         }
 
         private sealed class Mapper : OneToOneMapperBase

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoaderTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoaderTransform.cs
@@ -116,8 +116,8 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            if (!inputSchema.GetColumnType(srcCol).IsText)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, TextType.Instance.ToString(), inputSchema.GetColumnType(srcCol).ToString());
+            if (!inputSchema[srcCol].Type.IsText)
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, TextType.Instance.ToString(), inputSchema[srcCol].Type.ToString());
         }
 
         public override void Save(ModelSaveContext ctx)

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractorTransform.cs
@@ -405,9 +405,9 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
             var inputColName = _columns[col].Input;
-            var imageType = inputSchema.GetColumnType(srcCol) as ImageType;
+            var imageType = inputSchema[srcCol].Type as ImageType;
             if (imageType == null)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputColName, "image", inputSchema.GetColumnType(srcCol).ToString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputColName, "image", inputSchema[srcCol].Type.ToString());
             if (imageType.Height <= 0 || imageType.Width <= 0)
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputColName, "known-size image", "unknown-size image");
             if ((long)imageType.Height * imageType.Width > int.MaxValue / 4)

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizerTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizerTransform.cs
@@ -289,8 +289,8 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            if (!(inputSchema.GetColumnType(srcCol) is ImageType))
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _columns[col].Input, "image", inputSchema.GetColumnType(srcCol).ToString());
+            if (!(inputSchema[srcCol].Type is ImageType))
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _columns[col].Input, "image", inputSchema[srcCol].Type.ToString());
         }
 
         private sealed class Mapper : OneToOneMapperBase

--- a/src/Microsoft.ML.ImageAnalytics/VectorToImageTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/VectorToImageTransform.cs
@@ -340,7 +340,7 @@ namespace Microsoft.ML.Runtime.ImageAnalytics
             var ex = _exes[iinfo];
             bool needScale = ex.Offset != 0 || ex.Scale != 1;
             disposer = null;
-            var sourceType = InputSchema.GetColumnType(Infos[iinfo].Source);
+            var sourceType = InputSchema[Infos[iinfo].Source].Type;
             if (sourceType.ItemType == NumberType.R4 || sourceType.ItemType == NumberType.R8)
                 return GetterFromType<float>(input, iinfo, ex, needScale);
             else

--- a/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
+++ b/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Legacy
                     if (dataView.Schema[colIndex].HasSlotNames(n))
                     {
                         var slots = default(VBuffer<ReadOnlyMemory<char>>);
-                        dataView.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colIndex, ref slots);
+                        dataView.Schema[colIndex].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slots);
 
                         bool appendEllipse = false;
                         IEnumerable<ReadOnlyMemory<char>> slotNames = slots.Items(true).Select(x => x.Value);

--- a/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
+++ b/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Legacy
 
         private static List<int> GetColIndices(IDataView dataView)
         {
-            int totalColCount = dataView.Schema.ColumnCount;
+            int totalColCount = dataView.Schema.Count;
             // getting distinct columns
             HashSet<string> columnNames = new HashSet<string>();
             var colIndices = new List<int>();

--- a/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
+++ b/src/Microsoft.ML.Legacy/LearningPipelineDebugProxy.cs
@@ -86,13 +86,13 @@ namespace Microsoft.ML.Legacy
                 var colIndex = colIndices[i];
                 result[i] = new PipelineItemDebugColumn()
                 {
-                    Name = dataView.Schema.GetColumnName(colIndex),
-                    Type = dataView.Schema.GetColumnType(colIndex).ToString()
+                    Name = dataView.Schema[colIndex].Name,
+                    Type = dataView.Schema[colIndex].Type.ToString()
                 };
 
-                if (dataView.Schema.GetColumnType(colIndex).IsVector)
+                if (dataView.Schema[colIndex].Type.IsVector)
                 {
-                    var n = dataView.Schema.GetColumnType(colIndex).VectorSize;
+                    var n = dataView.Schema[colIndex].Type.VectorSize;
                     if (dataView.Schema[colIndex].HasSlotNames(n))
                     {
                         var slots = default(VBuffer<ReadOnlyMemory<char>>);
@@ -214,7 +214,7 @@ namespace Microsoft.ML.Legacy
             var colIndices = new List<int>();
             for (int i = totalColCount - 1; i >= 0; i--)
             {
-                var name = dataView.Schema.GetColumnName(i);
+                var name = dataView.Schema[i].Name;
                 if (columnNames.Add(name))
                     colIndices.Add(i);
             }

--- a/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
+++ b/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Legacy.Models
 
             RowCursor cursor = confusionMatrix.GetRowCursor(col => col == countColumn);
             var slots = default(VBuffer<ReadOnlyMemory<char>>);
-            confusionMatrix.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, countColumn, ref slots);
+            confusionMatrix.Schema[countColumn].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slots);
             var slotsValues = slots.GetValues();
             string[] classNames = new string[slotsValues.Length];
             for (int i = 0; i < slotsValues.Length; i++)

--- a/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
+++ b/src/Microsoft.ML.Legacy/Models/ConfusionMatrix.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Legacy.Models
                 classNames[i] = slotsValues[i].ToString();
             }
 
-            ColumnType type = confusionMatrix.Schema.GetColumnType(countColumn);
+            ColumnType type = confusionMatrix.Schema[countColumn].Type;
             env.Assert(type.IsVector);
             ValueGetter<VBuffer<double>> countGetter = cursor.GetGetter<VBuffer<double>>(countColumn);
             VBuffer<double> countValues = default;

--- a/src/Microsoft.ML.Legacy/PredictionModel.cs
+++ b/src/Microsoft.ML.Legacy/PredictionModel.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Legacy
             if (!schema.TryGetColumnIndex(scoreColumnName, out colIndex))
                 return false;
 
-            int expectedLabelCount = schema.GetColumnType(colIndex).ValueCount;
+            int expectedLabelCount = schema[colIndex].Type.ValueCount;
             if (!schema[colIndex].HasSlotNames(expectedLabelCount))
                 return false;
 

--- a/src/Microsoft.ML.Legacy/PredictionModel.cs
+++ b/src/Microsoft.ML.Legacy/PredictionModel.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Legacy
                 return false;
 
             VBuffer<ReadOnlyMemory<char>> labels = default;
-            schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colIndex, ref labels);
+            schema[colIndex].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref labels);
 
             if (labels.Length != expectedLabelCount)
                 return false;

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/ExecuteGraphCommand.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/ExecuteGraphCommand.cs
@@ -242,7 +242,7 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
             using (var handle = _host.CreateOutputFile(path))
             using (var fs = handle.CreateWriteStream())
             {
-                saver.SaveData(fs, idv, Utils.GetIdentityPermutation(idv.Schema.ColumnCount)
+                saver.SaveData(fs, idv, Utils.GetIdentityPermutation(idv.Schema.Count)
                     .Where(x => saver.IsColumnSavable(idv.Schema.GetColumnType(x))).ToArray());
             }
         }

--- a/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/ExecuteGraphCommand.cs
+++ b/src/Microsoft.ML.Legacy/Runtime/EntryPoints/JsonUtils/ExecuteGraphCommand.cs
@@ -243,7 +243,7 @@ namespace Microsoft.ML.Runtime.EntryPoints.JsonUtils
             using (var fs = handle.CreateWriteStream())
             {
                 saver.SaveData(fs, idv, Utils.GetIdentityPermutation(idv.Schema.Count)
-                    .Where(x => saver.IsColumnSavable(idv.Schema.GetColumnType(x))).ToArray());
+                    .Where(x => saver.IsColumnSavable(idv.Schema[x].Type)).ToArray());
             }
         }
     }

--- a/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
+++ b/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
@@ -214,11 +214,11 @@ namespace Microsoft.ML.Runtime.Model.Onnx
             //Create graph inputs.
             for (int i = 0; i < source.Schema.Count; i++)
             {
-                string colName = source.Schema.GetColumnName(i);
+                string colName = source.Schema[i].Name;
                 if(_inputsToDrop.Contains(colName))
                     continue;
 
-                ctx.AddInputVariable(source.Schema.GetColumnType(i), colName);
+                ctx.AddInputVariable(source.Schema[i].Type, colName);
                 inputColumns.Add(colName);
             }
 
@@ -235,7 +235,7 @@ namespace Microsoft.ML.Runtime.Model.Onnx
                 if (end.Schema[i].IsHidden)
                     continue;
 
-                var idataviewColumnName = end.Schema.GetColumnName(i);
+                var idataviewColumnName = end.Schema[i].Name;
 
                 // Since the last IDataView also contains columns of the initial IDataView, last IDataView's columns found in
                 // _inputToDrop should be removed too.
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Runtime.Model.Onnx
                 var variableName = ctx.TryGetVariableName(idataviewColumnName);
                 var trueVariableName = ctx.AddIntermediateVariable(null, idataviewColumnName, true);
                 ctx.CreateNode("Identity", variableName, trueVariableName, ctx.GetNodeName("Identity"), "");
-                ctx.AddOutputVariable(end.Schema.GetColumnType(i), trueVariableName);
+                ctx.AddOutputVariable(end.Schema[i].Type, trueVariableName);
             }
 
             var model = ctx.MakeModel();

--- a/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
+++ b/src/Microsoft.ML.Onnx/SaveOnnxCommand.cs
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Runtime.Model.Onnx
 
             HashSet<string> inputColumns = new HashSet<string>();
             //Create graph inputs.
-            for (int i = 0; i < source.Schema.ColumnCount; i++)
+            for (int i = 0; i < source.Schema.Count; i++)
             {
                 string colName = source.Schema.GetColumnName(i);
                 if(_inputsToDrop.Contains(colName))
@@ -230,7 +230,7 @@ namespace Microsoft.ML.Runtime.Model.Onnx
             }
 
             //Add graph outputs.
-            for (int i = 0; i < end.Schema.ColumnCount; ++i)
+            for (int i = 0; i < end.Schema.Count; ++i)
             {
                 if (end.Schema[i].IsHidden)
                     continue;

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Transforms
                     if (!inputSchema.TryGetColumnIndex(_parent.Inputs[i], out _inputColIndices[i]))
                         throw Host.Except($"Column {_parent.Inputs[i]} doesn't exist");
 
-                    var type = inputSchema.GetColumnType(_inputColIndices[i]);
+                    var type = inputSchema[_inputColIndices[i]].Type;
                     _isInputVector[i] = type.IsVector;
 
                     if (type.IsVector && type.VectorSize == 0)

--- a/src/Microsoft.ML.PCA/PcaTransform.cs
+++ b/src/Microsoft.ML.PCA/PcaTransform.cs
@@ -449,7 +449,7 @@ namespace Microsoft.ML.Transforms.Projections
 
             Double[] totalColWeight = new Double[_numColumns];
 
-            bool[] activeColumns = new bool[trainingData.Schema.ColumnCount];
+            bool[] activeColumns = new bool[trainingData.Schema.Count];
             foreach (var sInfo in _schemaInfos)
             {
                 activeColumns[sInfo.InputIndex] = true;

--- a/src/Microsoft.ML.PCA/PcaTransform.cs
+++ b/src/Microsoft.ML.PCA/PcaTransform.cs
@@ -544,7 +544,7 @@ namespace Microsoft.ML.Transforms.Projections
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            ValidatePcaInput(Host, inputSchema.GetColumnName(srcCol), inputSchema.GetColumnType(srcCol));
+            ValidatePcaInput(Host, inputSchema[srcCol].Name, inputSchema[srcCol].Type);
         }
 
         internal static void ValidatePcaInput(IExceptionContext ectx, string name, ColumnType type)

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Runtime.Data
             var saver = new BinarySaver(_host, saverArgs);
             using (var strm = new MemoryStream())
             {
-                var allColumns = Enumerable.Range(0, Schema.ColumnCount).ToArray();
+                var allColumns = Enumerable.Range(0, Schema.Count).ToArray();
                 saver.SaveData(strm, noRows, allColumns);
                 ctx.SaveBinaryStream(SchemaCtxName, w => w.WriteByteArray(strm.ToArray()));
             }
@@ -460,7 +460,7 @@ namespace Microsoft.ML.Runtime.Data
                 _rand = rand;
 
                 // Create Getter delegates
-                Utils.BuildSubsetMaps(Schema.ColumnCount, predicate, out _actives, out _colToActivesIndex);
+                Utils.BuildSubsetMaps(Schema.Count, predicate, out _actives, out _colToActivesIndex);
                 _readerOptions = new ReaderOptions
                 {
                     Count = _loader._columnChunkReadSize,

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -312,7 +312,7 @@ namespace Microsoft.ML.Trainers.Recommender
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                         return col => (col == _matrixColumnIndexColumnIndex || col == _matrixRowIndexCololumnIndex);
@@ -342,7 +342,7 @@ namespace Microsoft.ML.Trainers.Recommender
             private Delegate[] CreateGetter(Row input, bool[] active)
             {
                 _env.CheckValue(input, nameof(input));
-                _env.Assert(Utils.Size(active) == OutputSchema.ColumnCount);
+                _env.Assert(Utils.Size(active) == OutputSchema.Count);
 
                 var getters = new Delegate[1];
                 if (active[0])
@@ -360,7 +360,7 @@ namespace Microsoft.ML.Trainers.Recommender
 
             public Row GetRow(Row input, Func<int, bool> active)
             {
-                var activeArray = Utils.BuildArray(OutputSchema.ColumnCount, active);
+                var activeArray = Utils.BuildArray(OutputSchema.Count, active);
                 var getters = CreateGetter(input, activeArray);
                 return new SimpleRow(OutputSchema, input, getters);
             }

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -329,12 +329,12 @@ namespace Microsoft.ML.Trainers.Recommender
             private void CheckInputSchema(Schema schema, int matrixColumnIndexCol, int matrixRowIndexCol)
             {
                 // See if matrix-column-index role's type matches the one expected in the trained predictor
-                var type = schema.GetColumnType(matrixColumnIndexCol);
+                var type = schema[matrixColumnIndexCol].Type;
                 string msg = string.Format("Input column index type '{0}' incompatible with predictor's column index type '{1}'", type, _parent.MatrixColumnIndexType);
                 _env.CheckParam(type.Equals(_parent.MatrixColumnIndexType), nameof(schema), msg);
 
                 // See if matrix-column-index  role's type matches the one expected in the trained predictor
-                type = schema.GetColumnType(matrixRowIndexCol);
+                type = schema[matrixRowIndexCol].Type;
                 msg = string.Format("Input row index type '{0}' incompatible with predictor' row index type '{1}'", type, _parent.MatrixRowIndexType);
                 _env.CheckParam(type.Equals(_parent.MatrixRowIndexType), nameof(schema), msg);
             }
@@ -402,10 +402,10 @@ namespace Microsoft.ML.Trainers.Recommender
 
             if (!trainSchema.TryGetColumnIndex(MatrixColumnIndexColumnName, out int xCol))
                 throw Host.ExceptSchemaMismatch(nameof(MatrixColumnIndexColumnName), RecommenderUtils.MatrixColumnIndexKind.Value, MatrixColumnIndexColumnName);
-            MatrixColumnIndexColumnType = trainSchema.GetColumnType(xCol);
+            MatrixColumnIndexColumnType = trainSchema[xCol].Type;
             if (!trainSchema.TryGetColumnIndex(MatrixRowIndexColumnName, out int yCol))
                 throw Host.ExceptSchemaMismatch(nameof(yCol), RecommenderUtils.MatrixRowIndexKind.Value, MatrixRowIndexColumnName);
-            MatrixRowIndexColumnType = trainSchema.GetColumnType(yCol);
+            MatrixRowIndexColumnType = trainSchema[yCol].Type;
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, model);
 
@@ -440,11 +440,11 @@ namespace Microsoft.ML.Trainers.Recommender
 
             if (!TrainSchema.TryGetColumnIndex(MatrixColumnIndexColumnName, out int xCol))
                 throw Host.ExceptSchemaMismatch(nameof(MatrixColumnIndexColumnName), RecommenderUtils.MatrixColumnIndexKind.Value, MatrixColumnIndexColumnName);
-            MatrixColumnIndexColumnType = TrainSchema.GetColumnType(xCol);
+            MatrixColumnIndexColumnType = TrainSchema[xCol].Type;
 
             if (!TrainSchema.TryGetColumnIndex(MatrixRowIndexColumnName, out int yCol))
                 throw Host.ExceptSchemaMismatch(nameof(MatrixRowIndexColumnName), RecommenderUtils.MatrixRowIndexKind.Value, MatrixRowIndexColumnName);
-            MatrixRowIndexColumnType = TrainSchema.GetColumnType(yCol);
+            MatrixRowIndexColumnType = TrainSchema[yCol].Type;
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, Model);
 

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachinePredictor.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachinePredictor.cs
@@ -230,7 +230,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             {
                 if (!trainSchema.TryGetColumnIndex(feat, out int col))
                     throw Host.ExceptSchemaMismatch(nameof(featureColumns), RoleMappedSchema.ColumnRole.Feature.Value, feat);
-                FeatureColumnTypes[i++] = trainSchema.GetColumnType(col);
+                FeatureColumnTypes[i++] = trainSchema[col].Type;
             }
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, model);
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
                 FeatureColumns[i] = ctx.LoadString();
                 if (!TrainSchema.TryGetColumnIndex(FeatureColumns[i], out int col))
                     throw Host.ExceptSchemaMismatch(nameof(FeatureColumns), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumns[i]);
-                FeatureColumnTypes[i] = TrainSchema.GetColumnType(col);
+                FeatureColumnTypes[i] = TrainSchema[col].Type;
             }
 
             _threshold = ctx.Reader.ReadSingle();
@@ -286,8 +286,8 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
                 if (!inputSchema.TryGetColumnIndex(feat, out int col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, feat, FeatureColumnTypes[i].ToString(), null);
 
-                if (!inputSchema.GetColumnType(col).Equals(FeatureColumnTypes[i]))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, feat, FeatureColumnTypes[i].ToString(), inputSchema.GetColumnType(col).ToString());
+                if (!inputSchema[col].Type.Equals(FeatureColumnTypes[i]))
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, feat, FeatureColumnTypes[i].ToString(), inputSchema[col].Type.ToString());
             }
 
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -75,7 +75,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
         {
             Contracts.AssertValue(env);
             Contracts.AssertValue(schema);
-            Contracts.CheckParam(outputSchema.ColumnCount == 2, nameof(outputSchema));
+            Contracts.CheckParam(outputSchema.Count == 2, nameof(outputSchema));
             Contracts.CheckParam(outputSchema.GetColumnType(0).IsNumber, nameof(outputSchema));
             Contracts.CheckParam(outputSchema.GetColumnType(1).IsNumber, nameof(outputSchema));
             Contracts.AssertValue(pred);
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
 
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
         {
-            if (Enumerable.Range(0, OutputSchema.ColumnCount).Any(predicate))
+            if (Enumerable.Range(0, OutputSchema.Count).Any(predicate))
                 return index => _inputColumnIndexes.Any(c => c == index);
             else
                 return index => false;

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -76,8 +76,8 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
             Contracts.AssertValue(env);
             Contracts.AssertValue(schema);
             Contracts.CheckParam(outputSchema.Count == 2, nameof(outputSchema));
-            Contracts.CheckParam(outputSchema.GetColumnType(0).IsNumber, nameof(outputSchema));
-            Contracts.CheckParam(outputSchema.GetColumnType(1).IsNumber, nameof(outputSchema));
+            Contracts.CheckParam(outputSchema[0].Type.IsNumber, nameof(outputSchema));
+            Contracts.CheckParam(outputSchema[1].Type.IsNumber, nameof(outputSchema));
             Contracts.AssertValue(pred);
 
             _env = env;

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -213,7 +213,7 @@ namespace Microsoft.ML.Runtime.Learners
             var featureLength = CurrentWeights.Length - BiasCount;
             var namesSpans = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(featureLength);
             if (schema[featureColIdx].HasSlotNames(featureLength))
-                schema.GetMetadata(MetadataUtils.Kinds.SlotNames, featureColIdx, ref namesSpans);
+                schema[featureColIdx].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref namesSpans);
             Host.Assert(namesSpans.Length == featureLength);
 
             // Inverse mapping of non-zero weight slots.

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Runtime.Learners
             }
 
             VBuffer<ReadOnlyMemory<char>> labelNames = default;
-            schema.GetMetadata(MetadataUtils.Kinds.KeyValues, labelIdx, ref labelNames);
+            schema[labelIdx].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref labelNames);
 
             // If label names is not dense or contain NA or default value, then it follows that
             // at least one class does not have a valid name for its label. If the label names we

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -128,7 +128,7 @@ namespace Microsoft.ML.Runtime.Learners
             // Try to get the label key values metedata.
             var schema = data.Data.Schema;
             var labelIdx = data.Schema.Label.Index;
-            var labelMetadataType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, labelIdx);
+            var labelMetadataType = schema[labelIdx].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             if (labelMetadataType == null || !labelMetadataType.IsKnownSizeVector || !labelMetadataType.ItemType.IsText ||
                 labelMetadataType.VectorSize != _numClasses)
             {

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -13,14 +13,13 @@ using Microsoft.ML.Runtime.Learners;
 using Microsoft.ML.Runtime.Model;
 using Microsoft.ML.Runtime.Model.Pfa;
 using Microsoft.ML.Runtime.Training;
+using Microsoft.ML.Trainers;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
-
-using System.Collections.Generic;
-using Microsoft.ML.Trainers;
 
 [assembly: LoadableClass(Ova.Summary, typeof(Ova), typeof(Ova.Arguments),
     new[] { typeof(SignatureMultiClassClassifierTrainer), typeof(SignatureTrainer) },
@@ -34,10 +33,10 @@ using Microsoft.ML.Trainers;
 [assembly: EntryPointModule(typeof(OvaPredictor))]
 namespace Microsoft.ML.Trainers
 {
+    using CR = RoleMappedSchema.ColumnRole;
+    using TDistPredictor = IDistPredictorProducing<float, float>;
     using TScalarPredictor = IPredictorProducing<float>;
     using TScalarTrainer = ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>>;
-    using TDistPredictor = IDistPredictorProducing<float, float>;
-    using CR = RoleMappedSchema.ColumnRole;
 
     public sealed class Ova : MetaMulticlassTrainer<MulticlassPredictionTransformer<OvaPredictor>, OvaPredictor>
     {

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -795,7 +795,7 @@ namespace Microsoft.ML.Transforms
                     if (!inputSchema.TryGetColumnIndex(_parent.Inputs[i], out _inputColIndices[i]))
                         throw Host.Except($"Column {_parent.Inputs[i]} doesn't exist");
 
-                    var type = inputSchema.GetColumnType(_inputColIndices[i]);
+                    var type = inputSchema[_inputColIndices[i]].Type;
                     if (type is VectorType vecType && vecType.Size == 0)
                         throw Host.Except("Variable length input columns not supported");
 

--- a/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             if (!inputSchema.TryGetColumnIndex(InputColumnName, out var col))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName);
 
-            var colType = inputSchema.GetColumnType(col);
+            var colType = inputSchema[col].Type;
             if (colType != NumberType.R4)
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName, NumberType.R4.ToString(), colType.ToString());
 

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.TimeSeries
             if (innerMappers.Length == 0)
             {
                 bool differentActive = false;
-                for (int c = 0; c < input.Schema.ColumnCount; ++c)
+                for (int c = 0; c < input.Schema.Count; ++c)
                 {
                     bool wantsActive = active(c);
                     bool isActive = input.IsColumnActive(c);

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.TimeSeries
                     differentActive |= wantsActive != isActive;
 
                     if (wantsActive && !isActive)
-                        throw Contracts.ExceptParam(nameof(input), $"Mapper required column '{input.Schema.GetColumnName(c)}' active but it was not.");
+                        throw Contracts.ExceptParam(nameof(input), $"Mapper required column '{input.Schema[c].Name}' active but it was not.");
                 }
 
                 var row = mapper.GetRow(input, active);

--- a/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
@@ -592,7 +592,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
                 if (!inputSchema.TryGetColumnIndex(parent.InputColumnName, out _inputColumnIndex))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", parent.InputColumnName);
 
-                var colType = inputSchema.GetColumnType(_inputColumnIndex);
+                var colType = inputSchema[_inputColumnIndex].Type;
                 if (colType != NumberType.R4)
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", parent.InputColumnName, NumberType.R4.ToString(), colType.ToString());
 

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -381,7 +381,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             public Cursor(SequentialTransformBase<TInput, TOutput, TState> parent, RowCursor input)
                 : base(parent.Host, input)
             {
-                Ch.Assert(input.Schema.ColumnCount == parent.OutputSchema.ColumnCount);
+                Ch.Assert(input.Schema.Count == parent.OutputSchema.Count);
                 _parent = parent;
             }
 
@@ -389,7 +389,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             public override bool IsColumnActive(int col)
             {
-                Ch.Check(0 <= col && col < Schema.ColumnCount, "col");
+                Ch.Check(0 <= col && col < Schema.Count, "col");
                 return Input.IsColumnActive(col);
             }
 

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -326,7 +326,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             if (!_transform.Schema.TryGetColumnIndex(OutputColumnName, out colIndex))
                 throw Host.Except(String.Format("The column {0} does not exist in the schema.", OutputColumnName));
 
-            bs.TryWriteTypeDescription(ctx.Writer.BaseStream, _transform.Schema.GetColumnType(colIndex), out byteWritten);
+            bs.TryWriteTypeDescription(ctx.Writer.BaseStream, _transform.Schema[colIndex].Type, out byteWritten);
         }
 
         private static void MapFunction(DataBox<TInput> input, DataBox<TOutput> output, TState state)

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -470,7 +470,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             public Func<int, bool> GetDependencies(Func<int, bool> predicate)
             {
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
                         return col => true;
@@ -505,7 +505,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             {
                 Contracts.CheckValue(schema, nameof(schema));
                 Contracts.CheckValue(input, nameof(input));
-                Contracts.Check(Utils.Size(getters) == schema.ColumnCount);
+                Contracts.Check(Utils.Size(getters) == schema.Count);
                 _schema = schema;
                 _input = input;
                 _getters = getters ?? new Delegate[0];
@@ -556,7 +556,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             public Cursor(IHost host, SequentialDataTransform parent, RowCursor input)
                 : base(host, input)
             {
-                Ch.Assert(input.Schema.ColumnCount == parent.OutputSchema.ColumnCount);
+                Ch.Assert(input.Schema.Count == parent.OutputSchema.Count);
                 _parent = parent;
             }
 
@@ -564,7 +564,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             public override bool IsColumnActive(int col)
             {
-                Ch.Check(0 <= col && col < Schema.ColumnCount, "col");
+                Ch.Check(0 <= col && col < Schema.Count, "col");
                 return Input.IsColumnActive(col);
             }
 
@@ -660,12 +660,12 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
         /// </summary>
         private bool[] GetActive(Func<int, bool> predicate, out Func<int, bool> predicateInput)
         {
-            int n = _bindings.Schema.ColumnCount;
+            int n = _bindings.Schema.Count;
             var active = Utils.BuildArray(n, predicate);
             Contracts.Assert(active.Length == n);
 
             var activeInput = _bindings.GetActiveInput(predicate);
-            Contracts.Assert(activeInput.Length == _bindings.InputSchema.ColumnCount);
+            Contracts.Assert(activeInput.Length == _bindings.InputSchema.Count);
 
             // Get a predicate that determines which outputs are active.
             var predicateOut = GetActiveOutputColumns(active);
@@ -683,7 +683,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
         private Func<int, bool> GetActiveOutputColumns(bool[] active)
         {
             Contracts.AssertValue(active);
-            Contracts.Assert(active.Length == _bindings.Schema.ColumnCount);
+            Contracts.Assert(active.Length == _bindings.Schema.Count);
 
             return
                 col =>
@@ -766,8 +766,8 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             using (var ch = Host.Start("GetEntireRow"))
             {
-                var activeArr = new bool[OutputSchema.ColumnCount];
-                for (int i = 0; i < OutputSchema.ColumnCount; i++)
+                var activeArr = new bool[OutputSchema.Count];
+                for (int i = 0; i < OutputSchema.Count; i++)
                     activeArr[i] = active(i);
                 var pred = GetActiveOutputColumns(activeArr);
                 var getters = _mapper.CreateGetters(input, pred, out Action disp);
@@ -858,7 +858,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
 
             public override bool IsColumnActive(int col)
             {
-                Ch.Check(0 <= col && col < _bindings.Schema.ColumnCount);
+                Ch.Check(0 <= col && col < _bindings.Schema.Count);
                 return _active[col];
             }
 

--- a/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SlidingWindowTransformBase.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             var sch = OutputSchema;
             int index;
             sch.TryGetColumnIndex(InputColumnName, out index);
-            ColumnType col = sch.GetColumnType(index);
+            ColumnType col = sch[index].Type;
             TInput nanValue = Conversions.Instance.GetNAOrDefault<TInput>(col);
 
             // We store the nan_value here to avoid getting it each time a state is instanciated.

--- a/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             if (!inputSchema.TryGetColumnIndex(InputColumnName, out var col))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName);
 
-            var colType = inputSchema.GetColumnType(col);
+            var colType = inputSchema[col].Type;
             if (colType != NumberType.R4)
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName, NumberType.R4.ToString(), colType.ToString());
 

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
 
             var schema = input.Schema;
             var size = columns.Length;
-            var activeInput = new bool[schema.ColumnCount];
+            var activeInput = new bool[schema.Count];
             var colSrcs = new int[size];
             var colTypes = new ColumnType[size];
             colSizes = new int[size];

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                 if (!schema.TryGetColumnIndex(colName, out colSrc))
                     throw env.ExceptUserArg(nameof(CountFeatureSelectingEstimator.Arguments.Column), "Source column '{0}' not found", colName);
 
-                var colType = schema.GetColumnType(colSrc);
+                var colType = schema[colSrc].Type;
                 if (colType.IsVector && !colType.IsKnownSizeVector)
                     throw env.ExceptUserArg(nameof(CountFeatureSelectingEstimator.Arguments.Column), "Variable length column '{0}' is not allowed", colName);
 

--- a/src/Microsoft.ML.Transforms/CustomMappingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/CustomMappingTransformer.cs
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Transforms
             {
                 var dstRow = new DataViewConstructionUtils.InputRow<TDst>(_host, _parent.AddedSchema);
                 // All the output columns of dstRow are our outputs.
-                return Enumerable.Range(0, dstRow.Schema.ColumnCount).Select(x => new Schema.DetachedColumn(dstRow.Schema[x])).ToArray();
+                return Enumerable.Range(0, dstRow.Schema.Count).Select(x => new Schema.DetachedColumn(dstRow.Schema[x])).ToArray();
             }
 
             public void Save(ModelSaveContext ctx)

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -305,9 +305,9 @@ namespace Microsoft.ML.Transforms.Projections
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var inType = inputSchema.GetColumnType(srcCol);
+            var inType = inputSchema[srcCol].Type;
             if (!LpNormalizingEstimatorBase.IsColumnTypeValid(inType))
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputSchema.GetColumnName(srcCol), LpNormalizingEstimatorBase.ExpectedColumnType, inType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputSchema[srcCol].Name, LpNormalizingEstimatorBase.ExpectedColumnType, inType.ToString());
         }
         /// <summary>
         /// Create a <see cref="LpNormalizingTransformer"/> that takes multiple pairs of columns.

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -375,13 +375,13 @@ namespace Microsoft.ML.Transforms
             {
                 CheckColumnInRange(col);
                 if (col < _groupCount)
-                    return _input.GetMetadataTypes(GroupIds[col]);
+                    return _input[GroupIds[col]].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
 
                 col -= _groupCount;
                 var result = new List<KeyValuePair<string, ColumnType>>();
                 foreach (var kind in _preservedMetadata)
                 {
-                    var colType = _input.GetMetadataTypeOrNull(kind, KeepIds[col]);
+                    var colType = _input[KeepIds[col]].Metadata.Schema.GetColumnOrNull(kind)?.Type;
                     if (colType != null)
                         result.Add(colType.GetPair(kind));
                 }
@@ -393,11 +393,11 @@ namespace Microsoft.ML.Transforms
             {
                 CheckColumnInRange(col);
                 if (col < _groupCount)
-                    return _input.GetMetadataTypeOrNull(kind, GroupIds[col]);
+                    return _input[GroupIds[col]].Metadata.Schema.GetColumnOrNull(kind)?.Type;
 
                 col -= _groupCount;
                 if (_preservedMetadata.Contains(kind))
-                    return _input.GetMetadataTypeOrNull(kind, KeepIds[col]);
+                    return _input[KeepIds[col]].Metadata.Schema.GetColumnOrNull(kind)?.Type;
                 return null;
             }
 

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Transforms
                 var types = new ColumnType[ids.Length];
                 for (int i = 0; i < ids.Length; i++)
                 {
-                    var srcType = input.GetColumnType(ids[i]);
+                    var srcType = input[ids[i]].Type;
                     var primitiveType = srcType as PrimitiveType;
                     Contracts.Assert(primitiveType != null);
                     types[i] = new VectorType(primitiveType, size: 0);
@@ -333,7 +333,7 @@ namespace Microsoft.ML.Transforms
                     if (!schema.TryGetColumnIndex(names[i], out col))
                         throw except(string.Format("Could not find column '{0}'", names[i]));
 
-                    var colType = schema.GetColumnType(col);
+                    var colType = schema[col].Type;
                     if (!colType.IsPrimitive)
                         throw except(string.Format("Column '{0}' has type '{1}', but must have a primitive type", names[i], colType));
 
@@ -367,7 +367,7 @@ namespace Microsoft.ML.Transforms
             {
                 CheckColumnInRange(col);
                 if (col < _groupCount)
-                    return _input.GetColumnType(GroupIds[col]);
+                    return _input[GroupIds[col]].Type;
                 return _columnTypes[col - _groupCount];
             }
 
@@ -469,7 +469,7 @@ namespace Microsoft.ML.Transforms
                 public GroupKeyColumnChecker(Row row, int col)
                 {
                     Contracts.AssertValue(row);
-                    var type = row.Schema.GetColumnType(col);
+                    var type = row.Schema[col].Type;
 
                     Func<Row, int, Func<bool>> del = MakeSameChecker<int>;
                     var mi = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(type.RawType);
@@ -493,7 +493,7 @@ namespace Microsoft.ML.Transforms
                 public static KeepColumnAggregator Create(Row row, int col)
                 {
                     Contracts.AssertValue(row);
-                    var colType = row.Schema.GetColumnType(col);
+                    var colType = row.Schema[col].Type;
                     Contracts.Assert(colType.IsPrimitive);
 
                     var type = typeof(ListAggregator<>);

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -567,12 +567,12 @@ namespace Microsoft.ML.Transforms
                 _active = Utils.BuildArray(schema.ColumnCount, predicate);
                 _groupCount = schema.GroupIds.Length;
 
-                bool[] srcActiveLeading = new bool[_parent.Source.Schema.ColumnCount];
+                bool[] srcActiveLeading = new bool[_parent.Source.Schema.Count];
                 foreach (var col in schema.GroupIds)
                     srcActiveLeading[col] = true;
                 _leadingCursor = parent.Source.GetRowCursor(x => srcActiveLeading[x]);
 
-                bool[] srcActiveTrailing = new bool[_parent.Source.Schema.ColumnCount];
+                bool[] srcActiveTrailing = new bool[_parent.Source.Schema.Count];
                 for (int i = 0; i < _groupCount; i++)
                 {
                     if (_active[i])

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -406,14 +406,14 @@ namespace Microsoft.ML.Transforms
                 CheckColumnInRange(col);
                 if (col < _groupCount)
                 {
-                    _input.GetMetadata(kind, GroupIds[col], ref value);
+                    _input[GroupIds[col]].Metadata.GetValue(kind, ref value);
                     return;
                 }
 
                 col -= _groupCount;
                 if (_preservedMetadata.Contains(kind))
                 {
-                    _input.GetMetadata(kind, KeepIds[col], ref value);
+                    _input[KeepIds[col]].Metadata.GetValue(kind, ref value);
                     return;
                 }
 

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -419,7 +419,7 @@ namespace Microsoft.ML.Transforms.Conversions
             VBuffer<ReadOnlyMemory<char>> srcSlotNames = default;
             if (!useDefaultSlotNames)
             {
-                Source.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, Infos[iinfo].Source, ref srcSlotNames);
+                Source.Schema[Infos[iinfo].Source].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref srcSlotNames);
                 useDefaultSlotNames =
                     !srcSlotNames.IsDense
                     || srcSlotNames.Length != Infos[iinfo].TypeSrc.ValueCount;

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -414,7 +414,7 @@ namespace Microsoft.ML.Transforms.Conversions
             int n = _exes[iinfo].OutputValueCount;
             var dstEditor = VBufferEditor.Create(ref dst, n);
 
-            var srcColumnName = Source.Schema.GetColumnName(Infos[iinfo].Source);
+            var srcColumnName = Source.Schema[Infos[iinfo].Source].Name;
             bool useDefaultSlotNames = !Source.Schema[Infos[iinfo].Source].HasSlotNames(Infos[iinfo].TypeSrc.VectorSize);
             VBuffer<ReadOnlyMemory<char>> srcSlotNames = default;
             if (!useDefaultSlotNames)

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             string reason = TestIsKey(type);
             if (reason != null)
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, reason, type.ToString());
@@ -222,7 +222,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 {
                     if (!inputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out int colSrc))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].input);
-                    var type = inputSchema.GetColumnType(colSrc);
+                    var type = inputSchema[colSrc].Type;
                     _parent.CheckInputColumn(inputSchema, i, colSrc);
                     infos[i] = new ColInfo(_parent.ColumnPairs[i].output, _parent.ColumnPairs[i].input, type);
                 }

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -103,9 +103,9 @@ namespace Microsoft.ML.Transforms
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var inType = inputSchema.GetColumnType(srcCol);
+            var inType = inputSchema[srcCol].Type;
             if (!inType.IsVector)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputSchema.GetColumnName(srcCol), "Vector", inType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputSchema[srcCol].Name, "Vector", inType.ToString());
         }
 
         // Factory method for SignatureLoadModel

--- a/src/Microsoft.ML.Transforms/MissingValueHandlingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueHandlingTransformer.cs
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Transforms
                 // so that they can be concatenated.
                 if (!input.Schema.TryGetColumnIndex(column.Source, out int inputCol))
                     throw h.Except("Column '{0}' does not exist", column.Source);
-                var replaceType = input.Schema.GetColumnType(inputCol);
+                var replaceType = input.Schema[inputCol].Type;
                 if (!Runtime.Data.Conversion.Conversions.Instance.TryGetStandardConversion(BoolType.Instance, replaceType.ItemType, out Delegate conv, out bool identity))
                 {
                     throw h.Except("Cannot concatenate indicator column of type '{0}' to input column of type '{1}'",

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -204,7 +204,7 @@ namespace Microsoft.ML.Transforms
                     throw MetadataUtils.ExceptGetMetadata();
 
                 var names = default(VBuffer<ReadOnlyMemory<char>>);
-                Source.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, Infos[iinfo].Source, ref names);
+                Source.Schema[Infos[iinfo].Source].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref names);
 
                 // We both assert and check. If this fails, there is a bug somewhere (possibly in this code
                 // but more likely in the implementation of Base. On the other hand, we don't want to proceed

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -150,8 +150,7 @@ namespace Microsoft.ML.Transforms
                     // Produce slot names metadata iff the source has (valid) slot names.
                     ColumnType typeNames;
                     if (!type.IsKnownSizeVector ||
-                        (typeNames = Source.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames,
-                            Infos[iinfo].Source)) == null ||
+                        (typeNames = Source.Schema[Infos[iinfo].Source].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type) == null ||
                         typeNames.VectorSize != type.VectorSize ||
                         !typeNames.ItemType.IsText)
                     {
@@ -200,7 +199,7 @@ namespace Microsoft.ML.Transforms
                 Host.Assert(size == 2 * type.VectorSize);
 
                 // REVIEW: Do we need to verify that there is metadata or should we just call GetMetadata?
-                var typeNames = Source.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, Infos[iinfo].Source);
+                var typeNames = Source.Schema[Infos[iinfo].Source].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
                 if (typeNames == null || typeNames.VectorSize != type.VectorSize || !typeNames.ItemType.IsText)
                     throw MetadataUtils.ExceptGetMetadata();
 

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -190,7 +190,7 @@ namespace Microsoft.ML.Transforms
             if (!type.IsVector)
             {
                 Host.Assert(_types[iinfo].VectorSize == 2);
-                var columnName = Source.Schema.GetColumnName(Infos[iinfo].Source);
+                var columnName = Source.Schema[Infos[iinfo].Source].Name;
                 editor.Values[0] = columnName.AsMemory();
                 editor.Values[1] = (columnName + IndicatorSuffix).AsMemory();
             }

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.ML.Transforms
                     if (!inputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out int colSrc))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].input);
                     _parent.CheckInputColumn(inputSchema, i, colSrc);
-                    var inType = inputSchema.GetColumnType(colSrc);
+                    var inType = inputSchema[colSrc].Type;
                     ColumnType outType;
                     if (!(inType is VectorType vectorType))
                         outType = BoolType.Instance;

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -236,7 +236,7 @@ namespace Microsoft.ML.Transforms
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             string reason = TestType(type);
             if (reason != null)
                 throw Host.ExceptParam(nameof(inputSchema), reason);
@@ -325,7 +325,7 @@ namespace Microsoft.ML.Transforms
             {
                 input.Schema.TryGetColumnIndex(columns[iinfo].Input, out int colSrc);
                 sources[iinfo] = colSrc;
-                var type = input.Schema.GetColumnType(colSrc);
+                var type = input.Schema[colSrc].Type;
                 if (type is VectorType vectorType)
                      type = new VectorType((PrimitiveType)type.ItemType, vectorType);
                 Delegate isNa = GetIsNADelegate(type);
@@ -627,7 +627,7 @@ namespace Microsoft.ML.Transforms
                     if (!inputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out int colSrc))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].input);
                     _parent.CheckInputColumn(inputSchema, i, colSrc);
-                    var type = inputSchema.GetColumnType(colSrc);
+                    var type = inputSchema[colSrc].Type;
                     infos[i] = new ColInfo(_parent.ColumnPairs[i].output, _parent.ColumnPairs[i].input, type);
                 }
                 return infos;

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -375,7 +375,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                         "Label column '{0}' not found", labelColumnName);
                 }
 
-                var labelType = schema.GetColumnType(labelCol);
+                var labelType = schema[labelCol].Type;
                 if (!IsValidColumnType(labelType))
                 {
                     throw _host.ExceptUserArg(nameof(MutualInformationFeatureSelectingEstimator.Arguments.LabelColumn),
@@ -393,7 +393,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                             "Source column '{0}' not found", colName);
                     }
 
-                    var colType = schema.GetColumnType(colSrc);
+                    var colType = schema[colSrc].Type;
                     if (colType.IsVector && !colType.IsKnownSizeVector)
                     {
                         throw _host.ExceptUserArg(nameof(MutualInformationFeatureSelectingEstimator.Arguments.Column),
@@ -521,7 +521,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
             private Single[] ComputeMutualInformation(Transposer trans, int col)
             {
                 // Note: NAs have their own separate bin.
-                var type = trans.Schema.GetColumnType(col);
+                var type = trans.Schema[col].Type;
                 if (type.ItemType == NumberType.I4)
                 {
                     return ComputeMutualInformation(trans, col,
@@ -586,7 +586,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
             /// </summary>
             private float[] ComputeMutualInformation<T>(Transposer trans, int col, Mapper<T> mapper)
             {
-                var slotCount = trans.Schema.GetColumnType(col).ValueCount;
+                var slotCount = trans.Schema[col].Type.ValueCount;
                 var scores = new float[slotCount];
                 int iScore = 0;
                 VBuffer<int> slotValues = default(VBuffer<int>);

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Transforms
                     int col;
                     bool success = input.TryGetColumnIndex(names[i], out col);
                     Contracts.CheckUserArg(success, nameof(args.Column));
-                    columnTypes[i] = input.GetColumnType(col);
+                    columnTypes[i] = input[col].Type;
                     srcCols[i] = col;
                 }
 

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Transforms
 
                 ch.Info("Number of slots: " + numSlots);
                 if (data.Schema[featuresColumnIndex].HasSlotNames(numSlots))
-                    data.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, featuresColumnIndex, ref slotNames);
+                    data.Schema[featuresColumnIndex].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slotNames);
 
                 if (slotNames.Length != numSlots)
                     slotNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(numSlots);

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Transforms.Projections
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             string reason = TestColumnType(type);
             if (reason != null)
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, reason, type.ToString());
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Transforms.Projections
             for (int i = 0; i < columns.Length; i++)
             {
                 input.Schema.TryGetColumnIndex(columns[i].Input, out int srcCol);
-                var typeSrc = input.Schema.GetColumnType(srcCol);
+                var typeSrc = input.Schema[srcCol].Type;
                 _transformInfos[i] = new TransformInfo(Host.Register(string.Format("column{0}", i)), columns[i],
                     typeSrc.ValueCount, avgDistances[i]);
             }
@@ -317,7 +317,7 @@ namespace Microsoft.ML.Transforms.Projections
             {
                 if (!input.Schema.TryGetColumnIndex(ColumnPairs[i].input, out int srcCol))
                     throw Host.ExceptSchemaMismatch(nameof(input), "input", ColumnPairs[i].input);
-                var type = input.Schema.GetColumnType(srcCol);
+                var type = input.Schema[srcCol].Type;
                 string reason = TestColumnType(type);
                 if (reason != null)
                     throw Host.ExceptSchemaMismatch(nameof(input), "input", ColumnPairs[i].input, reason, type.ToString());
@@ -330,7 +330,7 @@ namespace Microsoft.ML.Transforms.Projections
                 for (int i = 0; i < columns.Length; i++)
                 {
                     var rng = columns[i].Seed.HasValue ? RandomUtils.Create(columns[i].Seed.Value) : Host.Rand;
-                    var srcType = input.Schema.GetColumnType(srcCols[i]);
+                    var srcType = input.Schema[srcCols[i]].Type;
                     if (srcType.IsVector)
                     {
                         var get = cursor.GetGetter<VBuffer<float>>(srcCols[i]);

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -311,7 +311,7 @@ namespace Microsoft.ML.Transforms.Projections
         {
             var avgDistances = new float[columns.Length];
             const int reservoirSize = 5000;
-            bool[] activeColumns = new bool[input.Schema.ColumnCount];
+            bool[] activeColumns = new bool[input.Schema.Count];
             int[] srcCols = new int[columns.Length];
             for (int i = 0; i < columns.Length; i++)
             {

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -236,7 +236,7 @@ namespace Microsoft.ML.Transforms
 
             public override bool IsColumnActive(int col)
             {
-                Contracts.CheckParam(0 <= col && col < Schema.ColumnCount, nameof(col));
+                Contracts.CheckParam(0 <= col && col < Schema.Count, nameof(col));
                 bool isSrc;
                 int iCol = _parent._bindings.MapColumnIndex(out isSrc, col);
                 if (isSrc)
@@ -246,7 +246,7 @@ namespace Microsoft.ML.Transforms
 
             public override ValueGetter<TValue> GetGetter<TValue>(int col)
             {
-                Contracts.CheckParam(0 <= col && col < Schema.ColumnCount, nameof(col));
+                Contracts.CheckParam(0 <= col && col < Schema.Count, nameof(col));
                 bool isSrc;
                 int iCol = _parent._bindings.MapColumnIndex(out isSrc, col);
                 return isSrc ?

--- a/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
@@ -143,9 +143,9 @@ namespace Microsoft.ML.Transforms.Categorical
                 ectx.Assert(_values == null);
                 ectx.AssertValue(cursor);
                 ectx.Assert(0 <= colTerm && colTerm < cursor.Schema.Count);
-                ectx.Assert(cursor.Schema.GetColumnType(colTerm).IsText);
+                ectx.Assert(cursor.Schema[colTerm].Type.IsText);
                 ectx.Assert(0 <= colValue && colValue < cursor.Schema.Count);
-                ectx.Assert(cursor.Schema.GetColumnType(colValue).Equals(Type));
+                ectx.Assert(cursor.Schema[colValue].Type.Equals(Type));
 
                 var getTerm = cursor.GetGetter<ReadOnlyMemory<char>>(colTerm);
                 var getValue = cursor.GetGetter<TRes>(colValue);
@@ -501,9 +501,9 @@ namespace Microsoft.ML.Transforms.Categorical
 
             // REVIEW: Should we allow term to be a vector of text (each term in the vector
             // would map to the same value)?
-            var typeTerm = schema.GetColumnType(colTerm);
+            var typeTerm = schema[colTerm].Type;
             host.CheckUserArg(typeTerm.IsText, nameof(Arguments.TermColumn), "term column must contain text");
-            var typeValue = schema.GetColumnType(colValue);
+            var typeValue = schema[colValue].Type;
             var cols = new List<(string Source, string Name)>()
             {
                 (termColumn, "Term"),
@@ -574,10 +574,10 @@ namespace Microsoft.ML.Transforms.Categorical
 
             // REVIEW: Should we allow term to be a vector of text (each term in the vector
             // would map to the same value)?
-            ectx.Assert(ldr.Schema.GetColumnType(0).IsText);
+            ectx.Assert(ldr.Schema[0].Type.IsText);
 
             var schema = ldr.Schema;
-            var typeValue = schema.GetColumnType(1);
+            var typeValue = schema[1].Type;
 
             // REVIEW: We should know the number of rows - use that info to set initial capacity.
             var values = ValueMap.Create(typeValue);
@@ -660,7 +660,7 @@ namespace Microsoft.ML.Transforms.Categorical
         {
             Contracts.Assert(ldr != null);
             Contracts.Assert(ldr.Schema.Count == 2);
-            Contracts.Assert(ldr.Schema.GetColumnType(0).IsText);
+            Contracts.Assert(ldr.Schema[0].Type.IsText);
         }
 
         private static void ValidateLoader(IExceptionContext ectx, BinaryLoader ldr)
@@ -668,7 +668,7 @@ namespace Microsoft.ML.Transforms.Categorical
             if (ldr == null)
                 return;
             ectx.CheckDecode(ldr.Schema.Count == 2);
-            ectx.CheckDecode(ldr.Schema.GetColumnType(0).IsText);
+            ectx.CheckDecode(ldr.Schema[0].Type.IsText);
         }
 
         protected override ColumnType GetColumnTypeCore(int iinfo)

--- a/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
+++ b/src/Microsoft.ML.Transforms/TermLookupTransformer.cs
@@ -142,9 +142,9 @@ namespace Microsoft.ML.Transforms.Categorical
                 ectx.Assert(_terms == null);
                 ectx.Assert(_values == null);
                 ectx.AssertValue(cursor);
-                ectx.Assert(0 <= colTerm && colTerm < cursor.Schema.ColumnCount);
+                ectx.Assert(0 <= colTerm && colTerm < cursor.Schema.Count);
                 ectx.Assert(cursor.Schema.GetColumnType(colTerm).IsText);
-                ectx.Assert(0 <= colValue && colValue < cursor.Schema.ColumnCount);
+                ectx.Assert(0 <= colValue && colValue < cursor.Schema.Count);
                 ectx.Assert(cursor.Schema.GetColumnType(colValue).Equals(Type));
 
                 var getTerm = cursor.GetGetter<ReadOnlyMemory<char>>(colTerm);
@@ -570,7 +570,7 @@ namespace Microsoft.ML.Transforms.Categorical
         {
             Contracts.AssertValue(ectx);
             ectx.AssertValue(ldr);
-            ectx.Assert(ldr.Schema.ColumnCount == 2);
+            ectx.Assert(ldr.Schema.Count == 2);
 
             // REVIEW: Should we allow term to be a vector of text (each term in the vector
             // would map to the same value)?
@@ -659,7 +659,7 @@ namespace Microsoft.ML.Transforms.Categorical
         private static void DebugValidateLoader(BinaryLoader ldr)
         {
             Contracts.Assert(ldr != null);
-            Contracts.Assert(ldr.Schema.ColumnCount == 2);
+            Contracts.Assert(ldr.Schema.Count == 2);
             Contracts.Assert(ldr.Schema.GetColumnType(0).IsText);
         }
 
@@ -667,7 +667,7 @@ namespace Microsoft.ML.Transforms.Categorical
         {
             if (ldr == null)
                 return;
-            ectx.CheckDecode(ldr.Schema.ColumnCount == 2);
+            ectx.CheckDecode(ldr.Schema.Count == 2);
             ectx.CheckDecode(ldr.Schema.GetColumnType(0).IsText);
         }
 

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -936,7 +936,7 @@ namespace Microsoft.ML.Transforms.Text
                 if (!inputData.Schema.TryGetColumnIndex(columns[i].Input, out int srcCol))
                     throw env.ExceptSchemaMismatch(nameof(inputData), "input", columns[i].Input);
 
-                var srcColType = inputSchema.GetColumnType(srcCol);
+                var srcColType = inputSchema[srcCol].Type;
                 if (!srcColType.IsKnownSizeVector || !(srcColType.ItemType is NumberType))
                     throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].Input, "a fixed vector of floats", srcColType.ToString());
 

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -946,7 +946,7 @@ namespace Microsoft.ML.Transforms.Text
 
                 VBuffer<ReadOnlyMemory<char>> dst = default;
                 if (inputSchema[srcCol].HasSlotNames(srcColType.ValueCount))
-                    inputSchema.GetMetadata(MetadataUtils.Kinds.SlotNames, srcCol, ref dst);
+                    inputSchema[srcCol].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref dst);
                 else
                     dst = default(VBuffer<ReadOnlyMemory<char>>);
                 columnMappings.Add(dst);

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -924,7 +924,7 @@ namespace Microsoft.ML.Transforms.Text
             ch.AssertValue(states);
             ch.Assert(states.Length == columns.Length);
 
-            bool[] activeColumns = new bool[inputData.Schema.ColumnCount];
+            bool[] activeColumns = new bool[inputData.Schema.Count];
             int[] numVocabs = new int[columns.Length];
             int[] srcCols = new int[columns.Length];
 

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -692,7 +692,7 @@ namespace Microsoft.ML.Transforms.Text
 
             private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
-                var active = new bool[InputSchema.ColumnCount];
+                var active = new bool[InputSchema.Count];
                 for (int i = 0; i < _srcIndices.Length; i++)
                 {
                     if (activeOutput(i))
@@ -759,7 +759,7 @@ namespace Microsoft.ML.Transforms.Text
                 // One per iinfo (some may be null).
                 _iinfoToCollector = new InvertHashCollector<NGram>[_parent._columns.Length];
                 // One per source column (some may be null).
-                _srcTextGetters = new ValueMapper<uint, StringBuilder>[inputSchema.ColumnCount];
+                _srcTextGetters = new ValueMapper<uint, StringBuilder>[inputSchema.Count];
                 _invertHashMaxCounts = invertHashMaxCounts;
                 for (int i = 0; i < _srcTextGetters.Length; ++i)
                 {

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -356,8 +356,8 @@ namespace Microsoft.ML.Transforms.Text
                     {
                         if (!input.Schema.TryGetColumnIndex(_columns[i].Inputs[j], out int srcCol))
                             throw Host.ExceptSchemaMismatch(nameof(input), "input", _columns[i].Inputs[j]);
-                        var columnType = input.Schema.GetColumnType(srcCol);
-                        if (!NgramHashingEstimator.IsColumnTypeValid(input.Schema.GetColumnType(srcCol)))
+                        var columnType = input.Schema[srcCol].Type;
+                        if (!NgramHashingEstimator.IsColumnTypeValid(input.Schema[srcCol].Type))
                             throw Host.ExceptSchemaMismatch(nameof(input), "input", _columns[i].Inputs[j], NgramHashingEstimator.ExpectedColumnType, columnType.ToString());
                         sourceColumnsForInvertHash.Add(srcCol);
                     }
@@ -500,10 +500,10 @@ namespace Microsoft.ML.Transforms.Text
                         var srcName = _parent._columns[i].Inputs[j];
                         if (!inputSchema.TryGetColumnIndex(srcName, out int srcCol))
                             throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", srcName);
-                        var columnType = inputSchema.GetColumnType(srcCol);
+                        var columnType = inputSchema[srcCol].Type;
                         if (!NgramHashingEstimator.IsColumnTypeValid(columnType))
                             throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", srcName, NgramHashingEstimator.ExpectedColumnType, columnType.ToString());
-                        var srcType = inputSchema.GetColumnType(srcCol);
+                        var srcType = inputSchema[srcCol].Type;
                         _srcIndices[i][j] = srcCol;
                         _srcTypes[i][j] = srcType;
                     }

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Transforms.Text
             // i in _counts counts how many (i+1)-grams are in the pool for column iinfo.
             var counts = new int[columns.Length][];
             var ngramMaps = new SequencePool[columns.Length];
-            var activeInput = new bool[trainingData.Schema.ColumnCount];
+            var activeInput = new bool[trainingData.Schema.Count];
             var srcTypes = new ColumnType[columns.Length];
             var srcCols = new int[columns.Length];
             for (int iinfo = 0; iinfo < columns.Length; iinfo++)

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -604,7 +604,7 @@ namespace Microsoft.ML.Transforms.Text
                 var unigramNames = new VBuffer<ReadOnlyMemory<char>>();
 
                 // Get the key values of the unigrams.
-                InputSchema.GetMetadata(MetadataUtils.Kinds.KeyValues, _srcCols[iinfo], ref unigramNames);
+                InputSchema[_srcCols[iinfo]].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref unigramNames);
                 Host.Check(unigramNames.Length == keyCount);
 
                 var pool = _parent._ngramMaps[iinfo];

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -273,7 +273,7 @@ namespace Microsoft.ML.Transforms.Text
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             if (!NgramExtractingEstimator.IsColumnTypeValid(type))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, NgramExtractingEstimator.ExpectedColumnType, type.ToString());
         }
@@ -285,7 +285,7 @@ namespace Microsoft.ML.Transforms.Text
             for (int i = 0; i < columns.Length; i++)
             {
                 input.Schema.TryGetColumnIndex(columns[i].Input, out int srcCol);
-                var typeSrc = input.Schema.GetColumnType(srcCol);
+                var typeSrc = input.Schema[srcCol].Type;
                 transformInfos[i] = new TransformInfo(columns[i]);
             }
             _transformInfos = transformInfos.ToImmutableArray();
@@ -563,7 +563,7 @@ namespace Microsoft.ML.Transforms.Text
                 {
                     _types[i] = new VectorType(NumberType.Float, _parent._ngramMaps[i].Count);
                     inputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out _srcCols[i]);
-                    _srcTypes[i] = inputSchema.GetColumnType(_srcCols[i]);
+                    _srcTypes[i] = inputSchema[_srcCols[i]].Type;
                 }
             }
 

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -215,7 +215,7 @@ namespace Microsoft.ML.Transforms.Text
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             if (!StopWordsRemovingEstimator.IsColumnTypeValid(type))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, StopWordsRemovingEstimator.ExpectedColumnType, type.ToString());
         }
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Transforms.Text
                     _parent.CheckInputColumn(InputSchema, i, srcCol);
                     _colMapNewToOld.Add(i, srcCol);
 
-                    var srcType = InputSchema.GetColumnType(srcCol);
+                    var srcType = InputSchema[srcCol].Type;
                     if (!StopWordsRemovingEstimator.IsColumnTypeValid(srcType))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", parent._columns[i].Input, StopWordsRemovingEstimator.ExpectedColumnType, srcType.ToString());
 
@@ -977,7 +977,7 @@ namespace Microsoft.ML.Transforms.Text
                 for (int i = 0; i < _parent.ColumnPairs.Length; i++)
                 {
                     inputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out int srcCol);
-                    var srcType = inputSchema.GetColumnType(srcCol);
+                    var srcType = inputSchema[srcCol].Type;
                     if (!StopWordsRemovingEstimator.IsColumnTypeValid(srcType))
                         throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", parent.ColumnPairs[i].input, StopWordsRemovingEstimator.ExpectedColumnType, srcType.ToString());
 

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -493,7 +493,7 @@ namespace Microsoft.ML.Transforms.Text
 
             private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
-                var active = new bool[InputSchema.ColumnCount];
+                var active = new bool[InputSchema.Count];
                 foreach (var pair in _colMapNewToOld)
                     if (activeOutput(pair.Key))
                     {

--- a/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
@@ -115,7 +115,7 @@ namespace Microsoft.ML.Transforms.Text
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             if (!TextNormalizingEstimator.IsColumnTypeValid(type))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, TextNormalizingEstimator.ExpectedColumnType, type.ToString());
         }
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Transforms.Text
                 for (int i = 0; i < _types.Length; i++)
                 {
                     inputSchema.TryGetColumnIndex(_parent.ColumnPairs[i].input, out int srcCol);
-                    var srcType = inputSchema.GetColumnType(srcCol);
+                    var srcType = inputSchema[srcCol].Type;
                     _types[i] = srcType.IsVector ? new VectorType(TextType.Instance) : srcType;
                 }
             }

--- a/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
+++ b/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Transforms.Text
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             if (!TokenizingByCharactersEstimator.IsColumnTypeValid(type))
                 throw Host.ExceptParam(nameof(inputSchema), TokenizingByCharactersEstimator.ExpectedColumnType);
         }
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Transforms.Text
             {
                 Host.AssertValue(input);
 
-                int cv = input.Schema.GetColumnType(ColMapNewToOld[iinfo]).VectorSize;
+                int cv = input.Schema[ColMapNewToOld[iinfo]].Type.VectorSize;
                 Contracts.Assert(cv >= 0);
 
                 var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);

--- a/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Transforms.Text
                 h.CheckNonWhiteSpace(col.Source, nameof(col.Source));
                 int colId;
                 if (input.Schema.TryGetColumnIndex(col.Source, out colId) &&
-                    input.Schema.GetColumnType(colId).ItemType.IsText)
+                    input.Schema[colId].Type.ItemType.IsText)
                 {
                     termCols.Add(col);
                     isTermCol[i] = true;

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
@@ -322,9 +322,9 @@ namespace Microsoft.ML.Transforms.Text
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var colType = inputSchema.GetColumnType(srcCol);
+            var colType = inputSchema[srcCol].Type;
             if (!(colType.IsVector && colType.ItemType.IsText))
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, "Text", inputSchema.GetColumnType(srcCol).ToString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, "Text", inputSchema[srcCol].Type.ToString());
         }
 
         private sealed class Mapper : OneToOneMapperBase, ISaveAsOnnx
@@ -572,7 +572,7 @@ namespace Microsoft.ML.Transforms.Text
                 Host.AssertValue(input);
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
 
-                var colType = input.Schema.GetColumnType(ColMapNewToOld[iinfo]);
+                var colType = input.Schema[ColMapNewToOld[iinfo]].Type;
                 Host.Assert(colType.IsVector);
                 Host.Assert(colType.ItemType.IsText);
 

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Transforms.Text
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            var type = inputSchema.GetColumnType(srcCol);
+            var type = inputSchema[srcCol].Type;
             if (!WordTokenizingEstimator.IsColumnTypeValid(type))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, WordTokenizingEstimator.ExpectedColumnType, type.ToString());
         }
@@ -240,7 +240,7 @@ namespace Microsoft.ML.Transforms.Text
                 for (int i = 0; i < _isSourceVector.Length; i++)
                 {
                     inputSchema.TryGetColumnIndex(_parent._columns[i].Input, out int srcCol);
-                    var srcType = inputSchema.GetColumnType(srcCol);
+                    var srcType = inputSchema[srcCol].Type;
                     _isSourceVector[i] = srcType.IsVector;
                 }
             }
@@ -264,7 +264,7 @@ namespace Microsoft.ML.Transforms.Text
                 disposer = null;
 
                 input.Schema.TryGetColumnIndex(_parent._columns[iinfo].Input, out int srcCol);
-                var srcType = input.Schema.GetColumnType(srcCol);
+                var srcType = input.Schema[srcCol].Type;
                 Host.Assert(srcType.ItemType.IsText);
 
                 if (!srcType.IsVector)
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Transforms.Text
             {
                 Host.AssertValue(input);
 
-                int cv = input.Schema.GetColumnType(ColMapNewToOld[iinfo]).VectorSize;
+                int cv = input.Schema[ColMapNewToOld[iinfo]].Type.VectorSize;
                 Contracts.Assert(cv >= 0);
                 var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -417,8 +417,8 @@ namespace Microsoft.ML.Transforms
             {
                 _ectx.Check(0 <= col && col < ColumnCount);
                 if (!IsPivot(col))
-                    return _inputSchema.GetMetadataTypes(col);
-                return _inputSchema.GetMetadataTypes(col).Where(pair => ShouldPreserveMetadata(pair.Key));
+                    return _inputSchema[col].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type));
+                return _inputSchema[col].Metadata.Schema.Select(c => new KeyValuePair<string, ColumnType>(c.Name, c.Type)).Where(pair => ShouldPreserveMetadata(pair.Key));
             }
 
             public ColumnType GetMetadataTypeOrNull(string kind, int col)
@@ -426,7 +426,7 @@ namespace Microsoft.ML.Transforms
                 _ectx.Check(0 <= col && col < ColumnCount);
                 if (IsPivot(col) && !ShouldPreserveMetadata(kind))
                     return null;
-                return _inputSchema.GetMetadataTypeOrNull(kind, col);
+                return _inputSchema[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
             }
 
             public void GetMetadata<TValue>(string kind, int col, ref TValue value)

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Transforms
                 _ectx.Check(0 <= col && col < ColumnCount);
                 if (IsPivot(col) && !ShouldPreserveMetadata(kind))
                     throw _ectx.ExceptGetMetadata();
-                _inputSchema.GetMetadata(kind, col, ref value);
+                _inputSchema[col].Metadata.GetValue(kind, ref value);
             }
         }
 

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -287,7 +287,7 @@ namespace Microsoft.ML.Transforms
                     int col;
                     if (!inputSchema.TryGetColumnIndex(name, out col))
                         throw ectx.ExceptUserArg(nameof(Arguments.Column), "Pivot column '{0}' is not found", name);
-                    var colType = inputSchema.GetColumnType(col);
+                    var colType = inputSchema[col].Type;
                     if (!colType.IsVector || !colType.ItemType.IsPrimitive)
                         throw ectx.ExceptUserArg(nameof(Arguments.Column),
                             "Pivot column '{0}' has type '{1}', but must be a vector of primitive types", name, colType);
@@ -401,14 +401,14 @@ namespace Microsoft.ML.Transforms
 
             public string GetColumnName(int col)
             {
-                return _inputSchema.GetColumnName(col);
+                return _inputSchema[col].Name;
             }
 
             public ColumnType GetColumnType(int col)
             {
                 _ectx.Check(0 <= col && col < ColumnCount);
                 if (!IsPivot(col))
-                    return _inputSchema.GetColumnType(col);
+                    return _inputSchema[col].Type;
                 _ectx.Assert(0 <= _pivotIndex[col] && _pivotIndex[col] < _infos.Length);
                 return _infos[_pivotIndex[col]].ItemType;
             }

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -201,15 +201,15 @@ namespace Microsoft.ML.Transforms
             {
                 switch (kind)
                 {
-                case MetadataUtils.Kinds.IsNormalized:
-                case MetadataUtils.Kinds.KeyValues:
-                case MetadataUtils.Kinds.ScoreColumnSetId:
-                case MetadataUtils.Kinds.ScoreColumnKind:
-                case MetadataUtils.Kinds.ScoreValueKind:
-                case MetadataUtils.Kinds.IsUserVisible:
-                    return true;
-                default:
-                    return false;
+                    case MetadataUtils.Kinds.IsNormalized:
+                    case MetadataUtils.Kinds.KeyValues:
+                    case MetadataUtils.Kinds.ScoreColumnSetId:
+                    case MetadataUtils.Kinds.ScoreColumnKind:
+                    case MetadataUtils.Kinds.ScoreValueKind:
+                    case MetadataUtils.Kinds.IsUserVisible:
+                        return true;
+                    default:
+                        return false;
                 }
             }
 
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Transforms
                 CheckAndBind(_ectx, inputSchema, pivotColumns, out _infos);
 
                 _pivotColMap = new Dictionary<string, int>();
-                _pivotIndex = Utils.CreateArray(_inputSchema.ColumnCount, -1);
+                _pivotIndex = Utils.CreateArray(_inputSchema.Count, -1);
                 for (int i = 0; i < _infos.Length; i++)
                 {
                     var info = _infos[i];
@@ -392,10 +392,7 @@ namespace Microsoft.ML.Transforms
                 return size;
             }
 
-            public int ColumnCount
-            {
-                get { return _inputSchema.ColumnCount; }
-            }
+            public int ColumnCount => _inputSchema.Count;
 
             public bool TryGetColumnIndex(string name, out int col)
             {

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -75,12 +75,12 @@ namespace Microsoft.ML.Benchmarks
             var info = new HashingTransformer.ColumnInfo("Foo", "Bar", hashBits: hashBits);
             var xf = new HashingTransformer(_env, new[] { info });
             var mapper = xf.GetRowToRowMapper(_inRow.Schema);
-            mapper.OutputSchema.TryGetColumnIndex("Bar", out int outCol);
-            var outRow = mapper.GetRow(_inRow, c => c == outCol);
+            var column = mapper.OutputSchema["Bar"];
+            var outRow = mapper.GetRow(_inRow, c => c == column.Index);
             if (type is VectorType)
-                _vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+                _vecGetter = outRow.GetGetter<VBuffer<uint>>(column.Index);
             else
-                _getter = outRow.GetGetter<uint>(outCol);
+                _getter = outRow.GetGetter<uint>(column.Index);
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
@@ -326,8 +326,8 @@ namespace Microsoft.ML.Runtime.Core.Tests.UnitTests
 
                 if (f1 && f2)
                 {
-                    var type1 = curs1.Schema.GetColumnType(col);
-                    var type2 = curs2.Schema.GetColumnType(col);
+                    var type1 = curs1.Schema[col].Type;
+                    var type2 = curs2.Schema[col].Type;
                     if (!EqualTypes(type1, type2, exactTypes))
                     {
                         Fail($"Different types {type1} and {type2}");
@@ -415,8 +415,8 @@ namespace Microsoft.ML.Runtime.Core.Tests.UnitTests
                 for (int col = 0; col < colLim; col++)
                 {
                     Contracts.Assert(cursors[col] != null);
-                    var type1 = curs1.Schema.GetColumnType(col);
-                    var type2 = cursors[col].Schema.GetColumnType(col);
+                    var type1 = curs1.Schema[col].Type;
+                    var type2 = cursors[col].Schema[col].Type;
                     if (!EqualTypes(type1, type2, exactTypes))
                     {
                         Fail("Different types");

--- a/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
@@ -267,7 +267,7 @@ namespace Microsoft.ML.Runtime.Core.Tests.UnitTests
 
         protected bool CheckSameValues(IDataView view1, IDataView view2, bool exactTypes = true, bool exactDoubles = true, bool checkId = true)
         {
-            Contracts.Assert(view1.Schema.ColumnCount == view2.Schema.ColumnCount);
+            Contracts.Assert(view1.Schema.Count == view2.Schema.Count);
 
             bool all = true;
             bool tmp;
@@ -314,10 +314,10 @@ namespace Microsoft.ML.Runtime.Core.Tests.UnitTests
 
         protected bool CheckSameValues(RowCursor curs1, RowCursor curs2, bool exactTypes, bool exactDoubles, bool checkId, bool checkIdCollisions = true)
         {
-            Contracts.Assert(curs1.Schema.ColumnCount == curs2.Schema.ColumnCount);
+            Contracts.Assert(curs1.Schema.Count == curs2.Schema.Count);
 
             // Get the comparison delegates for each column.
-            int colLim = curs1.Schema.ColumnCount;
+            int colLim = curs1.Schema.Count;
             Func<bool>[] comps = new Func<bool>[colLim];
             for (int col = 0; col < colLim; col++)
             {
@@ -394,10 +394,10 @@ namespace Microsoft.ML.Runtime.Core.Tests.UnitTests
 
         protected bool CheckSameValues(RowCursor curs1, IDataView view2, bool exactTypes = true, bool exactDoubles = true, bool checkId = true)
         {
-            Contracts.Assert(curs1.Schema.ColumnCount == view2.Schema.ColumnCount);
+            Contracts.Assert(curs1.Schema.Count == view2.Schema.Count);
 
             // Get a cursor for each column.
-            int colLim = curs1.Schema.ColumnCount;
+            int colLim = curs1.Schema.Count;
             var cursors = new RowCursor[colLim];
             try
             {

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Runtime.RunTests
             Assert.Equal(5, schema.Count);
             var expected = new[] { "Label", "Workclass", "Categories", "NumericFeatures", "NumericFeatures" };
             for (int i = 0; i < schema.Count; i++)
-                Assert.Equal(expected[i], schema.GetColumnName(i));
+                Assert.Equal(expected[i], schema[i].Name);
         }
 
         [Fact]
@@ -976,8 +976,8 @@ namespace Microsoft.ML.Runtime.RunTests
 
             var schema = data.Schema;
             Assert.Equal(3, schema.Count);
-            Assert.Equal("Softmax", schema.GetColumnName(2));
-            Assert.Equal(10, (schema.GetColumnType(2) as VectorType)?.Size);
+            Assert.Equal("Softmax", schema[2].Name);
+            Assert.Equal(10, (schema[2].Type as VectorType)?.Size);
         }
     }
 #pragma warning restore 612, 618

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -492,7 +492,7 @@ namespace Microsoft.ML.Runtime.RunTests
             Assert.True(b);
             b = schema.TryGetColumnIndex("Fold Index", out foldCol);
             Assert.True(b);
-            var type = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, countCol);
+            var type = schema[countCol].Metadata.Schema[MetadataUtils.Kinds.SlotNames].Type;
             Assert.True(type is VectorType vecType && vecType.ItemType is TextType && vecType.Size == 10);
             var slotNames = default(VBuffer<ReadOnlyMemory<char>>);
             schema.GetMetadata(MetadataUtils.Kinds.SlotNames, countCol, ref slotNames);

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -495,7 +495,7 @@ namespace Microsoft.ML.Runtime.RunTests
             var type = schema[countCol].Metadata.Schema[MetadataUtils.Kinds.SlotNames].Type;
             Assert.True(type is VectorType vecType && vecType.ItemType is TextType && vecType.Size == 10);
             var slotNames = default(VBuffer<ReadOnlyMemory<char>>);
-            schema.GetMetadata(MetadataUtils.Kinds.SlotNames, countCol, ref slotNames);
+            schema[countCol].GetSlotNames(ref slotNames);
             var slotNameValues = slotNames.GetValues();
             for (int i = 0; i < slotNameValues.Length; i++)
             {

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestCSharpApi.cs
@@ -44,9 +44,9 @@ namespace Microsoft.ML.Runtime.RunTests
             var data = experiment.GetOutput(normalizeOutput.OutputData);
 
             var schema = data.Schema;
-            Assert.Equal(5, schema.ColumnCount);
+            Assert.Equal(5, schema.Count);
             var expected = new[] { "Label", "Workclass", "Categories", "NumericFeatures", "NumericFeatures" };
-            for (int i = 0; i < schema.ColumnCount; i++)
+            for (int i = 0; i < schema.Count; i++)
                 Assert.Equal(expected[i], schema.GetColumnName(i));
         }
 
@@ -975,7 +975,7 @@ namespace Microsoft.ML.Runtime.RunTests
             var data = experiment.GetOutput(tfTransformOutput.OutputData);
 
             var schema = data.Schema;
-            Assert.Equal(3, schema.ColumnCount);
+            Assert.Equal(3, schema.Count);
             Assert.Equal("Softmax", schema.GetColumnName(2));
             Assert.Equal(10, (schema.GetColumnType(2) as VectorType)?.Size);
         }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -849,7 +849,7 @@ namespace Microsoft.ML.Runtime.RunTests
             // Make sure the scorers have the correct types.
             var hasScoreCol = binaryScored.Schema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out int scoreIndex);
             Assert.True(hasScoreCol, "Data scored with binary ensemble does not have a score column");
-            var type = binaryScored.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex);
+            var type = binaryScored.Schema[scoreIndex].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
             Assert.True(type is TextType, "Binary ensemble scored data does not have correct type of metadata.");
             var kind = default(ReadOnlyMemory<char>);
             binaryScored.Schema.GetMetadata(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex, ref kind);
@@ -858,7 +858,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             hasScoreCol = regressionScored.Schema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIndex);
             Assert.True(hasScoreCol, "Data scored with regression ensemble does not have a score column");
-            type = regressionScored.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex);
+            type = regressionScored.Schema[scoreIndex].Metadata.Schema[MetadataUtils.Kinds.ScoreColumnKind].Type;
             Assert.True(type is TextType, "Regression ensemble scored data does not have correct type of metadata.");
             regressionScored.Schema.GetMetadata(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex, ref kind);
             Assert.True(ReadOnlyMemoryUtils.EqualsStr(MetadataUtils.Const.ScoreColumnKind.Regression, kind),
@@ -866,7 +866,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             hasScoreCol = anomalyScored.Schema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreIndex);
             Assert.True(hasScoreCol, "Data scored with anomaly detection ensemble does not have a score column");
-            type = anomalyScored.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex);
+            type = anomalyScored.Schema[scoreIndex].Metadata.Schema[MetadataUtils.Kinds.ScoreColumnKind].Type;
             Assert.True(type is TextType, "Anomaly detection ensemble scored data does not have correct type of metadata.");
             anomalyScored.Schema.GetMetadata(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex, ref kind);
             Assert.True(ReadOnlyMemoryUtils.EqualsStr(MetadataUtils.Const.ScoreColumnKind.AnomalyDetection, kind),

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -852,7 +852,7 @@ namespace Microsoft.ML.Runtime.RunTests
             var type = binaryScored.Schema[scoreIndex].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
             Assert.True(type is TextType, "Binary ensemble scored data does not have correct type of metadata.");
             var kind = default(ReadOnlyMemory<char>);
-            binaryScored.Schema.GetMetadata(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex, ref kind);
+            binaryScored.Schema[scoreIndex].Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnKind, ref kind);
             Assert.True(ReadOnlyMemoryUtils.EqualsStr(MetadataUtils.Const.ScoreColumnKind.BinaryClassification, kind),
                 $"Binary ensemble scored data column type should be '{MetadataUtils.Const.ScoreColumnKind.BinaryClassification}', but is instead '{kind}'");
 
@@ -860,7 +860,7 @@ namespace Microsoft.ML.Runtime.RunTests
             Assert.True(hasScoreCol, "Data scored with regression ensemble does not have a score column");
             type = regressionScored.Schema[scoreIndex].Metadata.Schema[MetadataUtils.Kinds.ScoreColumnKind].Type;
             Assert.True(type is TextType, "Regression ensemble scored data does not have correct type of metadata.");
-            regressionScored.Schema.GetMetadata(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex, ref kind);
+            regressionScored.Schema[scoreIndex].Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnKind, ref kind);
             Assert.True(ReadOnlyMemoryUtils.EqualsStr(MetadataUtils.Const.ScoreColumnKind.Regression, kind),
                 $"Regression ensemble scored data column type should be '{MetadataUtils.Const.ScoreColumnKind.Regression}', but is instead '{kind}'");
 
@@ -868,7 +868,7 @@ namespace Microsoft.ML.Runtime.RunTests
             Assert.True(hasScoreCol, "Data scored with anomaly detection ensemble does not have a score column");
             type = anomalyScored.Schema[scoreIndex].Metadata.Schema[MetadataUtils.Kinds.ScoreColumnKind].Type;
             Assert.True(type is TextType, "Anomaly detection ensemble scored data does not have correct type of metadata.");
-            anomalyScored.Schema.GetMetadata(MetadataUtils.Kinds.ScoreColumnKind, scoreIndex, ref kind);
+            anomalyScored.Schema[scoreIndex].Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnKind, ref kind);
             Assert.True(ReadOnlyMemoryUtils.EqualsStr(MetadataUtils.Const.ScoreColumnKind.AnomalyDetection, kind),
                 $"Anomaly detection ensemble scored data column type should be '{MetadataUtils.Const.ScoreColumnKind.AnomalyDetection}', but is instead '{kind}'");
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -151,7 +151,7 @@ namespace Microsoft.ML.Runtime.RunTests
             var scored2 = ScoreModel.Score(Env, new ScoreModel.Input() { Data = dataView, PredictorModel = lrModel.Apply(Env, trainData.Model) }).ScoredData;
             scored2 = ScoreModel.SelectColumns(Env, new ScoreModel.ScoreColumnSelectorInput() { Data = scored2, ExtraColumns = new[] { "Label" } }).OutputData;
 
-            Assert.Equal(4, scored1.Schema.ColumnCount);
+            Assert.Equal(4, scored1.Schema.Count);
             CheckSameValues(scored1, scored2);
             Done();
         }
@@ -721,7 +721,7 @@ namespace Microsoft.ML.Runtime.RunTests
             var scored2 = ScoreModel.Score(Env, new ScoreModel.Input() { Data = splitOutput.TestData[2], PredictorModel = calibratedLrModel }).ScoredData;
             scored2 = ScoreModel.SelectColumns(Env, new ScoreModel.ScoreColumnSelectorInput() { Data = scored2, ExtraColumns = new[] { "Label" } }).OutputData;
 
-            Assert.Equal(4, scored1.Schema.ColumnCount);
+            Assert.Equal(4, scored1.Schema.Count);
             CheckSameValues(scored1, scored2);
 
             var input = new Calibrate.NoArgumentsInput() { Data = splitOutput.TestData[1], UncalibratedPredictorModel = lrModel };

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestModelLoad.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestModelLoad.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Runtime.RunTests
             {
                 IDataLoader result = ModelFileUtils.LoadLoader(env, rep, new MultiFileSource(null), true);
 
-                Assert.Equal(2, result.Schema.ColumnCount);
+                Assert.Equal(2, result.Schema.Count);
                 Assert.Equal("Image", result.Schema[0].Name);
                 Assert.Equal("Class", result.Schema[1].Name);
             }
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Runtime.RunTests
             {
                 var result = ModelFileUtils.LoadPipeline(env, rep, new MultiFileSource(null), true);
 
-                Assert.Equal(3, result.Schema.ColumnCount);
+                Assert.Equal(3, result.Schema.Count);
                 Assert.Equal("Label", result.Schema[0].Name);
                 Assert.Equal("Features", result.Schema[1].Name);
                 Assert.Equal("Features", result.Schema[2].Name);

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
         private static T[] NaiveTranspose<T>(IDataView view, int col)
         {
-            var type = view.Schema.GetColumnType(col);
+            var type = view.Schema[col].Type;
             int rc = checked((int)DataViewUtils.ComputeRowCount(view));
             var vecType = type as VectorType;
             var itemType = vecType?.ItemType ?? type;
@@ -65,11 +65,11 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             int col = viewCol;
             VectorType type = trans.TransposeSchema.GetSlotType(col);
-            ColumnType colType = trans.Schema.GetColumnType(col);
-            Assert.Equal(view.Schema.GetColumnName(viewCol), trans.Schema.GetColumnName(col));
-            ColumnType expectedType = view.Schema.GetColumnType(viewCol);
+            ColumnType colType = trans.Schema[col].Type;
+            Assert.Equal(view.Schema[viewCol].Name, trans.Schema[col].Name);
+            ColumnType expectedType = view.Schema[viewCol].Type;
             Assert.Equal(expectedType, colType);
-            string desc = string.Format("Column {0} named '{1}'", col, trans.Schema.GetColumnName(col));
+            string desc = string.Format("Column {0} named '{1}'", col, trans.Schema[col].Name);
             Assert.Equal(DataViewUtils.ComputeRowCount(view), (long)type.Size);
             Assert.True(typeof(T) == type.ItemType.RawType, $"{desc} had wrong type for slot cursor");
             Assert.True(type.Size > 0, $"{desc} expected to be known sized vector but is not");

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -237,7 +237,7 @@ namespace Microsoft.ML.Runtime.RunTests
             using (MemoryStream mem = new MemoryStream())
             {
                 TransposeSaver saver = new TransposeSaver(Env, new TransposeSaver.Arguments());
-                saver.SaveData(mem, view, Utils.GetIdentityPermutation(view.Schema.ColumnCount));
+                saver.SaveData(mem, view, Utils.GetIdentityPermutation(view.Schema.Count));
                 src = new BytesStreamSource(mem.ToArray());
             }
             TransposeLoader loader = new TransposeLoader(Env, new TransposeLoader.Arguments(), src);

--- a/test/Microsoft.ML.StaticPipelineTesting/ImageAnalyticsTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/ImageAnalyticsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             var schema = reader.AsDynamic.GetOutputSchema();
             Assert.True(schema.TryGetColumnIndex("Data", out int col), "Could not find 'Data' column");
-            var type = schema.GetColumnType(col);
+            var type = schema[col].Type;
             var vecType = type as VectorType;
             Assert.True(vecType?.Size > 0, $"Type was supposed to be known size vector but was instead '{type}'");
             Assert.Equal(NumberType.R4, vecType.ItemType);

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -425,7 +425,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                     Separator = ",",
                     OutputHeader = false
                 });
-                saver.SaveData(stream, v, Utils.GetIdentityPermutation(v.Schema.ColumnCount));
+                saver.SaveData(stream, v, Utils.GetIdentityPermutation(v.Schema.Count));
                 Console.WriteLine(Encoding.UTF8.GetString(stream.ToArray()));
             }
         }

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -455,9 +455,9 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.True(schema[valuesCol].Type is VectorType valuesVecType && valuesVecType.ItemType is KeyType);
             Assert.True(schema[valuesKeyCol].Type is VectorType valuesKeyVecType && valuesKeyVecType.ItemType is KeyType);
 
-            var labelKeyType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, labelCol);
-            var valuesKeyType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, valuesCol);
-            var valuesKeyKeyType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, valuesKeyCol);
+            var labelKeyType = schema[labelCol].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
+            var valuesKeyType = schema[valuesCol].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
+            var valuesKeyKeyType = schema[valuesKeyCol].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             Assert.NotNull(labelKeyType);
             Assert.NotNull(valuesKeyType);
             Assert.NotNull(valuesKeyKeyType);

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -83,9 +83,9 @@ namespace Microsoft.ML.StaticPipelineTesting
             CheckSchemaHasColumn(schema, "text", out int textIdx);
             CheckSchemaHasColumn(schema, "numericFeatures", out int numericFeaturesIdx);
             // Next verify they have the expected types.
-            Assert.Equal(BoolType.Instance, schema.GetColumnType(labelIdx));
-            Assert.Equal(TextType.Instance, schema.GetColumnType(textIdx));
-            Assert.Equal(new VectorType(NumberType.R4, 3), schema.GetColumnType(numericFeaturesIdx));
+            Assert.Equal(BoolType.Instance, schema[labelIdx].Type);
+            Assert.Equal(TextType.Instance, schema[textIdx].Type);
+            Assert.Equal(new VectorType(NumberType.R4, 3), schema[numericFeaturesIdx].Type);
             // Next actually inspect the data.
             using (var cursor = textData.GetRowCursor(c => true))
             {
@@ -128,8 +128,8 @@ namespace Microsoft.ML.StaticPipelineTesting
             CheckSchemaHasColumn(schema, "label", out labelIdx);
             CheckSchemaHasColumn(schema, "text", out textIdx);
             // Next verify they have the expected types.
-            Assert.Equal(BoolType.Instance, schema.GetColumnType(textIdx));
-            Assert.Equal(new VectorType(NumberType.R4, 3), schema.GetColumnType(labelIdx));
+            Assert.Equal(BoolType.Instance, schema[textIdx].Type);
+            Assert.Equal(new VectorType(NumberType.R4, 3), schema[labelIdx].Type);
         }
 
         private sealed class Obnoxious1
@@ -172,7 +172,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             void Helper(Schema thisSchema, string name, ColumnType expected)
             {
                 Assert.True(thisSchema.TryGetColumnIndex(name, out int thisCol), $"Could not find column '{name}'");
-                Assert.Equal(expected, thisSchema.GetColumnType(thisCol));
+                Assert.Equal(expected, thisSchema[thisCol].Type);
             }
 
             var text = TextLoader.CreateReader(env, ctx => (
@@ -451,9 +451,9 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.True(schema.TryGetColumnIndex("valuesKey", out int valuesCol));
             Assert.True(schema.TryGetColumnIndex("valuesKeyKey", out int valuesKeyCol));
 
-            Assert.Equal(3, (schema.GetColumnType(labelCol) as KeyType)?.Count);
-            Assert.True(schema.GetColumnType(valuesCol) is VectorType valuesVecType && valuesVecType.ItemType is KeyType);
-            Assert.True(schema.GetColumnType(valuesKeyCol) is VectorType valuesKeyVecType && valuesKeyVecType.ItemType is KeyType);
+            Assert.Equal(3, (schema[labelCol].Type as KeyType)?.Count);
+            Assert.True(schema[valuesCol].Type is VectorType valuesVecType && valuesVecType.ItemType is KeyType);
+            Assert.True(schema[valuesKeyCol].Type is VectorType valuesKeyVecType && valuesKeyVecType.ItemType is KeyType);
 
             var labelKeyType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, labelCol);
             var valuesKeyType = schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, valuesCol);
@@ -495,7 +495,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             int[] expectedLen = new int[] { 1, 2, 5, 9 };
             for (int i = 0; i < idx.Length; ++i)
             {
-                var type = schema.GetColumnType(idx[i]);
+                var type = schema[idx[i]].Type;
                 types[i] = type as VectorType;
                 Assert.True(types[i]?.Size > 0, $"Col c{i} had unexpected type {type}");
                 Assert.Equal(expectedLen[i], types[i].Size);
@@ -526,11 +526,9 @@ namespace Microsoft.ML.StaticPipelineTesting
             var tdata = est.Fit(data).Transform(data);
             var schema = tdata.AsDynamic.Schema;
 
-            Assert.True(schema.TryGetColumnIndex("tokens", out int tokensCol));
-            var type = schema.GetColumnType(tokensCol);
+            var type = schema["tokens"].Type;
             Assert.True(type is VectorType vecType && vecType.Size == 0 && vecType.ItemType == TextType.Instance);
-            Assert.True(schema.TryGetColumnIndex("chars", out int charsCol));
-            type = schema.GetColumnType(charsCol);
+            type = schema["chars"].Type;
             Assert.True(type is VectorType vecType2 && vecType2.Size == 0 && vecType2.ItemType is KeyType
                     && vecType2.ItemType.RawType == typeof(ushort));
         }
@@ -556,11 +554,11 @@ namespace Microsoft.ML.StaticPipelineTesting
             var schema = tdata.AsDynamic.Schema;
 
             Assert.True(schema.TryGetColumnIndex("words_without_stopwords", out int stopwordsCol));
-            var type = schema.GetColumnType(stopwordsCol);
+            var type = schema[stopwordsCol].Type;
             Assert.True(type is VectorType vecType && vecType.Size == 0 && vecType.ItemType == TextType.Instance);
 
             Assert.True(schema.TryGetColumnIndex("normalized_text", out int normTextCol));
-            type = schema.GetColumnType(normTextCol);
+            type = schema[normTextCol].Type;
             Assert.Equal(TextType.Instance, type);
         }
 
@@ -585,11 +583,11 @@ namespace Microsoft.ML.StaticPipelineTesting
             var schema = tdata.AsDynamic.Schema;
 
             Assert.True(schema.TryGetColumnIndex("bagofword", out int bagofwordCol));
-            var type = schema.GetColumnType(bagofwordCol);
+            var type = schema[bagofwordCol].Type;
             Assert.True(type is VectorType vecType && vecType.Size > 0&& vecType.ItemType is NumberType);
 
             Assert.True(schema.TryGetColumnIndex("bagofhashedword", out int bagofhashedwordCol));
-            type = schema.GetColumnType(bagofhashedwordCol);
+            type = schema[bagofhashedwordCol].Type;
             Assert.True(type is VectorType vecType2 && vecType2.Size > 0 && vecType2.ItemType is NumberType);
         }
 
@@ -614,11 +612,11 @@ namespace Microsoft.ML.StaticPipelineTesting
             var schema = tdata.AsDynamic.Schema;
 
             Assert.True(schema.TryGetColumnIndex("ngrams", out int ngramsCol));
-            var type = schema.GetColumnType(ngramsCol);
+            var type = schema[ngramsCol].Type;
             Assert.True(type is VectorType vecType && vecType.Size > 0 && vecType.ItemType is NumberType);
 
             Assert.True(schema.TryGetColumnIndex("ngramshash", out int ngramshashCol));
-            type = schema.GetColumnType(ngramshashCol);
+            type = schema[ngramshashCol].Type;
             Assert.True(type is VectorType vecType2 && vecType2.Size > 0 && vecType2.ItemType is NumberType);
         }
 
@@ -645,19 +643,19 @@ namespace Microsoft.ML.StaticPipelineTesting
             var schema = tdata.AsDynamic.Schema;
 
             Assert.True(schema.TryGetColumnIndex("lpnorm", out int lpnormCol));
-            var type = schema.GetColumnType(lpnormCol);
+            var type = schema[lpnormCol].Type;
             Assert.True(type is VectorType vecType && vecType.Size > 0 && vecType.ItemType is NumberType);
 
             Assert.True(schema.TryGetColumnIndex("gcnorm", out int gcnormCol));
-            type = schema.GetColumnType(gcnormCol);
+            type = schema[gcnormCol].Type;
             Assert.True(type is VectorType vecType2 && vecType2.Size > 0 && vecType2.ItemType is NumberType);
 
             Assert.True(schema.TryGetColumnIndex("zcawhitened", out int zcawhitenedCol));
-            type = schema.GetColumnType(zcawhitenedCol);
+            type = schema[zcawhitenedCol].Type;
             Assert.True(type is VectorType vecType3 && vecType3.Size > 0 && vecType3.ItemType is NumberType);
 
             Assert.True(schema.TryGetColumnIndex("pcswhitened", out int pcswhitenedCol));
-            type = schema.GetColumnType(pcswhitenedCol);
+            type = schema[pcswhitenedCol].Type;
             Assert.True(type is VectorType vecType4 && vecType4.Size > 0 && vecType4.ItemType is NumberType);
         }
 
@@ -685,7 +683,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             var schema = tdata.AsDynamic.Schema;
             Assert.True(schema.TryGetColumnIndex("topics", out int topicsCol));
-            var type = schema.GetColumnType(topicsCol);
+            var type = schema[topicsCol].Type;
             Assert.True(type is VectorType vecType && vecType.Size > 0 && vecType.ItemType is NumberType);
         }
 
@@ -710,11 +708,11 @@ namespace Microsoft.ML.StaticPipelineTesting
             var schema = tdata.AsDynamic.Schema;
 
             Assert.True(schema.TryGetColumnIndex("bag_of_words_count", out int bagofwordCountCol));
-            var type = schema.GetColumnType(bagofwordCountCol);
+            var type = schema[bagofwordCountCol].Type;
             Assert.True(type is VectorType vecType && vecType.Size > 0 && vecType.ItemType is NumberType);
 
             Assert.True(schema.TryGetColumnIndex("bag_of_words_mi", out int bagofwordMiCol));
-            type = schema.GetColumnType(bagofwordMiCol);
+            type = schema[bagofwordMiCol].Type;
             Assert.True(type is VectorType vecType2 && vecType2.Size > 0 && vecType2.ItemType is NumberType);
         }
 
@@ -767,7 +765,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var schema = tdata.AsDynamic.Schema;
 
             Assert.True(schema.TryGetColumnIndex("pca", out int pcaCol));
-            var type = schema.GetColumnType(pcaCol);
+            var type = schema[pcaCol].Type;
             Assert.True(type is VectorType vecType && vecType.Size > 0 && vecType.ItemType is NumberType);
         }
 
@@ -837,22 +835,11 @@ namespace Microsoft.ML.StaticPipelineTesting
             var tdata = est.Fit(data).Transform(data);
             var schema = tdata.AsDynamic.Schema;
 
-            Assert.True(schema.TryGetColumnIndex("norm", out int norm));
-            var type = schema.GetColumnType(norm);
-            Assert.True(type is TextType);
-
-            Assert.True(schema.TryGetColumnIndex("norm_Upper", out int normUpper));
-            type = schema.GetColumnType(normUpper);
-            Assert.True(type is TextType);
-            Assert.True(schema.TryGetColumnIndex("norm_KeepDiacritics", out int diacritics));
-            type = schema.GetColumnType(diacritics);
-            Assert.True(type is TextType);
-            Assert.True(schema.TryGetColumnIndex("norm_NoPuctuations", out int punct));
-            type = schema.GetColumnType(punct);
-            Assert.True(type is TextType);
-            Assert.True(schema.TryGetColumnIndex("norm_NoNumbers", out int numbers));
-            type = schema.GetColumnType(numbers);
-            Assert.True(type is TextType);
+            Assert.True(schema["norm"].Type is TextType);
+            Assert.True(schema["norm_Upper"].Type is TextType);
+            Assert.True(schema["norm_KeepDiacritics"].Type is TextType);
+            Assert.True(schema["norm_NoPuctuations"].Type is TextType);
+            Assert.True(schema["norm_NoNumbers"].Type is TextType);
         }
 
         [Fact]

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
         }
 
         [Fact]
@@ -97,10 +97,10 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Now, let's see if that column is still there, and still text!
             var schema = data.AsDynamic.Schema;
             Assert.True(schema.TryGetColumnIndex("Score", out int scoreCol), "Score column not present!");
-            Assert.Equal(TextType.Instance, schema.GetColumnType(scoreCol));
+            Assert.Equal(TextType.Instance, schema[scoreCol].Type);
 
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
         }
 
         [Fact]
@@ -190,7 +190,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
         }
 
         [Fact]
@@ -340,7 +340,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);
             Assert.True(metrics.LogLoss > 0);
@@ -653,7 +653,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);
             Assert.True(metrics.LogLoss > 0);
@@ -871,7 +871,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);
             Assert.True(metrics.LogLoss > 0);
@@ -916,7 +916,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
             for (int c = 0; c < schema.Count; ++c)
-                Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
+                Console.WriteLine($"{schema[c].Name}, {schema[c].Type}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);
             Assert.True(metrics.LogLoss > 0);

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.True(schema.TryGetColumnIndex("Score", out int scoreCol), "Score column not present!");
             Assert.Equal(TextType.Instance, schema.GetColumnType(scoreCol));
 
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
         }
 
@@ -189,7 +189,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
         }
 
@@ -339,7 +339,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);
@@ -652,7 +652,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);
@@ -870,7 +870,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);
@@ -915,7 +915,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // Just output some data on the schema for fun.
             var schema = data.AsDynamic.Schema;
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
                 Console.WriteLine($"{schema.GetColumnName(c)}, {schema.GetColumnType(c)}");
 
             var metrics = ctx.Evaluate(data, r => r.label, r => r.preds, 2);

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -236,7 +236,7 @@ namespace Microsoft.ML.Runtime.RunTests
             else if (!CheckSameValues(pipe1, pipe2, checkId: checkId))
                 Failed();
 
-            if (pipe1.Schema.ColumnCount > 0)
+            if (pipe1.Schema.Count > 0)
             {
                 // The text saver fails if there are no columns, so we cannot check in that case.
                 if (!SaveLoadText(pipe1, _env, keepHidden, suffix, suffixBase, checkBaseline, forceDense, roundTripText))
@@ -397,7 +397,7 @@ namespace Microsoft.ML.Runtime.RunTests
             TextSaver saver = new TextSaver(env, new TextSaver.Arguments() { Dense = forceDense, OutputSchema = outputSchema, OutputHeader = outputHeader });
             var schema = view.Schema;
             List<int> savable = new List<int>();
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
             {
                 ColumnType type = schema.GetColumnType(c);
                 if (saver.IsColumnSavable(type) && (hidden || !schema[c].IsHidden))
@@ -420,7 +420,7 @@ namespace Microsoft.ML.Runtime.RunTests
             if (!roundTrip)
                 return true;
 
-            if (savable.Count < view.Schema.ColumnCount)
+            if (savable.Count < view.Schema.Count)
             {
                 // Restrict the comparison to the subset of columns we were able to save.
                 var chooseargs = new ChooseColumnsByIndexTransform.Arguments();
@@ -487,7 +487,7 @@ namespace Microsoft.ML.Runtime.RunTests
         protected bool CheckMetadataTypes(Schema sch)
         {
             var hs = new HashSet<string>();
-            for (int col = 0; col < sch.ColumnCount; col++)
+            for (int col = 0; col < sch.Count; col++)
             {
                 var typeSlot = sch.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, col);
                 var typeKeys = sch.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, col);
@@ -546,13 +546,13 @@ namespace Microsoft.ML.Runtime.RunTests
 
         protected bool CheckSameSchemas(Schema sch1, Schema sch2, bool exactTypes = true, bool keyNames = true)
         {
-            if (sch1.ColumnCount != sch2.ColumnCount)
+            if (sch1.Count != sch2.Count)
             {
-                Fail("column count mismatch: {0} vs {1}", sch1.ColumnCount, sch2.ColumnCount);
+                Fail("column count mismatch: {0} vs {1}", sch1.Count, sch2.Count);
                 return Failed();
             }
 
-            for (int col = 0; col < sch1.ColumnCount; col++)
+            for (int col = 0; col < sch1.Count; col++)
             {
                 string name1 = sch1.GetColumnName(col);
                 string name2 = sch2.GetColumnName(col);
@@ -682,7 +682,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             var schema = view.Schema;
             List<int> savable = new List<int>();
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
             {
                 ColumnType type = schema.GetColumnType(c);
                 if (saver.IsColumnSavable(type))
@@ -698,7 +698,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 Log("View saved in {0} bytes", stream.Length);
             }
 
-            if (savable.Count < view.Schema.ColumnCount)
+            if (savable.Count < view.Schema.Count)
             {
                 // Restrict the comparison to the subset of columns we were able to save.
                 var chooseargs = new ChooseColumnsByIndexTransform.Arguments();
@@ -728,7 +728,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
             var schema = view.Schema;
             List<int> savable = new List<int>();
-            for (int c = 0; c < schema.ColumnCount; ++c)
+            for (int c = 0; c < schema.Count; ++c)
             {
                 ColumnType type = schema.GetColumnType(c);
                 if (saver.IsColumnSavable(type))
@@ -749,7 +749,7 @@ namespace Microsoft.ML.Runtime.RunTests
                 Log("View saved in {0} bytes", stream.Length);
             }
 
-            if (savable.Count < view.Schema.ColumnCount)
+            if (savable.Count < view.Schema.Count)
             {
                 // Restrict the comparison to the subset of columns we were able to save.
                 var chooseargs = new ChooseColumnsByIndexTransform.Arguments();
@@ -805,7 +805,7 @@ namespace Microsoft.ML.Runtime.RunTests
 
         protected bool CheckSameValues(IDataView view1, IDataView view2, bool exactTypes = true, bool exactDoubles = true, bool checkId = true)
         {
-            Contracts.Assert(view1.Schema.ColumnCount == view2.Schema.ColumnCount);
+            Contracts.Assert(view1.Schema.Count == view2.Schema.Count);
 
             bool all = true;
             bool tmp;
@@ -852,10 +852,10 @@ namespace Microsoft.ML.Runtime.RunTests
 
         protected bool CheckSameValues(RowCursor curs1, RowCursor curs2, bool exactTypes, bool exactDoubles, bool checkId, bool checkIdCollisions = true)
         {
-            Contracts.Assert(curs1.Schema.ColumnCount == curs2.Schema.ColumnCount);
+            Contracts.Assert(curs1.Schema.Count == curs2.Schema.Count);
 
             // Get the comparison delegates for each column.
-            int colLim = curs1.Schema.ColumnCount;
+            int colLim = curs1.Schema.Count;
             Func<bool>[] comps = new Func<bool>[colLim];
             for (int col = 0; col < colLim; col++)
             {
@@ -933,10 +933,10 @@ namespace Microsoft.ML.Runtime.RunTests
 
         protected bool CheckSameValues(RowCursor curs1, IDataView view2, bool exactTypes = true, bool exactDoubles = true, bool checkId = true)
         {
-            Contracts.Assert(curs1.Schema.ColumnCount == view2.Schema.ColumnCount);
+            Contracts.Assert(curs1.Schema.Count == view2.Schema.Count);
 
             // Get a cursor for each column.
-            int colLim = curs1.Schema.ColumnCount;
+            int colLim = curs1.Schema.Count;
             var cursors = new RowCursor[colLim];
             try
             {

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -399,7 +399,7 @@ namespace Microsoft.ML.Runtime.RunTests
             List<int> savable = new List<int>();
             for (int c = 0; c < schema.Count; ++c)
             {
-                ColumnType type = schema.GetColumnType(c);
+                ColumnType type = schema[c].Type;
                 if (saver.IsColumnSavable(type) && (hidden || !schema[c].IsHidden))
                     savable.Add(c);
             }
@@ -554,15 +554,15 @@ namespace Microsoft.ML.Runtime.RunTests
 
             for (int col = 0; col < sch1.Count; col++)
             {
-                string name1 = sch1.GetColumnName(col);
-                string name2 = sch2.GetColumnName(col);
+                string name1 = sch1[col].Name;
+                string name2 = sch2[col].Name;
                 if (name1 != name2)
                 {
                     Fail("column name mismatch at index {0}: {1} vs {2}", col, name1, name2);
                     return Failed();
                 }
-                var type1 = sch1.GetColumnType(col);
-                var type2 = sch2.GetColumnType(col);
+                var type1 = sch1[col].Type;
+                var type2 = sch2[col].Type;
                 if (!EqualTypes(type1, type2, exactTypes))
                 {
                     Fail("column type mismatch at index {0}", col);
@@ -684,7 +684,7 @@ namespace Microsoft.ML.Runtime.RunTests
             List<int> savable = new List<int>();
             for (int c = 0; c < schema.Count; ++c)
             {
-                ColumnType type = schema.GetColumnType(c);
+                ColumnType type = schema[c].Type;
                 if (saver.IsColumnSavable(type))
                     savable.Add(c);
             }
@@ -730,7 +730,7 @@ namespace Microsoft.ML.Runtime.RunTests
             List<int> savable = new List<int>();
             for (int c = 0; c < schema.Count; ++c)
             {
-                ColumnType type = schema.GetColumnType(c);
+                ColumnType type = schema[c].Type;
                 if (saver.IsColumnSavable(type))
                     savable.Add(c);
             }
@@ -864,8 +864,8 @@ namespace Microsoft.ML.Runtime.RunTests
 
                 if (f1 && f2)
                 {
-                    var type1 = curs1.Schema.GetColumnType(col);
-                    var type2 = curs2.Schema.GetColumnType(col);
+                    var type1 = curs1.Schema[col].Type;
+                    var type2 = curs2.Schema[col].Type;
                     if (!EqualTypes(type1, type2, exactTypes))
                     {
                         Fail("Different types");
@@ -954,8 +954,8 @@ namespace Microsoft.ML.Runtime.RunTests
                 for (int col = 0; col < colLim; col++)
                 {
                     Contracts.Assert(cursors[col] != null);
-                    var type1 = curs1.Schema.GetColumnType(col);
-                    var type2 = cursors[col].Schema.GetColumnType(col);
+                    var type1 = curs1.Schema[col].Type;
+                    var type2 = cursors[col].Schema[col].Type;
                     if (!EqualTypes(type1, type2, exactTypes))
                     {
                         Fail("Different types");

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -635,8 +635,8 @@ namespace Microsoft.ML.Runtime.RunTests
                 return Failed();
             }
 
-            sch1.GetMetadata(kind, col, ref names1);
-            sch2.GetMetadata(kind, col, ref names2);
+            sch1[col].Metadata.GetValue(kind, ref names1);
+            sch2[col].Metadata.GetValue(kind, ref names2);
             if (!CompareVec(in names1, in names2, size, (a, b) => a.Span.SequenceEqual(b.Span)))
             {
                 Fail("Different {0} metadata values", kind);
@@ -649,7 +649,7 @@ namespace Microsoft.ML.Runtime.RunTests
         {
             try
             {
-                sch.GetMetadata(kind, col, ref names);
+                sch[col].Metadata.GetValue(kind, ref names);
                 Fail("Getting {0} metadata unexpectedly succeeded", kind);
                 return Failed();
             }

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -489,26 +489,25 @@ namespace Microsoft.ML.Runtime.RunTests
             var hs = new HashSet<string>();
             for (int col = 0; col < sch.Count; col++)
             {
-                var typeSlot = sch.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, col);
-                var typeKeys = sch.GetMetadataTypeOrNull(MetadataUtils.Kinds.KeyValues, col);
-                var all = sch.GetMetadataTypes(col);
+                var typeSlot = sch[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
+                var typeKeys = sch[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
 
                 hs.Clear();
-                foreach (var kvp in all)
+                foreach (var metaColumn in sch[col].Metadata.Schema)
                 {
-                    if (kvp.Key == null || kvp.Value == null)
+                    if (metaColumn.Name == null || metaColumn.Type == null)
                     {
                         Fail("Null returned from GetMetadataTypes");
                         return Failed();
                     }
-                    if (!hs.Add(kvp.Key))
+                    if (!hs.Add(metaColumn.Name))
                     {
-                        Fail("Duplicate metadata type: {0}", kvp.Key);
+                        Fail("Duplicate metadata type: {0}", metaColumn.Name);
                         return Failed();
                     }
-                    if (kvp.Key == MetadataUtils.Kinds.SlotNames)
+                    if (metaColumn.Name == MetadataUtils.Kinds.SlotNames)
                     {
-                        if (typeSlot == null || !typeSlot.Equals(kvp.Value))
+                        if (typeSlot == null || !typeSlot.Equals(metaColumn.Type))
                         {
                             Fail("SlotNames types don't match");
                             return Failed();
@@ -516,22 +515,14 @@ namespace Microsoft.ML.Runtime.RunTests
                         typeSlot = null;
                         continue;
                     }
-                    if (kvp.Key == MetadataUtils.Kinds.KeyValues)
+                    if (metaColumn.Name == MetadataUtils.Kinds.KeyValues)
                     {
-                        if (typeKeys == null || !typeKeys.Equals(kvp.Value))
+                        if (typeKeys == null || !typeKeys.Equals(metaColumn.Type))
                         {
                             Fail("KeyValues types don't match");
                             return Failed();
                         }
                         typeKeys = null;
-                        continue;
-                    }
-
-                    var type = sch.GetMetadataTypeOrNull(kvp.Key, col);
-                    if (type == null || !type.Equals(kvp.Value))
-                    {
-                        Fail("{0} types don't match", kvp.Key);
-                        return Failed();
                     }
                 }
 
@@ -607,8 +598,8 @@ namespace Microsoft.ML.Runtime.RunTests
             var names1 = default(VBuffer<ReadOnlyMemory<char>>);
             var names2 = default(VBuffer<ReadOnlyMemory<char>>);
 
-            var t1 = sch1.GetMetadataTypeOrNull(kind, col);
-            var t2 = sch2.GetMetadataTypeOrNull(kind, col);
+            var t1 = sch1[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
+            var t2 = sch2[col].Metadata.Schema.GetColumnOrNull(kind)?.Type;
             if ((t1 == null) != (t2 == null))
             {
                 Fail("Different null-ness of {0} metadata types", kind);

--- a/test/Microsoft.ML.Tests/TermEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TermEstimatorTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.ML.Tests
             var result = termTransformer.Transform(dataView);
             result.Schema.TryGetColumnIndex("T", out int termIndex);
             var names1 = default(VBuffer<ReadOnlyMemory<char>>);
-            var type1 = result.Schema.GetColumnType(termIndex);
+            var type1 = result.Schema[termIndex].Type;
             var itemType1 = (type1 as VectorType)?.ItemType ?? type1;
             int size = itemType1 is KeyType keyType ? keyType.Count : -1;
             result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, termIndex, ref names1);

--- a/test/Microsoft.ML.Tests/TermEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TermEstimatorTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.ML.Tests
             var type1 = result.Schema[termIndex].Type;
             var itemType1 = (type1 as VectorType)?.ItemType ?? type1;
             int size = itemType1 is KeyType keyType ? keyType.Count : -1;
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, termIndex, ref names1);
+            result.Schema[termIndex].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref names1);
             Assert.True(names1.GetValues().Length > 0);
         }
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -82,8 +82,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Get output schema and check its column names
             var outputSchema = model.GetOutputSchema(data.Schema);
             var expectedOutputNames = new string[] { labelColumnName, userColumnName, itemColumnName, scoreColumnName };
-            foreach (var (i, col) in outputSchema.GetColumns())
-                Assert.True(col.Name == expectedOutputNames[i]);
+            foreach (var col in outputSchema)
+                Assert.True(col.Name == expectedOutputNames[col.Index]);
 
             // Retrieve label column's index from the test IDataView
             testData.Schema.TryGetColumnIndex(labelColumnName, out int labelColumnId);

--- a/test/Microsoft.ML.Tests/Transformers/CategoricalHashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CategoricalHashTests.cs
@@ -133,92 +133,77 @@ namespace Microsoft.ML.Tests.Transformers
 
         private void ValidateMetadata(IDataView result)
         {
-            Assert.True(result.Schema.TryGetColumnIndex("CatA", out int colA));
-            Assert.True(result.Schema.TryGetColumnIndex("CatB", out int colB));
-            Assert.True(result.Schema.TryGetColumnIndex("CatC", out int colC));
-            Assert.True(result.Schema.TryGetColumnIndex("CatD", out int colD));
-            Assert.True(result.Schema.TryGetColumnIndex("CatE", out int colE));
-            Assert.True(result.Schema.TryGetColumnIndex("CatF", out int colF));
-            Assert.True(result.Schema.TryGetColumnIndex("CatG", out int colG));
-            Assert.True(result.Schema.TryGetColumnIndex("CatH", out int colH));
-            Assert.True(result.Schema.TryGetColumnIndex("CatI", out int colI));
-            Assert.True(result.Schema.TryGetColumnIndex("CatJ", out int colJ));
-            var types = result.Schema.GetMetadataTypes(colA);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
             VBuffer<ReadOnlyMemory<char>> slots = default;
             VBuffer<int> slotRanges = default;
-            bool normalized = default;
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colA, ref slots);
+
+            var column = result.Schema["CatA"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 65536);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "0:A", "1:B" });
 
-            types = result.Schema.GetMetadataTypes(colB);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colB, ref slots);
+            column = result.Schema["CatB"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 65536);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[1] { "C" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colB, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colC);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colC, ref slots);
+            column = result.Schema["CatC"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 65536);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[6] { "1:6", "1:2", "0:1", "0:3", "0:5", "1:4" });
 
-            types = result.Schema.GetMetadataTypes(colD);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colD, ref slots);
+            column = result.Schema["CatD"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 65536);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "-1", "1" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colD, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colE);
-            Assert.Equal(types.Select(x => x.Key), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colE, ref slots);
+            column = result.Schema["CatE"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 131072);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()).Distinct(), new string[14] { "[0].", "[0].0:E", "[0].0:D", "[0].1:E", "[0].1:D", "[0].0:A", "[0].1:A", "[1].", "[1].0:E", "[1].0:D", "[1].1:E", "[1].1:D", "[1].0:A", "[1].1:A" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colE, ref slotRanges);
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 4);
             Assert.Equal(slotRanges.Items().Select(x => x.Value.ToString()), new string[4] { "0", "65535", "65536", "131071" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colE, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colF);
-            Assert.Equal(types.Select(x => x.Key), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colF, ref slots);
+            column = result.Schema["CatF"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 65536);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "E", "D" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colF, ref slotRanges);
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 2);
             Assert.Equal(slotRanges.Items().Select(x => x.Value.ToString()), new string[2] { "0", "65535" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colF, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colG);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, colG, ref slots);
+            column = result.Schema["CatG"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.KeyValues });
+            column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref slots);
             Assert.True(slots.Length == 65536);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "0:A", "1:B" });
 
-            types = result.Schema.GetMetadataTypes(colH);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, colH, ref slots);
+            column = result.Schema["CatH"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.KeyValues });
+            column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref slots);
             Assert.True(slots.Length == 65536);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[1] { "C" });
 
-            types = result.Schema.GetMetadataTypes(colI);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colI, ref slots);
+            column = result.Schema["CatI"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 36);
 
-            types = result.Schema.GetMetadataTypes(colJ);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colJ, ref slots);
+            column = result.Schema["CatJ"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 18);
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colJ, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/Transformers/CategoricalTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CategoricalTests.cs
@@ -149,112 +149,92 @@ namespace Microsoft.ML.Tests.Transformers
 
         private void ValidateMetadata(IDataView result)
         {
-            Assert.True(result.Schema.TryGetColumnIndex("CatA", out int colA));
-            Assert.True(result.Schema.TryGetColumnIndex("CatB", out int colB));
-            Assert.True(result.Schema.TryGetColumnIndex("CatC", out int colC));
-            Assert.True(result.Schema.TryGetColumnIndex("CatD", out int colD));
-            Assert.True(result.Schema.TryGetColumnIndex("CatE", out int colE));
-            Assert.True(result.Schema.TryGetColumnIndex("CatF", out int colF));
-            Assert.True(result.Schema.TryGetColumnIndex("CatG", out int colG));
-            Assert.True(result.Schema.TryGetColumnIndex("CatH", out int colH));
-            Assert.True(result.Schema.TryGetColumnIndex("CatI", out int colI));
-            Assert.True(result.Schema.TryGetColumnIndex("CatJ", out int colJ));
-            Assert.True(result.Schema.TryGetColumnIndex("CatK", out int colK));
-            Assert.True(result.Schema.TryGetColumnIndex("CatL", out int colL));
-            var types = result.Schema.GetMetadataTypes(colA);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
             VBuffer<ReadOnlyMemory<char>> slots = default;
             VBuffer<int> slotRanges = default;
-            bool normalized = default;
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colA, ref slots);
+
+            var column = result.Schema["CatA"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "A", "B" });
 
-            types = result.Schema.GetMetadataTypes(colB);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colB, ref slots);
+            column = result.Schema["CatB"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 1);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[1] { "C" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colB, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colC);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colC, ref slots);
+            column = result.Schema["CatC"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "3", "5" });
 
-
-            types = result.Schema.GetMetadataTypes(colD);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colD, ref slots);
+            column = result.Schema["CatD"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "6", "1" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colD, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-
-            types = result.Schema.GetMetadataTypes(colE);
-            Assert.Equal(types.Select(x => x.Key), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colE, ref slots);
+            column = result.Schema["CatE"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 12);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[12] { "[0].1", "[0].2", "[0].3", "[0].4", "[0].5", "[0].6", "[1].1", "[1].2", "[1].3", "[1].4", "[1].5", "[1].6" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colE, ref slotRanges);
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 4);
             Assert.Equal(slotRanges.Items().Select(x => x.Value.ToString()), new string[4] { "0", "5", "6", "11" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colE, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colF);
-            Assert.Equal(types.Select(x => x.Key), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colF, ref slots);
+            column = result.Schema["CatF"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "1", "-1" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colF, ref slotRanges);
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 2);
             Assert.Equal(slotRanges.Items().Select(x => x.Value.ToString()), new string[2] { "0", "1" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colF, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colG);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues});
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, colG, ref slots);
+            column = result.Schema["CatG"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.KeyValues});
+            column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref slots);
             Assert.True(slots.Length == 3);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[3] {"A","D","E"});
 
-            types = result.Schema.GetMetadataTypes(colH);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues});
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, colH, ref slots);
+            column = result.Schema["CatH"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.KeyValues});
+            column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "D", "E" });
 
-            types = result.Schema.GetMetadataTypes(colI);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colI, ref slots);
+            column = result.Schema["CatI"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 6);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[6] { "[0].Bit2", "[0].Bit1", "[0].Bit0", "[1].Bit2", "[1].Bit1", "[1].Bit0" });
 
-            types = result.Schema.GetMetadataTypes(colJ);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colJ, ref slots);
+            column = result.Schema["CatJ"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "Bit1", "Bit0" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colJ, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colK);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colK, ref slots);
+            column = result.Schema["CatK"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 6);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[6] { "[0].Bit2", "[0].Bit1", "[0].Bit0", "[1].Bit2", "[1].Bit1", "[1].Bit0" });
 
-            types = result.Schema.GetMetadataTypes(colL);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colL, ref slots);
+            column = result.Schema["CatL"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 3);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[3] { "Bit2", "Bit1", "Bit0" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colL, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/Transformers/ConcatTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ConcatTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Tests.Transformers
             ColumnType GetType(Schema schema, string name)
             {
                 Assert.True(schema.TryGetColumnIndex(name, out int cIdx), $"Could not find '{name}'");
-                return schema.GetColumnType(cIdx);
+                return schema[cIdx].Type;
             }
             var pipe = new ColumnConcatenatingEstimator(Env, "f1", "float1")
                 .Append(new ColumnConcatenatingEstimator(Env, "f2", "float1", "float1"))
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Tests.Transformers
             ColumnType GetType(Schema schema, string name)
             {
                 Assert.True(schema.TryGetColumnIndex(name, out int cIdx), $"Could not find '{name}'");
-                return schema.GetColumnType(cIdx);
+                return schema[cIdx].Type;
             }
 
             data = TakeFilter.Create(Env, data, 10);

--- a/test/Microsoft.ML.Tests/Transformers/ConvertTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ConvertTests.cs
@@ -186,21 +186,15 @@ namespace Microsoft.ML.Tests.Transformers
 
         private void ValidateMetadata(IDataView result)
         {
-            Assert.True(result.Schema.TryGetColumnIndex("ConvA", out int colA));
-            Assert.True(result.Schema.TryGetColumnIndex("ConvB", out int colB));
-            var types = result.Schema.GetMetadataTypes(colA);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            Assert.Equal(result.Schema["ConvA"].Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
             VBuffer<ReadOnlyMemory<char>> slots = default;
-            bool normalized = default;
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colA, ref slots);
+            result.Schema["ConvA"].GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "1", "2" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colA, ref normalized);
-            Assert.True(normalized);
+            Assert.True(result.Schema["ConvA"].IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colB);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, colB, ref slots);
+            Assert.Equal(result.Schema["ConvB"].Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.KeyValues });
+            result.Schema["ConvB"].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "A", "B" });
         }

--- a/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
@@ -139,10 +139,10 @@ namespace Microsoft.ML.Tests
             result.Schema.TryGetColumnIndex("T1", out int copyIndex);
             var names1 = default(VBuffer<ReadOnlyMemory<char>>);
             var names2 = default(VBuffer<ReadOnlyMemory<char>>);
-            var type1 = result.Schema.GetColumnType(termIndex);
+            var type1 = result.Schema[termIndex].Type;
             var itemType1 = (type1 as VectorType)?.ItemType ?? type1;
             int size = (itemType1 as KeyType)?.Count ?? -1;
-            var type2 = result.Schema.GetColumnType(copyIndex);
+            var type2 = result.Schema[copyIndex].Type;
             result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, termIndex, ref names1);
             result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, copyIndex, ref names2);
             Assert.True(CompareVec(in names1, in names2, size, (a, b) => a.Span.SequenceEqual(b.Span)));

--- a/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
@@ -143,8 +143,8 @@ namespace Microsoft.ML.Tests
             var itemType1 = (type1 as VectorType)?.ItemType ?? type1;
             int size = (itemType1 as KeyType)?.Count ?? -1;
             var type2 = result.Schema[copyIndex].Type;
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, termIndex, ref names1);
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, copyIndex, ref names2);
+            result.Schema[termIndex].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref names1);
+            result.Schema[copyIndex].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref names2);
             Assert.True(CompareVec(in names1, in names2, size, (a, b) => a.Span.SequenceEqual(b.Span)));
         }
 

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -80,29 +80,21 @@ namespace Microsoft.ML.Tests.Transformers
 
         private void ValidateMetadata(IDataView result)
         {
-
-            Assert.True(result.Schema.TryGetColumnIndex("HashA", out int HashA));
-            Assert.True(result.Schema.TryGetColumnIndex("HashAUnlim", out int HashAUnlim));
-            Assert.True(result.Schema.TryGetColumnIndex("HashAUnlimOrdered", out int HashAUnlimOrdered));
             VBuffer<ReadOnlyMemory<char>> keys = default;
-            var types = result.Schema.GetMetadataTypes(HashA);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, HashA, ref keys);
-            Assert.True(keys.Length == 1024);
-            //REVIEW: This is weird. I specified invertHash to 1 so I expect only one value to be in key values, but i got two.
+            var column = result.Schema["HashA"];
+            Assert.Equal(column.Metadata.Schema.Single().Name, MetadataUtils.Kinds.KeyValues);
+            column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keys);
             Assert.Equal(keys.Items().Select(x => x.Value.ToString()), new string[2] { "2.5", "3.5" });
 
-            types = result.Schema.GetMetadataTypes(HashAUnlim);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, HashA, ref keys);
-            Assert.True(keys.Length == 1024);
+            column = result.Schema["HashAUnlim"];
+            Assert.Equal(column.Metadata.Schema.Single().Name, MetadataUtils.Kinds.KeyValues);
+            column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keys);
             Assert.Equal(keys.Items().Select(x => x.Value.ToString()), new string[2] { "2.5", "3.5" });
 
-            types = result.Schema.GetMetadataTypes(HashAUnlimOrdered);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.KeyValues });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.KeyValues, HashA, ref keys);
-            Assert.True(keys.Length == 1024);
-            Assert.Equal(keys.Items().Select(x => x.Value.ToString()), new string[2] { "2.5", "3.5" });
+            column = result.Schema["HashAUnlimOrdered"];
+            Assert.Equal(column.Metadata.Schema.Single().Name, MetadataUtils.Kinds.KeyValues);
+            column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keys);
+            Assert.Equal(keys.Items().Select(x => x.Value.ToString()), new string[2] { "0:3.5", "1:2.5" });
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
+++ b/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
@@ -120,33 +120,27 @@ namespace Microsoft.ML.Tests.Transformers
 
         private void ValidateMetadata(IDataView result)
         {
-            Assert.True(result.Schema.TryGetColumnIndex("CatA", out int colA));
-            Assert.True(result.Schema.TryGetColumnIndex("CatB", out int colB));
-            Assert.True(result.Schema.TryGetColumnIndex("CatC", out int colC));
-            Assert.True(result.Schema.TryGetColumnIndex("CatD", out int colD));
-            var types = result.Schema.GetMetadataTypes(colA);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
             VBuffer<ReadOnlyMemory<char>> slots = default;
-            bool normalized = default;
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colA, ref slots);
+
+            var column = result.Schema["CatA"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 6);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[6] { "[0].Bit2", "[0].Bit1", "[0].Bit0", "[1].Bit2", "[1].Bit1", "[1].Bit0" });
 
-            types = result.Schema.GetMetadataTypes(colB);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colB, ref slots);
+            column = result.Schema["CatB"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "Bit1", "Bit0" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colB, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colC);
-            Assert.Equal(types.Select(x => x.Key), new string[0]);
+            column = result.Schema["CatC"];
+            Assert.Empty(column.Metadata.Schema);
 
-            types = result.Schema.GetMetadataTypes(colD);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colD, ref normalized);
-            Assert.True(normalized);
+            column = result.Schema["CatD"];
+            Assert.Equal(column.Metadata.Schema.Single().Name, MetadataUtils.Kinds.IsNormalized);
+            Assert.True(column.IsNormalized());
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/Transformers/KeyToVectorEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/KeyToVectorEstimatorTests.cs
@@ -139,83 +139,68 @@ namespace Microsoft.ML.Tests.Transformers
 
         private void ValidateMetadata(IDataView result)
         {
-            Assert.True(result.Schema.TryGetColumnIndex("CatA", out int colA));
-            Assert.True(result.Schema.TryGetColumnIndex("CatB", out int colB));
-            Assert.True(result.Schema.TryGetColumnIndex("CatC", out int colC));
-            Assert.True(result.Schema.TryGetColumnIndex("CatD", out int colD));
-            Assert.True(result.Schema.TryGetColumnIndex("CatE", out int colE));
-            Assert.True(result.Schema.TryGetColumnIndex("CatF", out int colF));
-            Assert.True(result.Schema.TryGetColumnIndex("CatG", out int colG));
-            Assert.True(result.Schema.TryGetColumnIndex("CatH", out int colH));
-            var types = result.Schema.GetMetadataTypes(colA);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
             VBuffer<ReadOnlyMemory<char>> slots = default;
             VBuffer<int> slotRanges = default;
-            bool normalized = default;
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colA, ref slots);
+
+            var column = result.Schema["CatA"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "A", "B" });
 
-            types = result.Schema.GetMetadataTypes(colB);
-            Assert.Equal(types.Select(x => x.Key), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colB, ref slots);
+            column = result.Schema["CatB"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 1);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[1] { "C" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colB, ref slotRanges);
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 2);
             Assert.Equal(slotRanges.Items().Select(x => x.Value), new int[2] { 0, 0 });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colB, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colC);
-            Assert.Equal(types.Select(x => x.Key), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colC, ref slots);
+            column = result.Schema["CatC"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 4);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[4] { "[0].3", "[0].5", "[1].3", "[1].5" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colC, ref slotRanges);
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 4);
             Assert.Equal(slotRanges.Items().Select(x => x.Value), new int[4] { 0, 1, 2, 3 });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colC, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colD);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colD, ref slots);
+            column = result.Schema["CatD"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "6", "1" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colD, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-
-            types = result.Schema.GetMetadataTypes(colE);
-            Assert.Equal(types.Select(x => x.Key), new string[2] { MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colE, ref slotRanges);
+            column = result.Schema["CatE"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[2] { MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 4);
             Assert.Equal(slotRanges.Items().Select(x => x.Value), new int[4] { 0, 5, 6, 11 });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colE, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colF);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colF, ref normalized);
-            Assert.True(normalized);
+            column = result.Schema["CatF"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.IsNormalized });
+            Assert.True(column.IsNormalized());
 
-            types = result.Schema.GetMetadataTypes(colG);
-            Assert.Equal(types.Select(x => x.Key), new string[1] { MetadataUtils.Kinds.SlotNames });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colG, ref slots);
+            column = result.Schema["CatG"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[1] { MetadataUtils.Kinds.SlotNames });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 3);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[3] { "A", "D", "E" });
 
-            types = result.Schema.GetMetadataTypes(colH);
-            Assert.Equal(types.Select(x => x.Key), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, colH, ref slots);
+            column = result.Schema["CatH"];
+            Assert.Equal(column.Metadata.Schema.Select(x => x.Name), new string[3] { MetadataUtils.Kinds.SlotNames, MetadataUtils.Kinds.CategoricalSlotRanges, MetadataUtils.Kinds.IsNormalized });
+            column.GetSlotNames(ref slots);
             Assert.True(slots.Length == 2);
             Assert.Equal(slots.Items().Select(x => x.Value.ToString()), new string[2] { "D", "E" });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.CategoricalSlotRanges, colH, ref slotRanges);
+            column.Metadata.GetValue(MetadataUtils.Kinds.CategoricalSlotRanges, ref slotRanges);
             Assert.True(slotRanges.Length == 2);
             Assert.Equal(slotRanges.Items().Select(x => x.Value), new int[2] { 0, 1 });
-            result.Schema.GetMetadata(MetadataUtils.Kinds.IsNormalized, colH, ref normalized);
-            Assert.True(normalized);
+            Assert.True(column.IsNormalized());
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
@@ -133,7 +133,6 @@ namespace Microsoft.ML.Tests.Transformers
             // Check that slot names metadata was correctly created.
             var value = new VBuffer<ReadOnlyMemory<char>>();
             result.Schema[col].GetSlotNames(ref value);
-            result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, col, ref value);
             Assert.True(value.Length == 4);
             var mem = new ReadOnlyMemory<char>();
             value.GetItemOrDefault(0, ref mem);

--- a/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Tests.Transformers
             Assert.True(result.Schema[col].IsNormalized());
             // Check that slot names metadata was correctly created.
             var value = new VBuffer<ReadOnlyMemory<char>>();
-            var type = result.Schema.GetMetadataTypeOrNull(MetadataUtils.Kinds.SlotNames, col);
+            result.Schema[col].GetSlotNames(ref value);
             result.Schema.GetMetadata(MetadataUtils.Kinds.SlotNames, col, ref value);
             Assert.True(value.Length == 4);
             var mem = new ReadOnlyMemory<char>();

--- a/test/Microsoft.ML.Tests/Transformers/SelectColumnsTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/SelectColumnsTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             // Copied columns should equal AABBC, however we chose to keep A and C
             // so the result is AC
-            Assert.Equal(2, result.Schema.ColumnCount);
+            Assert.Equal(2, result.Schema.Count);
             var foundColumnA = result.Schema.TryGetColumnIndex("A", out int aIdx);
             var foundColumnB = result.Schema.TryGetColumnIndex("B", out int bIdx);
             var foundColumnC = result.Schema.TryGetColumnIndex("C", out int cIdx);
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             // Input for SelectColumns should be AABBC, we chose to keep A and B
             // and keep hidden columns is true, therefore the output should be AABB
-            Assert.Equal(4, result.Schema.ColumnCount);
+            Assert.Equal(4, result.Schema.Count);
             var foundColumnA = result.Schema.TryGetColumnIndex("A", out int aIdx);
             var foundColumnB = result.Schema.TryGetColumnIndex("B", out int bIdx);
             var foundColumnC = result.Schema.TryGetColumnIndex("C", out int cIdx);
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Tests.Transformers
                 ms.Position = 0;
                 var loadedTransformer = TransformerChain.LoadFrom(Env, ms);
                 var result = loadedTransformer.Transform(dataView);
-                Assert.Equal(2, result.Schema.ColumnCount);
+                Assert.Equal(2, result.Schema.Count);
                 Assert.Equal("A", result.Schema.GetColumnName(0));
                 Assert.Equal("B", result.Schema.GetColumnName(1));
             }
@@ -204,7 +204,7 @@ namespace Microsoft.ML.Tests.Transformers
                 ms.Position = 0;
                 var loadedTransformer = TransformerChain.LoadFrom(Env, ms);
                 var result = loadedTransformer.Transform(dataView);
-                Assert.Equal(2, result.Schema.ColumnCount);
+                Assert.Equal(2, result.Schema.Count);
                 Assert.Equal("A", result.Schema.GetColumnName(0));
                 Assert.Equal("B", result.Schema.GetColumnName(1));
             }
@@ -305,7 +305,7 @@ namespace Microsoft.ML.Tests.Transformers
             using (FileStream fs = File.OpenRead(chooseModelPath))
             {
                 var result = ModelFileUtils.LoadTransforms(Env, dataView, fs);
-                Assert.Equal(6, result.Schema.ColumnCount);
+                Assert.Equal(6, result.Schema.Count);
                 var foundColumnFeature = result.Schema.TryGetColumnIndex("Features", out int featureIdx);
                 var foundColumnLabel = result.Schema.TryGetColumnIndex("Label", out int labelIdx);
                 var foundColumnA = result.Schema.TryGetColumnIndex("A", out int aIdx);

--- a/test/Microsoft.ML.Tests/Transformers/SelectColumnsTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/SelectColumnsTests.cs
@@ -185,8 +185,8 @@ namespace Microsoft.ML.Tests.Transformers
                 var loadedTransformer = TransformerChain.LoadFrom(Env, ms);
                 var result = loadedTransformer.Transform(dataView);
                 Assert.Equal(2, result.Schema.Count);
-                Assert.Equal("A", result.Schema.GetColumnName(0));
-                Assert.Equal("B", result.Schema.GetColumnName(1));
+                Assert.Equal("A", result.Schema[0].Name);
+                Assert.Equal("B", result.Schema[1].Name);
             }
         }
 
@@ -205,8 +205,8 @@ namespace Microsoft.ML.Tests.Transformers
                 var loadedTransformer = TransformerChain.LoadFrom(Env, ms);
                 var result = loadedTransformer.Transform(dataView);
                 Assert.Equal(2, result.Schema.Count);
-                Assert.Equal("A", result.Schema.GetColumnName(0));
-                Assert.Equal("B", result.Schema.GetColumnName(1));
+                Assert.Equal("A", result.Schema[0].Name);
+                Assert.Equal("B", result.Schema[1].Name);
             }
         }
 

--- a/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Tests.Transformers
                 using (var fs = File.Create(outputPath))
                     DataSaverUtils.SaveDataView(ch, saver, savedData, fs, keepHidden: true);
 
-                Assert.Equal(10, (savedData.Schema.GetColumnType(0) as VectorType)?.Size);
+                Assert.Equal(10, (savedData.Schema[0].Type as VectorType)?.Size);
             }
 
             // Diabling this check due to the following issue with consitency of output.


### PR DESCRIPTION
Addresses #1500 

Made Schema implement ISchema explicitly. Removed all calls to the ISchema inteface when Schema is accessed, with the exception of TryGetColumnIndex, which was made internal.