### PR TITLE
Initial refactor to swap the predicates for an IEnumerable<Schema.Columns> in the GetRowCursor and GetRowCursorSet

### DIFF
--- a/src/Microsoft.ML.Core/Data/IDataView.cs
+++ b/src/Microsoft.ML.Core/Data/IDataView.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.ML.Data
@@ -32,8 +33,8 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
         /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
-        /// a getter for an inactive columns will throw. The <paramref name="colsNeeded"/> predicate must be
-        /// non-null.If set to <langword>null</langword> no column is active.
+        /// a getter for inactive columns will throw. The <paramref name="colsNeeded"/> indicate the columns that are needed
+        /// to iterate over.If set to an empty <see cref="IEnumerable"/> no column is requested.
         /// </summary>
         RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null);
 
@@ -55,9 +56,9 @@ namespace Microsoft.ML.Data
         /// scenarios will be content with pulling from the single serial cursor of
         /// <see cref="GetRowCursor(IEnumerable{Schema.Column}, Random)"/>.
         /// </summary>
-        /// <param name="colsNeeded">The active columns needed. If set to <langword>null</langword> no column is active.</param>
+        /// <param name="colsNeeded">The active columns needed. If passed an empty <see cref="IEnumerable"/> no column is requested.</param>
         /// <param name="n">The suggested degree of parallelism.</param>
-        /// <param name="rand">An instance </param>
+        /// <param name="rand">An instance of <see cref="Random"/> to seed randomizing the access.</param>
         /// <returns></returns>
         RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null);
 

--- a/src/Microsoft.ML.Core/Data/IDataView.cs
+++ b/src/Microsoft.ML.Core/Data/IDataView.cs
@@ -33,10 +33,10 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
         /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
-        /// a getter for inactive columns will throw. The <paramref name="colsNeeded"/> indicate the columns that are needed
+        /// a getter for inactive columns will throw. The <paramref name="columnsNeeded"/> indicate the columns that are needed
         /// to iterate over.If set to an empty <see cref="IEnumerable"/> no column is requested.
         /// </summary>
-        RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null);
+        RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null);
 
         /// <summary>
         /// This constructs a set of parallel batch cursors. The value <paramref name="n"/> is a recommended limit on
@@ -56,11 +56,11 @@ namespace Microsoft.ML.Data
         /// scenarios will be content with pulling from the single serial cursor of
         /// <see cref="GetRowCursor(IEnumerable{Schema.Column}, Random)"/>.
         /// </summary>
-        /// <param name="colsNeeded">The active columns needed. If passed an empty <see cref="IEnumerable"/> no column is requested.</param>
+        /// <param name="columnsNeeded">The active columns needed. If passed an empty <see cref="IEnumerable"/> no column is requested.</param>
         /// <param name="n">The suggested degree of parallelism.</param>
         /// <param name="rand">An instance of <see cref="Random"/> to seed randomizing the access.</param>
         /// <returns></returns>
-        RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null);
+        RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null);
 
         /// <summary>
         /// Gets an instance of Schema.

--- a/src/Microsoft.ML.Core/Data/IDataView.cs
+++ b/src/Microsoft.ML.Core/Data/IDataView.cs
@@ -32,10 +32,10 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
         /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
-        /// a getter for an inactive columns will throw. The <paramref name="needCol"/> predicate must be
-        /// non-null. To activate all columns, pass "col => true".
+        /// a getter for an inactive columns will throw. The <paramref name="colsNeeded"/> predicate must be
+        /// non-null.If set to <langword>null</langword> no column is active.
         /// </summary>
-        RowCursor GetRowCursor(Func<int, bool> needCol, Random rand = null);
+        RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null);
 
         /// <summary>
         /// This constructs a set of parallel batch cursors. The value <paramref name="n"/> is a recommended limit on
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Data
         /// recommendation: it is entirely possible that an implementation can return a different number of cursors.
         ///
         /// The cursors should return the same data as returned through
-        /// <see cref="GetRowCursor(Func{int, bool}, Random)"/>, except partitioned: no two cursors should return the
+        /// <see cref="GetRowCursor(IEnumerable{Schema.Column}, Random)"/>, except partitioned: no two cursors should return the
         /// "same" row as would have been returned through the regular serial cursor, but all rows should be returned by
         /// exactly one of the cursors returned from this cursor. The cursors can have their values reconciled
         /// downstream through the use of the <see cref="Row.Batch"/> property.
@@ -53,13 +53,13 @@ namespace Microsoft.ML.Data
         /// working threads that consume from them independently while, ultimately, the results are finally collated in
         /// the end by exploiting the ordering of the <see cref="Row.Batch"/> property described above. More typical
         /// scenarios will be content with pulling from the single serial cursor of
-        /// <see cref="GetRowCursor(Func{int, bool}, Random)"/>.
+        /// <see cref="GetRowCursor(IEnumerable{Schema.Column}, Random)"/>.
         /// </summary>
-        /// <param name="needCol">The predicate, where a column is active if this returns true.</param>
+        /// <param name="colsNeeded">The active columns needed. If set to <langword>null</langword> no column is active.</param>
         /// <param name="n">The suggested degree of parallelism.</param>
         /// <param name="rand">An instance </param>
         /// <returns></returns>
-        RowCursor[] GetRowCursorSet(Func<int, bool> needCol, int n, Random rand = null);
+        RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null);
 
         /// <summary>
         /// Gets an instance of Schema.
@@ -93,15 +93,15 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// This provides a means for reconciling multiple rows that have been produced generally from
-        /// <see cref="IDataView.GetRowCursorSet(Func{int, bool}, int, Random)"/>. When getting a set, there is a need
+        /// <see cref="IDataView.GetRowCursorSet(IEnumerable{Schema.Column}, int, Random)"/>. When getting a set, there is a need
         /// to, while allowing parallel processing to proceed, always have an aim that the original order should be
         /// reconverable. Note, whether or not a user cares about that original order in ones specific application is
         /// another story altogether (most callers of this as a practical matter do not, otherwise they would not call
         /// it), but at least in principle it should be possible to reconstruct the original order one would get from an
-        /// identically configured <see cref="IDataView.GetRowCursor(Func{int, bool}, Random)"/>. So: for any cursor
+        /// identically configured <see cref="IDataView.GetRowCursor(IEnumerable{Schema.Column}, Random)"/>. So: for any cursor
         /// implementation, batch numbers should be non-decreasing. Furthermore, any given batch number should only
         /// appear in one of the cursors as returned by
-        /// <see cref="IDataView.GetRowCursorSet(Func{int, bool}, int, Random)"/>. In this way, order is determined by
+        /// <see cref="IDataView.GetRowCursorSet(IEnumerable{Schema.Column}, int, Random)"/>. In this way, order is determined by
         /// batch number. An operation that reconciles these cursors to produce a consistent single cursoring, could do
         /// so by drawing from the single cursor, among all cursors in the set, that has the smallest batch number
         /// available.

--- a/src/Microsoft.ML.Core/Data/Schema.cs
+++ b/src/Microsoft.ML.Core/Data/Schema.cs
@@ -13,11 +13,7 @@ namespace Microsoft.ML.Data
 {
     /// <summary>
     /// This class represents the <see cref="Schema"/> of an object like, for interstance, an <see cref="IDataView"/> or an <see cref="Row"/>.
-    /// On the high level, the schema is a collection of 'columns'. Each column has the following properties:
-    /// - Column name.
-    /// - Column type.
-    /// - Metadata. The metadata itself is a 'single-row dataset' (namely, an instance of <see cref="Metadata"/>), that contains its own schema
-    /// and values.
+    /// On the high level, the schema is a collection of <see cref="Schema.Column"/>.
     /// </summary>
     [System.Diagnostics.DebuggerTypeProxy(typeof(SchemaDebuggerProxy))]
     public sealed class Schema : IReadOnlyList<Schema.Column>
@@ -67,18 +63,6 @@ namespace Microsoft.ML.Data
             if (_nameMap.TryGetValue(name, out int col))
                 return _columns[col];
             return null;
-        }
-
-        public IEnumerable<Column> GetColumns(params string[] names)
-        {
-            foreach (var name in names)
-                yield return this[name];
-        }
-
-        public IEnumerable<Column> GetColumns(params int[] indices)
-        {
-            foreach (var index in indices)
-                yield return this[index];
         }
 
         public IEnumerator<Column> GetEnumerator() => ((IEnumerable<Column>)_columns).GetEnumerator();

--- a/src/Microsoft.ML.Core/Data/Schema.cs
+++ b/src/Microsoft.ML.Core/Data/Schema.cs
@@ -69,14 +69,23 @@ namespace Microsoft.ML.Data
             return null;
         }
 
+        public IEnumerable<Column> GetColumns(params string[] names)
+        {
+            foreach (var name in names)
+                yield return this[name];
+        }
+
+        public IEnumerable<Column> GetColumns(params int[] indices)
+        {
+            foreach (var index in indices)
+                yield return this[index];
+        }
+
         public IEnumerator<Column> GetEnumerator() => ((IEnumerable<Column>)_columns).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public override string ToString()
-        {
-            return $"{Count} columns";
-        }
+        public override string ToString() => $"{Count} columns";
 
         /// <summary>
         /// This class describes one column in the particular schema.

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -794,8 +794,8 @@ namespace Microsoft.ML.Internal.Utilities
             foreach (var col in colsNeeded)
             {
                 Contracts.Check(col.Index < lim);
-                mapList.Add(col.Index);
                 invMap[col.Index] = mapList.Count;
+                mapList.Add(col.Index);
             }
 
             map = mapList.ToArray();

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -708,12 +708,12 @@ namespace Microsoft.ML.Internal.Utilities
             return result;
         }
 
-        public static bool[] BuildArray(int length, IEnumerable<Schema.Column> colsNeeded)
+        public static bool[] BuildArray(int length, IEnumerable<Schema.Column> columnsNeeded)
         {
             Contracts.CheckParam(length >= 0, nameof(length));
 
             var result = new bool[length];
-            foreach (var col in colsNeeded)
+            foreach (var col in columnsNeeded)
             {
                 if(col.Index < result.Length)
                     result[col.Index] = true;
@@ -773,25 +773,25 @@ namespace Microsoft.ML.Internal.Utilities
         /// map.
         /// </summary>
         /// <param name="lim">Indicates the exclusive upper bound on the tested values</param>
-        /// <param name="colsNeeded">The set of columns the calling component operates on.</param>
+        /// <param name="columnsNeeded">The set of columns the calling component operates on.</param>
         /// <param name="map">An ascending array of values from 0 inclusive
         /// to <paramref name="lim"/> exclusive, holding all values for which
-        /// <paramref name="colsNeeded"/> are present.
-        /// (The respective index appears in the <paramref name="colsNeeded"/> collection).</param>
+        /// <paramref name="columnsNeeded"/> are present.
+        /// (The respective index appears in the <paramref name="columnsNeeded"/> collection).</param>
         /// <param name="invMap">Forms an inverse mapping of <paramref name="map"/>,
         /// so that <c><paramref name="invMap"/>[<paramref name="map"/>[i]] == i</c>,
         /// and for other entries not appearing in <paramref name="map"/>,
         /// <c><paramref name="invMap"/>[i] == -1</c></param>
-        public static void BuildSubsetMaps(int lim, IEnumerable<Schema.Column> colsNeeded, out int[] map, out int[] invMap)
+        public static void BuildSubsetMaps(int lim, IEnumerable<Schema.Column> columnsNeeded, out int[] map, out int[] invMap)
         {
             Contracts.CheckParam(lim >= 0, nameof(lim));
-            Contracts.CheckValue(colsNeeded, nameof(colsNeeded));
+            Contracts.CheckValue(columnsNeeded, nameof(columnsNeeded));
 
             // REVIEW: Better names?
             List<int> mapList = new List<int>();
             invMap = invMap = Enumerable.Repeat(-1, lim).ToArray<int>();
 
-            foreach (var col in colsNeeded)
+            foreach (var col in columnsNeeded)
             {
                 Contracts.Check(col.Index < lim);
                 invMap[col.Index] = mapList.Count;

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -159,7 +159,8 @@ namespace Microsoft.ML.Data
                 Dictionary<string, double> averageMetric = new Dictionary<string, double>();
                 foreach (Dictionary<string, IDataView> mValue in metricValues)
                 {
-                    using (var cursor = mValue.First().Value.GetRowCursor(col => true))
+                    var data = mValue.First().Value;
+                    using (var cursor = data.GetRowCursor(data.Schema))
                     {
                         while (cursor.MoveNext())
                         {

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Data
                 foreach (Dictionary<string, IDataView> mValue in metricValues)
                 {
                     var data = mValue.First().Value;
-                    using (var cursor = data.GetRowCursor(data.Schema))
+                    using (var cursor = data.GetRowCursorForAllColumns())
                     {
                         while (cursor.MoveNext())
                         {

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Data
 
             int cthd = GetThreadCount(host);
             host.Assert(cthd > 0);
-            if (cthd == 1 || !AllCacheable(view.Schema, colsNeeded))
+            if (cthd == 1 || !AllCacheable(colsNeeded))
             {
                 curs = null;
                 return false;
@@ -198,21 +198,16 @@ namespace Microsoft.ML.Data
         /// Return whether all the active columns, as determined by the predicate, are
         /// cachable - either primitive types or vector types.
         /// </summary>
-        public static bool AllCacheable(Schema schema, IEnumerable<Schema.Column> colsNeeded)
+        public static bool AllCacheable(IEnumerable<Schema.Column> colsNeeded)
         {
-            Contracts.CheckValue(schema, nameof(schema));
+            Contracts.CheckValue(colsNeeded, nameof(colsNeeded));
 
             if (colsNeeded == null)
                 return false;
 
-            for (int col = 0; col < schema.Count; col++)
-            {
-                if (!colsNeeded.Any(x => x.Index == col))
-                    continue;
-                var type = schema[col].Type;
-                if (!IsCacheable(type))
+            foreach (var col in colsNeeded)
+                if (!IsCacheable(col.Type))
                     return false;
-            }
 
             return true;
         }
@@ -221,9 +216,7 @@ namespace Microsoft.ML.Data
         /// Determine whether the given type is cachable - either a primitive type or a vector type.
         /// </summary>
         public static bool IsCacheable(this ColumnType type)
-        {
-            return type != null && (type is PrimitiveType || type is VectorType);
-        }
+            => type != null && (type is PrimitiveType || type is VectorType);
 
         /// <summary>
         /// Tests whether the cursors are mutually compatible for consolidation,

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Data
             if (countNullable != null)
                 return countNullable.Value;
             long count = 0;
-            using (var cursor = view.GetRowCursor(null))
+            using (var cursor = view.GetRowCursor())
             {
                 while (cursor.MoveNext())
                     count++;

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -115,20 +115,20 @@ namespace Microsoft.ML.Data
         /// the target cardinality of the cursor set.
         /// </summary>
         public static bool TryCreateConsolidatingCursor(out RowCursor curs,
-            IDataView view, IEnumerable<Schema.Column> colsNeeded, IHost host, Random rand)
+            IDataView view, IEnumerable<Schema.Column> columnsNeeded, IHost host, Random rand)
         {
             Contracts.CheckValue(host, nameof(host));
             host.CheckValue(view, nameof(view));
 
             int cthd = GetThreadCount(host);
             host.Assert(cthd > 0);
-            if (cthd == 1 || !AllCacheable(colsNeeded))
+            if (cthd == 1 || !AllCacheable(columnsNeeded))
             {
                 curs = null;
                 return false;
             }
 
-            var inputs = view.GetRowCursorSet(colsNeeded, cthd, rand);
+            var inputs = view.GetRowCursorSet(columnsNeeded, cthd, rand);
             host.Check(Utils.Size(inputs) > 0);
 
             if (inputs.Length == 1)
@@ -198,14 +198,14 @@ namespace Microsoft.ML.Data
         /// Return whether all the active columns, as determined by the predicate, are
         /// cachable - either primitive types or vector types.
         /// </summary>
-        public static bool AllCacheable(IEnumerable<Schema.Column> colsNeeded)
+        public static bool AllCacheable(IEnumerable<Schema.Column> columnsNeeded)
         {
-            Contracts.CheckValue(colsNeeded, nameof(colsNeeded));
+            Contracts.CheckValue(columnsNeeded, nameof(columnsNeeded));
 
-            if (colsNeeded == null)
+            if (columnsNeeded == null)
                 return false;
 
-            foreach (var col in colsNeeded)
+            foreach (var col in columnsNeeded)
                 if (!IsCacheable(col.Type))
                     return false;
 

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -471,6 +471,25 @@ namespace Microsoft.ML.Data
             return new OneRowDataView(env, row);
         }
 
+        /// <summary>
+        /// Given a collection of <see cref="Schema.Column"/>, that is a subset of the Schema of the data, create a predicate,
+        /// that when passed a column index, will return <langword>true</langword> or <langword>false</langword>, based on whether
+        /// the column with the given <see cref="Schema.Column.Index"/> is part of the <paramref name="colsNeeded"/>.
+        /// </summary>
+        /// <param name="colsNeeded">The subset of columns from the <see cref="Schema"/> that are needed from this <see cref="RowCursor"/>.</param>
+        /// <param name="schemaColsCardinality">The total number of <see cref="Schema.Column"/> in the <see cref="Schema"/>.</param>
+        [BestFriend]
+        internal static Func<int, bool> FromColumnsToPredicate(IEnumerable<Schema.Column> colsNeeded, int schemaColsCardinality)
+        {
+            if (colsNeeded == null)
+                return c => false;
+
+            if (colsNeeded.Count() == schemaColsCardinality)
+                return c => true;
+
+            return c => colsNeeded.Any(x => x.Index == c);
+        }
+
         private sealed class OneRowDataView : IDataView
         {
             private readonly Row _row;

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -489,19 +489,17 @@ namespace Microsoft.ML.Data
                 _row = row;
             }
 
-            public RowCursor GetRowCursor(Func<int, bool> needCol, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colNeeded, Random rand = null)
             {
-                _host.CheckValue(needCol, nameof(needCol));
                 _host.CheckValueOrNull(rand);
-                bool[] active = Utils.BuildArray(Schema.Count, needCol);
+                bool[] active = Utils.BuildArray(Schema.Count, colNeeded);
                 return new Cursor(_host, this, active);
             }
 
-            public RowCursor[] GetRowCursorSet(Func<int, bool> needCol, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colNeeded, int n, Random rand = null)
             {
-                _host.CheckValue(needCol, nameof(needCol));
                 _host.CheckValueOrNull(rand);
-                return new RowCursor[] { GetRowCursor(needCol, rand) };
+                return new RowCursor[] { GetRowCursor(colNeeded, rand) };
             }
 
             public long? GetRowCount()

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -484,17 +484,20 @@ namespace Microsoft.ML.Data
             Contracts.CheckValue(colsNeeded, nameof(colsNeeded));
             Contracts.CheckValue(sourceSchema, nameof(sourceSchema));
 
-            bool[] indicesRequested = new bool[sourceSchema.Count];
+            if (colsNeeded.Count() == 0)
+                return c => false;
+
+            var indicesRequested = new HashSet<int>();
 
             foreach (var col in colsNeeded)
             {
-                if(col.Index >= indicesRequested.Length)
+                if(sourceSchema.GetColumnOrNull(col.Name) == null)
                     throw Contracts.Except($"The requested column: {col} is not part of the {nameof(sourceSchema)}");
 
-                indicesRequested[col.Index] = true;
+                indicesRequested.Add(col.Index);
             }
 
-            return c => indicesRequested[c];
+            return c => indicesRequested.Contains(c);
         }
 
         private sealed class OneRowDataView : IDataView

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -488,7 +488,9 @@ namespace Microsoft.ML.Data
 
             foreach (var col in colsNeeded)
             {
-                Contracts.Assert(col.Index < indicesRequested.Length, $"The requested column: {col} is not part of the {nameof(sourceSchema)}");
+                if(col.Index >= indicesRequested.Length)
+                    throw Contracts.Except($"The requested column: {col} is not part of the {nameof(sourceSchema)}");
+
                 indicesRequested[col.Index] = true;
             }
 

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -474,19 +474,19 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Given a collection of <see cref="Schema.Column"/>, that is a subset of the Schema of the data, create a predicate,
         /// that when passed a column index, will return <langword>true</langword> or <langword>false</langword>, based on whether
-        /// the column with the given <see cref="Schema.Column.Index"/> is part of the <paramref name="colsNeeded"/>.
+        /// the column with the given <see cref="Schema.Column.Index"/> is part of the <paramref name="columnsNeeded"/>.
         /// </summary>
-        /// <param name="colsNeeded">The subset of columns from the <see cref="Schema"/> that are needed from this <see cref="RowCursor"/>.</param>
-        /// <param name="sourceSchema">The <see cref="Schema"/> from where the colsNeeded originate.</param>
+        /// <param name="columnsNeeded">The subset of columns from the <see cref="Schema"/> that are needed from this <see cref="RowCursor"/>.</param>
+        /// <param name="sourceSchema">The <see cref="Schema"/> from where the columnsNeeded originate.</param>
         [BestFriend]
-        internal static Func<int, bool> FromColumnsToPredicate(IEnumerable<Schema.Column> colsNeeded, Schema sourceSchema)
+        internal static Func<int, bool> FromColumnsToPredicate(IEnumerable<Schema.Column> columnsNeeded, Schema sourceSchema)
         {
-            Contracts.CheckValue(colsNeeded, nameof(colsNeeded));
+            Contracts.CheckValue(columnsNeeded, nameof(columnsNeeded));
             Contracts.CheckValue(sourceSchema, nameof(sourceSchema));
 
             bool[] indicesRequested = new bool[sourceSchema.Count];
 
-            foreach (var col in colsNeeded)
+            foreach (var col in columnsNeeded)
             {
                 if (col.Index >= indicesRequested.Length)
                     throw Contracts.Except($"The requested column: {col} is not part of the {nameof(sourceSchema)}");

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -515,17 +515,17 @@ namespace Microsoft.ML.Data
                 _row = row;
             }
 
-            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colNeeded, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnNeeded, Random rand = null)
             {
                 _host.CheckValueOrNull(rand);
-                bool[] active = Utils.BuildArray(Schema.Count, colNeeded);
+                bool[] active = Utils.BuildArray(Schema.Count, columnNeeded);
                 return new Cursor(_host, this, active);
             }
 
-            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colNeeded, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnNeeded, int n, Random rand = null)
             {
                 _host.CheckValueOrNull(rand);
-                return new RowCursor[] { GetRowCursor(colNeeded, rand) };
+                return new RowCursor[] { GetRowCursor(columnNeeded, rand) };
             }
 
             public long? GetRowCount()

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -484,20 +484,17 @@ namespace Microsoft.ML.Data
             Contracts.CheckValue(colsNeeded, nameof(colsNeeded));
             Contracts.CheckValue(sourceSchema, nameof(sourceSchema));
 
-            if (colsNeeded.Count() == 0)
-                return c => false;
-
-            var indicesRequested = new HashSet<int>();
+            bool[] indicesRequested = new bool[sourceSchema.Count];
 
             foreach (var col in colsNeeded)
             {
-                if(sourceSchema.GetColumnOrNull(col.Name) == null)
+                if (col.Index >= indicesRequested.Length)
                     throw Contracts.Except($"The requested column: {col} is not part of the {nameof(sourceSchema)}");
 
-                indicesRequested.Add(col.Index);
+                indicesRequested[col.Index] = true;
             }
 
-            return c => indicesRequested.Contains(c);
+            return c => indicesRequested[c];
         }
 
         private sealed class OneRowDataView : IDataView

--- a/src/Microsoft.ML.Data/DataDebuggerPreview.cs
+++ b/src/Microsoft.ML.Data/DataDebuggerPreview.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Data
             for (int i = 0; i < columns.Length; i++)
                 columns[i] = new List<object>();
 
-            using (var cursor = data.GetRowCursor(c => true))
+            using (var cursor = data.GetRowCursor(data.Schema))
             {
                 var setters = new Action<RowInfo, List<object>>[n];
                 for (int i = 0; i < n; i++)

--- a/src/Microsoft.ML.Data/DataDebuggerPreview.cs
+++ b/src/Microsoft.ML.Data/DataDebuggerPreview.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Data
             for (int i = 0; i < columns.Length; i++)
                 columns[i] = new List<object>();
 
-            using (var cursor = data.GetRowCursor(data.Schema))
+            using (var cursor = data.GetRowCursorForAllColumns())
             {
                 var setters = new Action<RowInfo, List<object>>[n];
                 for (int i = 0; i < n; i++)

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -1212,29 +1212,29 @@ namespace Microsoft.ML.Data.IO
             return entry;
         }
 
-        private RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        private RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             if (rand != null && _randomShufflePoolRows > 0)
             {
                 // Don't bother with block shuffling, if the shuffle cursor is just going to hold
                 // the entire dataset in memory anyway.
                 var ourRand = _randomShufflePoolRows == _header.RowCount ? null : rand;
-                var cursor = new Cursor(this, colsNeeded, ourRand);
+                var cursor = new Cursor(this, columnsNeeded, ourRand);
                 return RowShufflingTransformer.GetShuffledCursor(_host, _randomShufflePoolRows, cursor, rand);
             }
-            return new Cursor(this, colsNeeded, rand);
+            return new Cursor(this, columnsNeeded, rand);
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            return GetRowCursorCore(colsNeeded, rand);
+            return GetRowCursorCore(columnsNeeded, rand);
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursorCore(colsNeeded, rand) };
+            return new RowCursor[] { GetRowCursorCore(columnsNeeded, rand) };
         }
 
         private sealed class Cursor : RootCursorBase
@@ -1268,7 +1268,7 @@ namespace Microsoft.ML.Data.IO
                 get { return 0; }
             }
 
-            public Cursor(BinaryLoader parent, IEnumerable<Schema.Column> colsNeeded, Random rand)
+            public Cursor(BinaryLoader parent, IEnumerable<Schema.Column> columnsNeeded, Random rand)
                 : base(parent._host)
             {
                 _parent = parent;
@@ -1278,7 +1278,7 @@ namespace Microsoft.ML.Data.IO
 
                 TableOfContentsEntry[] toc = _parent._aliveColumns;
                 int[] activeIndices;
-                Utils.BuildSubsetMaps(toc.Length, colsNeeded, out activeIndices, out _colToActivesIndex);
+                Utils.BuildSubsetMaps(toc.Length, columnsNeeded, out activeIndices, out _colToActivesIndex);
                 _actives = new TableOfContentsEntry[activeIndices.Length];
                 for (int i = 0; i < activeIndices.Length; ++i)
                     _actives[i] = toc[activeIndices[i]];

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -581,7 +581,7 @@ namespace Microsoft.ML.Data.IO
                 HashSet<int> activeSet = new HashSet<int>(activeColumns.Select(col => col.SourceIndex));
                 long blockIndex = 0;
                 int remainingInBlock = rowsPerBlock;
-                using (RowCursor cursor = data.GetRowCursor(activeSet.Contains))
+                using (RowCursor cursor = data.GetRowCursor(data.Schema.Where(x => activeSet.Contains(x.Index))))
                 {
                     WritePipe[] pipes = new WritePipe[activeColumns.Length];
                     for (int c = 0; c < activeColumns.Length; ++c)
@@ -739,7 +739,7 @@ namespace Microsoft.ML.Data.IO
             EstimatorDelegate del = EstimatorCore<int>;
             MethodInfo methInfo = del.GetMethodInfo().GetGenericMethodDefinition();
 
-            using (RowCursor cursor = data.GetRowCursor(active.Contains, rand))
+            using (RowCursor cursor = data.GetRowCursor(data.Schema.Where(x => active.Contains(x.Index)), rand))
             {
                 object[] args = new object[] { cursor, null, null, null };
                 var writers = new IValueWriter[actives.Length];

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -581,7 +581,7 @@ namespace Microsoft.ML.Data.IO
                 HashSet<int> activeSet = new HashSet<int>(activeColumns.Select(col => col.SourceIndex));
                 long blockIndex = 0;
                 int remainingInBlock = rowsPerBlock;
-                using (RowCursor cursor = data.GetRowCursor(data.Schema.Where(x => activeSet.Contains(x.Index))))
+                using (RowCursor cursor = data.GetRowCursor(activeSet.ToArray()))
                 {
                     WritePipe[] pipes = new WritePipe[activeColumns.Length];
                     for (int c = 0; c < activeColumns.Length; ++c)

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -581,7 +581,7 @@ namespace Microsoft.ML.Data.IO
                 HashSet<int> activeSet = new HashSet<int>(activeColumns.Select(col => col.SourceIndex));
                 long blockIndex = 0;
                 int remainingInBlock = rowsPerBlock;
-                using (RowCursor cursor = data.GetRowCursor(activeSet.ToArray()))
+                using (RowCursor cursor = data.GetRowCursor(data.Schema.Where(c => activeSet.Contains(c.Index))))
                 {
                     WritePipe[] pipes = new WritePipe[activeColumns.Length];
                     for (int c = 0; c < activeColumns.Length; ++c)

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -563,18 +563,16 @@ namespace Microsoft.ML.Data
 
         public Schema Schema => View.Schema;
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            _host.CheckValue(predicate, nameof(predicate));
             _host.CheckValueOrNull(rand);
-            return View.GetRowCursor(predicate, rand);
+            return View.GetRowCursor(colsNeeded, rand);
         }
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            _host.CheckValue(predicate, nameof(predicate));
             _host.CheckValueOrNull(rand);
-            return View.GetRowCursorSet(predicate, n, rand);
+            return View.GetRowCursorSet(colsNeeded, n, rand);
         }
 
         VectorType ITransposeDataView.GetSlotType(int col) => _tview?.GetSlotType(col);

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -563,15 +563,19 @@ namespace Microsoft.ML.Data
 
         public Schema Schema => View.Schema;
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
+            _host.AssertValue(columnsNeeded);
+
             return View.GetRowCursor(columnsNeeded, rand);
         }
 
         public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
+            _host.AssertValue(columnsNeeded);
+
             return View.GetRowCursorSet(columnsNeeded, n, rand);
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -566,13 +566,13 @@ namespace Microsoft.ML.Data
         public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            return View.GetRowCursor(colsNeeded, rand);
+            return View.GetRowCursor(columnsNeeded, rand);
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            return View.GetRowCursorSet(colsNeeded, n, rand);
+            return View.GetRowCursorSet(columnsNeeded, n, rand);
         }
 
         VectorType ITransposeDataView.GetSlotType(int col) => _tview?.GetSlotType(col);

--- a/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
@@ -292,14 +292,14 @@ namespace Microsoft.ML.Data
             return null;
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
-            return new Cursor(_host, this, _files, colsNeeded, rand);
+            return new Cursor(_host, this, _files, columnsNeeded, rand);
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
-            var cursor = new Cursor(_host, this, _files, colsNeeded, rand);
+            var cursor = new Cursor(_host, this, _files, columnsNeeded, rand);
             return new RowCursor[] { cursor };
         }
 
@@ -369,28 +369,28 @@ namespace Microsoft.ML.Data
             private Delegate[] _getters;
             private Delegate[] _subGetters; // Cached getters of the sub-cursor.
 
-            private readonly IEnumerable<Schema.Column> _colsNeeded;
-            private readonly IEnumerable<Schema.Column> _subActiveColsNeeded;
+            private readonly IEnumerable<Schema.Column> _columnsNeeded;
+            private readonly IEnumerable<Schema.Column> _subActivecolumnsNeeded;
 
             private ReadOnlyMemory<char>[] _colValues; // Column values cached from the file path.
             private RowCursor _subCursor; // Sub cursor of the current file.
 
             private IEnumerator<int> _fileOrder;
 
-            public Cursor(IChannelProvider provider, PartitionedFileLoader parent, IMultiStreamSource files, IEnumerable<Schema.Column> colsNeeded, Random rand)
+            public Cursor(IChannelProvider provider, PartitionedFileLoader parent, IMultiStreamSource files, IEnumerable<Schema.Column> columnsNeeded, Random rand)
                 : base(provider)
             {
                 Contracts.AssertValue(parent);
                 Contracts.AssertValue(files);
 
                 _parent = parent;
-                _colsNeeded = colsNeeded;
+                _columnsNeeded = columnsNeeded;
 
-                _active = Utils.BuildArray(Schema.Count, colsNeeded);
+                _active = Utils.BuildArray(Schema.Count, columnsNeeded);
                 _subActive = _active.Take(SubColumnCount).ToArray();
                 _colValues = new ReadOnlyMemory<char>[Schema.Count - SubColumnCount];
 
-                _subActiveColsNeeded = Schema.Where(x => (_subActive?.Length > x.Index) && _subActive[x.Index]);
+                _subActivecolumnsNeeded = Schema.Where(x => (_subActive?.Length > x.Index) && _subActive[x.Index]);
 
                 _subGetters = new Delegate[SubColumnCount];
                 _getters = CreateGetters();
@@ -461,7 +461,7 @@ namespace Microsoft.ML.Data
                         continue;
                     }
 
-                    _subCursor = loader.GetRowCursor(_subActiveColsNeeded);
+                    _subCursor = loader.GetRowCursor(_subActivecolumnsNeeded);
 
                     try
                     {

--- a/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
@@ -390,7 +390,6 @@ namespace Microsoft.ML.Data
                 _subActive = _active.Take(SubColumnCount).ToArray();
                 _colValues = new ReadOnlyMemory<char>[Schema.Count - SubColumnCount];
 
-                // sefilipi: Test this
                 _subActiveColsNeeded = Schema.Where(x => (_subActive?.Length > x.Index) && _subActive[x.Index]);
 
                 _subGetters = new Delegate[SubColumnCount];

--- a/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/PartitionedFileLoader.cs
@@ -391,7 +391,7 @@ namespace Microsoft.ML.Data
                 _colValues = new ReadOnlyMemory<char>[Schema.Count - SubColumnCount];
 
                 // sefilipi: Test this
-                _subActiveColsNeeded = Schema.Where((x, i) => _subActive[i]);
+                _subActiveColsNeeded = Schema.Where(x => (_subActive?.Length > x.Index) && _subActive[x.Index]);
 
                 _subGetters = new Delegate[SubColumnCount];
                 _getters = CreateGetters();

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1404,19 +1404,17 @@ namespace Microsoft.ML.Data
 
             public Schema Schema => _reader._bindings.OutputSchema;
 
-            public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
                 _host.CheckValueOrNull(rand);
-                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, predicate);
+                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, colsNeeded);
                 return Cursor.Create(_reader, _files, active);
             }
 
-            public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
                 _host.CheckValueOrNull(rand);
-                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, predicate);
+                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, colsNeeded);
                 return Cursor.CreateSet(_reader, _files, active, n);
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1404,17 +1404,17 @@ namespace Microsoft.ML.Data
 
             public Schema Schema => _reader._bindings.OutputSchema;
 
-            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
                 _host.CheckValueOrNull(rand);
-                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, colsNeeded);
+                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, columnsNeeded);
                 return Cursor.Create(_reader, _files, active);
             }
 
-            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
             {
                 _host.CheckValueOrNull(rand);
-                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, colsNeeded);
+                var active = Utils.BuildArray(_reader._bindings.OutputSchema.Count, columnsNeeded);
                 return Cursor.CreateSet(_reader, _files, active, n);
             }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Microsoft.ML;
@@ -383,12 +384,12 @@ namespace Microsoft.ML.Data.IO
             ch.AssertNonEmpty(cols);
 
             // Determine the active columns and whether there is header information.
-            bool[] active = new bool[data.Schema.Count];
+            var activeCols = new List<Schema.Column>();
             for (int i = 0; i < cols.Length; i++)
             {
-                ch.Check(0 <= cols[i] && cols[i] < active.Length);
+                ch.Check(0 <= cols[i] && cols[i] < data.Schema.Count);
                 ch.Check(data.Schema[cols[i]].Type.GetItemType().RawKind != 0);
-                active[cols[i]] = true;
+                activeCols.Add(data.Schema[cols[i]]);
             }
 
             bool hasHeader = false;
@@ -412,7 +413,7 @@ namespace Microsoft.ML.Data.IO
                 }
             }
 
-            using (var cursor = data.GetRowCursor(i => active[i]))
+            using (var cursor = data.GetRowCursor(activeCols))
             {
                 var pipes = new ValueWriter[cols.Length];
                 for (int i = 0; i < cols.Length; i++)

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -645,7 +645,7 @@ namespace Microsoft.ML.Data.IO
             // We don't want the type error, if there is one, to be handled by the get-getter, because
             // at the point we've gotten the interior cursor, but not yet constructed the slot cursor.
             ColumnType cursorType = ((ITransposeDataView)this).GetSlotType(col).ItemType;
-            RowCursor inputCursor = view.GetRowCursorForAllColumns(view.Schema);
+            RowCursor inputCursor = view.GetRowCursorForAllColumns();
             try
             {
                 return Utils.MarshalInvoke(GetSlotCursorCore<int>, cursorType.RawType, inputCursor);

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -615,21 +615,21 @@ namespace Microsoft.ML.Data.IO
             return _header.RowCount;
         }
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            _host.CheckValue(predicate, nameof(predicate));
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
             _host.CheckValueOrNull(rand);
             if (HasRowData)
-                return _schemaEntry.GetView().GetRowCursor(predicate, rand);
+                return _schemaEntry.GetView().GetRowCursor(colsNeeded, rand);
             return new Cursor(this, predicate);
         }
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            _host.CheckValue(predicate, nameof(predicate));
             if (HasRowData)
-                return _schemaEntry.GetView().GetRowCursorSet(predicate, n, rand);
-            return new RowCursor[] { GetRowCursor(predicate, rand) };
+                return _schemaEntry.GetView().GetRowCursorSet(colsNeeded, n, rand);
+            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
         }
 
         SlotCursor ITransposeDataView.GetSlotCursor(int col)
@@ -645,7 +645,7 @@ namespace Microsoft.ML.Data.IO
             // We don't want the type error, if there is one, to be handled by the get-getter, because
             // at the point we've gotten the interior cursor, but not yet constructed the slot cursor.
             ColumnType cursorType = ((ITransposeDataView)this).GetSlotType(col).ItemType;
-            RowCursor inputCursor = view.GetRowCursor(c => true);
+            RowCursor inputCursor = view.GetRowCursor(view.Schema);
             try
             {
                 return Utils.MarshalInvoke(GetSlotCursorCore<int>, cursorType.RawType, inputCursor);

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -617,7 +617,7 @@ namespace Microsoft.ML.Data.IO
 
         public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, _schemaEntry.GetView().Schema.Count);
 
             _host.CheckValueOrNull(rand);
             if (HasRowData)

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -645,7 +645,7 @@ namespace Microsoft.ML.Data.IO
             // We don't want the type error, if there is one, to be handled by the get-getter, because
             // at the point we've gotten the interior cursor, but not yet constructed the slot cursor.
             ColumnType cursorType = ((ITransposeDataView)this).GetSlotType(col).ItemType;
-            RowCursor inputCursor = view.GetRowCursor(view.Schema);
+            RowCursor inputCursor = view.GetRowCursorForAllColumns(view.Schema);
             try
             {
                 return Utils.MarshalInvoke(GetSlotCursorCore<int>, cursorType.RawType, inputCursor);

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -617,7 +617,7 @@ namespace Microsoft.ML.Data.IO
 
         public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, _schemaEntry.GetView().Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, _schemaEntry.GetView().Schema);
 
             _host.CheckValueOrNull(rand);
             if (HasRowData)

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -615,21 +615,21 @@ namespace Microsoft.ML.Data.IO
             return _header.RowCount;
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, _schemaEntry.GetView().Schema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, _schemaEntry.GetView().Schema);
 
             _host.CheckValueOrNull(rand);
             if (HasRowData)
-                return _schemaEntry.GetView().GetRowCursor(colsNeeded, rand);
+                return _schemaEntry.GetView().GetRowCursor(columnsNeeded, rand);
             return new Cursor(this, predicate);
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             if (HasRowData)
-                return _schemaEntry.GetView().GetRowCursorSet(colsNeeded, n, rand);
-            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
+                return _schemaEntry.GetView().GetRowCursorSet(columnsNeeded, n, rand);
+            return new RowCursor[] { GetRowCursor(columnsNeeded, rand) };
         }
 
         SlotCursor ITransposeDataView.GetSlotCursor(int col)

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -215,11 +215,9 @@ namespace Microsoft.ML.Data
                 _currentSourceIndex = 0;
                 _currentCursor = Sources[_currentSourceIndex].GetRowCursor(colsNeeded);
                 _currentIdGetter = _currentCursor.GetIdGetter();
-                for (int c = 0; c < Getters.Length; c++)
-                {
-                    if (colsNeeded.Any(x => x.Index == c))
-                        Getters[c] = CreateGetter(c);
-                }
+
+                foreach(var col in colsNeeded)
+                    Getters[col.Index] = CreateGetter(col.Index);
             }
 
             public override ValueGetter<RowId> GetIdGetter()
@@ -317,11 +315,9 @@ namespace Microsoft.ML.Data
                 }
                 _sampler = new MultinomialWithoutReplacementSampler(Ch, counts, rand);
                 _currentSourceIndex = -1;
-                for (int c = 0; c < Getters.Length; c++)
-                {
-                    if (colsNeeded.Any(x => x.Index == c))
-                        Getters[c] = CreateGetter(c);
-                }
+
+                foreach(var col in colsNeeded)
+                    Getters[col.Index] = CreateGetter(col.Index);
             }
 
             public override ValueGetter<RowId> GetIdGetter()

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.ML.Internal.Utilities;
@@ -143,17 +144,16 @@ namespace Microsoft.ML.Data
             return sum;
         }
 
-        public RowCursor GetRowCursor(Func<int, bool> needCol, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            _host.CheckValue(needCol, nameof(needCol));
             if (rand == null || !_canShuffle)
-                return new Cursor(this, needCol);
-            return new RandCursor(this, needCol, rand, _counts);
+                return new Cursor(this, colsNeeded);
+            return new RandCursor(this, colsNeeded, rand, _counts);
         }
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            return new RowCursor[] { GetRowCursor(predicate, rand) };
+            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
         }
 
         private abstract class CursorBase : RootCursorBase
@@ -209,17 +209,15 @@ namespace Microsoft.ML.Data
             private ValueGetter<RowId> _currentIdGetter;
             private int _currentSourceIndex;
 
-            public Cursor(AppendRowsDataView parent, Func<int, bool> needCol)
+            public Cursor(AppendRowsDataView parent, IEnumerable<Schema.Column> colsNeeded)
                 : base(parent)
             {
-                Ch.AssertValue(needCol);
-
                 _currentSourceIndex = 0;
-                _currentCursor = Sources[_currentSourceIndex].GetRowCursor(needCol);
+                _currentCursor = Sources[_currentSourceIndex].GetRowCursor(colsNeeded);
                 _currentIdGetter = _currentCursor.GetIdGetter();
                 for (int c = 0; c < Getters.Length; c++)
                 {
-                    if (needCol(c))
+                    if (colsNeeded.Any(x => x.Index == c))
                         Getters[c] = CreateGetter(c);
                 }
             }
@@ -269,7 +267,11 @@ namespace Microsoft.ML.Data
                     _currentCursor = null;
                     if (++_currentSourceIndex >= Sources.Length)
                         return false;
-                    _currentCursor = Sources[_currentSourceIndex].GetRowCursor(c => IsColumnActive(c));
+
+                    // sefilipi: double-check
+
+                    var colsNeeded = Schema.Where(col => col.Index >= 0);
+                    _currentCursor = Sources[_currentSourceIndex].GetRowCursor(colsNeeded);
                     _currentIdGetter = _currentCursor.GetIdGetter();
                 }
 
@@ -301,10 +303,9 @@ namespace Microsoft.ML.Data
             private readonly Random _rand;
             private int _currentSourceIndex;
 
-            public RandCursor(AppendRowsDataView parent, Func<int, bool> needCol, Random rand, int[] counts)
+            public RandCursor(AppendRowsDataView parent, IEnumerable<Schema.Column> colsNeeded, Random rand, int[] counts)
                 : base(parent)
             {
-                Ch.AssertValue(needCol);
                 Ch.AssertValue(rand);
 
                 _rand = rand;
@@ -314,13 +315,13 @@ namespace Microsoft.ML.Data
                 for (int i = 0; i < counts.Length; i++)
                 {
                     Ch.Assert(counts[i] >= 0);
-                    _cursorSet[i] = parent._sources[i].GetRowCursor(needCol, RandomUtils.Create(_rand));
+                    _cursorSet[i] = parent._sources[i].GetRowCursor(colsNeeded, RandomUtils.Create(_rand));
                 }
                 _sampler = new MultinomialWithoutReplacementSampler(Ch, counts, rand);
                 _currentSourceIndex = -1;
                 for (int c = 0; c < Getters.Length; c++)
                 {
-                    if (needCol(c))
+                    if (colsNeeded.Any(x => x.Index == c))
                         Getters[c] = CreateGetter(c);
                 }
             }

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -144,16 +144,16 @@ namespace Microsoft.ML.Data
             return sum;
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             if (rand == null || !_canShuffle)
-                return new Cursor(this, colsNeeded);
-            return new RandCursor(this, colsNeeded, rand, _counts);
+                return new Cursor(this, columnsNeeded);
+            return new RandCursor(this, columnsNeeded, rand, _counts);
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
-            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
+            return new RowCursor[] { GetRowCursor(columnsNeeded, rand) };
         }
 
         private abstract class CursorBase : RootCursorBase
@@ -209,14 +209,14 @@ namespace Microsoft.ML.Data
             private ValueGetter<RowId> _currentIdGetter;
             private int _currentSourceIndex;
 
-            public Cursor(AppendRowsDataView parent, IEnumerable<Schema.Column> colsNeeded)
+            public Cursor(AppendRowsDataView parent, IEnumerable<Schema.Column> columnsNeeded)
                 : base(parent)
             {
                 _currentSourceIndex = 0;
-                _currentCursor = Sources[_currentSourceIndex].GetRowCursor(colsNeeded);
+                _currentCursor = Sources[_currentSourceIndex].GetRowCursor(columnsNeeded);
                 _currentIdGetter = _currentCursor.GetIdGetter();
 
-                foreach(var col in colsNeeded)
+                foreach(var col in columnsNeeded)
                     Getters[col.Index] = CreateGetter(col.Index);
             }
 
@@ -266,8 +266,8 @@ namespace Microsoft.ML.Data
                     if (++_currentSourceIndex >= Sources.Length)
                         return false;
 
-                    var colsNeeded = Schema.Where(col => IsColumnActive(col.Index));
-                    _currentCursor = Sources[_currentSourceIndex].GetRowCursor(colsNeeded);
+                    var columnsNeeded = Schema.Where(col => IsColumnActive(col.Index));
+                    _currentCursor = Sources[_currentSourceIndex].GetRowCursor(columnsNeeded);
                     _currentIdGetter = _currentCursor.GetIdGetter();
                 }
 
@@ -299,7 +299,7 @@ namespace Microsoft.ML.Data
             private readonly Random _rand;
             private int _currentSourceIndex;
 
-            public RandCursor(AppendRowsDataView parent, IEnumerable<Schema.Column> colsNeeded, Random rand, int[] counts)
+            public RandCursor(AppendRowsDataView parent, IEnumerable<Schema.Column> columnsNeeded, Random rand, int[] counts)
                 : base(parent)
             {
                 Ch.AssertValue(rand);
@@ -311,12 +311,12 @@ namespace Microsoft.ML.Data
                 for (int i = 0; i < counts.Length; i++)
                 {
                     Ch.Assert(counts[i] >= 0);
-                    _cursorSet[i] = parent._sources[i].GetRowCursor(colsNeeded, RandomUtils.Create(_rand));
+                    _cursorSet[i] = parent._sources[i].GetRowCursor(columnsNeeded, RandomUtils.Create(_rand));
                 }
                 _sampler = new MultinomialWithoutReplacementSampler(Ch, counts, rand);
                 _currentSourceIndex = -1;
 
-                foreach(var col in colsNeeded)
+                foreach(var col in columnsNeeded)
                     Getters[col.Index] = CreateGetter(col.Index);
             }
 

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -268,9 +268,7 @@ namespace Microsoft.ML.Data
                     if (++_currentSourceIndex >= Sources.Length)
                         return false;
 
-                    // sefilipi: double-check
-
-                    var colsNeeded = Schema.Where(col => col.Index >= 0);
+                    var colsNeeded = Schema.Where(col => IsColumnActive(col.Index));
                     _currentCursor = Sources[_currentSourceIndex].GetRowCursor(colsNeeded);
                     _currentIdGetter = _currentCursor.GetIdGetter();
                 }

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -232,17 +232,17 @@ namespace Microsoft.ML.Data
                 _rowCount = rowCount;
             }
 
-            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
 
                 _host.CheckValueOrNull(rand);
                 return new Cursor(_host, this, predicate, rand);
             }
 
-            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
 
                 _host.CheckValueOrNull(rand);
                 return new RowCursor[] { new Cursor(_host, this, predicate, rand) };

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Data
 
             public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
 
                 _host.CheckValueOrNull(rand);
                 return new Cursor(_host, this, predicate, rand);
@@ -242,7 +242,7 @@ namespace Microsoft.ML.Data
 
             public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
 
                 _host.CheckValueOrNull(rand);
                 return new RowCursor[] { new Cursor(_host, this, predicate, rand) };

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Data
 
             public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
 
                 _host.CheckValueOrNull(rand);
                 return new Cursor(_host, this, predicate, rand);
@@ -242,7 +242,7 @@ namespace Microsoft.ML.Data
 
             public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
 
                 _host.CheckValueOrNull(rand);
                 return new RowCursor[] { new Cursor(_host, this, predicate, rand) };

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML.Internal.Utilities;
 
 namespace Microsoft.ML.Data
@@ -231,16 +232,18 @@ namespace Microsoft.ML.Data
                 _rowCount = rowCount;
             }
 
-            public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
                 _host.CheckValueOrNull(rand);
                 return new Cursor(_host, this, predicate, rand);
             }
 
-            public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
                 _host.CheckValueOrNull(rand);
                 return new RowCursor[] { new Cursor(_host, this, predicate, rand) };
             }

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Data
         {
             _host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
 
             // We have this explicit enumeration over the generic types to force different assembly
             // code to be generated for the different types, of both waiters and especially indexers.
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Data
         {
             _host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
 
             n = DataViewUtils.GetThreadCount(_host, n);
 
@@ -341,9 +341,9 @@ namespace Microsoft.ML.Data
                 if (Utils.Size(taskColumns) == 0 && _cacheDefaultWaiter != null)
                     return;
                 if (taskColumns == null)
-                    cursor = _subsetInput.GetRowCursor(null);
+                    cursor = _subsetInput.GetRowCursor();
                 else
-                    cursor = _subsetInput.GetRowCursor(taskColumns.ToArray());
+                    cursor = _subsetInput.GetRowCursor(_subsetInput.Schema.Where(c => taskColumns.Contains(c.Index)));
                 waiter = new OrderedWaiter(firstCleared: false);
                 _cacheDefaultWaiter = waiter;
                 caches = new ColumnCache[Utils.Size(taskColumns)];

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Data
             {
                 var type = schema[c].Type;
                 env.Assert(ip == prefetch.Length || c <= prefetch[ip]);
-                if (!type.IsCachable())
+                if (!type.IsCacheable())
                 {
                     if (inputToSubset == null)
                     {

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Data
         {
             _host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
 
             // We have this explicit enumeration over the generic types to force different assembly
             // code to be generated for the different types, of both waiters and especially indexers.
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Data
         {
             _host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
 
             n = DataViewUtils.GetThreadCount(_host, n);
 
@@ -343,7 +343,7 @@ namespace Microsoft.ML.Data
                 if (taskColumns == null)
                     cursor = _subsetInput.GetRowCursor(null);
                 else
-                    cursor = _subsetInput.GetRowCursor(Schema.Where(x => taskColumns.Contains(x.Index)));
+                    cursor = _subsetInput.GetRowCursor(taskColumns.ToArray());
                 waiter = new OrderedWaiter(firstCleared: false);
                 _cacheDefaultWaiter = waiter;
                 caches = new ColumnCache[Utils.Size(taskColumns)];

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -202,11 +202,11 @@ namespace Microsoft.ML.Data
             return _rowCount;
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
 
             // We have this explicit enumeration over the generic types to force different assembly
             // code to be generated for the different types, of both waiters and especially indexers.
@@ -248,16 +248,16 @@ namespace Microsoft.ML.Data
             return CreateCursor(predicate, RandomIndex<TWaiter>.Create(waiter, perm));
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
 
             n = DataViewUtils.GetThreadCount(_host, n);
 
             if (n <= 1)
-                return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
+                return new RowCursor[] { GetRowCursor(columnsNeeded, rand) };
 
             var waiter = WaiterWaiter.Create(this, predicate);
             if (waiter.IsTrivial)

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -576,7 +576,7 @@ namespace Microsoft.ML.Data
 
             public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
                 return new WrappedCursor(new Cursor(Host, "ListDataView", this, predicate, rand));
             }
 
@@ -672,7 +672,7 @@ namespace Microsoft.ML.Data
 
             public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
                 return new WrappedCursor (new Cursor(Host, this, predicate));
             }
 
@@ -743,7 +743,7 @@ namespace Microsoft.ML.Data
             public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
                 Contracts.Assert(_current != null, "The current object must be set prior to cursoring");
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
                 return new WrappedCursor (new Cursor(Host, this, predicate));
             }
 

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -576,7 +576,7 @@ namespace Microsoft.ML.Data
 
             public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
                 return new WrappedCursor(new Cursor(Host, "ListDataView", this, predicate, rand));
             }
 
@@ -672,7 +672,7 @@ namespace Microsoft.ML.Data
 
             public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
                 return new WrappedCursor (new Cursor(Host, this, predicate));
             }
 
@@ -743,7 +743,7 @@ namespace Microsoft.ML.Data
             public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
                 Contracts.Assert(_current != null, "The current object must be set prior to cursoring");
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
                 return new WrappedCursor (new Cursor(Host, this, predicate));
             }
 

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -397,11 +397,11 @@ namespace Microsoft.ML.Data
 
             public abstract long? GetRowCount();
 
-            public abstract RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null);
+            public abstract RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null);
 
-            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
             {
-                return new[] { GetRowCursor(colsNeeded, rand) };
+                return new[] { GetRowCursor(columnsNeeded, rand) };
             }
 
             public sealed class WrappedCursor : RowCursor
@@ -574,9 +574,9 @@ namespace Microsoft.ML.Data
                 return _data.Count;
             }
 
-            public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public override RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
                 return new WrappedCursor(new Cursor(Host, "ListDataView", this, predicate, rand));
             }
 
@@ -670,9 +670,9 @@ namespace Microsoft.ML.Data
                 return (_data as ICollection<TRow>)?.Count;
             }
 
-            public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public override RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
                 return new WrappedCursor (new Cursor(Host, this, predicate));
             }
 
@@ -740,10 +740,10 @@ namespace Microsoft.ML.Data
                 _current = value;
             }
 
-            public override RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public override RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
                 Contracts.Assert(_current != null, "The current object must be set prior to cursoring");
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
                 return new WrappedCursor (new Cursor(Host, this, predicate));
             }
 

--- a/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
@@ -11,22 +11,22 @@ namespace Microsoft.ML.Data
     internal static class DataViewExtensions
     {
         /// <summary>
-        /// Get a row cursor. The <paramref name="colsNeeded"/> are the active columns.
+        /// Get a row cursor. The <paramref name="columnsNeeded"/> are the active columns.
         /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
         /// a getter for an inactive columns will throw.
         /// </summary>
-        /// <param name="colsNeeded">The columns requested by this <see cref="RowCursor"/>, or as otherwise called, the active columns.
+        /// <param name="columnsNeeded">The columns requested by this <see cref="RowCursor"/>, or as otherwise called, the active columns.
         /// An empty collection indicates that no column is needed.</param>
-        /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="colsNeeded"/>.</param>
-        public static RowCursor GetRowCursor(this IDataView dv, params Schema.Column[] colsNeeded)
+        /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="columnsNeeded"/>.</param>
+        public static RowCursor GetRowCursor(this IDataView dv, params Schema.Column[] columnsNeeded)
         {
-            Contracts.AssertValue(colsNeeded, $"The {nameof(colsNeeded)} cannot be null. Pass an empty array, to indicate that no columns is needed.");
+            Contracts.AssertValue(columnsNeeded, $"The {nameof(columnsNeeded)} cannot be null. Pass an empty array, to indicate that no columns is needed.");
 
-            foreach (var col in colsNeeded)
+            foreach (var col in columnsNeeded)
                 Contracts.Assert(dv.Schema[col.Index].Equals(col), $"The requested column named: {col.Name}, with index: {col.Index} and type: {col.Type}" +
                     $" is not present in the {nameof(IDataView)} where the {nameof(RowCursor)} is being requested.");
 
-            return dv.GetRowCursor(colsNeeded);
+            return dv.GetRowCursor(columnsNeeded);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
@@ -18,8 +18,7 @@ namespace Microsoft.ML.Data
         /// <param name="colsNeeded">The columns requested by this <see cref="RowCursor"/>, or as otherwise called, the active columns.
         /// An empty collection indicates that no column is needed.</param>
         /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="colsNeeded"/>.</param>
-        [BestFriend]
-        internal static RowCursor GetRowCursor(this IDataView dv, params Schema.Column[] colsNeeded)
+        public static RowCursor GetRowCursor(this IDataView dv, params Schema.Column[] colsNeeded)
         {
             Contracts.AssertValue(colsNeeded, $"The {nameof(colsNeeded)} cannot be null. Pass an empty array, to indicate that no columns is needed.");
 
@@ -37,22 +36,22 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="colNeeded">The column requested by this <see cref="RowCursor"/>, or as otherwise called, the active column.</param>
         /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="colNeeded"/>.</param>
-        [BestFriend]
-        internal static RowCursor GetRowCursor(this IDataView dv, Schema.Column colNeeded)
+        public static RowCursor GetRowCursor(this IDataView dv, Schema.Column colNeeded)
         {
             Contracts.Assert(dv.Schema[colNeeded.Index].Equals(colNeeded), $"The requested column named: {colNeeded.Name}, with index: {colNeeded.Index} and type: {colNeeded.Type}" +
                    $" is not present in the {nameof(IDataView)} where the {nameof(RowCursor)} is being requested.");
 
-            var list = new List<Schema.Column>();
-            list.Add(colNeeded);
-
-            return dv.GetRowCursor(list);
+            return dv.GetRowCursor(Enumerable.Repeat(colNeeded,1));
         }
 
         /// <summary>
         /// Get a row cursor. No colums are needed by this <see cref="RowCursor"/>.
         /// </summary>
-        [BestFriend]
-        internal static RowCursor GetRowCursor(this IDataView dv) =>  dv.GetRowCursor(new List<Schema.Column>());
+        public static RowCursor GetRowCursor(this IDataView dv) =>  dv.GetRowCursor(new HashSet<Schema.Column>());
+
+        /// <summary>
+        /// Get a row cursor including all the columns of the <see cref="IDataView"/> it is called upon..
+        /// </summary>
+        public static RowCursor GetRowCursorForAllColumns(this IDataView dv) => dv.GetRowCursor(dv.Schema);
     }
 }

--- a/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
@@ -30,24 +30,24 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Get a row cursor. The <paramref name="colNeeded"/> is the active column.
+        /// Get a row cursor. The <paramref name="columnNeeded"/> is the active column.
         /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
         /// a getter for the other, inactive columns will throw.
         /// </summary>
-        /// <param name="colNeeded">The column requested by this <see cref="RowCursor"/>, or as otherwise called, the active column.</param>
-        /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="colNeeded"/>.</param>
-        public static RowCursor GetRowCursor(this IDataView dv, Schema.Column colNeeded)
+        /// <param name="columnNeeded">The column requested by this <see cref="RowCursor"/>, or as otherwise called, the active column.</param>
+        /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="columnNeeded"/>.</param>
+        public static RowCursor GetRowCursor(this IDataView dv, Schema.Column columnNeeded)
         {
-            Contracts.Assert(dv.Schema[colNeeded.Index].Equals(colNeeded), $"The requested column named: {colNeeded.Name}, with index: {colNeeded.Index} and type: {colNeeded.Type}" +
+            Contracts.Assert(dv.Schema[columnNeeded.Index].Equals(columnNeeded), $"The requested column named: {columnNeeded.Name}, with index: {columnNeeded.Index} and type: {columnNeeded.Type}" +
                    $" is not present in the {nameof(IDataView)} where the {nameof(RowCursor)} is being requested.");
 
-            return dv.GetRowCursor(Enumerable.Repeat(colNeeded,1));
+            return dv.GetRowCursor(Enumerable.Repeat(columnNeeded,1));
         }
 
         /// <summary>
         /// Get a row cursor. No colums are needed by this <see cref="RowCursor"/>.
         /// </summary>
-        public static RowCursor GetRowCursor(this IDataView dv) =>  dv.GetRowCursor(new HashSet<Schema.Column>());
+        public static RowCursor GetRowCursor(this IDataView dv) =>  dv.GetRowCursor(Enumerable.Empty<Schema.Column>());
 
         /// <summary>
         /// Get a row cursor including all the columns of the <see cref="IDataView"/> it is called upon..

--- a/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
@@ -2,44 +2,57 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Microsoft.ML.Data
 {
-    public static class DataViewExtensions
+    [BestFriend]
+    internal static class DataViewExtensions
     {
         /// <summary>
-        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
+        /// Get a row cursor. The <paramref name="colsNeeded"/> are the active columns.
         /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
-        /// a getter for an inactive columns will throw. The <paramref name="namesOfcolsNeeded"/> predicate must be
-        /// non-null.If set to <langword>null</langword> no column is active.
+        /// a getter for an inactive columns will throw.
         /// </summary>
-        public static RowCursor GetRowCursor(this IDataView dv, params string[] namesOfcolsNeeded)
-            => dv.GetRowCursor(dv.Schema.GetColumns(namesOfcolsNeeded));
+        /// <param name="colsNeeded">The columns requested by this <see cref="RowCursor"/>, or as otherwise called, the active columns.
+        /// An empty collection indicates that no column is needed.</param>
+        /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="colsNeeded"/>.</param>
+        [BestFriend]
+        internal static RowCursor GetRowCursor(this IDataView dv, params Schema.Column[] colsNeeded)
+        {
+            Contracts.AssertValue(colsNeeded, $"The {nameof(colsNeeded)} cannot be null. Pass an empty array, to indicate that no columns is needed.");
+
+            foreach (var col in colsNeeded)
+                Contracts.Assert(dv.Schema[col.Index].Equals(col), $"The requested column named: {col.Name}, with index: {col.Index} and type: {col.Type}" +
+                    $" is not present in the {nameof(IDataView)} where the {nameof(RowCursor)} is being requested.");
+
+            return dv.GetRowCursor(colsNeeded);
+        }
 
         /// <summary>
-        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
+        /// Get a row cursor. The <paramref name="colNeeded"/> is the active column.
         /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
-        /// a getter for an inactive columns will throw. The <paramref name="indicesOfcolsNeeded"/> predicate must be
-        /// non-null.If set to <langword>null</langword> no column is active.
+        /// a getter for the other, inactive columns will throw.
         /// </summary>
-        public static RowCursor GetRowCursor(this IDataView dv, params int[] indicesOfcolsNeeded)
-            => dv.GetRowCursor(dv.Schema.GetColumns(indicesOfcolsNeeded));
+        /// <param name="colNeeded">The column requested by this <see cref="RowCursor"/>, or as otherwise called, the active column.</param>
+        /// <param name="dv">The <see cref="IDataView"/> containing the <paramref name="colNeeded"/>.</param>
+        [BestFriend]
+        internal static RowCursor GetRowCursor(this IDataView dv, Schema.Column colNeeded)
+        {
+            Contracts.Assert(dv.Schema[colNeeded.Index].Equals(colNeeded), $"The requested column named: {colNeeded.Name}, with index: {colNeeded.Index} and type: {colNeeded.Type}" +
+                   $" is not present in the {nameof(IDataView)} where the {nameof(RowCursor)} is being requested.");
+
+            var list = new List<Schema.Column>();
+            list.Add(colNeeded);
+
+            return dv.GetRowCursor(list);
+        }
 
         /// <summary>
-        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
-        /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
-        /// a getter for an inactive columns will throw. The <paramref name="colNeeded"/> predicate must be
-        /// non-null.If set to <langword>null</langword> no column is active.
+        /// Get a row cursor. No colums are needed by this <see cref="RowCursor"/>.
         /// </summary>
-        public static RowCursor GetRowCursor(this IDataView dv, string colNeeded)
-            => dv.GetRowCursor(new[] { dv.Schema[colNeeded] });
-
-        /// <summary>
-        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
-        /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
-        /// a getter for an inactive columns will throw. The <paramref name="colNeeded"/> predicate must be
-        /// non-null.If set to <langword>null</langword> no column is active.
-        /// </summary>
-        public static RowCursor GetRowCursor(this IDataView dv, int colNeeded)
-            => dv.GetRowCursor(new[] { dv.Schema[colNeeded]});
+        [BestFriend]
+        internal static RowCursor GetRowCursor(this IDataView dv) =>  dv.GetRowCursor(new List<Schema.Column>());
     }
 }

--- a/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Data
+{
+    public static class DataViewExtensions
+    {
+        /// <summary>
+        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
+        /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
+        /// a getter for an inactive columns will throw. The <paramref name="namesOfcolsNeeded"/> predicate must be
+        /// non-null.If set to <langword>null</langword> no column is active.
+        /// </summary>
+        public static RowCursor GetRowCursor(this IDataView dv, params string[] namesOfcolsNeeded)
+            => dv.GetRowCursor(dv.Schema.GetColumns(namesOfcolsNeeded));
+
+        /// <summary>
+        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
+        /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
+        /// a getter for an inactive columns will throw. The <paramref name="indicesOfcolsNeeded"/> predicate must be
+        /// non-null.If set to <langword>null</langword> no column is active.
+        /// </summary>
+        public static RowCursor GetRowCursor(this IDataView dv, params int[] indicesOfcolsNeeded)
+            => dv.GetRowCursor(dv.Schema.GetColumns(indicesOfcolsNeeded));
+
+        /// <summary>
+        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
+        /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
+        /// a getter for an inactive columns will throw. The <paramref name="colNeeded"/> predicate must be
+        /// non-null.If set to <langword>null</langword> no column is active.
+        /// </summary>
+        public static RowCursor GetRowCursor(this IDataView dv, string colNeeded)
+            => dv.GetRowCursor(new[] { dv.Schema[colNeeded] });
+
+        /// <summary>
+        /// Get a row cursor. The active column indices are those for which needCol(col) returns true.
+        /// The schema of the returned cursor will be the same as the schema of the IDataView, but getting
+        /// a getter for an inactive columns will throw. The <paramref name="colNeeded"/> predicate must be
+        /// non-null.If set to <langword>null</langword> no column is active.
+        /// </summary>
+        public static RowCursor GetRowCursor(this IDataView dv, int colNeeded)
+            => dv.GetRowCursor(new[] { dv.Schema[colNeeded]});
+    }
+}

--- a/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
@@ -28,16 +28,16 @@ namespace Microsoft.ML.Data
 
         public long? GetRowCount() => 0;
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            return new Cursor(_host, Schema, colsNeeded);
+            return new Cursor(_host, Schema, columnsNeeded);
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            return new[] { new Cursor(_host, Schema, colsNeeded) };
+            return new[] { new Cursor(_host, Schema, columnsNeeded) };
         }
 
         private sealed class Cursor : RootCursorBase
@@ -47,12 +47,12 @@ namespace Microsoft.ML.Data
             public override Schema Schema { get; }
             public override long Batch => 0;
 
-            public Cursor(IChannelProvider provider, Schema schema, IEnumerable<Schema.Column> colsNeeded)
+            public Cursor(IChannelProvider provider, Schema schema, IEnumerable<Schema.Column> columnsNeeded)
                 : base(provider)
             {
                 Ch.AssertValue(schema);
                 Schema = schema;
-                _active = Utils.BuildArray(Schema.Count, colsNeeded);
+                _active = Utils.BuildArray(Schema.Count, columnsNeeded);
             }
 
             public override ValueGetter<RowId> GetIdGetter()

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Data
             protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
                 Host.AssertValueOrNull(rand);
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);
@@ -125,7 +125,7 @@ namespace Microsoft.ML.Data
             {
 
                 Host.CheckValueOrNull(rand);
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.ML.Data.Conversion;
 using Microsoft.ML.Model;
@@ -106,25 +108,29 @@ namespace Microsoft.ML.Data
                 return null;
             }
 
-            protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+            protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                Host.AssertValue(predicate, "predicate");
                 Host.AssertValueOrNull(rand);
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);
-                var input = Source.GetRowCursor(inputPred, rand);
+
+                var inputCols = colsNeeded.Where(x => inputPred(x.Index));
+                var input = Source.GetRowCursor(inputCols, rand);
                 return new Cursor(this, input, active);
             }
 
-            public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+            public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                Host.CheckValue(predicate, nameof(predicate));
+
                 Host.CheckValueOrNull(rand);
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);
-                var inputs = Source.GetRowCursorSet(inputPred, n, rand);
+                var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+                var inputs = Source.GetRowCursorSet(inputCols, n, rand);
                 Host.AssertNonEmpty(inputs);
 
                 // No need to split if this is given 1 input cursor.

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -108,10 +108,10 @@ namespace Microsoft.ML.Data
                 return null;
             }
 
-            protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
                 Host.AssertValueOrNull(rand);
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);
@@ -121,11 +121,11 @@ namespace Microsoft.ML.Data
                 return new Cursor(this, input, active);
             }
 
-            public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
             {
 
                 Host.CheckValueOrNull(rand);
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Data
             protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
                 Host.AssertValueOrNull(rand);
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);
@@ -125,7 +125,7 @@ namespace Microsoft.ML.Data
             {
 
                 Host.CheckValueOrNull(rand);
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Data
                 bool[] active;
                 Func<int, bool> inputPred = GetActive(predicate, out active);
 
-                var inputCols = colsNeeded.Where(x => inputPred(x.Index));
+                var inputCols = Source.Schema.Where(x => inputPred(x.Index));
                 var input = Source.GetRowCursor(inputCols, rand);
                 return new Cursor(this, input, active);
             }

--- a/src/Microsoft.ML.Data/DataView/OpaqueDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/OpaqueDataView.cs
@@ -24,10 +24,10 @@ namespace Microsoft.ML.Data
 
         public long? GetRowCount() => _source.GetRowCount();
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
-            =>_source.GetRowCursor(colsNeeded, rand);
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
+            =>_source.GetRowCursor(columnsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
-            => _source.GetRowCursorSet(colsNeeded, n, rand);
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
+            => _source.GetRowCursorSet(columnsNeeded, n, rand);
     }
 }

--- a/src/Microsoft.ML.Data/DataView/OpaqueDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/OpaqueDataView.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.ML.Data
 {
@@ -21,19 +22,12 @@ namespace Microsoft.ML.Data
             _source = source;
         }
 
-        public long? GetRowCount()
-        {
-            return _source.GetRowCount();
-        }
+        public long? GetRowCount() => _source.GetRowCount();
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
-        {
-            return _source.GetRowCursor(predicate, rand);
-        }
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            =>_source.GetRowCursor(colsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
-        {
-            return _source.GetRowCursorSet(predicate, n, rand);
-        }
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            => _source.GetRowCursorSet(colsNeeded, n, rand);
     }
 }

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -181,9 +181,9 @@ namespace Microsoft.ML.Data
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
@@ -192,11 +192,11 @@ namespace Microsoft.ML.Data
             return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.ML;
@@ -180,22 +181,29 @@ namespace Microsoft.ML.Data
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
-            return new Cursor(Host, Source.GetRowCursor(predicateInput, rand), this, active);
+
+            var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
+
+            return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
+
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
 
-            var inputs = Source.GetRowCursorSet(predicateInput, n, rand);
+            var inputCols = colsNeeded.Where(x => predicateInput(x.Index)).ToList().AsReadOnly();
+            var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 
             if (inputs.Length == 1 && n > 1 && _bindings.AddedColumnIndices.Any(predicate))

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Data
 
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
@@ -196,7 +196,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -183,11 +183,10 @@ namespace Microsoft.ML.Data
 
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
-
             var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
 
             return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
@@ -197,7 +196,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -202,7 +202,7 @@ namespace Microsoft.ML.Data
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
 
-            var inputCols = colsNeeded.Where(x => predicateInput(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
             var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -823,7 +823,7 @@ namespace Microsoft.ML.Data
 
             public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
 
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);
@@ -836,7 +836,7 @@ namespace Microsoft.ML.Data
             {
                 _host.CheckValueOrNull(rand);
 
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
 
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -280,15 +280,11 @@ namespace Microsoft.ML.Data
 
         public bool CanShuffle { get { return _view.CanShuffle; } }
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
-        {
-            return _view.GetRowCursor(predicate, rand);
-        }
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            => _view.GetRowCursor(colsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
-        {
-            return _view.GetRowCursorSet(predicate, n, rand);
-        }
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            => _view.GetRowCursorSet(colsNeeded, n, rand);
 
         public long? GetRowCount()
         {
@@ -379,7 +375,7 @@ namespace Microsoft.ML.Data
                         Ch.Check(IsGood, "Cannot get values in the cursor's current state");
                         if (!valid)
                         {
-                            using (var cursor = _view.GetRowCursor(c => c == _col))
+                            using (var cursor = _view.GetRowCursor(_view.Schema))
                             {
                                 int[] indices = null;
                                 T[] values = null;
@@ -530,7 +526,7 @@ namespace Microsoft.ML.Data
                 // is having its values loaded into _indices/_values/_counts while the current column is being
                 // served up to the consumer through _cbuff.
 
-                using (var cursor = _view.GetRowCursor(c => c == _colCurr))
+                using (var cursor = _view.GetRowCursor(_view.Schema))
                 {
                     // Make sure that the buffers (and subbuffers) are all of appropriate size.
                     Utils.EnsureSize(ref _indices, vecLen);
@@ -825,21 +821,26 @@ namespace Microsoft.ML.Data
                 splitCol = _colToSplitCol[col];
             }
 
-            public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);
-                return new Cursor(_host, this, _input.GetRowCursor(srcPred, rand), predicate, activeSplitters);
+                return new Cursor(_host, this, _input.GetRowCursor(colsNeeded, rand), predicate, activeSplitters);
             }
 
-            public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
                 _host.CheckValueOrNull(rand);
+
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);
-                var result = _input.GetRowCursorSet(srcPred, n, rand);
+
+                var srcCols = colsNeeded.Where( x => srcPred(x.Index));
+                var result = _input.GetRowCursorSet(srcCols, n, rand);
                 for (int i = 0; i < result.Length; ++i)
                     result[i] = new Cursor(_host, this, result[i], predicate, activeSplitters);
                 return result;
@@ -849,7 +850,7 @@ namespace Microsoft.ML.Data
             /// Given a possibly null predicate for this data view, produce the dependency predicate for the sources,
             /// as well as a list of all the splitters for which we should produce rowsets.
             /// </summary>
-            /// <param name="pred">The predicate input into the <see cref="GetRowCursor(Func{int, bool}, Random)"/> method.</param>
+            /// <param name="pred">The predicate input into the <see cref="GetRowCursor(IEnumerable{Schema.Column}, Random)"/> method.</param>
             /// <param name="activeSplitters">A boolean indicator array of length equal to the number of splitters,
             /// indicating whether that splitter has any active columns in its outputs or not</param>
             /// <returns>The predicate to use when constructing the row cursor from the source</returns>
@@ -1392,10 +1393,10 @@ namespace Microsoft.ML.Data
                 return valueCount;
             }
 
-            public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
-                return Utils.MarshalInvoke(GetRowCursor<int>, _type.GetItemType().RawType, predicate(0));
+                bool hasZero = colsNeeded != null && colsNeeded.Any(x => x.Index == 0);
+                return Utils.MarshalInvoke(GetRowCursor<int>, _type.GetItemType().RawType, hasZero);
             }
 
             private RowCursor GetRowCursor<T>(bool active)
@@ -1403,10 +1404,9 @@ namespace Microsoft.ML.Data
                 return new Cursor<T>(this, active);
             }
 
-            public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                _host.CheckValue(predicate, nameof(predicate));
-                return new RowCursor[] { GetRowCursor(predicate, rand) };
+                return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
             }
 
             private sealed class Cursor<T> : RootCursorBase

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -375,7 +375,7 @@ namespace Microsoft.ML.Data
                         Ch.Check(IsGood, "Cannot get values in the cursor's current state");
                         if (!valid)
                         {
-                            using (var cursor = _view.GetRowCursor(_view.Schema))
+                            using (var cursor = _view.GetRowCursor(new[] { _view.Schema[_col] }))
                             {
                                 int[] indices = null;
                                 T[] values = null;
@@ -526,7 +526,7 @@ namespace Microsoft.ML.Data
                 // is having its values loaded into _indices/_values/_counts while the current column is being
                 // served up to the consumer through _cbuff.
 
-                using (var cursor = _view.GetRowCursor(_view.Schema))
+                using (var cursor = _view.GetRowCursor(new[] { _view.Schema[_colCurr] }))
                 {
                     // Make sure that the buffers (and subbuffers) are all of appropriate size.
                     Utils.EnsureSize(ref _indices, vecLen);
@@ -827,7 +827,9 @@ namespace Microsoft.ML.Data
 
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);
-                return new Cursor(_host, this, _input.GetRowCursor(colsNeeded, rand), predicate, activeSplitters);
+
+                var inputCols = _input.Schema.Where(x => srcPred(x.Index));
+                return new Cursor(_host, this, _input.GetRowCursor(inputCols, rand), predicate, activeSplitters);
             }
 
             public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -280,11 +280,11 @@ namespace Microsoft.ML.Data
 
         public bool CanShuffle { get { return _view.CanShuffle; } }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
-            => _view.GetRowCursor(colsNeeded, rand);
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
+            => _view.GetRowCursor(columnsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
-            => _view.GetRowCursorSet(colsNeeded, n, rand);
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
+            => _view.GetRowCursorSet(columnsNeeded, n, rand);
 
         public long? GetRowCount()
         {
@@ -821,9 +821,9 @@ namespace Microsoft.ML.Data
                 splitCol = _colToSplitCol[col];
             }
 
-            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
 
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);
@@ -832,16 +832,16 @@ namespace Microsoft.ML.Data
                 return new Cursor(_host, this, _input.GetRowCursor(inputCols, rand), predicate, activeSplitters);
             }
 
-            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
             {
                 _host.CheckValueOrNull(rand);
 
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
 
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);
 
-                var srcCols = colsNeeded.Where( x => srcPred(x.Index));
+                var srcCols = columnsNeeded.Where( x => srcPred(x.Index));
                 var result = _input.GetRowCursorSet(srcCols, n, rand);
                 for (int i = 0; i < result.Length; ++i)
                     result[i] = new Cursor(_host, this, result[i], predicate, activeSplitters);
@@ -1395,9 +1395,9 @@ namespace Microsoft.ML.Data
                 return valueCount;
             }
 
-            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
-                bool hasZero = colsNeeded != null && colsNeeded.Any(x => x.Index == 0);
+                bool hasZero = columnsNeeded != null && columnsNeeded.Any(x => x.Index == 0);
                 return Utils.MarshalInvoke(GetRowCursor<int>, _type.GetItemType().RawType, hasZero);
             }
 
@@ -1406,9 +1406,9 @@ namespace Microsoft.ML.Data
                 return new Cursor<T>(this, active);
             }
 
-            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
             {
-                return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
+                return new RowCursor[] { GetRowCursor(columnsNeeded, rand) };
             }
 
             private sealed class Cursor<T> : RootCursorBase

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -375,7 +375,7 @@ namespace Microsoft.ML.Data
                         Ch.Check(IsGood, "Cannot get values in the cursor's current state");
                         if (!valid)
                         {
-                            using (var cursor = _view.GetRowCursor(new[] { _view.Schema[_col] }))
+                            using (var cursor = _view.GetRowCursor(_view.Schema[_col]))
                             {
                                 int[] indices = null;
                                 T[] values = null;
@@ -526,7 +526,7 @@ namespace Microsoft.ML.Data
                 // is having its values loaded into _indices/_values/_counts while the current column is being
                 // served up to the consumer through _cbuff.
 
-                using (var cursor = _view.GetRowCursor(new[] { _view.Schema[_colCurr] }))
+                using (var cursor = _view.GetRowCursor(_view.Schema[_colCurr]))
                 {
                     // Make sure that the buffers (and subbuffers) are all of appropriate size.
                     Utils.EnsureSize(ref _indices, vecLen);

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -823,7 +823,7 @@ namespace Microsoft.ML.Data
 
             public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
 
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);
@@ -836,7 +836,7 @@ namespace Microsoft.ML.Data
             {
                 _host.CheckValueOrNull(rand);
 
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
 
                 bool[] activeSplitters;
                 var srcPred = CreateInputPredicate(predicate, out activeSplitters);

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -72,7 +72,7 @@ namespace Microsoft.ML.Data
 
         public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
             _host.CheckValueOrNull(rand);
 
             var srcPredicates = _zipBinding.GetInputPredicates(predicate);
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Data
         private RowCursor GetMinimumCursor(IDataView dv)
         {
             _host.AssertValue(dv);
-            return dv.GetRowCursor(null);
+            return dv.GetRowCursor();
         }
 
         public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -70,9 +70,9 @@ namespace Microsoft.ML.Data
             return min;
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
             _host.CheckValueOrNull(rand);
 
             var srcPredicates = _zipBinding.GetInputPredicates(predicate);
@@ -98,9 +98,9 @@ namespace Microsoft.ML.Data
             return dv.GetRowCursor();
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
-            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
+            return new RowCursor[] { GetRowCursor(columnsNeeded, rand) };
         }
 
         private sealed class Cursor : RootCursorBase

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -70,9 +70,9 @@ namespace Microsoft.ML.Data
             return min;
         }
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            _host.CheckValue(predicate, nameof(predicate));
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             _host.CheckValueOrNull(rand);
 
             var srcPredicates = _zipBinding.GetInputPredicates(predicate);
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Data
             // One reason this is not done currently is because the API has 'somewhat mutable' data views, so potentially this
             // optimization might backfire.
             var srcCursors = _sources
-                .Select((dv, i) => srcPredicates[i] == null ? GetMinimumCursor(dv) : dv.GetRowCursor(srcPredicates[i], null)).ToArray();
+                .Select((dv, i) => srcPredicates[i] == null ? GetMinimumCursor(dv) : dv.GetRowCursor(dv.Schema.Where(x => srcPredicates[i](x.Index)), null)).ToArray();
             return new Cursor(this, srcCursors, predicate);
         }
 
@@ -95,12 +95,12 @@ namespace Microsoft.ML.Data
         private RowCursor GetMinimumCursor(IDataView dv)
         {
             _host.AssertValue(dv);
-            return dv.GetRowCursor(x => false);
+            return dv.GetRowCursor(null);
         }
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            return new RowCursor[] { GetRowCursor(predicate, rand) };
+            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
         }
 
         private sealed class Cursor : RootCursorBase

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -72,7 +72,7 @@ namespace Microsoft.ML.Data
 
         public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
             _host.CheckValueOrNull(rand);
 
             var srcPredicates = _zipBinding.GetInputPredicates(predicate);

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
@@ -240,25 +241,30 @@ namespace Microsoft.ML.Data
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate, "predicate");
             Host.AssertValueOrNull(rand);
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
-            var input = Source.GetRowCursor(inputPred, rand);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            var input = Source.GetRowCursor(inputCols, rand);
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public sealed override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public sealed override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
+
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
-            var inputs = Source.GetRowCursorSet(inputPred, n, rand);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 
             // No need to split if this is given 1 input cursor.

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ML.Data
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -241,10 +241,10 @@ namespace Microsoft.ML.Data
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -254,11 +254,11 @@ namespace Microsoft.ML.Data
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public sealed override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public sealed override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ML.Data
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -626,7 +626,7 @@ namespace Microsoft.ML.Data
             if (!metrics.TryGetValue(AnomalyDetectionEvaluator.TopKResults, out top))
                 throw Host.Except("Did not find the top-k results data view");
             var sb = new StringBuilder();
-            using (var cursor = top.GetRowCursor(col => true))
+            using (var cursor = top.GetRowCursor(top.Schema))
             {
                 int index;
                 if (!top.Schema.TryGetColumnIndex(AnomalyDetectionEvaluator.TopKResultsColumns.Instance, out index))
@@ -678,8 +678,8 @@ namespace Microsoft.ML.Data
             bool hasStratVals = overall.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratVal, out stratVal);
             Contracts.Assert(hasStrat == hasStratVals);
             long numAnomalies = 0;
-            using (var cursor = overall.GetRowCursor(col => col == numAnomIndex ||
-                (hasStrat && col == stratCol)))
+            using (var cursor = overall.GetRowCursor(overall.Schema.Where(col => col.Name.Equals(AnomalyDetectionEvaluator.OverallMetrics.NumAnomalies)||
+                (hasStrat && col.Name.Equals(MetricKinds.ColumnNames.StratCol)))))
             {
                 var numAnomGetter = cursor.GetGetter<long>(numAnomIndex);
                 ValueGetter<uint> stratGetter = null;

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -626,7 +626,7 @@ namespace Microsoft.ML.Data
             if (!metrics.TryGetValue(AnomalyDetectionEvaluator.TopKResults, out top))
                 throw Host.Except("Did not find the top-k results data view");
             var sb = new StringBuilder();
-            using (var cursor = top.GetRowCursor(top.Schema))
+            using (var cursor = top.GetRowCursorForAllColumns())
             {
                 int index;
                 if (!top.Schema.TryGetColumnIndex(AnomalyDetectionEvaluator.TopKResultsColumns.Instance, out index))

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -816,7 +816,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             CalibratedBinaryClassificationMetrics result;
-            using (var cursor = overall.GetRowCursor(i => true))
+            using (var cursor = overall.GetRowCursor(overall.Schema))
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);
@@ -853,7 +853,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             BinaryClassificationMetrics result;
-            using (var cursor = overall.GetRowCursor(i => true))
+            using (var cursor = overall.GetRowCursor(overall.Schema))
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -816,7 +816,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             CalibratedBinaryClassificationMetrics result;
-            using (var cursor = overall.GetRowCursor(overall.Schema))
+            using (var cursor = overall.GetRowCursorForAllColumns())
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);
@@ -853,7 +853,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             BinaryClassificationMetrics result;
-            using (var cursor = overall.GetRowCursor(overall.Schema))
+            using (var cursor = overall.GetRowCursorForAllColumns())
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             ClusteringMetrics result;
-            using (var cursor = overall.GetRowCursor(overall.Schema))
+            using (var cursor = overall.GetRowCursorForAllColumns())
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             ClusteringMetrics result;
-            using (var cursor = overall.GetRowCursor(i => true))
+            using (var cursor = overall.GetRowCursor(overall.Schema))
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Data
         // the metric. If there are stratified metrics, an additional column is added to the data view containing the
         // stratification value as text in the format "column x = y".
         private Dictionary<string, IDataView> ProcessData(IDataView data, RoleMappedSchema schema,
-            Func<int, bool> activeCols, TAgg aggregator, AggregatorDictionaryBase[] dictionaries)
+            Func<int, bool> activeColsIndices, TAgg aggregator, AggregatorDictionaryBase[] dictionaries)
         {
             Func<bool> finishPass =
                 () =>
@@ -140,6 +140,7 @@ namespace Microsoft.ML.Data
 
             bool needMorePasses = aggregator.Start();
 
+            var activeCols = data.Schema.Where(x => activeColsIndices(x.Index));
             // REVIEW: Add progress reporting.
             while (needMorePasses)
             {

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Data
                 }
             }
 
-            using (var cursor = metricsView.GetRowCursor(metricsView.Schema))
+            using (var cursor = metricsView.GetRowCursorForAllColumns())
             {
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;
@@ -1094,7 +1094,7 @@ namespace Microsoft.ML.Data
             int numResults = 0;
             int numWeightedResults = 0;
             AggregatedMetric[] agg;
-            using (var cursor = data.GetRowCursor(data.Schema))
+            using (var cursor = data.GetRowCursorForAllColumns())
             {
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -1703,7 +1703,7 @@ namespace Microsoft.ML.Data
                 int col;
                 if (warnings.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.WarningText, out col) && warnings.Schema[col].Type is TextType)
                 {
-                    using (var cursor = warnings.GetRowCursor(MetricKinds.ColumnNames.WarningText))
+                    using (var cursor = warnings.GetRowCursor(warnings.Schema[MetricKinds.ColumnNames.WarningText]))
                     {
                         var warning = default(ReadOnlyMemory<char>);
                         var getter = cursor.GetGetter<ReadOnlyMemory<char>>(col);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Data
                 }
             }
 
-            using (var cursor = metricsView.GetRowCursor(col => true))
+            using (var cursor = metricsView.GetRowCursor(metricsView.Schema))
             {
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;
@@ -1094,7 +1094,7 @@ namespace Microsoft.ML.Data
             int numResults = 0;
             int numWeightedResults = 0;
             AggregatedMetric[] agg;
-            using (var cursor = data.GetRowCursor(col => true))
+            using (var cursor = data.GetRowCursor(data.Schema))
             {
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;
@@ -1438,7 +1438,7 @@ namespace Microsoft.ML.Data
 
             int stratCol;
             var hasStrat = confusionDataView.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratCol, out stratCol);
-            using (var cursor = confusionDataView.GetRowCursor(col => col == countIndex || hasStrat && col == stratCol))
+            using (var cursor = confusionDataView.GetRowCursor(confusionDataView.Schema.Where(col => col.Index == countIndex || hasStrat && col.Index == stratCol)))
             {
                 var type = cursor.Schema[countIndex].Type as VectorType;
                 Contracts.Check(type != null && type.IsKnownSize && type.ItemType == NumberType.R8);
@@ -1703,7 +1703,7 @@ namespace Microsoft.ML.Data
                 int col;
                 if (warnings.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.WarningText, out col) && warnings.Schema[col].Type is TextType)
                 {
-                    using (var cursor = warnings.GetRowCursor(c => c == col))
+                    using (var cursor = warnings.GetRowCursor(warnings.Schema.Where(c => c.Name.Equals(MetricKinds.ColumnNames.WarningText))))
                     {
                         var warning = default(ReadOnlyMemory<char>);
                         var getter = cursor.GetGetter<ReadOnlyMemory<char>>(col);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -1703,7 +1703,7 @@ namespace Microsoft.ML.Data
                 int col;
                 if (warnings.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.WarningText, out col) && warnings.Schema[col].Type is TextType)
                 {
-                    using (var cursor = warnings.GetRowCursor(warnings.Schema.Where(c => c.Name.Equals(MetricKinds.ColumnNames.WarningText))))
+                    using (var cursor = warnings.GetRowCursor(MetricKinds.ColumnNames.WarningText))
                     {
                         var warning = default(ReadOnlyMemory<char>);
                         var getter = cursor.GetGetter<ReadOnlyMemory<char>>(col);

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -520,7 +520,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             MultiClassClassifierMetrics result;
-            using (var cursor = overall.GetRowCursor(overall.Schema))
+            using (var cursor = overall.GetRowCursorForAllColumns())
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -520,7 +520,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             MultiClassClassifierMetrics result;
-            using (var cursor = overall.GetRowCursor(i => true))
+            using (var cursor = overall.GetRowCursor(overall.Schema))
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -675,7 +675,7 @@ namespace Microsoft.ML.Data
             var colCount = fold.Schema.Count;
             var vBufferGetters = new ValueGetter<VBuffer<double>>[colCount];
 
-            using (var cursor = fold.GetRowCursor(fold.Schema))
+            using (var cursor = fold.GetRowCursorForAllColumns())
             {
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -675,7 +675,7 @@ namespace Microsoft.ML.Data
             var colCount = fold.Schema.Count;
             var vBufferGetters = new ValueGetter<VBuffer<double>>[colCount];
 
-            using (var cursor = fold.GetRowCursor(col => true))
+            using (var cursor = fold.GetRowCursor(fold.Schema))
             {
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -256,7 +256,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             RankerMetrics result;
-            using (var cursor = overall.GetRowCursor(data.Schema))
+            using (var cursor = overall.GetRowCursor(overall.Schema))
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -256,7 +256,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             RankerMetrics result;
-            using (var cursor = overall.GetRowCursor(i => true))
+            using (var cursor = overall.GetRowCursor(data.Schema))
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);
@@ -608,15 +608,11 @@ namespace Microsoft.ML.Data
             return _transform.GetRowCount();
         }
 
-        public RowCursor GetRowCursor(Func<int, bool> needCol, Random rand = null)
-        {
-            return _transform.GetRowCursor(needCol, rand);
-        }
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            => _transform.GetRowCursor(colsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> needCol, int n, Random rand = null)
-        {
-            return _transform.GetRowCursorSet(needCol, n, rand);
-        }
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            => _transform.GetRowCursorSet(colsNeeded, n, rand);
 
         private sealed class Transform : PerGroupTransformBase<short, Single, Transform.RowCursorState>
         {

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -256,7 +256,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             RankerMetrics result;
-            using (var cursor = overall.GetRowCursor(overall.Schema))
+            using (var cursor = overall.GetRowCursorForAllColumns())
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankerEvaluator.cs
@@ -608,11 +608,11 @@ namespace Microsoft.ML.Data
             return _transform.GetRowCount();
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
-            => _transform.GetRowCursor(colsNeeded, rand);
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
+            => _transform.GetRowCursor(columnsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
-            => _transform.GetRowCursorSet(colsNeeded, n, rand);
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
+            => _transform.GetRowCursorSet(columnsNeeded, n, rand);
 
         private sealed class Transform : PerGroupTransformBase<short, Single, Transform.RowCursorState>
         {

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -176,7 +176,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             RegressionMetrics result;
-            using (var cursor = overall.GetRowCursor(i => true))
+            using (var cursor = overall.GetRowCursor(overall.Schema))
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -176,7 +176,7 @@ namespace Microsoft.ML.Data
             var overall = resultDict[MetricKinds.OverallMetrics];
 
             RegressionMetrics result;
-            using (var cursor = overall.GetRowCursor(overall.Schema))
+            using (var cursor = overall.GetRowCursorForAllColumns())
             {
                 var moved = cursor.MoveNext();
                 Host.Assert(moved);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -823,7 +823,7 @@ namespace Microsoft.ML.Internal.Calibration
                     weightCol = weightIdx;
                 ch.Info("Training calibrator.");
 
-                int[] cols = weightCol > -1 ? new int[] { labelCol, scoreCol, weightCol } : new int[] { labelCol, scoreCol };
+                var cols = weightCol > -1 ? new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol], scored.Schema[weightCol] } : new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol] };
                 using (var cursor = scored.GetRowCursor(cols))
                 {
                     var labelGetter = RowCursorUtils.GetLabelGetter(cursor, labelCol);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -822,7 +822,8 @@ namespace Microsoft.ML.Internal.Calibration
                 if (data.Schema.Weight?.Name is string weightName && scored.Schema.GetColumnOrNull(weightName)?.Index is int weightIdx)
                     weightCol = weightIdx;
                 ch.Info("Training calibrator.");
-                var cols = scored.Schema.Where(col => col.Index == labelCol || col.Index == scoreCol || col.Index == weightCol);
+
+                int[] cols = weightCol > -1 ? new int[] { labelCol, scoreCol, weightCol } : new int[] { labelCol, scoreCol };
                 using (var cursor = scored.GetRowCursor(cols))
                 {
                     var labelGetter = RowCursorUtils.GetLabelGetter(cursor, labelCol);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -822,7 +822,8 @@ namespace Microsoft.ML.Internal.Calibration
                 if (data.Schema.Weight?.Name is string weightName && scored.Schema.GetColumnOrNull(weightName)?.Index is int weightIdx)
                     weightCol = weightIdx;
                 ch.Info("Training calibrator.");
-                using (var cursor = scored.GetRowCursor(col => col == labelCol || col == scoreCol || col == weightCol))
+                var cols = scored.Schema.Where(col => col.Index == labelCol || col.Index == scoreCol || col.Index == weightCol);
+                using (var cursor = scored.GetRowCursor(cols))
                 {
                     var labelGetter = RowCursorUtils.GetLabelGetter(cursor, labelCol);
                     var scoreGetter = RowCursorUtils.GetGetterAs<Single>(NumberType.R4, cursor, scoreCol);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -823,7 +823,10 @@ namespace Microsoft.ML.Internal.Calibration
                     weightCol = weightIdx;
                 ch.Info("Training calibrator.");
 
-                var cols = weightCol > -1 ? new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol], scored.Schema[weightCol] } : new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol] };
+                var cols = weightCol > -1 ?
+                    new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol], scored.Schema[weightCol] } :
+                    new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol] };
+
                 using (var cursor = scored.GetRowCursor(cols))
                 {
                     var labelGetter = RowCursorUtils.GetLabelGetter(cursor, labelCol);

--- a/src/Microsoft.ML.Data/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.Data/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Predictor.Tests" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.TimeSeries.Tests" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Benchmarks" + PublicKey.TestValue)]
+[assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.StaticPipelineTesting" + PublicKey.TestValue)]
 
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.EntryPoints" + PublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Maml" + PublicKey.Value)]

--- a/src/Microsoft.ML.Data/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.Data/Properties/AssemblyInfo.cs
@@ -12,6 +12,7 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.OnnxTransformTest" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Predictor.Tests" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.TimeSeries.Tests" + PublicKey.TestValue)]
+[assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Benchmarks" + PublicKey.TestValue)]
 
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.EntryPoints" + PublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Maml" + PublicKey.Value)]

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -119,11 +119,11 @@ namespace Microsoft.ML.Data
         /// </summary>
         protected abstract bool WantParallelCursors(Func<int, bool> predicate);
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Contracts.AssertValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var bindings = GetBindings();
             Func<int, bool> inputPred;
@@ -135,11 +135,11 @@ namespace Microsoft.ML.Data
             return new Cursor(Host, this, input, active, predicateMapper);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var bindings = GetBindings();
             Func<int, bool> inputPred;

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Data
         {
             Contracts.AssertValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var bindings = GetBindings();
             Func<int, bool> inputPred;
@@ -139,7 +139,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var bindings = GetBindings();
             Func<int, bool> inputPred;

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Data
         {
             Contracts.AssertValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var bindings = GetBindings();
             Func<int, bool> inputPred;
@@ -139,7 +139,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var bindings = GetBindings();
             Func<int, bool> inputPred;

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -119,29 +119,35 @@ namespace Microsoft.ML.Data
         /// </summary>
         protected abstract bool WantParallelCursors(Func<int, bool> predicate);
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Contracts.AssertValue(predicate);
             Contracts.AssertValueOrNull(rand);
 
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
             var bindings = GetBindings();
-            Func<int, bool> predicateInput;
+            Func<int, bool> inputPred;
             Func<int, bool> predicateMapper;
-            var active = GetActive(bindings, predicate, out predicateInput, out predicateMapper);
-            var input = Source.GetRowCursor(predicateInput, rand);
+            var active = GetActive(bindings, predicate, out inputPred, out predicateMapper);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            var input = Source.GetRowCursor(inputCols, rand);
             return new Cursor(Host, this, input, active, predicateMapper);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
 
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
             var bindings = GetBindings();
-            Func<int, bool> predicateInput;
+            Func<int, bool> inputPred;
             Func<int, bool> predicateMapper;
-            var active = GetActive(bindings, predicate, out predicateInput, out predicateMapper);
-            var inputs = Source.GetRowCursorSet(predicateInput, n, rand);
+            var active = GetActive(bindings, predicate, out inputPred, out predicateMapper);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Contracts.AssertNonEmpty(inputs);
 
             if (inputs.Length == 1 && n > 1 && WantParallelCursors(predicate) && (Source.GetRowCount() ?? int.MaxValue) > n)

--- a/src/Microsoft.ML.Data/Training/TrainerUtils.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerUtils.cs
@@ -226,13 +226,13 @@ namespace Microsoft.ML.Training
             var columns = data.Data.Schema.Where(x => extraCols.Contains(x.Index));
 
             if ((opt & CursOpt.Label) != 0)
-                columns.Append(data.Schema.Label.Value);
+                columns = columns.Append(data.Schema.Label.Value);
             if ((opt & CursOpt.Features) != 0)
-                columns.Append(data.Schema.Feature.Value);
+                columns = columns.Append(data.Schema.Feature.Value);
             if ((opt & CursOpt.Weight) != 0)
-                columns.Append(data.Schema.Weight.Value);
+                columns = columns.Append(data.Schema.Weight.Value);
             if ((opt & CursOpt.Group) != 0)
-                columns.Append(data.Schema.Group.Value);
+                columns = columns.Append(data.Schema.Group.Value);
             return columns;
         }
 

--- a/src/Microsoft.ML.Data/Training/TrainerUtils.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerUtils.cs
@@ -223,7 +223,7 @@ namespace Microsoft.ML.Training
             Contracts.AssertValue(data);
             Contracts.AssertValueOrNull(extraCols);
 
-            var columns = data.Data.Schema.GetColumns(extraCols.ToArray());
+            var columns = data.Data.Schema.Where(c => extraCols.Contains(c.Index));
 
             if ((opt & CursOpt.Label) != 0)
                 columns = columns.Append(data.Schema.Label.Value);

--- a/src/Microsoft.ML.Data/Training/TrainerUtils.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerUtils.cs
@@ -223,7 +223,7 @@ namespace Microsoft.ML.Training
             Contracts.AssertValue(data);
             Contracts.AssertValueOrNull(extraCols);
 
-            var columns = data.Data.Schema.Where(x => extraCols.Contains(x.Index));
+            var columns = data.Data.Schema.GetColumns(extraCols.ToArray());
 
             if ((opt & CursOpt.Label) != 0)
                 columns = columns.Append(data.Schema.Label.Value);

--- a/src/Microsoft.ML.Data/Training/TrainerUtils.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerUtils.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML.Core.Data;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
@@ -217,26 +218,22 @@ namespace Microsoft.ML.Training
             throw Contracts.ExceptParam(nameof(data), "Training group column '{0}' type is invalid: {1}. Must be Key type.", col.Name, col.Type);
         }
 
-        private static Func<int, bool> CreatePredicate(RoleMappedData data, CursOpt opt, IEnumerable<int> extraCols)
+        private static IEnumerable<Schema.Column> CreatePredicate(RoleMappedData data, CursOpt opt, IEnumerable<int> extraCols)
         {
             Contracts.AssertValue(data);
             Contracts.AssertValueOrNull(extraCols);
 
-            var cols = new HashSet<int>();
+            var columns = data.Data.Schema.Where(x => extraCols.Contains(x.Index));
+
             if ((opt & CursOpt.Label) != 0)
-                AddOpt(cols, data.Schema.Label);
+                columns.Append(data.Schema.Label.Value);
             if ((opt & CursOpt.Features) != 0)
-                AddOpt(cols, data.Schema.Feature);
+                columns.Append(data.Schema.Feature.Value);
             if ((opt & CursOpt.Weight) != 0)
-                AddOpt(cols, data.Schema.Weight);
+                columns.Append(data.Schema.Weight.Value);
             if ((opt & CursOpt.Group) != 0)
-                AddOpt(cols, data.Schema.Group);
-            if (extraCols != null)
-            {
-                foreach (var col in extraCols)
-                    cols.Add(col);
-            }
-            return cols.Contains;
+                columns.Append(data.Schema.Group.Value);
+            return columns;
         }
 
         /// <summary>
@@ -525,7 +522,7 @@ namespace Microsoft.ML.Training
             private readonly object _lock;
             private CursOpt _opts;
 
-            public RoleMappedData Data { get { return _data; } }
+            public RoleMappedData Data => _data;
 
             protected FactoryBase(RoleMappedData data, CursOpt opt)
             {
@@ -543,7 +540,7 @@ namespace Microsoft.ML.Training
             }
 
             /// <summary>
-            /// The typed analog to <see cref="IDataView.GetRowCursor(Func{int,bool},Random)"/>.
+            /// The typed analog to <see cref="IDataView.GetRowCursor(IEnumerable{Schema.Column},Random)"/>.
             /// </summary>
             /// <param name="rand">Non-null if we are requesting a shuffled cursor.</param>
             /// <param name="extraCols">The extra columns to activate on the row cursor

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -624,9 +624,9 @@ namespace Microsoft.ML.Transforms
 
             public long? GetRowCount() => Source.GetRowCount();
 
-            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
                 _host.AssertValueOrNull(rand);
 
                 // Build out the active state for the input
@@ -636,13 +636,13 @@ namespace Microsoft.ML.Transforms
                 var inputRowCursor = Source.GetRowCursor(inputCols, rand);
 
                 // Build the active state for the output
-                var active = Utils.BuildArray(_mapper.OutputSchema.Count, colsNeeded);
+                var active = Utils.BuildArray(_mapper.OutputSchema.Count, columnsNeeded);
                 return new Cursor(_host, _mapper, inputRowCursor, active);
             }
 
-            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
                 _host.CheckValueOrNull(rand);
 
                 // Build out the active state for the input
@@ -651,7 +651,7 @@ namespace Microsoft.ML.Transforms
                 var inputs = Source.GetRowCursorSet(inputCols, n, rand);
 
                 // Build out the acitve state for the output
-                var active = Utils.BuildArray(_mapper.OutputSchema.Count, colsNeeded);
+                var active = Utils.BuildArray(_mapper.OutputSchema.Count, columnsNeeded);
                 _host.AssertNonEmpty(inputs);
 
                 // No need to split if this is given 1 input cursor.

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -631,9 +631,10 @@ namespace Microsoft.ML.Transforms
 
                 // Build out the active state for the input
                 var inputPred = GetDependencies(predicate);
-
-                var inputRowCursor = Source.GetRowCursor(colsNeeded, rand);
                 var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+
+                var inputRowCursor = Source.GetRowCursor(inputCols, rand);
+
                 // Build the active state for the output
                 var active = Utils.BuildArray(_mapper.OutputSchema.Count, colsNeeded);
                 return new Cursor(_host, _mapper, inputRowCursor, active);

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -626,7 +626,7 @@ namespace Microsoft.ML.Transforms
 
             public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
                 _host.AssertValueOrNull(rand);
 
                 // Build out the active state for the input
@@ -642,7 +642,7 @@ namespace Microsoft.ML.Transforms
 
             public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
                 _host.CheckValueOrNull(rand);
 
                 // Build out the active state for the input

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -624,31 +624,33 @@ namespace Microsoft.ML.Transforms
 
             public long? GetRowCount() => Source.GetRowCount();
 
-            public RowCursor GetRowCursor(Func<int, bool> needCol, Random rand = null)
+            public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                _host.AssertValue(needCol, nameof(needCol));
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
                 _host.AssertValueOrNull(rand);
 
                 // Build out the active state for the input
-                var inputPred = GetDependencies(needCol);
-                var inputRowCursor = Source.GetRowCursor(inputPred, rand);
+                var inputPred = GetDependencies(predicate);
 
+                var inputRowCursor = Source.GetRowCursor(colsNeeded, rand);
+                var inputCols = Source.Schema.Where(x => inputPred(x.Index));
                 // Build the active state for the output
-                var active = Utils.BuildArray(_mapper.OutputSchema.Count, needCol);
+                var active = Utils.BuildArray(_mapper.OutputSchema.Count, colsNeeded);
                 return new Cursor(_host, _mapper, inputRowCursor, active);
             }
 
-            public RowCursor[] GetRowCursorSet(Func<int, bool> needCol, int n, Random rand = null)
+            public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                _host.CheckValue(needCol, nameof(needCol));
+                Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
                 _host.CheckValueOrNull(rand);
 
                 // Build out the active state for the input
-                var inputPred = GetDependencies(needCol);
-                var inputs = Source.GetRowCursorSet(inputPred, n, rand);
+                var inputPred = GetDependencies(predicate);
+                var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+                var inputs = Source.GetRowCursorSet(inputCols, n, rand);
 
                 // Build out the acitve state for the output
-                var active = Utils.BuildArray(_mapper.OutputSchema.Count, needCol);
+                var active = Utils.BuildArray(_mapper.OutputSchema.Count, colsNeeded);
                 _host.AssertNonEmpty(inputs);
 
                 // No need to split if this is given 1 input cursor.

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -626,7 +626,7 @@ namespace Microsoft.ML.Transforms
 
             public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
                 _host.AssertValueOrNull(rand);
 
                 // Build out the active state for the input
@@ -642,7 +642,7 @@ namespace Microsoft.ML.Transforms
 
             public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
             {
-                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+                var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
                 _host.CheckValueOrNull(rand);
 
                 // Build out the active state for the input

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
@@ -332,29 +333,33 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate, "predicate");
             Host.AssertValueOrNull(rand);
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
-            var input = Source.GetRowCursor(inputPred);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var input = Source.GetRowCursor(inputCols);
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(predicate);
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+
             var active = _bindings.GetActive(predicate);
             RowCursor input;
 
             if (n > 1 && ShouldUseParallelCursors(predicate) != false)
             {
-                var inputs = Source.GetRowCursorSet(inputPred, n);
+                var inputs = Source.GetRowCursorSet(inputCols, n);
                 Host.AssertNonEmpty(inputs);
 
                 if (inputs.Length != 1)
@@ -367,7 +372,7 @@ namespace Microsoft.ML.Transforms
                 input = inputs[0];
             }
             else
-                input = Source.GetRowCursor(inputPred);
+                input = Source.GetRowCursor(inputCols);
 
             return new RowCursor[] { new Cursor(Host, _bindings, input, active) };
         }

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Transforms
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -349,7 +349,7 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -333,10 +333,10 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -346,10 +346,10 @@ namespace Microsoft.ML.Transforms
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -341,7 +341,7 @@ namespace Microsoft.ML.Transforms
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
 
-            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var input = Source.GetRowCursor(inputCols);
             return new Cursor(Host, _bindings, input, active);
         }
@@ -352,7 +352,7 @@ namespace Microsoft.ML.Transforms
             Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(predicate);
-            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
 
             var active = _bindings.GetActive(predicate);
             RowCursor input;

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Transforms
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -349,7 +349,7 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -254,12 +254,13 @@ namespace Microsoft.ML.Transforms.Conversions
             var types = new ColumnType[_columns.Length];
             List<int> invertIinfos = null;
             List<int> invertHashMaxCounts = null;
-            HashSet<int> sourceColumnsForInvertHash = new HashSet<int>();
+            var sourceColumnsForInvertHash = new List<Schema.Column>();
             for (int i = 0; i < _columns.Length; i++)
             {
-                if (!input.Schema.TryGetColumnIndex(ColumnPairs[i].input, out int srcCol))
+                Schema.Column? srcCol = input.Schema.GetColumnOrNull(ColumnPairs[i].input);
+                if (srcCol != null)
                     throw Host.ExceptSchemaMismatch(nameof(input), "input", ColumnPairs[i].input);
-                CheckInputColumn(input.Schema, i, srcCol);
+                CheckInputColumn(input.Schema, i, srcCol.Value.Index);
 
                 types[i] = GetOutputType(input.Schema, _columns[i]);
                 int invertHashMaxCount;
@@ -271,12 +272,12 @@ namespace Microsoft.ML.Transforms.Conversions
                 {
                     Utils.Add(ref invertIinfos, i);
                     Utils.Add(ref invertHashMaxCounts, invertHashMaxCount);
-                    sourceColumnsForInvertHash.Add(srcCol);
+                    sourceColumnsForInvertHash.Add(srcCol.Value);
                 }
             }
             if (Utils.Size(sourceColumnsForInvertHash) > 0)
             {
-                using (RowCursor srcCursor = input.GetRowCursor(sourceColumnsForInvertHash.Contains))
+                using (RowCursor srcCursor = input.GetRowCursor(sourceColumnsForInvertHash))
                 {
                     using (var ch = Host.Start("Invert hash building"))
                     {

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -258,7 +258,7 @@ namespace Microsoft.ML.Transforms.Conversions
             for (int i = 0; i < _columns.Length; i++)
             {
                 Schema.Column? srcCol = input.Schema.GetColumnOrNull(ColumnPairs[i].input);
-                if (srcCol != null)
+                if (srcCol == null)
                     throw Host.ExceptSchemaMismatch(nameof(input), "input", ColumnPairs[i].input);
                 CheckInputColumn(input.Schema, i, srcCol.Value.Index);
 

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -208,10 +208,9 @@ namespace Microsoft.ML.Transforms
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
-            bool[] active;
-            Func<int, bool> inputPred = GetActive(predicate, out active);
+            Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var input = Source.GetRowCursor(inputCols, rand);
@@ -221,10 +220,9 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
-            bool[] active;
-            Func<int, bool> inputPred = GetActive(predicate, out active);
+            Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var inputs = Source.GetRowCursorSet(inputCols, n, rand);

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -213,7 +213,7 @@ namespace Microsoft.ML.Transforms
             bool[] active;
             Func<int, bool> inputPred = GetActive(predicate, out active);
 
-            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var input = Source.GetRowCursor(inputCols, rand);
             return new Cursor(this, input, active);
         }
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Transforms
             bool[] active;
             Func<int, bool> inputPred = GetActive(predicate, out active);
 
-            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -5,6 +5,7 @@
 // REVIEW: As soon as we stop writing sizeof(Float), or when we retire the double builds, we can remove this.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
@@ -204,25 +205,29 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate, "predicate");
             Host.AssertValueOrNull(rand);
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             bool[] active;
             Func<int, bool> inputPred = GetActive(predicate, out active);
-            var input = Source.GetRowCursor(inputPred, rand);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var input = Source.GetRowCursor(inputCols, rand);
             return new Cursor(this, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             bool[] active;
             Func<int, bool> inputPred = GetActive(predicate, out active);
-            var inputs = Source.GetRowCursorSet(inputPred, n, rand);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 
             // No need to split if this is given 1 input cursor.

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Transforms
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -205,10 +205,10 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 
@@ -217,10 +217,10 @@ namespace Microsoft.ML.Transforms
             return new Cursor(this, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 

--- a/src/Microsoft.ML.Data/Transforms/NopTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/NopTransform.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
@@ -117,15 +118,11 @@ namespace Microsoft.ML.Data
             return Source.GetRowCount();
         }
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
-        {
-            return Source.GetRowCursor(predicate, rand);
-        }
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            => Source.GetRowCursor(colsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
-        {
-            return Source.GetRowCursorSet(predicate, n, rand);
-        }
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            => Source.GetRowCursorSet(colsNeeded, n, rand);
 
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
         {

--- a/src/Microsoft.ML.Data/Transforms/NopTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/NopTransform.cs
@@ -118,11 +118,11 @@ namespace Microsoft.ML.Data
             return Source.GetRowCount();
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
-            => Source.GetRowCursor(colsNeeded, rand);
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
+            => Source.GetRowCursor(columnsNeeded, rand);
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
-            => Source.GetRowCursorSet(colsNeeded, n, rand);
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
+            => Source.GetRowCursorSet(columnsNeeded, n, rand);
 
         public Func<int, bool> GetDependencies(Func<int, bool> predicate)
         {

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -402,7 +402,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 if (!success)
                     throw env.ExceptSchemaMismatch(nameof(data), "input", info.Input);
                 srcTypes[i] = data.Schema[srcCols[i]].Type;
-                activeCols.Add(data.Schema[srcCols[i]]); //sefilipi: check how does the Schema indexer deal with columns that have the same name. Is the index and the col.Index the same?
+                activeCols.Add(data.Schema[srcCols[i]]);
 
                 var supervisedBinColumn = info as NormalizingEstimator.SupervisedBinningColumn;
                 if(supervisedBinColumn != null)

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -391,7 +391,7 @@ namespace Microsoft.ML.Transforms.Normalizers
             env.CheckValue(data, nameof(data));
             env.CheckValue(columns, nameof(columns));
 
-            bool[] activeInput = new bool[data.Schema.Count];
+            var activeCols = new List<Schema.Column>();
 
             var srcCols = new int[columns.Length];
             var srcTypes = new ColumnType[columns.Length];
@@ -402,14 +402,11 @@ namespace Microsoft.ML.Transforms.Normalizers
                 if (!success)
                     throw env.ExceptSchemaMismatch(nameof(data), "input", info.Input);
                 srcTypes[i] = data.Schema[srcCols[i]].Type;
-                activeInput[srcCols[i]] = true;
+                activeCols.Add(data.Schema[srcCols[i]]); //sefilipi: check how does the Schema indexer deal with columns that have the same name. Is the index and the col.Index the same?
 
                 var supervisedBinColumn = info as NormalizingEstimator.SupervisedBinningColumn;
                 if(supervisedBinColumn != null)
-                {
-                    var labelColumnId = SupervisedBinUtils.GetLabelColumnId(env, data.Schema, supervisedBinColumn.LabelColumn);
-                    activeInput[labelColumnId] = true;
-                }
+                    activeCols.Add(data.Schema[supervisedBinColumn.LabelColumn]);
             }
 
             var functionBuilders = new IColumnFunctionBuilder[columns.Length];
@@ -421,7 +418,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 long numRows = 0;
 
                 pch.SetHeader(new ProgressHeader("examples"), e => e.SetProgress(0, numRows));
-                using (var cursor = data.GetRowCursor(col => activeInput[col]))
+                using (var cursor = data.GetRowCursor(activeCols))
                 {
                     for (int i = 0; i < columns.Length; i++)
                     {

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -153,15 +153,15 @@ namespace Microsoft.ML.Data
             return Source.GetRowCount();
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
+            return new RowCursor[] { GetRowCursor(columnsNeeded, rand) };
         }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             Host.CheckValueOrNull(rand);
             // If we aren't selecting any of the output columns, don't construct our cursor.

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Data
 
         public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             Host.CheckValueOrNull(rand);
             // If we aren't selecting any of the output columns, don't construct our cursor.

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Data
 
         public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             Host.CheckValueOrNull(rand);
             // If we aren't selecting any of the output columns, don't construct our cursor.
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Data
             if (!bindings.AnyNewColumnsActive(predicate))
             {
                 var activeInput = bindings.GetActiveInput(predicate);
-                var activeCols = Source.Schema.Where(x => activeInput[x.Index]);
+                var activeCols = Source.Schema.Where(x => activeInput.Length > x.Index && activeInput[x.Index]);
                 var inputCursor = Source.GetRowCursor(activeCols, null);
                 return new BindingsWrappedRowCursor(Host, inputCursor, bindings);
             }

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML.Model;
 
 namespace Microsoft.ML.Data
@@ -151,16 +153,16 @@ namespace Microsoft.ML.Data
             return Source.GetRowCount();
         }
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursor(predicate, rand) };
+            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
         }
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
             Host.CheckValueOrNull(rand);
             // If we aren't selecting any of the output columns, don't construct our cursor.
             // Note that because we cannot support random due to the inherently
@@ -170,7 +172,8 @@ namespace Microsoft.ML.Data
             if (!bindings.AnyNewColumnsActive(predicate))
             {
                 var activeInput = bindings.GetActiveInput(predicate);
-                var inputCursor = Source.GetRowCursor(c => activeInput[c], null);
+                var activeCols = Source.Schema.Where(x => activeInput[x.Index]);
+                var inputCursor = Source.GetRowCursor(activeCols, null);
                 return new BindingsWrappedRowCursor(Host, inputCursor, bindings);
             }
             return GetRowCursorCore(predicate);
@@ -183,7 +186,10 @@ namespace Microsoft.ML.Data
             Contracts.Assert(active.Length == bindings.ColumnCount);
 
             var predInput = bindings.GetDependencies(predicate);
-            return new Cursor(this, Source.GetRowCursor(predInput, null), Source.GetRowCursor(predInput, null), active);
+
+            var cols = Source.Schema.Where(x => predInput(x.Index));
+
+            return new Cursor(this, Source.GetRowCursor(cols, null), Source.GetRowCursor(cols, null), active);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
@@ -204,25 +206,30 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate, "predicate");
             Host.AssertValueOrNull(rand);
 
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             bool[] active;
             Func<int, bool> inputPred = GetActive(predicate, out active);
-            var input = Source.GetRowCursor(inputPred, rand);
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+
+            var input = Source.GetRowCursor(inputCols, rand);
             return CreateCursorCore(input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
+
             Host.CheckValueOrNull(rand);
 
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             bool[] active;
             Func<int, bool> inputPred = GetActive(predicate, out active);
-            var inputs = Source.GetRowCursorSet(inputPred, n, rand);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 
             // No need to split if this is given 1 input cursor.

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -210,9 +210,8 @@ namespace Microsoft.ML.Transforms
         {
             Host.AssertValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
-            bool[] active;
-            Func<int, bool> inputPred = GetActive(predicate, out active);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
 
             var input = Source.GetRowCursor(inputCols, rand);
@@ -224,9 +223,8 @@ namespace Microsoft.ML.Transforms
 
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
-            bool[] active;
-            Func<int, bool> inputPred = GetActive(predicate, out active);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var inputs = Source.GetRowCursorSet(inputCols, n, rand);

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -206,11 +206,11 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
 
@@ -218,12 +218,12 @@ namespace Microsoft.ML.Transforms
             return CreateCursorCore(input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
 
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -228,7 +228,7 @@ namespace Microsoft.ML.Transforms
             bool[] active;
             Func<int, bool> inputPred = GetActive(predicate, out active);
 
-            var inputCols = Source.Schema.Where(x => inputPred(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.AssertValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
 
@@ -223,7 +223,7 @@ namespace Microsoft.ML.Transforms
 
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             Func<int, bool> inputPred = GetActive(predicate, out bool[] active);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -248,9 +248,8 @@ namespace Microsoft.ML.Transforms
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate, "predicate");
             Host.AssertValueOrNull(rand);
 
             // REVIEW: This is slightly interesting. Our mechanism for inducing
@@ -279,7 +278,7 @@ namespace Microsoft.ML.Transforms
                 rand = myRandom;
             Random sourceRand = shouldShuffleSource ? RandomUtils.Create(myRandom) : null;
 
-            var input = _subsetInput.GetRowCursor(predicate, sourceRand);
+            var input = _subsetInput.GetRowCursor(colsNeeded, sourceRand);
             // If rand is null (so we're not doing pool shuffling) or number of pool rows is 1
             // (so any pool shuffling, if attempted, would be trivial anyway), just return the
             // source cursor.
@@ -288,11 +287,10 @@ namespace Microsoft.ML.Transforms
             return new Cursor(Host, _poolRows, input, rand);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursorCore(predicate, rand) };
+            return new RowCursor[] { GetRowCursorCore(colsNeeded, rand) };
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Transforms
             for (int c = 0; c < schema.Count; ++c)
             {
                 var type = schema[c].Type;
-                if (!type.IsCachable())
+                if (!type.IsCacheable())
                     Utils.Add(ref columnsToDrop, c);
             }
             if (Utils.Size(columnsToDrop) == 0)
@@ -213,7 +213,7 @@ namespace Microsoft.ML.Transforms
             for (int c = 0; c < schema.Count; ++c)
             {
                 var type = schema[c].Type;
-                if (!type.IsCachable())
+                if (!type.IsCacheable())
                     return false;
             }
             return true;

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -248,7 +248,7 @@ namespace Microsoft.ML.Transforms
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
 
@@ -278,7 +278,7 @@ namespace Microsoft.ML.Transforms
                 rand = myRandom;
             Random sourceRand = shouldShuffleSource ? RandomUtils.Create(myRandom) : null;
 
-            var input = _subsetInput.GetRowCursor(colsNeeded, sourceRand);
+            var input = _subsetInput.GetRowCursor(columnsNeeded, sourceRand);
             // If rand is null (so we're not doing pool shuffling) or number of pool rows is 1
             // (so any pool shuffling, if attempted, would be trivial anyway), just return the
             // source cursor.
@@ -287,10 +287,10 @@ namespace Microsoft.ML.Transforms
             return new Cursor(Host, _poolRows, input, rand);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursorCore(colsNeeded, rand) };
+            return new RowCursor[] { GetRowCursorCore(columnsNeeded, rand) };
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
@@ -187,21 +188,19 @@ namespace Microsoft.ML.Transforms
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate);
             Host.AssertValueOrNull(rand);
 
-            var input = Source.GetRowCursor(predicate);
-            var activeColumns = Utils.BuildArray(OutputSchema.Count, predicate);
+            var input = Source.GetRowCursor(colsNeeded);
+            var activeColumns = Utils.BuildArray(OutputSchema.Count, colsNeeded);
             return new Cursor(Host, input, OutputSchema, activeColumns, _skip, _take);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursorCore(predicate) };
+            return new RowCursor[] { GetRowCursorCore(colsNeeded) };
         }
 
         private sealed class Cursor : LinkedRowRootCursorBase

--- a/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/SkipTakeFilter.cs
@@ -188,19 +188,19 @@ namespace Microsoft.ML.Transforms
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
 
-            var input = Source.GetRowCursor(colsNeeded);
-            var activeColumns = Utils.BuildArray(OutputSchema.Count, colsNeeded);
+            var input = Source.GetRowCursor(columnsNeeded);
+            var activeColumns = Utils.BuildArray(OutputSchema.Count, columnsNeeded);
             return new Cursor(Host, input, OutputSchema, activeColumns, _skip, _take);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursorCore(colsNeeded) };
+            return new RowCursor[] { GetRowCursorCore(columnsNeeded) };
         }
 
         private sealed class Cursor : LinkedRowRootCursorBase

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var rng = CanShuffle ? rand : null;
             bool? useParallel = ShouldUseParallelCursors(predicate);
@@ -725,7 +725,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var rng = CanShuffle ? rand : null;
             bool? useParallel = ShouldUseParallelCursors(predicate);
@@ -725,7 +725,7 @@ namespace Microsoft.ML.Data
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -59,11 +59,11 @@ namespace Microsoft.ML.Data
 
         public abstract Schema OutputSchema { get; }
 
-        public RowCursor GetRowCursor(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var rng = CanShuffle ? rand : null;
             bool? useParallel = ShouldUseParallelCursors(predicate);
@@ -74,12 +74,12 @@ namespace Microsoft.ML.Data
             // this is RangeFilter.
             RowCursor curs;
             if (useParallel != false &&
-                DataViewUtils.TryCreateConsolidatingCursor(out curs, this, colsNeeded, Host, rng))
+                DataViewUtils.TryCreateConsolidatingCursor(out curs, this, columnsNeeded, Host, rng))
             {
                 return curs;
             }
 
-            return GetRowCursorCore(colsNeeded, rng);
+            return GetRowCursorCore(columnsNeeded, rng);
         }
 
         /// <summary>
@@ -93,9 +93,9 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Create a single (non-parallel) row cursor.
         /// </summary>
-        protected abstract RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null);
+        protected abstract RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null);
 
-        public abstract RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null);
+        public abstract RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null);
     }
 
     /// <summary>
@@ -707,11 +707,11 @@ namespace Microsoft.ML.Data
             return _bindings.AnyNewColumnsActive(predicate);
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
 
-            Func<int, bool> needCol = c=> colsNeeded == null ? false: colsNeeded.Any(x => x.Index == c);
+            Func<int, bool> needCol = c=> columnsNeeded == null ? false: columnsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(needCol);
             var active = _bindings.GetActive(needCol);
@@ -721,11 +721,11 @@ namespace Microsoft.ML.Data
             return new Cursor(Host, this, input, active);
         }
 
-        public sealed override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public sealed override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -711,11 +711,13 @@ namespace Microsoft.ML.Data
         {
             Host.AssertValueOrNull(rand);
 
-            Func<int, bool> needCol = c => colsNeeded.Any(x => x.Index == c);
+            Func<int, bool> needCol = c=> colsNeeded == null ? false: colsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(needCol);
             var active = _bindings.GetActive(needCol);
-            var input = Source.GetRowCursor(colsNeeded, rand);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            var input = Source.GetRowCursor(inputCols, rand);
             return new Cursor(Host, this, input, active);
         }
 
@@ -724,8 +726,6 @@ namespace Microsoft.ML.Data
             Host.CheckValueOrNull(rand);
 
             Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
-            //var indices = colsNeeded == null? null : colsNeeded.Select(x => x.Index);
-            //Func<int, bool> predicate = c => indices == null ? false: indices.Contains(OutputSchema[c].Index);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);

--- a/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
@@ -399,7 +399,7 @@ namespace Microsoft.ML.Transforms.Conversions
             var keyType = dataView.Schema[keyIdx].Type;
             var valueType = dataView.Schema[valueIdx].Type;
             var valueMap = ValueMap.Create(keyType, valueType, _valueMetadata);
-            using (var cursor = dataView.GetRowCursor(dataView.Schema.Where(c => c.Index == keyIdx || c.Index == valueIdx)))
+            using (var cursor = dataView.GetRowCursor(dataView.Schema[keyIdx], dataView.Schema[valueIdx]))
                 valueMap.Train(Host, cursor);
             return valueMap;
         }

--- a/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
@@ -399,7 +399,7 @@ namespace Microsoft.ML.Transforms.Conversions
             var keyType = dataView.Schema[keyIdx].Type;
             var valueType = dataView.Schema[valueIdx].Type;
             var valueMap = ValueMap.Create(keyType, valueType, _valueMetadata);
-            using (var cursor = dataView.GetRowCursor(c => c == keyIdx || c == valueIdx))
+            using (var cursor = dataView.GetRowCursor(dataView.Schema.Where(c => c.Index == keyIdx || c.Index == valueIdx)))
                 valueMap.Train(Host, cursor);
             return valueMap;
         }
@@ -416,7 +416,7 @@ namespace Microsoft.ML.Transforms.Conversions
             ulong keyMax = ulong.MinValue;
 
             // scan the input to create convert the values as key types
-            using (var cursor = loader.GetRowCursor(c => true))
+            using (var cursor = loader.GetRowCursor(loader.Schema))
             {
                 using (var ch = env.Start($"Processing key values from file {fileName}"))
                 {
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
             idv.Schema.TryGetColumnIndex(keyColumnName, out int keyIdx);
             idv.Schema.TryGetColumnIndex(valueColumnName, out int valueIdx);
-            using (var cursor = idv.GetRowCursor(c => true))
+            using (var cursor = idv.GetRowCursor(idv.Schema))
             {
                 using (var ch = env.Start("Processing key values"))
                 {

--- a/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
@@ -416,7 +416,7 @@ namespace Microsoft.ML.Transforms.Conversions
             ulong keyMax = ulong.MinValue;
 
             // scan the input to create convert the values as key types
-            using (var cursor = loader.GetRowCursor(loader.Schema))
+            using (var cursor = loader.GetRowCursorForAllColumns())
             {
                 using (var ch = env.Start($"Processing key values from file {fileName}"))
                 {
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
             idv.Schema.TryGetColumnIndex(keyColumnName, out int keyIdx);
             idv.Schema.TryGetColumnIndex(valueColumnName, out int valueIdx);
-            using (var cursor = idv.GetRowCursor(idv.Schema))
+            using (var cursor = idv.GetRowCursorForAllColumns())
             {
                 using (var ch = env.Start("Processing key values"))
                 {

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -483,7 +483,7 @@ namespace Microsoft.ML.Transforms.Conversions
             if (!autoConvert && !typeSrc.Equals(bldr.ItemType))
                 throw ch.ExceptUserArg(nameof(termsColumn), "Must be of type '{0}' but was '{1}'", bldr.ItemType, typeSrc);
 
-            using (var cursor = termData.GetRowCursor(termData.Schema.Where(x => x.Index == colSrc)))
+            using (var cursor = termData.GetRowCursor(colSrc))
             using (var pch = env.StartProgressChannel("Building term dictionary from file"))
             {
                 var header = new ProgressHeader(new[] { "Total Terms" }, new[] { "examples" });
@@ -583,7 +583,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 int[] trainerInfo = new int[trainsNeeded];
                 // Open the cursor, then instantiate the trainers.
                 int itrainer;
-                using (var cursor = trainingData.GetRowCursor(trainingData.Schema.Where(x => toTrain.Contains(x.Index))))
+                using (var cursor = trainingData.GetRowCursor(toTrain.ToArray()))
                 using (var pch = env.StartProgressChannel("Building term dictionary"))
                 {
                     long rowCur = 0;

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -483,7 +483,7 @@ namespace Microsoft.ML.Transforms.Conversions
             if (!autoConvert && !typeSrc.Equals(bldr.ItemType))
                 throw ch.ExceptUserArg(nameof(termsColumn), "Must be of type '{0}' but was '{1}'", bldr.ItemType, typeSrc);
 
-            using (var cursor = termData.GetRowCursor(colSrc))
+            using (var cursor = termData.GetRowCursor(termData.Schema[colSrc]))
             using (var pch = env.StartProgressChannel("Building term dictionary from file"))
             {
                 var header = new ProgressHeader(new[] { "Total Terms" }, new[] { "examples" });
@@ -583,7 +583,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 int[] trainerInfo = new int[trainsNeeded];
                 // Open the cursor, then instantiate the trainers.
                 int itrainer;
-                using (var cursor = trainingData.GetRowCursor(toTrain.ToArray()))
+                using (var cursor = trainingData.GetRowCursor(trainingData.Schema.Where(c => toTrain.Contains(c.Index))))
                 using (var pch = env.StartProgressChannel("Building term dictionary"))
                 {
                     long rowCur = 0;

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -483,7 +483,7 @@ namespace Microsoft.ML.Transforms.Conversions
             if (!autoConvert && !typeSrc.Equals(bldr.ItemType))
                 throw ch.ExceptUserArg(nameof(termsColumn), "Must be of type '{0}' but was '{1}'", bldr.ItemType, typeSrc);
 
-            using (var cursor = termData.GetRowCursor(col => col == colSrc))
+            using (var cursor = termData.GetRowCursor(termData.Schema.Where(x => x.Index == colSrc)))
             using (var pch = env.StartProgressChannel("Building term dictionary from file"))
             {
                 var header = new ProgressHeader(new[] { "Total Terms" }, new[] { "examples" });
@@ -583,7 +583,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 int[] trainerInfo = new int[trainsNeeded];
                 // Open the cursor, then instantiate the trainers.
                 int itrainer;
-                using (var cursor = trainingData.GetRowCursor(toTrain.Contains))
+                using (var cursor = trainingData.GetRowCursor(trainingData.Schema.Where(x => toTrain.Contains(x.Index))))
                 using (var pch = env.StartProgressChannel("Building term dictionary"))
                 {
                     long rowCur = 0;

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.ML.Data
 {
@@ -82,7 +83,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col.Equals))
+            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
             {
                 var getter = cursor.GetGetter<T>(col);
                 T curValue = default;
@@ -99,7 +100,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col.Equals))
+            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
             {
                 var getter = cursor.GetGetter<TData>(col);
                 TData curValue = default;
@@ -116,7 +117,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col.Equals))
+            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
             {
                 var getter = cursor.GetGetter<VBuffer<T>>(col);
                 VBuffer<T> curValue = default;
@@ -137,7 +138,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col.Equals))
+            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
             {
                 var getter = cursor.GetGetter<VBuffer<TData>>(col);
                 VBuffer<TData> curValue = default;

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col))
+            using (var cursor = data.GetRowCursor(data.Schema[col]))
             {
                 var getter = cursor.GetGetter<T>(col);
                 T curValue = default;
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col))
+            using (var cursor = data.GetRowCursor(data.Schema[col]))
             {
                 var getter = cursor.GetGetter<TData>(col);
                 TData curValue = default;
@@ -117,7 +117,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col))
+            using (var cursor = data.GetRowCursor(data.Schema[col]))
             {
                 var getter = cursor.GetGetter<VBuffer<T>>(col);
                 VBuffer<T> curValue = default;
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(col))
+            using (var cursor = data.GetRowCursor(data.Schema[col]))
             {
                 var getter = cursor.GetGetter<VBuffer<TData>>(col);
                 VBuffer<TData> curValue = default;

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
+            using (var cursor = data.GetRowCursor(col))
             {
                 var getter = cursor.GetGetter<T>(col);
                 T curValue = default;
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
+            using (var cursor = data.GetRowCursor(col))
             {
                 var getter = cursor.GetGetter<TData>(col);
                 TData curValue = default;
@@ -117,7 +117,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
+            using (var cursor = data.GetRowCursor(col))
             {
                 var getter = cursor.GetGetter<VBuffer<T>>(col);
                 VBuffer<T> curValue = default;
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema.Where(c => c.Index == col)))
+            using (var cursor = data.GetRowCursor(col))
             {
                 var getter = cursor.GetGetter<VBuffer<TData>>(col);
                 VBuffer<TData> curValue = default;

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Model
                 var repoStreamWrapper = new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile);
                 var loader = new TextLoader(env, dataSample: repoStreamWrapper).Read(repoStreamWrapper);
 
-                using (var cursor = loader.GetRowCursor(c => true))
+                using (var cursor = loader.GetRowCursor(loader.Schema))
                 {
                     var roleGetter = cursor.GetGetter<ReadOnlyMemory<char>>(0);
                     var colGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Model
                 var repoStreamWrapper = new RepositoryStreamWrapper(rep, DirTrainingInfo, RoleMappingFile);
                 var loader = new TextLoader(env, dataSample: repoStreamWrapper).Read(repoStreamWrapper);
 
-                using (var cursor = loader.GetRowCursor(loader.Schema))
+                using (var cursor = loader.GetRowCursorForAllColumns())
                 {
                     var roleGetter = cursor.GetGetter<ReadOnlyMemory<char>>(0);
                     var colGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -328,7 +328,7 @@ namespace Microsoft.ML.Ensemble
                 if (caliTrainer.NeedsTraining)
                 {
                     var bound = new Bound(this, new RoleMappedSchema(data.Schema));
-                    using (var curs = data.GetRowCursor(col => true))
+                    using (var curs = data.GetRowCursor(data.Schema))
                     {
                         var scoreGetter = (ValueGetter<Single>)bound.CreateScoreGetter(curs, col => true, out Action disposer);
 

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -328,7 +328,7 @@ namespace Microsoft.ML.Ensemble
                 if (caliTrainer.NeedsTraining)
                 {
                     var bound = new Bound(this, new RoleMappedSchema(data.Schema));
-                    using (var curs = data.GetRowCursor(data.Schema))
+                    using (var curs = data.GetRowCursorForAllColumns())
                     {
                         var scoreGetter = (ValueGetter<Single>)bound.CreateScoreGetter(curs, col => true, out Action disposer);
 

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1842,18 +1842,24 @@ namespace Microsoft.ML.Trainers.FastTree
                         e => e.SetProgress(0, pos, rowCountDbl));
                     // REVIEW: Should we ignore rows with bad label, weight, or group? The previous code seemed to let
                     // them through (but filtered out bad features).
-                    CursOpt curOptions = CursOpt.Label | CursOpt.Features | CursOpt.Weight;
+                    CursOpt curOptions = CursOpt.Label | CursOpt.Features;
                     bool hasGroup = false;
                     if (PredictionKind == PredictionKind.Ranking)
                     {
-                        curOptions |= CursOpt.Group;
                         hasGroup = _data.Schema.Group != null;
+
+                        if(hasGroup)
+                            curOptions |= CursOpt.Group;
                     }
                     else
                     {
                         if (_data.Schema.Group != null)
                             ch.Warning("This is not ranking problem, Group Id '{0}' column will be ignored", _data.Schema.Group.Value.Name);
                     }
+
+                    if (_data.Schema.Weight.HasValue)
+                        curOptions |= CursOpt.Weight;
+
                     using (var cursor = new FloatLabelCursor(_data, curOptions))
                     {
                         ulong groupPrev = 0;

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Trainers.HalLearners
                 if (examples.Schema.Weight.HasValue)
                     cursorOpt |= CursOpt.Weight;
 
-                var cursorFactory = new FloatLabelCursor.Factory(examples, cursorOpt);//sefilipi: double-check on the change.
+                var cursorFactory = new FloatLabelCursor.Factory(examples, cursorOpt);
 
                 return TrainCore(ch, cursorFactory, typeFeat.Size);
             }

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -131,7 +131,11 @@ namespace Microsoft.ML.Trainers.HalLearners
                 if (typeFeat.ItemType != NumberType.Float)
                     throw ch.Except("Incompatible feature column type {0}, must be vector of {1}", typeFeat, NumberType.Float);
 
-                var cursorFactory = new FloatLabelCursor.Factory(examples, CursOpt.Label | CursOpt.Features);
+                CursOpt cursorOpt = CursOpt.Label | CursOpt.Features;
+                if (examples.Schema.Weight.HasValue)
+                    cursorOpt |= CursOpt.Weight;
+
+                var cursorFactory = new FloatLabelCursor.Factory(examples, cursorOpt);//sefilipi: double-check on the change.
 
                 return TrainCore(ch, cursorFactory, typeFeat.Size);
             }

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -352,7 +352,7 @@ namespace Microsoft.ML.Transforms.Projections
 
             int maxRows = columns.Max(i => i.MaxRow);
             long r = 0;
-            using (var cursor = inputData.GetRowCursor(null))
+            using (var cursor = inputData.GetRowCursor())
             {
                 while (r < maxRows && cursor.MoveNext())
                     r++;

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Transforms.Projections
             }
             var idxDst = new int[columns.Length];
 
-            using (var cursor = inputData.GetRowCursor(cols))
+            using (var cursor = inputData.GetRowCursor(inputData.Schema.Where(c => cols.Any(col => c.Index == col))))
             {
                 var getters = new ValueGetter<VBuffer<float>>[columns.Length];
                 for (int i = 0; i < columns.Length; i++)

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -352,7 +352,7 @@ namespace Microsoft.ML.Transforms.Projections
 
             int maxRows = columns.Max(i => i.MaxRow);
             long r = 0;
-            using (var cursor = inputData.GetRowCursor(col => false))
+            using (var cursor = inputData.GetRowCursor(null))
             {
                 while (r < maxRows && cursor.MoveNext())
                     r++;
@@ -434,8 +434,7 @@ namespace Microsoft.ML.Transforms.Projections
             }
             var idxDst = new int[columns.Length];
 
-            var colsSet = new HashSet<int>(cols);
-            using (var cursor = inputData.GetRowCursor(colsSet.Contains))
+            using (var cursor = inputData.GetRowCursor(inputData.Schema.Where(x => cols.Contains(x.Index))))
             {
                 var getters = new ValueGetter<VBuffer<float>>[columns.Length];
                 for (int i = 0; i < columns.Length; i++)

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Transforms.Projections
             }
             var idxDst = new int[columns.Length];
 
-            using (var cursor = inputData.GetRowCursor(inputData.Schema.Where(x => cols.Contains(x.Index))))
+            using (var cursor = inputData.GetRowCursor(cols))
             {
                 var getters = new ValueGetter<VBuffer<float>>[columns.Length];
                 for (int i = 0; i < columns.Length; i++)

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -175,7 +175,11 @@ namespace Microsoft.ML.Trainers.KMeans
             long missingFeatureCount;
             long totalTrainingInstances;
 
-            var cursorFactory = new FeatureFloatVectorCursor.Factory(data, CursOpt.Features | CursOpt.Id | CursOpt.Weight);
+            CursOpt cursorOpt = CursOpt.Id | CursOpt.Features;
+            if (data.Schema.Weight.HasValue)
+                cursorOpt |= CursOpt.Weight;
+
+            var cursorFactory = new FeatureFloatVectorCursor.Factory(data, cursorOpt);
             // REVIEW: It would be nice to extract these out into subcomponents in the future. We should
             // revisit and even consider breaking these all into individual KMeans-flavored trainers, they
             // all produce a valid set of output centroids with various trade-offs in runtime (with perhaps

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -197,9 +197,12 @@ namespace Microsoft.ML.LightGBM
 
         private FloatLabelCursor.Factory CreateCursorFactory(RoleMappedData data)
         {
-            var loadFlags = CursOpt.AllLabels | CursOpt.AllWeights | CursOpt.Features;
+            var loadFlags = CursOpt.AllLabels | CursOpt.Features;
             if (PredictionKind == PredictionKind.Ranking)
                 loadFlags |= CursOpt.Group;
+
+            if (data.Schema.Weight.HasValue)
+                loadFlags |= CursOpt.AllWeights;
 
             var factory = new FloatLabelCursor.Factory(data, loadFlags);
             return factory;

--- a/src/Microsoft.ML.PCA/PcaTrainer.cs
+++ b/src/Microsoft.ML.PCA/PcaTrainer.cs
@@ -179,7 +179,11 @@ namespace Microsoft.ML.Trainers.PCA
 
             var omega = GaussianMatrix(oversampledRank, dimension, _seed);
 
-            var cursorFactory = new FeatureFloatVectorCursor.Factory(data, CursOpt.Features | CursOpt.Weight);
+            CursOpt cursorOpt = CursOpt.Features;
+            if (data.Schema.Weight.HasValue)
+                cursorOpt |= CursOpt.Weight;
+
+            var cursorFactory = new FeatureFloatVectorCursor.Factory(data, cursorOpt);
             long numBad;
             Project(Host, cursorFactory, ref mean, omega, y, out numBad);
             if (numBad > 0)

--- a/src/Microsoft.ML.PCA/PcaTransform.cs
+++ b/src/Microsoft.ML.PCA/PcaTransform.cs
@@ -453,7 +453,8 @@ namespace Microsoft.ML.Transforms.Projections
                     activeColumns[sInfo.WeightColumnIndex] = true;
             }
 
-            using (var cursor = trainingData.GetRowCursor(col => activeColumns[col]))
+            var inputCols = trainingData.Schema.Where(x => activeColumns[x.Index]);
+            using (var cursor = trainingData.GetRowCursor(inputCols))
             {
                 var weightGetters = new ValueGetter<float>[_numColumns];
                 var columnGetters = new ValueGetter<VBuffer<float>>[_numColumns];

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -392,9 +392,8 @@ namespace Microsoft.ML.Data
 
         public RowCursor GetRowCursor(IEnumerable<ML.Data.Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
-
             _host.CheckValueOrNull(rand);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
             return new Cursor(this, predicate, rand);
         }
 

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -390,17 +390,17 @@ namespace Microsoft.ML.Data
             return _rowCount;
         }
 
-        public RowCursor GetRowCursor(IEnumerable<ML.Data.Schema.Column> colsNeeded, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<ML.Data.Schema.Column> columnsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
             return new Cursor(this, predicate, rand);
         }
 
-        public RowCursor[] GetRowCursorSet(IEnumerable<ML.Data.Schema.Column> colsNeeded, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<ML.Data.Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
+            return new RowCursor[] { GetRowCursor(columnsNeeded, rand) };
         }
 
         public void Save(ModelSaveContext ctx)

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -393,7 +393,7 @@ namespace Microsoft.ML.Data
         public RowCursor GetRowCursor(IEnumerable<ML.Data.Schema.Column> colsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Schema);
             return new Cursor(this, predicate, rand);
         }
 

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -390,18 +390,18 @@ namespace Microsoft.ML.Data
             return _rowCount;
         }
 
-        public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
+        public RowCursor GetRowCursor(IEnumerable<ML.Data.Schema.Column> colsNeeded, Random rand = null)
         {
-            _host.CheckValue(predicate, nameof(predicate));
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
             _host.CheckValueOrNull(rand);
             return new Cursor(this, predicate, rand);
         }
 
-        public RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public RowCursor[] GetRowCursorSet(IEnumerable<ML.Data.Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            _host.CheckValue(predicate, nameof(predicate));
             _host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursor(predicate, rand) };
+            return new RowCursor[] { GetRowCursor(colsNeeded, rand) };
         }
 
         public void Save(ModelSaveContext ctx)

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -331,7 +331,8 @@ namespace Microsoft.ML.Trainers
             ch.Assert(colCount > 0);
 
             // Checks for equality on the validation set ensure it is correct here.
-            using (var cursor = data.Data.GetRowCursor(c => c == matrixColumnIndexColInfo.Index || c == matrixRowIndexColInfo.Index || c == data.Schema.Label.Value.Index))
+            var columns = data.Data.Schema.Where(c => c.Index == matrixColumnIndexColInfo.Index || c.Index == matrixRowIndexColInfo.Index || c.Index == data.Schema.Label.Value.Index);
+            using (var cursor = data.Data.GetRowCursor(columns))
             {
                 // LibMF works only over single precision floats, but we want to be able to consume either.
                 var labGetter = RowCursorUtils.GetGetterAs<float>(NumberType.R4, cursor, data.Schema.Label.Value.Index);
@@ -350,8 +351,7 @@ namespace Microsoft.ML.Trainers
                 else
                 {
                     RecommenderUtils.CheckAndGetMatrixIndexColumns(validData, out var validMatrixColumnIndexColInfo, out var validMatrixRowIndexColInfo, isDecode: false);
-                    using (var validCursor = validData.Data.GetRowCursor(
-                        c => c == validMatrixColumnIndexColInfo.Index || c == validMatrixRowIndexColInfo.Index || c == validData.Schema.Label.Value.Index))
+                    using (var validCursor = validData.Data.GetRowCursor(columns))
                     {
                         ValueGetter<float> validLabelGetter = RowCursorUtils.GetGetterAs<float>(NumberType.R4, validCursor, validData.Schema.Label.Value.Index);
                         var validMatrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberType.U4, validCursor, validMatrixColumnIndexColInfo.Index);

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -331,7 +331,7 @@ namespace Microsoft.ML.Trainers
             ch.Assert(colCount > 0);
 
             // Checks for equality on the validation set ensure it is correct here.
-            using (var cursor = data.Data.GetRowCursor(matrixColumnIndexColInfo.Index, matrixRowIndexColInfo.Index, data.Schema.Label.Value.Index))
+            using (var cursor = data.Data.GetRowCursor(matrixColumnIndexColInfo, matrixRowIndexColInfo, data.Schema.Label.Value))
             {
                 // LibMF works only over single precision floats, but we want to be able to consume either.
                 var labGetter = RowCursorUtils.GetGetterAs<float>(NumberType.R4, cursor, data.Schema.Label.Value.Index);
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Trainers
                 else
                 {
                     RecommenderUtils.CheckAndGetMatrixIndexColumns(validData, out var validMatrixColumnIndexColInfo, out var validMatrixRowIndexColInfo, isDecode: false);
-                    using (var validCursor = validData.Data.GetRowCursor(matrixColumnIndexColInfo.Index, matrixRowIndexColInfo.Index, data.Schema.Label.Value.Index))
+                    using (var validCursor = validData.Data.GetRowCursor(matrixColumnIndexColInfo, matrixRowIndexColInfo, data.Schema.Label.Value))
                     {
                         ValueGetter<float> validLabelGetter = RowCursorUtils.GetGetterAs<float>(NumberType.R4, validCursor, validData.Schema.Label.Value.Index);
                         var validMatrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberType.U4, validCursor, validMatrixColumnIndexColInfo.Index);

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -350,6 +350,7 @@ namespace Microsoft.ML.Trainers
                 }
                 else
                 {
+                    columns = validData.Data.Schema.Where(c => c.Index == matrixColumnIndexColInfo.Index || c.Index == matrixRowIndexColInfo.Index || c.Index == data.Schema.Label.Value.Index);
                     RecommenderUtils.CheckAndGetMatrixIndexColumns(validData, out var validMatrixColumnIndexColInfo, out var validMatrixRowIndexColInfo, isDecode: false);
                     using (var validCursor = validData.Data.GetRowCursor(columns))
                     {

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -331,8 +331,7 @@ namespace Microsoft.ML.Trainers
             ch.Assert(colCount > 0);
 
             // Checks for equality on the validation set ensure it is correct here.
-            var columns = data.Data.Schema.Where(c => c.Index == matrixColumnIndexColInfo.Index || c.Index == matrixRowIndexColInfo.Index || c.Index == data.Schema.Label.Value.Index);
-            using (var cursor = data.Data.GetRowCursor(columns))
+            using (var cursor = data.Data.GetRowCursor(matrixColumnIndexColInfo.Index, matrixRowIndexColInfo.Index, data.Schema.Label.Value.Index))
             {
                 // LibMF works only over single precision floats, but we want to be able to consume either.
                 var labGetter = RowCursorUtils.GetGetterAs<float>(NumberType.R4, cursor, data.Schema.Label.Value.Index);
@@ -350,9 +349,8 @@ namespace Microsoft.ML.Trainers
                 }
                 else
                 {
-                    columns = validData.Data.Schema.Where(c => c.Index == matrixColumnIndexColInfo.Index || c.Index == matrixRowIndexColInfo.Index || c.Index == data.Schema.Label.Value.Index);
                     RecommenderUtils.CheckAndGetMatrixIndexColumns(validData, out var validMatrixColumnIndexColInfo, out var validMatrixRowIndexColInfo, isDecode: false);
-                    using (var validCursor = validData.Data.GetRowCursor(columns))
+                    using (var validCursor = validData.Data.GetRowCursor(matrixColumnIndexColInfo.Index, matrixRowIndexColInfo.Index, data.Schema.Label.Value.Index))
                     {
                         ValueGetter<float> validLabelGetter = RowCursorUtils.GetGetterAs<float>(NumberType.R4, validCursor, validData.Schema.Label.Value.Index);
                         var validMatrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberType.U4, validCursor, validMatrixColumnIndexColInfo.Index);

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -438,7 +438,11 @@ namespace Microsoft.ML.Learners
                     _weights = new float[1000];
             }
 
-            var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Features | CursOpt.Label | CursOpt.Weight);
+            CursOpt cursorOpt = CursOpt.Label | CursOpt.Features;
+            if (data.Schema.Weight.HasValue)
+                cursorOpt |= CursOpt.Weight;
+
+            var cursorFactory = new FloatLabelCursor.Factory(data, cursorOpt);
 
             long numBad;
             // REVIEW: This pass seems overly expensive for the benefit when multi-threading is off....

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -285,7 +285,11 @@ namespace Microsoft.ML.Trainers.Online
             }
 
             var rand = shuffle ? Host.Rand : null;
-            var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight);
+            CursOpt cursorOpt = CursOpt.Label | CursOpt.Features;
+            if (data.Schema.Weight.HasValue)
+                cursorOpt |= CursOpt.Weight;
+
+            var cursorFactory = new FloatLabelCursor.Factory(data, cursorOpt);
             long numBad = 0;
             while (state.Iteration < Args.NumIterations)
             {

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -285,7 +285,12 @@ namespace Microsoft.ML.Trainers
 
             int numFeatures = data.Schema.Feature.Value.Type.GetVectorSize();
             long maxTrainingExamples = MaxDualTableSize / weightSetCount;
-            var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight | CursOpt.Id);
+
+            CursOpt cursorOpt = CursOpt.Label | CursOpt.Features | CursOpt.Id;
+            if (data.Schema.Weight.HasValue)
+                cursorOpt |= CursOpt.Weight;
+
+            var cursorFactory = new FloatLabelCursor.Factory(data, cursorOpt);
             int numThreads;
             if (Args.NumThreads.HasValue)
             {
@@ -1747,6 +1752,11 @@ namespace Microsoft.ML.Trainers
             Contracts.Assert(data.Schema.Feature.HasValue);
 
             int numFeatures = data.Schema.Feature.Value.Type.GetVectorSize();
+
+            CursOpt cursorOpt = CursOpt.Label | CursOpt.Features;
+            if (data.Schema.Weight.HasValue)
+                cursorOpt |= CursOpt.Weight;
+
             var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight);
 
             int numThreads;

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -1757,7 +1757,7 @@ namespace Microsoft.ML.Trainers
             if (data.Schema.Weight.HasValue)
                 cursorOpt |= CursOpt.Weight;
 
-            var cursorFactory = new FloatLabelCursor.Factory(data, CursOpt.Label | CursOpt.Features | CursOpt.Weight);
+            var cursorFactory = new FloatLabelCursor.Factory(data, cursorOpt);
 
             int numThreads;
             if (_options.NumThreads.HasValue)

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Core.Data;
@@ -291,11 +292,13 @@ namespace Microsoft.ML.Trainers
             double pos = 0;
             double neg = 0;
 
-            int col = labelCol.Index;
             int colWeight = -1;
             if (data.Schema.Weight?.Type == NumberType.Float)
                 colWeight = data.Schema.Weight.Value.Index;
-            using (var cursor = data.Data.GetRowCursor(data.Schema.Schema.GetColumns(col, colWeight)))
+
+            int[] cols = colWeight > -1 ? new int[] { labelCol.Index, colWeight } : new int[] { labelCol.Index };
+
+            using (var cursor = data.Data.GetRowCursor(data.Schema.Schema.GetColumns(cols)))
             {
                 var getLab = cursor.GetLabelFloatGetter(data);
                 var getWeight = colWeight >= 0 ? cursor.GetGetter<float>(colWeight) : null;

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -295,7 +295,7 @@ namespace Microsoft.ML.Trainers
             int colWeight = -1;
             if (data.Schema.Weight?.Type == NumberType.Float)
                 colWeight = data.Schema.Weight.Value.Index;
-            using (var cursor = data.Data.GetRowCursor(c => c == col || c == colWeight))
+            using (var cursor = data.Data.GetRowCursor(data.Schema.Schema.Where(c => c.Index == col || c.Index == colWeight)))
             {
                 var getLab = cursor.GetLabelFloatGetter(data);
                 var getWeight = colWeight >= 0 ? cursor.GetGetter<float>(colWeight) : null;

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -296,9 +296,9 @@ namespace Microsoft.ML.Trainers
             if (data.Schema.Weight?.Type == NumberType.Float)
                 colWeight = data.Schema.Weight.Value.Index;
 
-            int[] cols = colWeight > -1 ? new int[] { labelCol.Index, colWeight } : new int[] { labelCol.Index };
+            var cols = colWeight > -1 ? new Schema.Column[] { labelCol, data.Schema.Weight.Value } : new Schema.Column[] { labelCol };
 
-            using (var cursor = data.Data.GetRowCursor(data.Schema.Schema.GetColumns(cols)))
+            using (var cursor = data.Data.GetRowCursor(cols))
             {
                 var getLab = cursor.GetLabelFloatGetter(data);
                 var getWeight = colWeight >= 0 ? cursor.GetGetter<float>(colWeight) : null;

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -295,7 +295,7 @@ namespace Microsoft.ML.Trainers
             int colWeight = -1;
             if (data.Schema.Weight?.Type == NumberType.Float)
                 colWeight = data.Schema.Weight.Value.Index;
-            using (var cursor = data.Data.GetRowCursor(data.Schema.Schema.Where(c => c.Index == col || c.Index == colWeight)))
+            using (var cursor = data.Data.GetRowCursor(data.Schema.Schema.GetColumns(col, colWeight)))
             {
                 var getLab = cursor.GetLabelFloatGetter(data);
                 var getWeight = colWeight >= 0 ? cursor.GetGetter<float>(colWeight) : null;

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -431,10 +431,10 @@ namespace Microsoft.ML.Transforms
             if (args.MetricOperation != null)
                 fetchList.Add(args.MetricOperation);
 
-            var hashedIndices = new HashSet<int>(inputColIndices);
+            var cols = input.Schema.Where(c => inputColIndices.Contains(c.Index));
             for (int epoch = 0; epoch < args.Epoch; epoch++)
             {
-                using (var cursor = input.GetRowCursor(a => hashedIndices.Contains(a)))
+                using (var cursor = input.GetRowCursor(cols))
                 {
                     var srcTensorGetters = GetTensorValueGetters(cursor, inputColIndices, isInputVector, tfInputTypes, tfInputShapes);
 

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -431,7 +431,7 @@ namespace Microsoft.ML.Transforms
             if (args.MetricOperation != null)
                 fetchList.Add(args.MetricOperation);
 
-            var cols = input.Schema.GetColumns(inputColIndices);
+            var cols = input.Schema.Where(c => inputColIndices.Contains(c.Index));
             for (int epoch = 0; epoch < args.Epoch; epoch++)
             {
                 using (var cursor = input.GetRowCursor(cols))

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -431,7 +431,7 @@ namespace Microsoft.ML.Transforms
             if (args.MetricOperation != null)
                 fetchList.Add(args.MetricOperation);
 
-            var cols = input.Schema.Where(c => inputColIndices.Contains(c.Index));
+            var cols = input.Schema.GetColumns(inputColIndices);
             for (int epoch = 0; epoch < args.Epoch; epoch++)
             {
                 using (var cursor = input.GetRowCursor(cols))

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1232,13 +1232,14 @@ namespace Microsoft.ML.TimeSeriesProcessing
                 throw _host.ExceptSchemaMismatch(nameof(data), "feature", featureCol.Name, "R4", featureCol.Type.ToString());
 
             Single[] dataArray = new Single[_trainSize];
-            int col = featureCol.Index;
+            var col = new List<Schema.Column>();
+            col.Add(featureCol);
 
             int count = 0;
-            using (var cursor = data.Data.GetRowCursor(c => c == col))
+            using (var cursor = data.Data.GetRowCursor(col))
             {
-                var getVal = cursor.GetGetter<Single>(col);
-                Single val = default(Single);
+                var getVal = cursor.GetGetter<Single>(featureCol.Index);
+                Single val = default;
                 while (cursor.MoveNext() && count < _trainSize)
                 {
                     getVal(ref val);

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1232,11 +1232,9 @@ namespace Microsoft.ML.TimeSeriesProcessing
                 throw _host.ExceptSchemaMismatch(nameof(data), "feature", featureCol.Name, "R4", featureCol.Type.ToString());
 
             Single[] dataArray = new Single[_trainSize];
-            var col = new List<Schema.Column>();
-            col.Add(featureCol);
 
             int count = 0;
-            using (var cursor = data.Data.GetRowCursor(col))
+            using (var cursor = data.Data.GetRowCursor(featureCol))
             {
                 var getVal = cursor.GetGetter<Single>(featureCol.Index);
                 Single val = default;

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.ML.Data;
 using Microsoft.ML.Data.IO;
 using Microsoft.ML.Internal.Utilities;
@@ -351,9 +352,9 @@ namespace Microsoft.ML.TimeSeriesProcessing
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            var srcCursor = _transform.GetRowCursor(predicate, rand);
+            var srcCursor = _transform.GetRowCursor(colsNeeded, rand);
             return new Cursor(this, srcCursor);
         }
 
@@ -364,10 +365,8 @@ namespace Microsoft.ML.TimeSeriesProcessing
             return _transform.GetRowCount();
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
-        {
-            return new RowCursor[] { GetRowCursorCore(predicate, rand) };
-        }
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+            => new RowCursor[] { GetRowCursorCore(colsNeeded, rand) };
 
         /// <summary>
         /// A wrapper around the cursor which replaces the schema.

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -352,9 +352,9 @@ namespace Microsoft.ML.TimeSeriesProcessing
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
-            var srcCursor = _transform.GetRowCursor(colsNeeded, rand);
+            var srcCursor = _transform.GetRowCursor(columnsNeeded, rand);
             return new Cursor(this, srcCursor);
         }
 
@@ -365,8 +365,8 @@ namespace Microsoft.ML.TimeSeriesProcessing
             return _transform.GetRowCount();
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
-            => new RowCursor[] { GetRowCursorCore(colsNeeded, rand) };
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
+            => new RowCursor[] { GetRowCursorCore(columnsNeeded, rand) };
 
         /// <summary>
         /// A wrapper around the cursor which replaces the schema.

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -429,9 +429,9 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
             public override bool CanShuffle { get { return false; } }
 
-            protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+            protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
             {
-                var srcCursor = _transform.GetRowCursor(colsNeeded, rand);
+                var srcCursor = _transform.GetRowCursor(columnsNeeded, rand);
                 var clone = (SequentialDataTransform)MemberwiseClone();
                 clone.CloneStateInMapper();
                 return new Cursor(Host, clone, srcCursor);
@@ -446,8 +446,8 @@ namespace Microsoft.ML.TimeSeriesProcessing
             public override long? GetRowCount()
                 => _transform.GetRowCount();
 
-            public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
-                => new RowCursor[] { GetRowCursorCore(colsNeeded, rand) };
+            public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
+                => new RowCursor[] { GetRowCursorCore(columnsNeeded, rand) };
 
             public override void Save(ModelSaveContext ctx)
             {
@@ -696,21 +696,21 @@ namespace Microsoft.ML.TimeSeriesProcessing
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Func<int, bool> predicateInput;
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             var active = GetActive(predicate, out predicateInput);
             var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
             return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
              Host.CheckValueOrNull(rand);
 
             Func<int, bool> predicateInput;
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             var active = GetActive(predicate, out predicateInput);
 
             var inputCols = Source.Schema.Where(x => predicateInput(x.Index));

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -698,8 +698,8 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             Func<int, bool> predicateInput;
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var active = GetActive(predicate, out predicateInput);
             var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
             return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
@@ -707,10 +707,10 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
-            Host.CheckValueOrNull(rand);
+             Host.CheckValueOrNull(rand);
 
             Func<int, bool> predicateInput;
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var active = GetActive(predicate, out predicateInput);
 
             var inputCols = Source.Schema.Where(x => predicateInput(x.Index));

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.ML.Data;
@@ -428,9 +429,9 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
             public override bool CanShuffle { get { return false; } }
 
-            protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+            protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
             {
-                var srcCursor = _transform.GetRowCursor(predicate, rand);
+                var srcCursor = _transform.GetRowCursor(colsNeeded, rand);
                 var clone = (SequentialDataTransform)MemberwiseClone();
                 clone.CloneStateInMapper();
                 return new Cursor(Host, clone, srcCursor);
@@ -443,14 +444,10 @@ namespace Microsoft.ML.TimeSeriesProcessing
             }
 
             public override long? GetRowCount()
-            {
-                return _transform.GetRowCount();
-            }
+                => _transform.GetRowCount();
 
-            public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
-            {
-                return new RowCursor[] { GetRowCursorCore(predicate, rand) };
-            }
+            public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+                => new RowCursor[] { GetRowCursorCore(colsNeeded, rand) };
 
             public override void Save(ModelSaveContext ctx)
             {
@@ -699,22 +696,25 @@ namespace Microsoft.ML.TimeSeriesProcessing
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
-            return new Cursor(Host, Source.GetRowCursor(predicateInput, rand), this, active);
+            var inputCols = Source.Schema.Where(x => predicateInput(x.Index)).ToList().AsReadOnly();
+            return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             Host.CheckValueOrNull(rand);
 
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
 
-            var inputs = Source.GetRowCursorSet(predicateInput, n, rand);
+            var inputCols = Source.Schema.Where(x => predicateInput(x.Index)).ToList().AsReadOnly();
+            var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 
             if (inputs.Length == 1 && n > 1 && _bindings.AddedColumnIndices.Any(predicate))

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -699,7 +699,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Func<int, bool> predicateInput;
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var active = GetActive(predicate, out predicateInput);
             var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
             return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
@@ -710,7 +710,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
              Host.CheckValueOrNull(rand);
 
             Func<int, bool> predicateInput;
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var active = GetActive(predicate, out predicateInput);
 
             var inputCols = Source.Schema.Where(x => predicateInput(x.Index));

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -701,7 +701,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
             Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
-            var inputCols = Source.Schema.Where(x => predicateInput(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
             return new Cursor(Host, Source.GetRowCursor(inputCols, rand), this, active);
         }
 
@@ -713,7 +713,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
             Func<int, bool> predicateInput;
             var active = GetActive(predicate, out predicateInput);
 
-            var inputCols = Source.Schema.Where(x => predicateInput(x.Index)).ToList().AsReadOnly();
+            var inputCols = Source.Schema.Where(x => predicateInput(x.Index));
             var inputs = Source.GetRowCursorSet(inputCols, n, rand);
             Host.AssertNonEmpty(inputs);
 

--- a/src/Microsoft.ML.Transforms/BootstrapSamplingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/BootstrapSamplingTransformer.cs
@@ -164,20 +164,20 @@ namespace Microsoft.ML.Transforms
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             // We do not use the input random because this cursor does not support shuffling.
             var rgen = new TauswortheHybrid(_state);
-            var input = Source.GetRowCursor(colsNeeded, _shuffleInput ? new TauswortheHybrid(rgen) : null);
+            var input = Source.GetRowCursor(columnsNeeded, _shuffleInput ? new TauswortheHybrid(rgen) : null);
             RowCursor cursor = new Cursor(this, input, rgen);
             if (_poolSize > 1)
                 cursor = RowShufflingTransformer.GetShuffledCursor(Host, _poolSize, cursor, new TauswortheHybrid(rgen));
             return cursor;
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
-            var cursor = GetRowCursorCore(colsNeeded, rand);
+            var cursor = GetRowCursorCore(columnsNeeded, rand);
             return new RowCursor[] { cursor };
         }
 

--- a/src/Microsoft.ML.Transforms/BootstrapSamplingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/BootstrapSamplingTransformer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
@@ -163,20 +164,20 @@ namespace Microsoft.ML.Transforms
             return false;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             // We do not use the input random because this cursor does not support shuffling.
             var rgen = new TauswortheHybrid(_state);
-            var input = Source.GetRowCursor(predicate, _shuffleInput ? new TauswortheHybrid(rgen) : null);
+            var input = Source.GetRowCursor(colsNeeded, _shuffleInput ? new TauswortheHybrid(rgen) : null);
             RowCursor cursor = new Cursor(this, input, rgen);
             if (_poolSize > 1)
                 cursor = RowShufflingTransformer.GetShuffledCursor(Host, _poolSize, cursor, new TauswortheHybrid(rgen));
             return cursor;
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            var cursor = GetRowCursorCore(predicate, rand);
+            var cursor = GetRowCursorCore(colsNeeded, rand);
             return new RowCursor[] { cursor };
         }
 

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
 
             var schema = input.Schema;
             var size = columns.Length;
-            var activeInput = new bool[schema.Count];
+            var activeCols = new List<Schema.Column>();
             var colSrcs = new int[size];
             var colTypes = new ColumnType[size];
             colSizes = new int[size];
@@ -249,7 +249,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                 if (colType is VectorType vectorType && !vectorType.IsKnownSize)
                     throw env.ExceptUserArg(nameof(CountFeatureSelectingEstimator.Arguments.Column), "Variable length column '{0}' is not allowed", colName);
 
-                activeInput[colSrc] = true;
+                activeCols.Add(schema[colSrc]);
                 colSrcs[i] = colSrc;
                 colTypes[i] = colType;
                 colSizes[i] = colType.GetValueCount();
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
             long rowCur = 0;
             double rowCount = input.GetRowCount() ?? double.NaN;
             using (var pch = env.StartProgressChannel("Aggregating counts"))
-            using (var cursor = input.GetRowCursor(col => activeInput[col]))
+            using (var cursor = input.GetRowCursor(activeCols))
             {
                 var header = new ProgressHeader(new[] { "rows" });
                 pch.SetHeader(header, e => { e.SetProgress(0, rowCur, rowCount); });

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -539,6 +539,8 @@ namespace Microsoft.ML.Transforms
                     if (_active[i + _groupCount])
                         srcActiveTrailing[binding.KeepColumnIndexes[i]] = true;
                 }
+
+                activeCols = _parent.Source.Schema.Where(x => x.Index < srcActiveTrailing.Length && srcActiveTrailing[x.Index]);
                 _trailingCursor = parent.Source.GetRowCursor(activeCols);
 
                 _groupCheckers = new GroupKeyColumnChecker[_groupCount];

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -155,10 +155,10 @@ namespace Microsoft.ML.Transforms
 
         public override Schema OutputSchema => _groupBinding.OutputSchema;
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             return new Cursor(this, predicate);
         }
 
@@ -171,10 +171,10 @@ namespace Microsoft.ML.Transforms
 
         public override bool CanShuffle { get { return false; } }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            return new RowCursor[] { GetRowCursorCore(colsNeeded) };
+            return new RowCursor[] { GetRowCursorCore(columnsNeeded) };
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -157,9 +157,8 @@ namespace Microsoft.ML.Transforms
 
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             Host.CheckValueOrNull(rand);
-
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             return new Cursor(this, predicate);
         }
 

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Transforms
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             return new Cursor(this, predicate);
         }
 

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -320,7 +320,7 @@ namespace Microsoft.ML.Transforms
             List<int> columnsToImpute = null;
             // REVIEW: Would like to get rid of the sourceColumns list but seems to be the best way to provide
             // the cursor with what columns to cursor through.
-            HashSet<int> sourceColumns = null;
+           var sourceColumns = new List<Schema.Column>();
             for (int iinfo = 0; iinfo < columns.Length; iinfo++)
             {
                 input.Schema.TryGetColumnIndex(columns[iinfo].Input, out int colSrc);
@@ -346,7 +346,7 @@ namespace Microsoft.ML.Transforms
                             throw Host.Except("Cannot perform mean imputations on non-numeric '{0}'", type.GetItemType());
                         imputationModes[iinfo] = kind;
                         Utils.Add(ref columnsToImpute, iinfo);
-                        Utils.Add(ref sourceColumns, colSrc);
+                        sourceColumns.Add(input.Schema[colSrc]);
                         break;
                     default:
                         Host.Assert(false);
@@ -360,7 +360,7 @@ namespace Microsoft.ML.Transforms
 
             // Impute values.
             using (var ch = Host.Start("Computing Statistics"))
-            using (var cursor = input.GetRowCursor(sourceColumns.Contains))
+            using (var cursor = input.GetRowCursor(sourceColumns))
             {
                 StatAggregator[] statAggregators = new StatAggregator[columnsToImpute.Count];
                 for (int ii = 0; ii < columnsToImpute.Count; ii++)

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -300,7 +300,7 @@ namespace Microsoft.ML.Transforms
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -314,7 +314,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
 

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -297,10 +297,10 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -310,11 +310,11 @@ namespace Microsoft.ML.Transforms
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
 

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -300,7 +300,7 @@ namespace Microsoft.ML.Transforms
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
@@ -314,7 +314,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
 

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
@@ -296,29 +297,33 @@ namespace Microsoft.ML.Transforms
             return null;
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate, "predicate");
             Host.AssertValueOrNull(rand);
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
 
             var inputPred = _bindings.GetDependencies(predicate);
             var active = _bindings.GetActive(predicate);
-            var input = Source.GetRowCursor(inputPred);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            var input = Source.GetRowCursor(inputCols);
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
 
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             var inputPred = _bindings.GetDependencies(predicate);
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+
             var active = _bindings.GetActive(predicate);
             RowCursor input;
 
             if (n > 1 && ShouldUseParallelCursors(predicate) != false)
             {
-                var inputs = Source.GetRowCursorSet(inputPred, n);
+                var inputs = Source.GetRowCursorSet(inputCols, n);
                 Host.AssertNonEmpty(inputs);
 
                 if (inputs.Length != 1)
@@ -331,7 +336,7 @@ namespace Microsoft.ML.Transforms
                 input = inputs[0];
             }
             else
-                input = Source.GetRowCursor(inputPred);
+                input = Source.GetRowCursor(inputCols);
 
             return new RowCursor[] { new Cursor(Host, _bindings, input, active) };
         }

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Transforms
                 var valuesRowCount = 0;
                 // REVIEW: Seems like if the labels are NaN, so that all metrics are NaN, this command will be useless.
                 // In which case probably erroring out is probably the most useful thing.
-                using (var cursor = data.GetRowCursor(featuresColumnIndex))
+                using (var cursor = data.GetRowCursor(featuresColumn))
                 {
                     var featuresGetter = cursor.GetGetter<VBuffer<float>>(featuresColumnIndex);
                     var featuresBuffer = default(VBuffer<float>);

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Transforms
                 var valuesRowCount = 0;
                 // REVIEW: Seems like if the labels are NaN, so that all metrics are NaN, this command will be useless.
                 // In which case probably erroring out is probably the most useful thing.
-                using (var cursor = data.GetRowCursor(data.Schema.Where(x =>  x.Index == featuresColumnIndex)))
+                using (var cursor = data.GetRowCursor(featuresColumnIndex))
                 {
                     var featuresGetter = cursor.GetGetter<VBuffer<float>>(featuresColumnIndex);
                     var featuresBuffer = default(VBuffer<float>);

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Transforms
                 var valuesRowCount = 0;
                 // REVIEW: Seems like if the labels are NaN, so that all metrics are NaN, this command will be useless.
                 // In which case probably erroring out is probably the most useful thing.
-                using (var cursor = data.GetRowCursor(col => col == featuresColumnIndex))
+                using (var cursor = data.GetRowCursor(data.Schema.Where(x =>  x.Index == featuresColumnIndex)))
                 {
                     var featuresGetter = cursor.GetGetter<VBuffer<float>>(featuresColumnIndex);
                     var featuresBuffer = default(VBuffer<float>);

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -137,11 +137,11 @@ namespace Microsoft.ML.Transforms
             _bindings.Save(ctx);
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
             Host.AssertValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var input = Source.GetRowCursor(inputCols, rand);
@@ -150,10 +150,10 @@ namespace Microsoft.ML.Transforms
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             var inputPred = _bindings.GetDependencies(predicate);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -141,7 +141,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.AssertValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var input = Source.GetRowCursor(inputCols, rand);
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var inputPred = _bindings.GetDependencies(predicate);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -141,7 +141,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.AssertValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var inputPred = _bindings.GetDependencies(predicate);
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));
             var input = Source.GetRowCursor(inputCols, rand);
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
             Host.CheckValueOrNull(rand);
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var inputPred = _bindings.GetDependencies(predicate);
 
             var inputCols = Source.Schema.Where(x => inputPred(x.Index));

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
@@ -135,25 +137,27 @@ namespace Microsoft.ML.Transforms
             _bindings.Save(ctx);
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Host.AssertValue(predicate, "predicate");
             Host.AssertValueOrNull(rand);
 
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             var inputPred = _bindings.GetDependencies(predicate);
-            var input = Source.GetRowCursor(inputPred, rand);
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            var input = Source.GetRowCursor(inputCols, rand);
             bool active = predicate(_bindings.MapIinfoToCol(0));
 
             return new Cursor(Host, _bindings, input, active);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate, int n, Random rand = null)
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded, int n, Random rand = null)
         {
-            Host.CheckValue(predicate, nameof(predicate));
             Host.CheckValueOrNull(rand);
-
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             var inputPred = _bindings.GetDependencies(predicate);
-            RowCursor[] cursors = Source.GetRowCursorSet(inputPred, n, rand);
+
+            var inputCols = Source.Schema.Where(x => inputPred(x.Index));
+            RowCursor[] cursors = Source.GetRowCursorSet(inputCols, n, rand);
             bool active = predicate(_bindings.MapIinfoToCol(0));
             for (int c = 0; c < cursors.Length; ++c)
                 cursors[c] = new Cursor(Host, _bindings, cursors[c], active);

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.ML;
@@ -307,7 +308,7 @@ namespace Microsoft.ML.Transforms.Projections
         {
             var avgDistances = new float[columns.Length];
             const int reservoirSize = 5000;
-            bool[] activeColumns = new bool[input.Schema.Count];
+            var activeColumns = new List<Schema.Column>();
             int[] srcCols = new int[columns.Length];
             for (int i = 0; i < columns.Length; i++)
             {
@@ -318,10 +319,10 @@ namespace Microsoft.ML.Transforms.Projections
                 if (reason != null)
                     throw Host.ExceptSchemaMismatch(nameof(input), "input", ColumnPairs[i].input, reason, type.ToString());
                 srcCols[i] = srcCol;
-                activeColumns[srcCol] = true;
+                activeColumns.Add(input.Schema[srcCol]);
             }
             var reservoirSamplers = new ReservoirSamplerWithReplacement<VBuffer<float>>[columns.Length];
-            using (var cursor = input.GetRowCursor(col => activeColumns[col]))
+            using (var cursor = input.GetRowCursor(activeColumns))
             {
                 for (int i = 0; i < columns.Length; i++)
                 {

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.CheckValueOrNull(rand);
 
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var activeInputs = _bindings.GetActiveInput(predicate);
             Func<int, bool> inputPred = c => activeInputs[c];
 

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -176,7 +176,10 @@ namespace Microsoft.ML.Transforms
 
                 var appendedDataView = new DataViewConstructionUtils.SingleRowLoopDataView<TDst>(parent.Host, _parent._addedSchema);
                 appendedDataView.SetCurrentRowObject(_dst);
-                _appendedRow = appendedDataView.GetRowCursor(colsNeeded);
+                var appendedIndices = _parent._bindings.AddedColumnIndices;
+
+                var cols = colsNeeded.Select(c => c.Name);
+                _appendedRow = appendedDataView.GetRowCursor(appendedDataView.Schema.Where(c => cols.Contains(c.Name)));
             }
 
             protected override void Dispose(bool disposing)

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -178,7 +178,14 @@ namespace Microsoft.ML.Transforms
                 var appendedDataView = new DataViewConstructionUtils.SingleRowLoopDataView<TDst>(parent.Host, _parent._addedSchema);
                 appendedDataView.SetCurrentRowObject(_dst);
 
-                _appendedRow = appendedDataView.GetRowCursor(_parent._bindings.Schema);
+                Func<int, bool> appendedPredicate =
+                col =>
+                {
+                    col = _parent._bindings.AddedColumnIndices[col];
+                    return predicate(col);
+                };
+
+                _appendedRow = appendedDataView.GetRowCursor(appendedDataView.Schema);
             }
 
             protected override void Dispose(bool disposing)

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -185,7 +185,7 @@ namespace Microsoft.ML.Transforms
                     return predicate(col);
                 };
 
-                _appendedRow = appendedDataView.GetRowCursor(appendedDataView.Schema);
+                _appendedRow = appendedDataView.GetRowCursorForAllColumns();
             }
 
             protected override void Dispose(bool disposing)

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.CheckValueOrNull(rand);
 
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var activeInputs = _bindings.GetActiveInput(predicate);
             Func<int, bool> inputPred = c => activeInputs[c];
 

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -951,7 +951,7 @@ namespace Microsoft.ML.Transforms.Text
                     throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].Input, "a fixed vector of floats", srcColType.ToString());
 
                 srcCols[i] = srcCol;
-                activeColumns.Add(inputData.Schema[srcCol]); //sefilipi: is this correct, or do i filter by x.Index?
+                activeColumns.Add(inputData.Schema[srcCol]);
                 numVocabs[i] = 0;
 
                 VBuffer<ReadOnlyMemory<char>> dst = default;

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -934,7 +934,7 @@ namespace Microsoft.ML.Transforms.Text
             ch.AssertValue(states);
             ch.Assert(states.Length == columns.Length);
 
-            bool[] activeColumns = new bool[inputData.Schema.Count];
+            var activeColumns = new List<Schema.Column>();
             int[] numVocabs = new int[columns.Length];
             int[] srcCols = new int[columns.Length];
 
@@ -951,7 +951,7 @@ namespace Microsoft.ML.Transforms.Text
                     throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].Input, "a fixed vector of floats", srcColType.ToString());
 
                 srcCols[i] = srcCol;
-                activeColumns[srcCol] = true;
+                activeColumns.Add(inputData.Schema[srcCol]); //sefilipi: is this correct, or do i filter by x.Index?
                 numVocabs[i] = 0;
 
                 VBuffer<ReadOnlyMemory<char>> dst = default;
@@ -968,7 +968,7 @@ namespace Microsoft.ML.Transforms.Text
             long[] corpusSize = new long[columns.Length];
             int[] numDocArray = new int[columns.Length];
 
-            using (var cursor = inputData.GetRowCursor(col => activeColumns[col]))
+            using (var cursor = inputData.GetRowCursor(activeColumns))
             {
                 var getters = new ValueGetter<VBuffer<Double>>[columns.Length];
                 for (int i = 0; i < columns.Length; i++)
@@ -977,7 +977,7 @@ namespace Microsoft.ML.Transforms.Text
                     numDocArray[i] = 0;
                     getters[i] = RowCursorUtils.GetVecGetterAs<Double>(NumberType.R8, cursor, srcCols[i]);
                 }
-                VBuffer<Double> src = default(VBuffer<Double>);
+                VBuffer<Double> src = default;
                 long rowCount = 0;
                 while (cursor.MoveNext())
                 {
@@ -1045,7 +1045,7 @@ namespace Microsoft.ML.Transforms.Text
                 states[i] = state;
             }
 
-            using (var cursor = inputData.GetRowCursor(col => activeColumns[col]))
+            using (var cursor = inputData.GetRowCursor(activeColumns))
             {
                 int[] docSizeCheck = new int[columns.Length];
                 // This could be optimized so that if multiple trainers consume the same column, it is
@@ -1057,7 +1057,7 @@ namespace Microsoft.ML.Transforms.Text
                     getters[i] = RowCursorUtils.GetVecGetterAs<Double>(NumberType.R8, cursor, srcCols[i]);
                 }
 
-                VBuffer<Double> src = default(VBuffer<Double>);
+                VBuffer<double> src = default;
 
                 while (cursor.MoveNext())
                 {

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -817,12 +817,12 @@ namespace Microsoft.ML.Transforms.Text
             private readonly int[] _invertHashMaxCounts;
             private readonly int[][] _srcIndices;
 
-            public InvertHashHelper(NgramHashingTransformer parent, Schema inputSchema, string[][] friendlyNames, IEnumerable<Schema.Column> colsNeeded, int[] invertHashMaxCounts)
+            public InvertHashHelper(NgramHashingTransformer parent, Schema inputSchema, string[][] friendlyNames, IEnumerable<Schema.Column> columnsNeeded, int[] invertHashMaxCounts)
             {
                 Contracts.AssertValue(parent);
                 Contracts.AssertValue(friendlyNames);
                 Contracts.Assert(friendlyNames.Length == parent._columns.Length);
-                Contracts.AssertValue(colsNeeded);
+                Contracts.AssertValue(columnsNeeded);
                 Contracts.AssertValue(invertHashMaxCounts);
                 Contracts.Assert(invertHashMaxCounts.Length == parent._columns.Length);
                 _parent = parent;
@@ -832,7 +832,7 @@ namespace Microsoft.ML.Transforms.Text
                 _srcTextGetters = new ValueMapper<uint, StringBuilder>[inputSchema.Count];
                 _invertHashMaxCounts = invertHashMaxCounts;
 
-                foreach(var col in colsNeeded)
+                foreach(var col in columnsNeeded)
                 {
                     Contracts.Assert(col.Index < _srcTextGetters.Length);
                     _srcTextGetters[col.Index] = InvertHashUtils.GetSimpleMapper<uint>(inputSchema, col.Index);

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -401,7 +401,7 @@ namespace Microsoft.ML.Transforms.Text
                 var active = new bool[1];
                 string[][] friendlyNames = _columns.Select(c => c.FriendlyNames).ToArray();
                 // We will create invert hash helper class, which would store in itself all original ngrams and their mapping into hash values.
-                var helper = new InvertHashHelper(this, input.Schema, friendlyNames, c => sourceColumnsForInvertHash.Any(col => col.Index == c), invertHashMaxCounts);
+                var helper = new InvertHashHelper(this, input.Schema, friendlyNames, sourceColumnsForInvertHash, invertHashMaxCounts);
                 // in order to get all original ngrams we have to go data in same way as we would process it, so let's create mapper with decorate function.
                 var mapper = new Mapper(this, input.Schema, helper.Decorate);
                 // Let's create cursor to iterate over input data.
@@ -817,12 +817,12 @@ namespace Microsoft.ML.Transforms.Text
             private readonly int[] _invertHashMaxCounts;
             private readonly int[][] _srcIndices;
 
-            public InvertHashHelper(NgramHashingTransformer parent, Schema inputSchema, string[][] friendlyNames, Func<int, bool> inputPred, int[] invertHashMaxCounts)
+            public InvertHashHelper(NgramHashingTransformer parent, Schema inputSchema, string[][] friendlyNames, IEnumerable<Schema.Column> colsNeeded, int[] invertHashMaxCounts)
             {
                 Contracts.AssertValue(parent);
                 Contracts.AssertValue(friendlyNames);
                 Contracts.Assert(friendlyNames.Length == parent._columns.Length);
-                Contracts.AssertValue(inputPred);
+                Contracts.AssertValue(colsNeeded);
                 Contracts.AssertValue(invertHashMaxCounts);
                 Contracts.Assert(invertHashMaxCounts.Length == parent._columns.Length);
                 _parent = parent;
@@ -831,11 +831,13 @@ namespace Microsoft.ML.Transforms.Text
                 // One per source column (some may be null).
                 _srcTextGetters = new ValueMapper<uint, StringBuilder>[inputSchema.Count];
                 _invertHashMaxCounts = invertHashMaxCounts;
-                for (int i = 0; i < _srcTextGetters.Length; ++i)
+
+                foreach(var col in colsNeeded)
                 {
-                    if (inputPred(i))
-                        _srcTextGetters[i] = InvertHashUtils.GetSimpleMapper<uint>(inputSchema, i);
+                    Contracts.Assert(col.Index < _srcTextGetters.Length);
+                    _srcTextGetters[col.Index] = InvertHashUtils.GetSimpleMapper<uint>(inputSchema, col.Index);
                 }
+
                 _srcIndices = new int[_parent._columns.Length][];
                 for (int i = 0; i < _parent._columns.Length; i++)
                 {

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -372,7 +372,7 @@ namespace Microsoft.ML.Transforms.Text
             // Let's validate input schema and check which columns requried invertHash.
             int[] invertHashMaxCounts = new int[_columns.Length];
             HashSet<int> columnWithInvertHash = new HashSet<int>();
-            HashSet<int> sourceColumnsForInvertHash = new HashSet<int>();
+            var sourceColumnsForInvertHash = new List<Schema.Column>();
             for (int i = 0; i < _columns.Length; i++)
             {
                 int invertHashMaxCount;
@@ -391,7 +391,7 @@ namespace Microsoft.ML.Transforms.Text
                         var columnType = input.Schema[srcCol].Type;
                         if (!NgramHashingEstimator.IsColumnTypeValid(input.Schema[srcCol].Type))
                             throw Host.ExceptSchemaMismatch(nameof(input), "input", _columns[i].Inputs[j], NgramHashingEstimator.ExpectedColumnType, columnType.ToString());
-                        sourceColumnsForInvertHash.Add(srcCol);
+                        sourceColumnsForInvertHash.Add(input.Schema[srcCol]);
                     }
                 }
             }
@@ -401,11 +401,11 @@ namespace Microsoft.ML.Transforms.Text
                 var active = new bool[1];
                 string[][] friendlyNames = _columns.Select(c => c.FriendlyNames).ToArray();
                 // We will create invert hash helper class, which would store in itself all original ngrams and their mapping into hash values.
-                var helper = new InvertHashHelper(this, input.Schema, friendlyNames, sourceColumnsForInvertHash.Contains, invertHashMaxCounts);
+                var helper = new InvertHashHelper(this, input.Schema, friendlyNames, c => sourceColumnsForInvertHash.Any(col => col.Index == c), invertHashMaxCounts);
                 // in order to get all original ngrams we have to go data in same way as we would process it, so let's create mapper with decorate function.
                 var mapper = new Mapper(this, input.Schema, helper.Decorate);
                 // Let's create cursor to iterate over input data.
-                using (var rowCursor = input.GetRowCursor(sourceColumnsForInvertHash.ToArray()))
+                using (var rowCursor = input.GetRowCursor(sourceColumnsForInvertHash))
                 {
                     Action disp;
                     // We create mapper getters on top of input cursor

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -405,7 +405,7 @@ namespace Microsoft.ML.Transforms.Text
                 // in order to get all original ngrams we have to go data in same way as we would process it, so let's create mapper with decorate function.
                 var mapper = new Mapper(this, input.Schema, helper.Decorate);
                 // Let's create cursor to iterate over input data.
-                using (var rowCursor = input.GetRowCursor(input.Schema.Where(x => sourceColumnsForInvertHash.Contains(x.Index))))
+                using (var rowCursor = input.GetRowCursor(sourceColumnsForInvertHash.ToArray()))
                 {
                     Action disp;
                     // We create mapper getters on top of input cursor

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -405,7 +405,7 @@ namespace Microsoft.ML.Transforms.Text
                 // in order to get all original ngrams we have to go data in same way as we would process it, so let's create mapper with decorate function.
                 var mapper = new Mapper(this, input.Schema, helper.Decorate);
                 // Let's create cursor to iterate over input data.
-                using (var rowCursor = input.GetRowCursor(sourceColumnsForInvertHash.Contains))
+                using (var rowCursor = input.GetRowCursor(input.Schema.Where(x => sourceColumnsForInvertHash.Contains(x.Index))))
                 {
                     Action disp;
                     // We create mapper getters on top of input cursor

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -301,16 +301,16 @@ namespace Microsoft.ML.Transforms.Text
             // i in _counts counts how many (i+1)-grams are in the pool for column iinfo.
             var counts = new int[columns.Length][];
             var ngramMaps = new SequencePool[columns.Length];
-            var activeInput = new bool[trainingData.Schema.Count];
+            var activeCols = new List<Schema.Column>();
             var srcTypes = new ColumnType[columns.Length];
             var srcCols = new int[columns.Length];
             for (int iinfo = 0; iinfo < columns.Length; iinfo++)
             {
                 trainingData.Schema.TryGetColumnIndex(columns[iinfo].Input, out srcCols[iinfo]);
                 srcTypes[iinfo] = trainingData.Schema[srcCols[iinfo]].Type;
-                activeInput[srcCols[iinfo]] = true;
+                activeCols.Add(trainingData.Schema[srcCols[iinfo]]);
             }
-            using (var cursor = trainingData.GetRowCursor(col => activeInput[col]))
+            using (var cursor = trainingData.GetRowCursor(activeCols))
             using (var pch = env.StartProgressChannel("Building n-gram dictionary"))
             {
                 for (int iinfo = 0; iinfo < columns.Length; iinfo++)

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -769,17 +769,17 @@ namespace Microsoft.ML.Transforms.Text
             {
                 string srcCol = stopwordsColumn;
                 var loader = GetLoaderForStopwords(ch, dataFile, loaderFactory, ref srcCol);
-                int colSrc;
-                if (!loader.Schema.TryGetColumnIndex(srcCol, out colSrc))
+
+                if (!loader.Schema.TryGetColumnIndex(srcCol, out int colSrcIndex))
                     throw ch.ExceptUserArg(nameof(Arguments.StopwordsColumn), "Unknown column '{0}'", srcCol);
-                var typeSrc = loader.Schema[colSrc].Type;
+                var typeSrc = loader.Schema[colSrcIndex].Type;
                 ch.CheckUserArg(typeSrc is TextType, nameof(Arguments.StopwordsColumn), "Must be a scalar text column");
 
                 // Accumulate the stopwords.
-                using (var cursor = loader.GetRowCursor(col => col == colSrc))
+                using (var cursor = loader.GetRowCursor(loader.Schema.Where(col => col.Name.Equals(srcCol)))) //sefilipi: Should we go by name, or index. Duplicate names?
                 {
                     bool warnEmpty = true;
-                    var getter = cursor.GetGetter<ReadOnlyMemory<char>>(colSrc);
+                    var getter = cursor.GetGetter<ReadOnlyMemory<char>>(colSrcIndex);
                     while (cursor.MoveNext())
                     {
                         getter(ref src);

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -776,7 +776,7 @@ namespace Microsoft.ML.Transforms.Text
                 ch.CheckUserArg(typeSrc is TextType, nameof(Arguments.StopwordsColumn), "Must be a scalar text column");
 
                 // Accumulate the stopwords.
-                using (var cursor = loader.GetRowCursor(loader.Schema.Where(col => col.Name.Equals(srcCol)))) //sefilipi: Should we go by name, or index. Duplicate names?
+                using (var cursor = loader.GetRowCursor(srcCol))
                 {
                     bool warnEmpty = true;
                     var getter = cursor.GetGetter<ReadOnlyMemory<char>>(colSrcIndex);

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -776,7 +776,7 @@ namespace Microsoft.ML.Transforms.Text
                 ch.CheckUserArg(typeSrc is TextType, nameof(Arguments.StopwordsColumn), "Must be a scalar text column");
 
                 // Accumulate the stopwords.
-                using (var cursor = loader.GetRowCursor(srcCol))
+                using (var cursor = loader.GetRowCursor(loader.Schema[srcCol]))
                 {
                     bool warnEmpty = true;
                     var getter = cursor.GetGetter<ReadOnlyMemory<char>>(colSrcIndex);

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Transforms
 
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
 
             var inputCols = Source.Schema.Where(x => activeInput[x.Index]);
@@ -190,7 +190,7 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded,
             int n, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
 
             var inputCols = Source.Schema.Where(x => activeInput[x.Index]);

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -177,18 +177,25 @@ namespace Microsoft.ML.Transforms
             get { return false; }
         }
 
-        protected override RowCursor GetRowCursorCore(Func<int, bool> predicate, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
-            var inputCursor = Source.GetRowCursor(col => activeInput[col], null);
+
+            var inputCols = Source.Schema.Where(x => activeInput[x.Index]);
+            var inputCursor = Source.GetRowCursor(inputCols, null);
             return new Cursor(Host, inputCursor, _ungroupBinding, predicate);
         }
 
-        public override RowCursor[] GetRowCursorSet(Func<int, bool> predicate,
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded,
             int n, Random rand = null)
         {
+            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
-            var inputCursors = Source.GetRowCursorSet(col => activeInput[col], n, null);
+
+            var inputCols = Source.Schema.Where(x => activeInput[x.Index]);
+            var inputCursors = Source.GetRowCursorSet(inputCols, n, null);
             return Utils.BuildArray<RowCursor>(inputCursors.Length,
                 x => new Cursor(Host, inputCursors[x], _ungroupBinding, predicate));
         }

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -179,8 +179,7 @@ namespace Microsoft.ML.Transforms
 
         protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
-
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
 
             var inputCols = Source.Schema.Where(x => activeInput[x.Index]);
@@ -191,7 +190,7 @@ namespace Microsoft.ML.Transforms
         public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded,
             int n, Random rand = null)
         {
-            Func<int, bool> predicate = c => colsNeeded == null ? false : colsNeeded.Any(x => x.Index == c);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, Source.Schema.Count);
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
 
             var inputCols = Source.Schema.Where(x => activeInput[x.Index]);

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -177,9 +177,9 @@ namespace Microsoft.ML.Transforms
             get { return false; }
         }
 
-        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> colsNeeded, Random rand = null)
+        protected override RowCursor GetRowCursorCore(IEnumerable<Schema.Column> columnsNeeded, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
 
             var inputCols = Source.Schema.Where(x => activeInput[x.Index]);
@@ -187,10 +187,10 @@ namespace Microsoft.ML.Transforms
             return new Cursor(Host, inputCursor, _ungroupBinding, predicate);
         }
 
-        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> colsNeeded,
+        public override RowCursor[] GetRowCursorSet(IEnumerable<Schema.Column> columnsNeeded,
             int n, Random rand = null)
         {
-            var predicate = RowCursorUtils.FromColumnsToPredicate(colsNeeded, OutputSchema);
+            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, OutputSchema);
             var activeInput = _ungroupBinding.GetActiveInput(predicate);
 
             var inputCols = Source.Schema.Where(x => activeInput[x.Index]);

--- a/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
+++ b/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
@@ -38,12 +38,11 @@ namespace Microsoft.ML.Benchmarks
             var dv = builder.GetDataView();
             var cacheDv = ctx.Data.Cache(dv);
 
-            var cols = cacheDv.Schema.Where(x => x.Name.Equals("A"));
-
+            var col = cacheDv.Schema.GetColumnOrNull("A").Value;
             // First do one pass through.
-            using (var cursor = cacheDv.GetRowCursor(cols))
+            using (var cursor = cacheDv.GetRowCursor("A"))
             {
-                var getter = cursor.GetGetter<int>(cols.First().Index);
+                var getter = cursor.GetGetter<int>(col.Index);
                 int val = 0;
                 int count = 0;
                 while (cursor.MoveNext())

--- a/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
+++ b/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.ML.Benchmarks.Harness;
 using Microsoft.ML.Data;
@@ -40,7 +39,7 @@ namespace Microsoft.ML.Benchmarks
 
             var col = cacheDv.Schema.GetColumnOrNull("A").Value;
             // First do one pass through.
-            using (var cursor = cacheDv.GetRowCursor("A"))
+            using (var cursor = cacheDv.GetRowCursor(col))
             {
                 var getter = cursor.GetGetter<int>(col.Index);
                 int val = 0;

--- a/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
+++ b/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
@@ -70,11 +70,9 @@ namespace Microsoft.ML.Benchmarks
         [Benchmark]
         public void CacheWithCursor()
         {
-            var cols = new List<Schema.Column>();
-            cols.Add(_col);
-            // This setup takes very less time to execute as compared to the actual _cursorGetter.
+           // This setup takes very less time to execute as compared to the actual _cursorGetter.
             // The most preferable position for this setup will be in GlobalSetup.
-            _cursor = _cacheDataView.GetRowCursor(cols);
+            _cursor = _cacheDataView.GetRowCursor(_col);
             _cursorGetter = _cursor.GetGetter<int>(_col.Index);
 
             int val = 0;

--- a/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.RunTests;
@@ -271,8 +272,8 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             bool all = true;
             bool tmp;
 
-            using (var curs1 = view1.GetRowCursor(col => true))
-            using (var curs2 = view2.GetRowCursor(col => true))
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs2 = view2.GetRowCursor(view2.Schema))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -281,8 +282,9 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             Check(tmp, "All same failed");
             all &= tmp;
 
-            using (var curs1 = view1.GetRowCursor(col => true))
-            using (var curs2 = view2.GetRowCursor(col => (col & 1) == 0, null))
+            var view2EvenCols = view2.Schema.Where(col => (col.Index & 1) == 0);
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs2 = view2.GetRowCursor(view2EvenCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -291,8 +293,9 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             Check(tmp, "Even same failed");
             all &= tmp;
 
-            using (var curs1 = view1.GetRowCursor(col => true))
-            using (var curs2 = view2.GetRowCursor(col => (col & 1) != 0, null))
+            var view2OddCols = view2.Schema.Where(col => (col.Index & 1) == 0);
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs2 = view2.GetRowCursor(view2OddCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -300,7 +303,7 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             }
             Check(tmp, "Odd same failed");
 
-            using (var curs1 = view1.GetRowCursor(col => true))
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 tmp = CheckSameValues(curs1, view2, exactTypes, exactDoubles, checkId);
@@ -404,7 +407,7 @@ namespace Microsoft.ML.Core.Tests.UnitTests
                 {
                     // curs1 should have all columns active (for simplicity of the code here).
                     Contracts.Assert(curs1.IsColumnActive(col));
-                    cursors[col] = view2.GetRowCursor(c => c == col);
+                    cursors[col] = view2.GetRowCursor(curs1.Schema);
                 }
 
                 // Get the comparison delegates for each column.

--- a/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
@@ -407,7 +407,7 @@ namespace Microsoft.ML.Core.Tests.UnitTests
                 {
                     // curs1 should have all columns active (for simplicity of the code here).
                     Contracts.Assert(curs1.IsColumnActive(col));
-                    cursors[col] = view2.GetRowCursor(curs1.Schema);
+                    cursors[col] = view2.GetRowCursor(view2.Schema[col]);
                 }
 
                 // Get the comparison delegates for each column.

--- a/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
@@ -272,8 +272,8 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             bool all = true;
             bool tmp;
 
-            using (var curs1 = view1.GetRowCursor(view1.Schema))
-            using (var curs2 = view2.GetRowCursor(view2.Schema))
+            using (var curs1 = view1.GetRowCursorForAllColumns())
+            using (var curs2 = view2.GetRowCursorForAllColumns())
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             all &= tmp;
 
             var view2EvenCols = view2.Schema.Where(col => (col.Index & 1) == 0);
-            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs1 = view1.GetRowCursorForAllColumns())
             using (var curs2 = view2.GetRowCursor(view2EvenCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
@@ -294,7 +294,7 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             all &= tmp;
 
             var view2OddCols = view2.Schema.Where(col => (col.Index & 1) == 0);
-            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs1 = view1.GetRowCursorForAllColumns())
             using (var curs2 = view2.GetRowCursor(view2OddCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.RunTests
         private static int CountRows(IDataView dataView)
         {
             int totalRows = 0;
-            using (var cursor = dataView.GetRowCursor(col => false))
+            using (var cursor = dataView.GetRowCursor(null))
             {
                 while (cursor.MoveNext())
                     totalRows++;
@@ -487,10 +487,10 @@ namespace Microsoft.ML.RunTests
 
             var avgComb = new Average(Env).GetCombiner();
             var medComb = new Median(Env).GetCombiner();
-            using (var curs1 = avgScored.GetRowCursor(col => true))
-            using (var curs2 = medScored.GetRowCursor(col => true))
-            using (var curs3 = regScored.GetRowCursor(col => true))
-            using (var curs4 = zippedScores.GetRowCursor(col => true))
+            using (var curs1 = avgScored.GetRowCursor(avgScored.Schema))
+            using (var curs2 = medScored.GetRowCursor(medScored.Schema))
+            using (var curs3 = regScored.GetRowCursor(regScored.Schema))
+            using (var curs4 = zippedScores.GetRowCursor(zippedScores.Schema))
             {
                 var scoreColumn = curs1.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -864,16 +864,16 @@ namespace Microsoft.ML.RunTests
                     PredictorModel = loadedFromSaved
                 }).ScoredData;
 
-            using (var cursReg = regressionScored.GetRowCursor(col => true))
-            using (var cursBin = binaryScored.GetRowCursor(col => true))
-            using (var cursBinCali = binaryScoredCalibrated.GetRowCursor(col => true))
-            using (var cursAnom = anomalyScored.GetRowCursor(col => true))
-            using (var curs0 = individualScores[0].GetRowCursor(col => true))
-            using (var curs1 = individualScores[1].GetRowCursor(col => true))
-            using (var curs2 = individualScores[2].GetRowCursor(col => true))
-            using (var curs3 = individualScores[3].GetRowCursor(col => true))
-            using (var curs4 = individualScores[4].GetRowCursor(col => true))
-            using (var cursSaved = scoredFromSaved.GetRowCursor(col => true))
+            using (var cursReg = regressionScored.GetRowCursor(regressionScored.Schema))
+            using (var cursBin = binaryScored.GetRowCursor(binaryScored.Schema))
+            using (var cursBinCali = binaryScoredCalibrated.GetRowCursor(binaryScoredCalibrated.Schema))
+            using (var cursAnom = anomalyScored.GetRowCursor(anomalyScored.Schema))
+            using (var curs0 = individualScores[0].GetRowCursor(individualScores[0].Schema))
+            using (var curs1 = individualScores[1].GetRowCursor(individualScores[1].Schema))
+            using (var curs2 = individualScores[2].GetRowCursor(individualScores[2].Schema))
+            using (var curs3 = individualScores[3].GetRowCursor(individualScores[3].Schema))
+            using (var curs4 = individualScores[4].GetRowCursor(individualScores[4].Schema))
+            using (var cursSaved = scoredFromSaved.GetRowCursor(scoredFromSaved.Schema))
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -1086,15 +1086,15 @@ namespace Microsoft.ML.RunTests
                     PredictorModel = loadedFromSaved
                 }).ScoredData;
 
-            using (var cursReg = regressionScored.GetRowCursor(col => true))
-            using (var cursBin = binaryScored.GetRowCursor(col => true))
-            using (var cursBinCali = binaryScoredCalibrated.GetRowCursor(col => true))
-            using (var curs0 = individualScores[0].GetRowCursor(col => true))
-            using (var curs1 = individualScores[1].GetRowCursor(col => true))
-            using (var curs2 = individualScores[2].GetRowCursor(col => true))
-            using (var curs3 = individualScores[3].GetRowCursor(col => true))
-            using (var curs4 = individualScores[4].GetRowCursor(col => true))
-            using (var cursSaved = scoredFromSaved.GetRowCursor(col => true))
+            using (var cursReg = regressionScored.GetRowCursor(regressionScored.Schema))
+            using (var cursBin = binaryScored.GetRowCursor(binaryScored.Schema))
+            using (var cursBinCali = binaryScoredCalibrated.GetRowCursor(binaryScoredCalibrated.Schema))
+            using (var curs0 = individualScores[0].GetRowCursor(individualScores[0].Schema))
+            using (var curs1 = individualScores[1].GetRowCursor(individualScores[1].Schema))
+            using (var curs2 = individualScores[2].GetRowCursor(individualScores[2].Schema))
+            using (var curs3 = individualScores[3].GetRowCursor(individualScores[3].Schema))
+            using (var curs4 = individualScores[4].GetRowCursor(individualScores[4].Schema))
+            using (var cursSaved = scoredFromSaved.GetRowCursor(scoredFromSaved.Schema))
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -1246,13 +1246,13 @@ namespace Microsoft.ML.RunTests
                     PredictorModel = loadedFromSaved
                 }).ScoredData;
 
-            using (var curs = mcScored.GetRowCursor(col => true))
-            using (var cursSaved = scoredFromSaved.GetRowCursor(col => true))
-            using (var curs0 = individualScores[0].GetRowCursor(col => true))
-            using (var curs1 = individualScores[1].GetRowCursor(col => true))
-            using (var curs2 = individualScores[2].GetRowCursor(col => true))
-            using (var curs3 = individualScores[3].GetRowCursor(col => true))
-            using (var curs4 = individualScores[4].GetRowCursor(col => true))
+            using (var curs = mcScored.GetRowCursor(mcScored.Schema))
+            using (var cursSaved = scoredFromSaved.GetRowCursor(scoredFromSaved.Schema))
+            using (var curs0 = individualScores[0].GetRowCursor(individualScores[0].Schema))
+            using (var curs1 = individualScores[1].GetRowCursor(individualScores[1].Schema))
+            using (var curs2 = individualScores[2].GetRowCursor(individualScores[2].Schema))
+            using (var curs3 = individualScores[3].GetRowCursor(individualScores[3].Schema))
+            using (var curs4 = individualScores[4].GetRowCursor(individualScores[4].Schema))
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -1657,7 +1657,7 @@ namespace Microsoft.ML.RunTests
 
             using (var loader = new BinaryLoader(Env, new BinaryLoader.Arguments(), outputPath))
             {
-                using (var cursor = loader.GetRowCursor(col => true))
+                using (var cursor = loader.GetRowCursor(loader.Schema))
                 {
                     ReadOnlyMemory<char> cat = default;
                     ReadOnlyMemory<char> catValue = default;
@@ -2707,7 +2707,7 @@ namespace Microsoft.ML.RunTests
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
             Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursor(col => true))
+            using (var cursor = metrics.GetRowCursor(metrics.Schema))
             {
                 var aucCol = cursor.Schema.GetColumnOrNull("AUC");
                 Assert.True(aucCol.HasValue);
@@ -2812,7 +2812,7 @@ namespace Microsoft.ML.RunTests
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
             Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursor(col => true))
+            using (var cursor = metrics.GetRowCursor(metrics.Schema))
             {
                 var aucCol = cursor.Schema.GetColumnOrNull("AUC");
                 Assert.True(aucCol.HasValue);
@@ -2979,10 +2979,10 @@ namespace Microsoft.ML.RunTests
             Action<IDataView> validateAuc = (metricsIdv) =>
             {
                 Assert.NotNull(metricsIdv);
-                using (var cursor = metricsIdv.GetRowCursor(col => true))
+                using (var cursor = metricsIdv.GetRowCursor(metricsIdv.Schema))
                 {
                     var aucCol = cursor.Schema.GetColumnOrNull("AUC");
-                    var aucGetter = cursor.GetGetter<double>(aucCol.Value.Index);
+                    var aucGetter = cursor.GetGetter<double>(aucCol.Value);
                     Assert.True(cursor.MoveNext());
                     double auc = 0;
                     aucGetter(ref auc);
@@ -3170,7 +3170,7 @@ namespace Microsoft.ML.RunTests
             Action<IDataView> aucValidate = (metricsIdv) =>
             {
                 Assert.NotNull(metricsIdv);
-                using (var cursor = metrics.GetRowCursor(col => true))
+                using (var cursor = metrics.GetRowCursor(metrics.Schema))
                 {
                     var aucColumn = cursor.Schema.GetColumnOrNull("AUC");
                     Assert.True(aucColumn.HasValue);
@@ -3511,7 +3511,7 @@ namespace Microsoft.ML.RunTests
 
             using (var loader = new BinaryLoader(Env, new BinaryLoader.Arguments(), outputPath))
             {
-                using (var cursor = loader.GetRowCursor(col => true))
+                using (var cursor = loader.GetRowCursor(loader.Schema))
                 {
                     ReadOnlyMemory<char> predictedLabel = default;
 
@@ -3584,7 +3584,7 @@ namespace Microsoft.ML.RunTests
             VBuffer<float> treeValues = default(VBuffer<float>);
             VBuffer<float> leafIndicators = default(VBuffer<float>);
             VBuffer<float> pathIndicators = default(VBuffer<float>);
-            using (var curs = view.GetRowCursor(c => c == treesCol.Value.Index || c == leavesCol.Value.Index || c == pathsCol.Value.Index))
+            using (var curs = view.GetRowCursor(treesCol.Value, leavesCol.Value, pathsCol.Value))
             {
                 var treesGetter = curs.GetGetter<VBuffer<float>>(treesCol.Value.Index);
                 var leavesGetter = curs.GetGetter<VBuffer<float>>(leavesCol.Value.Index);
@@ -3633,7 +3633,7 @@ namespace Microsoft.ML.RunTests
                 ModelKind = WordEmbeddingsExtractingTransformer.PretrainedModelKind.Sswe
             });
             var result = embedding.OutputData;
-            using (var cursor = result.GetRowCursor((x => true)))
+            using (var cursor = result.GetRowCursor(result.Schema))
             {
                 var featColumn = result.Schema.GetColumnOrNull("Features");
                 Assert.True(featColumn.HasValue);
@@ -4055,7 +4055,7 @@ namespace Microsoft.ML.RunTests
             var schema = data.Schema;
             var aucCol = schema.GetColumnOrNull("AUC");
             Assert.True(aucCol.HasValue);
-            using (var cursor = data.GetRowCursor(col => col == aucCol.Value.Index))
+            using (var cursor = data.GetRowCursor(aucCol.Value))
             {
                 var getter = cursor.GetGetter<double>(aucCol.Value.Index);
                 var b = cursor.MoveNext();
@@ -4239,7 +4239,7 @@ namespace Microsoft.ML.RunTests
             Assert.True(foldCol.HasValue);
             var isWeightedCol = schema.GetColumnOrNull("IsWeighted");
             Assert.True(isWeightedCol.HasValue);
-            using (var cursor = data.GetRowCursor(col => col == metricCol.Value.Index || col == foldCol.Value.Index || col == isWeightedCol.Value.Index))
+            using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value, isWeightedCol.Value))
             {
                 var getter = cursor.GetGetter<double>(metricCol.Value.Index);
                 var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
@@ -4421,7 +4421,7 @@ namespace Microsoft.ML.RunTests
             Assert.True(metricCol.HasValue);
             var foldCol = schema.GetColumnOrNull("Fold Index");
             Assert.True(foldCol.HasValue);
-            using (var cursor = data.GetRowCursor(col => col == metricCol.Value.Index || col == foldCol.Value.Index))
+            using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value))
             {
                 var getter = cursor.GetGetter<double>(metricCol.Value.Index);
                 var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
@@ -4475,7 +4475,7 @@ namespace Microsoft.ML.RunTests
             {
                 Assert.True(ReadOnlyMemoryUtils.EqualsStr(i.ToString(), slotNameValues[i]));
             }
-            using (var curs = confusion.GetRowCursor(col => true))
+            using (var curs = confusion.GetRowCursor(confusion.Schema))
             {
                 var countGetter = curs.GetGetter<VBuffer<double>>(countCol.Value.Index);
                 var foldGetter = curs.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
@@ -4499,7 +4499,7 @@ namespace Microsoft.ML.RunTests
             }
 
             var warnings = runner.GetOutput<IDataView>("warnings");
-            using (var cursor = warnings.GetRowCursor(col => true))
+            using (var cursor = warnings.GetRowCursor(warnings.Schema))
                 Assert.False(cursor.MoveNext());
         }
 
@@ -4647,7 +4647,7 @@ namespace Microsoft.ML.RunTests
             var schema = warnings.Schema;
             var warningCol = schema.GetColumnOrNull("WarningText");
             Assert.True(warningCol.HasValue);
-            using (var cursor = warnings.GetRowCursor(col => col == warningCol.Value.Index))
+            using (var cursor = warnings.GetRowCursor(warningCol.Value))
             {
                 var getter = cursor.GetGetter<ReadOnlyMemory<char>>(warningCol.Value.Index);
 
@@ -4830,7 +4830,7 @@ namespace Microsoft.ML.RunTests
             var foldCol = schema.GetColumnOrNull("Fold Index");
             Assert.True(foldCol.HasValue);
             bool b;
-            using (var cursor = data.GetRowCursor(col => col == metricCol.Value.Index || col == foldCol.Value.Index))
+            using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value))
             {
                 var getter = cursor.GetGetter<double>(metricCol.Value.Index);
                 var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
@@ -5134,7 +5134,7 @@ namespace Microsoft.ML.RunTests
             var foldCol = schema.GetColumnOrNull("Fold Index");
             Assert.True(foldCol.HasValue);
             bool b;
-            using (var cursor = data.GetRowCursor(col => col == metricCol.Value.Index || col == foldCol.Value.Index))
+            using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value))
             {
                 var getter = cursor.GetGetter<VBuffer<double>>(metricCol.Value.Index);
                 var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
@@ -5186,7 +5186,7 @@ namespace Microsoft.ML.RunTests
             data = runner.GetOutput<IDataView>("perInstanceMetric");
             var nameCol = data.Schema.GetColumnOrNull("Instance");
             Assert.True(nameCol.HasValue);
-            using (var cursor = data.GetRowCursor(col => col == nameCol.Value.Index))
+            using (var cursor = data.GetRowCursor(nameCol.Value))
             {
                 var getter = cursor.GetGetter<ReadOnlyMemory<char>>(nameCol.Value.Index);
                 while (cursor.MoveNext())
@@ -5351,7 +5351,7 @@ namespace Microsoft.ML.RunTests
             var accCol = schema.GetColumnOrNull(MultiClassClassifierEvaluator.AccuracyMacro);
             Assert.True(accCol.HasValue);
             bool b;
-            using (var cursor = data.GetRowCursor(col => col == accCol.Value.Index))
+            using (var cursor = data.GetRowCursor(accCol.Value))
             {
                 var getter = cursor.GetGetter<double>(accCol.Value.Index);
                 b = cursor.MoveNext();
@@ -5523,7 +5523,7 @@ namespace Microsoft.ML.RunTests
             var accCol = schema.GetColumnOrNull(MultiClassClassifierEvaluator.AccuracyMacro);
             Assert.True(accCol.HasValue);
             bool b;
-            using (var cursor = data.GetRowCursor(col => col == accCol.Value.Index))
+            using (var cursor = data.GetRowCursor(accCol.Value))
             {
                 var getter = cursor.GetGetter<double>(accCol.Value.Index);
                 b = cursor.MoveNext();

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -2975,19 +2975,14 @@ namespace Microsoft.ML.RunTests
             Assert.NotNull(model);
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
-<<<<<<< HEAD
 
-            Action<IDataView> validateAuc = (metricsIdv) =>
-=======
-            Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursorForAllColumns())
->>>>>>> Addressing the PR review comments.
-            {
+            Action<IDataView> validateAuc = (metricsIdv) => 
+            { 
                 Assert.NotNull(metricsIdv);
-                using (var cursor = metricsIdv.GetRowCursor(metricsIdv.Schema))
+                using (var cursor = metricsIdv.GetRowCursorForAllColumns())
                 {
                     var aucCol = cursor.Schema.GetColumnOrNull("AUC");
-                    var aucGetter = cursor.GetGetter<double>(aucCol.Value);
+                    var aucGetter = cursor.GetGetter<double>(aucCol.Value.Index);
                     Assert.True(cursor.MoveNext());
                     double auc = 0;
                     aucGetter(ref auc);
@@ -2998,20 +2993,7 @@ namespace Microsoft.ML.RunTests
             validateAuc(metrics);
 
             metrics = runner.GetOutput<IDataView>("OverallMetrics2");
-<<<<<<< HEAD
             validateAuc(metrics);
-=======
-            Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursorForAllColumns())
-            {
-                Assert.True(cursor.Schema.TryGetColumnIndex("AUC", out int aucCol));
-                var aucGetter = cursor.GetGetter<double>(aucCol);
-                Assert.True(cursor.MoveNext());
-                double auc = 0;
-                aucGetter(ref auc);
-                Assert.True(auc > 0.99);
-            }
->>>>>>> Addressing the PR review comments.
         }
 
         [Fact]
@@ -3184,16 +3166,11 @@ namespace Microsoft.ML.RunTests
             Assert.NotNull(model[0]);
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
-<<<<<<< HEAD
 
-            Action<IDataView> aucValidate = (metricsIdv) =>
-=======
-            Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursorForAllColumns())
->>>>>>> Addressing the PR review comments.
-            {
+            Action<IDataView> aucValidate = (metricsIdv) => 
+            { 
                 Assert.NotNull(metricsIdv);
-                using (var cursor = metrics.GetRowCursor(metrics.Schema))
+                using (var cursor = metrics.GetRowCursorForAllColumns())
                 {
                     var aucColumn = cursor.Schema.GetColumnOrNull("AUC");
                     Assert.True(aucColumn.HasValue);
@@ -3208,20 +3185,7 @@ namespace Microsoft.ML.RunTests
             aucValidate(metrics);
 
             metrics = runner.GetOutput<IDataView>("OverallMetrics2");
-<<<<<<< HEAD
             aucValidate(metrics);
-=======
-            Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursorForAllColumns())
-            {
-                Assert.True(cursor.Schema.TryGetColumnIndex("AUC", out int aucCol));
-                var aucGetter = cursor.GetGetter<double>(aucCol);
-                Assert.True(cursor.MoveNext());
-                double auc = 0;
-                aucGetter(ref auc);
-                Assert.True(auc > 0.99);
-            }
->>>>>>> Addressing the PR review comments.
         }
 
         [Fact]

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -487,10 +487,10 @@ namespace Microsoft.ML.RunTests
 
             var avgComb = new Average(Env).GetCombiner();
             var medComb = new Median(Env).GetCombiner();
-            using (var curs1 = avgScored.GetRowCursor(avgScored.Schema))
-            using (var curs2 = medScored.GetRowCursor(medScored.Schema))
-            using (var curs3 = regScored.GetRowCursor(regScored.Schema))
-            using (var curs4 = zippedScores.GetRowCursor(zippedScores.Schema))
+            using (var curs1 = avgScored.GetRowCursorForAllColumns())
+            using (var curs2 = medScored.GetRowCursorForAllColumns())
+            using (var curs3 = regScored.GetRowCursorForAllColumns())
+            using (var curs4 = zippedScores.GetRowCursorForAllColumns())
             {
                 var scoreColumn = curs1.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -864,16 +864,16 @@ namespace Microsoft.ML.RunTests
                     PredictorModel = loadedFromSaved
                 }).ScoredData;
 
-            using (var cursReg = regressionScored.GetRowCursor(regressionScored.Schema))
-            using (var cursBin = binaryScored.GetRowCursor(binaryScored.Schema))
-            using (var cursBinCali = binaryScoredCalibrated.GetRowCursor(binaryScoredCalibrated.Schema))
-            using (var cursAnom = anomalyScored.GetRowCursor(anomalyScored.Schema))
-            using (var curs0 = individualScores[0].GetRowCursor(individualScores[0].Schema))
-            using (var curs1 = individualScores[1].GetRowCursor(individualScores[1].Schema))
-            using (var curs2 = individualScores[2].GetRowCursor(individualScores[2].Schema))
-            using (var curs3 = individualScores[3].GetRowCursor(individualScores[3].Schema))
-            using (var curs4 = individualScores[4].GetRowCursor(individualScores[4].Schema))
-            using (var cursSaved = scoredFromSaved.GetRowCursor(scoredFromSaved.Schema))
+            using (var cursReg = regressionScored.GetRowCursorForAllColumns())
+            using (var cursBin = binaryScored.GetRowCursorForAllColumns())
+            using (var cursBinCali = binaryScoredCalibrated.GetRowCursorForAllColumns())
+            using (var cursAnom = anomalyScored.GetRowCursorForAllColumns())
+            using (var curs0 = individualScores[0].GetRowCursorForAllColumns())
+            using (var curs1 = individualScores[1].GetRowCursorForAllColumns())
+            using (var curs2 = individualScores[2].GetRowCursorForAllColumns())
+            using (var curs3 = individualScores[3].GetRowCursorForAllColumns())
+            using (var curs4 = individualScores[4].GetRowCursorForAllColumns())
+            using (var cursSaved = scoredFromSaved.GetRowCursorForAllColumns())
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -1086,15 +1086,15 @@ namespace Microsoft.ML.RunTests
                     PredictorModel = loadedFromSaved
                 }).ScoredData;
 
-            using (var cursReg = regressionScored.GetRowCursor(regressionScored.Schema))
-            using (var cursBin = binaryScored.GetRowCursor(binaryScored.Schema))
-            using (var cursBinCali = binaryScoredCalibrated.GetRowCursor(binaryScoredCalibrated.Schema))
-            using (var curs0 = individualScores[0].GetRowCursor(individualScores[0].Schema))
-            using (var curs1 = individualScores[1].GetRowCursor(individualScores[1].Schema))
-            using (var curs2 = individualScores[2].GetRowCursor(individualScores[2].Schema))
-            using (var curs3 = individualScores[3].GetRowCursor(individualScores[3].Schema))
-            using (var curs4 = individualScores[4].GetRowCursor(individualScores[4].Schema))
-            using (var cursSaved = scoredFromSaved.GetRowCursor(scoredFromSaved.Schema))
+            using (var cursReg = regressionScored.GetRowCursorForAllColumns())
+            using (var cursBin = binaryScored.GetRowCursorForAllColumns())
+            using (var cursBinCali = binaryScoredCalibrated.GetRowCursorForAllColumns())
+            using (var curs0 = individualScores[0].GetRowCursorForAllColumns())
+            using (var curs1 = individualScores[1].GetRowCursorForAllColumns())
+            using (var curs2 = individualScores[2].GetRowCursorForAllColumns())
+            using (var curs3 = individualScores[3].GetRowCursorForAllColumns())
+            using (var curs4 = individualScores[4].GetRowCursorForAllColumns())
+            using (var cursSaved = scoredFromSaved.GetRowCursorForAllColumns())
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -1246,13 +1246,13 @@ namespace Microsoft.ML.RunTests
                     PredictorModel = loadedFromSaved
                 }).ScoredData;
 
-            using (var curs = mcScored.GetRowCursor(mcScored.Schema))
-            using (var cursSaved = scoredFromSaved.GetRowCursor(scoredFromSaved.Schema))
-            using (var curs0 = individualScores[0].GetRowCursor(individualScores[0].Schema))
-            using (var curs1 = individualScores[1].GetRowCursor(individualScores[1].Schema))
-            using (var curs2 = individualScores[2].GetRowCursor(individualScores[2].Schema))
-            using (var curs3 = individualScores[3].GetRowCursor(individualScores[3].Schema))
-            using (var curs4 = individualScores[4].GetRowCursor(individualScores[4].Schema))
+            using (var curs = mcScored.GetRowCursorForAllColumns())
+            using (var cursSaved = scoredFromSaved.GetRowCursorForAllColumns())
+            using (var curs0 = individualScores[0].GetRowCursorForAllColumns())
+            using (var curs1 = individualScores[1].GetRowCursorForAllColumns())
+            using (var curs2 = individualScores[2].GetRowCursorForAllColumns())
+            using (var curs3 = individualScores[3].GetRowCursorForAllColumns())
+            using (var curs4 = individualScores[4].GetRowCursorForAllColumns())
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
@@ -1657,7 +1657,7 @@ namespace Microsoft.ML.RunTests
 
             using (var loader = new BinaryLoader(Env, new BinaryLoader.Arguments(), outputPath))
             {
-                using (var cursor = loader.GetRowCursor(loader.Schema))
+                using (var cursor = loader.GetRowCursorForAllColumns())
                 {
                     ReadOnlyMemory<char> cat = default;
                     ReadOnlyMemory<char> catValue = default;
@@ -2707,7 +2707,7 @@ namespace Microsoft.ML.RunTests
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
             Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursor(metrics.Schema))
+            using (var cursor = metrics.GetRowCursorForAllColumns())
             {
                 var aucCol = cursor.Schema.GetColumnOrNull("AUC");
                 Assert.True(aucCol.HasValue);
@@ -2812,7 +2812,7 @@ namespace Microsoft.ML.RunTests
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
             Assert.NotNull(metrics);
-            using (var cursor = metrics.GetRowCursor(metrics.Schema))
+            using (var cursor = metrics.GetRowCursorForAllColumns())
             {
                 var aucCol = cursor.Schema.GetColumnOrNull("AUC");
                 Assert.True(aucCol.HasValue);
@@ -2975,8 +2975,13 @@ namespace Microsoft.ML.RunTests
             Assert.NotNull(model);
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
+<<<<<<< HEAD
 
             Action<IDataView> validateAuc = (metricsIdv) =>
+=======
+            Assert.NotNull(metrics);
+            using (var cursor = metrics.GetRowCursorForAllColumns())
+>>>>>>> Addressing the PR review comments.
             {
                 Assert.NotNull(metricsIdv);
                 using (var cursor = metricsIdv.GetRowCursor(metricsIdv.Schema))
@@ -2993,7 +2998,20 @@ namespace Microsoft.ML.RunTests
             validateAuc(metrics);
 
             metrics = runner.GetOutput<IDataView>("OverallMetrics2");
+<<<<<<< HEAD
             validateAuc(metrics);
+=======
+            Assert.NotNull(metrics);
+            using (var cursor = metrics.GetRowCursorForAllColumns())
+            {
+                Assert.True(cursor.Schema.TryGetColumnIndex("AUC", out int aucCol));
+                var aucGetter = cursor.GetGetter<double>(aucCol);
+                Assert.True(cursor.MoveNext());
+                double auc = 0;
+                aucGetter(ref auc);
+                Assert.True(auc > 0.99);
+            }
+>>>>>>> Addressing the PR review comments.
         }
 
         [Fact]
@@ -3166,8 +3184,13 @@ namespace Microsoft.ML.RunTests
             Assert.NotNull(model[0]);
 
             var metrics = runner.GetOutput<IDataView>("OverallMetrics");
+<<<<<<< HEAD
 
             Action<IDataView> aucValidate = (metricsIdv) =>
+=======
+            Assert.NotNull(metrics);
+            using (var cursor = metrics.GetRowCursorForAllColumns())
+>>>>>>> Addressing the PR review comments.
             {
                 Assert.NotNull(metricsIdv);
                 using (var cursor = metrics.GetRowCursor(metrics.Schema))
@@ -3185,7 +3208,20 @@ namespace Microsoft.ML.RunTests
             aucValidate(metrics);
 
             metrics = runner.GetOutput<IDataView>("OverallMetrics2");
+<<<<<<< HEAD
             aucValidate(metrics);
+=======
+            Assert.NotNull(metrics);
+            using (var cursor = metrics.GetRowCursorForAllColumns())
+            {
+                Assert.True(cursor.Schema.TryGetColumnIndex("AUC", out int aucCol));
+                var aucGetter = cursor.GetGetter<double>(aucCol);
+                Assert.True(cursor.MoveNext());
+                double auc = 0;
+                aucGetter(ref auc);
+                Assert.True(auc > 0.99);
+            }
+>>>>>>> Addressing the PR review comments.
         }
 
         [Fact]
@@ -3511,7 +3547,7 @@ namespace Microsoft.ML.RunTests
 
             using (var loader = new BinaryLoader(Env, new BinaryLoader.Arguments(), outputPath))
             {
-                using (var cursor = loader.GetRowCursor(loader.Schema))
+                using (var cursor = loader.GetRowCursorForAllColumns())
                 {
                     ReadOnlyMemory<char> predictedLabel = default;
 
@@ -3633,7 +3669,7 @@ namespace Microsoft.ML.RunTests
                 ModelKind = WordEmbeddingsExtractingTransformer.PretrainedModelKind.Sswe
             });
             var result = embedding.OutputData;
-            using (var cursor = result.GetRowCursor(result.Schema))
+            using (var cursor = result.GetRowCursorForAllColumns())
             {
                 var featColumn = result.Schema.GetColumnOrNull("Features");
                 Assert.True(featColumn.HasValue);
@@ -4475,7 +4511,7 @@ namespace Microsoft.ML.RunTests
             {
                 Assert.True(ReadOnlyMemoryUtils.EqualsStr(i.ToString(), slotNameValues[i]));
             }
-            using (var curs = confusion.GetRowCursor(confusion.Schema))
+            using (var curs = confusion.GetRowCursorForAllColumns())
             {
                 var countGetter = curs.GetGetter<VBuffer<double>>(countCol.Value.Index);
                 var foldGetter = curs.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
@@ -4499,7 +4535,7 @@ namespace Microsoft.ML.RunTests
             }
 
             var warnings = runner.GetOutput<IDataView>("warnings");
-            using (var cursor = warnings.GetRowCursor(warnings.Schema))
+            using (var cursor = warnings.GetRowCursorForAllColumns())
                 Assert.False(cursor.MoveNext());
         }
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.RunTests
         private static int CountRows(IDataView dataView)
         {
             int totalRows = 0;
-            using (var cursor = dataView.GetRowCursor(null))
+            using (var cursor = dataView.GetRowCursor())
             {
                 while (cursor.MoveNext())
                     totalRows++;

--- a/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("output_1", out int output);
-            using (var cursor = result.GetRowCursor(result.Schema.Where(x => x.Name.Equals("output_1"))))
+            using (var cursor = result.GetRowCursor("output_1"))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Tests
                 var loadedView = ModelFileUtils.LoadTransforms(Env, dataView, ms);
 
                 loadedView.Schema.TryGetColumnIndex(outputNames, out int softMaxOut1);
-                using (var cursor = loadedView.GetRowCursor(loadedView.Schema.Where(x => x.Name.Equals(outputNames))))
+                using (var cursor = loadedView.GetRowCursor(outputNames))
                 {
                     VBuffer<float> softMaxValue = default;
                     var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);

--- a/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("output_1", out int output);
-            using (var cursor = result.GetRowCursor("output_1"))
+            using (var cursor = result.GetRowCursor(result.Schema["output_1"]))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Tests
                 var loadedView = ModelFileUtils.LoadTransforms(Env, dataView, ms);
 
                 loadedView.Schema.TryGetColumnIndex(outputNames, out int softMaxOut1);
-                using (var cursor = loadedView.GetRowCursor(outputNames))
+                using (var cursor = loadedView.GetRowCursor(loadedView.Schema[outputNames]))
                 {
                     VBuffer<float> softMaxValue = default;
                     var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);

--- a/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.ML;
 using Microsoft.ML.Core.Data;
@@ -122,7 +123,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("output_1", out int output);
-            using (var cursor = result.GetRowCursor(col => col == output))
+            using (var cursor = result.GetRowCursor(result.Schema.Where(x => x.Name.Equals("output_1"))))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -168,7 +169,7 @@ namespace Microsoft.ML.Tests
                 var loadedView = ModelFileUtils.LoadTransforms(Env, dataView, ms);
 
                 loadedView.Schema.TryGetColumnIndex(outputNames, out int softMaxOut1);
-                using (var cursor = loadedView.GetRowCursor(col => col == softMaxOut1))
+                using (var cursor = loadedView.GetRowCursor(loadedView.Schema.Where(x => x.Name.Equals(outputNames))))
                 {
                     VBuffer<float> softMaxValue = default;
                     var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);

--- a/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/DnnImageFeaturizerTest.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.ML;
 using Microsoft.ML.Core.Data;

--- a/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Tests
 
                 loadedView.Schema.TryGetColumnIndex(outputNames[0], out int softMaxOut1);
 
-                using (var cursor = loadedView.GetRowCursor(softMaxOut1))
+                using (var cursor = loadedView.GetRowCursor(loadedView.Schema[softMaxOut1]))
                 {
                     VBuffer<float> softMaxValue = default;
                     var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Tests
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("softmaxout_1", out int output);
 
-            using (var cursor = result.GetRowCursor("softmaxout_1"))
+            using (var cursor = result.GetRowCursor(result.Schema["softmaxout_1"]))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -267,7 +267,7 @@ namespace Microsoft.ML.Tests
 
                 onnx.Schema.TryGetColumnIndex("softmaxout_1", out int score);
 
-                using (var curs = onnx.GetRowCursor("softmaxout_1"))
+                using (var curs = onnx.GetRowCursor(onnx.Schema["softmaxout_1"]))
                 {
                     var getScores = curs.GetGetter<VBuffer<float>>(score);
                     var buffer = default(VBuffer<float>);
@@ -303,7 +303,7 @@ namespace Microsoft.ML.Tests
 
                 onnx.Schema.TryGetColumnIndex("outa", out int scoresa);
                 onnx.Schema.TryGetColumnIndex("outb", out int scoresb);
-                using (var curs = onnx.GetRowCursor("outa","outb"))
+                using (var curs = onnx.GetRowCursor(onnx.Schema["outa"], onnx.Schema["outb"]))
                 {
                     var getScoresa = curs.GetGetter<VBuffer<float>>(scoresa);
                     var getScoresb = curs.GetGetter<VBuffer<float>>(scoresb);

--- a/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Tests
 
                 loadedView.Schema.TryGetColumnIndex(outputNames[0], out int softMaxOut1);
 
-                using (var cursor = loadedView.GetRowCursor(loadedView.Schema.Where(x => x.Index == softMaxOut1)))
+                using (var cursor = loadedView.GetRowCursor(softMaxOut1))
                 {
                     VBuffer<float> softMaxValue = default;
                     var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Tests
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("softmaxout_1", out int output);
 
-            using (var cursor = result.GetRowCursor(result.Schema.Where(x => x.Name.Equals("softmaxout_1"))))
+            using (var cursor = result.GetRowCursor("softmaxout_1"))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -267,7 +267,7 @@ namespace Microsoft.ML.Tests
 
                 onnx.Schema.TryGetColumnIndex("softmaxout_1", out int score);
 
-                using (var curs = onnx.GetRowCursor(onnx.Schema.Where(x => x.Name.Equals("softmaxout_1"))))
+                using (var curs = onnx.GetRowCursor("softmaxout_1"))
                 {
                     var getScores = curs.GetGetter<VBuffer<float>>(score);
                     var buffer = default(VBuffer<float>);
@@ -303,7 +303,7 @@ namespace Microsoft.ML.Tests
 
                 onnx.Schema.TryGetColumnIndex("outa", out int scoresa);
                 onnx.Schema.TryGetColumnIndex("outb", out int scoresb);
-                using (var curs = onnx.GetRowCursor(onnx.Schema.Where(x => x.Name.Equals("outa") || x.Name.Equals("outb"))))
+                using (var curs = onnx.GetRowCursor("outa","outb"))
                 {
                     var getScoresa = curs.GetGetter<VBuffer<float>>(scoresa);
                     var getScoresb = curs.GetGetter<VBuffer<float>>(scoresb);

--- a/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
@@ -159,7 +159,8 @@ namespace Microsoft.ML.Tests
                 var loadedView = ModelFileUtils.LoadTransforms(Env, dataView, ms);
 
                 loadedView.Schema.TryGetColumnIndex(outputNames[0], out int softMaxOut1);
-                using (var cursor = loadedView.GetRowCursor(col => col == softMaxOut1))
+
+                using (var cursor = loadedView.GetRowCursor(loadedView.Schema.Where(x => x.Index == softMaxOut1)))
                 {
                     VBuffer<float> softMaxValue = default;
                     var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);
@@ -216,7 +217,8 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("softmaxout_1", out int output);
-            using (var cursor = result.GetRowCursor(col => col == output))
+
+            using (var cursor = result.GetRowCursor(result.Schema.Where(x => x.Name.Equals("softmaxout_1"))))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -263,10 +265,11 @@ namespace Microsoft.ML.Tests
 
                 var onnx = new OnnxTransformer(env, modelFile, "data_0", "softmaxout_1").Transform(dataView);
 
-                onnx.Schema.TryGetColumnIndex("softmaxout_1", out int scores);
-                using (var curs = onnx.GetRowCursor(col => col == scores))
+                onnx.Schema.TryGetColumnIndex("softmaxout_1", out int score);
+
+                using (var curs = onnx.GetRowCursor(onnx.Schema.Where(x => x.Name.Equals("softmaxout_1"))))
                 {
-                    var getScores = curs.GetGetter<VBuffer<float>>(scores);
+                    var getScores = curs.GetGetter<VBuffer<float>>(score);
                     var buffer = default(VBuffer<float>);
                     while (curs.MoveNext())
                     {
@@ -300,7 +303,7 @@ namespace Microsoft.ML.Tests
 
                 onnx.Schema.TryGetColumnIndex("outa", out int scoresa);
                 onnx.Schema.TryGetColumnIndex("outb", out int scoresb);
-                using (var curs = onnx.GetRowCursor(col => col == scoresa || col == scoresb))
+                using (var curs = onnx.GetRowCursor(onnx.Schema.Where(x => x.Name.Equals("outa") || x.Name.Equals("outb"))))
                 {
                     var getScoresa = curs.GetGetter<VBuffer<float>>(scoresa);
                     var getScoresb = curs.GetGetter<VBuffer<float>>(scoresb);

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -673,7 +673,7 @@ namespace Microsoft.ML.RunTests
             }
 
             var cursors = new RowCursor[predCount];
-            var cols = scored.Schema.GetColumns("Score", "Probability", "PredictedLabel");
+            var cols = scored.Schema.Where( c => c.Name.Equals("Score") || c.Name.Equals("Probability") || c.Name.Equals("PredictedLabel"));
 
             for (int i = 0; i < predCount; i++)
                 cursors[i] = scoredArray[i].GetRowCursor(cols);

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -673,7 +673,7 @@ namespace Microsoft.ML.RunTests
             }
 
             var cursors = new RowCursor[predCount];
-            var cols = scored.Schema.Where(c => c.Name.Equals("Score") || c.Name.Equals("Probability") || c.Name.Equals("PredictedLabel"));
+            var cols = scored.Schema.GetColumns("Score", "Probability", "PredictedLabel");
 
             for (int i = 0; i < predCount; i++)
                 cursors[i] = scoredArray[i].GetRowCursor(cols);
@@ -879,7 +879,7 @@ namespace Microsoft.ML.RunTests
                     var vectorScoreGetters = new ValueGetter<VBuffer<float>>[predCount];
                     var probGetters = new ValueGetter<float>[predCount];
                     var predGetters = new ValueGetter<bool>[predCount];
-                    for (int i = 0; i< predCount; i++)
+                    for (int i = 0; i < predCount; i++)
                     {
                         scoreGetters[i] = predictionKind == PredictionKind.MultiClassClassification ?
                             (ref float dst) => dst = 0 :

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -673,12 +673,14 @@ namespace Microsoft.ML.RunTests
             }
 
             var cursors = new RowCursor[predCount];
+            var cols = scored.Schema.Where(c => c.Name.Equals("Score") || c.Name.Equals("Probability") || c.Name.Equals("PredictedLabel"));
+
             for (int i = 0; i < predCount; i++)
-                cursors[i] = scoredArray[i].GetRowCursor(c => c == scoreColArray[i] || c == probColArray[i] || c == predColArray[i]);
+                cursors[i] = scoredArray[i].GetRowCursor(cols);
 
             try
             {
-                using (var curs = scored.GetRowCursor(c => c == scoreCol || c == probCol || c == predCol))
+                using (var curs = scored.GetRowCursor(cols))
                 {
                     var scoreGetter = curs.GetGetter<float>(scoreCol);
                     var probGetter = curs.GetGetter<float>(probCol);
@@ -851,12 +853,14 @@ namespace Microsoft.ML.RunTests
             }
 
             var cursors = new RowCursor[predCount];
+            var cols = scored.Schema.Where(c => c.Name.Equals("Score") || c.Name.Equals("Probability") || c.Name.Equals("PredictedLabel"));
+
             for (int i = 0; i < predCount; i++)
-                cursors[i] = scoredArray[i].GetRowCursor(c => c == scoreColArray[i] || c == probColArray[i] || c == predColArray[i]);
+                cursors[i] = scoredArray[i].GetRowCursor(cols);
 
             try
             {
-                using (var curs = scored.GetRowCursor(c => c == scoreCol || c == probCol || c == predCol))
+                using (var curs = scored.GetRowCursor(cols))
                 {
                     var scoreGetter = predictionKind == PredictionKind.MultiClassClassification ?
                         (ref float dst) => dst = 0 :

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Data.IO;
 using Microsoft.ML.Internal.Utilities;
@@ -30,7 +31,7 @@ namespace Microsoft.ML.RunTests
             Assert.NotEqual(0, vecType?.Size);
             T[] retval = new T[rc * (vecType?.Size ?? 1)];
 
-            using (var cursor = view.GetRowCursor(c => c == col))
+            using (var cursor = view.GetRowCursor(view.Schema.Where(x => x.Index == col)))
             {
                 if (type is VectorType)
                 {

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.RunTests
             Assert.NotEqual(0, vecType?.Size);
             T[] retval = new T[rc * (vecType?.Size ?? 1)];
 
-            using (var cursor = view.GetRowCursor(col))
+            using (var cursor = view.GetRowCursor(view.Schema[col]))
             {
                 if (type is VectorType)
                 {

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.RunTests
             Assert.NotEqual(0, vecType?.Size);
             T[] retval = new T[rc * (vecType?.Size ?? 1)];
 
-            using (var cursor = view.GetRowCursor(view.Schema.Where(x => x.Index == col)))
+            using (var cursor = view.GetRowCursor(col))
             {
                 if (type is VectorType)
                 {

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.Equal(TextType.Instance, schema[textIdx].Type);
             Assert.Equal(new VectorType(NumberType.R4, 3), schema[numericFeaturesIdx].Type);
             // Next actually inspect the data.
-            using (var cursor = textData.GetRowCursor(textData.Schema))
+            using (var cursor = textData.GetRowCursorForAllColumns())
             {
                 var textGetter = cursor.GetGetter<ReadOnlyMemory<char>>(textIdx);
                 var numericFeaturesGetter = cursor.GetGetter<VBuffer<float>>(numericFeaturesIdx);

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.Equal(TextType.Instance, schema[textIdx].Type);
             Assert.Equal(new VectorType(NumberType.R4, 3), schema[numericFeaturesIdx].Type);
             // Next actually inspect the data.
-            using (var cursor = textData.GetRowCursor(c => true))
+            using (var cursor = textData.GetRowCursor(textData.Schema))
             {
                 var textGetter = cursor.GetGetter<ReadOnlyMemory<char>>(textIdx);
                 var numericFeaturesGetter = cursor.GetGetter<VBuffer<float>>(numericFeaturesIdx);

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ML.RunTests
                 {
                     // Verify that the Vec columns match the corresponding VecXX columns. This verifies that conversion
                     // happened correctly in KeyToVector.
-                    using (var c = pipe.GetRowCursor(col => true))
+                    using (var c = pipe.GetRowCursor(pipe.Schema))
                     {
                         var cols = new[] { "MarVec", "MarVecU8", "CombBagVec", "CombBagVecU1", "CombIndVec", "CombIndVecU1" };
                         var getters = new ValueGetter<VBuffer<Float>>[cols.Length];
@@ -571,7 +571,7 @@ namespace Microsoft.ML.RunTests
                     // Column F13 contains the ngram counts of column Two, and column F23 contains the ngram counts
                     // of columns Two and One. Therefore, make sure that the ngrams in column Two were hashed to the same 
                     // slots in F13 as they were in column F23. We do this by checking that for every slot, F23 is >= F13.
-                    using (var c = pipe.GetRowCursor(col => true))
+                    using (var c = pipe.GetRowCursor(pipe.Schema))
                     {
                         int col1;
                         bool tmp1 = c.Schema.TryGetColumnIndex("F13", out col1);
@@ -584,8 +584,8 @@ namespace Microsoft.ML.RunTests
 
                         var get1 = c.GetGetter<VBuffer<Float>>(col1);
                         var get2 = c.GetGetter<VBuffer<Float>>(col2);
-                        VBuffer<Float> bag1 = default(VBuffer<Float>);
-                        VBuffer<Float> bag2 = default(VBuffer<Float>);
+                        VBuffer<Float> bag1 = default;
+                        VBuffer<Float> bag2 = default;
                         while (c.MoveNext())
                         {
                             get1(ref bag1);
@@ -615,7 +615,7 @@ namespace Microsoft.ML.RunTests
                 (pipe) =>
                 {
                     // Verify that F2 = 2 * F1
-                    using (var c = pipe.GetRowCursor(col => true))
+                    using (var c = pipe.GetRowCursor(pipe.Schema))
                     {
                         int col1;
                         bool tmp1 = c.Schema.TryGetColumnIndex("F1", out col1);
@@ -628,8 +628,8 @@ namespace Microsoft.ML.RunTests
 
                         var get1 = c.GetGetter<VBuffer<Float>>(col1);
                         var get2 = c.GetGetter<VBuffer<Float>>(col2);
-                        VBuffer<Float> bag1 = default(VBuffer<Float>);
-                        VBuffer<Float> bag2 = default(VBuffer<Float>);
+                        VBuffer<Float> bag1 = default;
+                        VBuffer<Float> bag2 = default;
                         while (c.MoveNext())
                         {
                             get1(ref bag1);
@@ -769,7 +769,7 @@ namespace Microsoft.ML.RunTests
                 (pipe) =>
                 {
                     // Verify that WB2 = 2 * WB1
-                    using (var c = pipe.GetRowCursor(col => true))
+                    using (var c = pipe.GetRowCursor(pipe.Schema))
                     {
                         var b1 = default(VBuffer<Float>);
                         var b2 = default(VBuffer<Float>);
@@ -918,7 +918,7 @@ namespace Microsoft.ML.RunTests
                     ReadOnlyMemory<char>[] values1 = { "erythromycin".AsMemory(), "treating".AsMemory(), "pneumonia".AsMemory() };
                     expected[1] = new VBuffer<ReadOnlyMemory<char>>(values1.Length, values1);
 
-                    using (var c = pipe.GetRowCursor(col => true))
+                    using (var c = pipe.GetRowCursor(pipe.Schema))
                     {
                         int col;
                         bool res = c.Schema.TryGetColumnIndex("T", out col);
@@ -1105,7 +1105,7 @@ namespace Microsoft.ML.RunTests
             var srcView = builder.GetDataView();
 
             var hashTransform = new HashingTransformer(Env, new HashingTransformer.ColumnInfo("F1", "F1", 5, 42)).Transform(srcView);
-            using (var cursor = hashTransform.GetRowCursor(c => true))
+            using (var cursor = hashTransform.GetRowCursor(hashTransform.Schema))
             {
                 var resultGetter = cursor.GetGetter<uint>(1);
                 uint resultRow = 0;
@@ -1136,7 +1136,7 @@ namespace Microsoft.ML.RunTests
         {
             var srcView = builder.GetDataView();
             var hashTransform = new HashingTransformer(Env, new HashingTransformer.ColumnInfo("F1V", "F1V", 5, 42)).Transform(srcView);
-            using (var cursor = hashTransform.GetRowCursor(c => true))
+            using (var cursor = hashTransform.GetRowCursor(hashTransform.Schema))
             {
                 var resultGetter = cursor.GetGetter<VBuffer<uint>>(1);
                 VBuffer<uint> resultRow = new VBuffer<uint>();
@@ -1177,7 +1177,7 @@ namespace Microsoft.ML.RunTests
             var ldaTransformer = est.Fit(srcView);
             var transformedData = ldaTransformer.Transform(srcView);
 
-            using (var cursor = transformedData.GetRowCursor(c => true))
+            using (var cursor = transformedData.GetRowCursor(transformedData.Schema))
             {
                 var resultGetter = cursor.GetGetter<VBuffer<Float>>(1);
                 VBuffer<Float> resultFirstRow = new VBuffer<Float>();

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -1104,20 +1104,8 @@ namespace Microsoft.ML.RunTests
             builder.AddColumn("F1", type, data);
             var srcView = builder.GetDataView();
 
-<<<<<<< HEAD
             var hashTransform = new HashingTransformer(Env, new HashingTransformer.ColumnInfo("F1", "F1", 5, 42)).Transform(srcView);
-            using (var cursor = hashTransform.GetRowCursor(hashTransform.Schema))
-=======
-            var col = new HashingTransformer.Column();
-            col.Name = "F1";
-            col.HashBits = 5;
-            col.Seed = 42;
-            var args = new HashingTransformer.Arguments();
-            args.Column = new HashingTransformer.Column[] { col };
-
-            var hashTransform = HashingTransformer.Create(Env, args, srcView);
             using (var cursor = hashTransform.GetRowCursorForAllColumns())
->>>>>>> Addressing the PR review comments.
             {
                 var resultGetter = cursor.GetGetter<uint>(1);
                 uint resultRow = 0;
@@ -1147,20 +1135,8 @@ namespace Microsoft.ML.RunTests
         private void TestHashTransformVectorHelper(ArrayDataViewBuilder builder, uint[][] results)
         {
             var srcView = builder.GetDataView();
-<<<<<<< HEAD
             var hashTransform = new HashingTransformer(Env, new HashingTransformer.ColumnInfo("F1V", "F1V", 5, 42)).Transform(srcView);
-            using (var cursor = hashTransform.GetRowCursor(hashTransform.Schema))
-=======
-            var col = new HashingTransformer.Column();
-            col.Name = "F1V";
-            col.HashBits = 5;
-            col.Seed = 42;
-            var args = new HashingTransformer.Arguments();
-            args.Column = new HashingTransformer.Column[] { col };
-
-            var hashTransform = HashingTransformer.Create(Env, args, srcView);
             using (var cursor = hashTransform.GetRowCursorForAllColumns())
->>>>>>> Addressing the PR review comments.
             {
                 var resultGetter = cursor.GetGetter<VBuffer<uint>>(1);
                 VBuffer<uint> resultRow = new VBuffer<uint>();

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ML.RunTests
                 {
                     // Verify that the Vec columns match the corresponding VecXX columns. This verifies that conversion
                     // happened correctly in KeyToVector.
-                    using (var c = pipe.GetRowCursor(pipe.Schema))
+                    using (var c = pipe.GetRowCursorForAllColumns())
                     {
                         var cols = new[] { "MarVec", "MarVecU8", "CombBagVec", "CombBagVecU1", "CombIndVec", "CombIndVecU1" };
                         var getters = new ValueGetter<VBuffer<Float>>[cols.Length];
@@ -571,7 +571,7 @@ namespace Microsoft.ML.RunTests
                     // Column F13 contains the ngram counts of column Two, and column F23 contains the ngram counts
                     // of columns Two and One. Therefore, make sure that the ngrams in column Two were hashed to the same 
                     // slots in F13 as they were in column F23. We do this by checking that for every slot, F23 is >= F13.
-                    using (var c = pipe.GetRowCursor(pipe.Schema))
+                    using (var c = pipe.GetRowCursorForAllColumns())
                     {
                         int col1;
                         bool tmp1 = c.Schema.TryGetColumnIndex("F13", out col1);
@@ -615,7 +615,7 @@ namespace Microsoft.ML.RunTests
                 (pipe) =>
                 {
                     // Verify that F2 = 2 * F1
-                    using (var c = pipe.GetRowCursor(pipe.Schema))
+                    using (var c = pipe.GetRowCursorForAllColumns())
                     {
                         int col1;
                         bool tmp1 = c.Schema.TryGetColumnIndex("F1", out col1);
@@ -769,7 +769,7 @@ namespace Microsoft.ML.RunTests
                 (pipe) =>
                 {
                     // Verify that WB2 = 2 * WB1
-                    using (var c = pipe.GetRowCursor(pipe.Schema))
+                    using (var c = pipe.GetRowCursorForAllColumns())
                     {
                         var b1 = default(VBuffer<Float>);
                         var b2 = default(VBuffer<Float>);
@@ -918,7 +918,7 @@ namespace Microsoft.ML.RunTests
                     ReadOnlyMemory<char>[] values1 = { "erythromycin".AsMemory(), "treating".AsMemory(), "pneumonia".AsMemory() };
                     expected[1] = new VBuffer<ReadOnlyMemory<char>>(values1.Length, values1);
 
-                    using (var c = pipe.GetRowCursor(pipe.Schema))
+                    using (var c = pipe.GetRowCursorForAllColumns())
                     {
                         int col;
                         bool res = c.Schema.TryGetColumnIndex("T", out col);
@@ -1104,8 +1104,20 @@ namespace Microsoft.ML.RunTests
             builder.AddColumn("F1", type, data);
             var srcView = builder.GetDataView();
 
+<<<<<<< HEAD
             var hashTransform = new HashingTransformer(Env, new HashingTransformer.ColumnInfo("F1", "F1", 5, 42)).Transform(srcView);
             using (var cursor = hashTransform.GetRowCursor(hashTransform.Schema))
+=======
+            var col = new HashingTransformer.Column();
+            col.Name = "F1";
+            col.HashBits = 5;
+            col.Seed = 42;
+            var args = new HashingTransformer.Arguments();
+            args.Column = new HashingTransformer.Column[] { col };
+
+            var hashTransform = HashingTransformer.Create(Env, args, srcView);
+            using (var cursor = hashTransform.GetRowCursorForAllColumns())
+>>>>>>> Addressing the PR review comments.
             {
                 var resultGetter = cursor.GetGetter<uint>(1);
                 uint resultRow = 0;
@@ -1135,8 +1147,20 @@ namespace Microsoft.ML.RunTests
         private void TestHashTransformVectorHelper(ArrayDataViewBuilder builder, uint[][] results)
         {
             var srcView = builder.GetDataView();
+<<<<<<< HEAD
             var hashTransform = new HashingTransformer(Env, new HashingTransformer.ColumnInfo("F1V", "F1V", 5, 42)).Transform(srcView);
             using (var cursor = hashTransform.GetRowCursor(hashTransform.Schema))
+=======
+            var col = new HashingTransformer.Column();
+            col.Name = "F1V";
+            col.HashBits = 5;
+            col.Seed = 42;
+            var args = new HashingTransformer.Arguments();
+            args.Column = new HashingTransformer.Column[] { col };
+
+            var hashTransform = HashingTransformer.Create(Env, args, srcView);
+            using (var cursor = hashTransform.GetRowCursorForAllColumns())
+>>>>>>> Addressing the PR review comments.
             {
                 var resultGetter = cursor.GetGetter<VBuffer<uint>>(1);
                 VBuffer<uint> resultRow = new VBuffer<uint>();
@@ -1177,7 +1201,7 @@ namespace Microsoft.ML.RunTests
             var ldaTransformer = est.Fit(srcView);
             var transformedData = ldaTransformer.Transform(srcView);
 
-            using (var cursor = transformedData.GetRowCursor(transformedData.Schema))
+            using (var cursor = transformedData.GetRowCursorForAllColumns())
             {
                 var resultGetter = cursor.GetGetter<VBuffer<Float>>(1);
                 VBuffer<Float> resultFirstRow = new VBuffer<Float>();

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ML.RunTests
                     // Set the concurrency to 1 for this; restore later.
                     int conc = _env.ConcurrencyFactor;
                     _env.ConcurrencyFactor = 1;
-                    using (var curs = pipe1.GetRowCursor(pipe1.Schema))
+                    using (var curs = pipe1.GetRowCursorForAllColumns())
                     {
                         while (curs.MoveNext())
                         {
@@ -256,7 +256,7 @@ namespace Microsoft.ML.RunTests
                 if (!newPipe.CanShuffle)
                 {
                     using (var c1 = newPipe.GetRowCursor(newPipe.Schema, new Random(123)))
-                    using (var c2 = newPipe.GetRowCursor(newPipe.Schema))
+                    using (var c2 = newPipe.GetRowCursorForAllColumns())
                     {
                         if (!CheckSameValues(c1, c2, true, true, true))
                             Failed();
@@ -800,8 +800,8 @@ namespace Microsoft.ML.RunTests
             bool all = true;
             bool tmp;
 
-            using (var curs1 = view1.GetRowCursor(view1.Schema))
-            using (var curs2 = view2.GetRowCursor(view2.Schema))
+            using (var curs1 = view1.GetRowCursorForAllColumns())
+            using (var curs2 = view2.GetRowCursorForAllColumns())
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -811,7 +811,7 @@ namespace Microsoft.ML.RunTests
             all &= tmp;
 
             var view2EvenCols = view2.Schema.Where(col => (col.Index & 1) == 0); 
-            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs1 = view1.GetRowCursorForAllColumns())
             using (var curs2 = view2.GetRowCursor(view2EvenCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
@@ -822,7 +822,7 @@ namespace Microsoft.ML.RunTests
             all &= tmp;
 
             var view2OddCols = view2.Schema.Where(col => (col.Index & 1) != 0);
-            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs1 = view1.GetRowCursorForAllColumns())
             using (var curs2 = view2.GetRowCursor(view2OddCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
@@ -831,7 +831,7 @@ namespace Microsoft.ML.RunTests
             }
             Check(tmp, "Odd same failed");
 
-            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs1 = view1.GetRowCursorForAllColumns())
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 tmp = CheckSameValues(curs1, view2, exactTypes, exactDoubles, checkId);
@@ -936,7 +936,7 @@ namespace Microsoft.ML.RunTests
                 {
                     // curs1 should have all columns active (for simplicity of the code here).
                     Contracts.Assert(curs1.IsColumnActive(col));
-                    cursors[col] = view2.GetRowCursor(view2.Schema);
+                    cursors[col] = view2.GetRowCursorForAllColumns();
                 }
 
                 // Get the comparison delegates for each column.

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ML.RunTests
                     // Set the concurrency to 1 for this; restore later.
                     int conc = _env.ConcurrencyFactor;
                     _env.ConcurrencyFactor = 1;
-                    using (var curs = pipe1.GetRowCursor(c => true, null))
+                    using (var curs = pipe1.GetRowCursor(pipe1.Schema))
                     {
                         while (curs.MoveNext())
                         {
@@ -255,8 +255,8 @@ namespace Microsoft.ML.RunTests
                 var newPipe = ApplyTransformUtils.ApplyAllTransformsToData(_env, comp.View, cachedData);
                 if (!newPipe.CanShuffle)
                 {
-                    using (var c1 = newPipe.GetRowCursor(col => true, new Random(123)))
-                    using (var c2 = newPipe.GetRowCursor(col => true))
+                    using (var c1 = newPipe.GetRowCursor(newPipe.Schema, new Random(123)))
+                    using (var c2 = newPipe.GetRowCursor(newPipe.Schema))
                     {
                         if (!CheckSameValues(c1, c2, true, true, true))
                             Failed();
@@ -800,8 +800,8 @@ namespace Microsoft.ML.RunTests
             bool all = true;
             bool tmp;
 
-            using (var curs1 = view1.GetRowCursor(col => true))
-            using (var curs2 = view2.GetRowCursor(col => true))
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs2 = view2.GetRowCursor(view2.Schema))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -810,8 +810,9 @@ namespace Microsoft.ML.RunTests
             Check(tmp, "All same failed");
             all &= tmp;
 
-            using (var curs1 = view1.GetRowCursor(col => true))
-            using (var curs2 = view2.GetRowCursor(col => (col & 1) == 0, null))
+            var view2EvenCols = view2.Schema.Where(col => (col.Index & 1) == 0); 
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs2 = view2.GetRowCursor(view2EvenCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -820,8 +821,9 @@ namespace Microsoft.ML.RunTests
             Check(tmp, "Even same failed");
             all &= tmp;
 
-            using (var curs1 = view1.GetRowCursor(col => true))
-            using (var curs2 = view2.GetRowCursor(col => (col & 1) != 0, null))
+            var view2OddCols = view2.Schema.Where(col => (col.Index & 1) != 0);
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
+            using (var curs2 = view2.GetRowCursor(view2OddCols))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 Check(curs2.Schema == view2.Schema, "Schema of view 2 and its cursor differed");
@@ -829,7 +831,7 @@ namespace Microsoft.ML.RunTests
             }
             Check(tmp, "Odd same failed");
 
-            using (var curs1 = view1.GetRowCursor(col => true))
+            using (var curs1 = view1.GetRowCursor(view1.Schema))
             {
                 Check(curs1.Schema == view1.Schema, "Schema of view 1 and its cursor differed");
                 tmp = CheckSameValues(curs1, view2, exactTypes, exactDoubles, checkId);
@@ -858,7 +860,7 @@ namespace Microsoft.ML.RunTests
                     var type2 = curs2.Schema[col].Type;
                     if (!EqualTypes(type1, type2, exactTypes))
                     {
-                        Fail("Different types");
+                        Fail($"Different types {type1} and {type2}");
                         return Failed();
                     }
                     comps[col] = GetColumnComparer(curs1, curs2, col, type1, exactDoubles);
@@ -934,7 +936,7 @@ namespace Microsoft.ML.RunTests
                 {
                     // curs1 should have all columns active (for simplicity of the code here).
                     Contracts.Assert(curs1.IsColumnActive(col));
-                    cursors[col] = view2.GetRowCursor(c => c == col);
+                    cursors[col] = view2.GetRowCursor(view2.Schema);
                 }
 
                 // Get the comparison delegates for each column.

--- a/test/Microsoft.ML.TestFramework/TestCommandBase.cs
+++ b/test/Microsoft.ML.TestFramework/TestCommandBase.cs
@@ -516,7 +516,7 @@ namespace Microsoft.ML.RunTests
                     out pipe, rep, ModelFileUtils.DirDataLoaderModel, files);
             }
 
-            using (var c = pipe.GetRowCursor(col => true))
+            using (var c = pipe.GetRowCursor(pipe.Schema))
                 tmp = CheckSameValues(c, pipe, true, true, true);
             Check(tmp, "Single value same failed");
         }

--- a/test/Microsoft.ML.TestFramework/TestCommandBase.cs
+++ b/test/Microsoft.ML.TestFramework/TestCommandBase.cs
@@ -516,7 +516,7 @@ namespace Microsoft.ML.RunTests
                     out pipe, rep, ModelFileUtils.DirDataLoaderModel, files);
             }
 
-            using (var c = pipe.GetRowCursor(pipe.Schema))
+            using (var c = pipe.GetRowCursorForAllColumns())
                 tmp = CheckSameValues(c, pipe, true, true, true);
             Check(tmp, "Single value same failed");
         }

--- a/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
+++ b/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.RunTests
             var data = env.CreateStreamingDataView(inputs);
             var value = new VBuffer<T>();
             int n = 0;
-            using (var cur = data.GetRowCursor(data.Schema))
+            using (var cur = data.GetRowCursorForAllColumns())
             {
                 var getter = cur.GetGetter<VBuffer<T>>(0);
                 while (cur.MoveNext())
@@ -91,7 +91,7 @@ namespace Microsoft.ML.RunTests
             var data = env.CreateStreamingDataView(inputs);
             var value = new VBuffer<T>();
             int n = 0;
-            using (var cur = data.GetRowCursor(data.Schema))
+            using (var cur = data.GetRowCursorForAllColumns())
             {
                 var getter = cur.GetGetter<VBuffer<T>>(0);
                 while (cur.MoveNext())

--- a/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
+++ b/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.RunTests
             var data = env.CreateStreamingDataView(inputs);
             var value = new VBuffer<T>();
             int n = 0;
-            using (var cur = data.GetRowCursor(i => true))
+            using (var cur = data.GetRowCursor(data.Schema))
             {
                 var getter = cur.GetGetter<VBuffer<T>>(0);
                 while (cur.MoveNext())
@@ -91,7 +91,7 @@ namespace Microsoft.ML.RunTests
             var data = env.CreateStreamingDataView(inputs);
             var value = new VBuffer<T>();
             int n = 0;
-            using (var cur = data.GetRowCursor(i => true))
+            using (var cur = data.GetRowCursor(data.Schema))
             {
                 var getter = cur.GetGetter<VBuffer<T>>(0);
                 while (cur.MoveNext())

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.ML.Tests
 
             cropped.Schema.TryGetColumnIndex("ImagePath", out int pathColumn);
             cropped.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = cropped.GetRowCursor(cropped.Schema))
+            using (var cursor = cropped.GetRowCursorForAllColumns())
             {
                 var pathGetter = cursor.GetGetter<ReadOnlyMemory<char>>(pathColumn);
                 ReadOnlyMemory<char> path = default;
@@ -159,7 +159,7 @@ namespace Microsoft.ML.Tests
             DeleteOutputPath(fname);
 
             grey.Schema.TryGetColumnIndex("ImageGrey", out int greyColumn);
-            using (var cursor = grey.GetRowCursor(grey.Schema))
+            using (var cursor = grey.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(greyColumn);
                 Bitmap bitmap = default;
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -355,7 +355,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -422,7 +422,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -488,7 +488,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -554,7 +554,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -620,7 +620,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -685,7 +685,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
+            using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.ML.Tests
 
             cropped.Schema.TryGetColumnIndex("ImagePath", out int pathColumn);
             cropped.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = cropped.GetRowCursor((x) => true))
+            using (var cursor = cropped.GetRowCursor(cropped.Schema))
             {
                 var pathGetter = cursor.GetGetter<ReadOnlyMemory<char>>(pathColumn);
                 ReadOnlyMemory<char> path = default;
@@ -159,7 +159,7 @@ namespace Microsoft.ML.Tests
             DeleteOutputPath(fname);
 
             grey.Schema.TryGetColumnIndex("ImageGrey", out int greyColumn);
-            using (var cursor = grey.GetRowCursor((x) => true))
+            using (var cursor = grey.GetRowCursor(grey.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(greyColumn);
                 Bitmap bitmap = default;
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -355,7 +355,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -422,7 +422,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -488,7 +488,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -554,7 +554,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -620,7 +620,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;
@@ -685,7 +685,7 @@ namespace Microsoft.ML.Tests
 
             backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
             backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
-            using (var cursor = backToBitmaps.GetRowCursor((x) => true))
+            using (var cursor = backToBitmaps.GetRowCursor(backToBitmaps.Schema))
             {
                 var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
                 Bitmap restoredBitmap = default;

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -481,8 +481,8 @@ namespace Microsoft.ML.Tests
             var leftColumnIndex = left.Schema[leftColumnName].Index;
             var rightColumnIndex = right.Schema[rightColumnName].Index;
 
-            using (var expectedCursor = left.GetRowCursor(left.Schema.Where(columnIndex => leftColumnIndex == columnIndex.Index)))
-            using (var actualCursor = right.GetRowCursor(right.Schema.Where(columnIndex => rightColumnIndex == columnIndex.Index)))
+            using (var expectedCursor = left.GetRowCursor(left.Schema[leftColumnIndex]))
+            using (var actualCursor = right.GetRowCursor(right.Schema[rightColumnIndex]))
             {
                 VBuffer<float> expected = default;
                 VBuffer<float> actual = default;
@@ -505,8 +505,8 @@ namespace Microsoft.ML.Tests
             var leftColumnIndex = left.Schema[leftColumnName].Index;
             var rightColumnIndex = right.Schema[rightColumnName].Index;
 
-            using (var expectedCursor = left.GetRowCursor(left.Schema.Where(columnIndex => leftColumnIndex == columnIndex.Index)))
-            using (var actualCursor = right.GetRowCursor(right.Schema.Where(columnIndex => rightColumnIndex == columnIndex.Index)))
+            using (var expectedCursor = left.GetRowCursor(left.Schema[leftColumnIndex]))
+            using (var actualCursor = right.GetRowCursor(right.Schema[rightColumnIndex]))
             {
                 float expected = default;
                 VBuffer<float> actual = default;

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -481,8 +481,8 @@ namespace Microsoft.ML.Tests
             var leftColumnIndex = left.Schema[leftColumnName].Index;
             var rightColumnIndex = right.Schema[rightColumnName].Index;
 
-            using (var expectedCursor = left.GetRowCursor(columnIndex => leftColumnIndex == columnIndex))
-            using (var actualCursor = right.GetRowCursor(columnIndex => rightColumnIndex == columnIndex))
+            using (var expectedCursor = left.GetRowCursor(left.Schema.Where(columnIndex => leftColumnIndex == columnIndex.Index)))
+            using (var actualCursor = right.GetRowCursor(right.Schema.Where(columnIndex => rightColumnIndex == columnIndex.Index)))
             {
                 VBuffer<float> expected = default;
                 VBuffer<float> actual = default;
@@ -505,8 +505,8 @@ namespace Microsoft.ML.Tests
             var leftColumnIndex = left.Schema[leftColumnName].Index;
             var rightColumnIndex = right.Schema[rightColumnName].Index;
 
-            using (var expectedCursor = left.GetRowCursor(columnIndex => leftColumnIndex == columnIndex))
-            using (var actualCursor = right.GetRowCursor(columnIndex => rightColumnIndex == columnIndex))
+            using (var expectedCursor = left.GetRowCursor(left.Schema.Where(columnIndex => leftColumnIndex == columnIndex.Index)))
+            using (var actualCursor = right.GetRowCursor(right.Schema.Where(columnIndex => rightColumnIndex == columnIndex.Index)))
             {
                 float expected = default;
                 VBuffer<float> actual = default;

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                     Assert.NotNull(input.Channel);
                     return false;
                 }, null);
-            filter1.GetRowCursor(col => true).MoveNext();
+            filter1.GetRowCursor(filter1.Schema).MoveNext();
 
             // Error case: non-IChannel field marked with attribute.
             var data2 = Utils.CreateArray(10, new OneStringWithAttribute());
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 }, null);
             try
             {
-                filter2.GetRowCursor(col => true).MoveNext();
+                filter2.GetRowCursor(filter2.Schema).MoveNext();
                 Assert.True(false, "Throw an error if attribute is applied to a field that is not an IChannel.");
             }
             catch (InvalidOperationException ex)
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 }, null);
             try
             {
-                filter3.GetRowCursor(col => true).MoveNext();
+                filter3.GetRowCursor(filter3.Schema).MoveNext();
                 Assert.True(false, "Throw an error if attribute is applied to a field that is not an IChannel.");
             }
             catch (InvalidOperationException ex)
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                     Assert.NotNull(input.ChannelTwo);
                     return false;
                 }, null);
-            filter1.GetRowCursor(col => true).MoveNext();
+            filter1.GetRowCursor(filter1.Schema).MoveNext();
         }
 
         public class BreastCancerExample

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                     Assert.NotNull(input.Channel);
                     return false;
                 }, null);
-            filter1.GetRowCursor(filter1.Schema).MoveNext();
+            filter1.GetRowCursorForAllColumns().MoveNext();
 
             // Error case: non-IChannel field marked with attribute.
             var data2 = Utils.CreateArray(10, new OneStringWithAttribute());
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 }, null);
             try
             {
-                filter2.GetRowCursor(filter2.Schema).MoveNext();
+                filter2.GetRowCursorForAllColumns().MoveNext();
                 Assert.True(false, "Throw an error if attribute is applied to a field that is not an IChannel.");
             }
             catch (InvalidOperationException ex)
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 }, null);
             try
             {
-                filter3.GetRowCursor(filter3.Schema).MoveNext();
+                filter3.GetRowCursorForAllColumns().MoveNext();
                 Assert.True(false, "Throw an error if attribute is applied to a field that is not an IChannel.");
             }
             catch (InvalidOperationException ex)
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                     Assert.NotNull(input.ChannelTwo);
                     return false;
                 }, null);
-            filter1.GetRowCursor(filter1.Schema).MoveNext();
+            filter1.GetRowCursorForAllColumns().MoveNext();
         }
 
         public class BreastCancerExample

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -244,9 +244,8 @@ namespace Microsoft.ML.Scenarios
             tf.Schema.TryGetColumnIndex("detection_scores", out int scores);
             tf.Schema.TryGetColumnIndex("num_detections", out int num);
             tf.Schema.TryGetColumnIndex("detection_classes", out int classes);
-            var cols = tf.Schema.Where(col => col.Name.Equals("image_tensor") || col.Name.Equals("detection_boxes") 
-            || col.Name.Equals("detection_scores") || col.Name.Equals("num_detections") || col.Name.Equals("detection_classes"));
-            using (var curs = tf.GetRowCursor(cols))
+
+            using (var curs = tf.GetRowCursor("image_tensor", "detection_boxes", "detection_scores", "detection_classes", "num_detections"))
             {
                 var getInput = curs.GetGetter<VBuffer<byte>>(input);
                 var getBoxes = curs.GetGetter<VBuffer<float>>(boxes);
@@ -281,7 +280,7 @@ namespace Microsoft.ML.Scenarios
 
             tf.Schema.TryGetColumnIndex("input", out int input);
             tf.Schema.TryGetColumnIndex("softmax2_pre_activation", out int b);
-            using (var curs = tf.GetRowCursor(tf.Schema.Where(col => col.Name.Equals("input") || col.Name.Equals("softmax2_pre_activation"))))
+            using (var curs = tf.GetRowCursor("input","softmax2_pre_activation"))
             {
                 var get = curs.GetGetter<VBuffer<float>>(b);
                 var getInput = curs.GetGetter<VBuffer<float>>(input);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Scenarios
             tf.Schema.TryGetColumnIndex("num_detections", out int num);
             tf.Schema.TryGetColumnIndex("detection_classes", out int classes);
 
-            using (var curs = tf.GetRowCursor("image_tensor", "detection_boxes", "detection_scores", "detection_classes", "num_detections"))
+            using (var curs = tf.GetRowCursor(tf.Schema["image_tensor"], tf.Schema["detection_boxes"], tf.Schema["detection_scores"], tf.Schema["detection_classes"], tf.Schema["num_detections"]))
             {
                 var getInput = curs.GetGetter<VBuffer<byte>>(input);
                 var getBoxes = curs.GetGetter<VBuffer<float>>(boxes);
@@ -280,7 +280,7 @@ namespace Microsoft.ML.Scenarios
 
             tf.Schema.TryGetColumnIndex("input", out int input);
             tf.Schema.TryGetColumnIndex("softmax2_pre_activation", out int b);
-            using (var curs = tf.GetRowCursor("input","softmax2_pre_activation"))
+            using (var curs = tf.GetRowCursor(tf.Schema["input"], tf.Schema["softmax2_pre_activation"]))
             {
                 var get = curs.GetGetter<VBuffer<float>>(b);
                 var getInput = curs.GetGetter<VBuffer<float>>(input);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -742,7 +742,7 @@ namespace Microsoft.ML.Scenarios
             IDataView trans = new TensorFlowTransformer(mlContext, tensorFlowModel, "Input", "Output").Transform(pixels);
 
             trans.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = trans.GetRowCursorForAllColumns())
+            using (var cursor = trans.GetRowCursor(trans.Schema["Output"]))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Scenarios
                                                      3.0f, 3.0f } } }));
             var trans = new TensorFlowTransformer(mlContext, modelLocation, new[] { "a", "b" }, new[] { "c" }).Transform(loader);
 
-            using (var cursor = trans.GetRowCursor(trans.Schema))
+            using (var cursor = trans.GetRowCursorForAllColumns())
             {
                 var cgetter = cursor.GetGetter<VBuffer<float>>(2);
                 Assert.True(cursor.MoveNext());
@@ -462,7 +462,7 @@ namespace Microsoft.ML.Scenarios
 
 
                 var trainDataTransformed = trainedModel.Transform(trainData);
-                using (var cursor = trainDataTransformed.GetRowCursor(trainDataTransformed.Schema))
+                using (var cursor = trainDataTransformed.GetRowCursorForAllColumns())
                 {
                     trainDataTransformed.Schema.TryGetColumnIndex("b", out int bias);
                     var getter = cursor.GetGetter<VBuffer<float>>(bias);
@@ -743,7 +743,7 @@ namespace Microsoft.ML.Scenarios
             IDataView trans = new TensorFlowTransformer(mlContext, tensorFlowModel, "Input", "Output").Transform(pixels);
 
             trans.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = trans.GetRowCursor(trans.Schema))
+            using (var cursor = trans.GetRowCursorForAllColumns())
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -784,7 +784,7 @@ namespace Microsoft.ML.Scenarios
             IDataView trans = new TensorFlowTransformer(mlContext, tensorFlowModel, "Input", "Output").Transform(pixels);
 
             trans.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = trans.GetRowCursor(trans.Schema))
+            using (var cursor = trans.GetRowCursorForAllColumns())
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
 using System.Linq;
 using Microsoft.ML.Data;
@@ -143,7 +142,7 @@ namespace Microsoft.ML.Scenarios
             var outputs = new string[] { "o_f64", "o_f32", "o_i64", "o_i32", "o_i16", "o_i8", "o_u64", "o_u32", "o_u16", "o_u8", "o_b" };
             var trans = new TensorFlowTransformer(mlContext, model_location, inputs, outputs).Transform(loader); ;
 
-            using (var cursor = trans.GetRowCursor(a => true))
+            using (var cursor = trans.GetRowCursorForAllColumns())
             {
                 var f64getter = cursor.GetGetter<VBuffer<double>>(11);
                 var f32getter = cursor.GetGetter<VBuffer<float>>(12);

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.ML.Tests
             result.Schema.TryGetColumnIndex("a", out int ColA);
             result.Schema.TryGetColumnIndex("b", out int ColB);
             result.Schema.TryGetColumnIndex("c", out int ColC);
-            using (var cursor = result.GetRowCursor(result.Schema))
+            using (var cursor = result.GetRowCursorForAllColumns())
             {
                 VBuffer<float> avalue = default;
                 VBuffer<float> bvalue = default;

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = result.GetRowCursor(result.Schema.Where(c => c.Name.Equals("Output"))))
+            using (var cursor = result.GetRowCursor("Output"))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = result.GetRowCursor(result.Schema.Where(c => c.Name.Equals("Output"))))
+            using (var cursor = result.GetRowCursor("Output"))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.ML.Core.Data;
 using Microsoft.ML.Data;
 using Microsoft.ML.Model;
@@ -164,7 +165,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = result.GetRowCursor(col => col == output))
+            using (var cursor = result.GetRowCursor(result.Schema.Where(c => c.Name.Equals("Output"))))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -211,7 +212,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = result.GetRowCursor(col => col == output))
+            using (var cursor = result.GetRowCursor(result.Schema.Where(c => c.Name.Equals("Output"))))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -231,7 +232,7 @@ namespace Microsoft.ML.Tests
             result.Schema.TryGetColumnIndex("a", out int ColA);
             result.Schema.TryGetColumnIndex("b", out int ColB);
             result.Schema.TryGetColumnIndex("c", out int ColC);
-            using (var cursor = result.GetRowCursor(x => true))
+            using (var cursor = result.GetRowCursor(result.Schema))
             {
                 VBuffer<float> avalue = default;
                 VBuffer<float> bvalue = default;

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = result.GetRowCursor("Output"))
+            using (var cursor = result.GetRowCursor(result.Schema["Output"]))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Tests
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
             result.Schema.TryGetColumnIndex("Output", out int output);
-            using (var cursor = result.GetRowCursor("Output"))
+            using (var cursor = result.GetRowCursor(result.Schema["Output"]))
             {
                 var buffer = default(VBuffer<float>);
                 var getter = cursor.GetGetter<VBuffer<float>>(output);

--- a/test/Microsoft.ML.Tests/TermEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TermEstimatorTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.ML.Tests
             result.Schema.TryGetColumnIndex("TermA", out int ColA);
             result.Schema.TryGetColumnIndex("TermB", out int ColB);
             result.Schema.TryGetColumnIndex("TermC", out int ColC);
-            using (var cursor = result.GetRowCursor(x => true))
+            using (var cursor = result.GetRowCursor(result.Schema))
             {
                 uint avalue = 0;
                 uint bvalue = 0;

--- a/test/Microsoft.ML.Tests/TermEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TermEstimatorTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.ML.Tests
             result.Schema.TryGetColumnIndex("TermA", out int ColA);
             result.Schema.TryGetColumnIndex("TermB", out int ColB);
             result.Schema.TryGetColumnIndex("TermC", out int ColC);
-            using (var cursor = result.GetRowCursor(result.Schema))
+            using (var cursor = result.GetRowCursorForAllColumns())
             {
                 uint avalue = 0;
                 uint bvalue = 0;

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.EntryPoints.Tests
                 "loader=Text{col=DvInt1:I1:0 col=DvInt2:I2:1 col=DvInt4:I4:2 col=DvInt8:I8:3 sep=comma}",
                 }, logCurs: true);
 
-            using (var cursor = data.GetRowCursor(data.Schema))
+            using (var cursor = data.GetRowCursorForAllColumns())
             {
                 var col1 = cursor.GetGetter<sbyte>(0);
                 var col2 = cursor.GetGetter<short>(1);
@@ -294,7 +294,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var data = runner.GetOutput<IDataView>("data"); Assert.NotNull(data);
 
-            using (var cursor = data.GetRowCursor(data.Schema))
+            using (var cursor = data.GetRowCursorForAllColumns())
             {
                 var IDGetter = cursor.GetGetter<float>(0);
                 var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);
@@ -441,7 +441,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             var data = runner.GetOutput<IDataView>("data");
             Assert.NotNull(data);
 
-            using (var cursor = data.GetRowCursor(data.Schema))
+            using (var cursor = data.GetRowCursorForAllColumns())
             {
                 var getters = new ValueGetter<float>[]{
                         cursor.GetGetter<float>(0),
@@ -555,7 +555,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             var data = runner.GetOutput<IDataView>("data");
             Assert.NotNull(data);
 
-            using (var cursor = data.GetRowCursor(data.Schema))
+            using (var cursor = data.GetRowCursorForAllColumns())
             {
                 var IDGetter = cursor.GetGetter<float>(0);
                 var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.EntryPoints.Tests
                 "loader=Text{col=DvInt1:I1:0 col=DvInt2:I2:1 col=DvInt4:I4:2 col=DvInt8:I8:3 sep=comma}",
                 }, logCurs: true);
 
-            using (var cursor = data.GetRowCursor((a => true)))
+            using (var cursor = data.GetRowCursor(data.Schema))
             {
                 var col1 = cursor.GetGetter<sbyte>(0);
                 var col2 = cursor.GetGetter<short>(1);
@@ -294,7 +294,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var data = runner.GetOutput<IDataView>("data"); Assert.NotNull(data);
 
-            using (var cursor = data.GetRowCursor((a => true)))
+            using (var cursor = data.GetRowCursor(data.Schema))
             {
                 var IDGetter = cursor.GetGetter<float>(0);
                 var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);
@@ -441,7 +441,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             var data = runner.GetOutput<IDataView>("data");
             Assert.NotNull(data);
 
-            using (var cursor = data.GetRowCursor((a => true)))
+            using (var cursor = data.GetRowCursor(data.Schema))
             {
                 var getters = new ValueGetter<float>[]{
                         cursor.GetGetter<float>(0),
@@ -555,7 +555,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             var data = runner.GetOutput<IDataView>("data");
             Assert.NotNull(data);
 
-            using (var cursor = data.GetRowCursor((a => true)))
+            using (var cursor = data.GetRowCursor(data.Schema))
             {
                 var IDGetter = cursor.GetGetter<float>(0);
                 var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);

--- a/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Tests
 
         private void ValidateCopyColumnTransformer(IDataView result)
         {
-            using (var cursor = result.GetRowCursor(result.Schema))
+            using (var cursor = result.GetRowCursorForAllColumns())
             {
                 int avalue = 0;
                 int bvalue = 0;

--- a/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Tests
 
         private void ValidateCopyColumnTransformer(IDataView result)
         {
-            using (var cursor = result.GetRowCursor(x => true))
+            using (var cursor = result.GetRowCursor(result.Schema))
             {
                 int avalue = 0;
                 int bvalue = 0;

--- a/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new StopWordsRemovingTransformer.Column() { Name = "Text", Source = "Text" }
                 });
 
-            using (var cursor = xf.GetRowCursor(xf.Schema))
+            using (var cursor = xf.GetRowCursorForAllColumns())
             {
                 VBuffer<ReadOnlyMemory<char>> text = default;
                 var getter = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(cursor.Schema["Text"].Index);

--- a/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new StopWordsRemovingTransformer.Column() { Name = "Text", Source = "Text" }
                 });
 
-            using (var cursor = xf.GetRowCursor(col => true))
+            using (var cursor = xf.GetRowCursor(xf.Schema))
             {
                 VBuffer<ReadOnlyMemory<char>> text = default;
                 var getter = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(cursor.Schema["Text"].Index);

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor((col) => true);
+            var cursor = result.GetRowCursorForAllColumns();
             var getterD = cursor.GetGetter<ReadOnlyMemory<char>>(result.Schema["DOutput"].Index);
             cursor.MoveNext();
 

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor(result.Schema);
+            var cursor = result.GetRowCursorForAllColumns();
             var getterD = cursor.GetGetter<int>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
@@ -92,7 +92,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor(result.Schema);
+            var cursor = result.GetRowCursorForAllColumns();
             var getterD = cursor.GetGetter<VBuffer<int>>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<VBuffer<int>>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<VBuffer<int>>(result.Schema["F"].Index);
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor(result.Schema);
+            var cursor = result.GetRowCursorForAllColumns();
             var getterD = cursor.GetGetter<int>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
@@ -222,7 +222,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor(result.Schema);
+            var cursor = result.GetRowCursorForAllColumns();
             var getterD = cursor.GetGetter<uint>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<uint>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<uint>(result.Schema["F"].Index);
@@ -261,7 +261,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor(result.Schema);
+            var cursor = result.GetRowCursorForAllColumns();
             var getterD = cursor.GetGetter<ulong>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<ulong>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<ulong>(result.Schema["F"].Index);
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor(result.Schema);
+            var cursor = result.GetRowCursorForAllColumns();
             var getterD = cursor.GetGetter<uint>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<uint>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<uint>(result.Schema["F"].Index);

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor((col) => true);
+            var cursor = result.GetRowCursor(result.Schema);
             var getterD = cursor.GetGetter<int>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
@@ -92,7 +92,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor((col) => true);
+            var cursor = result.GetRowCursor(result.Schema);
             var getterD = cursor.GetGetter<VBuffer<int>>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<VBuffer<int>>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<VBuffer<int>>(result.Schema["F"].Index);
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor((col) => true);
+            var cursor = result.GetRowCursor(result.Schema);
             var getterD = cursor.GetGetter<int>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
@@ -222,7 +222,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor((col) => true);
+            var cursor = result.GetRowCursor(result.Schema);
             var getterD = cursor.GetGetter<uint>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<uint>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<uint>(result.Schema["F"].Index);
@@ -261,7 +261,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor((col) => true);
+            var cursor = result.GetRowCursor(result.Schema);
             var getterD = cursor.GetGetter<ulong>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<ulong>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<ulong>(result.Schema["F"].Index);
@@ -298,7 +298,7 @@ namespace Microsoft.ML.Tests.Transformers
             var t = estimator.Fit(dataView);
 
             var result = t.Transform(dataView);
-            var cursor = result.GetRowCursor((col) => true);
+            var cursor = result.GetRowCursor(result.Schema);
             var getterD = cursor.GetGetter<uint>(result.Schema["D"].Index);
             var getterE = cursor.GetGetter<uint>(result.Schema["E"].Index);
             var getterF = cursor.GetGetter<uint>(result.Schema["F"].Index);


### PR DESCRIPTION
Addresses #1529 by swapping the predicates for IEnumerable<Schema.Columns> in the GetRowCursor and GetRowCursorSet
