### PR TITLE
Publish test trx files on failure

### DIFF
--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -55,7 +55,9 @@ phases:
       condition: not(succeeded())
       inputs:
         sourceFolder: $(Build.SourcesDirectory)/bin
-        contents: '**/TestOutput/**/*'
+        contents: |
+          **/TestOutput/**/*
+          **/*.trx
         targetFolder: $(Build.ArtifactStagingDirectory)
     - task: PublishBuildArtifacts@1
       displayName: Publish build and test logs


### PR DESCRIPTION
There are times when the tests fail, but we don't know why. Publish the trx files as well during test failures.