### PR TITLE
Replace ColumnInfo usage with Schema.Column, remove ColumnInfo

### DIFF
--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -748,8 +748,7 @@ namespace Microsoft.ML.Runtime.Data
             if (other == this)
                 return true;
 
-            var tmp = other as KeyType;
-            if (tmp == null)
+            if (!(other is KeyType tmp))
                 return false;
             if (RawKind != tmp.RawKind)
                 return false;

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -332,11 +332,9 @@ namespace Microsoft.ML.Data
             Contracts.CheckValueOrNull(schema);
             Contracts.CheckParam(vectorSize >= 0, nameof(vectorSize));
 
-            IReadOnlyList<ColumnInfo> list;
-            if ((list = schema?.GetColumns(role)) == null || list.Count != 1 || !schema.Schema[list[0].Index].HasSlotNames(vectorSize))
-            {
+            IReadOnlyList<Schema.Column> list = schema?.GetColumns(role);
+            if (list?.Count != 1 || !schema.Schema[list[0].Index].HasSlotNames(vectorSize))
                 VBufferUtils.Resize(ref slotNames, vectorSize, 0);
-            }
             else
                 schema.Schema[list[0].Index].Metadata.GetValue(Kinds.SlotNames, ref slotNames);
         }

--- a/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
+++ b/src/Microsoft.ML.Core/Data/RoleMappedSchema.cs
@@ -9,57 +9,6 @@ using Microsoft.ML.Runtime.Internal.Utilities;
 namespace Microsoft.ML.Runtime.Data
 {
     /// <summary>
-    /// This contains information about a column in an <see cref="IDataView"/>. It is essentially a convenience cache
-    /// containing the name, column index, and column type for the column. The intended usage is that users of <see cref="RoleMappedSchema"/>
-    /// will have a convenient method of getting the index and type without having to separately query it through the <see cref="Schema"/>,
-    /// since practically the first thing a consumer of a <see cref="RoleMappedSchema"/> will want to do once they get a mappping is get
-    /// the type and index of the corresponding column.
-    /// </summary>
-    public sealed class ColumnInfo
-    {
-        public readonly string Name;
-        public readonly int Index;
-        public readonly ColumnType Type;
-
-        private ColumnInfo(string name, int index, ColumnType type)
-        {
-            Name = name;
-            Index = index;
-            Type = type;
-        }
-
-        /// <summary>
-        /// Tries to create a ColumnInfo for the column with the given name in the given schema. Returns
-        /// false if the name doesn't map to a column.
-        /// </summary>
-        public static bool TryCreateFromName(Schema schema, string name, out ColumnInfo colInfo)
-        {
-            Contracts.CheckValue(schema, nameof(schema));
-            Contracts.CheckNonEmpty(name, nameof(name));
-
-            colInfo = null;
-            if (!schema.TryGetColumnIndex(name, out int index))
-                return false;
-
-            colInfo = new ColumnInfo(name, index, schema[index].Type);
-            return true;
-        }
-
-        /// <summary>
-        /// Creates a ColumnInfo for the column with the given column index. Note that the name
-        /// of the column might actually map to a different column, so this should be used with care
-        /// and rarely.
-        /// </summary>
-        public static ColumnInfo CreateFromIndex(Schema schema, int index)
-        {
-            Contracts.CheckValue(schema, nameof(schema));
-            Contracts.CheckParam(0 <= index && index < schema.Count, nameof(index));
-
-            return new ColumnInfo(schema[index].Name, index, schema[index].Type);
-        }
-    }
-
-    /// <summary>
     /// Encapsulates an <see cref="Schema"/> plus column role mapping information. The purpose of role mappings is to
     /// provide information on what the intended usage is for. That is: while a given data view may have a column named
     /// "Features", by itself that is insufficient: the trainer must be fed a role mapping that says that the role

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.ML.Data;
-using Microsoft.ML.Runtime.CommandLine;
 using Microsoft.ML.Runtime.Data.IO;
 using Microsoft.ML.Runtime.Internal.Utilities;
 
@@ -36,7 +35,7 @@ namespace Microsoft.ML.Runtime.Data
         public readonly int RowCount;
         // -1 for input columns that were not transposed, a non-negative index into _cols for those that were.
         private readonly int[] _inputToTransposed;
-        private readonly ColumnInfo[] _cols;
+        private readonly Schema.Column[] _cols;
         private readonly int[] _splitLim;
         private readonly SchemaImpl _tschema;
         private bool _disposed;
@@ -104,13 +103,13 @@ namespace Microsoft.ML.Runtime.Data
                 columnSet = columnSet.Where(c => ttschema.GetSlotType(c) == null);
             }
             columns = columnSet.ToArray();
-            _cols = new ColumnInfo[columns.Length];
+            _cols = new Schema.Column[columns.Length];
             var schema = _view.Schema;
             _nameToICol = new Dictionary<string, int>();
             _inputToTransposed = Utils.CreateArray(schema.Count, -1);
             for (int c = 0; c < columns.Length; ++c)
             {
-                _nameToICol[(_cols[c] = ColumnInfo.CreateFromIndex(schema, columns[c])).Name] = c;
+                _nameToICol[(_cols[c] = schema[columns[c]]).Name] = c;
                 _inputToTransposed[columns[c]] = c;
             }
 
@@ -305,7 +304,7 @@ namespace Microsoft.ML.Runtime.Data
                 _slotTypes = new VectorType[_parent._cols.Length];
                 for (int c = 0; c < _slotTypes.Length; ++c)
                 {
-                    ColumnInfo srcInfo = _parent._cols[c];
+                    var srcInfo = _parent._cols[c];
                     var ctype = srcInfo.Type.ItemType;
                     var primitiveType = ctype as PrimitiveType;
                     _ectx.Assert(primitiveType != null);

--- a/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
+++ b/src/Microsoft.ML.Data/Depricated/Instances/HeaderSchema.cs
@@ -185,13 +185,14 @@ namespace Microsoft.ML.Runtime.Internal.Internallearn
         {
             // REVIEW: This shim should be deleted as soon as is convenient.
             Contracts.CheckValue(schema, nameof(schema));
-            Contracts.CheckParam(schema.Feature != null, nameof(schema), "Cannot create feature name collection if we have no features");
-            Contracts.CheckParam(schema.Feature.Type.ValueCount > 0, nameof(schema), "Cannot create feature name collection if our features are not of known size");
+            Contracts.CheckParam(schema.Feature.HasValue, nameof(schema), "Cannot create feature name collection if we have no features");
+            var featureCol = schema.Feature.Value;
+            Contracts.CheckParam(schema.Feature.Value.Type.ValueCount > 0, nameof(schema), "Cannot create feature name collection if our features are not of known size");
 
             VBuffer<ReadOnlyMemory<char>> slotNames = default;
-            int len = schema.Feature.Type.ValueCount;
-            if (schema.Schema[schema.Feature.Index].HasSlotNames(len))
-                schema.Schema[schema.Feature.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slotNames);
+            int len = featureCol.Type.ValueCount;
+            if (featureCol.HasSlotNames(len))
+                featureCol.Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slotNames);
             else
                 slotNames = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(len);
             var slotNameValues = slotNames.GetValues();

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -125,12 +125,11 @@ namespace Microsoft.ML.Runtime.EntryPoints
             labelType = null;
             if (trainRms.Label != null)
             {
-                labelType = trainRms.Label.Type;
-                if (labelType.IsKey &&
-                    trainRms.Schema[trainRms.Label.Index].HasKeyValues(labelType.KeyCount))
+                labelType = trainRms.Label.Value.Type;
+                if (labelType is KeyType && trainRms.Label.Value.HasKeyValues(labelType.KeyCount))
                 {
                     VBuffer<ReadOnlyMemory<char>> keyValues = default;
-                    trainRms.Schema[trainRms.Label.Index].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keyValues);
+                    trainRms.Label.Value.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keyValues);
                     return keyValues.DenseValues().Select(v => v.ToString()).ToArray();
                 }
             }

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -97,15 +97,15 @@ namespace Microsoft.ML.Runtime.Data
             var t = score.Type;
             if (t != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type '{1}' but must be R4", score, t).MarkSensitive(MessageSensitivity.Schema);
-            Host.Check(schema.Label != null, "Could not find the label column");
-            t = schema.Label.Type;
+            Host.Check(schema.Label.HasValue, "Could not find the label column");
+            t = schema.Label.Value.Type;
             if (t != NumberType.Float && t.KeyCount != 2)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4 or a 2-value key", schema.Label.Name, t).MarkSensitive(MessageSensitivity.Schema);
+                throw Host.Except("Label column '{0}' has type '{1}' but must be R4 or a 2-value key", schema.Label.Value.Name, t).MarkSensitive(MessageSensitivity.Schema);
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
         {
-            return new Aggregator(Host, _aucCount, _numTopResults, _k, _p, _streaming, schema.Name == null ? -1 : schema.Name.Index, stratName);
+            return new Aggregator(Host, _aucCount, _numTopResults, _k, _p, _streaming, schema.Name == null ? -1 : schema.Name.Value.Index, stratName);
         }
 
         internal override IDataTransform GetPerInstanceMetricsCore(RoleMappedData data)
@@ -501,11 +501,11 @@ namespace Microsoft.ML.Runtime.Data
             internal override void InitializeNextPass(Row row, RoleMappedSchema schema)
             {
                 Host.Assert(!_streaming && PassNum < 2 || PassNum < 1);
-                Host.AssertValue(schema.Label);
+                Host.Assert(schema.Label.HasValue);
 
                 var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
 
-                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Index);
+                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
                 _scoreGetter = row.GetGetter<float>(score.Index);
                 Host.AssertValue(_labelGetter);
                 Host.AssertValue(_scoreGetter);
@@ -745,10 +745,10 @@ namespace Microsoft.ML.Runtime.Data
         private protected override IEnumerable<string> GetPerInstanceColumnsToSave(RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
-            Host.CheckValue(schema.Label, nameof(schema), "Data must contain a label column");
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Data must contain a label column");
 
             // The anomaly detection evaluator outputs the label and the score.
-            yield return schema.Label.Name;
+            yield return schema.Label.Value.Name;
             var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.AnomalyDetection);
             yield return scoreInfo.Name;

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -749,9 +749,9 @@ namespace Microsoft.ML.Runtime.Data
 
             // The anomaly detection evaluator outputs the label and the score.
             yield return schema.Label.Value.Name;
-            var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
+            var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.AnomalyDetection);
-            yield return scoreInfo.Name;
+            yield return scoreCol.Name;
 
             // No additional output columns.
         }

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -1175,14 +1175,14 @@ namespace Microsoft.ML.Runtime.Data
         {
             var cols = base.GetInputColumnRolesCore(schema);
 
-            var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
+            var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.BinaryClassification);
 
             // Get the optional probability column.
-            var probInfo = EvaluateUtils.GetOptAuxScoreColumnInfo(Host, schema.Schema, _probCol, nameof(Arguments.ProbabilityColumn),
-                scoreInfo.Index, MetadataUtils.Const.ScoreValueKind.Probability, t => t == NumberType.Float);
-            if (probInfo != null)
-                cols = MetadataUtils.Prepend(cols, RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probInfo.Name));
+            var probCol = EvaluateUtils.GetOptAuxScoreColumn(Host, schema.Schema, _probCol, nameof(Arguments.ProbabilityColumn),
+                scoreCol.Index, MetadataUtils.Const.ScoreValueKind.Probability, NumberType.Float.Equals);
+            if (probCol.HasValue)
+                cols = MetadataUtils.Prepend(cols, RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probCol.Value.Name));
             return cols;
         }
 
@@ -1485,15 +1485,15 @@ namespace Microsoft.ML.Runtime.Data
 
             // The binary classifier evaluator outputs the label, score and probability columns.
             yield return schema.Label.Value.Name;
-            var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
+            var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.BinaryClassification);
-            yield return scoreInfo.Name;
-            var probInfo = EvaluateUtils.GetOptAuxScoreColumnInfo(Host, schema.Schema, _probCol, nameof(Arguments.ProbabilityColumn),
-                scoreInfo.Index, MetadataUtils.Const.ScoreValueKind.Probability, t => t == NumberType.Float);
+            yield return scoreCol.Name;
+            var probCol = EvaluateUtils.GetOptAuxScoreColumn(Host, schema.Schema, _probCol, nameof(Arguments.ProbabilityColumn),
+                scoreCol.Index, MetadataUtils.Const.ScoreValueKind.Probability, NumberType.Float.Equals);
             // Return the output columns. The LogLoss column is returned only if the probability column exists.
-            if (probInfo != null)
+            if (probCol.HasValue)
             {
-                yield return probInfo.Name;
+                yield return probCol.Value.Name;
                 yield return BinaryPerInstanceEvaluator.LogLoss;
             }
 

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -129,11 +129,11 @@ namespace Microsoft.ML.Runtime.Data
             var host = Host.SchemaSensitive();
             var t = score.Type;
             if (t.IsVector || t.ItemType != NumberType.Float)
-                throw host.SchemaSensitive().Except("Score column '{0}' has type '{1}' but must be R4", score, t);
+                throw host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "R4", t.ToString());
             host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.KeyCount != 2)
-                throw host.SchemaSensitive().Except("Label column '{0}' has type '{1}' but must be R4, R8, BL or a 2-value key", schema.Label.Value.Name, t);
+                throw host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "R4, R8, BL or a 2-value key", t.ToString());
         }
 
         private protected override void CheckCustomColumnTypesCore(RoleMappedSchema schema)
@@ -142,14 +142,14 @@ namespace Microsoft.ML.Runtime.Data
             var host = Host.SchemaSensitive();
             if (prob != null)
             {
-                host.Check(prob.Count == 1, "Cannot have multiple probability columns");
+                host.CheckParam(prob.Count == 1, nameof(schema), "Cannot have multiple probability columns");
                 var probType = prob[0].Type;
                 if (probType != NumberType.Float)
-                    throw host.SchemaSensitive().Except("Probability column '{0}' has type '{1}' but must be R4", prob[0].Name, probType);
+                    throw host.ExceptSchemaMismatch(nameof(schema), "probability", prob[0].Name, "R4", probType.ToString());
             }
             else if (!_useRaw)
             {
-                throw host.Except(
+                throw host.ExceptParam(nameof(schema),
                     "Cannot compute the predicted label from the probability column because it does not exist");
             }
         }

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -130,10 +130,10 @@ namespace Microsoft.ML.Runtime.Data
             var t = score.Type;
             if (t.IsVector || t.ItemType != NumberType.Float)
                 throw host.SchemaSensitive().Except("Score column '{0}' has type '{1}' but must be R4", score, t);
-            host.Check(schema.Label != null, "Could not find the label column");
-            t = schema.Label.Type;
+            host.Check(schema.Label.HasValue, "Could not find the label column");
+            t = schema.Label.Value.Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.KeyCount != 2)
-                throw host.SchemaSensitive().Except("Label column '{0}' has type '{1}' but must be R4, R8, BL or a 2-value key", schema.Label.Name, t);
+                throw host.SchemaSensitive().Except("Label column '{0}' has type '{1}' but must be R4, R8, BL or a 2-value key", schema.Label.Value.Name, t);
         }
 
         private protected override void CheckCustomColumnTypesCore(RoleMappedSchema schema)
@@ -172,13 +172,13 @@ namespace Microsoft.ML.Runtime.Data
         private ReadOnlyMemory<char>[] GetClassNames(RoleMappedSchema schema)
         {
             // Get the label names if they exist, or use the default names.
-            ColumnType type;
             var labelNames = default(VBuffer<ReadOnlyMemory<char>>);
-            if (schema.Label.Type.IsKey &&
-                (type = schema.Schema[schema.Label.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type) != null &&
-                type.ItemType.IsKnownSizeVector && type.ItemType.IsText)
+            var labelCol = schema.Label.Value;
+            if (labelCol.Type is KeyType &&
+                labelCol.Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type is VectorType vecType &&
+                vecType.Size > 0 && vecType.ItemType == TextType.Instance)
             {
-                schema.Schema[schema.Label.Index].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref labelNames);
+                labelCol.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref labelNames);
             }
             else
                 labelNames = new VBuffer<ReadOnlyMemory<char>>(2, new[] { "positive".AsMemory(), "negative".AsMemory() });
@@ -193,11 +193,10 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.CheckParam(schema.Label != null, nameof(schema), "Could not find the label column");
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
-            Contracts.AssertValue(scoreInfo);
 
             var probInfos = schema.GetColumns(MetadataUtils.Const.ScoreValueKind.Probability);
             var probCol = Utils.Size(probInfos) > 0 ? probInfos[0].Name : null;
-            return new BinaryPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, probCol, schema.Label.Name, _threshold, _useRaw);
+            return new BinaryPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, probCol, schema.Label.Value.Name, _threshold, _useRaw);
         }
 
         public override IEnumerable<MetricColumn> GetOverallMetricColumns()
@@ -611,12 +610,12 @@ namespace Microsoft.ML.Runtime.Data
 
             internal override void InitializeNextPass(Row row, RoleMappedSchema schema)
             {
-                Host.AssertValue(schema.Label);
+                Host.Assert(schema.Label.HasValue);
                 Host.Assert(PassNum < 1);
 
                 var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
 
-                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Index);
+                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
                 _scoreGetter = row.GetGetter<Single>(score.Index);
                 Host.AssertValue(_labelGetter);
                 Host.AssertValue(_scoreGetter);
@@ -631,7 +630,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 Host.Assert((schema.Weight != null) == Weighted);
                 if (Weighted)
-                    _weightGetter = row.GetGetter<Single>(schema.Weight.Index);
+                    _weightGetter = row.GetGetter<Single>(schema.Weight.Value.Index);
             }
 
             public override void ProcessRow()
@@ -1482,10 +1481,10 @@ namespace Microsoft.ML.Runtime.Data
         private protected override IEnumerable<string> GetPerInstanceColumnsToSave(RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
-            Host.CheckParam(schema.Label != null, nameof(schema), "Schema must contain a label column");
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Schema must contain a label column");
 
             // The binary classifier evaluator outputs the label, score and probability columns.
-            yield return schema.Label.Name;
+            yield return schema.Label.Value.Name;
             var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.BinaryClassification);
             yield return scoreInfo.Name;

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -96,12 +96,12 @@ namespace Microsoft.ML.Runtime.Data
 
         private protected override void CheckScoreAndLabelTypes(RoleMappedSchema schema)
         {
-            ColumnType type;
-            if (schema.Label != null && (type = schema.Label.Type) != NumberType.Float && type.KeyCount == 0)
+            ColumnType type = schema.Label?.Type;
+            if (type != null && type != NumberType.Float && !(type is KeyType keyType && keyType.Count > 0))
             {
                 throw Host.Except("Clustering evaluator: label column '{0}' type must be {1} or Key of known cardinality." +
                     " Provide a correct label column, or none: it is optional.",
-                    schema.Label.Name, NumberType.Float);
+                    schema.Label.Value.Name, NumberType.Float);
             }
 
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
@@ -114,12 +114,12 @@ namespace Microsoft.ML.Runtime.Data
         {
             if (_calculateDbi)
             {
-                Host.AssertValue(schema.Feature);
-                var t = schema.Feature.Type;
+                Host.Assert(schema.Feature.HasValue);
+                var t = schema.Feature.Value.Type;
                 if (!t.IsKnownSizeVector || t.ItemType != NumberType.Float)
                 {
                     throw Host.Except("Features column '{0}' type must be {1} vector of known-size",
-                        schema.Feature.Name, NumberType.Float);
+                        schema.Feature.Value.Name, NumberType.Float);
                 }
             }
         }
@@ -129,13 +129,13 @@ namespace Microsoft.ML.Runtime.Data
             var pred = base.GetActiveColsCore(schema);
             // We also need the features column for dbi calculation.
             Host.Assert(!_calculateDbi || schema.Feature != null);
-            return i => _calculateDbi && i == schema.Feature.Index || pred(i);
+            return i => _calculateDbi && i == schema.Feature.Value.Index || pred(i);
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
         {
             Host.AssertValue(schema);
-            Host.Assert(!_calculateDbi || (schema.Feature != null && schema.Feature.Type.IsKnownSizeVector));
+            Host.Assert(!_calculateDbi || schema.Feature?.Type.IsKnownSizeVector == true);
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             Host.Assert(score.Type.VectorSize > 0);
             int numClusters = score.Type.VectorSize;
@@ -316,7 +316,7 @@ namespace Microsoft.ML.Runtime.Data
                     }
                 }
 
-                public Counters(int numClusters, bool calculateDbi, ColumnInfo features)
+                public Counters(int numClusters, bool calculateDbi, Schema.Column? features)
                 {
                     _numClusters = numClusters;
                     CalculateDbi = calculateDbi;
@@ -326,10 +326,10 @@ namespace Microsoft.ML.Runtime.Data
                     _confusionMatrix = new List<Double[]>();
                     if (CalculateDbi)
                     {
-                        Contracts.AssertValue(features);
+                        Contracts.Assert(features.HasValue);
                         _clusterCentroids = new VBuffer<Single>[_numClusters];
                         for (int i = 0; i < _numClusters; i++)
-                            _clusterCentroids[i] = VBufferUtils.CreateEmpty<Single>(features.Type.VectorSize);
+                            _clusterCentroids[i] = VBufferUtils.CreateEmpty<Single>(features.Value.Type.VectorSize);
                         _distancesToCentroids = new Double[_numClusters];
                     }
                 }
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Runtime.Data
 
             private readonly bool _calculateDbi;
 
-            public Aggregator(IHostEnvironment env, ColumnInfo features, int scoreVectorSize, bool calculateDbi, bool weighted, string stratName)
+            internal Aggregator(IHostEnvironment env, Schema.Column? features, int scoreVectorSize, bool calculateDbi, bool weighted, string stratName)
                 : base(env, stratName)
             {
                 _calculateDbi = calculateDbi;
@@ -407,10 +407,10 @@ namespace Microsoft.ML.Runtime.Data
                 WeightedCounters = Weighted ? new Counters(scoreVectorSize, _calculateDbi, features) : null;
                 if (_calculateDbi)
                 {
-                    Host.AssertValue(features);
+                    Host.Assert(features.HasValue);
                     _clusterCentroids = new VBuffer<Single>[scoreVectorSize];
                     for (int i = 0; i < scoreVectorSize; i++)
-                        _clusterCentroids[i] = VBufferUtils.CreateEmpty<Single>(features.Type.VectorSize);
+                        _clusterCentroids[i] = VBufferUtils.CreateEmpty<Single>(features.Value.Type.VectorSize);
                 }
             }
 
@@ -493,8 +493,8 @@ namespace Microsoft.ML.Runtime.Data
 
                 if (_calculateDbi)
                 {
-                    Host.AssertValue(schema.Feature);
-                    _featGetter = row.GetGetter<VBuffer<Single>>(schema.Feature.Index);
+                    Host.Assert(schema.Feature.HasValue);
+                    _featGetter = row.GetGetter<VBuffer<Single>>(schema.Feature.Value.Index);
                 }
                 var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
                 Host.Assert(score.Type.VectorSize == _scoresArr.Length);
@@ -502,12 +502,12 @@ namespace Microsoft.ML.Runtime.Data
 
                 if (PassNum == 0)
                 {
-                    if (schema.Label != null)
-                        _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Index);
+                    if (schema.Label.HasValue)
+                        _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
                     else
                         _labelGetter = (ref Single value) => value = Single.NaN;
-                    if (schema.Weight != null)
-                        _weightGetter = row.GetGetter<Single>(schema.Weight.Index);
+                    if (schema.Weight.HasValue)
+                        _weightGetter = row.GetGetter<Single>(schema.Weight.Value.Index);
                 }
                 else
                 {
@@ -821,8 +821,8 @@ namespace Microsoft.ML.Runtime.Data
             Host.CheckValue(schema, nameof(schema));
 
             // Output the label column if it exists.
-            if (schema.Label != null)
-                yield return schema.Label.Name;
+            if (schema.Label.HasValue)
+                yield return schema.Label.Value.Name;
 
             // Return the output columns.
             yield return ClusteringPerInstanceEvaluator.ClusterId;

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -99,15 +99,14 @@ namespace Microsoft.ML.Runtime.Data
             ColumnType type = schema.Label?.Type;
             if (type != null && type != NumberType.Float && !(type is KeyType keyType && keyType.Count > 0))
             {
-                throw Host.Except("Clustering evaluator: label column '{0}' type must be {1} or Key of known cardinality." +
-                    " Provide a correct label column, or none: it is optional.",
-                    schema.Label.Value.Name, NumberType.Float);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name,
+                    "R4 or key of known cardinality", type.ToString());
             }
 
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             type = score.Type;
             if (!type.IsKnownSizeVector || type.ItemType != NumberType.Float)
-                throw Host.Except("Scores column '{0}' type must be a float vector of known size", score.Name);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "R4 vector of known size", type.ToString());
         }
 
         private protected override void CheckCustomColumnTypesCore(RoleMappedSchema schema)
@@ -118,8 +117,8 @@ namespace Microsoft.ML.Runtime.Data
                 var t = schema.Feature.Value.Type;
                 if (!t.IsKnownSizeVector || t.ItemType != NumberType.Float)
                 {
-                    throw Host.Except("Features column '{0}' type must be {1} vector of known-size",
-                        schema.Feature.Value.Name, NumberType.Float);
+                    throw Host.ExceptSchemaMismatch(nameof(schema), "features", schema.Feature.Value.Name,
+                        "R4 vector of known size", t.ToString());
                 }
             }
         }

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -49,8 +49,8 @@ namespace Microsoft.ML.Runtime.Data
         private protected void CheckColumnTypes(RoleMappedSchema schema)
         {
             // Check the weight column type.
-            if (schema.Weight != null)
-                EvaluateUtils.CheckWeightType(Host, schema.Weight.Type);
+            if (schema.Weight.HasValue)
+                EvaluateUtils.CheckWeightType(Host, schema.Weight.Value.Type);
             CheckScoreAndLabelTypes(schema);
             // Check the other column types.
             CheckCustomColumnTypesCore(schema);
@@ -92,8 +92,8 @@ namespace Microsoft.ML.Runtime.Data
         private protected virtual Func<int, bool> GetActiveColsCore(RoleMappedSchema schema)
         {
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
-            var label = schema.Label == null ? -1 : schema.Label.Index;
-            var weight = schema.Weight == null ? -1 : schema.Weight.Index;
+            int label = schema.Label?.Index ?? -1;
+            int weight = schema.Weight?.Index ?? -1;
             return i => i == score.Index || i == label || i == weight;
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -101,11 +101,11 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Find the score column to use. If name is specified, that is used. Otherwise, this searches for the
-        /// most recent score set of the given kind. If there is no such score set and defName is specifed it
-        /// uses defName. Otherwise, it throws.
+        /// Find the score column to use. If <paramref name="name"/> is specified, that is used. Otherwise, this searches
+        /// for the most recent score set of the given <paramref name="kind"/>. If there is no such score set and
+        /// <paramref name="defName"/> is specifed it uses <paramref name="defName"/>. Otherwise, it throws.
         /// </summary>
-        public static ColumnInfo GetScoreColumnInfo(IExceptionContext ectx, Schema schema, string name, string argName, string kind,
+        public static Schema.Column GetScoreColumn(IExceptionContext ectx, Schema schema, string name, string argName, string kind,
             string valueKind = MetadataUtils.Const.ScoreValueKind.Score, string defName = null)
         {
             Contracts.CheckValueOrNull(ectx);
@@ -115,39 +115,40 @@ namespace Microsoft.ML.Runtime.Data
             ectx.CheckNonEmpty(kind, nameof(kind));
             ectx.CheckNonEmpty(valueKind, nameof(valueKind));
 
-            int colTmp;
-            ColumnInfo info;
             if (!string.IsNullOrWhiteSpace(name))
             {
-#pragma warning disable MSML_ContractsNameUsesNameof
-                if (!ColumnInfo.TryCreateFromName(schema, name, out info))
+#pragma warning disable MSML_ContractsNameUsesNameof // This utility method is meant to reflect the argument name of whatever is calling it, so we take that as a parameter, rather than using nameof directly as in most cases.
+                var col = schema.GetColumnOrNull(name);
+                if (!col.HasValue)
                     throw ectx.ExceptUserArg(argName, "Score column is missing");
 #pragma warning restore MSML_ContractsNameUsesNameof
-                return info;
+                return col.Value;
             }
 
-            var maxSetNum = schema.GetMaxMetadataKind(out colTmp, MetadataUtils.Kinds.ScoreColumnSetId,
+            var maxSetNum = schema.GetMaxMetadataKind(out int colTmp, MetadataUtils.Kinds.ScoreColumnSetId,
                 (s, c) => IsScoreColumnKind(ectx, s, c, kind));
 
             ReadOnlyMemory<char> tmp = default;
-            foreach (var col in schema.GetColumnSet(MetadataUtils.Kinds.ScoreColumnSetId, maxSetNum))
+            foreach (var colIdx in schema.GetColumnSet(MetadataUtils.Kinds.ScoreColumnSetId, maxSetNum))
             {
+                var col = schema[colIdx];
 #if DEBUG
-                schema[col].Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnKind, ref tmp);
+                col.Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnKind, ref tmp);
                 ectx.Assert(ReadOnlyMemoryUtils.EqualsStr(kind, tmp));
 #endif
                 // REVIEW: What should this do about hidden columns? Currently we ignore them.
-                if (schema[col].IsHidden)
+                if (col.IsHidden)
                     continue;
-                if (schema.TryGetMetadata(TextType.Instance, MetadataUtils.Kinds.ScoreValueKind, col, ref tmp) &&
-                    ReadOnlyMemoryUtils.EqualsStr(valueKind, tmp))
+                if (col.Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreValueKind)?.Type == TextType.Instance)
                 {
-                    return ColumnInfo.CreateFromIndex(schema, col);
+                    col.Metadata.GetValue(MetadataUtils.Kinds.ScoreValueKind, ref tmp);
+                    if (ReadOnlyMemoryUtils.EqualsStr(valueKind, tmp))
+                        return col;
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(defName) && ColumnInfo.TryCreateFromName(schema, defName, out info))
-                return info;
+            if (!string.IsNullOrWhiteSpace(defName) && schema.GetColumnOrNull(defName) is Schema.Column defCol)
+                return defCol;
 
 #pragma warning disable MSML_ContractsNameUsesNameof
             throw ectx.ExceptUserArg(argName, "Score column is missing");
@@ -155,11 +156,11 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// Find the optional auxilliary score column to use. If name is specified, that is used.
-        /// Otherwise, if colScore is part of a score set, this looks in the score set for a column
-        /// with the given valueKind. If none is found, it returns null.
+        /// Find the optional auxilliary score column to use. If <paramref name="name"/> is specified, that is used.
+        /// Otherwise, if <paramref name="colScore"/> is part of a score set, this looks in the score set for a column
+        /// with the given <paramref name="valueKind"/>. If none is found, it returns <see langword="null"/>.
         /// </summary>
-        public static ColumnInfo GetOptAuxScoreColumnInfo(IExceptionContext ectx, Schema schema, string name, string argName,
+        public static Schema.Column? GetOptAuxScoreColumn(IExceptionContext ectx, Schema schema, string name, string argName,
             int colScore, string valueKind, Func<ColumnType, bool> testType)
         {
             Contracts.CheckValueOrNull(ectx);
@@ -171,14 +172,14 @@ namespace Microsoft.ML.Runtime.Data
 
             if (!string.IsNullOrWhiteSpace(name))
             {
-                ColumnInfo info;
 #pragma warning disable MSML_ContractsNameUsesNameof
-                if (!ColumnInfo.TryCreateFromName(schema, name, out info))
+                var col = schema.GetColumnOrNull(name);
+                if (!col.HasValue)
                     throw ectx.ExceptUserArg(argName, "{0} column is missing", valueKind);
-                if (!testType(info.Type))
+                if (!testType(col.Value.Type))
                     throw ectx.ExceptUserArg(argName, "{0} column has incompatible type", valueKind);
 #pragma warning restore MSML_ContractsNameUsesNameof
-                return info;
+                return col.Value;
             }
 
             // Get the score column set id from colScore.
@@ -192,17 +193,18 @@ namespace Microsoft.ML.Runtime.Data
             schema[colScore].Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnSetId, ref setId);
 
             ReadOnlyMemory<char> tmp = default;
-            foreach (var col in schema.GetColumnSet(MetadataUtils.Kinds.ScoreColumnSetId, setId))
+            foreach (var colIdx in schema.GetColumnSet(MetadataUtils.Kinds.ScoreColumnSetId, setId))
             {
                 // REVIEW: What should this do about hidden columns? Currently we ignore them.
-                if (schema[col].IsHidden)
+                var col = schema[colIdx];
+                if (col.IsHidden)
                     continue;
-                if (schema.TryGetMetadata(TextType.Instance, MetadataUtils.Kinds.ScoreValueKind, col, ref tmp) &&
-                    ReadOnlyMemoryUtils.EqualsStr(valueKind, tmp))
+
+                if (col.Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreValueKind)?.Type == TextType.Instance)
                 {
-                    var res = ColumnInfo.CreateFromIndex(schema, col);
-                    if (testType(res.Type))
-                        return res;
+                    col.Metadata.GetValue(MetadataUtils.Kinds.ScoreValueKind, ref tmp);
+                    if (ReadOnlyMemoryUtils.EqualsStr(valueKind, tmp) && testType(col.Type))
+                        return col;
                 }
             }
 

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -226,20 +226,17 @@ namespace Microsoft.ML.Runtime.Data
         }
 
         /// <summary>
-        /// If str is non-empty, returns it. Otherwise if info is non-null, returns info.Name.
-        /// Otherwise, returns def.
+        /// If <paramref name="str"/> is non-empty, returns it. Otherwise if <paramref name="info"/> is non-<see langword="null"/>,
+        /// returns its <see cref="Schema.Column.Name"/>. Otherwise, returns <paramref name="def"/>.
         /// </summary>
-        public static string GetColName(string str, ColumnInfo info, string def)
+        public static string GetColName(string str, Schema.Column? info, string def)
         {
             Contracts.CheckValueOrNull(str);
-            Contracts.CheckValueOrNull(info);
             Contracts.CheckValueOrNull(def);
 
             if (!string.IsNullOrEmpty(str))
                 return str;
-            if (info != null)
-                return info.Name;
-            return def;
+            return info?.Name ?? def;
         }
 
         public static void CheckWeightType(IExceptionContext ectx, ColumnType type)

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -134,9 +134,9 @@ namespace Microsoft.ML.Runtime.Data
         private protected virtual IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRolesCore(RoleMappedSchema schema)
         {
             // Get the score column information.
-            var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(ArgumentsBase.ScoreColumn),
+            var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(ArgumentsBase.ScoreColumn),
                 ScoreColumnKind);
-            yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);
+            yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreCol.Name);
 
             // Get the label column information.
             string label = EvaluateUtils.GetColName(LabelCol, schema.Label, DefaultColumnNames.Label);

--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -119,8 +119,8 @@ namespace Microsoft.ML.Runtime.Data
                 ? Enumerable.Empty<KeyValuePair<RoleMappedSchema.ColumnRole, string>>()
                 : StratCols.Select(col => RoleMappedSchema.CreatePair(Strat, col));
 
-            if (needName && schema.Name != null)
-                roles = MetadataUtils.Prepend(roles, RoleMappedSchema.ColumnRole.Name.Bind(schema.Name.Name));
+            if (needName && schema.Name.HasValue)
+                roles = MetadataUtils.Prepend(roles, RoleMappedSchema.ColumnRole.Name.Bind(schema.Name.Value.Name));
 
             return roles.Concat(GetInputColumnRolesCore(schema));
         }
@@ -239,7 +239,12 @@ namespace Microsoft.ML.Runtime.Data
                 colsToKeep.Add(MetricKinds.ColumnNames.FoldIndex);
 
             // Maml always outputs a name column, if it doesn't exist add a GenerateNumberTransform.
-            if (perInst.Schema.Name == null)
+            if (perInst.Schema.Name?.Name is string nameName)
+            {
+                cols.Add((nameName, "Instance"));
+                colsToKeep.Add("Instance");
+            }
+            else
             {
                 var args = new GenerateNumberTransform.Arguments();
                 args.Column = new[] { new GenerateNumberTransform.Column() { Name = "Instance" } };
@@ -247,15 +252,10 @@ namespace Microsoft.ML.Runtime.Data
                 idv = new GenerateNumberTransform(Host, args, idv);
                 colsToKeep.Add("Instance");
             }
-            else
-            {
-                cols.Add((perInst.Schema.Name.Name, "Instance"));
-                colsToKeep.Add("Instance");
-            }
 
             // Maml outputs the weight column if it exists.
-            if (perInst.Schema.Weight != null)
-                colsToKeep.Add(perInst.Schema.Weight.Name);
+            if (perInst.Schema.Weight?.Name is string weightName)
+                colsToKeep.Add(weightName);
 
             // Get the other columns from the evaluator.
             foreach (var col in GetPerInstanceColumnsToSave(perInst.Schema))

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -78,10 +78,10 @@ namespace Microsoft.ML.Runtime.Data
             var t = score.Type;
             if (t.VectorSize < 2 || t.ItemType != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type {1} but must be a vector of two or more items of type R4", score.Name, t);
-            Host.Check(schema.Label != null, "Could not find the label column");
-            t = schema.Label.Type;
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Could not find the label column");
+            t = schema.Label.Value.Type;
             if (t != NumberType.Float && t.KeyCount <= 0)
-                throw Host.Except("Label column '{0}' has type {1} but must be a float or a known-cardinality key", schema.Label.Name, t);
+                throw Host.Except("Label column '{0}' has type {1} but must be a float or a known-cardinality key", schema.Label.Value.Name, t);
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
@@ -119,10 +119,10 @@ namespace Microsoft.ML.Runtime.Data
 
         private protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
         {
-            Host.CheckParam(schema.Label != null, nameof(schema), "Schema must contain a label column");
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Schema must contain a label column");
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             int numClasses = scoreInfo.Type.VectorSize;
-            return new MultiClassPerInstanceEvaluator(Host, schema.Schema, scoreInfo, schema.Label.Name);
+            return new MultiClassPerInstanceEvaluator(Host, schema.Schema, scoreInfo, schema.Label.Value.Name);
         }
 
         public override IEnumerable<MetricColumn> GetOverallMetricColumns()
@@ -390,17 +390,17 @@ namespace Microsoft.ML.Runtime.Data
             internal override void InitializeNextPass(Row row, RoleMappedSchema schema)
             {
                 Host.Assert(PassNum < 1);
-                Host.AssertValue(schema.Label);
+                Host.Assert(schema.Label.HasValue);
 
                 var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
                 Host.Assert(score.Type.VectorSize == _scoresArr.Length);
-                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Index);
+                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
                 _scoreGetter = row.GetGetter<VBuffer<float>>(score.Index);
                 Host.AssertValue(_labelGetter);
                 Host.AssertValue(_scoreGetter);
 
-                if (schema.Weight != null)
-                    _weightGetter = row.GetGetter<float>(schema.Weight.Index);
+                if (schema.Weight.HasValue)
+                    _weightGetter = row.GetGetter<float>(schema.Weight.Value.Index);
             }
 
             public override void ProcessRow()
@@ -567,15 +567,15 @@ namespace Microsoft.ML.Runtime.Data
         private readonly ReadOnlyMemory<char>[] _classNames;
         private readonly ColumnType[] _types;
 
-        public MultiClassPerInstanceEvaluator(IHostEnvironment env, Schema schema, ColumnInfo scoreInfo, string labelCol)
-            : base(env, schema, Contracts.CheckRef(scoreInfo, nameof(scoreInfo)).Name, labelCol)
+        public MultiClassPerInstanceEvaluator(IHostEnvironment env, Schema schema, Schema.Column scoreColumn, string labelCol)
+            : base(env, schema, scoreColumn.Name, labelCol)
         {
             CheckInputColumnTypes(schema);
 
-            _numClasses = scoreInfo.Type.VectorSize;
+            _numClasses = scoreColumn.Type.VectorSize;
             _types = new ColumnType[4];
 
-            if (schema[(int) ScoreIndex].HasSlotNames(_numClasses))
+            if (schema[ScoreIndex].HasSlotNames(_numClasses))
             {
                 var classNames = default(VBuffer<ReadOnlyMemory<char>>);
                 schema[(int) ScoreIndex].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref classNames);
@@ -981,10 +981,10 @@ namespace Microsoft.ML.Runtime.Data
         private protected override IEnumerable<string> GetPerInstanceColumnsToSave(RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
-            Host.CheckParam(schema.Label != null, nameof(schema), "Schema must contain a label column");
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Schema must contain a label column");
 
             // Output the label column.
-            yield return schema.Label.Name;
+            yield return schema.Label.Value.Name;
 
             // Return the output columns.
             yield return MultiClassPerInstanceEvaluator.Assigned;
@@ -998,13 +998,14 @@ namespace Microsoft.ML.Runtime.Data
         {
             // If the label column is a key without key values, convert it to I8, just for saving the per-instance
             // text file, since if there are different key counts the columns cannot be appended.
-            if (!perInst.Schema.TryGetColumnIndex(schema.Label.Name, out int labelCol))
-                throw Host.Except("Could not find column '{0}'", schema.Label.Name);
+            string labelName = schema.Label.Value.Name;
+            if (!perInst.Schema.TryGetColumnIndex(labelName, out int labelCol))
+                throw Host.Except("Could not find column '{0}'", labelName);
             var labelType = perInst.Schema[labelCol].Type;
-            if (labelType is KeyType keyType && (!(bool) perInst.Schema[labelCol].HasKeyValues(keyType.KeyCount) || labelType.RawKind != DataKind.U4))
+            if (labelType is KeyType keyType && (!(bool)perInst.Schema[labelCol].HasKeyValues(keyType.KeyCount) || labelType.RawKind != DataKind.U4))
             {
-                perInst = LambdaColumnMapper.Create(Host, "ConvertToDouble", perInst, schema.Label.Name,
-                    schema.Label.Name, perInst.Schema[labelCol].Type, NumberType.R8,
+                perInst = LambdaColumnMapper.Create(Host, "ConvertToDouble", perInst, labelName,
+                    labelName, perInst.Schema[labelCol].Type, NumberType.R8,
                     (in uint src, ref double dst) => dst = src == 0 ? double.NaN : src - 1 + (double)keyType.Min);
             }
 
@@ -1022,7 +1023,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 var type = perInst.Schema[sortedScoresIndex].Type;
                 if (_numTopClasses < type.VectorSize)
-                   perInst = new SlotsDroppingTransformer(Host, MultiClassPerInstanceEvaluator.SortedScores, min: _numTopClasses).Transform(perInst);
+                    perInst = new SlotsDroppingTransformer(Host, MultiClassPerInstanceEvaluator.SortedScores, min: _numTopClasses).Transform(perInst);
             }
             return perInst;
         }

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -77,11 +77,11 @@ namespace Microsoft.ML.Runtime.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type;
             if (t.VectorSize < 2 || t.ItemType != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type {1} but must be a vector of two or more items of type R4", score.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "vector of two or more items of type R4", t.ToString());
             Host.CheckParam(schema.Label.HasValue, nameof(schema), "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.Float && t.KeyCount <= 0)
-                throw Host.Except("Label column '{0}' has type {1} but must be a float or a known-cardinality key", schema.Label.Value.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or a known-cardinality key", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -60,11 +60,11 @@ namespace Microsoft.ML.Runtime.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type;
             if (t.VectorSize == 0 || t.ItemType != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type '{1}' but must be a known length vector of type R4", score.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "known size vector of R4", t.ToString());
             Host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (!t.IsKnownSizeVector || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
-                throw Host.Except("Label column '{0}' has type '{1}' but must be a known-size vector of R4 or R8", schema.Label.Value.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "known size vector of R4 or R8", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -645,9 +645,9 @@ namespace Microsoft.ML.Runtime.Data
             {
                 yield return schema.Label.Value.Name;
 
-                var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
+                var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                     MetadataUtils.Const.ScoreColumnKind.MultiOutputRegression);
-                yield return scoreInfo.Name;
+                yield return scoreCol.Name;
             }
 
             // Return the output columns.

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -49,11 +49,10 @@ namespace Microsoft.ML.Runtime.Data
 
         private protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
         {
-            Host.CheckParam(schema.Label != null, nameof(schema), "Could not find the label column");
-            var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
-            Host.AssertValue(scoreInfo);
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Could not find the label column");
+            var scoreCol = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
 
-            return new MultiOutputRegressionPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, schema.Label.Name);
+            return new MultiOutputRegressionPerInstanceEvaluator(Host, schema.Schema, scoreCol.Name, schema.Label.Value.Name);
         }
 
         private protected override void CheckScoreAndLabelTypes(RoleMappedSchema schema)
@@ -62,10 +61,10 @@ namespace Microsoft.ML.Runtime.Data
             var t = score.Type;
             if (t.VectorSize == 0 || t.ItemType != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type '{1}' but must be a known length vector of type R4", score.Name, t);
-            Host.Check(schema.Label != null, "Could not find the label column");
-            t = schema.Label.Type;
+            Host.Check(schema.Label.HasValue, "Could not find the label column");
+            t = schema.Label.Value.Type;
             if (!t.IsKnownSizeVector || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
-                throw Host.Except("Label column '{0}' has type '{1}' but must be a known-size vector of R4 or R8", schema.Label.Name, t);
+                throw Host.Except("Label column '{0}' has type '{1}' but must be a known-size vector of R4 or R8", schema.Label.Value.Name, t);
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
@@ -302,17 +301,17 @@ namespace Microsoft.ML.Runtime.Data
             internal override void InitializeNextPass(Row row, RoleMappedSchema schema)
             {
                 Contracts.Assert(PassNum < 1);
-                Contracts.AssertValue(schema.Label);
+                Contracts.Assert(schema.Label.HasValue);
 
                 var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
 
-                _labelGetter = RowCursorUtils.GetVecGetterAs<Float>(NumberType.Float, row, schema.Label.Index);
+                _labelGetter = RowCursorUtils.GetVecGetterAs<Float>(NumberType.Float, row, schema.Label.Value.Index);
                 _scoreGetter = row.GetGetter<VBuffer<Float>>(score.Index);
                 Contracts.AssertValue(_labelGetter);
                 Contracts.AssertValue(_scoreGetter);
 
-                if (schema.Weight != null)
-                    _weightGetter = row.GetGetter<Float>(schema.Weight.Index);
+                if (schema.Weight.HasValue)
+                    _weightGetter = row.GetGetter<Float>(schema.Weight.Value.Index);
             }
 
             public override void ProcessRow()
@@ -644,7 +643,7 @@ namespace Microsoft.ML.Runtime.Data
             // The multi output regression evaluator outputs the label and score column if requested by the user.
             if (!_supressScoresAndLabels)
             {
-                yield return schema.Label.Name;
+                yield return schema.Label.Value.Name;
 
                 var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                     MetadataUtils.Const.ScoreColumnKind.MultiOutputRegression);

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -545,9 +545,9 @@ namespace Microsoft.ML.Runtime.Data
 
             // The quantile regression evaluator outputs the label and score columns.
             yield return schema.Label.Value.Name;
-            var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
+            var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.QuantileRegression);
-            yield return scoreInfo.Name;
+            yield return scoreCol.Name;
 
             // Return the output columns.
             yield return RegressionPerInstanceEvaluator.L1;

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Runtime.Data
             Host.CheckParam(schema.Label.HasValue, nameof(schema), "Must contain a label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "score", schema.Label.Value.Name, "R4", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "R4", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -58,14 +58,11 @@ namespace Microsoft.ML.Runtime.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type;
             if (t.VectorSize == 0 || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
-            {
-                throw Host.Except(
-                    "Score column '{0}' has type '{1}' but must be a known length vector of type R4 or R8", score.Name, t);
-            }
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "vector of type R4 or R8", t.ToString());
             Host.CheckParam(schema.Label.HasValue, nameof(schema), "Must contain a label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4", schema.Label.Value.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", schema.Label.Value.Name, "R4", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -938,9 +938,9 @@ namespace Microsoft.ML.Runtime.Data
             // The ranking evaluator outputs the label, group key and score columns.
             yield return schema.Group.Value.Name;
             yield return schema.Label.Value.Name;
-            var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
+            var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.Ranking);
-            yield return scoreInfo.Name;
+            yield return scoreCol.Name;
 
             // Return the output columns.
             yield return RankerPerInstanceTransform.Ndcg;

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -89,14 +89,14 @@ namespace Microsoft.ML.Runtime.Data
             var t = schema.Label.Value.Type;
             if (t != NumberType.Float && !(t is KeyType))
             {
-                throw Host.ExceptUserArg(nameof(RankerMamlEvaluator.Arguments.LabelColumn), "Label column '{0}' has type '{1}' but must be R4 or a key",
-                    schema.Label.Value.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(RankerMamlEvaluator.Arguments.LabelColumn),
+                    "label", schema.Label.Value.Name, "R4 or a key", t.ToString());
             }
-            var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
-            if (scoreInfo.Type != NumberType.Float)
+            var scoreCol = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
+            if (scoreCol.Type != NumberType.Float)
             {
-                throw Host.ExceptUserArg(nameof(RankerMamlEvaluator.Arguments.ScoreColumn), "Score column '{0}' has type '{1}' but must be R4",
-                    scoreInfo.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(RankerMamlEvaluator.Arguments.ScoreColumn),
+                    "score", scoreCol.Name, "R4", t.ToString());
             }
         }
 
@@ -105,9 +105,8 @@ namespace Microsoft.ML.Runtime.Data
             var t = schema.Group.Value.Type;
             if (!(t is KeyType))
             {
-                throw Host.ExceptUserArg(nameof(RankerMamlEvaluator.Arguments.GroupIdColumn),
-                    "Group column '{0}' has type '{1}' but must be a key",
-                    schema.Group.Value.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(RankerMamlEvaluator.Arguments.GroupIdColumn),
+                    "group", schema.Group.Value.Name, "key", t.ToString());
             }
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -57,11 +57,11 @@ namespace Microsoft.ML.Runtime.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type;
             if (t != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type '{1}' but must be R4", score, t);
-            Host.Check(schema.Label.HasValue, "Could not find the label column");
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "R4", t.ToString());
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4", schema.Label.Value.Name, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "R4", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -356,9 +356,9 @@ namespace Microsoft.ML.Runtime.Data
 
             // The regression evaluator outputs the label and score columns.
             yield return schema.Label.Value.Name;
-            var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
+            var scoreCol = EvaluateUtils.GetScoreColumn(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.Regression);
-            yield return scoreInfo.Name;
+            yield return scoreCol.Name;
 
             // Return the output columns.
             yield return RegressionPerInstanceEvaluator.L1;

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -56,12 +56,12 @@ namespace Microsoft.ML.Runtime.Data
         {
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type;
-            if (t.IsVector || t.ItemType != NumberType.Float)
+            if (t != NumberType.Float)
                 throw Host.Except("Score column '{0}' has type '{1}' but must be R4", score, t);
-            Host.Check(schema.Label != null, "Could not find the label column");
-            t = schema.Label.Type;
+            Host.Check(schema.Label.HasValue, "Could not find the label column");
+            t = schema.Label.Value.Type;
             if (t != NumberType.R4)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4", schema.Label.Name, t);
+                throw Host.Except("Label column '{0}' has type '{1}' but must be R4", schema.Label.Value.Name, t);
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
@@ -71,11 +71,10 @@ namespace Microsoft.ML.Runtime.Data
 
         private protected override IRowMapper CreatePerInstanceRowMapper(RoleMappedSchema schema)
         {
-            Contracts.CheckParam(schema.Label != null, nameof(schema), "Could not find the label column");
+            Contracts.CheckParam(schema.Label.HasValue, nameof(schema), "Could not find the label column");
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
-            Contracts.AssertValue(scoreInfo);
 
-            return new RegressionPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, schema.Label.Name);
+            return new RegressionPerInstanceEvaluator(Host, schema.Schema, scoreInfo.Name, schema.Label.Value.Name);
         }
 
         public override IEnumerable<MetricColumn> GetOverallMetricColumns()
@@ -353,10 +352,10 @@ namespace Microsoft.ML.Runtime.Data
         private protected override IEnumerable<string> GetPerInstanceColumnsToSave(RoleMappedSchema schema)
         {
             Host.CheckValue(schema, nameof(schema));
-            Host.CheckParam(schema.Label != null, nameof(schema), "Schema must contain a label column");
+            Host.CheckParam(schema.Label.HasValue, nameof(schema), "Schema must contain a label column");
 
             // The regression evaluator outputs the label and score columns.
-            yield return schema.Label.Name;
+            yield return schema.Label.Value.Name;
             var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, schema.Schema, ScoreCol, nameof(Arguments.ScoreColumn),
                 MetadataUtils.Const.ScoreColumnKind.Regression);
             yield return scoreInfo.Name;

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluatorBase.cs
@@ -197,17 +197,17 @@ namespace Microsoft.ML.Runtime.Data
             internal override void InitializeNextPass(Row row, RoleMappedSchema schema)
             {
                 Contracts.Assert(PassNum < 1);
-                Contracts.AssertValue(schema.Label);
+                Contracts.Assert(schema.Label.HasValue);
 
                 var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
 
-                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Index);
+                _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
                 _scoreGetter = row.GetGetter<TScore>(score.Index);
                 Contracts.AssertValue(_labelGetter);
                 Contracts.AssertValue(_scoreGetter);
 
-                if (schema.Weight != null)
-                    _weightGetter = row.GetGetter<float>(schema.Weight.Index);
+                if (schema.Weight.HasValue)
+                    _weightGetter = row.GetGetter<float>(schema.Weight.Value.Index);
             }
 
             public override void ProcessRow()

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -122,10 +122,9 @@ namespace Microsoft.ML.Runtime.Data
             using (var ch = env.Register("SchemaBindableWrapper").Start("Bind"))
             {
                 ch.CheckValue(schema, nameof(schema));
-                if (schema.Feature != null)
+                if (schema.Feature?.Type is ColumnType type)
                 {
                     // Ensure that the feature column type is compatible with the needed input type.
-                    var type = schema.Feature.Type;
                     var typeIn = ValueMapper != null ? ValueMapper.InputType : new VectorType(NumberType.Float);
                     if (type != typeIn)
                     {
@@ -199,7 +198,7 @@ namespace Microsoft.ML.Runtime.Data
             {
                 Contracts.AssertValue(schema);
                 Contracts.AssertValue(parent);
-                Contracts.AssertValue(schema.Feature);
+                Contracts.Assert(schema.Feature.HasValue);
                 Contracts.Assert(outputSchema.Count == 1);
 
                 _parent = parent;
@@ -212,14 +211,14 @@ namespace Microsoft.ML.Runtime.Data
                 for (int i = 0; i < OutputSchema.Count; i++)
                 {
                     if (predicate(i))
-                        return col => col == InputRoleMappedSchema.Feature.Index;
+                        return col => col == InputRoleMappedSchema.Feature.Value.Index;
                 }
                 return col => false;
             }
 
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {
-                yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputRoleMappedSchema.Feature.Name);
+                yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputRoleMappedSchema.Feature.Value.Name);
             }
 
             public Schema InputSchema => InputRoleMappedSchema.Schema;
@@ -231,7 +230,7 @@ namespace Microsoft.ML.Runtime.Data
 
                 var getters = new Delegate[1];
                 if (predicate(0))
-                    getters[0] = _parent.GetPredictionGetter(input, InputRoleMappedSchema.Feature.Index);
+                    getters[0] = _parent.GetPredictionGetter(input, InputRoleMappedSchema.Feature.Value.Index);
                 return new SimpleRow(OutputSchema, input, getters);
             }
         }
@@ -290,11 +289,11 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(ctx, nameof(ctx));
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.Assert(ValueMapper is ISingleCanSavePfa);
-            Contracts.AssertValue(schema.Feature);
+            Contracts.Assert(schema.Feature.HasValue);
             Contracts.Assert(Utils.Size(outputNames) == 1); // Score.
             var mapper = (ISingleCanSavePfa)ValueMapper;
             // If the features column was not produced, we must hide the outputs.
-            var featureToken = ctx.TokenOrNullForName(schema.Feature.Name);
+            var featureToken = ctx.TokenOrNullForName(schema.Feature.Value.Name);
             if (featureToken == null)
                 ctx.Hide(outputNames);
             var scoreToken = mapper.SaveAsPfa(ctx, featureToken);
@@ -306,15 +305,14 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(ctx, nameof(ctx));
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.Assert(ValueMapper is ISingleCanSaveOnnx);
-            Contracts.AssertValue(schema.Feature);
+            Contracts.Assert(schema.Feature.HasValue);
             Contracts.Assert(Utils.Size(outputNames) <= 2); // PredictedLabel and/or Score.
             var mapper = (ISingleCanSaveOnnx)ValueMapper;
-            if (!ctx.ContainsColumn(schema.Feature.Name))
+            string featName = schema.Feature.Value.Name;
+            if (!ctx.ContainsColumn(featName))
                 return false;
-
-            Contracts.Assert(ctx.ContainsColumn(schema.Feature.Name));
-
-            return mapper.SaveAsOnnx(ctx, outputNames, ctx.GetVariableName(schema.Feature.Name));
+            Contracts.Assert(ctx.ContainsColumn(featName));
+            return mapper.SaveAsOnnx(ctx, outputNames, ctx.GetVariableName(featName));
         }
 
         private protected override ISchemaBoundMapper BindCore(IChannel ch, RoleMappedSchema schema)
@@ -401,11 +399,11 @@ namespace Microsoft.ML.Runtime.Data
             Contracts.CheckValue(ctx, nameof(ctx));
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.Assert(ValueMapper is IDistCanSavePfa);
-            Contracts.AssertValue(schema.Feature);
+            Contracts.Assert(schema.Feature.HasValue);
             Contracts.Assert(Utils.Size(outputNames) == 2); // Score and prob.
             var mapper = (IDistCanSavePfa)ValueMapper;
             // If the features column was not produced, we must hide the outputs.
-            string featureToken = ctx.TokenOrNullForName(schema.Feature.Name);
+            string featureToken = ctx.TokenOrNullForName(schema.Feature.Value.Name);
             if (featureToken == null)
                 ctx.Hide(outputNames);
 
@@ -423,15 +421,14 @@ namespace Microsoft.ML.Runtime.Data
 
             var mapper = ValueMapper as ISingleCanSaveOnnx;
             Contracts.CheckValue(mapper, nameof(mapper));
-            Contracts.AssertValue(schema.Feature);
+            Contracts.Assert(schema.Feature.HasValue);
             Contracts.Assert(Utils.Size(outputNames) == 3); // Predicted Label, Score and Probablity.
 
-            if (!ctx.ContainsColumn(schema.Feature.Name))
+            var featName = schema.Feature.Value.Name;
+            if (!ctx.ContainsColumn(featName))
                 return false;
-
-            Contracts.Assert(ctx.ContainsColumn(schema.Feature.Name));
-
-            return mapper.SaveAsOnnx(ctx, outputNames, ctx.GetVariableName(schema.Feature.Name));
+            Contracts.Assert(ctx.ContainsColumn(featName));
+            return mapper.SaveAsOnnx(ctx, outputNames, ctx.GetVariableName(featName));
         }
 
         private void CheckValid(out IValueMapperDist distMapper)
@@ -481,15 +478,13 @@ namespace Microsoft.ML.Runtime.Data
                 Contracts.AssertValue(parent);
                 Contracts.Assert(parent._distMapper != null);
                 Contracts.AssertValue(schema);
-                Contracts.AssertValueOrNull(schema.Feature);
 
                 _parent = parent;
                 InputRoleMappedSchema = schema;
                 OutputSchema = Schema.Create(new BinaryClassifierSchema());
 
-                if (schema.Feature != null)
+                if (schema.Feature?.Type is ColumnType typeSrc)
                 {
-                    var typeSrc = InputRoleMappedSchema.Feature.Type;
                     Contracts.Check(typeSrc.IsKnownSizeVector && typeSrc.ItemType == NumberType.Float,
                         "Invalid feature column type");
                 }
@@ -499,8 +494,8 @@ namespace Microsoft.ML.Runtime.Data
             {
                 for (int i = 0; i < OutputSchema.Count; i++)
                 {
-                    if (predicate(i) && InputRoleMappedSchema.Feature != null)
-                        return col => col == InputRoleMappedSchema.Feature.Index;
+                    if (predicate(i) && InputRoleMappedSchema.Feature?.Index is int idx)
+                        return col => col == idx;
                 }
                 return col => false;
             }
@@ -519,7 +514,7 @@ namespace Microsoft.ML.Runtime.Data
                 if (active[0] || active[1])
                 {
                     // Put all captured locals at this scope.
-                    var featureGetter = InputRoleMappedSchema.Feature != null ? input.GetGetter<VBuffer<Float>>(InputRoleMappedSchema.Feature.Index) : null;
+                    var featureGetter = InputRoleMappedSchema.Feature?.Index is int idx ? input.GetGetter<VBuffer<Float>>(idx) : null;
                     Float prob = 0;
                     Float score = 0;
                     long cachedPosition = -1;

--- a/src/Microsoft.ML.Data/Transforms/NormalizeUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeUtils.cs
@@ -70,27 +70,6 @@ namespace Microsoft.ML.Runtime.Data
         NormalizingTransformer.NormalizerModelParametersBase GetNormalizerModelParams();
     }
 
-    internal static class NormalizeUtils
-    {
-        /// <summary>
-        /// Returns whether the feature column in the schema is indicated to be normalized. If the features column is not
-        /// specified on the schema, then this will return <c>null</c>.
-        /// </summary>
-        /// <param name="schema">The role-mapped schema to query</param>
-        /// <returns>Returns null if <paramref name="schema"/> does not have <see cref="RoleMappedSchema.Feature"/>
-        /// defined, and otherwise returns a Boolean value as returned from <see cref="MetadataUtils.IsNormalized(Schema.Column)"/>
-        /// on that feature column</returns>
-        /// <seealso cref="MetadataUtils.IsNormalized(Schema.Column)"/>
-        public static bool? FeaturesAreNormalized(this RoleMappedSchema schema)
-        {
-            // REVIEW: The role mapped data has the ability to have multiple columns fill the role of features, which is
-            // useful in some trainers that are nonetheless parameteric and can therefore benefit from normalization.
-            Contracts.CheckValue(schema, nameof(schema));
-            var featInfo = schema.Feature;
-            return featInfo == null ? default(bool?) : schema.Schema[featInfo.Index].IsNormalized();
-        }
-    }
-
     /// <summary>
     /// This contains entry-point definitions related to <see cref="NormalizeTransform"/>.
     /// </summary>

--- a/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
+++ b/src/Microsoft.ML.Ensemble/EnsembleUtils.cs
@@ -18,17 +18,18 @@ namespace Microsoft.ML.Runtime.Ensemble
         {
             Contracts.AssertValue(host);
             Contracts.AssertValue(data);
-            Contracts.Assert(data.Schema.Feature != null);
+            Contracts.Assert(data.Schema.Feature.HasValue);
             Contracts.AssertValue(features);
+            var featCol = data.Schema.Feature.Value;
 
-            var type = data.Schema.Feature.Type;
+            var type = featCol.Type;
             Contracts.Assert(features.Length == type.VectorSize);
             int card = Utils.GetCardinality(features);
             if (card == type.VectorSize)
                 return data;
 
             // REVIEW: This doesn't preserve metadata on the features column. Should it?
-            var name = data.Schema.Feature.Name;
+            var name = featCol.Name;
             var view = LambdaColumnMapper.Create(
                 host, "FeatureSelector", data.Data, name, name, type, type,
                 (in VBuffer<Single> src, ref VBuffer<Single> dst) => SelectFeatures(in src, features, card, ref dst));

--- a/src/Microsoft.ML.Ensemble/Selector/FeatureSelector/RandomFeatureSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/FeatureSelector/RandomFeatureSelector.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.FeatureSelector
             _host.CheckValue(data, nameof(data));
             data.CheckFeatureFloatVector();
 
-            var type = data.Schema.Feature.Type;
+            var type = data.Schema.Feature.Value.Type;
             int len = type.VectorSize;
             var features = new BitArray(len);
             for (int j = 0; j < len; j++)

--- a/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseSubModelSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseSubModelSelector.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubModelSelector
             switch (PredictionKind)
             {
                 case PredictionKind.BinaryClassification:
-                    yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Name);
+                    yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Value.Name);
                     var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, scoredSchema, null, nameof(BinaryClassifierMamlEvaluator.ArgumentsBase.ScoreColumn),
                         MetadataUtils.Const.ScoreColumnKind.BinaryClassification);
                     yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);
@@ -117,13 +117,13 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubModelSelector
                         yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probInfo.Name);
                     yield break;
                 case PredictionKind.Regression:
-                    yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Name);
+                    yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Value.Name);
                     scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, scoredSchema, null, nameof(RegressionMamlEvaluator.Arguments.ScoreColumn),
                         MetadataUtils.Const.ScoreColumnKind.Regression);
                     yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);
                     yield break;
                 case PredictionKind.MultiClassClassification:
-                    yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Name);
+                    yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Value.Name);
                     scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, scoredSchema, null, nameof(MultiClassMamlEvaluator.Arguments.ScoreColumn),
                         MetadataUtils.Const.ScoreColumnKind.MultiClassClassification);
                     yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);

--- a/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseSubModelSelector.cs
+++ b/src/Microsoft.ML.Ensemble/Selector/SubModelSelector/BaseSubModelSelector.cs
@@ -107,26 +107,26 @@ namespace Microsoft.ML.Runtime.Ensemble.Selector.SubModelSelector
             {
                 case PredictionKind.BinaryClassification:
                     yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Value.Name);
-                    var scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, scoredSchema, null, nameof(BinaryClassifierMamlEvaluator.ArgumentsBase.ScoreColumn),
+                    var scoreCol = EvaluateUtils.GetScoreColumn(Host, scoredSchema, null, nameof(BinaryClassifierMamlEvaluator.ArgumentsBase.ScoreColumn),
                         MetadataUtils.Const.ScoreColumnKind.BinaryClassification);
-                    yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);
+                    yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreCol.Name);
                     // Get the optional probability column.
-                    var probInfo = EvaluateUtils.GetOptAuxScoreColumnInfo(Host, scoredSchema, null, nameof(BinaryClassifierMamlEvaluator.Arguments.ProbabilityColumn),
-                        scoreInfo.Index, MetadataUtils.Const.ScoreValueKind.Probability, t => t == NumberType.Float);
-                    if (probInfo != null)
-                        yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probInfo.Name);
+                    var probCol = EvaluateUtils.GetOptAuxScoreColumn(Host, scoredSchema, null, nameof(BinaryClassifierMamlEvaluator.Arguments.ProbabilityColumn),
+                        scoreCol.Index, MetadataUtils.Const.ScoreValueKind.Probability, NumberType.Float.Equals);
+                    if (probCol.HasValue)
+                        yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Probability, probCol.Value.Name);
                     yield break;
                 case PredictionKind.Regression:
                     yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Value.Name);
-                    scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, scoredSchema, null, nameof(RegressionMamlEvaluator.Arguments.ScoreColumn),
+                    scoreCol = EvaluateUtils.GetScoreColumn(Host, scoredSchema, null, nameof(RegressionMamlEvaluator.Arguments.ScoreColumn),
                         MetadataUtils.Const.ScoreColumnKind.Regression);
-                    yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);
+                    yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreCol.Name);
                     yield break;
                 case PredictionKind.MultiClassClassification:
                     yield return RoleMappedSchema.CreatePair(RoleMappedSchema.ColumnRole.Label, testSchema.Label.Value.Name);
-                    scoreInfo = EvaluateUtils.GetScoreColumnInfo(Host, scoredSchema, null, nameof(MultiClassMamlEvaluator.Arguments.ScoreColumn),
+                    scoreCol = EvaluateUtils.GetScoreColumn(Host, scoredSchema, null, nameof(MultiClassMamlEvaluator.Arguments.ScoreColumn),
                         MetadataUtils.Const.ScoreColumnKind.MultiClassClassification);
-                    yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreInfo.Name);
+                    yield return RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, scoreCol.Name);
                     yield break;
                 default:
                     throw Host.Except("Unrecognized prediction kind '{0}'", PredictionKind);

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -149,7 +149,7 @@ namespace Microsoft.ML.Runtime.EntryPoints
             return viewTrain;
         }
 
-        private static List<KeyToVectorMappingTransformer.ColumnInfo> ConvertFeatures(ColumnInfo[] feats, HashSet<string> featNames, List<KeyValuePair<string, string>> concatNames, IChannel ch,
+        private static List<KeyToVectorMappingTransformer.ColumnInfo> ConvertFeatures(IEnumerable<Schema.Column> feats, HashSet<string> featNames, List<KeyValuePair<string, string>> concatNames, IChannel ch,
             out List<TypeConvertingTransformer.ColumnInfo> cvt, out int errCount)
         {
             Contracts.AssertValue(feats);

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 trainData.CheckBinaryLabel();
                 trainData.CheckFeatureFloatVector();
                 trainData.CheckOptFloatWeight();
-                FeatureCount = trainData.Schema.Feature.Type.ValueCount;
+                FeatureCount = trainData.Schema.Feature.Value.Type.ValueCount;
                 ConvertData(trainData);
                 TrainCore(ch);
             }

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -125,7 +125,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 var maxLabel = GetLabelGains().Length - 1;
                 ConvertData(trainData);
                 TrainCore(ch);
-                FeatureCount = trainData.Schema.Feature.Type.ValueCount;
+                FeatureCount = trainData.Schema.Feature.Value.Type.ValueCount;
             }
             return new FastTreeRankingModelParameters(Host, TrainedEnsemble, FeatureCount, InnerArgs);
         }

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 trainData.CheckRegressionLabel();
                 trainData.CheckFeatureFloatVector();
                 trainData.CheckOptFloatWeight();
-                FeatureCount = trainData.Schema.Feature.Type.ValueCount;
+                FeatureCount = trainData.Schema.Feature.Value.Type.ValueCount;
                 ConvertData(trainData);
                 TrainCore(ch);
             }

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 trainData.CheckRegressionLabel();
                 trainData.CheckFeatureFloatVector();
                 trainData.CheckOptFloatWeight();
-                FeatureCount = trainData.Schema.Feature.Type.ValueCount;
+                FeatureCount = trainData.Schema.Feature.Value.Type.ValueCount;
                 ConvertData(trainData);
                 TrainCore(ch);
             }

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 trainData.CheckBinaryLabel();
                 trainData.CheckFeatureFloatVector();
                 trainData.CheckOptFloatWeight();
-                FeatureCount = trainData.Schema.Feature.Type.ValueCount;
+                FeatureCount = trainData.Schema.Feature.Value.Type.ValueCount;
                 ConvertData(trainData);
                 TrainCore(ch);
             }

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -201,7 +201,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 trainData.CheckRegressionLabel();
                 trainData.CheckFeatureFloatVector();
                 trainData.CheckOptFloatWeight();
-                FeatureCount = trainData.Schema.Feature.Type.ValueCount;
+                FeatureCount = trainData.Schema.Feature.Value.Type.ValueCount;
                 ConvertData(trainData);
                 TrainCore(ch);
             }

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsemble.cs
@@ -413,8 +413,8 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
         public FeaturesToContentMap(RoleMappedSchema schema)
         {
             Contracts.AssertValue(schema);
-            var feat = schema.Feature;
-            Contracts.AssertValue(feat);
+            Contracts.Assert(schema.Feature.HasValue);
+            var feat = schema.Feature.Value;
             Contracts.Assert(feat.Type.ValueCount > 0);
 
             var sch = schema.Schema;

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -141,16 +141,16 @@ namespace Microsoft.ML.Trainers.HalLearners
             {
                 ch.CheckValue(context, nameof(context));
                 var examples = context.TrainingSet;
-                ch.CheckParam(examples.Schema.Feature != null, nameof(examples), "Need a feature column");
-                ch.CheckParam(examples.Schema.Label != null, nameof(examples), "Need a labelColumn column");
+                ch.CheckParam(examples.Schema.Feature.HasValue, nameof(examples), "Need a feature column");
+                ch.CheckParam(examples.Schema.Label.HasValue, nameof(examples), "Need a labelColumn column");
 
                 // The labelColumn type must be either Float or a key type based on int (if allowKeyLabels is true).
-                var typeLab = examples.Schema.Label.Type;
+                var typeLab = examples.Schema.Label.Value.Type;
                 if (typeLab != NumberType.Float)
                     throw ch.Except("Incompatible labelColumn column type {0}, must be {1}", typeLab, NumberType.Float);
 
                 // The feature type must be a vector of Float.
-                var typeFeat = examples.Schema.Feature.Type;
+                var typeFeat = examples.Schema.Feature.Value.Type;
                 if (!typeFeat.IsKnownSizeVector)
                     throw ch.Except("Incompatible feature column type {0}, must be known sized vector of {1}", typeFeat, NumberType.Float);
                 if (typeFeat.ItemType != NumberType.Float)

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -124,13 +124,12 @@ namespace Microsoft.ML.Trainers.SymSgd
             var roles = examples.Schema.GetColumnRoleNames();
             var examplesToFeedTrain = new RoleMappedData(idvToFeedTrain, roles);
 
-            ch.AssertValue(examplesToFeedTrain.Schema.Label);
-            ch.AssertValue(examplesToFeedTrain.Schema.Feature);
-            if (examples.Schema.Weight != null)
-                ch.AssertValue(examplesToFeedTrain.Schema.Weight);
+            ch.Assert(examplesToFeedTrain.Schema.Label.HasValue);
+            ch.Assert(examplesToFeedTrain.Schema.Feature.HasValue);
+            if (examples.Schema.Weight.HasValue)
+                ch.Assert(examplesToFeedTrain.Schema.Weight.HasValue);
 
-            int numFeatures = examplesToFeedTrain.Schema.Feature.Type.VectorSize;
-            ch.Check(numFeatures > 0, "Training set has no features, aborting training.");
+            ch.Check(examplesToFeedTrain.Schema.Feature.Value.Type is VectorType vecType && vecType.Size > 0, "Training set has no features, aborting training.");
             return examplesToFeedTrain;
         }
 
@@ -637,7 +636,7 @@ namespace Microsoft.ML.Trainers.SymSgd
 
         private TPredictor TrainCore(IChannel ch, RoleMappedData data, LinearModelParameters predictor, int weightSetCount)
         {
-            int numFeatures = data.Schema.Feature.Type.VectorSize;
+            int numFeatures = data.Schema.Feature.Value.Type.VectorSize;
             var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight);
             int numThreads = 1;
             ch.CheckUserArg(numThreads > 0, nameof(_args.NumberOfThreads),

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -142,11 +142,11 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
             Host.AssertValue(ch);
             base.CheckDataValid(ch, data);
-            var labelType = data.Schema.Label.Type;
-            if (!(labelType.IsBool || labelType.IsKey || labelType == NumberType.R4))
+            var labelType = data.Schema.Label.Value.Type;
+            if (!(labelType is BoolType || labelType is KeyType || labelType == NumberType.R4))
             {
                 throw ch.ExceptParam(nameof(data),
-                    $"Label column '{data.Schema.Label.Name}' is of type '{labelType}', but must be key, boolean or R4.");
+                    $"Label column '{data.Schema.Label.Value.Name}' is of type '{labelType}', but must be key, boolean or R4.");
             }
         }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -113,11 +113,11 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
             Host.AssertValue(ch);
             base.CheckDataValid(ch, data);
-            var labelType = data.Schema.Label.Type;
+            var labelType = data.Schema.Label.Value.Type;
             if (!(labelType.IsBool || labelType.IsKey || labelType == NumberType.R4))
             {
                 throw ch.ExceptParam(nameof(data),
-                    $"Label column '{data.Schema.Label.Name}' is of type '{labelType}', but must be key, boolean or R4.");
+                    $"Label column '{data.Schema.Label.Value.Name}' is of type '{labelType}', but must be key, boolean or R4.");
             }
         }
 
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Runtime.LightGBM
                 if (maxLabel >= _maxNumClass)
                     throw ch.ExceptParam(nameof(data), $"max labelColumn cannot exceed {_maxNumClass}");
 
-                if (data.Schema.Label.Type is KeyType keyType)
+                if (data.Schema.Label.Value.Type is KeyType keyType)
                 {
                     ch.Check(keyType.Contiguous, "labelColumn value should be contiguous");
                     if (hasNaNLabel)

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -123,18 +123,21 @@ namespace Microsoft.ML.Runtime.LightGBM
             Host.AssertValue(ch);
             base.CheckDataValid(ch, data);
             // Check label types.
-            var labelType = data.Schema.Label.Type;
-            if (!(labelType.IsKey || labelType == NumberType.R4))
+            var labelCol = data.Schema.Label.Value;
+            var labelType = labelCol.Type;
+            if (!(labelType is KeyType || labelType == NumberType.R4))
             {
                 throw ch.ExceptParam(nameof(data),
-                    $"Label column '{data.Schema.Label.Name}' is of type '{labelType}', but must be key or R4.");
+                    $"Label column '{labelCol.Name}' is of type '{labelType}', but must be key or R4.");
             }
             // Check group types.
-            var groupType = data.Schema.Group.Type;
-            if (!(groupType == NumberType.U4 || groupType.IsKey))
+            ch.CheckParam(data.Schema.Group.HasValue, nameof(data), "Need a group column.");
+            var groupCol = data.Schema.Group.Value;
+            var groupType = groupCol.Type;
+            if (!(groupType == NumberType.U4 || groupType is KeyType))
             {
                 throw ch.ExceptParam(nameof(data),
-                   $"Group column '{data.Schema.Group.Name}' is of type '{groupType}', but must be U4 or a Key.");
+                   $"Group column '{groupCol.Name}' is of type '{groupType}', but must be U4 or a Key.");
             }
         }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -131,11 +131,11 @@ namespace Microsoft.ML.Runtime.LightGBM
         {
             Host.AssertValue(ch);
             base.CheckDataValid(ch, data);
-            var labelType = data.Schema.Label.Type;
+            var labelType = data.Schema.Label.Value.Type;
             if (!(labelType.IsBool || labelType.IsKey || labelType == NumberType.R4))
             {
                 throw ch.ExceptParam(nameof(data),
-                    $"Label column '{data.Schema.Label.Name}' is of type '{labelType}', but must be key, boolean or R4.");
+                    $"Label column '{data.Schema.Label.Value.Name}' is of type '{labelType}', but must be key, boolean or R4.");
             }
         }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Runtime.LightGBM
         private protected virtual void CheckDataValid(IChannel ch, RoleMappedData data)
         {
             data.CheckFeatureFloatVector();
-            ch.CheckParam(data.Schema.Label != null, nameof(data), "Need a label column");
+            ch.CheckParam(data.Schema.Label.HasValue, nameof(data), "Need a label column");
         }
 
         protected virtual void GetDefaultParameters(IChannel ch, int numRow, bool hasCategarical, int totalCats, bool hiddenMsg=false)
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Runtime.LightGBM
                 trainData.Schema.Schema.TryGetColumnIndex(DefaultColumnNames.Features, out int featureIndex);
                 MetadataUtils.TryGetCategoricalFeatureIndices(trainData.Schema.Schema, featureIndex, out categoricalFeatures);
             }
-            var colType = trainData.Schema.Feature.Type;
+            var colType = trainData.Schema.Feature.Value.Type;
             int rawNumCol = colType.VectorSize;
             FeatureCount = rawNumCol;
             catMetaData.TotalCats = 0;

--- a/src/Microsoft.ML.Recommender/RecommenderUtils.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderUtils.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
@@ -13,7 +12,7 @@ namespace Microsoft.ML.Runtime.Recommender
     {
         /// <summary>
         /// Check if the considered data, <see cref="RoleMappedData"/>, contains column roles specified by <see cref="MatrixColumnIndexKind"/> and <see cref="MatrixRowIndexKind"/>.
-        /// If the column roles, <see cref="MatrixColumnIndexKind"/> and <see cref="MatrixRowIndexKind"/>, uniquely exist in data, their <see cref="ColumnInfo"/> would be assigned
+        /// If the column roles, <see cref="MatrixColumnIndexKind"/> and <see cref="MatrixRowIndexKind"/>, uniquely exist in data, their <see cref="Schema.Column"/> would be assigned
         /// to the two out parameters below.
         /// </summary>
         /// <param name="data">The considered data being checked</param>
@@ -39,8 +38,8 @@ namespace Microsoft.ML.Runtime.Recommender
         }
 
         /// <summary>
-        /// Checks whether a column kind in a RoleMappedData is unique, and its type
-        /// is a U4 key of known cardinality.
+        /// Checks whether a column kind in a <see cref="RoleMappedData"/> is unique, and its type
+        /// is a <see cref="DataKind.U4"/> key of known cardinality.
         /// </summary>
         /// <param name="data">The training examples</param>
         /// <param name="role">The column role to try to extract</param>

--- a/src/Microsoft.ML.Recommender/RecommenderUtils.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderUtils.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime.Data;
 using Microsoft.ML.Runtime.Internal.Utilities;
 
@@ -16,10 +17,10 @@ namespace Microsoft.ML.Runtime.Recommender
         /// to the two out parameters below.
         /// </summary>
         /// <param name="data">The considered data being checked</param>
-        /// <param name="matrixColumnIndexColumn">The column as role row index in the input data</param>
-        /// <param name="matrixRowIndexColumn">The column as role column index in the input data</param>
+        /// <param name="matrixColumnIndexColumn">The schema column as the row in the input data</param>
+        /// <param name="matrixRowIndexColumn">The schema column as the column in the input data</param>
         /// <param name="isDecode">Whether a non-user error should be thrown as a decode</param>
-        public static void CheckAndGetMatrixIndexColumns(RoleMappedData data, out ColumnInfo matrixColumnIndexColumn, out ColumnInfo matrixRowIndexColumn, bool isDecode)
+        public static void CheckAndGetMatrixIndexColumns(RoleMappedData data, out Schema.Column matrixColumnIndexColumn, out Schema.Column matrixRowIndexColumn, bool isDecode)
         {
             Contracts.AssertValue(data);
             CheckRowColumnType(data, MatrixColumnIndexKind, out matrixColumnIndexColumn, isDecode);
@@ -43,10 +44,10 @@ namespace Microsoft.ML.Runtime.Recommender
         /// </summary>
         /// <param name="data">The training examples</param>
         /// <param name="role">The column role to try to extract</param>
-        /// <param name="info">The extracted column info</param>
+        /// <param name="col">The extracted schema column</param>
         /// <param name="isDecode">Whether a non-user error should be thrown as a decode</param>
         /// <returns>The type cast to a key-type</returns>
-        private static KeyType CheckRowColumnType(RoleMappedData data, RoleMappedSchema.ColumnRole role, out ColumnInfo info, bool isDecode)
+        private static KeyType CheckRowColumnType(RoleMappedData data, RoleMappedSchema.ColumnRole role, out Schema.Column col, bool isDecode)
         {
             Contracts.AssertValue(data);
             Contracts.AssertValue(role.Value);
@@ -59,17 +60,17 @@ namespace Microsoft.ML.Runtime.Recommender
                     throw Contracts.ExceptDecode(format2, role.Value, kindCount);
                 throw Contracts.Except(format2, role.Value, kindCount);
             }
-            info = data.Schema.GetColumns(role)[0];
+            col = data.Schema.GetColumns(role)[0];
 
             // REVIEW tfinley: Should we be a bit less restrictive? This doesn't seem like
             // too terrible of a restriction.
             const string format = "Column '{0}' with role {1} should be a known cardinality U4 key, but is instead '{2}'";
             KeyType keyType;
-            if (!TryMarshalGoodRowColumnType(info.Type, out keyType))
+            if (!TryMarshalGoodRowColumnType(col.Type, out keyType))
             {
                 if (isDecode)
-                    throw Contracts.ExceptDecode(format, info.Name, role.Value, info.Type);
-                throw Contracts.Except(format, info.Name, role.Value, info.Type);
+                    throw Contracts.ExceptDecode(format, col.Name, role.Value, col.Type);
+                throw Contracts.Except(format, col.Name, role.Value, col.Type);
             }
             return keyType;
         }

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Runtime.FactorizationMachine
 
         public ISchemaBindableMapper Bindable => _pred;
 
-        private readonly ColumnInfo[] _columns;
+        private readonly Schema.Column[] _columns;
         private readonly List<int> _inputColumnIndexes;
         private readonly IHostEnvironment _env;
 

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -208,12 +208,12 @@ namespace Microsoft.ML.Runtime.Learners
             ch.Info("AIC:               \t{0}", 2 * numParams + deviance);
 
             // Show the coefficients statistics table.
-            var featureColIdx = cursorFactory.Data.Schema.Feature.Index;
+            var featureCol = cursorFactory.Data.Schema.Feature.Value;
             var schema = cursorFactory.Data.Data.Schema;
             var featureLength = CurrentWeights.Length - BiasCount;
             var namesSpans = VBufferUtils.CreateEmpty<ReadOnlyMemory<char>>(featureLength);
-            if (schema[featureColIdx].HasSlotNames(featureLength))
-                schema[featureColIdx].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref namesSpans);
+            if (featureCol.HasSlotNames(featureLength))
+                featureCol.Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref namesSpans);
             Host.Assert(namesSpans.Length == featureLength);
 
             // Inverse mapping of non-zero weight slots.

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -126,18 +126,15 @@ namespace Microsoft.ML.Runtime.Learners
             _prior = new Double[_numClasses];
 
             // Try to get the label key values metedata.
-            var schema = data.Data.Schema;
-            var labelIdx = data.Schema.Label.Index;
-            var labelMetadataType = schema[labelIdx].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
-            if (labelMetadataType == null || !labelMetadataType.IsKnownSizeVector || !labelMetadataType.ItemType.IsText ||
-                labelMetadataType.VectorSize != _numClasses)
+            var labelCol = data.Schema.Label.Value;
+            var labelMetadataType = labelCol.Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
+            if (!(labelMetadataType is VectorType vecType && vecType.ItemType == TextType.Instance && vecType.Size == _numClasses))
             {
                 _labelNames = null;
                 return;
             }
-
             VBuffer<ReadOnlyMemory<char>> labelNames = default;
-            schema[labelIdx].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref labelNames);
+            labelCol.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref labelNames);
 
             // If label names is not dense or contain NA or default value, then it follows that
             // at least one class does not have a valid name for its label. If the label names we

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -97,9 +97,9 @@ namespace Microsoft.ML.Runtime.Learners
             Host.Assert(type.RawType == typeof(T));
             Host.AssertValue(equalsTarget);
             Host.AssertValue(data);
-            Host.AssertValue(data.Schema.Label);
+            Host.Assert(data.Schema.Label.HasValue);
 
-            var lab = data.Schema.Label;
+            var lab = data.Schema.Label.Value;
 
             InPredicate<T> isMissing;
             if (!Args.ImputeMissingLabelsAsNegative && Conversions.Instance.TryGetIsNAPredicate(type, out isMissing))

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MultiClassNaiveBayesTrainer.cs
@@ -93,16 +93,17 @@ namespace Microsoft.ML.Trainers
         {
             Host.CheckValue(context, nameof(context));
             var data = context.TrainingSet;
-            Host.Check(data.Schema.Label != null, "Missing Label column");
-            Host.Check(data.Schema.Label.Type == NumberType.Float || data.Schema.Label.Type is KeyType,
+            Host.Check(data.Schema.Label.HasValue, "Missing Label column");
+            var labelCol = data.Schema.Label.Value;
+            Host.Check(labelCol.Type == NumberType.Float || labelCol.Type is KeyType,
                 "Invalid type for Label column, only floats and known-size keys are supported");
 
-            Host.Check(data.Schema.Feature != null, "Missing Feature column");
+            Host.Check(data.Schema.Feature.HasValue, "Missing Feature column");
             int featureCount;
             data.CheckFeatureFloatVector(out featureCount);
             int labelCount = 0;
-            if (data.Schema.Label.Type.IsKey)
-                labelCount = data.Schema.Label.Type.KeyCount;
+            if (labelCol.Type is KeyType labelKeyType)
+                labelCount = labelKeyType.Count;
 
             int[] labelHistogram = new int[labelCount];
             int[][] featureHistogram = new int[labelCount][];

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Trainers
         {
             var view = MapLabels(data, cls);
 
-            string trainerLabel = data.Schema.Label.Name;
+            string trainerLabel = data.Schema.Label.Value.Name;
 
             // REVIEW: In principle we could support validation sets and the like via the train context, but
             // this is currently unsupported.
@@ -144,8 +144,8 @@ namespace Microsoft.ML.Trainers
 
         private IDataView MapLabels(RoleMappedData data, int cls)
         {
-            var lab = data.Schema.Label;
-            Host.Assert(!data.Schema.Schema[lab.Index].IsHidden);
+            var lab = data.Schema.Label.Value;
+            Host.Assert(!lab.IsHidden);
             Host.Assert(lab.Type.KeyCount > 0 || lab.Type == NumberType.R4 || lab.Type == NumberType.R8);
 
             if (lab.Type.KeyCount > 0)

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Pkpd.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Trainers
         {
             // this should not be necessary when the legacy constructor doesn't exist, and the label column is not an optional parameter on the
             // MetaMulticlassTrainer constructor.
-            string trainerLabel = data.Schema.Label.Name;
+            string trainerLabel = data.Schema.Label.Value.Name;
 
             var view = MapLabels(data, cls1, cls2);
             var transformer = trainer.Fit(view);
@@ -144,8 +144,8 @@ namespace Microsoft.ML.Trainers
 
         private IDataView MapLabels(RoleMappedData data, int cls1, int cls2)
         {
-            var lab = data.Schema.Label;
-            Host.Assert(!data.Schema.Schema[lab.Index].IsHidden);
+            var lab = data.Schema.Label.Value;
+            Host.Assert(!lab.IsHidden);
             Host.Assert(lab.Type.KeyCount > 0 || lab.Type == NumberType.R4 || lab.Type == NumberType.R8);
 
             if (lab.Type.KeyCount > 0)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -120,13 +120,12 @@ namespace Microsoft.ML.Trainers
             var roles = examples.Schema.GetColumnRoleNames();
             var examplesToFeedTrain = new RoleMappedData(idvToFeedTrain, roles);
 
-            ch.AssertValue(examplesToFeedTrain.Schema.Label);
-            ch.AssertValue(examplesToFeedTrain.Schema.Feature);
-            if (examples.Schema.Weight != null)
-                ch.AssertValue(examplesToFeedTrain.Schema.Weight);
+            ch.Assert(examplesToFeedTrain.Schema.Label.HasValue);
+            ch.Assert(examplesToFeedTrain.Schema.Feature.HasValue);
+            if (examples.Schema.Weight.HasValue)
+                ch.Assert(examplesToFeedTrain.Schema.Weight.HasValue);
 
-            int numFeatures = examplesToFeedTrain.Schema.Feature.Type.VectorSize;
-            ch.Check(numFeatures > 0, "Training set has no features, aborting training.");
+            ch.Check(examplesToFeedTrain.Schema.Feature.Value.Type is VectorType vecType && vecType.Size > 0, "Training set has no features, aborting training.");
             return examplesToFeedTrain;
         }
 
@@ -287,7 +286,7 @@ namespace Microsoft.ML.Trainers
             Contracts.Assert(predictor == null, "SDCA based trainers don't support continuous training.");
             Contracts.Assert(weightSetCount >= 1);
 
-            int numFeatures = data.Schema.Feature.Type.VectorSize;
+            int numFeatures = data.Schema.Feature.Value.Type.VectorSize;
             long maxTrainingExamples = MaxDualTableSize / weightSetCount;
             var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight | CursOpt.Id);
             int numThreads;
@@ -1761,8 +1760,9 @@ namespace Microsoft.ML.Trainers
             Contracts.AssertValue(data);
             Contracts.Assert(weightSetCount == 1);
             Contracts.AssertValueOrNull(predictor);
+            Contracts.Assert(data.Schema.Feature.HasValue);
 
-            int numFeatures = data.Schema.Feature.Type.VectorSize;
+            int numFeatures = data.Schema.Feature.Value.Type.VectorSize;
             var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight);
 
             int numThreads;

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -278,19 +278,20 @@ namespace Microsoft.ML.Trainers
 
         private protected override PriorPredictor Train(TrainContext context)
         {
-            Contracts.CheckValue(context, nameof(context));
+            Host.CheckValue(context, nameof(context));
             var data = context.TrainingSet;
             data.CheckBinaryLabel();
-            Contracts.CheckParam(data.Schema.Label != null, nameof(data), "Missing Label column");
-            Contracts.CheckParam(data.Schema.Label.Type == NumberType.Float, nameof(data), "Invalid type for Label column");
+            Host.CheckParam(data.Schema.Label.HasValue, nameof(data), "Missing Label column");
+            var labelCol = data.Schema.Label.Value;
+            Host.CheckParam(labelCol.Type == NumberType.Float, nameof(data), "Invalid type for Label column");
 
             double pos = 0;
             double neg = 0;
 
-            int col = data.Schema.Label.Index;
+            int col = labelCol.Index;
             int colWeight = -1;
             if (data.Schema.Weight?.Type == NumberType.Float)
-                colWeight = data.Schema.Weight.Index;
+                colWeight = data.Schema.Weight.Value.Index;
             using (var cursor = data.Data.GetRowCursor(c => c == col || c == colWeight))
             {
                 var getLab = cursor.GetLabelFloatGetter(data);

--- a/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
@@ -85,13 +85,12 @@ namespace Microsoft.ML.Runtime.Learners
             var roles = examples.Schema.GetColumnRoleNames();
             var examplesToFeedTrain = new RoleMappedData(idvToFeedTrain, roles);
 
-            ch.AssertValue(examplesToFeedTrain.Schema.Label);
-            ch.AssertValue(examplesToFeedTrain.Schema.Feature);
-            if (examples.Schema.Weight != null)
-                ch.AssertValue(examplesToFeedTrain.Schema.Weight);
+            ch.Assert(examplesToFeedTrain.Schema.Label.HasValue);
+            ch.Assert(examplesToFeedTrain.Schema.Feature.HasValue);
+            if (examples.Schema.Weight.HasValue)
+                ch.Assert(examplesToFeedTrain.Schema.Weight.HasValue);
 
-            int numFeatures = examplesToFeedTrain.Schema.Feature.Type.VectorSize;
-            ch.Check(numFeatures > 0, "Training set has no features, aborting training.");
+            ch.Check(examplesToFeedTrain.Schema.Feature.Value.Type is VectorType vecType && vecType.Size > 0, "Training set has no features, aborting training.");
             return examplesToFeedTrain;
         }
 

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1229,7 +1229,7 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
             _host.CheckParam(data.Schema.Feature.HasValue, nameof(data), "Must have features column.");
             var featureCol = data.Schema.Feature.Value;
             if (featureCol.Type != NumberType.Float)
-                throw _host.ExceptParam(nameof(data), "The feature column has  type '{0}', but must be a float.", featureCol.Type);
+                throw _host.ExceptSchemaMismatch(nameof(data), "feature", featureCol.Name, "R4", featureCol.Type.ToString());
 
             Single[] dataArray = new Single[_trainSize];
             int col = featureCol.Index;

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1225,12 +1225,14 @@ namespace Microsoft.ML.Runtime.TimeSeriesProcessing
         /// <param name="data">The training time-series.</param>
         internal override void Train(RoleMappedData data)
         {
-            _host.CheckParam(data != null, nameof(data), "The input series for training cannot be null.");
-            if (data.Schema.Feature.Type != NumberType.Float)
-                throw _host.ExceptUserArg(nameof(data.Schema.Feature.Name), "The feature column has  type '{0}', but must be a float.", data.Schema.Feature.Type);
+            _host.CheckValue(data, nameof(data));
+            _host.CheckParam(data.Schema.Feature.HasValue, nameof(data), "Must have features column.");
+            var featureCol = data.Schema.Feature.Value;
+            if (featureCol.Type != NumberType.Float)
+                throw _host.ExceptParam(nameof(data), "The feature column has  type '{0}', but must be a float.", featureCol.Type);
 
             Single[] dataArray = new Single[_trainSize];
-            int col = data.Schema.Feature.Index;
+            int col = featureCol.Index;
 
             int count = 0;
             using (var cursor = data.Data.GetRowCursor(c => c == col))


### PR DESCRIPTION
Fixes #1923. As usual commits are structured in such a way as to make the code approachable. Since the first usage was against `RoleMappedSchema` and that was used in many, *many* places, I'm sorry to say that is probably the biggest change.