### PR TITLE
Say good-bye to transpose ISchema

### DIFF
--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -91,11 +91,11 @@ namespace Microsoft.ML.Data
                 foreach (var view in viewChainReversed.Reverse())
                 {
                     writer.WriteLine("---- {0} ----", view.GetType().Name);
-                    PrintSchema(writer, args, view.Schema, (view as ITransposeDataView)?.TransposeSlotTypes);
+                    PrintSchema(writer, args, view.Schema, view as ITransposeDataView);
                 }
             }
             else
-                PrintSchema(writer, args, data.Schema, (data as ITransposeDataView)?.TransposeSlotTypes);
+                PrintSchema(writer, args, data.Schema, data as ITransposeDataView);
         }
 
         /// <summary>
@@ -113,12 +113,12 @@ namespace Microsoft.ML.Data
             }
         }
 
-        private static void PrintSchema(TextWriter writer, Arguments args, Schema schema, VectorType[] transposeSchema)
+        private static void PrintSchema(TextWriter writer, Arguments args, Schema schema, ITransposeDataView transposeDataView)
         {
             Contracts.AssertValue(writer);
             Contracts.AssertValue(args);
             Contracts.AssertValue(schema);
-            Contracts.AssertValueOrNull(transposeSchema);
+            Contracts.AssertValueOrNull(transposeDataView);
 #if !CORECLR
             if (args.ShowJson)
             {
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Data
                 {
                     var name = schema[col].Name;
                     var type = schema[col].Type;
-                    var slotType = transposeSchema == null ? null : transposeSchema[col];
+                    var slotType = transposeDataView?.GetSlotType(col);
                     itw.WriteLine("{0}: {1}{2}", name, type, slotType == null ? "" : " (T)");
 
                     bool metaVals = args.ShowMetadataValues;

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -91,11 +91,11 @@ namespace Microsoft.ML.Data
                 foreach (var view in viewChainReversed.Reverse())
                 {
                     writer.WriteLine("---- {0} ----", view.GetType().Name);
-                    PrintSchema(writer, args, view.Schema, (view as ITransposeDataView)?.TransposeSlotTypeHolder);
+                    PrintSchema(writer, args, view.Schema, (view as ITransposeDataView)?.TransposeSlotTypes);
                 }
             }
             else
-                PrintSchema(writer, args, data.Schema, (data as ITransposeDataView)?.TransposeSlotTypeHolder);
+                PrintSchema(writer, args, data.Schema, (data as ITransposeDataView)?.TransposeSlotTypes);
         }
 
         /// <summary>
@@ -113,12 +113,12 @@ namespace Microsoft.ML.Data
             }
         }
 
-        private static void PrintSchema(TextWriter writer, Arguments args, Schema schema, ITransposeSlotTypeHolder transposeSlotTypeHolder)
+        private static void PrintSchema(TextWriter writer, Arguments args, Schema schema, VectorType[] transposeSchema)
         {
             Contracts.AssertValue(writer);
             Contracts.AssertValue(args);
             Contracts.AssertValue(schema);
-            Contracts.AssertValueOrNull(transposeSlotTypeHolder);
+            Contracts.AssertValueOrNull(transposeSchema);
 #if !CORECLR
             if (args.ShowJson)
             {
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Data
                 {
                     var name = schema[col].Name;
                     var type = schema[col].Type;
-                    var slotType = transposeSlotTypeHolder == null ? null : transposeSlotTypeHolder.GetSlotType(col);
+                    var slotType = transposeSchema == null ? null : transposeSchema[col];
                     itw.WriteLine("{0}: {1}{2}", name, type, slotType == null ? "" : " (T)");
 
                     bool metaVals = args.ShowMetadataValues;

--- a/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/ShowSchemaCommand.cs
@@ -91,11 +91,11 @@ namespace Microsoft.ML.Data
                 foreach (var view in viewChainReversed.Reverse())
                 {
                     writer.WriteLine("---- {0} ----", view.GetType().Name);
-                    PrintSchema(writer, args, view.Schema, (view as ITransposeDataView)?.TransposeSchema);
+                    PrintSchema(writer, args, view.Schema, (view as ITransposeDataView)?.TransposeSlotTypeHolder);
                 }
             }
             else
-                PrintSchema(writer, args, data.Schema, (data as ITransposeDataView)?.TransposeSchema);
+                PrintSchema(writer, args, data.Schema, (data as ITransposeDataView)?.TransposeSlotTypeHolder);
         }
 
         /// <summary>
@@ -113,12 +113,12 @@ namespace Microsoft.ML.Data
             }
         }
 
-        private static void PrintSchema(TextWriter writer, Arguments args, Schema schema, ITransposeSchema tschema)
+        private static void PrintSchema(TextWriter writer, Arguments args, Schema schema, ITransposeSlotTypeHolder transposeSlotTypeHolder)
         {
             Contracts.AssertValue(writer);
             Contracts.AssertValue(args);
             Contracts.AssertValue(schema);
-            Contracts.AssertValueOrNull(tschema);
+            Contracts.AssertValueOrNull(transposeSlotTypeHolder);
 #if !CORECLR
             if (args.ShowJson)
             {
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Data
                 {
                     var name = schema[col].Name;
                     var type = schema[col].Type;
-                    var slotType = tschema == null ? null : tschema.GetSlotType(col);
+                    var slotType = transposeSlotTypeHolder == null ? null : transposeSlotTypeHolder.GetSlotType(col);
                     itw.WriteLine("{0}: {1}{2}", name, type, slotType == null ? "" : " (T)");
 
                     bool metaVals = args.ShowMetadataValues;

--- a/src/Microsoft.ML.Data/Data/ITransposeDataView.cs
+++ b/src/Microsoft.ML.Data/Data/ITransposeDataView.cs
@@ -20,18 +20,17 @@ namespace Microsoft.ML.Data
     /// <see cref="IDataView"/>.
     ///
     /// The interface only advertises that columns may be accessible in slot-wise fashion. A column
-    /// is accessible in this fashion iff <see cref="TransposeSchema"/>'s
-    /// <see cref="ITransposeSchema.GetSlotType"/> returns a non-null value.
+    /// is accessible in this fashion iff <see cref="TransposeSlotTypeHolder"/>'s
+    /// <see cref="ITransposeSlotTypeHolder.GetSlotType"/> returns a non-null value.
     /// </summary>
     [BestFriend]
     internal interface ITransposeDataView : IDataView
     {
         /// <summary>
         /// An enhanced schema, containing information on the transposition properties, if any,
-        /// of each column. Note that there is no contract or suggestion that this property
-        /// should be equal to <see cref="IDataView.Schema"/>.
+        /// of each column.
         /// </summary>
-        ITransposeSchema TransposeSchema { get; }
+        ITransposeSlotTypeHolder TransposeSlotTypeHolder { get; }
 
         /// <summary>
         /// Presents a cursor over the slots of a transposable column, or throws if the column
@@ -44,15 +43,15 @@ namespace Microsoft.ML.Data
     /// The transpose schema returns the schema information of the view we have transposed.
     /// </summary>
     [BestFriend]
-    internal interface ITransposeSchema : ISchema
+    internal interface ITransposeSlotTypeHolder
     {
         /// <summary>
-        /// Analogous to <see cref="ISchema.GetColumnType"/>, except instead of returning the type of value
-        /// accessible through the <see cref="RowCursor"/>, returns the item type of value accessible
-        /// through the <see cref="SlotCursor"/>. This will return <c>null</c> iff this particular
-        /// column is not transposable, that is, it cannot be viewed in a slotwise fashion. Observe from
-        /// the return type that this will always be a vector type. This vector type should be of fixed
-        /// size and one dimension.
+        /// Analogous to <see cref="ColumnType"/> in <see cref="Schema"/>, except instead of returning
+        /// the type of value accessible through the <see cref="RowCursor"/>, returns the item type of
+        /// value accessible through the <see cref="SlotCursor"/>. This will return <c>null</c> iff
+        /// this particular column is not transposable, that is, it cannot be viewed in a slotwise fashion.
+        /// Observe from the return type that this will always be a vector type. This vector type should
+        /// be of fixed size and one dimension.
         /// </summary>
         VectorType GetSlotType(int col);
     }

--- a/src/Microsoft.ML.Data/Data/ITransposeDataView.cs
+++ b/src/Microsoft.ML.Data/Data/ITransposeDataView.cs
@@ -20,8 +20,7 @@ namespace Microsoft.ML.Data
     /// way of accessing the data stored in a <see cref="IDataView"/>.
     ///
     /// The interface only advertises that columns may be accessible in slot-wise fashion. The i-th column
-    /// is accessible in this fashion iff <see cref="TransposeSlotTypes"/>[i] is not <see langword="null"/>
-    /// and <see cref="TransposeSlotTypes"/>[i] is not <see langword="null"/>.
+    /// is accessible in this fashion iff <see cref="GetSlotType"/> with col=i doesn't return <see langword="null"/>.
     /// </summary>
     [BestFriend]
     internal interface ITransposeDataView : IDataView
@@ -33,11 +32,12 @@ namespace Microsoft.ML.Data
         SlotCursor GetSlotCursor(int col);
 
         /// <summary>
-        /// <see cref="TransposeSlotTypes"/>[i] specifies the type of all values at the i-th column of <see cref="IDataView"/>.
-        /// For example, if <see cref="IDataView.Schema"/>[i] is a scalar float column, then <see cref="TransposeSlotTypes"/>[i]
-        /// may return a <see cref="VectorType"/> whose <see cref="VectorType.ItemType"/> field is <see cref="NumberType.R4"/>.
-        /// If the i-th column can't be iterated column-wisely, <see cref="TransposeSlotTypes"/>[i] may be <see langword="null"/>.
+        /// <see cref="GetSlotType"/> (input argument is named col) specifies the type of all values at the col-th column of
+        /// <see cref="IDataView"/>.  For example, if <see cref="IDataView.Schema"/>[i] is a scalar float column, then
+        /// <see cref="GetSlotType"/> with col=i may return a <see cref="VectorType"/> whose <see cref="VectorType.ItemType"/>
+        /// field is <see cref="NumberType.R4"/>. If the i-th column can't be iterated column-wisely, this function may
+        /// return <see langword="null"/>.
         /// </summary>
-        VectorType[] TransposeSlotTypes { get; }
+        VectorType GetSlotType(int col);
     }
 }

--- a/src/Microsoft.ML.Data/Data/ITransposeDataView.cs
+++ b/src/Microsoft.ML.Data/Data/ITransposeDataView.cs
@@ -14,45 +14,30 @@ namespace Microsoft.ML.Data
     /// <summary>
     /// A view of data where columns can optionally be accessed slot by slot, as opposed to row
     /// by row in a typical dataview. A slot-accessible column can be accessed with a slot-by-slot
-    /// cursor via an <see cref="SlotCursor"/> (naturally, as opposed to row-by-row through an
-    /// <see cref="RowCursor"/>). This interface is intended to be implemented by classes that
-    /// want to provide an option for an alternate way of accessing the data stored in a
-    /// <see cref="IDataView"/>.
+    /// cursor via an <see cref="SlotCursor"/> returned by <see cref="GetSlotCursor(int)"/>
+    /// (naturally, as opposed to row-by-row through an <see cref="RowCursor"/>). This interface
+    /// is intended to be implemented by classes that want to provide an option for an alternate
+    /// way of accessing the data stored in a <see cref="IDataView"/>.
     ///
-    /// The interface only advertises that columns may be accessible in slot-wise fashion. A column
-    /// is accessible in this fashion iff <see cref="TransposeSlotTypeHolder"/>'s
-    /// <see cref="ITransposeSlotTypeHolder.GetSlotType"/> returns a non-null value.
+    /// The interface only advertises that columns may be accessible in slot-wise fashion. The i-th column
+    /// is accessible in this fashion iff <see cref="TransposeSlotTypes"/>[i] is not <see langword="null"/>
+    /// and <see cref="TransposeSlotTypes"/>[i] is not <see langword="null"/>.
     /// </summary>
     [BestFriend]
     internal interface ITransposeDataView : IDataView
     {
         /// <summary>
-        /// An enhanced schema, containing information on the transposition properties, if any,
-        /// of each column.
-        /// </summary>
-        ITransposeSlotTypeHolder TransposeSlotTypeHolder { get; }
-
-        /// <summary>
         /// Presents a cursor over the slots of a transposable column, or throws if the column
         /// is not transposable.
         /// </summary>
         SlotCursor GetSlotCursor(int col);
-    }
 
-    /// <summary>
-    /// The transpose schema returns the schema information of the view we have transposed.
-    /// </summary>
-    [BestFriend]
-    internal interface ITransposeSlotTypeHolder
-    {
         /// <summary>
-        /// Analogous to <see cref="ColumnType"/> in <see cref="Schema"/>, except instead of returning
-        /// the type of value accessible through the <see cref="RowCursor"/>, returns the item type of
-        /// value accessible through the <see cref="SlotCursor"/>. This will return <c>null</c> iff
-        /// this particular column is not transposable, that is, it cannot be viewed in a slotwise fashion.
-        /// Observe from the return type that this will always be a vector type. This vector type should
-        /// be of fixed size and one dimension.
+        /// <see cref="TransposeSlotTypes"/>[i] specifies the type of all values at the i-th column of <see cref="IDataView"/>.
+        /// For example, if <see cref="IDataView.Schema"/>[i] is a scalar float column, then <see cref="TransposeSlotTypes"/>[i]
+        /// may return a <see cref="VectorType"/> whose <see cref="VectorType.ItemType"/> field is <see cref="NumberType.R4"/>.
+        /// If the i-th column can't be iterated column-wisely, <see cref="TransposeSlotTypes"/>[i] may be <see langword="null"/>.
         /// </summary>
-        VectorType GetSlotType(int col);
+        VectorType[] TransposeSlotTypes { get; }
     }
 }

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -182,7 +182,8 @@ namespace Microsoft.ML.Data
         /// Given the item type, typeDst, and a slot cursor, return a ValueGetter{VBuffer{TDst}} for the
         /// vector-valued column with a conversion to a vector of typeDst, if needed.
         /// </summary>
-        public static ValueGetter<VBuffer<TDst>> GetVecGetterAs<TDst>(PrimitiveType typeDst, SlotCursor cursor)
+        [BestFriend]
+        internal static ValueGetter<VBuffer<TDst>> GetVecGetterAs<TDst>(PrimitiveType typeDst, SlotCursor cursor)
         {
             Contracts.CheckValue(typeDst, nameof(typeDst));
             Contracts.CheckParam(typeDst.RawType == typeof(TDst), nameof(typeDst));
@@ -402,7 +403,8 @@ namespace Microsoft.ML.Data
                 };
         }
 
-        public static ValueGetter<VBuffer<Single>> GetLabelGetter(SlotCursor cursor)
+        [BestFriend]
+        internal static ValueGetter<VBuffer<Single>> GetLabelGetter(SlotCursor cursor)
         {
             var type = cursor.GetSlotType().ItemType;
             if (type == NumberType.R4)

--- a/src/Microsoft.ML.Data/Data/SlotCursor.cs
+++ b/src/Microsoft.ML.Data/Data/SlotCursor.cs
@@ -45,14 +45,14 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// The slot type for this cursor. Note that this should equal the
-        /// <see cref="ITransposeSlotTypeHolder.GetSlotType"/> for the column from which this slot cursor
+        /// <see cref="ITransposeDataView.TransposeSlotTypes"/> for the column from which this slot cursor
         /// was created.
         /// </summary>
         public abstract VectorType GetSlotType();
 
         /// <summary>
         /// A getter delegate for the slot values. The type <typeparamref name="TValue"/> must correspond
-        /// to the item type from <see cref="ITransposeSlotTypeHolder.GetSlotType"/>.
+        /// to the item type from <see cref="ITransposeDataView.TransposeSlotTypes"/>.
         /// </summary>
         public abstract ValueGetter<VBuffer<TValue>> GetGetter<TValue>();
 

--- a/src/Microsoft.ML.Data/Data/SlotCursor.cs
+++ b/src/Microsoft.ML.Data/Data/SlotCursor.cs
@@ -10,7 +10,8 @@ namespace Microsoft.ML.Data
     /// A cursor that allows slot-by-slot access of data. This is to <see cref="ITransposeDataView"/>
     /// what <see cref="RowCursor"/> is to <see cref="IDataView"/>.
     /// </summary>
-    public abstract class SlotCursor : IDisposable
+    [BestFriend]
+    internal abstract class SlotCursor : IDisposable
     {
         [BestFriend]
         private protected readonly IChannel Ch;

--- a/src/Microsoft.ML.Data/Data/SlotCursor.cs
+++ b/src/Microsoft.ML.Data/Data/SlotCursor.cs
@@ -46,14 +46,14 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// The slot type for this cursor. Note that this should equal the
-        /// <see cref="ITransposeDataView.TransposeSlotTypes"/> for the column from which this slot cursor
+        /// <see cref="ITransposeDataView.GetSlotType"/> for the column from which this slot cursor
         /// was created.
         /// </summary>
         public abstract VectorType GetSlotType();
 
         /// <summary>
         /// A getter delegate for the slot values. The type <typeparamref name="TValue"/> must correspond
-        /// to the item type from <see cref="ITransposeDataView.TransposeSlotTypes"/>.
+        /// to the item type from <see cref="ITransposeDataView.GetSlotType"/>.
         /// </summary>
         public abstract ValueGetter<VBuffer<TValue>> GetGetter<TValue>();
 

--- a/src/Microsoft.ML.Data/Data/SlotCursor.cs
+++ b/src/Microsoft.ML.Data/Data/SlotCursor.cs
@@ -45,14 +45,14 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// The slot type for this cursor. Note that this should equal the
-        /// <see cref="ITransposeSchema.GetSlotType"/> for the column from which this slot cursor
+        /// <see cref="ITransposeSlotTypeHolder.GetSlotType"/> for the column from which this slot cursor
         /// was created.
         /// </summary>
         public abstract VectorType GetSlotType();
 
         /// <summary>
         /// A getter delegate for the slot values. The type <typeparamref name="TValue"/> must correspond
-        /// to the item type from <see cref="ITransposeSchema.GetSlotType"/>.
+        /// to the item type from <see cref="ITransposeSlotTypeHolder.GetSlotType"/>.
         /// </summary>
         public abstract ValueGetter<VBuffer<TValue>> GetGetter<TValue>();
 

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -409,9 +409,9 @@ namespace Microsoft.ML.Data
             View = transforms[transforms.Length - 1].Transform;
             _tview = View as ITransposeDataView;
             if (_tview == null || _tview.TransposeSlotTypes == null)
-                TransposeSlotTypes = null;
+                _transposeSlotTypes = null;
             else
-                TransposeSlotTypes = _tview.TransposeSlotTypes;
+                _transposeSlotTypes = _tview.TransposeSlotTypes;
 
             var srcLoader = transforms[0].Transform.Source as IDataLoader;
 
@@ -568,7 +568,9 @@ namespace Microsoft.ML.Data
 
         public Schema Schema => View.Schema;
 
-        public VectorType[] TransposeSlotTypes { get; }
+        private VectorType[] _transposeSlotTypes;
+
+        VectorType[] ITransposeDataView.TransposeSlotTypes => _transposeSlotTypes;
 
         public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
         {
@@ -587,7 +589,7 @@ namespace Microsoft.ML.Data
         public SlotCursor GetSlotCursor(int col)
         {
             _host.CheckParam(0 <= col && col < Schema.Count, nameof(col));
-            if (TransposeSlotTypes == null || (TransposeSlotTypes != null && TransposeSlotTypes[col] == null))
+            if (_transposeSlotTypes == null || (_transposeSlotTypes != null && _transposeSlotTypes[col] == null))
             {
                 throw _host.ExceptParam(nameof(col), "Bad call to GetSlotCursor on untransposable column '{0}'",
                     Schema[col].Name);

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -408,7 +408,7 @@ namespace Microsoft.ML.Data
 
             View = transforms[transforms.Length - 1].Transform;
             _tview = View as ITransposeDataView;
-            _transposeSchema = _tview?.TransposeSchema ?? new TransposerUtils.SimpleTransposeSchema(View.Schema);
+            _transposeSlotTypeHolder = _tview?.TransposeSlotTypeHolder ?? new TransposerUtils.SimpleTransposeSchema(View.Schema);
 
             var srcLoader = transforms[0].Transform.Source as IDataLoader;
 
@@ -565,8 +565,8 @@ namespace Microsoft.ML.Data
 
         public Schema Schema => View.Schema;
 
-        private readonly ITransposeSchema _transposeSchema;
-        ITransposeSchema ITransposeDataView.TransposeSchema => _transposeSchema;
+        private readonly ITransposeSlotTypeHolder _transposeSlotTypeHolder;
+        ITransposeSlotTypeHolder ITransposeDataView.TransposeSlotTypeHolder => _transposeSlotTypeHolder;
 
         public RowCursor GetRowCursor(Func<int, bool> predicate, Random rand = null)
         {
@@ -585,7 +585,7 @@ namespace Microsoft.ML.Data
         public SlotCursor GetSlotCursor(int col)
         {
             _host.CheckParam(0 <= col && col < Schema.Count, nameof(col));
-            if (_transposeSchema?.GetSlotType(col) == null)
+            if (_transposeSlotTypeHolder?.GetSlotType(col) == null)
             {
                 throw _host.ExceptParam(nameof(col), "Bad call to GetSlotCursor on untransposable column '{0}'",
                     Schema[col].Name);

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -586,7 +586,7 @@ namespace Microsoft.ML.Data
             return View.GetRowCursorSet(predicate, n, rand);
         }
 
-        public SlotCursor GetSlotCursor(int col)
+        SlotCursor ITransposeDataView.GetSlotCursor(int col)
         {
             _host.CheckParam(0 <= col && col < Schema.Count, nameof(col));
             if (_transposeSlotTypes == null || (_transposeSlotTypes != null && _transposeSlotTypes[col] == null))

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -793,7 +793,7 @@ namespace Microsoft.ML.Data.IO
                 Ch.Assert(0 <= col && col < Schema.Count);
                 Ch.Assert(_colToActivesIndex[col] >= 0);
                 var type = Schema[col].Type;
-                Ch.Assert((type as VectorType).GetValueCount() == _parent._header.RowCount);
+                Ch.Assert(((VectorType)type).GetValueCount() == _parent._header.RowCount);
                 Action<int> func = InitOne<int>;
                 ColumnType itemType = type;
                 if (type is VectorType vectorType)

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -645,7 +645,7 @@ namespace Microsoft.ML.Data.IO
             return new RowCursor[] { GetRowCursor(predicate, rand) };
         }
 
-        public SlotCursor GetSlotCursor(int col)
+        SlotCursor ITransposeDataView.GetSlotCursor(int col)
         {
             _host.CheckParam(0 <= col && col < _header.ColumnCount, nameof(col));
             var view = _entries[col].GetViewOrNull();

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Data.IO
             header.Signature = TransposeLoader.Header.SignatureValue;
             header.Version = TransposeLoader.Header.WriterVersion;
             header.CompatibleVersion = TransposeLoader.Header.WriterVersion;
-            var slotType = data.TransposeSlotTypes[cols[0]];
+            var slotType = data.GetSlotType(cols[0]);
             ch.AssertValue(slotType);
             header.RowCount = slotType.Size;
             header.ColumnCount = cols.Length;

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Data.IO
             header.Signature = TransposeLoader.Header.SignatureValue;
             header.Version = TransposeLoader.Header.WriterVersion;
             header.CompatibleVersion = TransposeLoader.Header.WriterVersion;
-            VectorType slotType = data.TransposeSchema.GetSlotType(cols[0]);
+            VectorType slotType = data.TransposeSlotTypeHolder.GetSlotType(cols[0]);
             ch.AssertValue(slotType);
             header.RowCount = slotType.Size;
             header.ColumnCount = cols.Length;

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeSaver.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Data.IO
             header.Signature = TransposeLoader.Header.SignatureValue;
             header.Version = TransposeLoader.Header.WriterVersion;
             header.CompatibleVersion = TransposeLoader.Header.WriterVersion;
-            VectorType slotType = data.TransposeSlotTypeHolder.GetSlotType(cols[0]);
+            var slotType = data.TransposeSlotTypes[cols[0]];
             ch.AssertValue(slotType);
             header.RowCount = slotType.Size;
             header.ColumnCount = cols.Length;

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -278,8 +278,13 @@ namespace Microsoft.ML.Data
                 }
 
                 var originalColumn = _view.Schema[i];
-                var originalElementType = (originalColumn.Type as VectorType).ItemType as PrimitiveType;
+                PrimitiveType originalElementType = null;
+                if (originalColumn.Type is PrimitiveType)
+                    originalElementType = originalColumn.Type as PrimitiveType;
+                else if (originalColumn.Type is VectorType)
+                    originalElementType = (originalColumn.Type as VectorType).ItemType;
                 _host.Assert(originalElementType != null);
+                _host.Assert(originalElementType.GetValueCount() == 1);
                 transposeSchema[i] = new VectorType(originalElementType, RowCount);
             }
             return transposeSchema;

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -323,6 +323,7 @@ namespace Microsoft.ML.Data
 
             public override VectorType GetSlotType()
             {
+                Ch.Assert(0 <= _col && _col < _parent.Schema.Count);
                 return ((ITransposeDataView)_parent).GetSlotType(_col);
             }
 

--- a/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/LabelConvertTransform.cs
@@ -190,7 +190,8 @@ namespace Microsoft.ML.Transforms
             return _slotType;
         }
 
-        protected override SlotCursor GetSlotCursorCore(int iinfo)
+        [BestFriend]
+        internal override SlotCursor GetSlotCursorCore(int iinfo)
         {
             Host.Assert(0 <= iinfo && iinfo < Infos.Length);
             Host.AssertValue(Infos[iinfo].SlotTypeSrc);

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -294,7 +294,7 @@ namespace Microsoft.ML.Data
                 Contracts.Assert(Utils.Size(infos) == InfoCount);
 
                 _parent = parent;
-                TransposeSchema = _parent?.TransposeSlotTypes;
+                TransposeSchema = (_parent as ITransposeDataView)?.TransposeSlotTypes;
                 Infos = infos;
             }
 
@@ -623,7 +623,7 @@ namespace Microsoft.ML.Data
 
         public sealed override Schema OutputSchema => _bindings.AsSchema;
 
-        public VectorType[] TransposeSlotTypes => _bindings?.TransposeSchema;
+        VectorType[] ITransposeDataView.TransposeSlotTypes => _bindings?.TransposeSchema;
 
         /// <summary>
         /// Return the (destination) column index for the indicated added column.

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -274,7 +274,6 @@ namespace Microsoft.ML.Data
         {
             // The parent transform.
             private readonly OneToOneTransformBase _parent;
-            // The source input transform schema, or null if the input was not a transpose dataview.
 
             /// <summary>
             /// Information about each added column.
@@ -283,7 +282,7 @@ namespace Microsoft.ML.Data
 
             public VectorType GetSlotType(int col)
             {
-                var tidv = _parent as ITransposeDataView;
+                var tidv = _parent.InputTranspose;
                 return tidv?.GetSlotType(col);
             }
 

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -736,8 +736,8 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Returns a standard exception for responding to an invalid call to <see cref="GetSlotCursor"/>,
-        /// on a column that is not transposable.
+        /// Returns a standard exception for responding to an invalid call to <see cref="ITransposeDataView.GetSlotCursor"/>
+        /// implementation in <see langword="this"/> on a column that is not transposable.
         /// </summary>
         protected Exception ExceptGetSlotCursor(int col)
         {
@@ -746,7 +746,7 @@ namespace Microsoft.ML.Data
                 OutputSchema[col].Name);
         }
 
-        public SlotCursor GetSlotCursor(int col)
+        SlotCursor ITransposeDataView.GetSlotCursor(int col)
         {
             Host.CheckParam(0 <= col && col < _bindings.ColumnCount, nameof(col));
 
@@ -771,7 +771,8 @@ namespace Microsoft.ML.Data
         /// null for all new columns, and so reaching this is only possible if there is a
         /// bug.
         /// </summary>
-        protected virtual SlotCursor GetSlotCursorCore(int iinfo)
+        [BestFriend]
+        internal virtual SlotCursor GetSlotCursorCore(int iinfo)
         {
             Host.Assert(false);
             throw Host.ExceptNotImpl("Data view indicated it could transpose a column, but apparently it could not");

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -1405,7 +1405,7 @@ namespace Microsoft.ML.Trainers.FastTree
                         BinFinder finder = new BinFinder();
                         FeaturesToContentMap fmap = new FeaturesToContentMap(examples.Schema);
 
-                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>(trans.TransposeSlotTypes[featIdx]);
+                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>((trans as ITransposeDataView).TransposeSlotTypes[featIdx]);
                         // There is no good mechanism to filter out rows with missing feature values on transposed data.
                         // So, we instead perform one featurization pass which, if successful, will remain one pass but,
                         // if we ever encounter missing values will become a "detect missing features" pass, which will

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -226,8 +226,8 @@ namespace Microsoft.ML.Trainers.FastTree
             if (useTranspose.HasValue)
                 return useTranspose.Value;
 
-            ITransposeDataView td = data.Data as ITransposeDataView;
-            return td?.TransposeSlotTypes != null && td.TransposeSlotTypes[data.Schema.Feature.Value.Index] != null;
+            var itdv = data.Data as ITransposeDataView;
+            return itdv?.GetSlotType(data.Schema.Feature.Value.Index) != null;
         }
 
         protected void TrainCore(IChannel ch)
@@ -1405,7 +1405,7 @@ namespace Microsoft.ML.Trainers.FastTree
                         BinFinder finder = new BinFinder();
                         FeaturesToContentMap fmap = new FeaturesToContentMap(examples.Schema);
 
-                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>((trans as ITransposeDataView).TransposeSlotTypes[featIdx]);
+                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>(((ITransposeDataView)trans).GetSlotType(featIdx));
                         // There is no good mechanism to filter out rows with missing feature values on transposed data.
                         // So, we instead perform one featurization pass which, if successful, will remain one pass but,
                         // if we ever encounter missing values will become a "detect missing features" pass, which will

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -227,7 +227,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 return useTranspose.Value;
 
             ITransposeDataView td = data.Data as ITransposeDataView;
-            return td != null && td.TransposeSlotTypeHolder.GetSlotType(data.Schema.Feature.Value.Index) != null;
+            return td?.TransposeSlotTypes != null && td.TransposeSlotTypes[data.Schema.Feature.Value.Index] != null;
         }
 
         protected void TrainCore(IChannel ch)
@@ -1405,7 +1405,7 @@ namespace Microsoft.ML.Trainers.FastTree
                         BinFinder finder = new BinFinder();
                         FeaturesToContentMap fmap = new FeaturesToContentMap(examples.Schema);
 
-                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>(trans.TransposeSlotTypeHolder.GetSlotType(featIdx));
+                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>(trans.TransposeSlotTypes[featIdx]);
                         // There is no good mechanism to filter out rows with missing feature values on transposed data.
                         // So, we instead perform one featurization pass which, if successful, will remain one pass but,
                         // if we ever encounter missing values will become a "detect missing features" pass, which will

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -227,7 +227,7 @@ namespace Microsoft.ML.Trainers.FastTree
                 return useTranspose.Value;
 
             ITransposeDataView td = data.Data as ITransposeDataView;
-            return td != null && td.TransposeSchema.GetSlotType(data.Schema.Feature.Value.Index) != null;
+            return td != null && td.TransposeSlotTypeHolder.GetSlotType(data.Schema.Feature.Value.Index) != null;
         }
 
         protected void TrainCore(IChannel ch)
@@ -1405,7 +1405,7 @@ namespace Microsoft.ML.Trainers.FastTree
                         BinFinder finder = new BinFinder();
                         FeaturesToContentMap fmap = new FeaturesToContentMap(examples.Schema);
 
-                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>(trans.TransposeSchema.GetSlotType(featIdx));
+                        var hasMissingPred = Conversions.Instance.GetHasMissingPredicate<Float>(trans.TransposeSlotTypeHolder.GetSlotType(featIdx));
                         // There is no good mechanism to filter out rows with missing feature values on transposed data.
                         // So, we instead perform one featurization pass which, if successful, will remain one pass but,
                         // if we ever encounter missing values will become a "detect missing features" pass, which will

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             if (useTranspose.HasValue)
                 return useTranspose.Value;
-            return data.Data is ITransposeDataView td && td.TransposeSchema.GetSlotType(data.Schema.Feature.Value.Index) != null;
+            return data.Data is ITransposeDataView td && td.TransposeSlotTypeHolder.GetSlotType(data.Schema.Feature.Value.Index) != null;
         }
 
         private void TrainCore(IChannel ch)

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -268,7 +268,8 @@ namespace Microsoft.ML.Trainers.FastTree
 
             if (useTranspose.HasValue)
                 return useTranspose.Value;
-            return data.Data is ITransposeDataView td && td.TransposeSlotTypeHolder.GetSlotType(data.Schema.Feature.Value.Index) != null;
+            return data.Data is ITransposeDataView td && td.TransposeSlotTypes != null
+                && td.TransposeSlotTypes[data.Schema.Feature.Value.Index] != null;
         }
 
         private void TrainCore(IChannel ch)

--- a/src/Microsoft.ML.FastTree/GamTrainer.cs
+++ b/src/Microsoft.ML.FastTree/GamTrainer.cs
@@ -268,8 +268,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
             if (useTranspose.HasValue)
                 return useTranspose.Value;
-            return data.Data is ITransposeDataView td && td.TransposeSlotTypes != null
-                && td.TransposeSlotTypes[data.Schema.Feature.Value.Index] != null;
+            return (data.Data as ITransposeDataView)?.GetSlotType(data.Schema.Feature.Value.Index) != null;
         }
 
         private void TrainCore(IChannel ch)

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.RunTests
         private static void TransposeCheckHelper<T>(IDataView view, int viewCol, ITransposeDataView trans)
         {
             int col = viewCol;
-            VectorType type = trans.TransposeSlotTypeHolder.GetSlotType(col);
+            VectorType type = trans.TransposeSlotTypes[col];
             ColumnType colType = trans.Schema[col].Type;
             Assert.Equal(view.Schema[viewCol].Name, trans.Schema[col].Name);
             ColumnType expectedType = view.Schema[viewCol].Type;
@@ -184,7 +184,7 @@ namespace Microsoft.ML.RunTests
                     Assert.True(trueIndex == index, $"Transpose schema had column '{names[i]}' at unexpected index");
                 }
                 // Check the contents
-                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(2)); // C check to see that it's not transposable.
+                Assert.Null(trans.TransposeSlotTypes[2]); // C check to see that it's not transposable.
                 TransposeCheckHelper<int>(view, 0, trans); // A check.
                 TransposeCheckHelper<Double>(view, 1, trans); // B check.
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
@@ -199,9 +199,9 @@ namespace Microsoft.ML.RunTests
             using (Transposer trans = Transposer.Create(Env, view, true, 3, 5, 4))
             {
                 // Check to see that A, B, and C were not transposed somehow.
-                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(0));
-                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(1));
-                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(2));
+                Assert.Null(trans.TransposeSlotTypes[0]);
+                Assert.Null(trans.TransposeSlotTypes[1]);
+                Assert.Null(trans.TransposeSlotTypes[2]);
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
                 TransposeCheckHelper<uint>(view, 4, trans);   // E check.
                 TransposeCheckHelper<int>(view, 5, trans); // F check.

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.RunTests
         private static void TransposeCheckHelper<T>(IDataView view, int viewCol, ITransposeDataView trans)
         {
             int col = viewCol;
-            VectorType type = trans.TransposeSchema.GetSlotType(col);
+            VectorType type = trans.TransposeSlotTypeHolder.GetSlotType(col);
             ColumnType colType = trans.Schema[col].Type;
             Assert.Equal(view.Schema[viewCol].Name, trans.Schema[col].Name);
             ColumnType expectedType = view.Schema[viewCol].Type;
@@ -184,7 +184,7 @@ namespace Microsoft.ML.RunTests
                     Assert.True(trueIndex == index, $"Transpose schema had column '{names[i]}' at unexpected index");
                 }
                 // Check the contents
-                Assert.Null(trans.TransposeSchema.GetSlotType(2)); // C check to see that it's not transposable.
+                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(2)); // C check to see that it's not transposable.
                 TransposeCheckHelper<int>(view, 0, trans); // A check.
                 TransposeCheckHelper<Double>(view, 1, trans); // B check.
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
@@ -199,9 +199,9 @@ namespace Microsoft.ML.RunTests
             using (Transposer trans = Transposer.Create(Env, view, true, 3, 5, 4))
             {
                 // Check to see that A, B, and C were not transposed somehow.
-                Assert.Null(trans.TransposeSchema.GetSlotType(0));
-                Assert.Null(trans.TransposeSchema.GetSlotType(1));
-                Assert.Null(trans.TransposeSchema.GetSlotType(2));
+                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(0));
+                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(1));
+                Assert.Null(trans.TransposeSlotTypeHolder.GetSlotType(2));
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
                 TransposeCheckHelper<uint>(view, 4, trans);   // E check.
                 TransposeCheckHelper<int>(view, 5, trans); // F check.

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -184,7 +184,7 @@ namespace Microsoft.ML.RunTests
                     Assert.True(trueIndex == index, $"Transpose schema had column '{names[i]}' at unexpected index");
                 }
                 // Check the contents
-                Assert.Null(trans.TransposeSlotTypes[2]); // C check to see that it's not transposable.
+                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[2]); // C check to see that it's not transposable.
                 TransposeCheckHelper<int>(view, 0, trans); // A check.
                 TransposeCheckHelper<Double>(view, 1, trans); // B check.
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
@@ -199,9 +199,9 @@ namespace Microsoft.ML.RunTests
             using (Transposer trans = Transposer.Create(Env, view, true, 3, 5, 4))
             {
                 // Check to see that A, B, and C were not transposed somehow.
-                Assert.Null(trans.TransposeSlotTypes[0]);
-                Assert.Null(trans.TransposeSlotTypes[1]);
-                Assert.Null(trans.TransposeSlotTypes[2]);
+                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[0]);
+                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[1]);
+                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[2]);
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
                 TransposeCheckHelper<uint>(view, 4, trans);   // E check.
                 TransposeCheckHelper<int>(view, 5, trans); // F check.

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -199,9 +199,10 @@ namespace Microsoft.ML.RunTests
             using (Transposer trans = Transposer.Create(Env, view, true, 3, 5, 4))
             {
                 // Check to see that A, B, and C were not transposed somehow.
-                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[0]);
-                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[1]);
-                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[2]);
+                var itdv = trans as ITransposeDataView;
+                Assert.Null(itdv.TransposeSlotTypes[0]);
+                Assert.Null(itdv.TransposeSlotTypes[1]);
+                Assert.Null(itdv.TransposeSlotTypes[2]);
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
                 TransposeCheckHelper<uint>(view, 4, trans);   // E check.
                 TransposeCheckHelper<int>(view, 5, trans); // F check.

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -63,14 +63,17 @@ namespace Microsoft.ML.RunTests
 
         private static void TransposeCheckHelper<T>(IDataView view, int viewCol, ITransposeDataView trans)
         {
+            Assert.NotNull(view);
+            Assert.NotNull(trans);
+
             int col = viewCol;
-            VectorType type = trans.TransposeSlotTypes[col];
+            VectorType type = trans.GetSlotType(col);
             ColumnType colType = trans.Schema[col].Type;
             Assert.Equal(view.Schema[viewCol].Name, trans.Schema[col].Name);
             ColumnType expectedType = view.Schema[viewCol].Type;
             Assert.Equal(expectedType, colType);
             string desc = string.Format("Column {0} named '{1}'", col, trans.Schema[col].Name);
-            Assert.Equal(DataViewUtils.ComputeRowCount(view), (long)type.Size);
+            Assert.Equal(DataViewUtils.ComputeRowCount(view), type.Size);
             Assert.True(typeof(T) == type.ItemType.RawType, $"{desc} had wrong type for slot cursor");
             Assert.True(type.Size > 0, $"{desc} expected to be known sized vector but is not");
             int valueCount = (colType as VectorType)?.Size ?? 1;
@@ -184,7 +187,7 @@ namespace Microsoft.ML.RunTests
                     Assert.True(trueIndex == index, $"Transpose schema had column '{names[i]}' at unexpected index");
                 }
                 // Check the contents
-                Assert.Null((trans as ITransposeDataView).TransposeSlotTypes[2]); // C check to see that it's not transposable.
+                Assert.Null(((ITransposeDataView)trans).GetSlotType(2)); // C check to see that it's not transposable.
                 TransposeCheckHelper<int>(view, 0, trans); // A check.
                 TransposeCheckHelper<Double>(view, 1, trans); // B check.
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
@@ -199,10 +202,10 @@ namespace Microsoft.ML.RunTests
             using (Transposer trans = Transposer.Create(Env, view, true, 3, 5, 4))
             {
                 // Check to see that A, B, and C were not transposed somehow.
-                var itdv = trans as ITransposeDataView;
-                Assert.Null(itdv.TransposeSlotTypes[0]);
-                Assert.Null(itdv.TransposeSlotTypes[1]);
-                Assert.Null(itdv.TransposeSlotTypes[2]);
+                var itdv = (ITransposeDataView)trans;
+                Assert.Null(itdv.GetSlotType(0));
+                Assert.Null(itdv.GetSlotType(1));
+                Assert.Null(itdv.GetSlotType(2));
                 TransposeCheckHelper<Double>(view, 3, trans); // D check.
                 TransposeCheckHelper<uint>(view, 4, trans);   // E check.
                 TransposeCheckHelper<int>(view, 5, trans); // F check.


### PR DESCRIPTION
We remove `ITransposeSchema` and move `GetSlotType` to `TransposeSlotTypes` field in `ITransposeDataView`. Several derived classes' `ISchema` members are removed because they are not used at all.

Party of #1501 continues.