### PR TITLE
Replacing TryGetColumnIndex with invocations of GetColumnOrNull 

### DIFF
--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -53,9 +53,10 @@ namespace Microsoft.ML.Ensemble
                 for (int i = 0; i < Parent._inputCols.Length; i++)
                 {
                     var name = Parent._inputCols[i];
-                    if (!InputRoleMappedSchema.Schema.TryGetColumnIndex(name, out int col))
+                    var col = InputRoleMappedSchema.Schema.GetColumnOrNull(name);
+                    if (!col.HasValue)
                         throw Parent.Host.Except("Schema does not contain required input column '{0}'", name);
-                    _inputColIndices.Add(col);
+                    _inputColIndices.Add(col.Value.Index);
                 }
 
                 Mappers = new ISchemaBoundRowMapper[Parent.PredictorModels.Length];
@@ -74,8 +75,10 @@ namespace Microsoft.ML.Ensemble
                         throw Parent.Host.Except("Predictor {0} is not a row to row mapper", i);
 
                     // Make sure there is a score column, and remember its index.
-                    if (!Mappers[i].OutputSchema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out ScoreCols[i]))
+                    var scoreCol = Mappers[i].OutputSchema.GetColumnOrNull(MetadataUtils.Const.ScoreValueKind.Score);
+                    if (!scoreCol.HasValue)
                         throw Parent.Host.Except("Predictor {0} does not contain a score column", i);
+                    ScoreCols[i] = scoreCol.Value.Index;
 
                     // Get the pipeline.
                     var dv = new EmptyDataView(Parent.Host, schema.Schema);

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Ensemble
                     var name = Parent._inputCols[i];
                     var col = InputRoleMappedSchema.Schema.GetColumnOrNull(name);
                     if (!col.HasValue)
-                        throw Parent.Host.Except("Schema does not contain required input column '{0}'", name);
+                        throw Parent.Host.ExceptSchemaMismatch(nameof(InputRoleMappedSchema), "input", name);
                     _inputColIndices.Add(col.Value.Index);
                 }
 

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -233,7 +233,7 @@ namespace Microsoft.ML.EntryPoints
 
             var labelCol = input.Data.Schema.GetColumnOrNull(input.LabelColumn);
             if (!labelCol.HasValue)
-                throw host.Except($"Column '{input.LabelColumn}' not found.");
+                throw host.ExceptSchemaMismatch(nameof(input), "Label", input.LabelColumn);
 
             var labelType = labelCol.Value.Type;
             if (labelType.IsKey || labelType is BoolType)
@@ -269,7 +269,7 @@ namespace Microsoft.ML.EntryPoints
 
             var predictedLabelCol = input.Data.Schema.GetColumnOrNull(input.PredictedLabelColumn);
             if (!predictedLabelCol.HasValue)
-                throw host.Except($"Column '{input.PredictedLabelColumn}' not found.");
+                throw host.ExceptSchemaMismatch(nameof(input), "PredictedLabel",input.PredictedLabelColumn);
             var predictedLabelType = predictedLabelCol.Value.Type;
             if (predictedLabelType is NumberType || predictedLabelType is BoolType)
             {

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -115,15 +115,15 @@ namespace Microsoft.ML.EntryPoints
         {
             Contracts.AssertValue(data);
             Contracts.AssertNonWhiteSpace(colName);
-            int col;
             var schema = data.Schema;
-            if (!schema.TryGetColumnIndex(colName, out col))
+            var col = schema.GetColumnOrNull(colName);
+            if (!col.HasValue)
                 return null;
-            var type = schema[col].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
+            var type = col.Value.Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
             if (type == null || !type.IsKnownSizeVector || !(type.ItemType is TextType))
                 return null;
             var metadata = default(VBuffer<ReadOnlyMemory<char>>);
-            schema[col].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref metadata);
+            col.Value.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref metadata);
             if (!metadata.IsDense)
                 return null;
             var sb = new StringBuilder();
@@ -231,10 +231,11 @@ namespace Microsoft.ML.EntryPoints
             host.CheckValue(input, nameof(input));
             EntryPointUtils.CheckInputArgs(host, input);
 
-            int labelCol;
-            if (!input.Data.Schema.TryGetColumnIndex(input.LabelColumn, out labelCol))
+            var labelCol = input.Data.Schema.GetColumnOrNull(input.LabelColumn);
+            if (!labelCol.HasValue)
                 throw host.Except($"Column '{input.LabelColumn}' not found.");
-            var labelType = input.Data.Schema[labelCol].Type;
+
+            var labelType = labelCol.Value.Type;
             if (labelType.IsKey || labelType is BoolType)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
@@ -266,10 +267,10 @@ namespace Microsoft.ML.EntryPoints
             host.CheckValue(input, nameof(input));
             EntryPointUtils.CheckInputArgs(host, input);
 
-            int predictedLabelCol;
-            if (!input.Data.Schema.TryGetColumnIndex(input.PredictedLabelColumn, out predictedLabelCol))
+            var predictedLabelCol = input.Data.Schema.GetColumnOrNull(input.PredictedLabelColumn);
+            if (!predictedLabelCol.HasValue)
                 throw host.Except($"Column '{input.PredictedLabelColumn}' not found.");
-            var predictedLabelType = input.Data.Schema[predictedLabelCol].Type;
+            var predictedLabelType = predictedLabelCol.Value.Type;
             if (predictedLabelType is NumberType || predictedLabelType is BoolType)
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);
@@ -288,10 +289,10 @@ namespace Microsoft.ML.EntryPoints
             host.CheckValue(input, nameof(input));
             EntryPointUtils.CheckInputArgs(host, input);
 
-            int labelCol;
-            if (!input.Data.Schema.TryGetColumnIndex(input.LabelColumn, out labelCol))
+            var labelCol = input.Data.Schema.GetColumnOrNull(input.LabelColumn);
+            if (!labelCol.HasValue)
                 throw host.Except($"Column '{input.LabelColumn}' not found.");
-            var labelType = input.Data.Schema[labelCol].Type;
+            var labelType = labelCol.Value.Type;
             if (labelType == NumberType.R4 || !(labelType is NumberType))
             {
                 var nop = NopTransform.CreateIfNeeded(env, input.Data);

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -1285,8 +1285,9 @@ namespace Microsoft.ML.Trainers.FastTree
                             new RoleMappedSchema.ColumnRole(MetadataUtils.Const.ScoreValueKind.Score).Bind(DefaultColumnNames.Score));
                     }
 
-                    _data.Schema.Schema.TryGetColumnIndex(DefaultColumnNames.Features, out int featureIndex);
-                    MetadataUtils.TryGetCategoricalFeatureIndices(_data.Schema.Schema, featureIndex, out _catsMap);
+                    var featureCol = _data.Schema.Schema.GetColumnOrNull(DefaultColumnNames.Features);
+                    ch.Assert(featureCol.HasValue);
+                    MetadataUtils.TryGetCategoricalFeatureIndices(_data.Schema.Schema, featureCol.Value.Index, out _catsMap);
                 }
 
                 public FeatureInfo GetInfoForIndex(int index) => FeatureInfo.GetInfoForIndex(this, index);

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -1285,9 +1285,8 @@ namespace Microsoft.ML.Trainers.FastTree
                             new RoleMappedSchema.ColumnRole(MetadataUtils.Const.ScoreValueKind.Score).Bind(DefaultColumnNames.Score));
                     }
 
-                    var featureCol = _data.Schema.Schema.GetColumnOrNull(DefaultColumnNames.Features);
-                    ch.Assert(featureCol.HasValue);
-                    MetadataUtils.TryGetCategoricalFeatureIndices(_data.Schema.Schema, featureCol.Value.Index, out _catsMap);
+                    var featureCol = _data.Schema.Schema[DefaultColumnNames.Features];
+                    MetadataUtils.TryGetCategoricalFeatureIndices(_data.Schema.Schema, featureCol.Index, out _catsMap);
                 }
 
                 public FeatureInfo GetInfoForIndex(int index) => FeatureInfo.GetInfoForIndex(this, index);

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -779,10 +779,11 @@ namespace Microsoft.ML.Data
             ch.AssertValue(input);
             ch.AssertNonWhiteSpace(labelName);
 
-            int col;
-            if (!input.Schema.TryGetColumnIndex(labelName, out col))
+            var col = input.Schema.GetColumnOrNull(labelName);
+            if (!col.HasValue)
                 throw ch.Except("Label column '{0}' not found.", labelName);
-            ColumnType labelType = input.Schema[col].Type;
+
+            ColumnType labelType = col.Value.Type;
             if (!labelType.IsKey)
             {
                 if (labelPermutationSeed != 0)

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -781,7 +781,7 @@ namespace Microsoft.ML.Data
 
             var col = input.Schema.GetColumnOrNull(labelName);
             if (!col.HasValue)
-                throw ch.Except("Label column '{0}' not found.", labelName);
+                throw ch.ExceptSchemaMismatch(nameof(input), "Label", labelName);
 
             ColumnType labelType = col.Value.Type;
             if (!labelType.IsKey)

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -381,9 +381,12 @@ namespace Microsoft.ML.Transforms.Projections
 
             for (int i = 0; i < columns.Length; i++)
             {
-                if (!inputSchema.TryGetColumnIndex(columns[i].Input, out cols[i]))
+                var col = inputSchema.GetColumnOrNull(columns[i].Input);
+                if (!col.HasValue)
                     throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].Input);
-                srcTypes[i] = inputSchema[cols[i]].Type;
+
+                cols[i] = col.Value.Index;
+                srcTypes[i] = col.Value.Type;
                 var reason = TestColumn(srcTypes[i]);
                 if (reason != null)
                     throw env.ExceptParam(nameof(inputData.Schema), reason);

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -285,9 +285,8 @@ namespace Microsoft.ML.LightGBM
                 ch.Info("Auto-tuning parameters: " + nameof(Args.UseCat) + " = " + useCat);
             if (useCat)
             {
-                var featureCol = trainData.Schema.Schema.GetColumnOrNull(DefaultColumnNames.Features);
-                ch.Assert(featureCol.HasValue);
-                MetadataUtils.TryGetCategoricalFeatureIndices(trainData.Schema.Schema, featureCol.Value.Index, out categoricalFeatures);
+                var featureCol = trainData.Schema.Schema[DefaultColumnNames.Features];
+                MetadataUtils.TryGetCategoricalFeatureIndices(trainData.Schema.Schema, featureCol.Index, out categoricalFeatures);
             }
             var colType = trainData.Schema.Feature.Value.Type;
             int rawNumCol = colType.VectorSize;

--- a/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmTrainerBase.cs
@@ -285,8 +285,9 @@ namespace Microsoft.ML.LightGBM
                 ch.Info("Auto-tuning parameters: " + nameof(Args.UseCat) + " = " + useCat);
             if (useCat)
             {
-                trainData.Schema.Schema.TryGetColumnIndex(DefaultColumnNames.Features, out int featureIndex);
-                MetadataUtils.TryGetCategoricalFeatureIndices(trainData.Schema.Schema, featureIndex, out categoricalFeatures);
+                var featureCol = trainData.Schema.Schema.GetColumnOrNull(DefaultColumnNames.Features);
+                ch.Assert(featureCol.HasValue);
+                MetadataUtils.TryGetCategoricalFeatureIndices(trainData.Schema.Schema, featureCol.Value.Index, out categoricalFeatures);
             }
             var colType = trainData.Schema.Feature.Value.Type;
             int rawNumCol = colType.VectorSize;

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -348,8 +348,10 @@ namespace Microsoft.ML.Transforms
                     _inputTensorShapes[i] = inputShape.ToList();
                     _inputOnnxTypes[i] = inputNodeInfo.Type;
 
-                    if (!inputSchema.TryGetColumnIndex(_parent.Inputs[i], out _inputColIndices[i]))
+                    var col = inputSchema.GetColumnOrNull(_parent.Inputs[i]);
+                    if (!col.HasValue)
                         throw Host.Except($"Column {_parent.Inputs[i]} doesn't exist");
+                    _inputColIndices[i] = col.Value.Index;
 
                     var type = inputSchema[_inputColIndices[i]].Type;
                     _isInputVector[i] = type.IsVector;

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Transforms
 
                     var col = inputSchema.GetColumnOrNull(_parent.Inputs[i]);
                     if (!col.HasValue)
-                        throw Host.Except($"Column {_parent.Inputs[i]} doesn't exist");
+                        throw Host.ExceptSchemaMismatch( nameof(inputSchema),"input", _parent.Inputs[i]);
                     _inputColIndices[i] = col.Value.Index;
 
                     var type = inputSchema[_inputColIndices[i]].Type;


### PR DESCRIPTION
Work towards #1500 by removing references of TryGetColumnIndex, and replacing them with GetColumnOrNull in a few projects. 

