### PR TITLE
Typo fixed: duplicate 'in case of' removed

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/MultiFileSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/MultiFileSource.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// Initializes a new instance of <see cref="MultiFileSource"/>.
-        /// In case of in case of usage from Maml, the paths would be wildcard concatenated in the first string of <paramref name="paths"/>.
+        /// In case of usage from Maml, the paths would be wildcard concatenated in the first string of <paramref name="paths"/>.
         /// </summary>
         /// <param name="paths">The paths of the files to load.</param>
         public MultiFileSource(params string[] paths)


### PR DESCRIPTION
There was a duplicate 'in case of' in the description of the constructor.