### PR TITLE
Remove ColumnType "Is" properties (except IsKey and IsVector)

### DIFF
--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -72,14 +72,6 @@ namespace Microsoft.ML.Data
         internal DataKind RawKind { get; }
 
         /// <summary>
-        /// Whether this type is a standard scalar type completely determined by its <see cref="RawType"/>
-        /// (not a <see cref="KeyType"/> or <see cref="StructuredType"/>, etc).
-        /// </summary>
-        [BestFriend]
-        internal bool IsStandardScalar => (this is NumberType)|| (this is TextType) || (this is BoolType) ||
-            (this is TimeSpanType) || (this is DateTimeType) || (this is DateTimeOffsetType);
-
-        /// <summary>
         /// Whether this type is a key type, which implies that the order of values is not significant,
         /// and arithmetic is non-sensical. A key type can define a cardinality.
         /// External code should use <c>is <see cref="KeyType"/></c>.

--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -21,7 +21,6 @@ namespace Microsoft.ML.Data
         // This private constructor sets all the IsXxx flags. It is invoked by other ctors.
         private ColumnType()
         {
-            IsPrimitive = this is PrimitiveType;
             IsVector = this is VectorType;
             IsNumber = this is NumberType;
             IsKey = this is KeyType;
@@ -72,12 +71,6 @@ namespace Microsoft.ML.Data
         /// </summary>
         [BestFriend]
         internal DataKind RawKind { get; }
-
-        /// <summary>
-        /// Whether this is a primitive type. External code should use <c>is <see cref="PrimitiveType"/></c>.
-        /// </summary>
-        [BestFriend]
-        internal bool IsPrimitive { get; }
 
         /// <summary>
         /// Whether this type is a standard numeric type. External code should use <c>is <see cref="NumberType"/></c>.
@@ -214,13 +207,11 @@ namespace Microsoft.ML.Data
         protected StructuredType(Type rawType)
             : base(rawType)
         {
-            Contracts.Assert(!IsPrimitive);
         }
 
         private protected StructuredType(Type rawType, DataKind rawKind)
             : base(rawType, rawKind)
         {
-            Contracts.Assert(!IsPrimitive);
         }
     }
 
@@ -233,7 +224,6 @@ namespace Microsoft.ML.Data
         protected PrimitiveType(Type rawType)
             : base(rawType)
         {
-            Contracts.Assert(IsPrimitive);
             Contracts.CheckParam(!typeof(IDisposable).IsAssignableFrom(RawType), nameof(rawType),
                 "A " + nameof(PrimitiveType) + " cannot have a disposable " + nameof(RawType));
         }
@@ -241,7 +231,6 @@ namespace Microsoft.ML.Data
         private protected PrimitiveType(Type rawType, DataKind rawKind)
             : base(rawType, rawKind)
         {
-            Contracts.Assert(IsPrimitive);
             Contracts.Assert(!typeof(IDisposable).IsAssignableFrom(RawType));
         }
 

--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -72,27 +72,11 @@ namespace Microsoft.ML.Data
         internal DataKind RawKind { get; }
 
         /// <summary>
-        /// Whether this type is the standard text type. External code should use <c>is <see cref="TextType"/></c>.
-        /// </summary>
-        [BestFriend]
-        internal bool IsText
-        {
-            get
-            {
-                if (!(this is TextType))
-                    return false;
-                // TextType is a singleton.
-                Contracts.Assert(this == TextType.Instance);
-                return true;
-            }
-        }
-
-        /// <summary>
         /// Whether this type is a standard scalar type completely determined by its <see cref="RawType"/>
         /// (not a <see cref="KeyType"/> or <see cref="StructuredType"/>, etc).
         /// </summary>
         [BestFriend]
-        internal bool IsStandardScalar => (this is NumberType)|| IsText || (this is BoolType) ||
+        internal bool IsStandardScalar => (this is NumberType)|| (this is TextType) || (this is BoolType) ||
             (this is TimeSpanType) || (this is DateTimeType) || (this is DateTimeOffsetType);
 
         /// <summary>

--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -102,27 +102,11 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Whether this type is the standard boolean type. External code should use <c>is <see cref="BoolType"/></c>.
-        /// </summary>
-        [BestFriend]
-        internal bool IsBool
-        {
-            get
-            {
-                if (!(this is BoolType))
-                    return false;
-                // BoolType is a singleton.
-                Contracts.Assert(this == BoolType.Instance);
-                return true;
-            }
-        }
-
-        /// <summary>
         /// Whether this type is a standard scalar type completely determined by its <see cref="RawType"/>
         /// (not a <see cref="KeyType"/> or <see cref="StructuredType"/>, etc).
         /// </summary>
         [BestFriend]
-        internal bool IsStandardScalar => IsNumber || IsText || IsBool ||
+        internal bool IsStandardScalar => IsNumber || IsText || (this is BoolType) ||
             (this is TimeSpanType) || (this is DateTimeType) || (this is DateTimeOffsetType);
 
         /// <summary>

--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -22,7 +22,6 @@ namespace Microsoft.ML.Data
         private ColumnType()
         {
             IsVector = this is VectorType;
-            IsNumber = this is NumberType;
             IsKey = this is KeyType;
         }
 
@@ -73,12 +72,6 @@ namespace Microsoft.ML.Data
         internal DataKind RawKind { get; }
 
         /// <summary>
-        /// Whether this type is a standard numeric type. External code should use <c>is <see cref="NumberType"/></c>.
-        /// </summary>
-        [BestFriend]
-        internal bool IsNumber { get; }
-
-        /// <summary>
         /// Whether this type is the standard text type. External code should use <c>is <see cref="TextType"/></c>.
         /// </summary>
         [BestFriend]
@@ -99,7 +92,7 @@ namespace Microsoft.ML.Data
         /// (not a <see cref="KeyType"/> or <see cref="StructuredType"/>, etc).
         /// </summary>
         [BestFriend]
-        internal bool IsStandardScalar => IsNumber || IsText || (this is BoolType) ||
+        internal bool IsStandardScalar => (this is NumberType)|| IsText || (this is BoolType) ||
             (this is TimeSpanType) || (this is DateTimeType) || (this is DateTimeOffsetType);
 
         /// <summary>
@@ -295,7 +288,6 @@ namespace Microsoft.ML.Data
         {
             Contracts.AssertNonEmpty(name);
             _name = name;
-            Contracts.Assert(IsNumber);
         }
 
         private static volatile NumberType _instI1;
@@ -469,7 +461,7 @@ namespace Microsoft.ML.Data
         {
             if (other == this)
                 return true;
-            Contracts.Assert(other == null || !other.IsNumber || other.RawKind != RawKind);
+            Contracts.Assert(other == null || !(other is NumberType) || other.RawKind != RawKind);
             return false;
         }
 

--- a/src/Microsoft.ML.Core/Data/ColumnTypeExtensions.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnTypeExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Data
+{
+    /// <summary>
+    /// Extension methods related to the ColumnType class.
+    /// </summary>
+    [BestFriend]
+    internal static class ColumnTypeExtensions
+    {
+        /// <summary>
+        /// Whether this type is a standard scalar type completely determined by its <see cref="ColumnType.RawType"/>
+        /// (not a <see cref="KeyType"/> or <see cref="StructuredType"/>, etc).
+        /// </summary>
+        public static bool IsStandardScalar(this ColumnType columnType) =>
+            (columnType is NumberType) || (columnType is TextType) || (columnType is BoolType) ||
+            (columnType is TimeSpanType) || (columnType is DateTimeType) || (columnType is DateTimeOffsetType);
+    }
+}

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -365,7 +365,7 @@ namespace Microsoft.ML.Data
         public static bool IsNormalized(this Schema.Column column)
         {
             var metaColumn = column.Metadata.Schema.GetColumnOrNull((Kinds.IsNormalized));
-            if (metaColumn == null || !metaColumn.Value.Type.IsBool)
+            if (metaColumn == null || !(metaColumn.Value.Type is BoolType))
                 return false;
 
             bool value = default;

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Data
             for (int col = 0; col < schema.Count; col++)
             {
                 var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
-                if (columnType != null && columnType.IsText)
+                if (columnType != null && columnType is TextType)
                 {
                     ReadOnlyMemory<char> val = default;
                     schema[col].Metadata.GetValue(metadataKind, ref val);
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Data
                 metaColumn != null
                 && metaColumn.Value.Type.IsVector
                 && metaColumn.Value.Type.VectorSize == vectorSize
-                && metaColumn.Value.Type.ItemType.IsText;
+                && metaColumn.Value.Type.ItemType is TextType;
         }
 
         public static void GetSlotNames(this Schema.Column column, ref VBuffer<ReadOnlyMemory<char>> slotNames)
@@ -348,7 +348,7 @@ namespace Microsoft.ML.Data
                 metaColumn != null
                 && metaColumn.Value.Type.IsVector
                 && metaColumn.Value.Type.VectorSize == keyCount
-                && metaColumn.Value.Type.ItemType.IsText;
+                && metaColumn.Value.Type.ItemType is TextType;
         }
 
         [BestFriend]
@@ -356,7 +356,7 @@ namespace Microsoft.ML.Data
         {
             return col.Metadata.TryFindColumn(Kinds.KeyValues, out var metaCol)
                 && metaCol.Kind == SchemaShape.Column.VectorKind.Vector
-                && metaCol.ItemType.IsText;
+                && metaCol.ItemType is TextType;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Commands/DataCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/DataCommand.cs
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Data
                             {
                                 var nameOfMetric = "TLC_" + cursor.Schema[currentIndex].Name;
                                 var type = cursor.Schema[currentIndex].Type;
-                                if (type.IsNumber)
+                                if (type is NumberType)
                                 {
                                     var getter = RowCursorUtils.GetGetterAs<double>(NumberType.R8, cursor, currentIndex);
                                     double metricValue = 0;

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -154,7 +154,7 @@ namespace Microsoft.ML.Data
                     ColumnType typeNames;
                     if ((typeNames = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type) == null)
                         continue;
-                    if (typeNames.VectorSize != type.VectorSize || !typeNames.ItemType.IsText)
+                    if (typeNames.VectorSize != type.VectorSize || !(typeNames.ItemType is TextType))
                     {
                         Contracts.Assert(false, "Unexpected slot names type");
                         continue;

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(type);
             Contracts.Assert(!type.IsVector);
 
-            if (!type.IsStandardScalar && !type.IsKey)
+            if (!type.IsStandardScalar() && !type.IsKey)
             {
                 itw.Write(": Can't display value of this type");
                 return;
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(type);
             Contracts.Assert(type.IsVector);
 
-            if (!type.ItemType.IsStandardScalar && !type.ItemType.IsKey)
+            if (!type.ItemType.IsStandardScalar() && !type.ItemType.IsKey)
             {
                 itw.Write(": Can't display value of this type");
                 return;

--- a/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Data.Commands
         {
             Contracts.AssertValue(ch);
             ch.AssertValue(type);
-            ch.Assert(type.IsStandardScalar);
+            ch.Assert(type.IsStandardScalar());
 
             var conv = Conversions.Instance;
             InPredicate<T> isNaDel;

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -457,7 +457,7 @@ namespace Microsoft.ML.Data.Conversion
                 conv = GetKeyParse(keyDst);
                 return true;
             }
-            else if (!typeDst.IsStandardScalar)
+            else if (!typeDst.IsStandardScalar())
                 return false;
 
             Contracts.Assert(typeSrc.RawKind != 0);
@@ -567,7 +567,7 @@ namespace Microsoft.ML.Data.Conversion
         public TryParseMapper<TDst> GetTryParseConversion<TDst>(ColumnType typeDst)
         {
             Contracts.CheckValue(typeDst, nameof(typeDst));
-            Contracts.CheckParam(typeDst.IsStandardScalar || typeDst.IsKey, nameof(typeDst),
+            Contracts.CheckParam(typeDst.IsStandardScalar() || typeDst.IsKey, nameof(typeDst),
                 "Parse conversion only supported for standard types");
             Contracts.Check(typeDst.RawType == typeof(TDst), "Wrong TDst type parameter");
 
@@ -676,7 +676,7 @@ namespace Microsoft.ML.Data.Conversion
 
             var t = type;
             Delegate del;
-            if (!t.IsStandardScalar && !t.IsKey || !_isDefaultDelegates.TryGetValue(t.RawKind, out del))
+            if (!t.IsStandardScalar() && !t.IsKey || !_isDefaultDelegates.TryGetValue(t.RawKind, out del))
                 throw Contracts.Except("No IsDefault predicate for '{0}'", type);
 
             return (InPredicate<T>)del;
@@ -719,7 +719,7 @@ namespace Microsoft.ML.Data.Conversion
                 Contracts.Assert(_isDefaultDelegates.ContainsKey(t.RawKind));
                 del = _isDefaultDelegates[t.RawKind];
             }
-            else if (!t.IsStandardScalar || !_isNADelegates.TryGetValue(t.RawKind, out del))
+            else if (!t.IsStandardScalar() || !_isNADelegates.TryGetValue(t.RawKind, out del))
             {
                 del = null;
                 return false;
@@ -742,7 +742,7 @@ namespace Microsoft.ML.Data.Conversion
                 Contracts.Assert(_hasZeroDelegates.ContainsKey(t.RawKind));
                 del = _hasZeroDelegates[t.RawKind];
             }
-            else if (!t.IsStandardScalar || !_hasNADelegates.TryGetValue(t.RawKind, out del))
+            else if (!t.IsStandardScalar() || !_hasNADelegates.TryGetValue(t.RawKind, out del))
                 throw Contracts.Except("No HasMissing predicate for '{0}'", type);
 
             return (InPredicate<VBuffer<T>>)del;

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -452,7 +452,7 @@ namespace Microsoft.ML.Data.Conversion
             }
             else if (typeDst is KeyType keyDst)
             {
-                if (!typeSrc.IsText)
+                if (!(typeSrc is TextType))
                     return false;
                 conv = GetKeyParse(keyDst);
                 return true;

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Data
         /// </summary>
         public static bool IsCachable(this ColumnType type)
         {
-            return type != null && (type.IsPrimitive || type.IsVector);
+            return type != null && (type is PrimitiveType || type.IsVector);
         }
 
         /// <summary>
@@ -859,7 +859,7 @@ namespace Microsoft.ML.Data
                         pipeType = typeof(ImplVec<>).MakeGenericType(type.ItemType.RawType);
                     else
                     {
-                        Contracts.Assert(type.IsPrimitive);
+                        Contracts.Assert(type is PrimitiveType);
                         pipeType = typeof(ImplOne<>).MakeGenericType(type.RawType);
                     }
                     var constructor = pipeType.GetConstructor(new Type[] { typeof(object) });

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -46,13 +46,13 @@ namespace Microsoft.ML.Data
         public static Delegate GetGetterAs(ColumnType typeDst, Row row, int col)
         {
             Contracts.CheckValue(typeDst, nameof(typeDst));
-            Contracts.CheckParam(typeDst.IsPrimitive, nameof(typeDst));
+            Contracts.CheckParam(typeDst is PrimitiveType, nameof(typeDst));
             Contracts.CheckValue(row, nameof(row));
             Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema[col].Type;
-            Contracts.Check(typeSrc.IsPrimitive, "Source column type must be primitive");
+            Contracts.Check(typeSrc is PrimitiveType, "Source column type must be primitive");
 
             Func<ColumnType, ColumnType, Row, int, ValueGetter<int>> del = GetGetterAsCore<int, int>;
             var methodInfo = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(typeSrc.RawType, typeDst.RawType);
@@ -66,14 +66,14 @@ namespace Microsoft.ML.Data
         public static ValueGetter<TDst> GetGetterAs<TDst>(ColumnType typeDst, Row row, int col)
         {
             Contracts.CheckValue(typeDst, nameof(typeDst));
-            Contracts.CheckParam(typeDst.IsPrimitive, nameof(typeDst));
+            Contracts.CheckParam(typeDst is PrimitiveType, nameof(typeDst));
             Contracts.CheckParam(typeDst.RawType == typeof(TDst), nameof(typeDst));
             Contracts.CheckValue(row, nameof(row));
             Contracts.CheckParam(0 <= col && col < row.Schema.Count, nameof(col));
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema[col].Type;
-            Contracts.Check(typeSrc.IsPrimitive, "Source column type must be primitive");
+            Contracts.Check(typeSrc is PrimitiveType, "Source column type must be primitive");
 
             Func<ColumnType, ColumnType, Row, int, ValueGetter<TDst>> del = GetGetterAsCore<int, TDst>;
             var methodInfo = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(typeSrc.RawType, typeof(TDst));
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Data
             Contracts.CheckParam(row.IsColumnActive(col), nameof(col), "column was not active");
 
             var typeSrc = row.Schema[col].Type;
-            Contracts.Check(typeSrc.IsPrimitive, "Source column type must be primitive");
+            Contracts.Check(typeSrc is PrimitiveType, "Source column type must be primitive");
             return Utils.MarshalInvoke(GetGetterAsStringBuilderCore<int>, typeSrc.RawType, typeSrc, row, col);
         }
 

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -356,7 +356,7 @@ namespace Microsoft.ML.Data
 
         public static string TestGetLabelGetter(ColumnType type, bool allowKeys)
         {
-            if (type == NumberType.R4 || type == NumberType.R8 || type.IsBool)
+            if (type == NumberType.R4 || type == NumberType.R8 || type is BoolType)
                 return null;
 
             if (allowKeys && type.IsKey)
@@ -394,7 +394,7 @@ namespace Microsoft.ML.Data
             Contracts.Assert(type != NumberType.R4 && type != NumberType.R8);
 
             // boolean type label mapping: True -> 1, False -> 0.
-            if (type.IsBool)
+            if (type is BoolType)
             {
                 var getBoolSrc = cursor.GetGetter<bool>(labelIndex);
                 return
@@ -429,7 +429,7 @@ namespace Microsoft.ML.Data
             var type = cursor.GetSlotType().ItemType;
             if (type == NumberType.R4)
                 return cursor.GetGetter<Single>();
-            if (type == NumberType.R8 || type.IsBool)
+            if (type == NumberType.R8 || type is BoolType)
                 return GetVecGetterAs<Single>(NumberType.R4, cursor);
             Contracts.Check(type.IsKey, "Only floating point number, boolean, and key type values can be used as label.");
             Contracts.Assert(TestGetLabelGetter(type) == null);

--- a/src/Microsoft.ML.Data/DataLoadSave/DataOperations.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataOperations.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML
             Environment.CheckParam(lowerBound <= upperBound, nameof(upperBound), "Must be no less than lowerBound");
 
             var type = input.Schema[columnName].Type;
-            if (!type.IsNumber)
+            if (!(type is NumberType))
                 throw Environment.ExceptSchemaMismatch(nameof(columnName), "filter", columnName, "number", type.ToString());
             return new RangeFilter(Environment, input, columnName, lowerBound, upperBound, false);
         }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Data
 
             private Func<RowSet, ColumnPipe> GetCreatorOneCore<T>(PrimitiveType type)
             {
-                Contracts.Assert(type.IsStandardScalar || type.IsKey);
+                Contracts.Assert(type.IsStandardScalar() || type.IsKey);
                 Contracts.Assert(typeof(T) == type.RawType);
                 var fn = _conv.GetTryParseConversion<T>(type);
                 return rows => new PrimitivePipe<T>(rows, type, fn);
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Data
 
             private Func<RowSet, ColumnPipe> GetCreatorVecCore<T>(PrimitiveType type)
             {
-                Contracts.Assert(type.IsStandardScalar || type.IsKey);
+                Contracts.Assert(type.IsStandardScalar() || type.IsKey);
                 Contracts.Assert(typeof(T) == type.RawType);
                 var fn = _conv.GetTryParseConversion<T>(type);
                 return rows => new VectorPipe<T>(rows, type, fn);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Data.IO
                 Contracts.Assert(type.RawType == typeof(T));
 
                 Sep = sep;
-                if (type.IsText)
+                if (type is TextType)
                 {
                     // For text we need to deal with escaping.
                     ValueMapper<ReadOnlyMemory<char>, StringBuilder> c = MapText;
@@ -154,7 +154,7 @@ namespace Microsoft.ML.Data.IO
                 ColumnType typeNames;
                 if (type.IsKnownSizeVector &&
                     (typeNames = cursor.Schema[source].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type) != null &&
-                    typeNames.VectorSize == type.VectorSize && typeNames.ItemType.IsText)
+                    typeNames.VectorSize == type.VectorSize && typeNames.ItemType is TextType)
                 {
                     cursor.Schema[source].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref _slotNames);
                     Contracts.Check(_slotNames.Length == typeNames.VectorSize, "Unexpected slot names length");
@@ -407,7 +407,7 @@ namespace Microsoft.ML.Data.IO
                     if (!type.IsKnownSizeVector)
                         continue;
                     var typeNames = data.Schema[cols[i]].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-                    if (typeNames != null && typeNames.VectorSize == type.VectorSize && typeNames.ItemType.IsText)
+                    if (typeNames != null && typeNames.VectorSize == type.VectorSize && typeNames.ItemType is TextType)
                         hasHeader = true;
                 }
             }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Data.IO
             protected ValueWriterBase(PrimitiveType type, int source, char sep)
                 : base(source)
             {
-                Contracts.Assert(type.IsStandardScalar || type.IsKey);
+                Contracts.Assert(type.IsStandardScalar() || type.IsKey);
                 Contracts.Assert(type.RawType == typeof(T));
 
                 Sep = sep;
@@ -314,7 +314,7 @@ namespace Microsoft.ML.Data.IO
         public bool IsColumnSavable(ColumnType type)
         {
             var item = type.ItemType;
-            return item.IsStandardScalar || item.IsKey;
+            return item.IsStandardScalar() || item.IsKey;
         }
 
         public void SaveData(Stream stream, IDataView data, params int[] cols)

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -1369,7 +1369,7 @@ namespace Microsoft.ML.Data
                     pipeType = typeof(ImplVec<>).MakeGenericType(type.ItemType.RawType);
                 else
                 {
-                    host.Assert(type.IsPrimitive);
+                    host.Assert(type is PrimitiveType);
                     pipeType = typeof(ImplOne<>).MakeGenericType(type.RawType);
                 }
                 if (_pipeConstructorTypes == null)

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -190,7 +190,7 @@ namespace Microsoft.ML.Data
                     del = CreateDirectVBufferGetterDelegate<int>;
                     genericType = colType.ItemType.RawType;
                 }
-                else if (colType.IsPrimitive)
+                else if (colType is PrimitiveType)
                 {
                     if (outputType == typeof(string))
                     {
@@ -932,7 +932,7 @@ namespace Microsoft.ML.Data
                     .MakeGenericMethod(MetadataType.ItemType.RawType)
                     .Invoke(this, new object[] { }) as ValueGetter<TDst>;
             }
-            if (MetadataType.IsPrimitive)
+            if (MetadataType is PrimitiveType)
             {
                 if (typeT == typeof(string))
                 {

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -168,7 +168,7 @@ namespace Microsoft.ML.Data
                     // String[] -> ReadOnlyMemory<char>
                     if (outputType.GetElementType() == typeof(string))
                     {
-                        Host.Assert(colType.ItemType.IsText);
+                        Host.Assert(colType.ItemType is TextType);
                         return CreateConvertingArrayGetterDelegate<string, ReadOnlyMemory<char>>(peek, x => x != null ? x.AsMemory() : ReadOnlyMemory<char>.Empty);
                     }
 
@@ -195,7 +195,7 @@ namespace Microsoft.ML.Data
                     if (outputType == typeof(string))
                     {
                         // String -> ReadOnlyMemory<char>
-                        Host.Assert(colType.IsText);
+                        Host.Assert(colType is TextType);
                         return CreateConvertingGetterDelegate<String, ReadOnlyMemory<char>>(peek, x => x != null ? x.AsMemory() : ReadOnlyMemory<char>.Empty);
                     }
 
@@ -937,7 +937,7 @@ namespace Microsoft.ML.Data
                 if (typeT == typeof(string))
                 {
                     // String -> ReadOnlyMemory<char>
-                    Contracts.Assert(MetadataType.IsText);
+                    Contracts.Assert(MetadataType is TextType);
                     ValueGetter<ReadOnlyMemory<char>> m = GetString;
                     return m as ValueGetter<TDst>;
                 }

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -416,7 +416,7 @@ namespace Microsoft.ML.Data
                     Ch.Assert(parent._splitLim[iinfo] - _col == 1);
                 }
                 Ch.AssertValue(_view);
-                Ch.Assert(_view.Schema[_col].Type.IsPrimitive);
+                Ch.Assert(_view.Schema[_col].Type is PrimitiveType);
                 Ch.Assert(_view.Schema[_col].Type.RawType == typeof(T));
                 _len = parent.RowCount;
             }
@@ -1015,7 +1015,7 @@ namespace Microsoft.ML.Data
                 public static Splitter Create(IDataView view, int col)
                 {
                     var type = view.Schema[col].Type;
-                    Contracts.Assert(type.IsPrimitive || type.VectorSize > 0);
+                    Contracts.Assert(type is PrimitiveType || type.VectorSize > 0);
                     const int defaultSplitThreshold = 16;
                     if (type.VectorSize <= defaultSplitThreshold)
                         return Utils.MarshalInvoke(CreateCore<int>, type.RawType, view, col);

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -296,7 +296,7 @@ namespace Microsoft.ML.Data
                     del = CreateVBufferToVBufferSetter<int>;
                     genericType = colType.ItemType.RawType;
                 }
-                else if (colType.IsPrimitive)
+                else if (colType is PrimitiveType)
                 {
                     if (fieldType == typeof(string))
                     {

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -274,7 +274,7 @@ namespace Microsoft.ML.Data
                     // VBuffer<ReadOnlyMemory<char>> -> String[]
                     if (fieldType.GetElementType() == typeof(string))
                     {
-                        Ch.Assert(colType.ItemType.IsText);
+                        Ch.Assert(colType.ItemType is TextType);
                         return CreateConvertingVBufferSetter<ReadOnlyMemory<char>, string>(input, index, poke, peek, x => x.ToString());
                     }
 
@@ -301,7 +301,7 @@ namespace Microsoft.ML.Data
                     if (fieldType == typeof(string))
                     {
                         // ReadOnlyMemory<char> -> String
-                        Ch.Assert(colType.IsText);
+                        Ch.Assert(colType is TextType);
                         Ch.Assert(peek == null);
                         return CreateConvertingActionSetter<ReadOnlyMemory<char>, string>(input, index, poke, x => x.ToString());
                     }

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -365,7 +365,7 @@ namespace Microsoft.ML.Data
                 Contracts.AssertNonWhiteSpace(stratCol);
                 Contracts.AssertValue(createAgg);
 
-                if (stratType.KeyCount == 0 && !stratType.IsText)
+                if (stratType.KeyCount == 0 && !(stratType is TextType))
                 {
                     throw Contracts.ExceptUserArg(nameof(MamlEvaluatorBase.ArgumentsBase.StratColumn),
                         "Stratification column '{0}' has type '{1}', but must be a known count key or text", stratCol, stratType);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Data
         private static bool CheckScoreColumnKindIsKnown(Schema schema, int col)
         {
             var columnType = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
-            if (columnType == null || !columnType.IsText)
+            if (columnType == null || !(columnType is TextType))
                 return false;
             ReadOnlyMemory<char> tmp = default;
             schema[col].Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnKind, ref tmp);
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Data
         private static bool CheckScoreColumnKind(Schema schema, int col)
         {
             var columnType = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
-            return columnType != null && columnType.IsText;
+            return columnType != null && columnType is TextType;
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace Microsoft.ML.Data
             ectx.CheckNonEmpty(kind, nameof(kind));
 
             var type = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnKind)?.Type;
-            if (type == null || !type.IsText)
+            if (type == null || !(type is TextType))
                 return false;
             var tmp = default(ReadOnlyMemory<char>);
             schema[col].Metadata.GetValue(MetadataUtils.Kinds.ScoreColumnKind, ref tmp);
@@ -346,7 +346,7 @@ namespace Microsoft.ML.Data
                             VBuffer<ReadOnlyMemory<char>> names = default;
                             var size = schema[i].Type.VectorSize;
                             var slotNamesType = schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-                            if (slotNamesType != null && slotNamesType.VectorSize == size && slotNamesType.ItemType.IsText)
+                            if (slotNamesType != null && slotNamesType.VectorSize == size && slotNamesType.ItemType is TextType)
                                 schema[i].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref names);
                             else
                             {
@@ -1014,7 +1014,7 @@ namespace Microsoft.ML.Data
                     vBufferGetters[i] = row.GetGetter<VBuffer<double>>(i);
                     metricCount += type.VectorSize;
                     var slotNamesType = schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-                    if (slotNamesType != null && slotNamesType.VectorSize == type.VectorSize && slotNamesType.ItemType.IsText)
+                    if (slotNamesType != null && slotNamesType.VectorSize == type.VectorSize && slotNamesType.ItemType is TextType)
                         schema[i].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref names);
                     else
                     {
@@ -1214,7 +1214,7 @@ namespace Microsoft.ML.Data
                 if (i == stratCol)
                 {
                     var keyValuesType = schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
-                    if (keyValuesType == null || !keyValuesType.ItemType.IsText ||
+                    if (keyValuesType == null || !(keyValuesType.ItemType is TextType) ||
                         keyValuesType.VectorSize != type.KeyCount)
                     {
                         throw env.Except("Column '{0}' must have key values metadata",
@@ -1343,7 +1343,7 @@ namespace Microsoft.ML.Data
             int countCol;
             host.Check(confusionDataView.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.Count, out countCol), "Did not find the count column");
             var type = confusionDataView.Schema[countCol].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-            host.Check(type != null && type.IsKnownSizeVector && type.ItemType.IsText, "The Count column does not have a text vector metadata of kind SlotNames.");
+            host.Check(type != null && type.IsKnownSizeVector && type.ItemType is TextType, "The Count column does not have a text vector metadata of kind SlotNames.");
 
             var labelNames = default(VBuffer<ReadOnlyMemory<char>>);
             confusionDataView.Schema[countCol].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref labelNames);
@@ -1687,7 +1687,7 @@ namespace Microsoft.ML.Data
             if (metrics.TryGetValue(MetricKinds.Warnings, out warnings))
             {
                 int col;
-                if (warnings.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.WarningText, out col) && warnings.Schema[col].Type.IsText)
+                if (warnings.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.WarningText, out col) && warnings.Schema[col].Type is TextType)
                 {
                     using (var cursor = warnings.GetRowCursor(c => c == col))
                     {

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -997,7 +997,7 @@ namespace Microsoft.ML.Data
 
                 var type = schema[i].Type;
                 var metricName = row.Schema[i].Name;
-                if (type.IsNumber)
+                if (type is NumberType)
                 {
                     getters[i] = RowCursorUtils.GetGetterAs<double>(NumberType.R8, row, i);
                     metricNames.Add(metricName);
@@ -1251,7 +1251,7 @@ namespace Microsoft.ML.Data
                     dvBldr.AddColumn(MetricKinds.ColumnNames.FoldIndex, TextType.Instance, foldVals);
                     weightedDvBldr?.AddColumn(MetricKinds.ColumnNames.FoldIndex, TextType.Instance, foldVals);
                 }
-                else if (type.IsNumber)
+                else if (type is NumberType)
                 {
                     dvBldr.AddScalarColumn(schema, agg, hasStdev, numFolds, iMetric);
                     weightedDvBldr?.AddScalarColumn(schema, weightedAgg, hasStdev, numFolds, iMetric);

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Data
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var mdType = schema.Schema[scoreInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
             var labelNames = default(VBuffer<ReadOnlyMemory<char>>);
-            if (mdType != null && mdType.IsKnownSizeVector && mdType.ItemType.IsText)
+            if (mdType != null && mdType.IsKnownSizeVector && mdType.ItemType is TextType)
             {
                 schema.Schema[scoreInfo.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref labelNames);
                 names = new ReadOnlyMemory<char>[labelNames.Length];

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -591,7 +591,7 @@ namespace Microsoft.ML.Data
         private ValueGetter<VBuffer<ReadOnlyMemory<char>>> CreateSlotNamesGetter(Schema schema, int column, int length, string prefix)
         {
             var type = schema[column].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-            if (type != null && type.IsText)
+            if (type != null && type is TextType)
             {
                 return
                     (ref VBuffer<ReadOnlyMemory<char>> dst) => schema[column].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref dst);

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Data
             var scoreInfo = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             int scoreSize = scoreInfo.Type.VectorSize;
             var type = schema.Schema[scoreInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-            Host.Check(type != null && type.IsKnownSizeVector && type.ItemType.IsText, "Quantile regression score column must have slot names");
+            Host.Check(type != null && type.IsKnownSizeVector && type.ItemType is TextType, "Quantile regression score column must have slot names");
             var quantiles = default(VBuffer<ReadOnlyMemory<char>>);
             schema.Schema[scoreInfo.Index].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref quantiles);
             Host.Assert(quantiles.IsDense && quantiles.Length == scoreSize);
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Data
             Host.Assert(t.VectorSize > 0 && (t.ItemType == NumberType.R4 || t.ItemType == NumberType.R8));
             var slotNames = default(VBuffer<ReadOnlyMemory<char>>);
             t = schema.Schema[scoreInfo.Index].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-            if (t != null && t.VectorSize == scoreInfo.Type.VectorSize && t.ItemType.IsText)
+            if (t != null && t.VectorSize == scoreInfo.Type.VectorSize && t.ItemType is TextType)
                 schema.Schema[scoreInfo.Index].GetSlotNames(ref slotNames);
             return new Aggregator(Host, LossFunction, schema.Weight != null, scoreInfo.Type.VectorSize, in slotNames, stratName);
         }

--- a/src/Microsoft.ML.Data/Model/Pfa/PfaUtils.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/PfaUtils.cs
@@ -173,7 +173,7 @@ namespace Microsoft.ML.Model.Pfa
             {
                 Contracts.AssertValue(itemType);
 
-                if (!itemType.IsPrimitive)
+                if (!(itemType is PrimitiveType))
                     return null;
 
                 if (itemType.IsKey)

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -537,7 +537,7 @@ namespace Microsoft.ML.Internal.Calibration
                 if (!_predictor.OutputSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out _scoreCol))
                     throw env.Except("Predictor does not output a score");
                 var scoreType = _predictor.OutputSchema[_scoreCol].Type;
-                env.Check(!scoreType.IsVector && scoreType.IsNumber);
+                env.Check(!scoreType.IsVector && scoreType is NumberType);
                 OutputSchema = Schema.Create(new BinaryClassifierSchema());
             }
 

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -791,7 +791,7 @@ namespace Microsoft.ML.Data
                         var srcName = _columnInfo.Inputs[i].name;
                         if ((srcTokens[i] = ctx.TokenOrNullForName(srcName)) == null)
                             return new KeyValuePair<string, JToken>(outName, null);
-                        srcPrimitive[i] = _srcTypes[i].IsPrimitive;
+                        srcPrimitive[i] = _srcTypes[i] is PrimitiveType;
                     }
                     Contracts.Assert(srcTokens.All(tok => tok != null));
                     var itemColumnType = OutputType.ItemType;

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -625,7 +625,7 @@ namespace Microsoft.ML.Data
                         if (inputMetadata != null && inputMetadata.Schema.TryGetColumnIndex(MetadataUtils.Kinds.SlotNames, out int idx))
                             typeNames = inputMetadata.Schema[idx].Type;
 
-                        if (typeNames != null && typeNames.VectorSize == typeSrc.VectorSize && typeNames.ItemType.IsText)
+                        if (typeNames != null && typeNames.VectorSize == typeSrc.VectorSize && typeNames.ItemType is TextType)
                         {
                             inputMetadata.GetValue(MetadataUtils.Kinds.SlotNames, ref names);
                             sb.Clear();

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -486,7 +486,7 @@ namespace Microsoft.ML.Data
                         hasSlotNames = true;
                 }
 
-                if (!itemType.IsNumber)
+                if (!(itemType is NumberType))
                     isNormalized = false;
                 if (totalSize == 0)
                 {

--- a/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/DropSlotsTransform.cs
@@ -475,7 +475,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
             /// a string, a key, a float or a double.
             /// </summary>
             private static bool IsValidColumnType(ColumnType type)
-                => (0 < type.KeyCount && type.KeyCount < Utils.ArrayMaxSize) || type == NumberType.R4 || type == NumberType.R8 || type.IsText;
+                => (0 < type.KeyCount && type.KeyCount < Utils.ArrayMaxSize) || type == NumberType.R4 || type == NumberType.R8 || type is TextType;
 
             /// <summary>
             /// Computes the types (column and slotnames), the length reduction, categorical feature indices

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.ML.Transforms.Conversions
         internal static bool IsColumnTypeValid(ColumnType type)
         {
             var itemType = type.ItemType;
-            return itemType.IsText || itemType.IsKey || itemType is NumberType || itemType is BoolType;
+            return itemType is TextType || itemType.IsKey || itemType is NumberType || itemType is BoolType;
         }
 
         internal const string ExpectedColumnType = "Expected Text, Key, numeric or Boolean item type";

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.ML.Transforms.Conversions
         internal static bool IsColumnTypeValid(ColumnType type)
         {
             var itemType = type.ItemType;
-            return itemType.IsText || itemType.IsKey || itemType.IsNumber || itemType is BoolType;
+            return itemType.IsText || itemType.IsKey || itemType is NumberType || itemType is BoolType;
         }
 
         internal const string ExpectedColumnType = "Expected Text, Key, numeric or Boolean item type";

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.ML.Transforms.Conversions
         internal static bool IsColumnTypeValid(ColumnType type)
         {
             var itemType = type.ItemType;
-            return itemType.IsText || itemType.IsKey || itemType.IsNumber || itemType.IsBool;
+            return itemType.IsText || itemType.IsKey || itemType.IsNumber || itemType is BoolType;
         }
 
         internal const string ExpectedColumnType = "Expected Text, Key, numeric or Boolean item type";

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -357,7 +357,7 @@ namespace Microsoft.ML.Data
                 throw ch.ExceptDecode();
             ch.AssertValue(codec);
             ch.CheckDecode(codec.Type.IsVector);
-            ch.CheckDecode(codec.Type.ItemType.IsText);
+            ch.CheckDecode(codec.Type.ItemType is TextType);
             var textCodec = (IValueCodec<VBuffer<ReadOnlyMemory<char>>>)codec;
 
             var bufferLen = ctx.Reader.ReadInt32();

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -464,7 +464,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     // probably, which I am not prepared to do.
                     var defaultToken = PfaUtils.Type.DefaultTokenOrNull(TypeOutput);
                     JArray jsonValues;
-                    if (TypeOutput.IsText)
+                    if (TypeOutput is TextType)
                     {
                         jsonValues = new JArray();
                         var keyValues = _values.GetValues();

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -758,7 +758,7 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if ((col.ItemType.ItemType.RawKind == default) || !(col.ItemType.IsVector || col.ItemType.IsPrimitive))
+                if ((col.ItemType.ItemType.RawKind == default) || !(col.ItemType.IsVector || col.ItemType is PrimitiveType))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
                 var metadata = new List<SchemaShape.Column>();

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -313,7 +313,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 int metaKeyValuesCol = 0;
                 if (inputMetadata.Schema.TryGetColumnIndex(MetadataUtils.Kinds.KeyValues, out metaKeyValuesCol))
                     typeNames = inputMetadata.Schema[metaKeyValuesCol].Type;
-                if (typeNames == null || !typeNames.IsKnownSizeVector || !typeNames.ItemType.IsText ||
+                if (typeNames == null || !typeNames.IsKnownSizeVector || !(typeNames.ItemType is TextType) ||
                     typeNames.VectorSize != _infos[iinfo].TypeSrc.ItemType.KeyCount)
                 {
                     typeNames = null;
@@ -377,7 +377,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 var inputMetadata = InputSchema[_infos[iinfo].Source].Metadata;
                 Contracts.AssertValue(inputMetadata);
                 var typeSlotSrc = inputMetadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-                if (typeSlotSrc != null && typeSlotSrc.VectorSize == typeSrc.VectorSize && typeSlotSrc.ItemType.IsText)
+                if (typeSlotSrc != null && typeSlotSrc.VectorSize == typeSrc.VectorSize && typeSlotSrc.ItemType is TextType)
                 {
                     inputMetadata.GetValue(MetadataUtils.Kinds.SlotNames, ref namesSlotSrc);
                     Host.Check(namesSlotSrc.Length == typeSrc.VectorSize);
@@ -763,7 +763,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
                 var metadata = new List<SchemaShape.Column>();
                 if (col.Metadata.TryFindColumn(MetadataUtils.Kinds.KeyValues, out var keyMeta))
-                    if (col.Kind != SchemaShape.Column.VectorKind.VariableVector && keyMeta.ItemType.IsText)
+                    if (col.Kind != SchemaShape.Column.VectorKind.VariableVector && keyMeta.ItemType is TextType)
                         metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, keyMeta.ItemType, false));
                 if (!colInfo.Bag && (col.Kind == SchemaShape.Column.VectorKind.Scalar || col.Kind == SchemaShape.Column.VectorKind.Vector))
                     metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.CategoricalSlotRanges, SchemaShape.Column.VectorKind.Vector, NumberType.I4, false));

--- a/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
+++ b/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
@@ -424,7 +424,7 @@ namespace Microsoft.ML.Data
                 Contracts.CheckNonEmpty(kind, nameof(kind));
                 Contracts.CheckValue(type, nameof(type));
                 Contracts.CheckParam(type.RawType == typeof(TValue), nameof(type), "Given type doesn't match type parameter");
-                Contracts.CheckParam(type.IsPrimitive, nameof(type), "Must be a primitive type");
+                Contracts.CheckParam(type is PrimitiveType, nameof(type), "Must be a primitive type");
 
                 if (_getters != null && _getters.Any(g => g.Kind == kind))
                     throw Contracts.Except("Duplicate specification of metadata");

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
@@ -370,14 +370,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             public static AffineColumnFunction Create(ModelLoadContext ctx, IHost host, ColumnType typeSrc)
             {
                 Contracts.CheckValue(host, nameof(host));
-                if (typeSrc.IsNumber)
+                if (typeSrc is NumberType)
                 {
                     if (typeSrc == NumberType.R4)
                         return Sng.ImplOne.Create(ctx, host, typeSrc);
                     if (typeSrc == NumberType.R8)
                         return Dbl.ImplOne.Create(ctx, host, typeSrc);
                 }
-                else if (typeSrc.ItemType.IsNumber)
+                else if (typeSrc.ItemType is NumberType)
                 {
                     if (typeSrc.ItemType == NumberType.R4)
                         return Sng.ImplVec.Create(ctx, host, typeSrc);
@@ -487,14 +487,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             public static CdfColumnFunction Create(ModelLoadContext ctx, IHost host, ColumnType typeSrc)
             {
                 Contracts.CheckValue(host, nameof(host));
-                if (typeSrc.IsNumber)
+                if (typeSrc is NumberType)
                 {
                     if (typeSrc == NumberType.R4)
                         return Sng.ImplOne.Create(ctx, host, typeSrc);
                     if (typeSrc == NumberType.R8)
                         return Dbl.ImplOne.Create(ctx, host, typeSrc);
                 }
-                else if (typeSrc.ItemType.IsNumber)
+                else if (typeSrc.ItemType is NumberType)
                 {
                     if (typeSrc.ItemType == NumberType.R4)
                         return Sng.ImplVec.Create(ctx, host, typeSrc);
@@ -621,14 +621,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             public static BinColumnFunction Create(ModelLoadContext ctx, IHost host, ColumnType typeSrc)
             {
                 Contracts.CheckValue(host, nameof(host));
-                if (typeSrc.IsNumber)
+                if (typeSrc is NumberType)
                 {
                     if (typeSrc == NumberType.R4)
                         return Sng.ImplOne.Create(ctx, host, typeSrc);
                     if (typeSrc == NumberType.R8)
                         return Dbl.ImplOne.Create(ctx, host, typeSrc);
                 }
-                if (typeSrc.IsVector && typeSrc.ItemType.IsNumber)
+                if (typeSrc.IsVector && typeSrc.ItemType is NumberType)
                 {
                     if (typeSrc.ItemType == NumberType.R4)
                         return Sng.ImplVec.Create(ctx, host, typeSrc);
@@ -746,7 +746,7 @@ namespace Microsoft.ML.Transforms.Normalizers
             {
                 // The label column type is checked as part of args validation.
                 var type = row.Schema[col].Type;
-                Host.Assert(type.IsKey || type.IsNumber);
+                Host.Assert(type.IsKey || type is NumberType);
 
                 if (type.IsKey)
                 {
@@ -914,14 +914,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             public static IColumnFunctionBuilder CreateBuilder(NormalizingEstimator.MinMaxColumn column, IHost host,
                 int srcIndex, ColumnType srcType, RowCursor cursor)
             {
-                if (srcType.IsNumber)
+                if (srcType is NumberType)
                 {
                     if (srcType == NumberType.R4)
                         return Sng.MinMaxOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
                     if (srcType == NumberType.R8)
                         return Dbl.MinMaxOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
                 }
-                if (srcType.IsKnownSizeVector && srcType.ItemType.IsNumber)
+                if (srcType.IsKnownSizeVector && srcType.ItemType is NumberType)
                 {
                     if (srcType.ItemType == NumberType.R4)
                         return Sng.MinMaxVecColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
@@ -953,14 +953,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             {
                 Contracts.AssertValue(host);
 
-                if (srcType.IsNumber)
+                if (srcType is NumberType)
                 {
                     if (srcType == NumberType.R4)
                         return Sng.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
                     if (srcType == NumberType.R8)
                         return Dbl.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
                 }
-                if (srcType.IsKnownSizeVector && srcType.ItemType.IsNumber)
+                if (srcType.IsKnownSizeVector && srcType.ItemType is NumberType)
                 {
                     if (srcType.ItemType == NumberType.R4)
                         return Sng.MeanVarVecColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
@@ -993,14 +993,14 @@ namespace Microsoft.ML.Transforms.Normalizers
                 Contracts.AssertValue(host);
                 host.AssertValue(column);
 
-                if (srcType.IsNumber)
+                if (srcType is NumberType)
                 {
                     if (srcType == NumberType.R4)
                         return Sng.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
                     if (srcType == NumberType.R8)
                         return Dbl.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
                 }
-                if (srcType.IsKnownSizeVector && srcType.ItemType.IsNumber)
+                if (srcType.IsKnownSizeVector && srcType.ItemType is NumberType)
                 {
                     if (srcType.ItemType == NumberType.R4)
                         return Sng.MeanVarVecColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
@@ -1032,14 +1032,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             {
                 Contracts.AssertValue(host);
 
-                if (srcType.IsNumber)
+                if (srcType is NumberType)
                 {
                     if (srcType == NumberType.R4)
                         return Sng.BinOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
                     if (srcType == NumberType.R8)
                         return Dbl.BinOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
                 }
-                if (srcType.IsKnownSizeVector && srcType.ItemType.IsNumber)
+                if (srcType.IsKnownSizeVector && srcType.ItemType is NumberType)
                 {
                     if (srcType.ItemType == NumberType.R4)
                         return Sng.BinVecColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
@@ -1065,7 +1065,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 if (labelColumnType.IsKey)
                     host.CheckUserArg(labelColumnType.KeyCount > 0, nameof(args.LabelColumn), "Label column must have a known cardinality");
                 else
-                    host.CheckUserArg(labelColumnType.IsNumber, nameof(args.LabelColumn), "Label column must be a number or a key type");
+                    host.CheckUserArg(labelColumnType is NumberType, nameof(args.LabelColumn), "Label column must be a number or a key type");
 
                 return CreateBuilder(
                     new NormalizingEstimator.SupervisedBinningColumn(
@@ -1091,14 +1091,14 @@ namespace Microsoft.ML.Transforms.Normalizers
             {
                 Contracts.AssertValue(host);
 
-                if (srcType.IsNumber)
+                if (srcType is NumberType)
                 {
                     if (srcType == NumberType.R4)
                         return Sng.SupervisedBinOneColumnFunctionBuilder.Create(column, host, srcIndex, labelColumnId, cursor);
                     if (srcType == NumberType.R8)
                         return Dbl.SupervisedBinOneColumnFunctionBuilder.Create(column, host, srcIndex, labelColumnId, cursor);
                 }
-                if (srcType.IsVector && srcType.ItemType.IsNumber)
+                if (srcType.IsVector && srcType.ItemType is NumberType)
                 {
                     if (srcType.ItemType == NumberType.R4)
                         return Sng.SupervisedBinVecColumnFunctionBuilder.Create(column, host, srcIndex, labelColumnId, cursor);

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -382,7 +382,7 @@ namespace Microsoft.ML.Transforms
                         pipeType = typeof(ImplVec<>).MakeGenericType(type.ItemType.RawType);
                     else
                     {
-                        Contracts.Assert(type.IsPrimitive);
+                        Contracts.Assert(type is PrimitiveType);
                         pipeType = typeof(ImplOne<>).MakeGenericType(type.RawType);
                     }
                     if (_pipeConstructorTypes == null)

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -899,21 +899,21 @@ namespace Microsoft.ML.Data
 
         protected static string TestIsText(ColumnType type)
         {
-            if (type.IsText)
+            if (type is TextType)
                 return null;
             return "Expected Text type";
         }
 
         protected static string TestIsTextItem(ColumnType type)
         {
-            if (type.ItemType.IsText)
+            if (type.ItemType is TextType)
                 return null;
             return "Expected Text type";
         }
 
         protected static string TestIsTextVector(ColumnType type)
         {
-            if (type.ItemType.IsText && type.IsVector)
+            if (type.ItemType is TextType && type.IsVector)
                 return null;
             return "Expected vector of Text type";
         }

--- a/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
+++ b/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
@@ -452,9 +452,9 @@ namespace Microsoft.ML.Transforms.Conversions
                     {
                         builder.Add(InputSchema[ColMapNewToOld[i]].Metadata, name => name == MetadataUtils.Kinds.KeyValues);
                     }
-                    if (srcType.ItemType.IsNumber && _types[i].ItemType.IsNumber)
+                    if (srcType.ItemType is NumberType && _types[i].ItemType is NumberType)
                         builder.Add(InputSchema[ColMapNewToOld[i]].Metadata, name => name == MetadataUtils.Kinds.IsNormalized);
-                    if (srcType is BoolType && _types[i].ItemType.IsNumber)
+                    if (srcType is BoolType && _types[i].ItemType is NumberType)
                     {
                         ValueGetter<bool> getter = (ref bool dst) => dst = true;
                         builder.Add(MetadataUtils.Kinds.IsNormalized, BoolType.Instance, getter);
@@ -558,7 +558,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 if (!Data.Conversion.Conversions.Instance.TryGetStandardConversion(col.ItemType, newType, out Delegate del, out bool identity))
                     throw Host.ExceptParam(nameof(inputSchema), $"Don't know how to convert {colInfo.Input} into {newType.ToString()}");
                 var metadata = new List<SchemaShape.Column>();
-                if (col.ItemType is BoolType && newType.ItemType.IsNumber)
+                if (col.ItemType is BoolType && newType.ItemType is NumberType)
                     metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar, BoolType.Instance, false));
                 if (col.Metadata.TryFindColumn(MetadataUtils.Kinds.SlotNames, out var slotMeta))
                     if (col.Kind == SchemaShape.Column.VectorKind.Vector)
@@ -567,7 +567,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     if (col.ItemType.IsKey)
                         metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.KeyValues, SchemaShape.Column.VectorKind.Vector, keyMeta.ItemType, false));
                 if (col.Metadata.TryFindColumn(MetadataUtils.Kinds.IsNormalized, out var normMeta))
-                    if (col.ItemType.IsNumber && newType.ItemType.IsNumber)
+                    if (col.ItemType is NumberType && newType.ItemType is NumberType)
                         metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.KeyValues, SchemaShape.Column.VectorKind.Vector, normMeta.ItemType, false));
                 result[colInfo.Output] = new SchemaShape.Column(colInfo.Output, col.Kind, newType, false, col.Metadata);
             }

--- a/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
+++ b/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
@@ -454,7 +454,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     }
                     if (srcType.ItemType.IsNumber && _types[i].ItemType.IsNumber)
                         builder.Add(InputSchema[ColMapNewToOld[i]].Metadata, name => name == MetadataUtils.Kinds.IsNormalized);
-                    if (srcType.IsBool && _types[i].ItemType.IsNumber)
+                    if (srcType is BoolType && _types[i].ItemType.IsNumber)
                     {
                         ValueGetter<bool> getter = (ref bool dst) => dst = true;
                         builder.Add(MetadataUtils.Kinds.IsNormalized, BoolType.Instance, getter);
@@ -558,7 +558,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 if (!Data.Conversion.Conversions.Instance.TryGetStandardConversion(col.ItemType, newType, out Delegate del, out bool identity))
                     throw Host.ExceptParam(nameof(inputSchema), $"Don't know how to convert {colInfo.Input} into {newType.ToString()}");
                 var metadata = new List<SchemaShape.Column>();
-                if (col.ItemType.IsBool && newType.ItemType.IsNumber)
+                if (col.ItemType is BoolType && newType.ItemType.IsNumber)
                     metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar, BoolType.Instance, false));
                 if (col.Metadata.TryFindColumn(MetadataUtils.Kinds.SlotNames, out var slotMeta))
                     if (col.Kind == SchemaShape.Column.VectorKind.Vector)

--- a/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
+++ b/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
@@ -364,7 +364,7 @@ namespace Microsoft.ML.Transforms.Conversions
             if (range != null)
             {
                 itemType = TypeParsingUtils.ConstructKeyType(kind, range);
-                if (!srcType.ItemType.IsKey && !srcType.ItemType.IsText)
+                if (!srcType.ItemType.IsKey && !(srcType.ItemType is TextType))
                     return false;
             }
             else if (!(srcType.ItemType is KeyType key))

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
-                if ((col.ItemType.ItemType.RawKind == default) || !(col.ItemType.IsVector || col.ItemType.IsPrimitive))
+                if ((col.ItemType.ItemType.RawKind == default) || !(col.ItemType.IsVector || col.ItemType is PrimitiveType))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
                 SchemaShape metadata;
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -263,7 +263,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
         internal string TestIsKnownDataKind(ColumnType type)
         {
-            if (type.ItemType.RawKind != default && (type.IsVector || type.IsPrimitive))
+            if (type.ItemType.RawKind != default && (type.IsVector || type is PrimitiveType))
                 return null;
             return "standard type or a vector of standard type";
         }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -758,7 +758,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
             private bool SaveAsOnnxCore(OnnxContext ctx, int iinfo, ColInfo info, string srcVariableName, string dstVariableName)
             {
-                if (!info.TypeSrc.ItemType.IsText)
+                if (!(info.TypeSrc.ItemType is TextType))
                     return false;
 
                 var terms = default(VBuffer<ReadOnlyMemory<char>>);
@@ -834,7 +834,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 Contracts.AssertValue(srcToken);
                 //Contracts.Assert(CanSavePfa);
 
-                if (!info.TypeSrc.ItemType.IsText)
+                if (!(info.TypeSrc.ItemType is TextType))
                     return null;
                 var terms = default(VBuffer<ReadOnlyMemory<char>>);
                 TermMap<ReadOnlyMemory<char>> map = (TermMap<ReadOnlyMemory<char>>)_termMap[iinfo].Map;

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
                 PrimitiveType itemType = type.ItemType as PrimitiveType;
                 Contracts.AssertValue(itemType);
-                if (itemType.IsText)
+                if (itemType is TextType)
                     return new TextImpl(sorted);
                 return Utils.MarshalInvoke(CreateCore<int>, itemType.RawType, itemType, sorted);
             }
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 var type = schema[col].Type;
                 Contracts.Assert(autoConvert || bldr.ItemType == type.ItemType);
                 // Auto conversion should only be possible when the type is text.
-                Contracts.Assert(type.IsText || !autoConvert);
+                Contracts.Assert(type is TextType || !autoConvert);
                 if (type.IsVector)
                     return Utils.MarshalInvoke(CreateVec<int>, bldr.ItemType.RawType, row, col, count, bldr);
                 return Utils.MarshalInvoke(CreateOne<int>, bldr.ItemType.RawType, row, col, autoConvert, count, bldr);
@@ -1041,7 +1041,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 {
                     if (TypedMap.Count == 0)
                         return;
-                    if (IsTextMetadata && !TypedMap.ItemType.IsText)
+                    if (IsTextMetadata && !(TypedMap.ItemType is TextType))
                     {
                         var conv = Data.Conversion.Conversions.Instance;
                         var stringMapper = conv.GetStringConversion<T>(TypedMap.ItemType);
@@ -1133,7 +1133,7 @@ namespace Microsoft.ML.Transforms.Conversions
                             dst = editor.Commit();
                         };
 
-                    if (IsTextMetadata && !srcMetaType.IsText)
+                    if (IsTextMetadata && !(srcMetaType is TextType))
                     {
                         var stringMapper = convInst.GetStringConversion<TMeta>(srcMetaType);
                         ValueGetter<VBuffer<ReadOnlyMemory<char>>> mgetter =

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Transforms.Conversions
             public static Builder Create(ColumnType type, SortOrder sortOrder)
             {
                 Contracts.AssertValue(type);
-                Contracts.Assert(type.IsVector || type.IsPrimitive);
+                Contracts.Assert(type.IsVector || type is PrimitiveType);
                 // Right now we have only two. This "public" interface externally looks like it might
                 // accept any value, but currently the internal implementations of Builder are split
                 // along this being a purely binary option, for now (though this can easily change
@@ -527,7 +527,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         IValueCodec codec;
                         if (!codecFactory.TryReadCodec(ctx.Reader.BaseStream, out codec))
                             throw ectx.Except("Unrecognized codec read");
-                        ectx.CheckDecode(codec.Type.IsPrimitive);
+                        ectx.CheckDecode(codec.Type is PrimitiveType);
                         int count = ctx.Reader.ReadInt32();
                         ectx.CheckDecode(count >= 0);
                         return Utils.MarshalInvoke(LoadCodecCore<int>, codec.Type.RawType, ctx, ectx, codec, count);
@@ -544,7 +544,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 ectx.AssertValue(ctx);
                 ectx.AssertValue(codec);
                 ectx.Assert(codec is IValueCodec<T>);
-                ectx.Assert(codec.Type.IsPrimitive);
+                ectx.Assert(codec.Type is PrimitiveType);
                 ectx.Assert(count >= 0);
 
                 IValueCodec<T> codecT = (IValueCodec<T>)codec;
@@ -699,7 +699,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         throw host.Except("We do not know how to serialize terms of type '{0}'", ItemType);
                     ctx.Writer.Write((byte)MapType.Codec);
                     host.Assert(codec.Type.Equals(ItemType));
-                    host.Assert(codec.Type.IsPrimitive);
+                    host.Assert(codec.Type is PrimitiveType);
                     codecFactory.WriteCodec(ctx.Writer.BaseStream, codec);
                     IValueCodec<T> codecT = (IValueCodec<T>)codec;
                     ctx.Writer.Write(_values.Count);

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Data
                 // Direct mapping is possible.
                 return GetColumnDirect<T>(data, col);
             }
-            else if (typeof(T) == typeof(string) && colType.IsText)
+            else if (typeof(T) == typeof(string) && colType is TextType)
             {
                 // Special case of ROM<char> to string conversion.
                 Delegate convert = (Func<ReadOnlyMemory<char>, string>)((ReadOnlyMemory<char> txt) => txt.ToString());
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Data
                     var meth = del.Method.GetGenericMethodDefinition().MakeGenericMethod(elementType);
                     return (IEnumerable<T>)meth.Invoke(null, new object[] { data, col });
                 }
-                else if (elementType == typeof(string) && colType.ItemType.IsText)
+                else if (elementType == typeof(string) && colType.ItemType is TextType)
                 {
                     // Conversion of DvText items to string items.
                     Delegate convert = (Func<ReadOnlyMemory<char>, string>)((ReadOnlyMemory<char> txt) => txt.ToString());

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -177,7 +177,7 @@ namespace Microsoft.ML.EntryPoints
                             continue;
                         }
                     }
-                    if (type.IsNumber || type is BoolType)
+                    if (type is NumberType || type is BoolType)
                     {
                         // Even if the column is R4 in training, we still want to add it to the conversion.
                         // The reason is that at scoring time, the column might have a slightly different type (R8 for example).
@@ -270,7 +270,7 @@ namespace Microsoft.ML.EntryPoints
             if (!input.Data.Schema.TryGetColumnIndex(input.PredictedLabelColumn, out predictedLabelCol))
                 throw host.Except($"Column '{input.PredictedLabelColumn}' not found.");
             var predictedLabelType = input.Data.Schema[predictedLabelCol].Type;
-            if (predictedLabelType.IsNumber || predictedLabelType is BoolType)
+            if (predictedLabelType is NumberType || predictedLabelType is BoolType)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
                 return new CommonOutputs.TransformOutput { Model = new TransformModelImpl(env, nop, input.Data), OutputData = nop };
@@ -292,7 +292,7 @@ namespace Microsoft.ML.EntryPoints
             if (!input.Data.Schema.TryGetColumnIndex(input.LabelColumn, out labelCol))
                 throw host.Except($"Column '{input.LabelColumn}' not found.");
             var labelType = input.Data.Schema[labelCol].Type;
-            if (labelType == NumberType.R4 || !labelType.IsNumber)
+            if (labelType == NumberType.R4 || !(labelType is NumberType))
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
                 return new CommonOutputs.TransformOutput { Model = new TransformModelImpl(env, nop, input.Data), OutputData = nop };

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -120,7 +120,7 @@ namespace Microsoft.ML.EntryPoints
             if (!schema.TryGetColumnIndex(colName, out col))
                 return null;
             var type = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
-            if (type == null || !type.IsKnownSizeVector || !type.ItemType.IsText)
+            if (type == null || !type.IsKnownSizeVector || !(type.ItemType is TextType))
                 return null;
             var metadata = default(VBuffer<ReadOnlyMemory<char>>);
             schema[col].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref metadata);

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -177,7 +177,7 @@ namespace Microsoft.ML.EntryPoints
                             continue;
                         }
                     }
-                    if (type.IsNumber || type.IsBool)
+                    if (type.IsNumber || type is BoolType)
                     {
                         // Even if the column is R4 in training, we still want to add it to the conversion.
                         // The reason is that at scoring time, the column might have a slightly different type (R8 for example).
@@ -235,7 +235,7 @@ namespace Microsoft.ML.EntryPoints
             if (!input.Data.Schema.TryGetColumnIndex(input.LabelColumn, out labelCol))
                 throw host.Except($"Column '{input.LabelColumn}' not found.");
             var labelType = input.Data.Schema[labelCol].Type;
-            if (labelType.IsKey || labelType.IsBool)
+            if (labelType.IsKey || labelType is BoolType)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
                 return new CommonOutputs.TransformOutput { Model = new TransformModelImpl(env, nop, input.Data), OutputData = nop };
@@ -270,7 +270,7 @@ namespace Microsoft.ML.EntryPoints
             if (!input.Data.Schema.TryGetColumnIndex(input.PredictedLabelColumn, out predictedLabelCol))
                 throw host.Except($"Column '{input.PredictedLabelColumn}' not found.");
             var predictedLabelType = input.Data.Schema[predictedLabelCol].Type;
-            if (predictedLabelType.IsNumber || predictedLabelType.IsBool)
+            if (predictedLabelType.IsNumber || predictedLabelType is BoolType)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
                 return new CommonOutputs.TransformOutput { Model = new TransformModelImpl(env, nop, input.Data), OutputData = nop };

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoaderTransform.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoaderTransform.cs
@@ -113,7 +113,7 @@ namespace Microsoft.ML.ImageAnalytics
 
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
-            if (!inputSchema[srcCol].Type.IsText)
+            if (!(inputSchema[srcCol].Type is TextType))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, TextType.Instance.ToString(), inputSchema[srcCol].Type.ToString());
         }
 
@@ -232,7 +232,7 @@ namespace Microsoft.ML.ImageAnalytics
             {
                 if (!inputSchema.TryFindColumn(input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", input);
-                if (!col.ItemType.IsText || col.Kind != SchemaShape.Column.VectorKind.Scalar)
+                if (!(col.ItemType is TextType) || col.Kind != SchemaShape.Column.VectorKind.Scalar)
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", input, TextType.Instance.ToString(), col.GetTypeString());
 
                 result[output] = new SchemaShape.Column(output, SchemaShape.Column.VectorKind.Scalar, _imageType, false);

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.ML.LightGBM
             Host.AssertValue(ch);
             base.CheckDataValid(ch, data);
             var labelType = data.Schema.Label.Value.Type;
-            if (!(labelType.IsBool || labelType.IsKey || labelType == NumberType.R4))
+            if (!(labelType is BoolType || labelType.IsKey || labelType == NumberType.R4))
             {
                 throw ch.ExceptParam(nameof(data),
                     $"Label column '{data.Schema.Label.Value.Name}' is of type '{labelType}', but must be key, boolean or R4.");

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.LightGBM
             Host.AssertValue(ch);
             base.CheckDataValid(ch, data);
             var labelType = data.Schema.Label.Value.Type;
-            if (!(labelType.IsBool || labelType.IsKey || labelType == NumberType.R4))
+            if (!(labelType is BoolType || labelType.IsKey || labelType == NumberType.R4))
             {
                 throw ch.ExceptParam(nameof(data),
                     $"Label column '{data.Schema.Label.Value.Name}' is of type '{labelType}', but must be key, boolean or R4.");

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -75,8 +75,8 @@ namespace Microsoft.ML.FactorizationMachine
             Contracts.AssertValue(env);
             Contracts.AssertValue(schema);
             Contracts.CheckParam(outputSchema.Count == 2, nameof(outputSchema));
-            Contracts.CheckParam(outputSchema[0].Type.IsNumber, nameof(outputSchema));
-            Contracts.CheckParam(outputSchema[1].Type.IsNumber, nameof(outputSchema));
+            Contracts.CheckParam(outputSchema[0].Type is NumberType, nameof(outputSchema));
+            Contracts.CheckParam(outputSchema[1].Type is NumberType, nameof(outputSchema));
             Contracts.AssertValue(pred);
 
             _env = env;

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
@@ -170,7 +170,7 @@ namespace Microsoft.ML.Trainers.Online
             if (labelCol.Kind != SchemaShape.Column.VectorKind.Scalar)
                 error();
 
-            if (!labelCol.IsKey && labelCol.ItemType != NumberType.R4 && labelCol.ItemType != NumberType.R8 && !labelCol.ItemType.IsBool)
+            if (!labelCol.IsKey && labelCol.ItemType != NumberType.R4 && labelCol.ItemType != NumberType.R8 && !(labelCol.ItemType is BoolType))
                 error();
         }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -1551,7 +1551,7 @@ namespace Microsoft.ML.Trainers
             if (labelCol.Kind != SchemaShape.Column.VectorKind.Scalar)
                 error();
 
-            if (!labelCol.IsKey && labelCol.ItemType != NumberType.R4 && labelCol.ItemType != NumberType.R8 && !labelCol.ItemType.IsBool)
+            if (!labelCol.IsKey && labelCol.ItemType != NumberType.R4 && labelCol.ItemType != NumberType.R8 && !(labelCol.ItemType is BoolType))
                 error();
         }
 

--- a/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlow/TensorflowUtils.cs
@@ -103,14 +103,14 @@ namespace Microsoft.ML.Transforms.TensorFlow
                 var type = schema[i].Type;
 
                 var metadataType = schema[i].Metadata.Schema.GetColumnOrNull(TensorFlowUtils.OpType)?.Type;
-                Contracts.Assert(metadataType != null && metadataType.IsText);
+                Contracts.Assert(metadataType != null && metadataType is TextType);
                 ReadOnlyMemory<char> opType = default;
                 schema[i].Metadata.GetValue(TensorFlowUtils.OpType, ref opType);
                 metadataType = schema[i].Metadata.Schema.GetColumnOrNull(TensorFlowUtils.InputOps)?.Type;
                 VBuffer<ReadOnlyMemory<char>> inputOps = default;
                 if (metadataType != null)
                 {
-                    Contracts.Assert(metadataType.IsKnownSizeVector && metadataType.ItemType.IsText);
+                    Contracts.Assert(metadataType.IsKnownSizeVector && metadataType.ItemType is TextType);
                     schema[i].Metadata.GetValue(TensorFlowUtils.InputOps, ref inputOps);
                 }
 

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
         }
 
         public static bool IsValidColumnType(ColumnType type)
-            => type == NumberType.R4 || type == NumberType.R8 || type.IsText;
+            => type == NumberType.R4 || type == NumberType.R8 || type is TextType;
 
         private static CountAggregator GetOneAggregator(Row row, ColumnType colType, int colSrc)
         {

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -325,7 +325,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
 
             public CountAggregator(ColumnType type, ValueGetter<T> getter)
             {
-                Contracts.Assert(type.IsPrimitive);
+                Contracts.Assert(type is PrimitiveType);
                 _count = new long[1];
                 _buffer = new VBuffer<T>(1, new T[1]);
                 var t = default(T);

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -332,7 +332,7 @@ namespace Microsoft.ML.Transforms
                         throw except(string.Format("Could not find column '{0}'", names[i]));
 
                     var colType = schema[col].Type;
-                    if (!colType.IsPrimitive)
+                    if (!(colType is PrimitiveType))
                         throw except(string.Format("Column '{0}' has type '{1}', but must have a primitive type", names[i], colType));
 
                     ids[i] = col;
@@ -492,7 +492,7 @@ namespace Microsoft.ML.Transforms
                 {
                     Contracts.AssertValue(row);
                     var colType = row.Schema[col].Type;
-                    Contracts.Assert(colType.IsPrimitive);
+                    Contracts.Assert(colType is PrimitiveType);
 
                     var type = typeof(ListAggregator<>);
 

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -254,7 +254,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 int metaKeyValuesCol = 0;
                 if (inputMetadata.Schema.TryGetColumnIndex(MetadataUtils.Kinds.KeyValues, out metaKeyValuesCol))
                     typeNames = inputMetadata.Schema[metaKeyValuesCol].Type;
-                if (typeNames == null || !typeNames.IsKnownSizeVector || !typeNames.ItemType.IsText ||
+                if (typeNames == null || !typeNames.IsKnownSizeVector || !(typeNames.ItemType is TextType) ||
                     typeNames.VectorSize != _infos[iinfo].TypeSrc.ItemType.KeyCount)
                 {
                     typeNames = null;
@@ -320,7 +320,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 ColumnType typeSlotSrc = null;
                 if (inputMetadata != null)
                     typeSlotSrc = inputMetadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-                if (typeSlotSrc != null && typeSlotSrc.VectorSize == typeSrc.VectorSize && typeSlotSrc.ItemType.IsText)
+                if (typeSlotSrc != null && typeSlotSrc.VectorSize == typeSrc.VectorSize && typeSlotSrc.ItemType is TextType)
                 {
                     inputMetadata.GetValue(MetadataUtils.Kinds.SlotNames, ref namesSlotSrc);
                     Host.Check(namesSlotSrc.Length == typeSrc.VectorSize);
@@ -483,7 +483,7 @@ namespace Microsoft.ML.Transforms.Conversions
 
                 var metadata = new List<SchemaShape.Column>();
                 if (col.Metadata.TryFindColumn(MetadataUtils.Kinds.KeyValues, out var keyMeta))
-                    if (col.Kind != SchemaShape.Column.VectorKind.VariableVector && keyMeta.ItemType.IsText)
+                    if (col.Kind != SchemaShape.Column.VectorKind.VariableVector && keyMeta.ItemType is TextType)
                         metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, keyMeta.ItemType, false));
                 if (col.Kind == SchemaShape.Column.VectorKind.Scalar)
                     metadata.Add(new SchemaShape.Column(MetadataUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar, BoolType.Instance, false));

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -478,7 +478,7 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if ((col.ItemType.ItemType.RawKind == default) || !(col.ItemType.IsVector || col.ItemType.IsPrimitive))
+                if ((col.ItemType.ItemType.RawKind == default) || !(col.ItemType.IsVector || col.ItemType is PrimitiveType))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
                 var metadata = new List<SchemaShape.Column>();

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransform.cs
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Transforms
                     if (!type.IsKnownSizeVector ||
                         (typeNames = Source.Schema[Infos[iinfo].Source].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type) == null ||
                         typeNames.VectorSize != type.VectorSize ||
-                        !typeNames.ItemType.IsText)
+                        !(typeNames.ItemType is TextType))
                     {
                         continue;
                     }
@@ -198,7 +198,7 @@ namespace Microsoft.ML.Transforms
 
                 // REVIEW: Do we need to verify that there is metadata or should we just call GetMetadata?
                 var typeNames = Source.Schema[Infos[iinfo].Source].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.SlotNames)?.Type;
-                if (typeNames == null || typeNames.VectorSize != type.VectorSize || !typeNames.ItemType.IsText)
+                if (typeNames == null || typeNames.VectorSize != type.VectorSize || !(typeNames.ItemType is TextType))
                     throw MetadataUtils.ExceptGetMetadata();
 
                 var names = default(VBuffer<ReadOnlyMemory<char>>);

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -341,7 +341,7 @@ namespace Microsoft.ML.Transforms
                     case ReplacementKind.Mean:
                     case ReplacementKind.Minimum:
                     case ReplacementKind.Maximum:
-                        if (!type.ItemType.IsNumber)
+                        if (!(type.ItemType is NumberType))
                             throw Host.Except("Cannot perform mean imputations on non-numeric '{0}'", type.ItemType);
                         imputationModes[iinfo] = kind;
                         Utils.Add(ref columnsToImpute, iinfo);

--- a/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
@@ -15,7 +15,7 @@ namespace Microsoft.ML.Transforms
     {
         private static StatAggregator CreateStatAggregator(IChannel ch, ColumnType type, ReplacementKind? kind, bool bySlot, RowCursor cursor, int col)
         {
-            ch.Assert(type.ItemType.IsNumber);
+            ch.Assert(type.ItemType is NumberType);
             if (!type.IsVector)
             {
                 // The type is a scalar.

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -335,7 +335,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
         {
             // REVIEW: Consider supporting all integer and unsigned types.
             return
-                (0 < type.KeyCount && type.KeyCount < Utils.ArrayMaxSize) || type.IsBool ||
+                (0 < type.KeyCount && type.KeyCount < Utils.ArrayMaxSize) || type is BoolType ||
                 type == NumberType.R4 || type == NumberType.R8 || type == NumberType.I4;
         }
 
@@ -468,7 +468,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                     BinDoubles(in tmp, ref labels, _numBins, out min, out lim);
                     _numLabels = lim - min;
                 }
-                else if (labelType.IsBool)
+                else if (labelType is BoolType)
                 {
                     var tmp = default(VBuffer<bool>);
                     trans.GetSingleSlotValue(labelCol, ref tmp);
@@ -545,7 +545,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
                             BinDoubles(in src, ref dst, _numBins, out min, out lim);
                         });
                 }
-                if (type.ItemType.IsBool)
+                if (type.ItemType is BoolType)
                 {
                     return ComputeMutualInformation(trans, col,
                         (ref VBuffer<bool> src, ref VBuffer<int> dst, out int min, out int lim) =>

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -540,7 +540,7 @@ namespace Microsoft.ML.Transforms.Text
             public const Language DefaultLanguage = Language.English;
         }
 
-        public static bool IsColumnTypeValid(ColumnType type) => type.ItemType.IsText && type.IsVector;
+        public static bool IsColumnTypeValid(ColumnType type) => type.ItemType is TextType && type.IsVector;
 
         internal const string ExpectedColumnType = "vector of Text type";
 
@@ -582,7 +582,7 @@ namespace Microsoft.ML.Transforms.Text
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if (col.Kind == SchemaShape.Column.VectorKind.Scalar || !col.ItemType.IsText)
+                if (col.Kind == SchemaShape.Column.VectorKind.Scalar || !(col.ItemType is TextType))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input, ExpectedColumnType, col.ItemType.ToString());
                 result[colInfo.Output] = new SchemaShape.Column(colInfo.Output, SchemaShape.Column.VectorKind.VariableVector, TextType.Instance, false);
             }
@@ -772,7 +772,7 @@ namespace Microsoft.ML.Transforms.Text
                 if (!loader.Schema.TryGetColumnIndex(srcCol, out colSrc))
                     throw ch.ExceptUserArg(nameof(Arguments.StopwordsColumn), "Unknown column '{0}'", srcCol);
                 var typeSrc = loader.Schema[colSrc].Type;
-                ch.CheckUserArg(typeSrc.IsText, nameof(Arguments.StopwordsColumn), "Must be a scalar text column");
+                ch.CheckUserArg(typeSrc is TextType, nameof(Arguments.StopwordsColumn), "Must be a scalar text column");
 
                 // Accumulate the stopwords.
                 using (var cursor = loader.GetRowCursor(col => col == colSrc))
@@ -1072,7 +1072,7 @@ namespace Microsoft.ML.Transforms.Text
             {
                 if (!inputSchema.TryFindColumn(colInfo.input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.input);
-                if (col.Kind == SchemaShape.Column.VectorKind.Scalar || !col.ItemType.IsText)
+                if (col.Kind == SchemaShape.Column.VectorKind.Scalar || !(col.ItemType is TextType))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.input, ExpectedColumnType, col.ItemType.ToString());
                 result[colInfo.output] = new SchemaShape.Column(colInfo.output, SchemaShape.Column.VectorKind.VariableVector, TextType.Instance, false);
             }

--- a/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
@@ -474,7 +474,7 @@ namespace Microsoft.ML.Transforms.Text
             {
                 if (!inputSchema.TryFindColumn(srcName, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", srcName);
-                if (!col.ItemType.IsText)
+                if (!(col.ItemType is TextType))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", srcName, "scalar or vector of text", col.GetTypeString());
             }
 

--- a/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Transforms.Text
                 disposer = null;
 
                 var srcType = input.Schema[_parent.ColumnPairs[iinfo].input].Type;
-                Host.Assert(srcType.ItemType.IsText);
+                Host.Assert(srcType.ItemType is TextType);
 
                 if (srcType.IsVector)
                 {
@@ -450,7 +450,7 @@ namespace Microsoft.ML.Transforms.Text
 
         }
 
-        public static bool IsColumnTypeValid(ColumnType type) => (type.ItemType.IsText);
+        public static bool IsColumnTypeValid(ColumnType type) => (type.ItemType is TextType);
 
         internal const string ExpectedColumnType = "Text or vector of text.";
 

--- a/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
+++ b/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
@@ -554,7 +554,7 @@ namespace Microsoft.ML.Transforms.Text
         {
             public const bool UseMarkerCharacters = true;
         }
-        public static bool IsColumnTypeValid(ColumnType type) => type.ItemType.IsText;
+        public static bool IsColumnTypeValid(ColumnType type) => type.ItemType is TextType;
 
         internal const string ExpectedColumnType = "Text";
 

--- a/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
@@ -285,7 +285,7 @@ namespace Microsoft.ML.Transforms.Text
                 h.CheckNonWhiteSpace(col.Source, nameof(col.Source));
                 int colId;
                 if (input.Schema.TryGetColumnIndex(col.Source, out colId) &&
-                    input.Schema[colId].Type.ItemType.IsText)
+                    input.Schema[colId].Type.ItemType is TextType)
                 {
                     termCols.Add(col);
                     isTermCol[i] = true;

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
@@ -320,7 +320,7 @@ namespace Microsoft.ML.Transforms.Text
         protected override void CheckInputColumn(Schema inputSchema, int col, int srcCol)
         {
             var colType = inputSchema[srcCol].Type;
-            if (!(colType.IsVector && colType.ItemType.IsText))
+            if (!(colType.IsVector && colType.ItemType is TextType))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].input, "Text", inputSchema[srcCol].Type.ToString());
         }
 
@@ -571,7 +571,7 @@ namespace Microsoft.ML.Transforms.Text
 
                 var colType = input.Schema[ColMapNewToOld[iinfo]].Type;
                 Host.Assert(colType.IsVector);
-                Host.Assert(colType.ItemType.IsText);
+                Host.Assert(colType.ItemType is TextType);
 
                 var srcGetter = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -264,7 +264,7 @@ namespace Microsoft.ML.Transforms.Text
 
                 input.Schema.TryGetColumnIndex(_parent._columns[iinfo].Input, out int srcCol);
                 var srcType = input.Schema[srcCol].Type;
-                Host.Assert(srcType.ItemType.IsText);
+                Host.Assert(srcType.ItemType is TextType);
 
                 if (!srcType.IsVector)
                     return MakeGetterOne(input, iinfo);
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Transforms.Text
     /// </summary>
     public sealed class WordTokenizingEstimator : TrivialEstimator<WordTokenizingTransformer>
     {
-        public static bool IsColumnTypeValid(ColumnType type) => type.ItemType.IsText;
+        public static bool IsColumnTypeValid(ColumnType type) => type.ItemType is TextType;
 
         internal const string ExpectedColumnType = "Text";
 

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -286,7 +286,7 @@ namespace Microsoft.ML.Transforms
                     if (!inputSchema.TryGetColumnIndex(name, out col))
                         throw ectx.ExceptUserArg(nameof(Arguments.Column), "Pivot column '{0}' is not found", name);
                     var colType = inputSchema[col].Type;
-                    if (!colType.IsVector || !colType.ItemType.IsPrimitive)
+                    if (!colType.IsVector || !(colType.ItemType is PrimitiveType))
                         throw ectx.ExceptUserArg(nameof(Arguments.Column),
                             "Pivot column '{0}' has type '{1}', but must be a vector of primitive types", name, colType);
                     infos[i] = new PivotColumnInfo(name, col, colType.VectorSize, (PrimitiveType)colType.ItemType);

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -617,7 +617,7 @@ namespace Microsoft.ML.RunTests
                 Fail("Different {0} metadata types: {0} vs {1}", kind, t1, t2);
                 return Failed();
             }
-            if (!t1.ItemType.IsText)
+            if (!(t1.ItemType is TextType))
             {
                 if (!mustBeText)
                 {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -231,7 +231,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             Assert.True(idv.Schema[1].Metadata.Schema.Count == 3);
             Assert.True(idv.Schema[1].Metadata.Schema[0].Name == kindStringArray);
-            Assert.True(idv.Schema[1].Metadata.Schema[0].Type.IsVector && idv.Schema[1].Metadata.Schema[0].Type.ItemType.IsText);
+            Assert.True(idv.Schema[1].Metadata.Schema[0].Type.IsVector && idv.Schema[1].Metadata.Schema[0].Type.ItemType is TextType);
             Assert.Throws<ArgumentOutOfRangeException>(() => idv.Schema[1].Metadata.Schema[kindFloat]);
 
             float retrievedFloat = 0;


### PR DESCRIPTION
Remove the following properties from ColumnType:

- IsPrimitive
- IsNumber
- IsText
- IsBool

And move `IsStandardScalar` to an extension method, so it can be left in ML.NET when ColumnType is extracted with IDataView to a separate package.

I plan on removing `IsKey` and `IsVector` each in their own PR along with the rest of the "Key" and "Vector" members on ColumnType.

Part of the work necessary for #1860 