### PR TITLE
Avoid using exceptions for control flow in GetBatch

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
@@ -444,27 +444,14 @@ namespace Microsoft.ML.Data
 
                 public LineBatch GetBatch()
                 {
-                    Exception inner = null;
-                    try
-                    {
-                        var batch = _queue.Take();
-                        if (batch.Exception == null)
-                            return batch;
-                        inner = batch.Exception;
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        // This code detects when there is no more content by catching the exception thrown by _queue.Take() at the end.
-                        // If _queue.IsAddingCompleted is true, we know that this exception was the result of that specifically.
-                        // This should probably be re-engineered to not rely on exception blocks.
-                        // REVIEW: Come up with a less strange scheme for the interthread communication here, that does not
-                        // rely on exceptions and timeouts throughout the pipeline.
-                        if (_queue.IsAddingCompleted)
-                            return default(LineBatch);
-                        throw;
-                    }
-                    Contracts.AssertValue(inner);
-                    throw Contracts.ExceptDecode(inner, "Stream reading encountered exception");
+                    if (!_queue.TryTake(out LineBatch batch, millisecondsTimeout: -1))
+                        return default;
+
+                    if (batch.Exception == null)
+                        return batch;
+
+                    Contracts.AssertValue(batch.Exception);
+                    throw Contracts.ExceptDecode(batch.Exception, "Stream reading encountered exception");
                 }
 
                 private void ThreadProc()


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/2137
Contributes to https://github.com/dotnet/machinelearning/issues/2099

This avoids using Take() in GetBatch, instead using TryTake with an infinite timeout, the only difference being whether it expects to eventually get data, and thus whether it throws or returns false when it finds the collection empty and marked for completion. This doesn't fix #2099, but it helps.  These exceptions are largely a side-effect of tons of threads getting created, which is another huge contributor to #2099.

cc: @TomFinley 