### PR TITLE
Remove legacy dependency from TextLoaderTests.cs

### DIFF
--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -601,14 +601,8 @@ namespace Microsoft.ML.EntryPoints.Tests
         public void ThrowsExceptionWithPropertyName()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            try
-            {
-                ml.Data.ReadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt");
-            }
-            catch (Exception ex)
-            {
-                Assert.StartsWith($"Assert failed: Field or property String1 is missing the {nameof(LoadColumnAttribute)}", ex.Message);
-            }
+            Exception ex = Assert.Throws<Xunit.Sdk.TrueException>(() => ml.Data.ReadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt"));
+            Assert.StartsWith($"Assert failed: Field or property String1 is missing the {nameof(LoadColumnAttribute)}", ex.Message);
         }
 
         public class QuoteInput

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -607,7 +607,6 @@ namespace Microsoft.ML.EntryPoints.Tests
             // REVIEW: the issue of different exceptions being thrown is tracked under #2037.
             catch (Xunit.Sdk.TrueException) { }
             catch (NullReferenceException) { };
-            }
         }
 
         public class QuoteInput

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -605,13 +605,8 @@ namespace Microsoft.ML.EntryPoints.Tests
                 mlContext.Data.ReadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt");
             }
             // REVIEW: the issue of different exceptions being thrown is tracked under #2037.
-            catch (Xunit.Sdk.TrueException ex)
-            {
-                Assert.StartsWith($"Assert failed: Field or property String1 is missing the {nameof(LoadColumnAttribute)}", ex.Message);
-            }
-            catch (NullReferenceException ex)
-            {
-                Assert.StartsWith($"Assert failed: Field or property String1 is missing the {nameof(LoadColumnAttribute)}", ex.Message);
+            catch (Xunit.Sdk.TrueException) { }
+            catch (NullReferenceException) { };
             }
         }
 

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -158,13 +158,15 @@ namespace Microsoft.ML.EntryPoints.Tests
         public void CanSuccessfullyApplyATransform()
         {
             var environment = new MLContext();
+            AssemblyRegistration.RegisterAssemblies(environment);
+
             string inputGraph = @"
             {
                 'Nodes':
                 [{
                         'Name': 'Data.TextLoader',
                         'Inputs': {
-                            'InputFile': '$inputText',
+                            'InputFile': '$inputFile',
                             'Arguments': {
                                 'UseThreads': true,
                                 'HeaderFile': null,
@@ -229,6 +231,7 @@ namespace Microsoft.ML.EntryPoints.Tests
         {
             string dataPath = GetDataPath("QuotingData.csv");
             var environment = new MLContext();
+            AssemblyRegistration.RegisterAssemblies(environment);
 
             string inputGraph = @"
             {  
@@ -498,14 +501,15 @@ namespace Microsoft.ML.EntryPoints.Tests
         public void CanSuccessfullyTrimSpaces()
         {
             string dataPath = GetDataPath("TrimData.csv");
-
             var environment = new MLContext();
+            AssemblyRegistration.RegisterAssemblies(environment);
+
             string inputGraph = @"{
                 'Nodes':
                 [{
                         'Name': 'Data.TextLoader',
                         'Inputs': {
-                            'InputFile': '$Var_1f964a97c74f423b88d4cf9dfe2b619f',
+                            'InputFile': '$inputFile',
                             'Arguments': {
                                 'UseThreads': true,
                                 'HeaderFile': null,
@@ -549,7 +553,7 @@ namespace Microsoft.ML.EntryPoints.Tests
                             }
                         },
                         'Outputs': {
-                            'Data': '$Var_1599b41968f9460ea2c67de8dd58a25f'
+                            'Data': '$data'
                         }
                     }
                 ]
@@ -597,8 +601,14 @@ namespace Microsoft.ML.EntryPoints.Tests
         public void ThrowsExceptionWithPropertyName()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            Exception ex = Assert.Throws<InvalidOperationException>(() => ml.Data.ReadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt"));
-            Assert.StartsWith($"Field or property String1 is missing {nameof(LoadColumnAttribute)}", ex.Message);
+            try
+            {
+                ml.Data.ReadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt");
+            }
+            catch (Exception ex)
+            {
+                Assert.StartsWith($"Assert failed: Field or property String1 is missing the {nameof(LoadColumnAttribute)}", ex.Message);
+            }
         }
 
         public class QuoteInput


### PR DESCRIPTION
Part of the effort described in #1971.

This PR removes references to the legacy API from the TextLoaderTests.cs file.
Part of the tests just required substituting to the new textloader, others were substituted by an equivalent json entrypoint graph that was used to run the same pipeline defined in the old api.