### PR TITLE
Replace MLContext.Log Action<string> delegate with an event

### DIFF
--- a/src/Microsoft.ML.Data/MLContext.cs
+++ b/src/Microsoft.ML.Data/MLContext.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML
         /// <summary>
         /// The handler for the log messages.
         /// </summary>
-        public Action<string> Log { get; set; }
+        public event EventHandler<string> Log;
 
         /// <summary>
         /// This is a MEF composition container catalog to be used for model loading.
@@ -102,13 +102,14 @@ namespace Microsoft.ML
 
         private void ProcessMessage(IMessageSource source, ChannelMessage message)
         {
-            if (Log == null)
+            var log = Log;
+
+            if (log == null)
                 return;
 
             var msg = $"[Source={source.FullName}, Kind={message.Kind}] {message.Message}";
-            // Log may have been reset from another thread.
-            // We don't care which logger we send the message to, just making sure we don't crash.
-            Log?.Invoke(msg);
+
+            log(this, msg);
         }
 
         int IHostEnvironment.ConcurrencyFactor => _env.ConcurrencyFactor;

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestHosts.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestHosts.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.ML.Data;
 using Xunit;
 
 namespace Microsoft.ML.RunTests
@@ -68,6 +69,24 @@ namespace Microsoft.ML.RunTests
                         children[currentHost].ForEach(x => queue.Enqueue(x));
                 }
             }
+        }
+
+        /// <summary>
+        /// Tests that MLContext's Log event intercepts messages properly.
+        /// </summary>
+        [Fact]
+        public void LogEventProcessesMessages()
+        {
+            var messages = new List<string>();
+
+            var env = new MLContext();
+            env.Log += (sender, message) => messages.Add(message);
+
+            // create a dummy text reader to trigger log messages
+            env.Data.CreateTextReader(
+                new TextLoader.Arguments {Column = new[] {new TextLoader.Column("TestColumn", null, 0)}});
+
+            Assert.True(messages.Count > 0);
         }
     }
 }


### PR DESCRIPTION
As proposed in #2042, this PR replaces the `Action<string> MLContext.Log` property with an event of the same name.

I changed the invocation logic slightly as well to guard again possible multithreaded null references. I created a very simple smoke test to help with the refactoring but I don't see much added value in it so I can scrap it when requested.

Fixed #2042