### PR TITLE
Allow NimbusML to access some internals

### DIFF
--- a/src/Microsoft.ML.Core/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.Core/Properties/AssemblyInfo.cs
@@ -96,5 +96,6 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "RunTestsAzurePublish" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "SseTests" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "TLC" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "DotNetBridge" + InternalPublicKey.Value)]
 
 [assembly: WantsToBeBestFriends]

--- a/src/Microsoft.ML.Data/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.Data/Properties/AssemblyInfo.cs
@@ -75,5 +75,6 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Runtime.Scope" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "TLC" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "RunTestsMore" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "DotNetBridge" + InternalPublicKey.Value)]
 
 [assembly: WantsToBeBestFriends]

--- a/src/Microsoft.ML.EntryPoints/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.EntryPoints/Properties/AssemblyInfo.cs
@@ -8,3 +8,4 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo("Microsoft.ML.Tests" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo("Microsoft.ML.Core.Tests" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo("RunTests" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo("DotNetBridge" + InternalPublicKey.Value)]


### PR DESCRIPTION
Added NimbusML's DotNetBridge to ML.Core/Data/Entrypoints. 

This closes #2062, closes #1957, closes #1958, closes #1959