### PR TITLE
Fix CategoricalHashTransform to handle OutputKind "Key"

### DIFF
--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Transforms.Categorical
             /// <param name="sort">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingTransformer.SortOrder.Occurrence"/> choosen they will be in the order encountered.
             /// If <see cref="ValueToKeyMappingTransformer.SortOrder.Value"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
             /// <param name="term">List of terms.</param>
-            public ColumnInfo(string input, string output=null,
+            public ColumnInfo(string input, string output = null,
                 OneHotEncodingTransformer.OutputKind outputKind = Defaults.OutKind,
                 int maxNumTerms = ValueToKeyMappingEstimator.Defaults.MaxNumTerms, ValueToKeyMappingTransformer.SortOrder sort = ValueToKeyMappingEstimator.Defaults.Sort,
                 string[] term = null)
@@ -268,7 +268,13 @@ namespace Microsoft.ML.Transforms.Categorical
             }
         }
 
-        public SchemaShape GetOutputSchema(SchemaShape inputSchema) => _term.Append(_toSomething).GetOutputSchema(inputSchema);
+        public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+        {
+            if (_toSomething != null)
+                return _term.Append(_toSomething).GetOutputSchema(inputSchema);
+            else
+                return _term.GetOutputSchema(inputSchema);
+        }
 
         public OneHotEncodingTransformer Fit(IDataView input) => new OneHotEncodingTransformer(_term, _toSomething, input);
 

--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ML.Transforms.Categorical
 
         private readonly TransformerChain<ITransformer> _transformer;
 
-        public OneHotEncodingTransformer(ValueToKeyMappingEstimator term, IEstimator<ITransformer> toVector, IDataView input)
+        internal OneHotEncodingTransformer(ValueToKeyMappingEstimator term, IEstimator<ITransformer> toVector, IDataView input)
         {
             if (toVector != null)
                 _transformer = term.Append(toVector).Fit(input);

--- a/src/Microsoft.ML.Transforms/OneHotHashEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotHashEncoding.cs
@@ -177,8 +177,10 @@ namespace Microsoft.ML.Transforms.Categorical
 
         internal OneHotHashEncoding(HashingEstimator hash, IEstimator<ITransformer> keyToVector, IDataView input)
         {
-            var chain = hash.Append(keyToVector);
-            _transformer = chain.Fit(input);
+            if (keyToVector != null)
+                _transformer = hash.Append(keyToVector).Fit(input);
+            else
+                _transformer = new TransformerChain<ITransformer>(hash.Fit(input));
         }
 
         public Schema GetOutputSchema(Schema inputSchema) => _transformer.GetOutputSchema(inputSchema);
@@ -312,7 +314,13 @@ namespace Microsoft.ML.Transforms.Categorical
             }
         }
 
-        public SchemaShape GetOutputSchema(SchemaShape inputSchema) => _hash.Append(_toSomething).GetOutputSchema(inputSchema);
+        public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+        {
+            if (_toSomething != null)
+                return _hash.Append(_toSomething).GetOutputSchema(inputSchema);
+            else
+                return _hash.GetOutputSchema(inputSchema);
+        }
 
         public OneHotHashEncoding Fit(IDataView input) => new OneHotHashEncoding(_hash, _toSomething, input);
     }


### PR DESCRIPTION
fixes #1939.
Duplicate of https://github.com/dotnet/machinelearning/pull/1941, but since Gani is out, I want to finish it.