### PR TITLE
Forecasting model framework for time series.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
@@ -70,8 +70,8 @@ namespace Samples.Dynamic
             var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
 
             // Forecast with the checkpointed model loaded from disk.
-            var forecastCopy = modelCopy.Forecast(5);
-            Console.WriteLine("[{0}]", string.Join(", ", forecastCopy));
+            forecast = modelCopy.Forecast(5);
+            Console.WriteLine("[{0}]", string.Join(", ", forecast));
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
 
             // Forecast with the original model(that was checkpointed to disk).

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ML;
+using Microsoft.ML.Transforms.TimeSeries;
+using Microsoft.ML.TimeSeries;
+
+namespace Samples.Dynamic
+{
+    public static class ForecastingWithConfidenceInternal
+    {
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot) and then
+        // does forecasting.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a recurring pattern
+            const int SeasonalitySize = 5;
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+            };
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup arguments.
+            var inputColumnName = nameof(TimeSeriesData.Value);
+
+            // Train the forecasting detector.
+            var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler(inputColumnName, data.Count, SeasonalitySize + 1, SeasonalitySize,
+                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, shouldComputeForecastIntervals: true, false);
+
+            // Train.
+            model.Train(dataView);
+
+            // Forecast next five values with confidence internal.
+            float[] forecast;
+            float[] confidenceIntervalLowerBounds;
+            float[] confidenceIntervalUpperBounds;
+            model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
+            Console.WriteLine($"Forecasted values:");
+            Console.WriteLine("[{0}]", string.Join(", ", forecast));
+            Console.WriteLine($"Confidence intervals:");
+            for(int index = 0; index < 5; index++)
+                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
+
+            // Forecasted values:
+            // [2.452744, 2.589339, 2.729183, 2.873005, 3.028931]
+            // Confidence intervals:
+            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
+
+            // Update with new observations.
+            dataView = ml.Data.LoadFromEnumerable(new List<TimeSeriesData>() { new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0) });
+            model.Update(dataView);
+
+            // Checkpoint.
+            ml.Model.SaveForecastingModel(model, "model.zip");
+
+            // Load the checkpointed model from disk.
+            var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
+
+            // Forecast with the checkpointed model loaded from disk.
+            float[] forecastCopy;
+            float[] confidenceIntervalLowerBoundsCopy;
+            float[] confidenceIntervalUpperBoundsCopy;
+            modelCopy.ForecastWithConfidenceIntervals(5, out forecastCopy, out confidenceIntervalLowerBoundsCopy, out confidenceIntervalUpperBoundsCopy);
+            Console.WriteLine($"Forecasted values:");
+            Console.WriteLine("[{0}]", string.Join(", ", forecastCopy));
+            Console.WriteLine($"Confidence intervals:");
+            for (int index = 0; index < 5; index++)
+                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBoundsCopy[index], confidenceIntervalUpperBoundsCopy[index]);
+
+            // Forecasted values:
+            // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
+            // Confidence intervals:
+            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
+
+            // Forecast with the original model(that was checkpointed to disk).
+            model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
+            Console.WriteLine($"Forecasted values:");
+            Console.WriteLine("[{0}]", string.Join(", ", forecast));
+            Console.WriteLine($"Confidence intervals:");
+            for (int index = 0; index < 5; index++)
+                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
+
+            // Forecasted values:
+            // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
+            // Confidence intervals:
+            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
+        }
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
@@ -45,7 +45,7 @@ namespace Samples.Dynamic
             // Setup arguments.
             var inputColumnName = nameof(TimeSeriesData.Value);
 
-            // Train the forecasting model.
+            // Instantiate the forecasting model.
             var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler(inputColumnName, data.Count, SeasonalitySize + 1, SeasonalitySize,
                 1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.TimeSeries;
 
 namespace Samples.Dynamic
 {
-    public static class ForecastingWithConfidenceInternal
+    public static class Forecasting
     {
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot) and then
         // does forecasting.
@@ -45,28 +45,19 @@ namespace Samples.Dynamic
             // Setup arguments.
             var inputColumnName = nameof(TimeSeriesData.Value);
 
-            // Train the forecasting detector.
+            // Train the forecasting model.
             var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler(inputColumnName, data.Count, SeasonalitySize + 1, SeasonalitySize,
-                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, shouldComputeForecastIntervals: true, false);
+                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
 
             // Train.
             model.Train(dataView);
 
-            // Forecast next five values with confidence internal.
-            float[] forecast;
-            float[] confidenceIntervalLowerBounds;
-            float[] confidenceIntervalUpperBounds;
-            model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
+            // Forecast next five values.
+            var forecast = model.Forecast(5);
             Console.WriteLine($"Forecasted values:");
             Console.WriteLine("[{0}]", string.Join(", ", forecast));
-            Console.WriteLine($"Confidence intervals:");
-            for(int index = 0; index < 5; index++)
-                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
-
             // Forecasted values:
             // [2.452744, 2.589339, 2.729183, 2.873005, 3.028931]
-            // Confidence intervals:
-            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
 
             // Update with new observations.
             dataView = ml.Data.LoadFromEnumerable(new List<TimeSeriesData>() { new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0) });
@@ -79,33 +70,15 @@ namespace Samples.Dynamic
             var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
 
             // Forecast with the checkpointed model loaded from disk.
-            float[] forecastCopy;
-            float[] confidenceIntervalLowerBoundsCopy;
-            float[] confidenceIntervalUpperBoundsCopy;
-            modelCopy.ForecastWithConfidenceIntervals(5, out forecastCopy, out confidenceIntervalLowerBoundsCopy, out confidenceIntervalUpperBoundsCopy);
-            Console.WriteLine($"Forecasted values:");
+            var forecastCopy = modelCopy.Forecast(5);
             Console.WriteLine("[{0}]", string.Join(", ", forecastCopy));
-            Console.WriteLine($"Confidence intervals:");
-            for (int index = 0; index < 5; index++)
-                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBoundsCopy[index], confidenceIntervalUpperBoundsCopy[index]);
-
-            // Forecasted values:
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
-            // Confidence intervals:
-            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
 
             // Forecast with the original model(that was checkpointed to disk).
-            model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
-            Console.WriteLine($"Forecasted values:");
+            forecast = model.Forecast(5);
             Console.WriteLine("[{0}]", string.Join(", ", forecast));
-            Console.WriteLine($"Confidence intervals:");
-            for (int index = 0; index < 5; index++)
-                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
-
-            // Forecasted values:
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
-            // Confidence intervals:
-            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
+
         }
 
         class TimeSeriesData

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ML;
+using Microsoft.ML.Transforms.TimeSeries;
+using Microsoft.ML.TimeSeries;
+
+namespace Samples.Dynamic
+{
+    public static class Forecasting
+    {
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot) and then
+        // does forecasting.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a recurring pattern
+            const int SeasonalitySize = 5;
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+            };
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup arguments.
+            var inputColumnName = nameof(TimeSeriesData.Value);
+
+            // Train the forecasting detector.
+            var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler(inputColumnName, data.Count, SeasonalitySize + 1, SeasonalitySize,
+                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
+
+            // Train.
+            model.Train(dataView);
+
+            // Forecast next five values.
+            var forecast = model.Forecast(5);
+            Console.WriteLine($"Forecasted values:");
+            Console.WriteLine("[{0}]", string.Join(", ", forecast));
+            // Forecasted values:
+            // [2.452744, 2.589339, 2.729183, 2.873005, 3.028931]
+
+            // Update with new observations.
+            dataView = ml.Data.LoadFromEnumerable(new List<TimeSeriesData>() { new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0) });
+            model.Update(dataView);
+
+            // Checkpoint.
+            ml.Model.SaveForecastingModel(model, "model.zip");
+
+            // Load the checkpointed model from disk.
+            var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
+
+            // Forecast with the checkpointed model loaded from disk.
+            var forecastCopy = modelCopy.Forecast(5);
+            Console.WriteLine("[{0}]", string.Join(", ", forecastCopy));
+            // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
+
+            // Forecast with the original model(that was checkpointed to disk).
+            forecast = model.Forecast(5);
+            Console.WriteLine("[{0}]", string.Join(", ", forecast));
+            // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
+
+        }
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.TimeSeries;
 
 namespace Samples.Dynamic
 {
-    public static class Forecasting
+    public static class ForecastingWithConfidenceInternal
     {
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot) and then
         // does forecasting.
@@ -45,19 +45,28 @@ namespace Samples.Dynamic
             // Setup arguments.
             var inputColumnName = nameof(TimeSeriesData.Value);
 
-            // Train the forecasting detector.
+            // Train the forecasting model.
             var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler(inputColumnName, data.Count, SeasonalitySize + 1, SeasonalitySize,
-                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
+                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, shouldComputeForecastIntervals: true, false);
 
             // Train.
             model.Train(dataView);
 
-            // Forecast next five values.
-            var forecast = model.Forecast(5);
+            // Forecast next five values with confidence internal.
+            float[] forecast;
+            float[] confidenceIntervalLowerBounds;
+            float[] confidenceIntervalUpperBounds;
+            model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
             Console.WriteLine($"Forecasted values:");
             Console.WriteLine("[{0}]", string.Join(", ", forecast));
+            Console.WriteLine($"Confidence intervals:");
+            for(int index = 0; index < 5; index++)
+                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
+
             // Forecasted values:
             // [2.452744, 2.589339, 2.729183, 2.873005, 3.028931]
+            // Confidence intervals:
+            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
 
             // Update with new observations.
             dataView = ml.Data.LoadFromEnumerable(new List<TimeSeriesData>() { new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0) });
@@ -70,15 +79,33 @@ namespace Samples.Dynamic
             var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
 
             // Forecast with the checkpointed model loaded from disk.
-            var forecastCopy = modelCopy.Forecast(5);
+            float[] forecastCopy;
+            float[] confidenceIntervalLowerBoundsCopy;
+            float[] confidenceIntervalUpperBoundsCopy;
+            modelCopy.ForecastWithConfidenceIntervals(5, out forecastCopy, out confidenceIntervalLowerBoundsCopy, out confidenceIntervalUpperBoundsCopy);
+            Console.WriteLine($"Forecasted values:");
             Console.WriteLine("[{0}]", string.Join(", ", forecastCopy));
+            Console.WriteLine($"Confidence intervals:");
+            for (int index = 0; index < 5; index++)
+                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBoundsCopy[index], confidenceIntervalUpperBoundsCopy[index]);
+
+            // Forecasted values:
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
+            // Confidence intervals:
+            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
 
             // Forecast with the original model(that was checkpointed to disk).
-            forecast = model.Forecast(5);
+            model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
+            Console.WriteLine($"Forecasted values:");
             Console.WriteLine("[{0}]", string.Join(", ", forecast));
-            // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
+            Console.WriteLine($"Confidence intervals:");
+            for (int index = 0; index < 5; index++)
+                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
 
+            // Forecasted values:
+            // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
+            // Confidence intervals:
+            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
         }
 
         class TimeSeriesData

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
@@ -45,7 +45,7 @@ namespace Samples.Dynamic
             // Setup arguments.
             var inputColumnName = nameof(TimeSeriesData.Value);
 
-            // Train the forecasting model.
+            // Instantiate forecasting model.
             var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler(inputColumnName, data.Count, SeasonalitySize + 1, SeasonalitySize,
                 1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, shouldComputeForecastIntervals: true, false);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
@@ -61,12 +61,12 @@ namespace Samples.Dynamic
             Console.WriteLine("[{0}]", string.Join(", ", forecast));
             Console.WriteLine($"Confidence intervals:");
             for(int index = 0; index < 5; index++)
-                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
+                Console.Write($"[{confidenceIntervalLowerBounds[index]} - {confidenceIntervalUpperBounds[index]}] ");
 
             // Forecasted values:
             // [2.452744, 2.589339, 2.729183, 2.873005, 3.028931]
             // Confidence intervals:
-            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
+            // [-0.2235315 - 5.12902] [-0.08777174 - 5.266451] [0.05076938 - 5.407597] [0.1925406 - 5.553469] [0.3469928 - 5.71087]
 
             // Update with new observations.
             dataView = ml.Data.LoadFromEnumerable(new List<TimeSeriesData>() { new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0), new TimeSeriesData(0) });
@@ -83,29 +83,29 @@ namespace Samples.Dynamic
             float[] confidenceIntervalLowerBoundsCopy;
             float[] confidenceIntervalUpperBoundsCopy;
             modelCopy.ForecastWithConfidenceIntervals(5, out forecastCopy, out confidenceIntervalLowerBoundsCopy, out confidenceIntervalUpperBoundsCopy);
-            Console.WriteLine($"Forecasted values:");
+            Console.WriteLine($"\n\nForecasted values:");
             Console.WriteLine("[{0}]", string.Join(", ", forecastCopy));
             Console.WriteLine($"Confidence intervals:");
             for (int index = 0; index < 5; index++)
-                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBoundsCopy[index], confidenceIntervalUpperBoundsCopy[index]);
+                Console.Write($"[{confidenceIntervalLowerBoundsCopy[index]} - {confidenceIntervalUpperBoundsCopy[index]}] ");
 
             // Forecasted values:
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
             // Confidence intervals:
-            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
+            // [-1.808158 - 3.544394] [-1.8586 - 3.495622] [-1.871486 - 3.485341] [-1.836414 - 3.524514] [-1.736431 - 3.627447]
 
             // Forecast with the original model(that was checkpointed to disk).
             model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
-            Console.WriteLine($"Forecasted values:");
+            Console.WriteLine($"\n\nForecasted values:");
             Console.WriteLine("[{0}]", string.Join(", ", forecast));
             Console.WriteLine($"Confidence intervals:");
             for (int index = 0; index < 5; index++)
-                Console.Write($"[{0} - {1}] ", confidenceIntervalLowerBounds[index], confidenceIntervalUpperBounds[index]);
+                Console.Write($"[{confidenceIntervalLowerBounds[index]} - {confidenceIntervalUpperBounds[index]}] ");
 
             // Forecasted values:
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
             // Confidence intervals:
-            // [0 - 1] [0 - 1] [0 - 1] [0 - 1] [0 - 1]
+            // [-1.808158 - 3.544394] [-1.8586 - 3.495622] [-1.871486 - 3.485341] [-1.836414 - 3.524514] [-1.736431 - 3.627447]
         }
 
         class TimeSeriesData

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs
@@ -57,12 +57,7 @@ namespace Samples.Dynamic
             float[] confidenceIntervalLowerBounds;
             float[] confidenceIntervalUpperBounds;
             model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
-            Console.WriteLine($"Forecasted values:");
-            Console.WriteLine("[{0}]", string.Join(", ", forecast));
-            Console.WriteLine($"Confidence intervals:");
-            for(int index = 0; index < 5; index++)
-                Console.Write($"[{confidenceIntervalLowerBounds[index]} - {confidenceIntervalUpperBounds[index]}] ");
-
+            PrintForecastValuesAndIntervals(forecast, confidenceIntervalLowerBounds, confidenceIntervalUpperBounds);
             // Forecasted values:
             // [2.452744, 2.589339, 2.729183, 2.873005, 3.028931]
             // Confidence intervals:
@@ -79,16 +74,8 @@ namespace Samples.Dynamic
             var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
 
             // Forecast with the checkpointed model loaded from disk.
-            float[] forecastCopy;
-            float[] confidenceIntervalLowerBoundsCopy;
-            float[] confidenceIntervalUpperBoundsCopy;
-            modelCopy.ForecastWithConfidenceIntervals(5, out forecastCopy, out confidenceIntervalLowerBoundsCopy, out confidenceIntervalUpperBoundsCopy);
-            Console.WriteLine($"\n\nForecasted values:");
-            Console.WriteLine("[{0}]", string.Join(", ", forecastCopy));
-            Console.WriteLine($"Confidence intervals:");
-            for (int index = 0; index < 5; index++)
-                Console.Write($"[{confidenceIntervalLowerBoundsCopy[index]} - {confidenceIntervalUpperBoundsCopy[index]}] ");
-
+            modelCopy.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
+            PrintForecastValuesAndIntervals(forecast, confidenceIntervalLowerBounds, confidenceIntervalUpperBounds);
             // Forecasted values:
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
             // Confidence intervals:
@@ -96,16 +83,21 @@ namespace Samples.Dynamic
 
             // Forecast with the original model(that was checkpointed to disk).
             model.ForecastWithConfidenceIntervals(5, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds);
-            Console.WriteLine($"\n\nForecasted values:");
-            Console.WriteLine("[{0}]", string.Join(", ", forecast));
-            Console.WriteLine($"Confidence intervals:");
-            for (int index = 0; index < 5; index++)
-                Console.Write($"[{confidenceIntervalLowerBounds[index]} - {confidenceIntervalUpperBounds[index]}] ");
-
+            PrintForecastValuesAndIntervals(forecast, confidenceIntervalLowerBounds, confidenceIntervalUpperBounds);
             // Forecasted values:
             // [0.8681176, 0.8185108, 0.8069275, 0.84405, 0.9455081]
             // Confidence intervals:
             // [-1.808158 - 3.544394] [-1.8586 - 3.495622] [-1.871486 - 3.485341] [-1.836414 - 3.524514] [-1.736431 - 3.627447]
+        }
+
+        static void PrintForecastValuesAndIntervals(float[] forecast, float[] confidenceIntervalLowerBounds, float[] confidenceIntervalUpperBounds)
+        {
+            Console.WriteLine($"Forecasted values:");
+            Console.WriteLine("[{0}]", string.Join(", ", forecast));
+            Console.WriteLine($"Confidence intervals:");
+            for (int index = 0; index < forecast.Length; index++)
+                Console.Write($"[{confidenceIntervalLowerBounds[index]} - {confidenceIntervalUpperBounds[index]}] ");
+            Console.WriteLine();
         }
 
         class TimeSeriesData

--- a/src/Microsoft.ML.Data/MLContext.cs
+++ b/src/Microsoft.ML.Data/MLContext.cs
@@ -47,6 +47,11 @@ namespace Microsoft.ML
         public AnomalyDetectionCatalog AnomalyDetection { get; }
 
         /// <summary>
+        /// Trainers and tasks specific to forecasting problems.
+        /// </summary>
+        public ForecastingCatalog Forecasting { get; }
+
+        /// <summary>
         /// Data processing operations.
         /// </summary>
         public TransformsCatalog Transforms { get; }
@@ -89,6 +94,7 @@ namespace Microsoft.ML
             Clustering = new ClusteringCatalog(_env);
             Ranking = new RankingCatalog(_env);
             AnomalyDetection = new AnomalyDetectionCatalog(_env);
+            Forecasting = new ForecastingCatalog(_env);
             Transforms = new TransformsCatalog(_env);
             Model = new ModelOperationsCatalog(_env);
             Data = new DataOperationsCatalog(_env);

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -721,7 +721,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Class used by <see cref="MLContext"/> to create instances of binary classification trainers.
+        /// Class used by <see cref="MLContext"/> to create instances of forecasting trainers.
         /// </summary>
         public sealed class Forecasters : CatalogInstantiatorBase
         {

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -704,4 +704,31 @@ namespace Microsoft.ML
             return eval.Evaluate(data, labelColumnName, scoreColumnName, predictedLabelColumnName);
         }
     }
+
+    /// <summary>
+    /// Class used by <see cref="MLContext"/> to create instances of forecasting components.
+    /// </summary>
+    public sealed class ForecastingCatalog : TrainCatalogBase
+    {
+        /// <summary>
+        /// The list of trainers for performing forecasting.
+        /// </summary>
+        public Forecasters Trainers { get; }
+
+        internal ForecastingCatalog(IHostEnvironment env) : base(env, nameof(ForecastingCatalog))
+        {
+            Trainers = new Forecasters(this);
+        }
+
+        /// <summary>
+        /// Class used by <see cref="MLContext"/> to create instances of binary classification trainers.
+        /// </summary>
+        public sealed class Forecasters : CatalogInstantiatorBase
+        {
+            internal Forecasters(ForecastingCatalog catalog)
+                : base(catalog)
+            {
+            }
+        }
+    }
 }

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1700,6 +1700,24 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
     public static class ForecastingCatalogExtension
     {
+        /// <summary>
+        /// Singular Spectrum Analysis (SSA) model for modeling univariate time-series.
+        /// For the details of the model, refer to http://arxiv.org/pdf/1206.6910.pdf.
+        /// </summary>
+        /// <param name="catalog">Catalog.</param>
+        /// <param name="inputColumnName">The name of the column on which forecasting needs to be performed.</param>
+        /// <param name="trainSize">The length of series from the begining used for training.</param>
+        /// <param name="seriesLength">The length of series that is kept in buffer for modeling (parameter N).</param>
+        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).</param>
+        /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
+        /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>
+        /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r). This parameter should be in the range in [1, windowSize].
+        /// If set to null, the rank is automatically determined based on prediction error minimization. (default = null)</param>
+        /// <param name="maxRank">The maximum rank considered during the rank selection process. If not provided (i.e. set to null), it is set to windowSize - 1.</param>
+        /// <param name="shouldComputeForecastIntervals">The flag determining whether the confidence bounds for the point forecasts should be computed. (default = true)</param>
+        /// <param name="shouldstablize">The flag determining whether the model should be stabilized.</param>
+        /// <param name="shouldMaintainInfo">The flag determining whether the meta information for the model needs to be maintained.</param>
+        /// <param name="maxGrowth">The maximum growth on the exponential trend</param>
         public static AdaptiveSingularSpectrumSequenceModeler AdaptiveSingularSpectrumSequenceModeler(this ForecastingCatalog catalog,
             string inputColumnName, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1, RankSelectionMethod rankSelectionMethod = RankSelectionMethod.Exact,
             int? rank = null, int? maxRank = null, bool shouldComputeForecastIntervals = true, bool shouldstablize = true, bool shouldMaintainInfo = false, GrowthRatio? maxGrowth = null) =>

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             private Double _growth;
 
             /// <summary>
-            /// Time span of growth ratio. Must be strictly positibe.
+            /// Time span of growth ratio. Must be strictly positive.
             /// </summary>
             public int TimeSpan
             {

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     public sealed class AdaptiveSingularSpectrumSequenceModeler : ICanForecast<float>
     {
         /// <summary>
-        /// Ranking selection method.
+        /// Ranking selection method for the signal.
         /// </summary>
         public enum RankSelectionMethod
         {
@@ -1697,7 +1697,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <param name="forecast">Forecasted values</param>
         /// <param name="confidenceIntervalLowerBounds">Lower bound confidence intervals of forecasted values.</param>
         /// <param name="confidenceIntervalUpperBounds">Upper bound confidence intervals of forecasted values.</param>
-        /// <param name="confidenceLevel">Confidence level.</param>
+        /// <param name="confidenceLevel">Forecast confidence level.</param>
         public void ForecastWithConfidenceIntervals(int horizon, out float[] forecast, out float[] confidenceIntervalLowerBounds, out float[] confidenceIntervalUpperBounds, float confidenceLevel = 0.95f) =>
             _modeler.ForecastWithConfidenceIntervals(horizon, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds, confidenceLevel);
     }

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1595,7 +1595,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
         }
 
-        public AdaptiveSingularSpectrumSequenceModeler LoadFrom(IHostEnvironment env, string filePath)
+        public ICanForecast<float> LoadFrom(IHostEnvironment env, string filePath)
         {
             using (var file = File.OpenRead(filePath))
             {

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -5,17 +5,20 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Numerics;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.CpuMath;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
+using Microsoft.ML.TimeSeries;
 using Microsoft.ML.Transforms.TimeSeries;
 
-[assembly: LoadableClass(typeof(AdaptiveSingularSpectrumSequenceModeler), typeof(AdaptiveSingularSpectrumSequenceModeler), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler),
+    typeof(AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler), null, typeof(SignatureLoadModel),
     "SSA Sequence Modeler",
-    AdaptiveSingularSpectrumSequenceModeler.LoaderSignature)]
+    AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler.LoaderSignature)]
 
 namespace Microsoft.ML.Transforms.TimeSeries
 {
@@ -23,28 +26,13 @@ namespace Microsoft.ML.Transforms.TimeSeries
     /// This class implements basic Singular Spectrum Analysis (SSA) model for modeling univariate time-series.
     /// For the details of the model, refer to http://arxiv.org/pdf/1206.6910.pdf.
     /// </summary>
-    public sealed class AdaptiveSingularSpectrumSequenceModeler : SequenceModelerBase<Single, Single>, ICanForecast<float>
+    public sealed class AdaptiveSingularSpectrumSequenceForecastingModeler : ICanForecast<float>
     {
-        internal const string LoaderSignature = "SSAModel";
-
         public enum RankSelectionMethod
         {
             Fixed,
             Exact,
             Fast
-        }
-
-        internal sealed class SsaForecastResult : ForecastResultBase<Single>
-        {
-            public VBuffer<Single> ForecastStandardDeviation;
-            public VBuffer<Single> UpperBound;
-            public VBuffer<Single> LowerBound;
-            public Single ConfidenceLevel;
-
-            internal bool CanComputeForecastIntervals;
-            internal Single BoundOffset;
-
-            public bool IsVarianceValid { get { return CanComputeForecastIntervals; } }
         }
 
         public struct GrowthRatio
@@ -90,1521 +78,1588 @@ namespace Microsoft.ML.Transforms.TimeSeries
             public Double Ratio { get { return Math.Pow(_growth, 1d / _timeSpan); } }
         }
 
-        public sealed class ModelInfo
-        {
-            /// <summary>
-            /// The singular values of the SSA of the input time-series
-            /// </summary>
-            public Single[] Spectrum;
+        private AdaptiveSingularSpectrumSequenceModeler _modeler;
 
-            /// <summary>
-            /// The roots of the characteristic polynomial after stabilization (meaningful only if the model is stabilized.)
-            /// </summary>
-            public Complex[] RootsAfterStabilization;
-
-            /// <summary>
-            /// The roots of the characteristic polynomial before stabilization (meaningful only if the model is stabilized.)
-            /// </summary>
-            public Complex[] RootsBeforeStabilization;
-
-            /// <summary>
-            /// The rank of the model
-            /// </summary>
-            public int Rank;
-
-            /// <summary>
-            /// The window size used to compute the SSA model
-            /// </summary>
-            public int WindowSize;
-
-            /// <summary>
-            /// The auto-regressive coefficients learned by the model
-            /// </summary>
-            public Single[] AutoRegressiveCoefficients;
-
-            /// <summary>
-            /// The flag indicating whether the model has been trained
-            /// </summary>
-            public bool IsTrained;
-
-            /// <summary>
-            /// The flag indicating a naive model is trained instead of SSA
-            /// </summary>
-            public bool IsNaiveModelTrained;
-
-            /// <summary>
-            /// The flag indicating whether the learned model has an exponential trend (meaningful only if the model is stabilized.)
-            /// </summary>
-            public bool IsExponentialTrendPresent;
-
-            /// <summary>
-            /// The flag indicating whether the learned model has a polynomial trend (meaningful only if the model is stabilized.)
-            /// </summary>
-            public bool IsPolynomialTrendPresent;
-
-            /// <summary>
-            /// The flag indicating whether the learned model has been stabilized
-            /// </summary>
-            public bool IsStabilized;
-
-            /// <summary>
-            /// The flag indicating whether any artificial seasonality (a seasonality with period greater than the window size) is removed
-            /// (meaningful only if the model is stabilized.)
-            /// </summary>
-            public bool IsArtificialSeasonalityRemoved;
-
-            /// <summary>
-            /// The exponential trend magnitude (meaningful only if the model is stabilized.)
-            /// </summary>
-            public Double ExponentialTrendFactor;
-        }
-
-        private ModelInfo _info;
-
-        /// <summary>
-        /// Returns the meta information about the learned model.
-        /// </summary>
-        public ModelInfo Info
-        {
-            get { return _info; }
-        }
-
-        private Single[] _alpha;
-        private Single[] _state;
-        private readonly FixedSizeQueue<Single> _buffer;
-        private CpuAlignedVector _x;
-        private CpuAlignedVector _xSmooth;
-        private int _windowSize;
-        private readonly int _seriesLength;
-        private readonly RankSelectionMethod _rankSelectionMethod;
-        private readonly Single _discountFactor;
-        private readonly int _trainSize;
-        private int _maxRank;
-        private readonly Double _maxTrendRatio;
-        private readonly bool _shouldStablize;
-        private readonly bool _shouldMaintainInfo;
-
-        private readonly IHost _host;
-
-        private CpuAlignedMatrixRow _wTrans;
-        private Single _observationNoiseVariance;
-        private Single _observationNoiseMean;
-        private Single _autoregressionNoiseVariance;
-        private Single _autoregressionNoiseMean;
-
-        private int _rank;
-        private CpuAlignedVector _y;
-        private Single _nextPrediction;
-
-        /// <summary>
-        /// Determines whether the confidence interval required for forecasting.
-        /// </summary>
-        public bool ShouldComputeForecastIntervals { get; set; }
-
-        /// <summary>
-        /// Returns the rank of the subspace used for SSA projection (parameter r).
-        /// </summary>
-        public int Rank { get { return _rank; } }
-
-        /// <summary>
-        /// Returns the smoothed (via SSA projection) version of the last series observation fed to the model.
-        /// </summary>
-        public Single LastSmoothedValue { get { return _state[_windowSize - 2]; } }
-
-        /// <summary>
-        /// Returns the last series observation fed to the model.
-        /// </summary>
-        public Single LastValue { get { return _buffer.Count > 0 ? _buffer[_buffer.Count - 1] : Single.NaN; } }
-
-        private static VersionInfo GetVersionInfo()
-        {
-            return new VersionInfo(
-                modelSignature: "SSAMODLR",
-                //verWrittenCur: 0x00010001, // Initial
-                verWrittenCur: 0x00010002, // Added saving _state and _nextPrediction
-                verReadableCur: 0x00010002,
-                verWeCanReadBack: 0x00010001,
-                loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(AdaptiveSingularSpectrumSequenceModeler).Assembly.FullName);
-        }
-
-        private const int VersionSavingStateAndPrediction = 0x00010002;
-
-        /// <summary>
-        /// The constructor for Adaptive SSA model.
-        /// </summary>
-        /// <param name="env">The exception context.</param>
-        /// <param name="trainSize">The length of series from the begining used for training.</param>
-        /// <param name="seriesLength">The length of series that is kept in buffer for modeling (parameter N).</param>
-        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).</param>
-        /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
-        /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>
-        /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r). This parameter should be in the range in [1, windowSize].
-        /// If set to null, the rank is automatically determined based on prediction error minimization. (default = null)</param>
-        /// <param name="maxRank">The maximum rank considered during the rank selection process. If not provided (i.e. set to null), it is set to windowSize - 1.</param>
-        /// <param name="shouldComputeForecastIntervals">The flag determining whether the confidence bounds for the point forecasts should be computed. (default = true)</param>
-        /// <param name="shouldstablize">The flag determining whether the model should be stabilized.</param>
-        /// <param name="shouldMaintainInfo">The flag determining whether the meta information for the model needs to be maintained.</param>
-        /// <param name="maxGrowth">The maximum growth on the exponential trend</param>
-        public AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1,
+        public AdaptiveSingularSpectrumSequenceForecastingModeler(IHostEnvironment env, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1,
             RankSelectionMethod rankSelectionMethod = RankSelectionMethod.Exact, int? rank = null, int? maxRank = null,
             bool shouldComputeForecastIntervals = true, bool shouldstablize = true, bool shouldMaintainInfo = false, GrowthRatio? maxGrowth = null)
-            : base()
         {
-            Contracts.CheckValue(env, nameof(env));
-            _host = env.Register(LoaderSignature);
-            _host.CheckParam(windowSize >= 2, nameof(windowSize), "The window size should be at least 2."); // ...because otherwise we have nothing to autoregress on
-            _host.CheckParam(seriesLength > windowSize, nameof(seriesLength), "The series length should be greater than the window size.");
-            _host.Check(trainSize > 2 * windowSize, "The input series length for training should be greater than twice the window size.");
-            _host.CheckParam(0 <= discountFactor && discountFactor <= 1, nameof(discountFactor), "The discount factor should be in [0,1].");
-
-            if (maxRank != null)
-            {
-                _maxRank = (int)maxRank;
-                _host.CheckParam(1 <= _maxRank && _maxRank < windowSize, nameof(maxRank),
-                    "The max rank should be in [1, windowSize).");
-            }
-            else
-                _maxRank = windowSize - 1;
-
-            _rankSelectionMethod = rankSelectionMethod;
-            if (_rankSelectionMethod == RankSelectionMethod.Fixed)
-            {
-                if (rank != null)
-                {
-                    _rank = (int)rank;
-                    _host.CheckParam(1 <= _rank && _rank < windowSize, nameof(rank), "The rank should be in [1, windowSize).");
-                }
-                else
-                    _rank = _maxRank;
-            }
-
-            _seriesLength = seriesLength;
-            _windowSize = windowSize;
-            _trainSize = trainSize;
-            _discountFactor = discountFactor;
-
-            _buffer = new FixedSizeQueue<Single>(seriesLength);
-
-            _alpha = new Single[windowSize - 1];
-            _state = new Single[windowSize - 1];
-            _x = new CpuAlignedVector(windowSize, CpuMathUtils.GetVectorAlignment());
-            _xSmooth = new CpuAlignedVector(windowSize, CpuMathUtils.GetVectorAlignment());
-            ShouldComputeForecastIntervals = shouldComputeForecastIntervals;
-
-            _observationNoiseVariance = 0;
-            _autoregressionNoiseVariance = 0;
-            _observationNoiseMean = 0;
-            _autoregressionNoiseMean = 0;
-            _shouldStablize = shouldstablize;
-            _maxTrendRatio = maxGrowth == null ? Double.PositiveInfinity : ((GrowthRatio)maxGrowth).Ratio;
-
-            _shouldMaintainInfo = shouldMaintainInfo;
-            if (_shouldMaintainInfo)
-            {
-                _info = new ModelInfo();
-                _info.WindowSize = _windowSize;
-            }
+            _modeler = new AdaptiveSingularSpectrumSequenceModeler(env, trainSize, seriesLength, windowSize, discountFactor,
+                rankSelectionMethod, rank, maxRank, shouldComputeForecastIntervals, shouldstablize, shouldMaintainInfo, maxGrowth);
         }
 
         /// <summary>
-        /// The copy constructor.
+        /// This class implements basic Singular Spectrum Analysis (SSA) model for modeling univariate time-series.
+        /// For the details of the model, refer to http://arxiv.org/pdf/1206.6910.pdf.
         /// </summary>
-        /// <param name="model">An object whose contents are copied to the current object.</param>
-        private AdaptiveSingularSpectrumSequenceModeler(AdaptiveSingularSpectrumSequenceModeler model)
+        internal sealed class AdaptiveSingularSpectrumSequenceModeler : SequenceModelerBase<Single, Single>, ICanForecast<float>
         {
-            _host = model._host.Register(LoaderSignature);
-            _host.Assert(model._windowSize >= 2);
-            _host.Assert(model._seriesLength > model._windowSize);
-            _host.Assert(model._trainSize > 2 * model._windowSize);
-            _host.Assert(0 <= model._discountFactor && model._discountFactor <= 1);
-            _host.Assert(1 <= model._rank && model._rank < model._windowSize);
+            internal const string LoaderSignature = "SSAModel";
 
-            _rank = model._rank;
-            _maxRank = model._maxRank;
-            _rankSelectionMethod = model._rankSelectionMethod;
-            _seriesLength = model._seriesLength;
-            _windowSize = model._windowSize;
-            _trainSize = model._trainSize;
-            _discountFactor = model._discountFactor;
-            ShouldComputeForecastIntervals = model.ShouldComputeForecastIntervals;
-            _observationNoiseVariance = model._observationNoiseVariance;
-            _autoregressionNoiseVariance = model._autoregressionNoiseVariance;
-            _observationNoiseMean = model._observationNoiseMean;
-            _autoregressionNoiseMean = model._autoregressionNoiseMean;
-            _nextPrediction = model._nextPrediction;
-            _maxTrendRatio = model._maxTrendRatio;
-            _shouldStablize = model._shouldStablize;
-            _shouldMaintainInfo = model._shouldMaintainInfo;
-            _info = model._info;
-            _buffer = model._buffer.Clone();
-            _alpha = new Single[_windowSize - 1];
-            Array.Copy(model._alpha, _alpha, _windowSize - 1);
-            _state = new Single[_windowSize - 1];
-            Array.Copy(model._state, _state, _windowSize - 1);
-
-            _x = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
-            _xSmooth = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
-
-            if (model._wTrans != null)
+            internal sealed class SsaForecastResult : ForecastResultBase<Single>
             {
-                _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
-                _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
-                _wTrans.CopyFrom(model._wTrans);
+                public VBuffer<Single> ForecastStandardDeviation;
+                public VBuffer<Single> UpperBound;
+                public VBuffer<Single> LowerBound;
+                public Single ConfidenceLevel;
+
+                internal bool CanComputeForecastIntervals;
+                internal Single BoundOffset;
+
+                public bool IsVarianceValid { get { return CanComputeForecastIntervals; } }
             }
-        }
 
-        public AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, ModelLoadContext ctx)
-        {
-            Contracts.CheckValue(env, nameof(env));
-            _host = env.Register(LoaderSignature);
-
-            // *** Binary format ***
-            // int: _seriesLength
-            // int: _windowSize
-            // int: _trainSize
-            // int: _rank
-            // float: _discountFactor
-            // RankSelectionMethod: _rankSelectionMethod
-            // bool: isWeightSet
-            // float[]: _alpha
-            // float[]: _state
-            // bool: ShouldComputeForecastIntervals
-            // float: _observationNoiseVariance
-            // float: _autoregressionNoiseVariance
-            // float: _observationNoiseMean
-            // float: _autoregressionNoiseMean
-            // float: _nextPrediction
-            // int: _maxRank
-            // bool: _shouldStablize
-            // bool: _shouldMaintainInfo
-            // double: _maxTrendRatio
-            // float[]: _wTrans (only if _isWeightSet == true)
-
-            _seriesLength = ctx.Reader.ReadInt32();
-            // Do an early check. We'll have the stricter check later.
-            _host.CheckDecode(_seriesLength > 2);
-
-            _windowSize = ctx.Reader.ReadInt32();
-            _host.CheckDecode(_windowSize >= 2);
-            _host.CheckDecode(_seriesLength > _windowSize);
-
-            _trainSize = ctx.Reader.ReadInt32();
-            _host.CheckDecode(_trainSize > 2 * _windowSize);
-
-            _rank = ctx.Reader.ReadInt32();
-            _host.CheckDecode(1 <= _rank && _rank < _windowSize);
-
-            _discountFactor = ctx.Reader.ReadSingle();
-            _host.CheckDecode(0 <= _discountFactor && _discountFactor <= 1);
-
-            byte temp;
-            temp = ctx.Reader.ReadByte();
-            _rankSelectionMethod = (RankSelectionMethod)temp;
-            bool isWeightSet = ctx.Reader.ReadBoolByte();
-
-            _alpha = ctx.Reader.ReadFloatArray();
-            _host.CheckDecode(Utils.Size(_alpha) == _windowSize - 1);
-
-            if (ctx.Header.ModelVerReadable >= VersionSavingStateAndPrediction)
+            public sealed class ModelInfo
             {
-                _state = ctx.Reader.ReadFloatArray();
-                _host.CheckDecode(Utils.Size(_state) == _windowSize - 1);
+                /// <summary>
+                /// The singular values of the SSA of the input time-series
+                /// </summary>
+                public Single[] Spectrum;
+
+                /// <summary>
+                /// The roots of the characteristic polynomial after stabilization (meaningful only if the model is stabilized.)
+                /// </summary>
+                public Complex[] RootsAfterStabilization;
+
+                /// <summary>
+                /// The roots of the characteristic polynomial before stabilization (meaningful only if the model is stabilized.)
+                /// </summary>
+                public Complex[] RootsBeforeStabilization;
+
+                /// <summary>
+                /// The rank of the model
+                /// </summary>
+                public int Rank;
+
+                /// <summary>
+                /// The window size used to compute the SSA model
+                /// </summary>
+                public int WindowSize;
+
+                /// <summary>
+                /// The auto-regressive coefficients learned by the model
+                /// </summary>
+                public Single[] AutoRegressiveCoefficients;
+
+                /// <summary>
+                /// The flag indicating whether the model has been trained
+                /// </summary>
+                public bool IsTrained;
+
+                /// <summary>
+                /// The flag indicating a naive model is trained instead of SSA
+                /// </summary>
+                public bool IsNaiveModelTrained;
+
+                /// <summary>
+                /// The flag indicating whether the learned model has an exponential trend (meaningful only if the model is stabilized.)
+                /// </summary>
+                public bool IsExponentialTrendPresent;
+
+                /// <summary>
+                /// The flag indicating whether the learned model has a polynomial trend (meaningful only if the model is stabilized.)
+                /// </summary>
+                public bool IsPolynomialTrendPresent;
+
+                /// <summary>
+                /// The flag indicating whether the learned model has been stabilized
+                /// </summary>
+                public bool IsStabilized;
+
+                /// <summary>
+                /// The flag indicating whether any artificial seasonality (a seasonality with period greater than the window size) is removed
+                /// (meaningful only if the model is stabilized.)
+                /// </summary>
+                public bool IsArtificialSeasonalityRemoved;
+
+                /// <summary>
+                /// The exponential trend magnitude (meaningful only if the model is stabilized.)
+                /// </summary>
+                public Double ExponentialTrendFactor;
             }
-            else
+
+            private ModelInfo _info;
+
+            /// <summary>
+            /// Returns the meta information about the learned model.
+            /// </summary>
+            public ModelInfo Info
+            {
+                get { return _info; }
+            }
+
+            private Single[] _alpha;
+            private Single[] _state;
+            private readonly FixedSizeQueue<Single> _buffer;
+            private CpuAlignedVector _x;
+            private CpuAlignedVector _xSmooth;
+            private int _windowSize;
+            private readonly int _seriesLength;
+            private readonly RankSelectionMethod _rankSelectionMethod;
+            private readonly Single _discountFactor;
+            private readonly int _trainSize;
+            private int _maxRank;
+            private readonly Double _maxTrendRatio;
+            private readonly bool _shouldStablize;
+            private readonly bool _shouldMaintainInfo;
+
+            private readonly IHost _host;
+
+            private CpuAlignedMatrixRow _wTrans;
+            private Single _observationNoiseVariance;
+            private Single _observationNoiseMean;
+            private Single _autoregressionNoiseVariance;
+            private Single _autoregressionNoiseMean;
+
+            private int _rank;
+            private CpuAlignedVector _y;
+            private Single _nextPrediction;
+
+            /// <summary>
+            /// Determines whether the confidence interval required for forecasting.
+            /// </summary>
+            public bool ShouldComputeForecastIntervals { get; set; }
+
+            /// <summary>
+            /// Returns the rank of the subspace used for SSA projection (parameter r).
+            /// </summary>
+            public int Rank { get { return _rank; } }
+
+            /// <summary>
+            /// Returns the smoothed (via SSA projection) version of the last series observation fed to the model.
+            /// </summary>
+            public Single LastSmoothedValue { get { return _state[_windowSize - 2]; } }
+
+            /// <summary>
+            /// Returns the last series observation fed to the model.
+            /// </summary>
+            public Single LastValue { get { return _buffer.Count > 0 ? _buffer[_buffer.Count - 1] : Single.NaN; } }
+
+            private static VersionInfo GetVersionInfo()
+            {
+                return new VersionInfo(
+                    modelSignature: "SSAMODLR",
+                    //verWrittenCur: 0x00010001, // Initial
+                    verWrittenCur: 0x00010002, // Added saving _state and _nextPrediction
+                    verReadableCur: 0x00010002,
+                    verWeCanReadBack: 0x00010001,
+                    loaderSignature: LoaderSignature,
+                    loaderAssemblyName: typeof(AdaptiveSingularSpectrumSequenceModeler).Assembly.FullName);
+            }
+
+            private const int VersionSavingStateAndPrediction = 0x00010002;
+
+            /// <summary>
+            /// The constructor for Adaptive SSA model.
+            /// </summary>
+            /// <param name="env">The exception context.</param>
+            /// <param name="trainSize">The length of series from the begining used for training.</param>
+            /// <param name="seriesLength">The length of series that is kept in buffer for modeling (parameter N).</param>
+            /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).</param>
+            /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
+            /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>
+            /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r). This parameter should be in the range in [1, windowSize].
+            /// If set to null, the rank is automatically determined based on prediction error minimization. (default = null)</param>
+            /// <param name="maxRank">The maximum rank considered during the rank selection process. If not provided (i.e. set to null), it is set to windowSize - 1.</param>
+            /// <param name="shouldComputeForecastIntervals">The flag determining whether the confidence bounds for the point forecasts should be computed. (default = true)</param>
+            /// <param name="shouldstablize">The flag determining whether the model should be stabilized.</param>
+            /// <param name="shouldMaintainInfo">The flag determining whether the meta information for the model needs to be maintained.</param>
+            /// <param name="maxGrowth">The maximum growth on the exponential trend</param>
+            public AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1,
+                RankSelectionMethod rankSelectionMethod = RankSelectionMethod.Exact, int? rank = null, int? maxRank = null,
+                bool shouldComputeForecastIntervals = true, bool shouldstablize = true, bool shouldMaintainInfo = false, GrowthRatio? maxGrowth = null)
+                : base()
+            {
+                Contracts.CheckValue(env, nameof(env));
+                _host = env.Register(LoaderSignature);
+                _host.CheckParam(windowSize >= 2, nameof(windowSize), "The window size should be at least 2."); // ...because otherwise we have nothing to autoregress on
+                _host.CheckParam(seriesLength > windowSize, nameof(seriesLength), "The series length should be greater than the window size.");
+                _host.Check(trainSize > 2 * windowSize, "The input series length for training should be greater than twice the window size.");
+                _host.CheckParam(0 <= discountFactor && discountFactor <= 1, nameof(discountFactor), "The discount factor should be in [0,1].");
+
+                if (maxRank != null)
+                {
+                    _maxRank = (int)maxRank;
+                    _host.CheckParam(1 <= _maxRank && _maxRank < windowSize, nameof(maxRank),
+                        "The max rank should be in [1, windowSize).");
+                }
+                else
+                    _maxRank = windowSize - 1;
+
+                _rankSelectionMethod = rankSelectionMethod;
+                if (_rankSelectionMethod == RankSelectionMethod.Fixed)
+                {
+                    if (rank != null)
+                    {
+                        _rank = (int)rank;
+                        _host.CheckParam(1 <= _rank && _rank < windowSize, nameof(rank), "The rank should be in [1, windowSize).");
+                    }
+                    else
+                        _rank = _maxRank;
+                }
+
+                _seriesLength = seriesLength;
+                _windowSize = windowSize;
+                _trainSize = trainSize;
+                _discountFactor = discountFactor;
+
+                _buffer = new FixedSizeQueue<Single>(seriesLength);
+
+                _alpha = new Single[windowSize - 1];
+                _state = new Single[windowSize - 1];
+                _x = new CpuAlignedVector(windowSize, CpuMathUtils.GetVectorAlignment());
+                _xSmooth = new CpuAlignedVector(windowSize, CpuMathUtils.GetVectorAlignment());
+                ShouldComputeForecastIntervals = shouldComputeForecastIntervals;
+
+                _observationNoiseVariance = 0;
+                _autoregressionNoiseVariance = 0;
+                _observationNoiseMean = 0;
+                _autoregressionNoiseMean = 0;
+                _shouldStablize = shouldstablize;
+                _maxTrendRatio = maxGrowth == null ? Double.PositiveInfinity : ((GrowthRatio)maxGrowth).Ratio;
+
+                _shouldMaintainInfo = shouldMaintainInfo;
+                if (_shouldMaintainInfo)
+                {
+                    _info = new ModelInfo();
+                    _info.WindowSize = _windowSize;
+                }
+            }
+
+            /// <summary>
+            /// The copy constructor.
+            /// </summary>
+            /// <param name="model">An object whose contents are copied to the current object.</param>
+            private AdaptiveSingularSpectrumSequenceModeler(AdaptiveSingularSpectrumSequenceModeler model)
+            {
+                _host = model._host.Register(LoaderSignature);
+                _host.Assert(model._windowSize >= 2);
+                _host.Assert(model._seriesLength > model._windowSize);
+                _host.Assert(model._trainSize > 2 * model._windowSize);
+                _host.Assert(0 <= model._discountFactor && model._discountFactor <= 1);
+                _host.Assert(1 <= model._rank && model._rank < model._windowSize);
+
+                _rank = model._rank;
+                _maxRank = model._maxRank;
+                _rankSelectionMethod = model._rankSelectionMethod;
+                _seriesLength = model._seriesLength;
+                _windowSize = model._windowSize;
+                _trainSize = model._trainSize;
+                _discountFactor = model._discountFactor;
+                ShouldComputeForecastIntervals = model.ShouldComputeForecastIntervals;
+                _observationNoiseVariance = model._observationNoiseVariance;
+                _autoregressionNoiseVariance = model._autoregressionNoiseVariance;
+                _observationNoiseMean = model._observationNoiseMean;
+                _autoregressionNoiseMean = model._autoregressionNoiseMean;
+                _nextPrediction = model._nextPrediction;
+                _maxTrendRatio = model._maxTrendRatio;
+                _shouldStablize = model._shouldStablize;
+                _shouldMaintainInfo = model._shouldMaintainInfo;
+                _info = model._info;
+                _buffer = model._buffer.Clone();
+                _alpha = new Single[_windowSize - 1];
+                Array.Copy(model._alpha, _alpha, _windowSize - 1);
                 _state = new Single[_windowSize - 1];
+                Array.Copy(model._state, _state, _windowSize - 1);
 
-            ShouldComputeForecastIntervals = ctx.Reader.ReadBoolByte();
+                _x = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
+                _xSmooth = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
 
-            _observationNoiseVariance = ctx.Reader.ReadSingle();
-            _host.CheckDecode(_observationNoiseVariance >= 0);
-
-            _autoregressionNoiseVariance = ctx.Reader.ReadSingle();
-            _host.CheckDecode(_autoregressionNoiseVariance >= 0);
-
-            _observationNoiseMean = ctx.Reader.ReadSingle();
-            _autoregressionNoiseMean = ctx.Reader.ReadSingle();
-            if (ctx.Header.ModelVerReadable >= VersionSavingStateAndPrediction)
-                _nextPrediction = ctx.Reader.ReadSingle();
-
-            _maxRank = ctx.Reader.ReadInt32();
-            _host.CheckDecode(1 <= _maxRank && _maxRank <= _windowSize - 1);
-
-            _shouldStablize = ctx.Reader.ReadBoolByte();
-            _shouldMaintainInfo = ctx.Reader.ReadBoolByte();
-            if (_shouldMaintainInfo)
-            {
-                _info = new ModelInfo();
-                _info.AutoRegressiveCoefficients = new Single[_windowSize - 1];
-                Array.Copy(_alpha, _info.AutoRegressiveCoefficients, _windowSize - 1);
-
-                _info.IsStabilized = _shouldStablize;
-                _info.Rank = _rank;
-                _info.WindowSize = _windowSize;
-            }
-
-            _maxTrendRatio = ctx.Reader.ReadDouble();
-            _host.CheckDecode(_maxTrendRatio >= 0);
-
-            if (isWeightSet)
-            {
-                var tempArray = ctx.Reader.ReadFloatArray();
-                _host.CheckDecode(Utils.Size(tempArray) == _rank * _windowSize);
-                _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
-                int i = 0;
-                _wTrans.CopyFrom(tempArray, ref i);
-                tempArray = ctx.Reader.ReadFloatArray();
-                i = 0;
-                _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
-                _y.CopyFrom(tempArray, ref i);
-            }
-
-            _buffer = TimeSeriesUtils.DeserializeFixedSizeQueueSingle(ctx.Reader, _host);
-            _x = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
-            _xSmooth = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
-        }
-
-        private protected override void SaveModel(ModelSaveContext ctx)
-        {
-            _host.CheckValue(ctx, nameof(ctx));
-            ctx.CheckAtModel();
-            ctx.SetVersionInfo(GetVersionInfo());
-
-            _host.Assert(_windowSize >= 2);
-            _host.Assert(_seriesLength > _windowSize);
-            _host.Assert(_trainSize > 2 * _windowSize);
-            _host.Assert(0 <= _discountFactor && _discountFactor <= 1);
-            _host.Assert(1 <= _rank && _rank < _windowSize);
-            _host.Assert(Utils.Size(_alpha) == _windowSize - 1);
-            _host.Assert(_observationNoiseVariance >= 0);
-            _host.Assert(_autoregressionNoiseVariance >= 0);
-            _host.Assert(1 <= _maxRank && _maxRank <= _windowSize - 1);
-            _host.Assert(_maxTrendRatio >= 0);
-
-            // *** Binary format ***
-            // int: _seriesLength
-            // int: _windowSize
-            // int: _trainSize
-            // int: _rank
-            // float: _discountFactor
-            // RankSelectionMethod: _rankSelectionMethod
-            // bool: _isWeightSet
-            // float[]: _alpha
-            // float[]: _state
-            // bool: ShouldComputeForecastIntervals
-            // float: _observationNoiseVariance
-            // float: _autoregressionNoiseVariance
-            // float: _observationNoiseMean
-            // float: _autoregressionNoiseMean
-            // float: _nextPrediction
-            // int: _maxRank
-            // bool: _shouldStablize
-            // bool: _shouldMaintainInfo
-            // double: _maxTrendRatio
-            // float[]: _wTrans (only if _isWeightSet == true)
-
-            ctx.Writer.Write(_seriesLength);
-            ctx.Writer.Write(_windowSize);
-            ctx.Writer.Write(_trainSize);
-            ctx.Writer.Write(_rank);
-            ctx.Writer.Write(_discountFactor);
-            ctx.Writer.Write((byte)_rankSelectionMethod);
-            ctx.Writer.WriteBoolByte(_wTrans != null);
-            ctx.Writer.WriteSingleArray(_alpha);
-            ctx.Writer.WriteSingleArray(_state);
-            ctx.Writer.WriteBoolByte(ShouldComputeForecastIntervals);
-            ctx.Writer.Write(_observationNoiseVariance);
-            ctx.Writer.Write(_autoregressionNoiseVariance);
-            ctx.Writer.Write(_observationNoiseMean);
-            ctx.Writer.Write(_autoregressionNoiseMean);
-            ctx.Writer.Write(_nextPrediction);
-            ctx.Writer.Write(_maxRank);
-            ctx.Writer.WriteBoolByte(_shouldStablize);
-            ctx.Writer.WriteBoolByte(_shouldMaintainInfo);
-            ctx.Writer.Write(_maxTrendRatio);
-
-            if (_wTrans != null)
-            {
-                // REVIEW: this may not be the most efficient way for serializing an aligned matrix.
-                var tempArray = new Single[_rank * _windowSize];
-                int iv = 0;
-                _wTrans.CopyTo(tempArray, ref iv);
-                ctx.Writer.WriteSingleArray(tempArray);
-                tempArray = new float[_rank];
-                iv = 0;
-                _y.CopyTo(tempArray, ref iv);
-                ctx.Writer.WriteSingleArray(tempArray);
-            }
-
-            TimeSeriesUtils.SerializeFixedSizeQueue(_buffer, ctx.Writer);
-        }
-
-        private static void ReconstructSignal(TrajectoryMatrix tMat, Single[] singularVectors, int rank, Single[] output)
-        {
-            Contracts.Assert(tMat != null);
-            Contracts.Assert(1 <= rank && rank <= tMat.WindowSize);
-            Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * rank);
-            Contracts.Assert(Utils.Size(output) >= tMat.SeriesLength);
-
-            var k = tMat.SeriesLength - tMat.WindowSize + 1;
-            Contracts.Assert(k > 0);
-
-            var v = new Single[k];
-            int i;
-
-            for (i = 0; i < tMat.SeriesLength; ++i)
-                output[i] = 0;
-
-            for (i = 0; i < rank; ++i)
-            {
-                // Reconstructing the i-th eigen triple component and adding it to output
-                tMat.MultiplyTranspose(singularVectors, v, false, tMat.WindowSize * i, 0);
-                tMat.RankOneHankelization(singularVectors, v, 1, output, true, tMat.WindowSize * i, 0, 0);
-            }
-        }
-
-        private static void ReconstructSignalTailFast(Single[] series, TrajectoryMatrix tMat, Single[] singularVectors, int rank, Single[] output)
-        {
-            Contracts.Assert(tMat != null);
-            Contracts.Assert(1 <= rank && rank <= tMat.WindowSize);
-            Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * rank);
-
-            int len = 2 * tMat.WindowSize - 1;
-            Contracts.Assert(Utils.Size(output) >= len);
-
-            Single v;
-            /*var k = tMat.SeriesLength - tMat.WindowSize + 1;
-            Contracts.Assert(k > 0);
-            var v = new Single[k];*/
-
-            Single temp;
-            int i;
-            int j;
-            int offset1 = tMat.SeriesLength - 2 * tMat.WindowSize + 1;
-            int offset2 = tMat.SeriesLength - tMat.WindowSize;
-
-            for (i = 0; i < len; ++i)
-                output[i] = 0;
-
-            for (i = 0; i < rank; ++i)
-            {
-                // Reconstructing the i-th eigen triple component and adding it to output
-                v = 0;
-                for (j = offset1; j < offset1 + tMat.WindowSize; ++j)
-                    v += series[j] * singularVectors[tMat.WindowSize * i - offset1 + j];
-
-                for (j = 0; j < tMat.WindowSize - 1; ++j)
-                    output[j] += v * singularVectors[tMat.WindowSize * i + j];
-
-                temp = v * singularVectors[tMat.WindowSize * (i + 1) - 1];
-
-                v = 0;
-                for (j = offset2; j < offset2 + tMat.WindowSize; ++j)
-                    v += series[j] * singularVectors[tMat.WindowSize * i - offset2 + j];
-
-                for (j = tMat.WindowSize; j < 2 * tMat.WindowSize - 1; ++j)
-                    output[j] += v * singularVectors[tMat.WindowSize * (i - 1) + j + 1];
-
-                temp += v * singularVectors[tMat.WindowSize * i];
-                output[tMat.WindowSize - 1] += (temp / 2);
-            }
-        }
-
-        private static void ComputeNoiseMoments(Single[] series, Single[] signal, Single[] alpha, out Single observationNoiseVariance, out Single autoregressionNoiseVariance,
-            out Single observationNoiseMean, out Single autoregressionNoiseMean, int startIndex = 0)
-        {
-            Contracts.Assert(Utils.Size(alpha) > 0);
-            Contracts.Assert(Utils.Size(signal) > 2 * Utils.Size(alpha)); // To assure that the autoregression noise variance is unbiased.
-            Contracts.Assert(Utils.Size(series) >= Utils.Size(signal) + startIndex);
-
-            var signalLength = Utils.Size(signal);
-            var windowSize = Utils.Size(alpha) + 1;
-            var k = signalLength - windowSize + 1;
-            Contracts.Assert(k > 0);
-
-            var y = new Single[k];
-            int i;
-
-            observationNoiseMean = 0;
-            observationNoiseVariance = 0;
-            autoregressionNoiseMean = 0;
-            autoregressionNoiseVariance = 0;
-
-            // Computing the observation noise moments
-            for (i = 0; i < signalLength; ++i)
-                observationNoiseMean += (series[i + startIndex] - signal[i]);
-            observationNoiseMean /= signalLength;
-
-            for (i = 0; i < signalLength; ++i)
-                observationNoiseVariance += (series[i + startIndex] - signal[i]) * (series[i + startIndex] - signal[i]);
-            observationNoiseVariance /= signalLength;
-            observationNoiseVariance -= (observationNoiseMean * observationNoiseMean);
-
-            // Computing the auto-regression noise moments
-            TrajectoryMatrix xTM = new TrajectoryMatrix(null, signal, windowSize - 1, signalLength - 1);
-            xTM.MultiplyTranspose(alpha, y);
-
-            for (i = 0; i < k; ++i)
-                autoregressionNoiseMean += (signal[windowSize - 1 + i] - y[i]);
-            autoregressionNoiseMean /= k;
-
-            for (i = 0; i < k; ++i)
-            {
-                autoregressionNoiseVariance += (signal[windowSize - 1 + i] - y[i] - autoregressionNoiseMean) *
-                                               (signal[windowSize - 1 + i] - y[i] - autoregressionNoiseMean);
-            }
-
-            autoregressionNoiseVariance /= (k - windowSize + 1);
-            Contracts.Assert(autoregressionNoiseVariance >= 0);
-        }
-
-        private static int DetermineSignalRank(Single[] series, TrajectoryMatrix tMat, Single[] singularVectors, Single[] singularValues,
-            Single[] outputSignal, int maxRank)
-        {
-            Contracts.Assert(tMat != null);
-            Contracts.Assert(Utils.Size(series) >= tMat.SeriesLength);
-            Contracts.Assert(Utils.Size(outputSignal) >= tMat.SeriesLength);
-            Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * tMat.WindowSize);
-            Contracts.Assert(Utils.Size(singularValues) >= tMat.WindowSize);
-            Contracts.Assert(1 <= maxRank && maxRank <= tMat.WindowSize - 1);
-
-            var inputSeriesLength = tMat.SeriesLength;
-            var k = inputSeriesLength - tMat.WindowSize + 1;
-            Contracts.Assert(k > 0);
-
-            var x = new Single[inputSeriesLength];
-            var y = new Single[k];
-            var alpha = new Single[tMat.WindowSize - 1];
-            var v = new Single[k];
-
-            Single nu = 0;
-            Double minErr = Double.MaxValue;
-            int minIndex = maxRank - 1;
-            int evaluationLength = Math.Min(Math.Max(tMat.WindowSize, 200), k);
-
-            TrajectoryMatrix xTM = new TrajectoryMatrix(null, x, tMat.WindowSize - 1, inputSeriesLength - 1);
-
-            int i;
-            int j;
-            int n;
-            Single temp;
-            Double error;
-            Double sumSingularVals = 0;
-            Single lambda;
-            Single observationNoiseMean;
-
-            FixedSizeQueue<Single> window = new FixedSizeQueue<float>(tMat.WindowSize - 1);
-
-            for (i = 0; i < tMat.WindowSize; ++i)
-                sumSingularVals += singularValues[i];
-
-            for (i = 0; i < maxRank; ++i)
-            {
-                // Updating the auto-regressive coefficients
-                lambda = singularVectors[tMat.WindowSize * i + tMat.WindowSize - 1];
-                for (j = 0; j < tMat.WindowSize - 1; ++j)
-                    alpha[j] += lambda * singularVectors[tMat.WindowSize * i + j];
-
-                // Updating nu
-                nu += lambda * lambda;
-
-                // Reconstructing the i-th eigen triple component and adding it to x
-                tMat.MultiplyTranspose(singularVectors, v, false, tMat.WindowSize * i, 0);
-                tMat.RankOneHankelization(singularVectors, v, 1, x, true, tMat.WindowSize * i, 0, 0);
-
-                observationNoiseMean = 0;
-                for (j = 0; j < inputSeriesLength; ++j)
-                    observationNoiseMean += (series[j] - x[j]);
-                observationNoiseMean /= inputSeriesLength;
-
-                for (j = inputSeriesLength - evaluationLength - tMat.WindowSize + 1; j < inputSeriesLength - evaluationLength; ++j)
-                    window.AddLast(x[j]);
-
-                error = 0;
-                for (j = inputSeriesLength - evaluationLength; j < inputSeriesLength; ++j)
+                if (model._wTrans != null)
                 {
-                    temp = 0;
-                    for (n = 0; n < tMat.WindowSize - 1; ++n)
-                        temp += alpha[n] * window[n];
-
-                    temp /= (1 - nu);
-                    temp += observationNoiseMean;
-                    window.AddLast(temp);
-                    error += Math.Abs(series[j] - temp);
-                    if (error > minErr)
-                        break;
-                }
-
-                if (error < minErr)
-                {
-                    minErr = error;
-                    minIndex = i;
-                    Array.Copy(x, outputSignal, inputSeriesLength);
+                    _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
+                    _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
+                    _wTrans.CopyFrom(model._wTrans);
                 }
             }
 
-            return minIndex + 1;
-        }
-
-        internal override void InitState()
-        {
-            for (int i = 0; i < _windowSize - 2; ++i)
-                _state[i] = 0;
-
-            _buffer.Clear();
-        }
-
-        private static int DetermineSignalRankFast(Single[] series, TrajectoryMatrix tMat, Single[] singularVectors, Single[] singularValues, int maxRank)
-        {
-            Contracts.Assert(tMat != null);
-            Contracts.Assert(Utils.Size(series) >= tMat.SeriesLength);
-            Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * tMat.WindowSize);
-            Contracts.Assert(Utils.Size(singularValues) >= tMat.WindowSize);
-            Contracts.Assert(1 <= maxRank && maxRank <= tMat.WindowSize - 1);
-
-            var inputSeriesLength = tMat.SeriesLength;
-            var k = inputSeriesLength - tMat.WindowSize + 1;
-            Contracts.Assert(k > 0);
-
-            var x = new Single[tMat.WindowSize - 1];
-            var alpha = new Single[tMat.WindowSize - 1];
-            Single v;
-
-            Single nu = 0;
-            Double minErr = Double.MaxValue;
-            int minIndex = maxRank - 1;
-            int evaluationLength = Math.Min(Math.Max(tMat.WindowSize, 200), k);
-
-            int i;
-            int j;
-            int n;
-            int offset;
-            Single temp;
-            Double error;
-            Single lambda;
-            Single observationNoiseMean;
-
-            FixedSizeQueue<Single> window = new FixedSizeQueue<float>(tMat.WindowSize - 1);
-
-            for (i = 0; i < maxRank; ++i)
+            public AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, ModelLoadContext ctx)
             {
-                // Updating the auto-regressive coefficients
-                lambda = singularVectors[tMat.WindowSize * i + tMat.WindowSize - 1];
-                for (j = 0; j < tMat.WindowSize - 1; ++j)
-                    alpha[j] += lambda * singularVectors[tMat.WindowSize * i + j];
+                Contracts.CheckValue(env, nameof(env));
+                _host = env.Register(LoaderSignature);
 
-                // Updating nu
-                nu += lambda * lambda;
+                // *** Binary format ***
+                // int: _seriesLength
+                // int: _windowSize
+                // int: _trainSize
+                // int: _rank
+                // float: _discountFactor
+                // RankSelectionMethod: _rankSelectionMethod
+                // bool: isWeightSet
+                // float[]: _alpha
+                // float[]: _state
+                // bool: ShouldComputeForecastIntervals
+                // float: _observationNoiseVariance
+                // float: _autoregressionNoiseVariance
+                // float: _observationNoiseMean
+                // float: _autoregressionNoiseMean
+                // float: _nextPrediction
+                // int: _maxRank
+                // bool: _shouldStablize
+                // bool: _shouldMaintainInfo
+                // double: _maxTrendRatio
+                // float[]: _wTrans (only if _isWeightSet == true)
 
-                // Reconstructing the i-th eigen triple component and adding it to x
-                v = 0;
-                offset = inputSeriesLength - evaluationLength - tMat.WindowSize + 1;
+                _seriesLength = ctx.Reader.ReadInt32();
+                // Do an early check. We'll have the stricter check later.
+                _host.CheckDecode(_seriesLength > 2);
 
-                for (j = offset; j <= inputSeriesLength - evaluationLength; ++j)
-                    v += series[j] * singularVectors[tMat.WindowSize * i - offset + j];
+                _windowSize = ctx.Reader.ReadInt32();
+                _host.CheckDecode(_windowSize >= 2);
+                _host.CheckDecode(_seriesLength > _windowSize);
 
-                for (j = 0; j < tMat.WindowSize - 1; ++j)
-                    x[j] += v * singularVectors[tMat.WindowSize * i + j];
+                _trainSize = ctx.Reader.ReadInt32();
+                _host.CheckDecode(_trainSize > 2 * _windowSize);
 
-                // Computing the empirical observation noise mean
-                observationNoiseMean = 0;
-                for (j = offset; j < inputSeriesLength - evaluationLength; ++j)
-                    observationNoiseMean += (series[j] - x[j - offset]);
-                observationNoiseMean /= (tMat.WindowSize - 1);
+                _rank = ctx.Reader.ReadInt32();
+                _host.CheckDecode(1 <= _rank && _rank < _windowSize);
 
-                for (j = 0; j < tMat.WindowSize - 1; ++j)
-                    window.AddLast(x[j]);
+                _discountFactor = ctx.Reader.ReadSingle();
+                _host.CheckDecode(0 <= _discountFactor && _discountFactor <= 1);
 
-                error = 0;
-                for (j = inputSeriesLength - evaluationLength; j < inputSeriesLength; ++j)
+                byte temp;
+                temp = ctx.Reader.ReadByte();
+                _rankSelectionMethod = (RankSelectionMethod)temp;
+                bool isWeightSet = ctx.Reader.ReadBoolByte();
+
+                _alpha = ctx.Reader.ReadFloatArray();
+                _host.CheckDecode(Utils.Size(_alpha) == _windowSize - 1);
+
+                if (ctx.Header.ModelVerReadable >= VersionSavingStateAndPrediction)
                 {
-                    temp = 0;
-                    for (n = 0; n < tMat.WindowSize - 1; ++n)
-                        temp += alpha[n] * window[n];
-
-                    temp /= (1 - nu);
-                    temp += observationNoiseMean;
-                    window.AddLast(temp);
-                    error += Math.Abs(series[j] - temp);
-                    if (error > minErr)
-                        break;
+                    _state = ctx.Reader.ReadFloatArray();
+                    _host.CheckDecode(Utils.Size(_state) == _windowSize - 1);
                 }
+                else
+                    _state = new Single[_windowSize - 1];
 
-                if (error < minErr)
-                {
-                    minErr = error;
-                    minIndex = i;
-                }
-            }
+                ShouldComputeForecastIntervals = ctx.Reader.ReadBoolByte();
 
-            return minIndex + 1;
-        }
+                _observationNoiseVariance = ctx.Reader.ReadSingle();
+                _host.CheckDecode(_observationNoiseVariance >= 0);
 
-        private class SignalComponent
-        {
-            public Double Phase;
-            public int Index;
-            public int Cluster;
+                _autoregressionNoiseVariance = ctx.Reader.ReadSingle();
+                _host.CheckDecode(_autoregressionNoiseVariance >= 0);
 
-            public SignalComponent(Double phase, int index)
-            {
-                Phase = phase;
-                Index = index;
-            }
-        }
+                _observationNoiseMean = ctx.Reader.ReadSingle();
+                _autoregressionNoiseMean = ctx.Reader.ReadSingle();
+                if (ctx.Header.ModelVerReadable >= VersionSavingStateAndPrediction)
+                    _nextPrediction = ctx.Reader.ReadSingle();
 
-        private bool Stabilize()
-        {
-            if (Utils.Size(_alpha) == 1)
-            {
-                if (_shouldMaintainInfo)
-                    _info.RootsBeforeStabilization = new[] { new Complex(_alpha[0], 0) };
+                _maxRank = ctx.Reader.ReadInt32();
+                _host.CheckDecode(1 <= _maxRank && _maxRank <= _windowSize - 1);
 
-                if (_alpha[0] > 1)
-                    _alpha[0] = 1;
-                else if (_alpha[0] < -1)
-                    _alpha[0] = -1;
-
+                _shouldStablize = ctx.Reader.ReadBoolByte();
+                _shouldMaintainInfo = ctx.Reader.ReadBoolByte();
                 if (_shouldMaintainInfo)
                 {
+                    _info = new ModelInfo();
+                    _info.AutoRegressiveCoefficients = new Single[_windowSize - 1];
+                    Array.Copy(_alpha, _info.AutoRegressiveCoefficients, _windowSize - 1);
+
+                    _info.IsStabilized = _shouldStablize;
+                    _info.Rank = _rank;
+                    _info.WindowSize = _windowSize;
+                }
+
+                _maxTrendRatio = ctx.Reader.ReadDouble();
+                _host.CheckDecode(_maxTrendRatio >= 0);
+
+                if (isWeightSet)
+                {
+                    var tempArray = ctx.Reader.ReadFloatArray();
+                    _host.CheckDecode(Utils.Size(tempArray) == _rank * _windowSize);
+                    _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
+                    int i = 0;
+                    _wTrans.CopyFrom(tempArray, ref i);
+                    tempArray = ctx.Reader.ReadFloatArray();
+                    i = 0;
+                    _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
+                    _y.CopyFrom(tempArray, ref i);
+                }
+
+                _buffer = TimeSeriesUtils.DeserializeFixedSizeQueueSingle(ctx.Reader, _host);
+                _x = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
+                _xSmooth = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
+            }
+
+            private protected override void SaveModel(ModelSaveContext ctx)
+            {
+                _host.CheckValue(ctx, nameof(ctx));
+                ctx.CheckAtModel();
+                ctx.SetVersionInfo(GetVersionInfo());
+
+                _host.Assert(_windowSize >= 2);
+                _host.Assert(_seriesLength > _windowSize);
+                _host.Assert(_trainSize > 2 * _windowSize);
+                _host.Assert(0 <= _discountFactor && _discountFactor <= 1);
+                _host.Assert(1 <= _rank && _rank < _windowSize);
+                _host.Assert(Utils.Size(_alpha) == _windowSize - 1);
+                _host.Assert(_observationNoiseVariance >= 0);
+                _host.Assert(_autoregressionNoiseVariance >= 0);
+                _host.Assert(1 <= _maxRank && _maxRank <= _windowSize - 1);
+                _host.Assert(_maxTrendRatio >= 0);
+
+                // *** Binary format ***
+                // int: _seriesLength
+                // int: _windowSize
+                // int: _trainSize
+                // int: _rank
+                // float: _discountFactor
+                // RankSelectionMethod: _rankSelectionMethod
+                // bool: _isWeightSet
+                // float[]: _alpha
+                // float[]: _state
+                // bool: ShouldComputeForecastIntervals
+                // float: _observationNoiseVariance
+                // float: _autoregressionNoiseVariance
+                // float: _observationNoiseMean
+                // float: _autoregressionNoiseMean
+                // float: _nextPrediction
+                // int: _maxRank
+                // bool: _shouldStablize
+                // bool: _shouldMaintainInfo
+                // double: _maxTrendRatio
+                // float[]: _wTrans (only if _isWeightSet == true)
+
+                ctx.Writer.Write(_seriesLength);
+                ctx.Writer.Write(_windowSize);
+                ctx.Writer.Write(_trainSize);
+                ctx.Writer.Write(_rank);
+                ctx.Writer.Write(_discountFactor);
+                ctx.Writer.Write((byte)_rankSelectionMethod);
+                ctx.Writer.WriteBoolByte(_wTrans != null);
+                ctx.Writer.WriteSingleArray(_alpha);
+                ctx.Writer.WriteSingleArray(_state);
+                ctx.Writer.WriteBoolByte(ShouldComputeForecastIntervals);
+                ctx.Writer.Write(_observationNoiseVariance);
+                ctx.Writer.Write(_autoregressionNoiseVariance);
+                ctx.Writer.Write(_observationNoiseMean);
+                ctx.Writer.Write(_autoregressionNoiseMean);
+                ctx.Writer.Write(_nextPrediction);
+                ctx.Writer.Write(_maxRank);
+                ctx.Writer.WriteBoolByte(_shouldStablize);
+                ctx.Writer.WriteBoolByte(_shouldMaintainInfo);
+                ctx.Writer.Write(_maxTrendRatio);
+
+                if (_wTrans != null)
+                {
+                    // REVIEW: this may not be the most efficient way for serializing an aligned matrix.
+                    var tempArray = new Single[_rank * _windowSize];
+                    int iv = 0;
+                    _wTrans.CopyTo(tempArray, ref iv);
+                    ctx.Writer.WriteSingleArray(tempArray);
+                    tempArray = new float[_rank];
+                    iv = 0;
+                    _y.CopyTo(tempArray, ref iv);
+                    ctx.Writer.WriteSingleArray(tempArray);
+                }
+
+                TimeSeriesUtils.SerializeFixedSizeQueue(_buffer, ctx.Writer);
+            }
+
+            private static void ReconstructSignal(TrajectoryMatrix tMat, Single[] singularVectors, int rank, Single[] output)
+            {
+                Contracts.Assert(tMat != null);
+                Contracts.Assert(1 <= rank && rank <= tMat.WindowSize);
+                Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * rank);
+                Contracts.Assert(Utils.Size(output) >= tMat.SeriesLength);
+
+                var k = tMat.SeriesLength - tMat.WindowSize + 1;
+                Contracts.Assert(k > 0);
+
+                var v = new Single[k];
+                int i;
+
+                for (i = 0; i < tMat.SeriesLength; ++i)
+                    output[i] = 0;
+
+                for (i = 0; i < rank; ++i)
+                {
+                    // Reconstructing the i-th eigen triple component and adding it to output
+                    tMat.MultiplyTranspose(singularVectors, v, false, tMat.WindowSize * i, 0);
+                    tMat.RankOneHankelization(singularVectors, v, 1, output, true, tMat.WindowSize * i, 0, 0);
+                }
+            }
+
+            private static void ReconstructSignalTailFast(Single[] series, TrajectoryMatrix tMat, Single[] singularVectors, int rank, Single[] output)
+            {
+                Contracts.Assert(tMat != null);
+                Contracts.Assert(1 <= rank && rank <= tMat.WindowSize);
+                Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * rank);
+
+                int len = 2 * tMat.WindowSize - 1;
+                Contracts.Assert(Utils.Size(output) >= len);
+
+                Single v;
+                /*var k = tMat.SeriesLength - tMat.WindowSize + 1;
+                Contracts.Assert(k > 0);
+                var v = new Single[k];*/
+
+                Single temp;
+                int i;
+                int j;
+                int offset1 = tMat.SeriesLength - 2 * tMat.WindowSize + 1;
+                int offset2 = tMat.SeriesLength - tMat.WindowSize;
+
+                for (i = 0; i < len; ++i)
+                    output[i] = 0;
+
+                for (i = 0; i < rank; ++i)
+                {
+                    // Reconstructing the i-th eigen triple component and adding it to output
+                    v = 0;
+                    for (j = offset1; j < offset1 + tMat.WindowSize; ++j)
+                        v += series[j] * singularVectors[tMat.WindowSize * i - offset1 + j];
+
+                    for (j = 0; j < tMat.WindowSize - 1; ++j)
+                        output[j] += v * singularVectors[tMat.WindowSize * i + j];
+
+                    temp = v * singularVectors[tMat.WindowSize * (i + 1) - 1];
+
+                    v = 0;
+                    for (j = offset2; j < offset2 + tMat.WindowSize; ++j)
+                        v += series[j] * singularVectors[tMat.WindowSize * i - offset2 + j];
+
+                    for (j = tMat.WindowSize; j < 2 * tMat.WindowSize - 1; ++j)
+                        output[j] += v * singularVectors[tMat.WindowSize * (i - 1) + j + 1];
+
+                    temp += v * singularVectors[tMat.WindowSize * i];
+                    output[tMat.WindowSize - 1] += (temp / 2);
+                }
+            }
+
+            private static void ComputeNoiseMoments(Single[] series, Single[] signal, Single[] alpha, out Single observationNoiseVariance, out Single autoregressionNoiseVariance,
+                out Single observationNoiseMean, out Single autoregressionNoiseMean, int startIndex = 0)
+            {
+                Contracts.Assert(Utils.Size(alpha) > 0);
+                Contracts.Assert(Utils.Size(signal) > 2 * Utils.Size(alpha)); // To assure that the autoregression noise variance is unbiased.
+                Contracts.Assert(Utils.Size(series) >= Utils.Size(signal) + startIndex);
+
+                var signalLength = Utils.Size(signal);
+                var windowSize = Utils.Size(alpha) + 1;
+                var k = signalLength - windowSize + 1;
+                Contracts.Assert(k > 0);
+
+                var y = new Single[k];
+                int i;
+
+                observationNoiseMean = 0;
+                observationNoiseVariance = 0;
+                autoregressionNoiseMean = 0;
+                autoregressionNoiseVariance = 0;
+
+                // Computing the observation noise moments
+                for (i = 0; i < signalLength; ++i)
+                    observationNoiseMean += (series[i + startIndex] - signal[i]);
+                observationNoiseMean /= signalLength;
+
+                for (i = 0; i < signalLength; ++i)
+                    observationNoiseVariance += (series[i + startIndex] - signal[i]) * (series[i + startIndex] - signal[i]);
+                observationNoiseVariance /= signalLength;
+                observationNoiseVariance -= (observationNoiseMean * observationNoiseMean);
+
+                // Computing the auto-regression noise moments
+                TrajectoryMatrix xTM = new TrajectoryMatrix(null, signal, windowSize - 1, signalLength - 1);
+                xTM.MultiplyTranspose(alpha, y);
+
+                for (i = 0; i < k; ++i)
+                    autoregressionNoiseMean += (signal[windowSize - 1 + i] - y[i]);
+                autoregressionNoiseMean /= k;
+
+                for (i = 0; i < k; ++i)
+                {
+                    autoregressionNoiseVariance += (signal[windowSize - 1 + i] - y[i] - autoregressionNoiseMean) *
+                                                   (signal[windowSize - 1 + i] - y[i] - autoregressionNoiseMean);
+                }
+
+                autoregressionNoiseVariance /= (k - windowSize + 1);
+                Contracts.Assert(autoregressionNoiseVariance >= 0);
+            }
+
+            private static int DetermineSignalRank(Single[] series, TrajectoryMatrix tMat, Single[] singularVectors, Single[] singularValues,
+                Single[] outputSignal, int maxRank)
+            {
+                Contracts.Assert(tMat != null);
+                Contracts.Assert(Utils.Size(series) >= tMat.SeriesLength);
+                Contracts.Assert(Utils.Size(outputSignal) >= tMat.SeriesLength);
+                Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * tMat.WindowSize);
+                Contracts.Assert(Utils.Size(singularValues) >= tMat.WindowSize);
+                Contracts.Assert(1 <= maxRank && maxRank <= tMat.WindowSize - 1);
+
+                var inputSeriesLength = tMat.SeriesLength;
+                var k = inputSeriesLength - tMat.WindowSize + 1;
+                Contracts.Assert(k > 0);
+
+                var x = new Single[inputSeriesLength];
+                var y = new Single[k];
+                var alpha = new Single[tMat.WindowSize - 1];
+                var v = new Single[k];
+
+                Single nu = 0;
+                Double minErr = Double.MaxValue;
+                int minIndex = maxRank - 1;
+                int evaluationLength = Math.Min(Math.Max(tMat.WindowSize, 200), k);
+
+                TrajectoryMatrix xTM = new TrajectoryMatrix(null, x, tMat.WindowSize - 1, inputSeriesLength - 1);
+
+                int i;
+                int j;
+                int n;
+                Single temp;
+                Double error;
+                Double sumSingularVals = 0;
+                Single lambda;
+                Single observationNoiseMean;
+
+                FixedSizeQueue<Single> window = new FixedSizeQueue<float>(tMat.WindowSize - 1);
+
+                for (i = 0; i < tMat.WindowSize; ++i)
+                    sumSingularVals += singularValues[i];
+
+                for (i = 0; i < maxRank; ++i)
+                {
+                    // Updating the auto-regressive coefficients
+                    lambda = singularVectors[tMat.WindowSize * i + tMat.WindowSize - 1];
+                    for (j = 0; j < tMat.WindowSize - 1; ++j)
+                        alpha[j] += lambda * singularVectors[tMat.WindowSize * i + j];
+
+                    // Updating nu
+                    nu += lambda * lambda;
+
+                    // Reconstructing the i-th eigen triple component and adding it to x
+                    tMat.MultiplyTranspose(singularVectors, v, false, tMat.WindowSize * i, 0);
+                    tMat.RankOneHankelization(singularVectors, v, 1, x, true, tMat.WindowSize * i, 0, 0);
+
+                    observationNoiseMean = 0;
+                    for (j = 0; j < inputSeriesLength; ++j)
+                        observationNoiseMean += (series[j] - x[j]);
+                    observationNoiseMean /= inputSeriesLength;
+
+                    for (j = inputSeriesLength - evaluationLength - tMat.WindowSize + 1; j < inputSeriesLength - evaluationLength; ++j)
+                        window.AddLast(x[j]);
+
+                    error = 0;
+                    for (j = inputSeriesLength - evaluationLength; j < inputSeriesLength; ++j)
+                    {
+                        temp = 0;
+                        for (n = 0; n < tMat.WindowSize - 1; ++n)
+                            temp += alpha[n] * window[n];
+
+                        temp /= (1 - nu);
+                        temp += observationNoiseMean;
+                        window.AddLast(temp);
+                        error += Math.Abs(series[j] - temp);
+                        if (error > minErr)
+                            break;
+                    }
+
+                    if (error < minErr)
+                    {
+                        minErr = error;
+                        minIndex = i;
+                        Array.Copy(x, outputSignal, inputSeriesLength);
+                    }
+                }
+
+                return minIndex + 1;
+            }
+
+            internal override void InitState()
+            {
+                for (int i = 0; i < _windowSize - 2; ++i)
+                    _state[i] = 0;
+
+                _buffer.Clear();
+            }
+
+            private static int DetermineSignalRankFast(Single[] series, TrajectoryMatrix tMat, Single[] singularVectors, Single[] singularValues, int maxRank)
+            {
+                Contracts.Assert(tMat != null);
+                Contracts.Assert(Utils.Size(series) >= tMat.SeriesLength);
+                Contracts.Assert(Utils.Size(singularVectors) >= tMat.WindowSize * tMat.WindowSize);
+                Contracts.Assert(Utils.Size(singularValues) >= tMat.WindowSize);
+                Contracts.Assert(1 <= maxRank && maxRank <= tMat.WindowSize - 1);
+
+                var inputSeriesLength = tMat.SeriesLength;
+                var k = inputSeriesLength - tMat.WindowSize + 1;
+                Contracts.Assert(k > 0);
+
+                var x = new Single[tMat.WindowSize - 1];
+                var alpha = new Single[tMat.WindowSize - 1];
+                Single v;
+
+                Single nu = 0;
+                Double minErr = Double.MaxValue;
+                int minIndex = maxRank - 1;
+                int evaluationLength = Math.Min(Math.Max(tMat.WindowSize, 200), k);
+
+                int i;
+                int j;
+                int n;
+                int offset;
+                Single temp;
+                Double error;
+                Single lambda;
+                Single observationNoiseMean;
+
+                FixedSizeQueue<Single> window = new FixedSizeQueue<float>(tMat.WindowSize - 1);
+
+                for (i = 0; i < maxRank; ++i)
+                {
+                    // Updating the auto-regressive coefficients
+                    lambda = singularVectors[tMat.WindowSize * i + tMat.WindowSize - 1];
+                    for (j = 0; j < tMat.WindowSize - 1; ++j)
+                        alpha[j] += lambda * singularVectors[tMat.WindowSize * i + j];
+
+                    // Updating nu
+                    nu += lambda * lambda;
+
+                    // Reconstructing the i-th eigen triple component and adding it to x
+                    v = 0;
+                    offset = inputSeriesLength - evaluationLength - tMat.WindowSize + 1;
+
+                    for (j = offset; j <= inputSeriesLength - evaluationLength; ++j)
+                        v += series[j] * singularVectors[tMat.WindowSize * i - offset + j];
+
+                    for (j = 0; j < tMat.WindowSize - 1; ++j)
+                        x[j] += v * singularVectors[tMat.WindowSize * i + j];
+
+                    // Computing the empirical observation noise mean
+                    observationNoiseMean = 0;
+                    for (j = offset; j < inputSeriesLength - evaluationLength; ++j)
+                        observationNoiseMean += (series[j] - x[j - offset]);
+                    observationNoiseMean /= (tMat.WindowSize - 1);
+
+                    for (j = 0; j < tMat.WindowSize - 1; ++j)
+                        window.AddLast(x[j]);
+
+                    error = 0;
+                    for (j = inputSeriesLength - evaluationLength; j < inputSeriesLength; ++j)
+                    {
+                        temp = 0;
+                        for (n = 0; n < tMat.WindowSize - 1; ++n)
+                            temp += alpha[n] * window[n];
+
+                        temp /= (1 - nu);
+                        temp += observationNoiseMean;
+                        window.AddLast(temp);
+                        error += Math.Abs(series[j] - temp);
+                        if (error > minErr)
+                            break;
+                    }
+
+                    if (error < minErr)
+                    {
+                        minErr = error;
+                        minIndex = i;
+                    }
+                }
+
+                return minIndex + 1;
+            }
+
+            private class SignalComponent
+            {
+                public Double Phase;
+                public int Index;
+                public int Cluster;
+
+                public SignalComponent(Double phase, int index)
+                {
+                    Phase = phase;
+                    Index = index;
+                }
+            }
+
+            private bool Stabilize()
+            {
+                if (Utils.Size(_alpha) == 1)
+                {
+                    if (_shouldMaintainInfo)
+                        _info.RootsBeforeStabilization = new[] { new Complex(_alpha[0], 0) };
+
+                    if (_alpha[0] > 1)
+                        _alpha[0] = 1;
+                    else if (_alpha[0] < -1)
+                        _alpha[0] = -1;
+
+                    if (_shouldMaintainInfo)
+                    {
+                        _info.IsStabilized = true;
+                        _info.RootsAfterStabilization = new[] { new Complex(_alpha[0], 0) };
+                        _info.IsExponentialTrendPresent = false;
+                        _info.IsPolynomialTrendPresent = false;
+                        _info.ExponentialTrendFactor = Math.Abs(_alpha[0]);
+                    }
+                    return true;
+                }
+
+                var coeff = new Double[_windowSize - 1];
+                Complex[] roots = null;
+                bool trendFound = false;
+                bool polynomialTrendFound = false;
+                Double maxTrendMagnitude = Double.NegativeInfinity;
+                Double maxNonTrendMagnitude = Double.NegativeInfinity;
+                Double eps = 1e-9;
+                Double highFrequenceyBoundry = Math.PI / 2;
+                var sortedComponents = new List<SignalComponent>();
+                var trendComponents = new List<int>();
+                int i;
+
+                // Computing the roots of the characteristic polynomial
+                for (i = 0; i < _windowSize - 1; ++i)
+                    coeff[i] = -_alpha[i];
+
+                if (!PolynomialUtils.FindPolynomialRoots(coeff, ref roots))
+                    return false;
+
+                if (_shouldMaintainInfo)
+                {
+                    _info.RootsBeforeStabilization = new Complex[_windowSize - 1];
+                    Array.Copy(roots, _info.RootsBeforeStabilization, _windowSize - 1);
+                }
+
+                // Detecting trend components
+                for (i = 0; i < _windowSize - 1; ++i)
+                {
+                    if (roots[i].Magnitude > 1 && (Math.Abs(roots[i].Phase) <= eps || Math.Abs(Math.Abs(roots[i].Phase) - Math.PI) <= eps))
+                        trendComponents.Add(i);
+                }
+
+                // Removing unobserved seasonalities and consequently introducing polynomial trend
+                for (i = 0; i < _windowSize - 1; ++i)
+                {
+                    if (roots[i].Phase != 0)
+                    {
+                        if (roots[i].Magnitude >= 1 && 2 * Math.PI / Math.Abs(roots[i].Phase) > _windowSize)
+                        {
+                            /*if (roots[i].Real > 1)
+                            {
+                                polynomialTrendFound = true;
+                                roots[i] = new Complex(Math.Max(1, roots[i].Magnitude), 0);
+                                maxPolynomialTrendMagnitude = Math.Max(maxPolynomialTrendMagnitude, roots[i].Magnitude);
+                            }
+                            else
+                                roots[i] = Complex.FromPolarCoordinates(1, 0);
+                            //roots[i] = Complex.FromPolarCoordinates(0.99, roots[i].Phase);*/
+
+                            /* if (_maxTrendRatio > 1)
+                             {
+                                 roots[i] = new Complex(roots[i].Real, 0);
+                                 polynomialTrendFound = true;
+                             }
+                             else
+                                 roots[i] = roots[i].Imaginary > 0 ? new Complex(roots[i].Real, 0) : new Complex(1, 0);*/
+
+                            roots[i] = new Complex(roots[i].Real, 0);
+                            polynomialTrendFound = true;
+
+                            if (_shouldMaintainInfo)
+                                _info.IsArtificialSeasonalityRemoved = true;
+                        }
+                        else if (roots[i].Magnitude > 1)
+                            sortedComponents.Add(new SignalComponent(roots[i].Phase, i));
+                    }
+                }
+
+                if (_maxTrendRatio > 1)
+                {
+                    // Combining the close exponential-seasonal components
+                    if (sortedComponents.Count > 1 && polynomialTrendFound)
+                    {
+                        sortedComponents.Sort((a, b) => a.Phase.CompareTo(b.Phase));
+                        var clusterNum = 0;
+
+                        for (i = 0; i < sortedComponents.Count - 1; ++i)
+                        {
+                            if ((sortedComponents[i].Phase < 0 && sortedComponents[i + 1].Phase < 0) ||
+                                (sortedComponents[i].Phase > 0 && sortedComponents[i + 1].Phase > 0))
+                            {
+                                sortedComponents[i].Cluster = clusterNum;
+                                if (Math.Abs(sortedComponents[i + 1].Phase - sortedComponents[i].Phase) > 0.05)
+                                    clusterNum++;
+                                sortedComponents[i + 1].Cluster = clusterNum;
+                            }
+                            else
+                                clusterNum++;
+                        }
+
+                        int start = 0;
+                        bool polynomialSeasonalityFound = false;
+                        Double largestSeasonalityPhase = 0;
+                        for (i = 1; i < sortedComponents.Count; ++i)
+                        {
+                            if (sortedComponents[i].Cluster != sortedComponents[i - 1].Cluster)
+                            {
+                                if (i - start > 1) // There are more than one point in the cluster
+                                {
+                                    Double avgPhase = 0;
+                                    Double avgMagnitude = 0;
+
+                                    for (var j = start; j < i; ++j)
+                                    {
+                                        avgPhase += sortedComponents[j].Phase;
+                                        avgMagnitude += roots[sortedComponents[j].Index].Magnitude;
+                                    }
+                                    avgPhase /= (i - start);
+                                    avgMagnitude /= (i - start);
+
+                                    for (var j = start; j < i; ++j)
+                                        roots[sortedComponents[j].Index] = Complex.FromPolarCoordinates(avgMagnitude,
+                                            avgPhase);
+
+                                    if (!polynomialSeasonalityFound && avgPhase > 0)
+                                    {
+                                        largestSeasonalityPhase = avgPhase;
+                                        polynomialSeasonalityFound = true;
+                                    }
+                                }
+
+                                start = i;
+                            }
+                        }
+                    }
+
+                    // Combining multiple exponential trends into polynomial ones
+                    if (!polynomialTrendFound)
+                    {
+                        var ind1 = -1;
+                        var ind2 = -1;
+
+                        foreach (var ind in trendComponents)
+                        {
+                            if (Math.Abs(roots[ind].Phase) <= eps)
+                            {
+                                ind1 = ind;
+                                break;
+                            }
+                        }
+
+                        for (i = 0; i < _windowSize - 1; ++i)
+                        {
+                            if (Math.Abs(roots[i].Phase) <= eps && 0.9 <= roots[i].Magnitude && i != ind1)
+                            {
+                                ind2 = i;
+                                break;
+                            }
+                        }
+
+                        if (ind1 >= 0 && ind2 >= 0 && ind1 != ind2)
+                        {
+                            roots[ind1] = Complex.FromPolarCoordinates(1, 0);
+                            roots[ind2] = Complex.FromPolarCoordinates(1, 0);
+                            polynomialTrendFound = true;
+                        }
+                    }
+                }
+
+                if (polynomialTrendFound) // Suppress the exponential trend
+                {
+                    maxTrendMagnitude = Math.Min(1, _maxTrendRatio);
+                    foreach (var ind in trendComponents)
+                        roots[ind] = Complex.FromPolarCoordinates(0.99, roots[ind].Phase);
+                }
+                else
+                {
+                    // Spotting the exponential trend components and finding the max trend magnitude
+                    for (i = 0; i < _windowSize - 1; ++i)
+                    {
+                        if (roots[i].Magnitude > 1 && Math.Abs(roots[i].Phase) <= eps)
+                        {
+                            trendFound = true;
+                            maxTrendMagnitude = Math.Max(maxTrendMagnitude, roots[i].Magnitude);
+                        }
+                        else
+                            maxNonTrendMagnitude = Math.Max(maxNonTrendMagnitude, roots[i].Magnitude);
+                    }
+
+                    if (!trendFound)
+                        maxTrendMagnitude = 1;
+
+                    maxTrendMagnitude = Math.Min(maxTrendMagnitude, _maxTrendRatio);
+                }
+
+                // Squeezing all components below the maximum trend magnitude
+                var smallTrendMagnitude = Math.Min(maxTrendMagnitude, (maxTrendMagnitude + 1) / 2);
+                for (i = 0; i < _windowSize - 1; ++i)
+                {
+                    if (roots[i].Magnitude >= maxTrendMagnitude)
+                    {
+                        if ((highFrequenceyBoundry < roots[i].Phase && roots[i].Phase < Math.PI - eps) ||
+                            (-Math.PI + eps < roots[i].Phase && roots[i].Phase < -highFrequenceyBoundry))
+                            roots[i] = Complex.FromPolarCoordinates(smallTrendMagnitude, roots[i].Phase);
+                        else
+                            roots[i] = Complex.FromPolarCoordinates(maxTrendMagnitude, roots[i].Phase);
+                    }
+                }
+
+                // Correcting all the other trend components
+                for (i = 0; i < _windowSize - 1; ++i)
+                {
+                    var phase = roots[i].Phase;
+                    if (Math.Abs(phase) <= eps)
+                        roots[i] = new Complex(roots[i].Magnitude, 0);
+                    else if (Math.Abs(phase - Math.PI) <= eps)
+                        roots[i] = new Complex(-roots[i].Magnitude, 0);
+                    else if (Math.Abs(phase + Math.PI) <= eps)
+                        roots[i] = new Complex(-roots[i].Magnitude, 0);
+                }
+
+                // Computing the characteristic polynomial from the modified roots
+                try
+                {
+                    if (!PolynomialUtils.FindPolynomialCoefficients(roots, ref coeff))
+                        return false;
+                }
+                catch (OverflowException)
+                {
+                    return false;
+                }
+
+                // Updating alpha
+                for (i = 0; i < _windowSize - 1; ++i)
+                    _alpha[i] = (Single)(-coeff[i]);
+
+                if (_shouldMaintainInfo)
+                {
+                    _info.RootsAfterStabilization = roots;
                     _info.IsStabilized = true;
-                    _info.RootsAfterStabilization = new[] { new Complex(_alpha[0], 0) };
-                    _info.IsExponentialTrendPresent = false;
-                    _info.IsPolynomialTrendPresent = false;
-                    _info.ExponentialTrendFactor = Math.Abs(_alpha[0]);
+                    _info.IsPolynomialTrendPresent = polynomialTrendFound;
+                    _info.IsExponentialTrendPresent = maxTrendMagnitude > 1;
+                    _info.ExponentialTrendFactor = maxTrendMagnitude;
                 }
+
                 return true;
             }
 
-            var coeff = new Double[_windowSize - 1];
-            Complex[] roots = null;
-            bool trendFound = false;
-            bool polynomialTrendFound = false;
-            Double maxTrendMagnitude = Double.NegativeInfinity;
-            Double maxNonTrendMagnitude = Double.NegativeInfinity;
-            Double eps = 1e-9;
-            Double highFrequenceyBoundry = Math.PI / 2;
-            var sortedComponents = new List<SignalComponent>();
-            var trendComponents = new List<int>();
-            int i;
-
-            // Computing the roots of the characteristic polynomial
-            for (i = 0; i < _windowSize - 1; ++i)
-                coeff[i] = -_alpha[i];
-
-            if (!PolynomialUtils.FindPolynomialRoots(coeff, ref roots))
-                return false;
-
-            if (_shouldMaintainInfo)
+            /// <summary>
+            /// Feeds the next observation on the series to the model and as a result changes the state of the model.
+            /// </summary>
+            /// <param name="input">The next observation on the series.</param>
+            /// <param name="updateModel">Determines whether the model parameters also need to be updated upon consuming the new observation (default = false).</param>
+            internal override void Consume(ref Single input, bool updateModel = false)
             {
-                _info.RootsBeforeStabilization = new Complex[_windowSize - 1];
-                Array.Copy(roots, _info.RootsBeforeStabilization, _windowSize - 1);
-            }
+                if (Single.IsNaN(input))
+                    return;
 
-            // Detecting trend components
-            for (i = 0; i < _windowSize - 1; ++i)
-            {
-                if (roots[i].Magnitude > 1 && (Math.Abs(roots[i].Phase) <= eps || Math.Abs(Math.Abs(roots[i].Phase) - Math.PI) <= eps))
-                    trendComponents.Add(i);
-            }
+                int i;
 
-            // Removing unobserved seasonalities and consequently introducing polynomial trend
-            for (i = 0; i < _windowSize - 1; ++i)
-            {
-                if (roots[i].Phase != 0)
+                if (_wTrans == null)
                 {
-                    if (roots[i].Magnitude >= 1 && 2 * Math.PI / Math.Abs(roots[i].Phase) > _windowSize)
-                    {
-                        /*if (roots[i].Real > 1)
-                        {
-                            polynomialTrendFound = true;
-                            roots[i] = new Complex(Math.Max(1, roots[i].Magnitude), 0);
-                            maxPolynomialTrendMagnitude = Math.Max(maxPolynomialTrendMagnitude, roots[i].Magnitude);
-                        }
-                        else
-                            roots[i] = Complex.FromPolarCoordinates(1, 0);
-                        //roots[i] = Complex.FromPolarCoordinates(0.99, roots[i].Phase);*/
+                    _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
+                    _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
+                    Single[] vecs = new Single[_rank * _windowSize];
 
-                        /* if (_maxTrendRatio > 1)
-                         {
-                             roots[i] = new Complex(roots[i].Real, 0);
-                             polynomialTrendFound = true;
-                         }
-                         else
-                             roots[i] = roots[i].Imaginary > 0 ? new Complex(roots[i].Real, 0) : new Complex(1, 0);*/
+                    for (i = 0; i < _rank; ++i)
+                        vecs[(_windowSize + 1) * i] = 1;
 
-                        roots[i] = new Complex(roots[i].Real, 0);
-                        polynomialTrendFound = true;
-
-                        if (_shouldMaintainInfo)
-                            _info.IsArtificialSeasonalityRemoved = true;
-                    }
-                    else if (roots[i].Magnitude > 1)
-                        sortedComponents.Add(new SignalComponent(roots[i].Phase, i));
-                }
-            }
-
-            if (_maxTrendRatio > 1)
-            {
-                // Combining the close exponential-seasonal components
-                if (sortedComponents.Count > 1 && polynomialTrendFound)
-                {
-                    sortedComponents.Sort((a, b) => a.Phase.CompareTo(b.Phase));
-                    var clusterNum = 0;
-
-                    for (i = 0; i < sortedComponents.Count - 1; ++i)
-                    {
-                        if ((sortedComponents[i].Phase < 0 && sortedComponents[i + 1].Phase < 0) ||
-                            (sortedComponents[i].Phase > 0 && sortedComponents[i + 1].Phase > 0))
-                        {
-                            sortedComponents[i].Cluster = clusterNum;
-                            if (Math.Abs(sortedComponents[i + 1].Phase - sortedComponents[i].Phase) > 0.05)
-                                clusterNum++;
-                            sortedComponents[i + 1].Cluster = clusterNum;
-                        }
-                        else
-                            clusterNum++;
-                    }
-
-                    int start = 0;
-                    bool polynomialSeasonalityFound = false;
-                    Double largestSeasonalityPhase = 0;
-                    for (i = 1; i < sortedComponents.Count; ++i)
-                    {
-                        if (sortedComponents[i].Cluster != sortedComponents[i - 1].Cluster)
-                        {
-                            if (i - start > 1) // There are more than one point in the cluster
-                            {
-                                Double avgPhase = 0;
-                                Double avgMagnitude = 0;
-
-                                for (var j = start; j < i; ++j)
-                                {
-                                    avgPhase += sortedComponents[j].Phase;
-                                    avgMagnitude += roots[sortedComponents[j].Index].Magnitude;
-                                }
-                                avgPhase /= (i - start);
-                                avgMagnitude /= (i - start);
-
-                                for (var j = start; j < i; ++j)
-                                    roots[sortedComponents[j].Index] = Complex.FromPolarCoordinates(avgMagnitude,
-                                        avgPhase);
-
-                                if (!polynomialSeasonalityFound && avgPhase > 0)
-                                {
-                                    largestSeasonalityPhase = avgPhase;
-                                    polynomialSeasonalityFound = true;
-                                }
-                            }
-
-                            start = i;
-                        }
-                    }
+                    i = 0;
+                    _wTrans.CopyFrom(vecs, ref i);
                 }
 
-                // Combining multiple exponential trends into polynomial ones
-                if (!polynomialTrendFound)
+                // Forming vector x
+
+                if (_buffer.Count == 0)
                 {
-                    var ind1 = -1;
-                    var ind2 = -1;
-
-                    foreach (var ind in trendComponents)
-                    {
-                        if (Math.Abs(roots[ind].Phase) <= eps)
-                        {
-                            ind1 = ind;
-                            break;
-                        }
-                    }
-
                     for (i = 0; i < _windowSize - 1; ++i)
-                    {
-                        if (Math.Abs(roots[i].Phase) <= eps && 0.9 <= roots[i].Magnitude && i != ind1)
-                        {
-                            ind2 = i;
-                            break;
-                        }
-                    }
-
-                    if (ind1 >= 0 && ind2 >= 0 && ind1 != ind2)
-                    {
-                        roots[ind1] = Complex.FromPolarCoordinates(1, 0);
-                        roots[ind2] = Complex.FromPolarCoordinates(1, 0);
-                        polynomialTrendFound = true;
-                    }
+                        _buffer.AddLast(_state[i]);
                 }
-            }
 
-            if (polynomialTrendFound) // Suppress the exponential trend
-            {
-                maxTrendMagnitude = Math.Min(1, _maxTrendRatio);
-                foreach (var ind in trendComponents)
-                    roots[ind] = Complex.FromPolarCoordinates(0.99, roots[ind].Phase);
-            }
-            else
-            {
-                // Spotting the exponential trend components and finding the max trend magnitude
-                for (i = 0; i < _windowSize - 1; ++i)
+                int len = _buffer.Count;
+                for (i = 0; i < _windowSize - len - 1; ++i)
+                    _x[i] = 0;
+                for (i = Math.Max(0, len - _windowSize + 1); i < len; ++i)
+                    _x[i - len + _windowSize - 1] = _buffer[i];
+                _x[_windowSize - 1] = input;
+
+                // Computing y: Eq. (11) in https://hal-institut-mines-telecom.archives-ouvertes.fr/hal-00479772/file/twocolumns.pdf
+                CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTimesSrc(_wTrans, _x, _y);
+
+                // Updating the state vector
+                CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTranTimesSrc(_wTrans, _y, _xSmooth);
+
+                _nextPrediction = _autoregressionNoiseMean + _observationNoiseMean;
+                for (i = 0; i < _windowSize - 2; ++i)
                 {
-                    if (roots[i].Magnitude > 1 && Math.Abs(roots[i].Phase) <= eps)
-                    {
-                        trendFound = true;
-                        maxTrendMagnitude = Math.Max(maxTrendMagnitude, roots[i].Magnitude);
-                    }
-                    else
-                        maxNonTrendMagnitude = Math.Max(maxNonTrendMagnitude, roots[i].Magnitude);
+                    _state[i] = ((_windowSize - 2 - i) * _state[i + 1] + _xSmooth[i + 1]) / (_windowSize - 1 - i);
+                    _nextPrediction += _state[i] * _alpha[i];
                 }
+                _state[_windowSize - 2] = _xSmooth[_windowSize - 1];
+                _nextPrediction += _state[_windowSize - 2] * _alpha[_windowSize - 2];
 
-                if (!trendFound)
-                    maxTrendMagnitude = 1;
-
-                maxTrendMagnitude = Math.Min(maxTrendMagnitude, _maxTrendRatio);
-            }
-
-            // Squeezing all components below the maximum trend magnitude
-            var smallTrendMagnitude = Math.Min(maxTrendMagnitude, (maxTrendMagnitude + 1) / 2);
-            for (i = 0; i < _windowSize - 1; ++i)
-            {
-                if (roots[i].Magnitude >= maxTrendMagnitude)
+                if (updateModel)
                 {
-                    if ((highFrequenceyBoundry < roots[i].Phase && roots[i].Phase < Math.PI - eps) ||
-                        (-Math.PI + eps < roots[i].Phase && roots[i].Phase < -highFrequenceyBoundry))
-                        roots[i] = Complex.FromPolarCoordinates(smallTrendMagnitude, roots[i].Phase);
-                    else
-                        roots[i] = Complex.FromPolarCoordinates(maxTrendMagnitude, roots[i].Phase);
+                    // REVIEW: to be implemented in the next version based on the FAPI algorithm
+                    // in https://hal-institut-mines-telecom.archives-ouvertes.fr/hal-00479772/file/twocolumns.pdf.
                 }
+
+                _buffer.AddLast(input);
             }
 
-            // Correcting all the other trend components
-            for (i = 0; i < _windowSize - 1; ++i)
+            /// <summary>
+            /// Train the model parameters based on a training series.
+            /// </summary>
+            /// <param name="data">The training time-series.</param>
+            internal override void Train(FixedSizeQueue<Single> data)
             {
-                var phase = roots[i].Phase;
-                if (Math.Abs(phase) <= eps)
-                    roots[i] = new Complex(roots[i].Magnitude, 0);
-                else if (Math.Abs(phase - Math.PI) <= eps)
-                    roots[i] = new Complex(-roots[i].Magnitude, 0);
-                else if (Math.Abs(phase + Math.PI) <= eps)
-                    roots[i] = new Complex(-roots[i].Magnitude, 0);
-            }
+                _host.CheckParam(data != null, nameof(data), "The input series for training cannot be null.");
+                _host.CheckParam(data.Count >= _trainSize, nameof(data), "The input series for training does not have enough points for training.");
 
-            // Computing the characteristic polynomial from the modified roots
-            try
-            {
-                if (!PolynomialUtils.FindPolynomialCoefficients(roots, ref coeff))
-                    return false;
-            }
-            catch (OverflowException)
-            {
-                return false;
-            }
+                Single[] dataArray = new Single[_trainSize];
 
-            // Updating alpha
-            for (i = 0; i < _windowSize - 1; ++i)
-                _alpha[i] = (Single)(-coeff[i]);
+                int i;
+                int count;
+                for (i = 0, count = 0; count < _trainSize && i < data.Count; ++i)
+                    if (!Single.IsNaN(data[i]))
+                        dataArray[count++] = data[i];
 
-            if (_shouldMaintainInfo)
-            {
-                _info.RootsAfterStabilization = roots;
-                _info.IsStabilized = true;
-                _info.IsPolynomialTrendPresent = polynomialTrendFound;
-                _info.IsExponentialTrendPresent = maxTrendMagnitude > 1;
-                _info.ExponentialTrendFactor = maxTrendMagnitude;
-            }
+                if (_shouldMaintainInfo)
+                {
+                    _info = new ModelInfo();
+                    _info.WindowSize = _windowSize;
+                }
 
-            return true;
-        }
-
-        /// <summary>
-        /// Feeds the next observation on the series to the model and as a result changes the state of the model.
-        /// </summary>
-        /// <param name="input">The next observation on the series.</param>
-        /// <param name="updateModel">Determines whether the model parameters also need to be updated upon consuming the new observation (default = false).</param>
-        internal override void Consume(ref Single input, bool updateModel = false)
-        {
-            if (Single.IsNaN(input))
-                return;
-
-            int i;
-
-            if (_wTrans == null)
-            {
-                _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
-                _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
-                Single[] vecs = new Single[_rank * _windowSize];
-
-                for (i = 0; i < _rank; ++i)
-                    vecs[(_windowSize + 1) * i] = 1;
-
-                i = 0;
-                _wTrans.CopyFrom(vecs, ref i);
-            }
-
-            // Forming vector x
-
-            if (_buffer.Count == 0)
-            {
-                for (i = 0; i < _windowSize - 1; ++i)
-                    _buffer.AddLast(_state[i]);
-            }
-
-            int len = _buffer.Count;
-            for (i = 0; i < _windowSize - len - 1; ++i)
-                _x[i] = 0;
-            for (i = Math.Max(0, len - _windowSize + 1); i < len; ++i)
-                _x[i - len + _windowSize - 1] = _buffer[i];
-            _x[_windowSize - 1] = input;
-
-            // Computing y: Eq. (11) in https://hal-institut-mines-telecom.archives-ouvertes.fr/hal-00479772/file/twocolumns.pdf
-            CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTimesSrc(_wTrans, _x, _y);
-
-            // Updating the state vector
-            CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTranTimesSrc(_wTrans, _y, _xSmooth);
-
-            _nextPrediction = _autoregressionNoiseMean + _observationNoiseMean;
-            for (i = 0; i < _windowSize - 2; ++i)
-            {
-                _state[i] = ((_windowSize - 2 - i) * _state[i + 1] + _xSmooth[i + 1]) / (_windowSize - 1 - i);
-                _nextPrediction += _state[i] * _alpha[i];
-            }
-            _state[_windowSize - 2] = _xSmooth[_windowSize - 1];
-            _nextPrediction += _state[_windowSize - 2] * _alpha[_windowSize - 2];
-
-            if (updateModel)
-            {
-                // REVIEW: to be implemented in the next version based on the FAPI algorithm
-                // in https://hal-institut-mines-telecom.archives-ouvertes.fr/hal-00479772/file/twocolumns.pdf.
-            }
-
-            _buffer.AddLast(input);
-        }
-
-        /// <summary>
-        /// Train the model parameters based on a training series.
-        /// </summary>
-        /// <param name="data">The training time-series.</param>
-        internal override void Train(FixedSizeQueue<Single> data)
-        {
-            _host.CheckParam(data != null, nameof(data), "The input series for training cannot be null.");
-            _host.CheckParam(data.Count >= _trainSize, nameof(data), "The input series for training does not have enough points for training.");
-
-            Single[] dataArray = new Single[_trainSize];
-
-            int i;
-            int count;
-            for (i = 0, count = 0; count < _trainSize && i < data.Count; ++i)
-                if (!Single.IsNaN(data[i]))
-                    dataArray[count++] = data[i];
-
-            if (_shouldMaintainInfo)
-            {
-                _info = new ModelInfo();
-                _info.WindowSize = _windowSize;
-            }
-
-            if (count <= 2 * _windowSize)
-            {
+                if (count <= 2 * _windowSize)
+                {
 #if !TLCSSA
-                using (var ch = _host.Start("Train"))
-                    ch.Warning(
-                        "Training cannot be completed because the input series for training does not have enough points.");
+                    using (var ch = _host.Start("Train"))
+                        ch.Warning(
+                            "Training cannot be completed because the input series for training does not have enough points.");
 #endif
-            }
-            else
-            {
-                if (count != _trainSize)
-                    Array.Resize(ref dataArray, count);
+                }
+                else
+                {
+                    if (count != _trainSize)
+                        Array.Resize(ref dataArray, count);
 
-                TrainCore(dataArray, count);
+                    TrainCore(dataArray, count);
+                }
             }
-        }
 
 #if !TLCSSA
-        /// <summary>
-        /// Train the model parameters based on a training series.
-        /// </summary>
-        /// <param name="data">The training time-series.</param>
-        internal override void Train(RoleMappedData data)
-        {
-            _host.CheckValue(data, nameof(data));
-            _host.CheckParam(data.Schema.Feature.HasValue, nameof(data), "Must have features column.");
-            var featureCol = data.Schema.Feature.Value;
-            if (featureCol.Type != NumberDataViewType.Single)
-                throw _host.ExceptSchemaMismatch(nameof(data), "feature", featureCol.Name, "Single", featureCol.Type.ToString());
-
-            Single[] dataArray = new Single[_trainSize];
-
-            int count = 0;
-            using (var cursor = data.Data.GetRowCursor(featureCol))
+            /// <summary>
+            /// Train the model parameters based on a training series.
+            /// </summary>
+            /// <param name="data">The training time-series.</param>
+            internal override void Train(RoleMappedData data)
             {
-                var getVal = cursor.GetGetter<Single>(featureCol);
-                Single val = default;
-                while (cursor.MoveNext() && count < _trainSize)
+                _host.CheckValue(data, nameof(data));
+                _host.CheckParam(data.Schema.Feature.HasValue, nameof(data), "Must have features column.");
+                var featureCol = data.Schema.Feature.Value;
+                if (featureCol.Type != NumberDataViewType.Single)
+                    throw _host.ExceptSchemaMismatch(nameof(data), "feature", featureCol.Name, "Single", featureCol.Type.ToString());
+
+                Single[] dataArray = new Single[_trainSize];
+
+                int count = 0;
+                using (var cursor = data.Data.GetRowCursor(featureCol))
                 {
-                    getVal(ref val);
-                    if (!Single.IsNaN(val))
-                        dataArray[count++] = val;
-                }
-            }
-
-            if (_shouldMaintainInfo)
-            {
-                _info = new ModelInfo();
-                _info.WindowSize = _windowSize;
-            }
-
-            if (count <= 2 * _windowSize)
-            {
-                using (var ch = _host.Start("Train"))
-                    ch.Warning("Training cannot be completed because the input series for training does not have enough points.");
-            }
-            else
-            {
-                if (count != _trainSize)
-                    Array.Resize(ref dataArray, count);
-
-                TrainCore(dataArray, count);
-            }
-        }
-#endif
-
-        private void TrainCore(Single[] dataArray, int originalSeriesLength)
-        {
-            _host.Assert(Utils.Size(dataArray) > 0);
-            Single[] singularVals;
-            Single[] leftSingularVecs;
-            var learnNaiveModel = false;
-
-            var signalLength = _rankSelectionMethod == RankSelectionMethod.Exact ? originalSeriesLength : 2 * _windowSize - 1;//originalSeriesLength;
-            var signal = new Single[signalLength];
-
-            int i;
-            // Creating the trajectory matrix for the series
-            TrajectoryMatrix tMat = new TrajectoryMatrix(_host, dataArray, _windowSize, originalSeriesLength);
-
-            // Computing the SVD of the trajectory matrix
-            if (!tMat.ComputeSvd(out singularVals, out leftSingularVecs))
-                learnNaiveModel = true;
-            else
-            {
-                for (i = 0; i < _windowSize * _maxRank; ++i)
-                {
-                    if (Single.IsNaN(leftSingularVecs[i]))
+                    var getVal = cursor.GetGetter<Single>(featureCol);
+                    Single val = default;
+                    while (cursor.MoveNext() && count < _trainSize)
                     {
-                        learnNaiveModel = true;
-                        break;
+                        getVal(ref val);
+                        if (!Single.IsNaN(val))
+                            dataArray[count++] = val;
                     }
                 }
-            }
 
-            // Checking for standard eigenvectors, if found reduce the window size and reset training.
-            if (!learnNaiveModel)
-            {
-                for (i = 0; i < _windowSize; ++i)
+                if (_shouldMaintainInfo)
                 {
-                    var v = leftSingularVecs[(i + 1) * _windowSize - 1];
-                    if (v * v == 1)
-                    {
-                        if (_windowSize > 2)
-                        {
-                            _windowSize--;
-                            _maxRank = _windowSize / 2;
-                            _alpha = new Single[_windowSize - 1];
-                            _state = new Single[_windowSize - 1];
-                            _x = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
-                            _xSmooth = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
+                    _info = new ModelInfo();
+                    _info.WindowSize = _windowSize;
+                }
 
-                            TrainCore(dataArray, originalSeriesLength);
-                            return;
-                        }
-                        else
+                if (count <= 2 * _windowSize)
+                {
+                    using (var ch = _host.Start("Train"))
+                        ch.Warning("Training cannot be completed because the input series for training does not have enough points.");
+                }
+                else
+                {
+                    if (count != _trainSize)
+                        Array.Resize(ref dataArray, count);
+
+                    TrainCore(dataArray, count);
+                }
+            }
+#endif
+
+            private void TrainCore(Single[] dataArray, int originalSeriesLength)
+            {
+                _host.Assert(Utils.Size(dataArray) > 0);
+                Single[] singularVals;
+                Single[] leftSingularVecs;
+                var learnNaiveModel = false;
+
+                var signalLength = _rankSelectionMethod == RankSelectionMethod.Exact ? originalSeriesLength : 2 * _windowSize - 1;//originalSeriesLength;
+                var signal = new Single[signalLength];
+
+                int i;
+                // Creating the trajectory matrix for the series
+                TrajectoryMatrix tMat = new TrajectoryMatrix(_host, dataArray, _windowSize, originalSeriesLength);
+
+                // Computing the SVD of the trajectory matrix
+                if (!tMat.ComputeSvd(out singularVals, out leftSingularVecs))
+                    learnNaiveModel = true;
+                else
+                {
+                    for (i = 0; i < _windowSize * _maxRank; ++i)
+                    {
+                        if (Single.IsNaN(leftSingularVecs[i]))
                         {
                             learnNaiveModel = true;
                             break;
                         }
                     }
                 }
-            }
 
-            // Learn the naive (averaging) model in case the eigen decomposition is not possible
-            if (learnNaiveModel)
-            {
-#if !TLCSSA
-                using (var ch = _host.Start("Train"))
-                    ch.Warning("The precise SSA model cannot be trained.");
-#endif
+                // Checking for standard eigenvectors, if found reduce the window size and reset training.
+                if (!learnNaiveModel)
+                {
+                    for (i = 0; i < _windowSize; ++i)
+                    {
+                        var v = leftSingularVecs[(i + 1) * _windowSize - 1];
+                        if (v * v == 1)
+                        {
+                            if (_windowSize > 2)
+                            {
+                                _windowSize--;
+                                _maxRank = _windowSize / 2;
+                                _alpha = new Single[_windowSize - 1];
+                                _state = new Single[_windowSize - 1];
+                                _x = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
+                                _xSmooth = new CpuAlignedVector(_windowSize, CpuMathUtils.GetVectorAlignment());
 
-                _rank = 1;
-                var temp = (Single)(1f / Math.Sqrt(_windowSize));
-                for (i = 0; i < _windowSize; ++i)
-                    leftSingularVecs[i] = temp;
-            }
-            else
-            {
-                // Computing the signal rank
-                if (_rankSelectionMethod == RankSelectionMethod.Exact)
-                    _rank = DetermineSignalRank(dataArray, tMat, leftSingularVecs, singularVals, signal, _maxRank);
-                else if (_rankSelectionMethod == RankSelectionMethod.Fast)
-                    _rank = DetermineSignalRankFast(dataArray, tMat, leftSingularVecs, singularVals, _maxRank);
-            }
+                                TrainCore(dataArray, originalSeriesLength);
+                                return;
+                            }
+                            else
+                            {
+                                learnNaiveModel = true;
+                                break;
+                            }
+                        }
+                    }
+                }
 
-            // Setting the the y vector
-            _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
-
-            // Setting the weight matrix
-            _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
-            i = 0;
-            _wTrans.CopyFrom(leftSingularVecs, ref i);
-
-            // Setting alpha
-            Single nu = 0;
-            for (i = 0; i < _rank; ++i)
-            {
-                _y[i] = leftSingularVecs[_windowSize * (i + 1) - 1];
-                nu += _y[i] * _y[i];
-            }
-
-            CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTranTimesSrc(_wTrans, _y, _xSmooth);
-            for (i = 0; i < _windowSize - 1; ++i)
-                _alpha[i] = _xSmooth[i] / (1 - nu);
-
-            // Stabilizing the model
-            if (_shouldStablize && !learnNaiveModel)
-            {
-                if (!Stabilize())
+                // Learn the naive (averaging) model in case the eigen decomposition is not possible
+                if (learnNaiveModel)
                 {
 #if !TLCSSA
                     using (var ch = _host.Start("Train"))
-                        ch.Warning("The trained model cannot be stablized.");
+                        ch.Warning("The precise SSA model cannot be trained.");
 #endif
+
+                    _rank = 1;
+                    var temp = (Single)(1f / Math.Sqrt(_windowSize));
+                    for (i = 0; i < _windowSize; ++i)
+                        leftSingularVecs[i] = temp;
+                }
+                else
+                {
+                    // Computing the signal rank
+                    if (_rankSelectionMethod == RankSelectionMethod.Exact)
+                        _rank = DetermineSignalRank(dataArray, tMat, leftSingularVecs, singularVals, signal, _maxRank);
+                    else if (_rankSelectionMethod == RankSelectionMethod.Fast)
+                        _rank = DetermineSignalRankFast(dataArray, tMat, leftSingularVecs, singularVals, _maxRank);
+                }
+
+                // Setting the the y vector
+                _y = new CpuAlignedVector(_rank, CpuMathUtils.GetVectorAlignment());
+
+                // Setting the weight matrix
+                _wTrans = new CpuAlignedMatrixRow(_rank, _windowSize, CpuMathUtils.GetVectorAlignment());
+                i = 0;
+                _wTrans.CopyFrom(leftSingularVecs, ref i);
+
+                // Setting alpha
+                Single nu = 0;
+                for (i = 0; i < _rank; ++i)
+                {
+                    _y[i] = leftSingularVecs[_windowSize * (i + 1) - 1];
+                    nu += _y[i] * _y[i];
+                }
+
+                CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTranTimesSrc(_wTrans, _y, _xSmooth);
+                for (i = 0; i < _windowSize - 1; ++i)
+                    _alpha[i] = _xSmooth[i] / (1 - nu);
+
+                // Stabilizing the model
+                if (_shouldStablize && !learnNaiveModel)
+                {
+                    if (!Stabilize())
+                    {
+#if !TLCSSA
+                        using (var ch = _host.Start("Train"))
+                            ch.Warning("The trained model cannot be stablized.");
+#endif
+                    }
+                }
+
+                // Computing the noise moments
+                if (ShouldComputeForecastIntervals)
+                {
+                    if (_rankSelectionMethod != RankSelectionMethod.Exact)
+                        ReconstructSignalTailFast(dataArray, tMat, leftSingularVecs, _rank, signal);
+
+                    ComputeNoiseMoments(dataArray, signal, _alpha, out _observationNoiseVariance, out _autoregressionNoiseVariance,
+                        out _observationNoiseMean, out _autoregressionNoiseMean, originalSeriesLength - signalLength);
+                    _observationNoiseMean = 0;
+                    _autoregressionNoiseMean = 0;
+                }
+
+                // Setting the state
+                _nextPrediction = _autoregressionNoiseMean + _observationNoiseMean;
+
+                if (_buffer.Count > 0) // Use the buffer to set the state when there are data points pushed into the buffer using the Consume() method
+                {
+                    int len = _buffer.Count;
+                    for (i = 0; i < _windowSize - len; ++i)
+                        _x[i] = 0;
+                    for (i = Math.Max(0, len - _windowSize); i < len; ++i)
+                        _x[i - len + _windowSize] = _buffer[i];
+                }
+                else // use the training data points otherwise
+                {
+                    for (i = originalSeriesLength - _windowSize; i < originalSeriesLength; ++i)
+                        _x[i - originalSeriesLength + _windowSize] = dataArray[i];
+                }
+
+                CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTimesSrc(_wTrans, _x, _y);
+                CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTranTimesSrc(_wTrans, _y, _xSmooth);
+
+                for (i = 1; i < _windowSize; ++i)
+                {
+                    _state[i - 1] = _xSmooth[i];
+                    _nextPrediction += _state[i - 1] * _alpha[i - 1];
+                }
+
+                if (_shouldMaintainInfo)
+                {
+                    _info.IsTrained = true;
+                    _info.WindowSize = _windowSize;
+                    _info.AutoRegressiveCoefficients = new Single[_windowSize - 1];
+                    Array.Copy(_alpha, _info.AutoRegressiveCoefficients, _windowSize - 1);
+                    _info.Rank = _rank;
+                    _info.IsNaiveModelTrained = learnNaiveModel;
+                    _info.Spectrum = singularVals;
                 }
             }
 
-            // Computing the noise moments
-            if (ShouldComputeForecastIntervals)
+            /// <summary>
+            /// Forecasts the future values of the series up to the given horizon.
+            /// </summary>
+            /// <param name="result">The forecast result.</param>
+            /// <param name="horizon">The forecast horizon.</param>
+            internal override void Forecast(ref ForecastResultBase<Single> result, int horizon = 1)
             {
-                if (_rankSelectionMethod != RankSelectionMethod.Exact)
-                    ReconstructSignalTailFast(dataArray, tMat, leftSingularVecs, _rank, signal);
+                _host.CheckParam(horizon >= 1, nameof(horizon), "The horizon parameter should be greater than 0.");
+                if (result == null)
+                    result = new SsaForecastResult();
 
-                ComputeNoiseMoments(dataArray, signal, _alpha, out _observationNoiseVariance, out _autoregressionNoiseVariance,
-                    out _observationNoiseMean, out _autoregressionNoiseMean, originalSeriesLength - signalLength);
-                _observationNoiseMean = 0;
-                _autoregressionNoiseMean = 0;
-            }
+                var str = "The result argument must be of type " + typeof(SsaForecastResult).ToString();
+                _host.CheckParam(result is SsaForecastResult, nameof(result), str);
 
-            // Setting the state
-            _nextPrediction = _autoregressionNoiseMean + _observationNoiseMean;
+                var output = result as SsaForecastResult;
 
-            if (_buffer.Count > 0) // Use the buffer to set the state when there are data points pushed into the buffer using the Consume() method
-            {
-                int len = _buffer.Count;
-                for (i = 0; i < _windowSize - len; ++i)
-                    _x[i] = 0;
-                for (i = Math.Max(0, len - _windowSize); i < len; ++i)
-                    _x[i - len + _windowSize] = _buffer[i];
-            }
-            else // use the training data points otherwise
-            {
-                for (i = originalSeriesLength - _windowSize; i < originalSeriesLength; ++i)
-                    _x[i - originalSeriesLength + _windowSize] = dataArray[i];
-            }
+                var resEditor = VBufferEditor.Create(ref result.PointForecast, horizon);
 
-            CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTimesSrc(_wTrans, _x, _y);
-            CpuAligenedMathUtils<CpuAlignedMatrixRow>.MatTranTimesSrc(_wTrans, _y, _xSmooth);
+                int i;
+                int j;
+                int k;
 
-            for (i = 1; i < _windowSize; ++i)
-            {
-                _state[i - 1] = _xSmooth[i];
-                _nextPrediction += _state[i - 1] * _alpha[i - 1];
-            }
-
-            if (_shouldMaintainInfo)
-            {
-                _info.IsTrained = true;
-                _info.WindowSize = _windowSize;
-                _info.AutoRegressiveCoefficients = new Single[_windowSize - 1];
-                Array.Copy(_alpha, _info.AutoRegressiveCoefficients, _windowSize - 1);
-                _info.Rank = _rank;
-                _info.IsNaiveModelTrained = learnNaiveModel;
-                _info.Spectrum = singularVals;
-            }
-        }
-
-        /// <summary>
-        /// Forecasts the future values of the series up to the given horizon.
-        /// </summary>
-        /// <param name="result">The forecast result.</param>
-        /// <param name="horizon">The forecast horizon.</param>
-        internal override void Forecast(ref ForecastResultBase<Single> result, int horizon = 1)
-        {
-            _host.CheckParam(horizon >= 1, nameof(horizon), "The horizon parameter should be greater than 0.");
-            if (result == null)
-                result = new SsaForecastResult();
-
-            var str = "The result argument must be of type " + typeof(SsaForecastResult).ToString();
-            _host.CheckParam(result is SsaForecastResult, nameof(result), str);
-
-            var output = result as SsaForecastResult;
-
-            var resEditor = VBufferEditor.Create(ref result.PointForecast, horizon);
-
-            int i;
-            int j;
-            int k;
-
-            // Computing the point forecasts
-            resEditor.Values[0] = _nextPrediction;
-            for (i = 1; i < horizon; ++i)
-            {
-                k = 0;
-                resEditor.Values[i] = _autoregressionNoiseMean + _observationNoiseMean;
-                for (j = i; j < _windowSize - 1; ++j, ++k)
-                    resEditor.Values[i] += _state[j] * _alpha[k];
-
-                for (j = Math.Max(0, i - _windowSize + 1); j < i; ++j, ++k)
-                    resEditor.Values[i] += resEditor.Values[j] * _alpha[k];
-            }
-
-            // Computing the forecast variances
-            if (ShouldComputeForecastIntervals)
-            {
-                var sdEditor = VBufferEditor.Create(ref output.ForecastStandardDeviation, horizon);
-                var lastCol = new FixedSizeQueue<Single>(_windowSize - 1);
-
-                for (i = 0; i < _windowSize - 3; ++i)
-                    lastCol.AddLast(0);
-                lastCol.AddLast(1);
-                lastCol.AddLast(_alpha[_windowSize - 2]);
-                sdEditor.Values[0] = _autoregressionNoiseVariance + _observationNoiseVariance;
-
+                // Computing the point forecasts
+                resEditor.Values[0] = _nextPrediction;
                 for (i = 1; i < horizon; ++i)
                 {
-                    Single temp = 0;
-                    for (j = 0; j < _windowSize - 1; ++j)
-                        temp += _alpha[j] * lastCol[j];
-                    lastCol.AddLast(temp);
+                    k = 0;
+                    resEditor.Values[i] = _autoregressionNoiseMean + _observationNoiseMean;
+                    for (j = i; j < _windowSize - 1; ++j, ++k)
+                        resEditor.Values[i] += _state[j] * _alpha[k];
 
-                    sdEditor.Values[i] = sdEditor.Values[i - 1] + _autoregressionNoiseVariance * temp * temp;
+                    for (j = Math.Max(0, i - _windowSize + 1); j < i; ++j, ++k)
+                        resEditor.Values[i] += resEditor.Values[j] * _alpha[k];
                 }
 
-                for (i = 0; i < horizon; ++i)
-                    sdEditor.Values[i] = (float)Math.Sqrt(sdEditor.Values[i]);
-
-                output.ForecastStandardDeviation = sdEditor.Commit();
-            }
-
-            result.PointForecast = resEditor.Commit();
-            output.CanComputeForecastIntervals = ShouldComputeForecastIntervals;
-            output.BoundOffset = 0;
-        }
-
-        /// <summary>
-        /// Predicts the next value on the series.
-        /// </summary>
-        /// <param name="output">The prediction result.</param>
-        internal override void PredictNext(ref Single output)
-        {
-            output = _nextPrediction;
-        }
-
-        internal override SequenceModelerBase<Single, Single> Clone()
-        {
-            return new AdaptiveSingularSpectrumSequenceModeler(this);
-        }
-
-        /// <summary>
-        /// Computes the forecast intervals for the input forecast object at the given confidence level. The results are stored in the forecast object.
-        /// </summary>
-        /// <param name="forecast">The input forecast object</param>
-        /// <param name="confidenceLevel">The confidence level in [0, 1)</param>
-        internal static void ComputeForecastIntervals(ref SsaForecastResult forecast, Single confidenceLevel = 0.95f)
-        {
-            Contracts.CheckParam(0 <= confidenceLevel && confidenceLevel < 1, nameof(confidenceLevel), "The confidence level must be in [0, 1).");
-            Contracts.CheckValue(forecast, nameof(forecast));
-            Contracts.Check(forecast.CanComputeForecastIntervals, "The forecast intervals cannot be computed for this forecast object.");
-
-            var meanForecast = forecast.PointForecast.GetValues();
-            var horizon = meanForecast.Length;
-            var sdForecast = forecast.ForecastStandardDeviation.GetValues();
-            Contracts.Check(sdForecast.Length >= horizon, "The forecast standard deviation values are not available.");
-
-            forecast.ConfidenceLevel = confidenceLevel;
-            if (horizon == 0)
-                return;
-
-            var upper = VBufferEditor.Create(ref forecast.UpperBound, horizon);
-            var lower = VBufferEditor.Create(ref forecast.LowerBound, horizon);
-
-            var z = ProbabilityFunctions.Probit(0.5 + confidenceLevel / 2.0);
-            double temp;
-
-            for (int i = 0; i < horizon; ++i)
-            {
-                temp = z * sdForecast[i];
-                upper.Values[i] = (Single)(meanForecast[i] + forecast.BoundOffset + temp);
-                lower.Values[i] = (Single)(meanForecast[i] + forecast.BoundOffset - temp);
-            }
-
-            forecast.UpperBound = upper.Commit();
-            forecast.LowerBound = lower.Commit();
-        }
-
-        public void Train(IDataView dataView, string inputColumnName) => Train(new RoleMappedData(dataView, null, inputColumnName));
-
-        public float[] Forecast(int horizon)
-        {
-            ForecastResultBase<float> result = null;
-            Forecast(ref result, horizon);
-            return result.PointForecast.GetValues().ToArray();
-        }
-
-        public void Update(IDataView dataView, string inputColumnName)
-        {
-            _host.CheckParam(dataView != null, nameof(dataView), "The input series for updating cannot be null.");
-
-            var data = new RoleMappedData(dataView, null, inputColumnName);
-            if (data.Schema.Feature.Type != NumberType.Float)
-                throw _host.ExceptUserArg(nameof(data.Schema.Feature.Name), "The time series input column has " +
-                    "type '{0}', but must be a float.", data.Schema.Feature.Type);
-
-            int col = data.Schema.Feature.Index;
-            using (var cursor = data.Data.GetRowCursor(c => c == col))
-            {
-                var getVal = cursor.GetGetter<Single>(col);
-                Single val = default(Single);
-                while (cursor.MoveNext())
+                // Computing the forecast variances
+                if (ShouldComputeForecastIntervals)
                 {
-                    getVal(ref val);
-                    if (!Single.IsNaN(val))
-                        Consume(ref val);
-                }
-            }
-        }
+                    var sdEditor = VBufferEditor.Create(ref output.ForecastStandardDeviation, horizon);
+                    var lastCol = new FixedSizeQueue<Single>(_windowSize - 1);
 
-        public void Checkpoint(IHostEnvironment env, string filePath)
-        {
-            using (var file = File.Create(filePath))
-            {
-                using (var ch = env.Start("Saving SSA forecasting model."))
-                {
-                    using (var rep = RepositoryWriter.CreateNew(file, ch))
+                    for (i = 0; i < _windowSize - 3; ++i)
+                        lastCol.AddLast(0);
+                    lastCol.AddLast(1);
+                    lastCol.AddLast(_alpha[_windowSize - 2]);
+                    sdEditor.Values[0] = _autoregressionNoiseVariance + _observationNoiseVariance;
+
+                    for (i = 1; i < horizon; ++i)
                     {
-                        ModelSaveContext.SaveModel(rep, this, LoaderSignature);
-                        rep.Commit();
+                        Single temp = 0;
+                        for (j = 0; j < _windowSize - 1; ++j)
+                            temp += _alpha[j] * lastCol[j];
+                        lastCol.AddLast(temp);
+
+                        sdEditor.Values[i] = sdEditor.Values[i - 1] + _autoregressionNoiseVariance * temp * temp;
+                    }
+
+                    for (i = 0; i < horizon; ++i)
+                        sdEditor.Values[i] = (float)Math.Sqrt(sdEditor.Values[i]);
+
+                    output.ForecastStandardDeviation = sdEditor.Commit();
+                }
+
+                result.PointForecast = resEditor.Commit();
+                output.CanComputeForecastIntervals = ShouldComputeForecastIntervals;
+                output.BoundOffset = 0;
+            }
+
+            /// <summary>
+            /// Predicts the next value on the series.
+            /// </summary>
+            /// <param name="output">The prediction result.</param>
+            internal override void PredictNext(ref Single output)
+            {
+                output = _nextPrediction;
+            }
+
+            internal override SequenceModelerBase<Single, Single> Clone()
+            {
+                return new AdaptiveSingularSpectrumSequenceModeler(this);
+            }
+
+            /// <summary>
+            /// Computes the forecast intervals for the input forecast object at the given confidence level. The results are stored in the forecast object.
+            /// </summary>
+            /// <param name="forecast">The input forecast object</param>
+            /// <param name="confidenceLevel">The confidence level in [0, 1)</param>
+            internal static void ComputeForecastIntervals(ref SsaForecastResult forecast, Single confidenceLevel = 0.95f)
+            {
+                Contracts.CheckParam(0 <= confidenceLevel && confidenceLevel < 1, nameof(confidenceLevel), "The confidence level must be in [0, 1).");
+                Contracts.CheckValue(forecast, nameof(forecast));
+                Contracts.Check(forecast.CanComputeForecastIntervals, "The forecast intervals cannot be computed for this forecast object.");
+
+                var meanForecast = forecast.PointForecast.GetValues();
+                var horizon = meanForecast.Length;
+                var sdForecast = forecast.ForecastStandardDeviation.GetValues();
+                Contracts.Check(sdForecast.Length >= horizon, "The forecast standard deviation values are not available.");
+
+                forecast.ConfidenceLevel = confidenceLevel;
+                if (horizon == 0)
+                    return;
+
+                var upper = VBufferEditor.Create(ref forecast.UpperBound, horizon);
+                var lower = VBufferEditor.Create(ref forecast.LowerBound, horizon);
+
+                var z = ProbabilityFunctions.Probit(0.5 + confidenceLevel / 2.0);
+                double temp;
+
+                for (int i = 0; i < horizon; ++i)
+                {
+                    temp = z * sdForecast[i];
+                    upper.Values[i] = (Single)(meanForecast[i] + forecast.BoundOffset + temp);
+                    lower.Values[i] = (Single)(meanForecast[i] + forecast.BoundOffset - temp);
+                }
+
+                forecast.UpperBound = upper.Commit();
+                forecast.LowerBound = lower.Commit();
+            }
+
+            public void Train(IDataView dataView, string inputColumnName) => Train(new RoleMappedData(dataView, null, inputColumnName));
+
+            public float[] Forecast(int horizon)
+            {
+                ForecastResultBase<float> result = null;
+                Forecast(ref result, horizon);
+                return result.PointForecast.GetValues().ToArray();
+            }
+
+            public void Update(IDataView dataView, string inputColumnName)
+            {
+                _host.CheckParam(dataView != null, nameof(dataView), "The input series for updating cannot be null.");
+
+                var data = new RoleMappedData(dataView, null, inputColumnName);
+                if (data.Schema.Feature.Value.Type != NumberDataViewType.Single)
+                    throw _host.ExceptUserArg(nameof(data.Schema.Feature.Value.Name), "The time series input column has " +
+                        "type '{0}', but must be a float.", data.Schema.Feature.Value.Type);
+
+                var col = data.Schema.Feature.Value;
+                using (var cursor = data.Data.GetRowCursor(data.Data.Schema))
+                {
+                    var getVal = cursor.GetGetter<Single>(col);
+                    Single val = default(Single);
+                    while (cursor.MoveNext())
+                    {
+                        getVal(ref val);
+                        if (!Single.IsNaN(val))
+                            Consume(ref val);
+                    }
+                }
+            }
+
+            public void Checkpoint(IHostEnvironment env, string filePath)
+            {
+                using (var file = File.Create(filePath))
+                {
+                    using (var ch = env.Start("Saving SSA forecasting model."))
+                    {
+                        using (var rep = RepositoryWriter.CreateNew(file, ch))
+                        {
+                            ModelSaveContext.SaveModel(rep, this, LoaderSignature);
+                            rep.Commit();
+                        }
+                    }
+                }
+            }
+
+            public ICanForecast<float> LoadFrom(IHostEnvironment env, string filePath)
+            {
+                using (var file = File.OpenRead(filePath))
+                {
+                    using (var rep = RepositoryReader.Open(file, env))
+                    {
+                        ModelLoadContext.LoadModel<AdaptiveSingularSpectrumSequenceModeler, SignatureLoadModel>(env, out var model, rep, LoaderSignature);
+                        return model;
                     }
                 }
             }
         }
 
-        public ICanForecast<float> LoadFrom(IHostEnvironment env, string filePath)
-        {
-            using (var file = File.OpenRead(filePath))
-            {
-                using (var rep = RepositoryReader.Open(file, env))
-                {
-                    ModelLoadContext.LoadModel<AdaptiveSingularSpectrumSequenceModeler, SignatureLoadModel>(env, out var model, rep, LoaderSignature);
-                    return model;
-                }
-            }
-        }
+        /// <summary>
+        /// Train a forecasting model from an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="dataView">Reference to the <see cref="IDataView"/></param>
+        /// <param name="inputColumnName">Name of the input column to train the forecasing model.</param>
+        public void Train(IDataView dataView, string inputColumnName) => _modeler.Train(dataView, inputColumnName);
+
+        /// <summary>
+        /// Update a forecasting model with the new observations in the form of an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="dataView">Reference to the observations as an <see cref="IDataView"/></param>
+        /// <param name="inputColumnName">Name of the input column to update from.</param>
+        public void Update(IDataView dataView, string inputColumnName) => _modeler.Update(dataView, inputColumnName);
+
+        /// <summary>
+        /// Perform forecasting until a particular <paramref name="horizon"/>.
+        /// </summary>
+        /// <param name="horizon">Number of values to forecast.</param>
+        /// <returns>Forecasted values.</returns>
+        public float[] Forecast(int horizon) => _modeler.Forecast(horizon);
+
+        /// <summary>
+        /// Serialize the forecasting model to disk to preserve the state of forecasting model.
+        /// </summary>
+        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
+        /// <param name="filePath">Name of the filepath to serialize the model to.</param>
+        public void Checkpoint(IHostEnvironment env, string filePath) => _modeler.Checkpoint(env, filePath);
+
+        /// <summary>
+        /// Deserialize the forecasting model from disk.
+        /// </summary>
+        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
+        /// <param name="filePath">Name of the filepath to deserialize the model from.</param>
+        public ICanForecast<float> LoadFrom(IHostEnvironment env, string filePath) => _modeler.LoadFrom(env, filePath);
     }
 }

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -13,16 +13,17 @@ using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.TimeSeries;
 using Microsoft.ML.Transforms.TimeSeries;
+using static Microsoft.ML.Transforms.TimeSeries.AdaptiveSingularSpectrumSequenceModeler;
 
-[assembly: LoadableClass(typeof(AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler),
-    typeof(AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(AdaptiveSingularSpectrumSequenceModeler.AdaptiveSingularSpectrumSequenceModelerInternal),
+    typeof(AdaptiveSingularSpectrumSequenceModeler.AdaptiveSingularSpectrumSequenceModelerInternal), null, typeof(SignatureLoadModel),
     "SSA Sequence Modeler",
-    AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler.LoaderSignature)]
+    AdaptiveSingularSpectrumSequenceModeler.AdaptiveSingularSpectrumSequenceModelerInternal.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(AdaptiveSingularSpectrumSequenceForecastingModeler),
-    typeof(AdaptiveSingularSpectrumSequenceForecastingModeler), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(AdaptiveSingularSpectrumSequenceModeler),
+    typeof(AdaptiveSingularSpectrumSequenceModeler), null, typeof(SignatureLoadModel),
     "SSA Sequence Modeler Wrapper",
-    AdaptiveSingularSpectrumSequenceForecastingModeler.LoaderSignature)]
+    AdaptiveSingularSpectrumSequenceModeler.LoaderSignature)]
 
 namespace Microsoft.ML.Transforms.TimeSeries
 {
@@ -30,7 +31,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     /// This class implements basic Singular Spectrum Analysis (SSA) model for modeling univariate time-series.
     /// For the details of the model, refer to http://arxiv.org/pdf/1206.6910.pdf.
     /// </summary>
-    public sealed class AdaptiveSingularSpectrumSequenceForecastingModeler : ICanForecast<float>
+    public sealed class AdaptiveSingularSpectrumSequenceModeler : ICanForecast<float>
     {
         /// <summary>
         /// Ranking selection method.
@@ -88,7 +89,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             public Double Ratio { get { return Math.Pow(_growth, 1d / _timeSpan); } }
         }
 
-        private AdaptiveSingularSpectrumSequenceModeler _modeler;
+        private AdaptiveSingularSpectrumSequenceModelerInternal _modeler;
 
         private readonly string _inputColumnName;
 
@@ -104,10 +105,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 verReadableCur: 0x00010001,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(AdaptiveSingularSpectrumSequenceForecastingModeler).Assembly.FullName);
+                loaderAssemblyName: typeof(AdaptiveSingularSpectrumSequenceModeler).Assembly.FullName);
         }
 
-        public AdaptiveSingularSpectrumSequenceForecastingModeler(IHostEnvironment env, string inputColumnName, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1,
+        internal AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, string inputColumnName, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1,
             RankSelectionMethod rankSelectionMethod = RankSelectionMethod.Exact, int? rank = null, int? maxRank = null,
             bool shouldComputeForecastIntervals = true, bool shouldstablize = true, bool shouldMaintainInfo = false, GrowthRatio? maxGrowth = null)
         {
@@ -116,23 +117,23 @@ namespace Microsoft.ML.Transforms.TimeSeries
             _host.CheckParam(!string.IsNullOrEmpty(inputColumnName), nameof(inputColumnName));
 
             _inputColumnName = inputColumnName;
-            _modeler = new AdaptiveSingularSpectrumSequenceModeler(env, trainSize, seriesLength, windowSize, discountFactor,
+            _modeler = new AdaptiveSingularSpectrumSequenceModelerInternal(env, trainSize, seriesLength, windowSize, discountFactor,
                 rankSelectionMethod, rank, maxRank, shouldComputeForecastIntervals, shouldstablize, shouldMaintainInfo, maxGrowth);
         }
 
-        internal AdaptiveSingularSpectrumSequenceForecastingModeler(IHostEnvironment env, ModelLoadContext ctx)
+        internal AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(LoaderSignature);
             _inputColumnName = ctx.Reader.ReadString();
-            ctx.LoadModel<AdaptiveSingularSpectrumSequenceModeler, SignatureLoadModel>(_host, out _modeler, "ForecastWrapper");
+            ctx.LoadModel<AdaptiveSingularSpectrumSequenceModelerInternal, SignatureLoadModel>(_host, out _modeler, "ForecastWrapper");
         }
 
         /// <summary>
         /// This class implements basic Singular Spectrum Analysis (SSA) model for modeling univariate time-series.
         /// For the details of the model, refer to http://arxiv.org/pdf/1206.6910.pdf.
         /// </summary>
-        internal sealed class AdaptiveSingularSpectrumSequenceModeler : SequenceModelerBase<Single, Single>
+        internal sealed class AdaptiveSingularSpectrumSequenceModelerInternal : SequenceModelerBase<Single, Single>
         {
             internal const string LoaderSignature = "SSAModel";
 
@@ -284,7 +285,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                     verReadableCur: 0x00010002,
                     verWeCanReadBack: 0x00010001,
                     loaderSignature: LoaderSignature,
-                    loaderAssemblyName: typeof(AdaptiveSingularSpectrumSequenceModeler).Assembly.FullName);
+                    loaderAssemblyName: typeof(AdaptiveSingularSpectrumSequenceModelerInternal).Assembly.FullName);
             }
 
             private const int VersionSavingStateAndPrediction = 0x00010002;
@@ -305,7 +306,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <param name="shouldstablize">The flag determining whether the model should be stabilized.</param>
             /// <param name="shouldMaintainInfo">The flag determining whether the meta information for the model needs to be maintained.</param>
             /// <param name="maxGrowth">The maximum growth on the exponential trend</param>
-            public AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1,
+            public AdaptiveSingularSpectrumSequenceModelerInternal(IHostEnvironment env, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1,
                 RankSelectionMethod rankSelectionMethod = RankSelectionMethod.Exact, int? rank = null, int? maxRank = null,
                 bool shouldComputeForecastIntervals = true, bool shouldstablize = true, bool shouldMaintainInfo = false, GrowthRatio? maxGrowth = null)
                 : base()
@@ -370,7 +371,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// The copy constructor.
             /// </summary>
             /// <param name="model">An object whose contents are copied to the current object.</param>
-            private AdaptiveSingularSpectrumSequenceModeler(AdaptiveSingularSpectrumSequenceModeler model)
+            private AdaptiveSingularSpectrumSequenceModelerInternal(AdaptiveSingularSpectrumSequenceModelerInternal model)
             {
                 _host = model._host.Register(LoaderSignature);
                 _host.Assert(model._windowSize >= 2);
@@ -413,7 +414,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 }
             }
 
-            public AdaptiveSingularSpectrumSequenceModeler(IHostEnvironment env, ModelLoadContext ctx)
+            public AdaptiveSingularSpectrumSequenceModelerInternal(IHostEnvironment env, ModelLoadContext ctx)
             {
                 Contracts.CheckValue(env, nameof(env));
                 _host = env.Register(LoaderSignature);
@@ -1567,7 +1568,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
             internal override SequenceModelerBase<Single, Single> Clone()
             {
-                return new AdaptiveSingularSpectrumSequenceModeler(this);
+                return new AdaptiveSingularSpectrumSequenceModelerInternal(this);
             }
 
             /// <summary>
@@ -1683,7 +1684,26 @@ namespace Microsoft.ML.Transforms.TimeSeries
             ctx.SaveModel(_modeler, "ForecastWrapper");
         }
 
+        /// <summary>
+        /// Perform forecasting until a particular <paramref name="horizon"/> and also computes confidence intervals.
+        /// For confidence intervals to be computed the model must be trained with <see cref="AdaptiveSingularSpectrumSequenceModelerInternal.ShouldComputeForecastIntervals"/>
+        /// set to true.
+        /// </summary>
+        /// <param name="horizon">Number of values to forecast.</param>
+        /// <param name="forecast">Forecasted values</param>
+        /// <param name="confidenceIntervalLowerBounds">Lower bound confidence intervals of forecasted values.</param>
+        /// <param name="confidenceIntervalUpperBounds">Upper bound confidence intervals of forecasted values.</param>
+        /// <param name="confidenceLevel">Confidence level.</param>
         public void ForecastWithConfidenceIntervals(int horizon, out float[] forecast, out float[] confidenceIntervalLowerBounds, out float[] confidenceIntervalUpperBounds, float confidenceLevel = 0.95f) =>
             _modeler.ForecastWithConfidenceIntervals(horizon, out forecast, out confidenceIntervalLowerBounds, out confidenceIntervalUpperBounds, confidenceLevel);
+    }
+
+    public static class ForecastingCatalogExtension
+    {
+        public static AdaptiveSingularSpectrumSequenceModeler AdaptiveSingularSpectrumSequenceModeler(this ForecastingCatalog catalog,
+            string inputColumnName, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1, RankSelectionMethod rankSelectionMethod = RankSelectionMethod.Exact,
+            int? rank = null, int? maxRank = null, bool shouldComputeForecastIntervals = true, bool shouldstablize = true, bool shouldMaintainInfo = false, GrowthRatio? maxGrowth = null) =>
+            new AdaptiveSingularSpectrumSequenceModeler(CatalogUtils.GetEnvironment(catalog), inputColumnName, trainSize, seriesLength, windowSize, discountFactor,
+            rankSelectionMethod, rank, maxRank, shouldComputeForecastIntervals, shouldstablize, shouldMaintainInfo, maxGrowth);
     }
 }

--- a/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms.TimeSeries;
+using static Microsoft.ML.Transforms.TimeSeries.AdaptiveSingularSpectrumSequenceModeler;
 
 namespace Microsoft.ML
 {
@@ -145,5 +147,37 @@ namespace Microsoft.ML
         public static SrCnnAnomalyEstimator DetectAnomalyBySrCnn(this TransformsCatalog catalog, string outputColumnName, string inputColumnName,
             int windowSize=64, int backAddWindowSize=5, int lookaheadWindowSize=5, int averageingWindowSize=3, int judgementWindowSize=21, double threshold=0.3)
             => new SrCnnAnomalyEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, windowSize, backAddWindowSize, lookaheadWindowSize, averageingWindowSize, judgementWindowSize, threshold, inputColumnName);
+
+        /// <summary>
+        /// Singular Spectrum Analysis (SSA) model for modeling univariate time-series.
+        /// For the details of the model, refer to http://arxiv.org/pdf/1206.6910.pdf.
+        /// </summary>
+        /// <param name="catalog">Catalog.</param>
+        /// <param name="inputColumnName">The name of the column on which forecasting needs to be performed.</param>
+        /// <param name="trainSize">The length of series from the begining used for training.</param>
+        /// <param name="seriesLength">The length of series that is kept in buffer for modeling (parameter N).</param>
+        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).</param>
+        /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
+        /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>
+        /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r). This parameter should be in the range in [1, windowSize].
+        /// If set to null, the rank is automatically determined based on prediction error minimization. (default = null)</param>
+        /// <param name="maxRank">The maximum rank considered during the rank selection process. If not provided (i.e. set to null), it is set to windowSize - 1.</param>
+        /// <param name="shouldComputeForecastIntervals">The flag determining whether the confidence bounds for the point forecasts should be computed. (default = true)</param>
+        /// <param name="shouldstablize">The flag determining whether the model should be stabilized.</param>
+        /// <param name="shouldMaintainInfo">The flag determining whether the meta information for the model needs to be maintained.</param>
+        /// <param name="maxGrowth">The maximum growth on the exponential trend</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[Forecasting](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/Forecasting.cs)]
+        /// [!code-csharp[ForecastingWithConfidenceInterval](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/ForecastingWithConfidenceInterval.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        public static AdaptiveSingularSpectrumSequenceModeler AdaptiveSingularSpectrumSequenceModeler(this ForecastingCatalog catalog,
+            string inputColumnName, int trainSize, int seriesLength, int windowSize, Single discountFactor = 1, RankSelectionMethod rankSelectionMethod = RankSelectionMethod.Exact,
+            int? rank = null, int? maxRank = null, bool shouldComputeForecastIntervals = true, bool shouldstablize = true, bool shouldMaintainInfo = false, GrowthRatio? maxGrowth = null) =>
+            new AdaptiveSingularSpectrumSequenceModeler(CatalogUtils.GetEnvironment(catalog), inputColumnName, trainSize, seriesLength, windowSize, discountFactor,
+            rankSelectionMethod, rank, maxRank, shouldComputeForecastIntervals, shouldstablize, shouldMaintainInfo, maxGrowth);
     }
 }

--- a/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Create <see cref="IidSpikeEstimator"/>, which predicts spikes in
-        /// <a href="https://en.wikipedia.org/wiki/Independent_and_identically_distributed_random_variables">independent identically distributed (i.i.d.)</a>
+        /// <a href="https://en.wikipedia.org/wiki/Independent_and_identically_distributed_random_variables"> independent identically distributed (i.i.d.)</a>
         /// time series based on adaptive kernel density estimations and martingale scores.
         /// </summary>
         /// <param name="catalog">The transform's catalog.</param>
@@ -132,10 +132,10 @@ namespace Microsoft.ML
         /// The column data is a vector of <see cref="System.Double"/>. The vector contains 3 elements: alert (1 means anomaly while 0 means normal), raw score, and magnitude of spectual residual.</param>
         /// <param name="inputColumnName">Name of column to transform. The column data must be <see cref="System.Single"/>.</param>
         /// <param name="windowSize">The size of the sliding window for computing spectral residual.</param>
-        /// <param name="backAddWindowSize">The number of points to add back of training window. No more than windowSize, usually keep default value.</param>
-        /// <param name="lookaheadWindowSize">The number of pervious points used in prediction. No more than windowSize, usually keep default value.</param>
-        /// <param name="averageingWindowSize">The size of sliding window to generate a saliency map for the series. No more than windowSize, usually keep default value.</param>
-        /// <param name="judgementWindowSize">The size of sliding window to calculate the anomaly score for each data point. No more than windowSize.</param>
+        /// <param name="backAddWindowSize">The number of points to add back of training window. No more than <paramref name="windowSize"/>, usually keep default value.</param>
+        /// <param name="lookaheadWindowSize">The number of pervious points used in prediction. No more than <paramref name="windowSize"/>, usually keep default value.</param>
+        /// <param name="averageingWindowSize">The size of sliding window to generate a saliency map for the series. No more than <paramref name="windowSize"/>, usually keep default value.</param>
+        /// <param name="judgementWindowSize">The size of sliding window to calculate the anomaly score for each data point. No more than <paramref name="windowSize"/>.</param>
         /// <param name="threshold">The threshold to determine anomaly, score larger than the threshold is considered as anomaly. Should be in (0,1)</param>
         /// <example>
         /// <format type="text/markdown">
@@ -155,14 +155,14 @@ namespace Microsoft.ML
         /// <param name="catalog">Catalog.</param>
         /// <param name="inputColumnName">The name of the column on which forecasting needs to be performed.</param>
         /// <param name="trainSize">The length of series from the begining used for training.</param>
-        /// <param name="seriesLength">The length of series that is kept in buffer for modeling (parameter N).</param>
-        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L).</param>
+        /// <param name="seriesLength">The length of series that is kept in buffer for modeling (parameter N from reference papar).</param>
+        /// <param name="windowSize">The length of the window on the series for building the trajectory matrix (parameter L from reference papar).</param>
         /// <param name="discountFactor">The discount factor in [0,1] used for online updates (default = 1).</param>
         /// <param name="rankSelectionMethod">The rank selection method (default = Exact).</param>
-        /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r). This parameter should be in the range in [1, windowSize].
+        /// <param name="rank">The desired rank of the subspace used for SSA projection (parameter r from reference papar). This parameter should be in the range in [1, <paramref name="windowSize"/>].
         /// If set to null, the rank is automatically determined based on prediction error minimization. (default = null)</param>
-        /// <param name="maxRank">The maximum rank considered during the rank selection process. If not provided (i.e. set to null), it is set to windowSize - 1.</param>
-        /// <param name="shouldComputeForecastIntervals">The flag determining whether the confidence bounds for the point forecasts should be computed. (default = true)</param>
+        /// <param name="maxRank">The maximum rank considered during the rank selection process. If not provided (i.e. set to null), it is set to <paramref name="windowSize"/> - 1.</param>
+        /// <param name="shouldComputeForecastIntervals">The flag determining whether the confidence bounds for the point forecasts should be computed. (default = <see langword="true"/>)</param>
         /// <param name="shouldstablize">The flag determining whether the model should be stabilized.</param>
         /// <param name="shouldMaintainInfo">The flag determining whether the meta information for the model needs to be maintained.</param>
         /// <param name="maxGrowth">The maximum growth on the exponential trend</param>

--- a/src/Microsoft.ML.TimeSeries/Forecast.cs
+++ b/src/Microsoft.ML.TimeSeries/Forecast.cs
@@ -36,8 +36,6 @@ namespace Microsoft.ML.TimeSeries
 
         /// <summary>
         /// Perform forecasting until a particular <paramref name="horizon"/> and also computes confidence intervals.
-        /// For confidence intervals to be computed the model must be trained with <see cref="AdaptiveSingularSpectrumSequenceModelerInternal.ShouldComputeForecastIntervals"/>
-        /// set to true.
         /// </summary>
         /// <param name="horizon">Number of values to forecast.</param>
         /// <param name="forecast">Forecasted values</param>

--- a/src/Microsoft.ML.TimeSeries/Forecast.cs
+++ b/src/Microsoft.ML.TimeSeries/Forecast.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.ML.Runtime;
+using Microsoft.ML.Runtime.Data;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.ML.TimeSeries
+{
+    /// <summary>
+    /// Interface for forecasting models.
+    /// </summary>
+    /// <typeparam name="T">The type of values that are forecasted.</typeparam>
+    public interface ICanForecast<out T>
+    {
+        /// <summary>
+        /// Train a forecasting model from an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="dataView">Reference to the <see cref="IDataView"/></param>
+        /// <param name="inputColumnName">Name of the input column to train the forecasing model.</param>
+        void Train(IDataView dataView, string inputColumnName);
+
+        /// <summary>
+        /// Update a forecasting model with the new observations in the form of an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="dataView">Reference to the observations as an <see cref="IDataView"/></param>
+        /// <param name="inputColumnName">Name of the input column to update from.</param>
+        void Update(IDataView dataView, string inputColumnName);
+
+        /// <summary>
+        /// Perform forecasting until a particular <paramref name="horizon"/>.
+        /// </summary>
+        /// <param name="horizon">Number of values to forecast.</param>
+        /// <returns></returns>
+        T[] Forecast(int horizon);
+
+        /// <summary>
+        /// Serialize the forecasting model to disk to preserve the state of forecasting model.
+        /// </summary>
+        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
+        /// <param name="filePath">Name of the filepath to serialize the model to.</param>
+        void Checkpoint(IHostEnvironment env, string filePath);
+
+        /// <summary>
+        /// Deserialize the forecasting model from disk.
+        /// </summary>
+        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
+        /// <param name="filePath">Name of the filepath to deserialize the model from.</param>
+        ICanForecast<T> LoadFrom(IHostEnvironment env, string filePath);
+    }
+}

--- a/src/Microsoft.ML.TimeSeries/Forecast.cs
+++ b/src/Microsoft.ML.TimeSeries/Forecast.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.ML.Runtime;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Runtime.Data;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.ML.TimeSeries
 {

--- a/src/Microsoft.ML.TimeSeries/Forecast.cs
+++ b/src/Microsoft.ML.TimeSeries/Forecast.cs
@@ -4,7 +4,7 @@
 
 using System.IO;
 using Microsoft.ML.Data;
-using static Microsoft.ML.Transforms.TimeSeries.AdaptiveSingularSpectrumSequenceForecastingModeler;
+using static Microsoft.ML.Transforms.TimeSeries.AdaptiveSingularSpectrumSequenceModeler;
 
 namespace Microsoft.ML.TimeSeries
 {
@@ -36,7 +36,7 @@ namespace Microsoft.ML.TimeSeries
 
         /// <summary>
         /// Perform forecasting until a particular <paramref name="horizon"/> and also computes confidence intervals.
-        /// For confidence intervals to be computed the model must be trained with <see cref="AdaptiveSingularSpectrumSequenceModeler.ShouldComputeForecastIntervals"/>
+        /// For confidence intervals to be computed the model must be trained with <see cref="AdaptiveSingularSpectrumSequenceModelerInternal.ShouldComputeForecastIntervals"/>
         /// set to true.
         /// </summary>
         /// <param name="horizon">Number of values to forecast.</param>

--- a/src/Microsoft.ML.TimeSeries/Forecast.cs
+++ b/src/Microsoft.ML.TimeSeries/Forecast.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.IO;
 using Microsoft.ML.Data;
 using static Microsoft.ML.Transforms.TimeSeries.AdaptiveSingularSpectrumSequenceForecastingModeler;
@@ -13,7 +12,7 @@ namespace Microsoft.ML.TimeSeries
     /// Interface for forecasting models.
     /// </summary>
     /// <typeparam name="T">The type of values that are forecasted.</typeparam>
-    public interface ICanForecast<out T> : ICanSaveModel
+    public interface ICanForecast<T> : ICanSaveModel
     {
         /// <summary>
         /// Train a forecasting model from an <see cref="IDataView"/>.
@@ -33,7 +32,19 @@ namespace Microsoft.ML.TimeSeries
         /// </summary>
         /// <param name="horizon">Number of values to forecast.</param>
         /// <returns>Forecasted values.</returns>
-        IEnumerable<T> Forecast(int horizon);
+        T[] Forecast(int horizon);
+
+        /// <summary>
+        /// Perform forecasting until a particular <paramref name="horizon"/> and also computes confidence intervals.
+        /// For confidence intervals to be computed the model must be trained with <see cref="AdaptiveSingularSpectrumSequenceModeler.ShouldComputeForecastIntervals"/>
+        /// set to true.
+        /// </summary>
+        /// <param name="horizon">Number of values to forecast.</param>
+        /// <param name="forecast">Forecasted values</param>
+        /// <param name="confidenceIntervalLowerBounds">Lower bound confidence intervals of forecasted values.</param>
+        /// <param name="confidenceIntervalUpperBounds">Upper bound confidence intervals of forecasted values.</param>
+        /// <param name="confidenceLevel">Confidence level.</param>
+        void ForecastWithConfidenceIntervals(int horizon, out T[] forecast, out float[] confidenceIntervalLowerBounds, out float[] confidenceIntervalUpperBounds, float confidenceLevel = 0.95f);
     }
 
     public static class ForecastExtensions

--- a/src/Microsoft.ML.TimeSeries/Forecast.cs
+++ b/src/Microsoft.ML.TimeSeries/Forecast.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.TimeSeries
         /// <summary>
         /// Train a forecasting model from an <see cref="IDataView"/>.
         /// </summary>
-        /// <param name="dataView">Reference to the <see cref="IDataView"/></param>
+        /// <param name="dataView">Training data.</param>
         void Train(IDataView dataView);
 
         /// <summary>
@@ -41,19 +41,19 @@ namespace Microsoft.ML.TimeSeries
         /// <param name="forecast">Forecasted values</param>
         /// <param name="confidenceIntervalLowerBounds">Lower bound confidence intervals of forecasted values.</param>
         /// <param name="confidenceIntervalUpperBounds">Upper bound confidence intervals of forecasted values.</param>
-        /// <param name="confidenceLevel">Confidence level.</param>
+        /// <param name="confidenceLevel">Forecast confidence level.</param>
         void ForecastWithConfidenceIntervals(int horizon, out T[] forecast, out float[] confidenceIntervalLowerBounds, out float[] confidenceIntervalUpperBounds, float confidenceLevel = 0.95f);
     }
 
     public static class ForecastExtensions
     {
         /// <summary>
-        /// Load a forecasting model.
+        /// Load a <see cref="ICanForecast{T}"/> model.
         /// </summary>
-        /// <typeparam name="T">The type of <see cref="ICanForecast{T}"/>, usually float. </typeparam>
+        /// <typeparam name="T">The type of <see cref="ICanForecast{T}"/>, usually float.</typeparam>
         /// <param name="catalog"><see cref="ModelOperationsCatalog"/></param>
-        /// <param name="filePath">File path to save the model to.</param>
-        /// <returns></returns>
+        /// <param name="filePath">File path to load the model from.</param>
+        /// <returns><see cref="ICanForecast{T}"/> model.</returns>
         public static ICanForecast<T> LoadForecastingModel<T>(this ModelOperationsCatalog catalog, string filePath)
         {
             var env = CatalogUtils.GetEnvironment(catalog);
@@ -68,12 +68,12 @@ namespace Microsoft.ML.TimeSeries
         }
 
         /// <summary>
-        /// Save a forecasting model.
+        /// Save a <see cref="ICanForecast{T}"/> model to a file specified by <paramref name="filePath"/>
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="catalog"><see cref="ModelOperationsCatalog"/></param>
-        /// <param name="model">Model to save.</param>
-        /// <param name="filePath">File path to load the model from.</param>
+        /// <param name="model"><see cref="ICanForecast{T}"/> model to save.</param>
+        /// <param name="filePath">File path to save the model to.</param>
         public static void SaveForecastingModel<T>(this ModelOperationsCatalog catalog, ICanForecast<T> model, string filePath)
         {
             var env = CatalogUtils.GetEnvironment(catalog);

--- a/src/Microsoft.ML.TimeSeries/Forecast.cs
+++ b/src/Microsoft.ML.TimeSeries/Forecast.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Runtime;
-using Microsoft.ML.Runtime.Data;
 
 namespace Microsoft.ML.TimeSeries
 {

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -11,6 +11,15 @@ using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.Transforms.TimeSeries
 {
+    internal interface ICanForecast<out T>
+    {
+        void Train(IDataView dataView, string inputColumnName);
+        T[] Forecast(int horizon);
+        void Update(IDataView dataView, string inputColumnName);
+        void Checkpoint(IHostEnvironment env, string filePath);
+        AdaptiveSingularSpectrumSequenceModeler LoadFrom(IHostEnvironment env, string filePath);
+    }
+
     internal interface IStatefulRowToRowMapper : IRowToRowMapper
     {
     }

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -11,13 +11,46 @@ using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.Transforms.TimeSeries
 {
-    internal interface ICanForecast<out T>
+    /// <summary>
+    /// Interface for forecasting models.
+    /// </summary>
+    /// <typeparam name="T">The type of values that are forecasted.</typeparam>
+    public interface ICanForecast<out T>
     {
+        /// <summary>
+        /// Train a forecasting model from an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="dataView">Reference to the <see cref="IDataView"/></param>
+        /// <param name="inputColumnName">Name of the input column to train the forecasing model.</param>
         void Train(IDataView dataView, string inputColumnName);
-        T[] Forecast(int horizon);
+
+        /// <summary>
+        /// Update a forecasting model with the new observations in the form of an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="dataView">Reference to the observations as an <see cref="IDataView"/></param>
+        /// <param name="inputColumnName">Name of the input column to update from.</param>
         void Update(IDataView dataView, string inputColumnName);
+
+        /// <summary>
+        /// Perform forecasting until a particular <paramref name="horizon"/>.
+        /// </summary>
+        /// <param name="horizon">Number of values to forecast.</param>
+        /// <returns></returns>
+        T[] Forecast(int horizon);
+
+        /// <summary>
+        /// Serialize the forecasting model to disk to preserve the state of forecasting model.
+        /// </summary>
+        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
+        /// <param name="filePath">Name of the filepath to serialize the model to.</param>
         void Checkpoint(IHostEnvironment env, string filePath);
-        AdaptiveSingularSpectrumSequenceModeler LoadFrom(IHostEnvironment env, string filePath);
+
+        /// <summary>
+        /// Deserialize the forecasting model from disk.
+        /// </summary>
+        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
+        /// <param name="filePath">Name of the filepath to deserialize the model from.</param>
+        ICanForecast<T> LoadFrom(IHostEnvironment env, string filePath);
     }
 
     internal interface IStatefulRowToRowMapper : IRowToRowMapper

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -11,48 +11,6 @@ using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.Transforms.TimeSeries
 {
-    /// <summary>
-    /// Interface for forecasting models.
-    /// </summary>
-    /// <typeparam name="T">The type of values that are forecasted.</typeparam>
-    public interface ICanForecast<out T>
-    {
-        /// <summary>
-        /// Train a forecasting model from an <see cref="IDataView"/>.
-        /// </summary>
-        /// <param name="dataView">Reference to the <see cref="IDataView"/></param>
-        /// <param name="inputColumnName">Name of the input column to train the forecasing model.</param>
-        void Train(IDataView dataView, string inputColumnName);
-
-        /// <summary>
-        /// Update a forecasting model with the new observations in the form of an <see cref="IDataView"/>.
-        /// </summary>
-        /// <param name="dataView">Reference to the observations as an <see cref="IDataView"/></param>
-        /// <param name="inputColumnName">Name of the input column to update from.</param>
-        void Update(IDataView dataView, string inputColumnName);
-
-        /// <summary>
-        /// Perform forecasting until a particular <paramref name="horizon"/>.
-        /// </summary>
-        /// <param name="horizon">Number of values to forecast.</param>
-        /// <returns></returns>
-        T[] Forecast(int horizon);
-
-        /// <summary>
-        /// Serialize the forecasting model to disk to preserve the state of forecasting model.
-        /// </summary>
-        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
-        /// <param name="filePath">Name of the filepath to serialize the model to.</param>
-        void Checkpoint(IHostEnvironment env, string filePath);
-
-        /// <summary>
-        /// Deserialize the forecasting model from disk.
-        /// </summary>
-        /// <param name="env">Reference to <see cref="IHostEnvironment"/>, typically <see cref="MLContext"/></param>
-        /// <param name="filePath">Name of the filepath to deserialize the model from.</param>
-        ICanForecast<T> LoadFrom(IHostEnvironment env, string filePath);
-    }
-
     internal interface IStatefulRowToRowMapper : IRowToRowMapper
     {
     }

--- a/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
@@ -201,8 +201,8 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 ErrorFunc = ErrorFunctionUtils.GetErrorFunction(ErrorFunction);
                 IsAdaptive = options.IsAdaptive;
                 // Creating the master SSA model
-                Model = new AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler(Host, options.InitialWindowSize, SeasonalWindowSize + 1, SeasonalWindowSize,
-                    DiscountFactor, AdaptiveSingularSpectrumSequenceForecastingModeler.RankSelectionMethod.Exact, null, SeasonalWindowSize / 2, false, false);
+                Model = new AdaptiveSingularSpectrumSequenceModeler.AdaptiveSingularSpectrumSequenceModelerInternal(Host, options.InitialWindowSize, SeasonalWindowSize + 1, SeasonalWindowSize,
+                    DiscountFactor, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalWindowSize / 2, false, false);
 
                 StateRef = new State();
                 StateRef.InitState(WindowSize, InitialWindowSize, this, Host);

--- a/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
@@ -201,8 +201,8 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 ErrorFunc = ErrorFunctionUtils.GetErrorFunction(ErrorFunction);
                 IsAdaptive = options.IsAdaptive;
                 // Creating the master SSA model
-                Model = new AdaptiveSingularSpectrumSequenceModeler(Host, options.InitialWindowSize, SeasonalWindowSize + 1, SeasonalWindowSize,
-                    DiscountFactor, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalWindowSize / 2, false, false);
+                Model = new AdaptiveSingularSpectrumSequenceForecastingModeler.AdaptiveSingularSpectrumSequenceModeler(Host, options.InitialWindowSize, SeasonalWindowSize + 1, SeasonalWindowSize,
+                    DiscountFactor, AdaptiveSingularSpectrumSequenceForecastingModeler.RankSelectionMethod.Exact, null, SeasonalWindowSize / 2, false, false);
 
                 StateRef = new State();
                 StateRef.InitState(WindowSize, InitialWindowSize, this, Host);

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -343,16 +343,16 @@ namespace Microsoft.ML.Tests
 
             List<Data> data = new List<Data>();
 
-            var ml = new MLContext(seed: 1, conc: 1);
-            var dataView = ml.CreateStreamingDataView(data);
+            var ml = new MLContext(seed: 1);
+            var dataView = ml.Data.LoadFromEnumerable<Data>(data);
 
             for (int j = 0; j < NumberOfSeasonsInTraining; j++)
                 for (int i = 0; i < SeasonalitySize; i++)
                     data.Add(new Data(i));
 
             // Create forecasting model.
-            var model = new AdaptiveSingularSpectrumSequenceModeler(ml, data.Count, SeasonalitySize + 1, SeasonalitySize,
-                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
+            var model = new AdaptiveSingularSpectrumSequenceForecastingModeler(ml, data.Count, SeasonalitySize + 1, SeasonalitySize,
+                1, AdaptiveSingularSpectrumSequenceForecastingModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
 
             // Train.
             model.Train(dataView, "Value");

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Tests
             }
         }
 
-        [ConditionalFact(typeof(BaseTestBaseline), nameof(BaseTestBaseline.LessThanNetCore30OrNotNetCore))]
+        [Fact]
         public void Forecasting()
         {
             const int SeasonalitySize = 10;
@@ -362,7 +362,7 @@ namespace Microsoft.ML.Tests
             var forecast = model.Forecast(5);
 
             // Update with new observations.
-            model.Update(dataView, "Value");
+            model.Update(dataView);
 
             // Checkpoint.
             ml.Model.SaveForecastingModel(model, "model.zip");
@@ -379,6 +379,59 @@ namespace Microsoft.ML.Tests
             // Both the forecasted values from model loaded from disk and 
             // already in memory model should be the same.
             Assert.Equal(forecast, forecastCopy);
+        }
+
+        [Fact]
+        public void ForecastingWithConfidenceInterval()
+        {
+            const int SeasonalitySize = 10;
+            const int NumberOfSeasonsInTraining = 5;
+
+            List<Data> data = new List<Data>();
+
+            var ml = new MLContext(seed: 1);
+            var dataView = ml.Data.LoadFromEnumerable<Data>(data);
+
+            for (int j = 0; j < NumberOfSeasonsInTraining; j++)
+                for (int i = 0; i < SeasonalitySize; i++)
+                    data.Add(new Data(i));
+
+            // Create forecasting model.
+            var model = new AdaptiveSingularSpectrumSequenceForecastingModeler(ml, "Value", data.Count, SeasonalitySize + 1, SeasonalitySize,
+                1, AdaptiveSingularSpectrumSequenceForecastingModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, shouldComputeForecastIntervals: true, false);
+
+            // Train.
+            model.Train(dataView);
+
+            // Forecast.
+            float[] forecast;
+            float[] lowConfInterval;
+            float[] upperConfInterval;
+            model.ForecastWithConfidenceIntervals(5, out forecast, out lowConfInterval, out upperConfInterval);
+
+            // Update with new observations.
+            model.Update(dataView);
+
+            // Checkpoint.
+            ml.Model.SaveForecastingModel(model, "model.zip");
+
+            // Load the checkpointed model from disk.
+            var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
+
+            // Forecast with the checkpointed model loaded from disk.
+            float[] forecastCopy;
+            float[] lowConfIntervalCopy;
+            float[] upperConfIntervalCopy;
+            modelCopy.ForecastWithConfidenceIntervals(5, out forecastCopy, out lowConfIntervalCopy, out upperConfIntervalCopy);
+
+            // Forecast with the original model(that was checkpointed to disk).
+            model.ForecastWithConfidenceIntervals(5, out forecast, out lowConfInterval, out upperConfInterval);
+
+            // Both the forecasted values from model loaded from disk and 
+            // already in memory model should be the same.
+            Assert.Equal(forecast, forecastCopy);
+            Assert.Equal(lowConfInterval, lowConfIntervalCopy);
+            Assert.Equal(upperConfInterval, upperConfIntervalCopy);
         }
     }
 }

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -352,8 +352,8 @@ namespace Microsoft.ML.Tests
                     data.Add(new Data(i));
 
             // Create forecasting model.
-            var model = new AdaptiveSingularSpectrumSequenceForecastingModeler(ml, "Value", data.Count, SeasonalitySize + 1, SeasonalitySize,
-                1, AdaptiveSingularSpectrumSequenceForecastingModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
+            var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler("Value", data.Count, SeasonalitySize + 1, SeasonalitySize,
+                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
 
             // Train.
             model.Train(dataView);
@@ -397,8 +397,8 @@ namespace Microsoft.ML.Tests
                     data.Add(new Data(i));
 
             // Create forecasting model.
-            var model = new AdaptiveSingularSpectrumSequenceForecastingModeler(ml, "Value", data.Count, SeasonalitySize + 1, SeasonalitySize,
-                1, AdaptiveSingularSpectrumSequenceForecastingModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, shouldComputeForecastIntervals: true, false);
+            var model = ml.Forecasting.AdaptiveSingularSpectrumSequenceModeler("Value", data.Count, SeasonalitySize + 1, SeasonalitySize,
+                1, AdaptiveSingularSpectrumSequenceModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, shouldComputeForecastIntervals: true, false);
 
             // Train.
             model.Train(dataView);

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.ML.Data;
 using Microsoft.ML.TestFramework.Attributes;
+using Microsoft.ML.TimeSeries;
 using Microsoft.ML.Transforms.TimeSeries;
 using Xunit;
 
@@ -351,11 +352,11 @@ namespace Microsoft.ML.Tests
                     data.Add(new Data(i));
 
             // Create forecasting model.
-            var model = new AdaptiveSingularSpectrumSequenceForecastingModeler(ml, data.Count, SeasonalitySize + 1, SeasonalitySize,
+            var model = new AdaptiveSingularSpectrumSequenceForecastingModeler(ml, "Value", data.Count, SeasonalitySize + 1, SeasonalitySize,
                 1, AdaptiveSingularSpectrumSequenceForecastingModeler.RankSelectionMethod.Exact, null, SeasonalitySize / 2, false, false);
 
             // Train.
-            model.Train(dataView, "Value");
+            model.Train(dataView);
 
             // Forecast.
             var forecast = model.Forecast(5);
@@ -364,10 +365,10 @@ namespace Microsoft.ML.Tests
             model.Update(dataView, "Value");
 
             // Checkpoint.
-            model.Checkpoint(ml, "model.zip");
+            ml.Model.SaveForecastingModel(model, "model.zip");
 
             // Load the checkpointed model from disk.
-            var modelCopy = model.LoadFrom(ml, "model.zip");
+            var modelCopy = ml.Model.LoadForecastingModel<float>("model.zip");
 
             // Forecast with the checkpointed model loaded from disk.
             var forecastCopy = modelCopy.Forecast(5);


### PR DESCRIPTION
This PR introduces forecasting framework/interface for time series. It allows the following:
1. Train forecasting model from an IDataView.
2. Update the model with new observation using an IDataView.
3. Forecast values up to a certain horizon (with confidence intervals).
4. Checkpoint the model to disk.
5. Load a model from disk.

fixes #929