### PR TITLE
Throwing exception if the underlying rsp fails with an exception

### DIFF
--- a/test/Microsoft.ML.Benchmarks/Helpers/ExecuteMaml.cs
+++ b/test/Microsoft.ML.Benchmarks/Helpers/ExecuteMaml.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Tools;
+using System;
+
+namespace Microsoft.ML.Benchmarks
+{
+    internal static class ExecuteMaml
+    {
+        public static void ExecuteMamlCommand(this string command, MLContext environment)
+        {
+            if (Maml.MainCore(environment, command, alwaysPrintStacktrace: false) < 0)
+                throw new Exception($"Command {command} returned negative error code");
+        }
+    }
+}

--- a/test/Microsoft.ML.Benchmarks/Numeric/Ranking.cs
+++ b/test/Microsoft.ML.Benchmarks/Numeric/Ranking.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using BenchmarkDotNet.Attributes;
 using Microsoft.ML.Data;
 using Microsoft.ML.LightGBM;
 using Microsoft.ML.RunTests;
-using Microsoft.ML.Tools;
 using Microsoft.ML.Trainers.FastTree;
 using Microsoft.ML.Transforms.Conversions;
+using System.IO;
 
 namespace Microsoft.ML.Benchmarks
 {
@@ -43,7 +42,7 @@ namespace Microsoft.ML.Benchmarks
                 " tr=FastTreeRanking{}";
 
             var environment = EnvironmentFactory.CreateRankingEnvironment<RankerEvaluator, TextLoader, HashingTransformer, FastTreeRankingTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
 
         [Benchmark]
@@ -58,7 +57,7 @@ namespace Microsoft.ML.Benchmarks
                 " tr=LightGBMRanking{}";
 
             var environment = EnvironmentFactory.CreateRankingEnvironment<RankerEvaluator, TextLoader, HashingTransformer, LightGbmMulticlassTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
     }
 
@@ -97,7 +96,7 @@ namespace Microsoft.ML.Benchmarks
                 " out={" + _modelPath_MSLR + "}";
 
             var environment = EnvironmentFactory.CreateRankingEnvironment<RankerEvaluator, TextLoader, HashingTransformer, FastTreeRankingTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
 
         [Benchmark]
@@ -107,7 +106,7 @@ namespace Microsoft.ML.Benchmarks
             string cmd = @"Test data=" + _mslrWeb10k_Test + " in=" + _modelPath_MSLR;
 
             var environment = EnvironmentFactory.CreateRankingEnvironment<RankerEvaluator, TextLoader, HashingTransformer, FastTreeRankingTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
     }
 }

--- a/test/Microsoft.ML.Benchmarks/Text/MultiClassClassification.cs
+++ b/test/Microsoft.ML.Benchmarks/Text/MultiClassClassification.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using BenchmarkDotNet.Attributes;
 using Microsoft.ML.Data;
 using Microsoft.ML.LightGBM;
 using Microsoft.ML.RunTests;
-using Microsoft.ML.Tools;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.Online;
 using Microsoft.ML.Transforms.Categorical;
+using System.IO;
 
 namespace Microsoft.ML.Benchmarks
 {
@@ -40,7 +39,7 @@ namespace Microsoft.ML.Benchmarks
                         " tr=OVA{p=AveragedPerceptron{iter=10}}";
 
             var environment = EnvironmentFactory.CreateClassificationEnvironment<TextLoader, OneHotEncodingTransformer, AveragedPerceptronTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
 
         [Benchmark]
@@ -55,7 +54,7 @@ namespace Microsoft.ML.Benchmarks
                     " tr=LightGBMMulticlass{iter=10}";
 
             var environment = EnvironmentFactory.CreateClassificationEnvironment<TextLoader, OneHotEncodingTransformer, LightGbmMulticlassTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
 
         [Benchmark]
@@ -71,7 +70,7 @@ namespace Microsoft.ML.Benchmarks
                 " xf=Concat{col=Features:FeaturesText,FeaturesWordEmbedding,logged_in,ns}";
 
             var environment = EnvironmentFactory.CreateClassificationEnvironment<TextLoader, OneHotEncodingTransformer, AveragedPerceptronTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
 
         [Benchmark]
@@ -87,7 +86,7 @@ namespace Microsoft.ML.Benchmarks
                 " xf=Concat{col=Features:FeaturesWordEmbedding,logged_in,ns}";
 
             var environment = EnvironmentFactory.CreateClassificationEnvironment<TextLoader, OneHotEncodingTransformer, SdcaMultiClassTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
     }
 
@@ -115,7 +114,7 @@ namespace Microsoft.ML.Benchmarks
                 " out={" + _modelPath_Wiki + "}";
 
             var environment = EnvironmentFactory.CreateClassificationEnvironment<TextLoader, OneHotEncodingTransformer, AveragedPerceptronTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
 
         [Benchmark]
@@ -126,7 +125,7 @@ namespace Microsoft.ML.Benchmarks
             string cmd = @"Test data=" + _dataPath_Wiki + " in=" + modelpath;
 
             var environment = EnvironmentFactory.CreateClassificationEnvironment<TextLoader, OneHotEncodingTransformer, AveragedPerceptronTrainer>();
-            Maml.MainCore(environment, cmd, alwaysPrintStacktrace: false);
+            cmd.ExecuteMamlCommand(environment);
         }
     }
 }


### PR DESCRIPTION
The benchmarks involving rsps don't fail even when the underlying rsp has thrown an exception
