### PR TITLE
Removing Iteration Setup from Benchmarks

### DIFF
--- a/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
+++ b/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
@@ -14,9 +14,10 @@ namespace Microsoft.ML.Benchmarks
 
         // Global.
         private IDataView _cacheDataView;
-        // Per iteration.
         private RowCursor _cursor;
-        private ValueGetter<int> _getter;
+        private ValueGetter<int> _seekerGetter;
+        private ValueGetter<int> _cursorGetter;
+        private Schema.Column _col;
 
         private RowSeeker _seeker;
         private long[] _positions;
@@ -57,30 +58,23 @@ namespace Microsoft.ML.Benchmarks
             var rand = new Random(0);
             for (int i = 0; i < _positions.Length; ++i)
                 _positions[i] = rand.Next(Length);
-        }
 
-        [IterationSetup(Target = nameof(CacheWithCursor))]
-        public void CacheWithCursorSetup()
-        {
-            var col = _cacheDataView.Schema.GetColumnOrNull("A").Value;
-            _cursor = _cacheDataView.GetRowCursor(colIndex => colIndex == col.Index);
-            _getter = _cursor.GetGetter<int>(col.Index);
+            _col = _cacheDataView.Schema.GetColumnOrNull("A").Value;
+            _seeker = ((IRowSeekable)_cacheDataView).GetSeeker(colIndex => colIndex == _col.Index);
+            _seekerGetter = _seeker.GetGetter<int>(_col.Index);
         }
 
         [Benchmark]
         public void CacheWithCursor()
         {
+            // This setup takes very less time to execute as compared to the actual _cursorGetter.
+            // The most preferable position for this setup will be in GlobalSetup.
+            _cursor = _cacheDataView.GetRowCursor(colIndex => colIndex == _col.Index);
+            _cursorGetter = _cursor.GetGetter<int>(_col.Index);
+
             int val = 0;
             while (_cursor.MoveNext())
-                _getter(ref val);
-        }
-
-        [IterationSetup(Target = nameof(CacheWithSeeker))]
-        public void CacheWithSeekerSetup()
-        {
-            var col = _cacheDataView.Schema.GetColumnOrNull("A").Value;
-            _seeker = ((IRowSeekable)_cacheDataView).GetSeeker(colIndex => colIndex == col.Index);
-            _getter = _seeker.GetGetter<int>(col.Index);
+                _cursorGetter(ref val); 
         }
 
         [Benchmark]
@@ -90,7 +84,7 @@ namespace Microsoft.ML.Benchmarks
             foreach (long pos in _positions)
             {
                 _seeker.MoveTo(pos);
-                _getter(ref val);
+                _seekerGetter(ref val);
             }
         }
     }


### PR DESCRIPTION
Specifying IterationSetup benchmark causes the benchmark to run just only once in an iteration. This is a problem if the benchmarks takes less than 100ms to execute.

As it is being executed just once per iteration and number of iterations is 20, no jitting is done on netcore3.0 (requires 30 calls).

The possible solutions were to increase the length + increase the warmCount to 30 (this could be a problem for other benchmarks)

Another solution is just removing the iterationSetup. In CacheWithSeeker we are not doing anything that is specific to an iteration and we can directly move the code to globalSetup.

for CacheWithCursor I moved the implementation to the actual benchmark as the iteration setup itseld was taking a small time. But it will good if we could move the iteration setup to globalSetup. @TomFinley any suggetions will be helpful.

Also Earlier this was reported as regression for netcore3.0 but after testing the benchmark with both the solutions, I found there is no regression in this benchmark.



