### PR TITLE
Remove ColumnType.RawKind usages Round 1.

### DIFF
--- a/src/Microsoft.ML.Onnx/OnnxUtils.cs
+++ b/src/Microsoft.ML.Onnx/OnnxUtils.cs
@@ -327,7 +327,7 @@ namespace Microsoft.ML.Model.Onnx
                 dataType = TensorProto.Types.DataType.Double;
             else
             {
-                string msg = "Unsupported type: " + rawType.ToString();
+                string msg = "Unsupported type: " + type.ToString();
                 Contracts.Check(false, msg);
             }
 

--- a/src/Microsoft.ML.Onnx/OnnxUtils.cs
+++ b/src/Microsoft.ML.Onnx/OnnxUtils.cs
@@ -295,56 +295,40 @@ namespace Microsoft.ML.Model.Onnx
             Contracts.CheckNonEmpty(colName, nameof(colName));
 
             TensorProto.Types.DataType dataType = TensorProto.Types.DataType.Undefined;
-            DataKind rawKind;
+            Type rawType;
             if (type is VectorType vectorType)
-                rawKind = vectorType.ItemType.RawKind;
-            else if (type is KeyType keyType)
-                rawKind = keyType.RawKind;
+                rawType = vectorType.ItemType.RawType;
             else
-                rawKind = type.RawKind;
+                rawType = type.RawType;
 
-            switch (rawKind)
+            if (rawType == typeof(bool))
+                dataType = TensorProto.Types.DataType.Float;
+            else if (rawType == typeof(ReadOnlyMemory<char>))
+                dataType = TensorProto.Types.DataType.String;
+            else if (rawType == typeof(sbyte))
+                dataType = TensorProto.Types.DataType.Int8;
+            else if (rawType == typeof(byte))
+                dataType = TensorProto.Types.DataType.Uint8;
+            else if (rawType == typeof(short))
+                dataType = TensorProto.Types.DataType.Int16;
+            else if (rawType == typeof(ushort))
+                dataType = TensorProto.Types.DataType.Uint16;
+            else if (rawType == typeof(int))
+                dataType = TensorProto.Types.DataType.Int32;
+            else if (rawType == typeof(uint))
+                dataType = TensorProto.Types.DataType.Int64;
+            else if (rawType == typeof(long))
+                dataType = TensorProto.Types.DataType.Int64;
+            else if (rawType == typeof(ulong))
+                dataType = TensorProto.Types.DataType.Uint64;
+            else if (rawType == typeof(float))
+                dataType = TensorProto.Types.DataType.Float;
+            else if (rawType == typeof(double))
+                dataType = TensorProto.Types.DataType.Double;
+            else
             {
-                case DataKind.BL:
-                    dataType = TensorProto.Types.DataType.Float;
-                    break;
-                case DataKind.TX:
-                    dataType = TensorProto.Types.DataType.String;
-                    break;
-                case DataKind.I1:
-                    dataType = TensorProto.Types.DataType.Int8;
-                    break;
-                case DataKind.U1:
-                    dataType = TensorProto.Types.DataType.Uint8;
-                    break;
-                case DataKind.I2:
-                    dataType = TensorProto.Types.DataType.Int16;
-                    break;
-                case DataKind.U2:
-                    dataType = TensorProto.Types.DataType.Uint16;
-                    break;
-                case DataKind.I4:
-                    dataType = TensorProto.Types.DataType.Int32;
-                    break;
-                case DataKind.U4:
-                    dataType = TensorProto.Types.DataType.Int64;
-                    break;
-                case DataKind.I8:
-                    dataType = TensorProto.Types.DataType.Int64;
-                    break;
-                case DataKind.U8:
-                    dataType = TensorProto.Types.DataType.Uint64;
-                    break;
-                case DataKind.R4:
-                    dataType = TensorProto.Types.DataType.Float;
-                    break;
-                case DataKind.R8:
-                    dataType = TensorProto.Types.DataType.Double;
-                    break;
-                default:
-                    string msg = "Unsupported type: DataKind " + rawKind.ToString();
-                    Contracts.Check(false, msg);
-                    break;
+                string msg = "Unsupported type: " + rawType.ToString();
+                Contracts.Check(false, msg);
             }
 
             string name = colName;

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -70,8 +70,8 @@ namespace Microsoft.ML.Trainers.Recommender
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(RegistrationName);
-            _host.Assert(matrixColumnIndexType.RawKind == DataKind.U4);
-            _host.Assert(matrixRowIndexType.RawKind == DataKind.U4);
+            _host.Assert(matrixColumnIndexType.RawType == typeof(uint));
+            _host.Assert(matrixRowIndexType.RawType == typeof(uint));
             _host.CheckValue(buffer, nameof(buffer));
             _host.CheckValue(matrixColumnIndexType, nameof(matrixColumnIndexType));
             _host.CheckValue(matrixRowIndexType, nameof(matrixRowIndexType));

--- a/src/Microsoft.ML.Recommender/RecommenderUtils.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderUtils.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Recommender
         private static bool TryMarshalGoodRowColumnType(ColumnType type, out KeyType keyType)
         {
             keyType = type as KeyType;
-            return keyType?.Count > 0 && type.RawKind == DataKind.U4;
+            return keyType?.Count > 0 && type.RawType == typeof(uint);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StaticPipe/SchemaAssertionContext.cs
+++ b/src/Microsoft.ML.StaticPipe/SchemaAssertionContext.cs
@@ -68,13 +68,13 @@ namespace Microsoft.ML.StaticPipe.Runtime
         /// <summary>Assertions over a column of <see cref="BoolType"/>.</summary>
         public PrimitiveTypeAssertions<bool> Bool => default;
 
-        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="DataKind.U1"/> <see cref="ColumnType.RawKind"/>.</summary>
+        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="byte"/> <see cref="ColumnType.RawType"/>.</summary>
         public KeyTypeSelectorAssertions<byte> KeyU1 => default;
-        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="DataKind.U2"/> <see cref="ColumnType.RawKind"/>.</summary>
+        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="ushort"/> <see cref="ColumnType.RawType"/>.</summary>
         public KeyTypeSelectorAssertions<ushort> KeyU2 => default;
-        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="DataKind.U4"/> <see cref="ColumnType.RawKind"/>.</summary>
+        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="uint"/> <see cref="ColumnType.RawType"/>.</summary>
         public KeyTypeSelectorAssertions<uint> KeyU4 => default;
-        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="DataKind.U8"/> <see cref="ColumnType.RawKind"/>.</summary>
+        /// <summary>Assertions over a column of <see cref="KeyType"/> with <see cref="ulong"/> <see cref="ColumnType.RawType"/>.</summary>
         public KeyTypeSelectorAssertions<ulong> KeyU8 => default;
 
         internal static SchemaAssertionContext Inst = new SchemaAssertionContext();

--- a/src/Microsoft.ML.StaticPipe/StaticSchemaShape.cs
+++ b/src/Microsoft.ML.StaticPipe/StaticSchemaShape.cs
@@ -134,7 +134,7 @@ namespace Microsoft.ML.StaticPipe.Runtime
 
             if (col.IsKey)
             {
-                Type physType = StaticKind(col.ItemType.RawKind);
+                Type physType = GetPhysicalType(col.ItemType);
                 Contracts.Assert(physType == typeof(byte) || physType == typeof(ushort)
                     || physType == typeof(uint) || physType == typeof(ulong));
                 var keyType = typeof(Key<>).MakeGenericType(physType);
@@ -158,7 +158,7 @@ namespace Microsoft.ML.StaticPipe.Runtime
 
             if (col.ItemType is PrimitiveType pt)
             {
-                Type physType = StaticKind(pt.RawKind);
+                Type physType = GetPhysicalType(pt);
                 // Though I am unaware of any existing instances, it is theoretically possible for a
                 // primitive type to exist, have the same data kind as one of the existing types, and yet
                 // not be one of the built in types. (For example, an outside analogy to the key types.) For this
@@ -266,7 +266,7 @@ namespace Microsoft.ML.StaticPipe.Runtime
 
             if (t is KeyType kt)
             {
-                Type physType = StaticKind(kt.RawKind);
+                Type physType = GetPhysicalType(kt);
                 Contracts.Assert(physType == typeof(byte) || physType == typeof(ushort)
                     || physType == typeof(uint) || physType == typeof(ulong));
                 var keyType = kt.Count > 0 ? typeof(Key<>) : typeof(VarKey<>);
@@ -302,7 +302,7 @@ namespace Microsoft.ML.StaticPipe.Runtime
 
             if (t is PrimitiveType pt)
             {
-                Type physType = StaticKind(pt.RawKind);
+                Type physType = GetPhysicalType(pt);
                 // Though I am unaware of any existing instances, it is theoretically possible for a
                 // primitive type to exist, have the same data kind as one of the existing types, and yet
                 // not be one of the built in types. (For example, an outside analogy to the key types.) For this
@@ -327,34 +327,21 @@ namespace Microsoft.ML.StaticPipe.Runtime
         /// type for communicating text.
         /// </summary>
         /// <returns>The basic type used to represent an item type in the static pipeline</returns>
-        private static Type StaticKind(DataKind kind)
+        private static Type GetPhysicalType(ColumnType columnType)
         {
-            switch (kind)
+            switch (columnType)
             {
-                // The default kind is reserved for unknown types.
-                case default(DataKind): return null;
-                case DataKind.I1: return typeof(sbyte);
-                case DataKind.I2: return typeof(short);
-                case DataKind.I4: return typeof(int);
-                case DataKind.I8: return typeof(long);
-
-                case DataKind.U1: return typeof(byte);
-                case DataKind.U2: return typeof(ushort);
-                case DataKind.U4: return typeof(uint);
-                case DataKind.U8: return typeof(ulong);
-                case DataKind.U16: return typeof(RowId);
-
-                case DataKind.R4: return typeof(float);
-                case DataKind.R8: return typeof(double);
-                case DataKind.BL: return typeof(bool);
-
-                case DataKind.Text: return typeof(string);
-                case DataKind.TimeSpan: return typeof(TimeSpan);
-                case DataKind.DateTime: return typeof(DateTime);
-                case DataKind.DateTimeZone: return typeof(DateTimeOffset);
+                case NumberType numberType:
+                case TimeSpanType timeSpanType:
+                case DateTimeType dateTimeType:
+                case DateTimeOffsetType dateTimeOffsetType:
+                case BoolType boolType:
+                    return columnType.RawType;
+                case TextType textType:
+                    return typeof(string);
 
                 default:
-                    throw Contracts.ExceptParam(nameof(kind), $"Unrecognized type '{kind}'");
+                    return null;
             }
         }
     }

--- a/src/Microsoft.ML.StaticPipe/StaticSchemaShape.cs
+++ b/src/Microsoft.ML.StaticPipe/StaticSchemaShape.cs
@@ -332,6 +332,7 @@ namespace Microsoft.ML.StaticPipe.Runtime
             switch (columnType)
             {
                 case NumberType numberType:
+                case KeyType keyType:
                 case TimeSpanType timeSpanType:
                 case DateTimeType dateTimeType:
                 case DateTimeOffsetType dateTimeOffsetType:

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -480,7 +480,7 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if ((col.ItemType.GetItemType().RawKind == default) || !(col.ItemType is VectorType || col.ItemType is PrimitiveType))
+                if (!(col.ItemType is VectorType || col.ItemType is PrimitiveType))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
                 var metadata = new List<SchemaShape.Column>();

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -901,16 +901,14 @@ namespace Microsoft.ML.Transforms
 
             private bool SaveAsOnnxCore(OnnxContext ctx, int iinfo, ColInfo info, string srcVariableName, string dstVariableName)
             {
-                DataKind rawKind;
+                Type rawType;
                 var type = _infos[iinfo].TypeSrc;
                 if (type is VectorType vectorType)
-                    rawKind = vectorType.ItemType.RawKind;
-                else if (type is KeyType keyType)
-                    rawKind = keyType.RawKind;
+                    rawType = vectorType.ItemType.RawType;
                 else
-                    rawKind = type.RawKind;
+                    rawType = type.RawType;
 
-                if (rawKind != DataKind.R4)
+                if (rawType != typeof(float))
                     return false;
 
                 string opType = "Imputer";

--- a/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
@@ -21,27 +21,17 @@ namespace Microsoft.ML.Transforms
                 // The type is a scalar.
                 if (kind == ReplacementKind.Mean)
                 {
-                    switch (type.RawKind)
-                    {
-                    case DataKind.R4:
+                    if (type.RawType == typeof(float))
                         return new R4.MeanAggregatorOne(ch, cursor, col);
-                    case DataKind.R8:
+                    else if (type.RawType == typeof(double))
                         return new R8.MeanAggregatorOne(ch, cursor, col);
-                    default:
-                        break;
-                    }
                 }
                 if (kind == ReplacementKind.Min || kind == ReplacementKind.Max)
                 {
-                    switch (type.RawKind)
-                    {
-                    case DataKind.R4:
+                    if (type.RawType == typeof(float))
                         return new R4.MinMaxAggregatorOne(ch, cursor, col, kind == ReplacementKind.Max);
-                    case DataKind.R8:
+                    else if (type.RawType == typeof(double))
                         return new R8.MinMaxAggregatorOne(ch, cursor, col, kind == ReplacementKind.Max);
-                    default:
-                        break;
-                    }
                 }
             }
             else if (bySlot)
@@ -53,27 +43,17 @@ namespace Microsoft.ML.Transforms
 
                 if (kind == ReplacementKind.Mean)
                 {
-                    switch (vectorType.ItemType.RawKind)
-                    {
-                    case DataKind.R4:
+                    if (vectorType.ItemType.RawType == typeof(float))
                         return new R4.MeanAggregatorBySlot(ch, vectorType, cursor, col);
-                    case DataKind.R8:
+                    else if (vectorType.ItemType.RawType == typeof(double))
                         return new R8.MeanAggregatorBySlot(ch, vectorType, cursor, col);
-                    default:
-                        break;
-                    }
                 }
                 else if (kind == ReplacementKind.Min || kind == ReplacementKind.Max)
                 {
-                    switch (vectorType.ItemType.RawKind)
-                    {
-                    case DataKind.R4:
+                    if (vectorType.ItemType.RawType == typeof(float))
                         return new R4.MinMaxAggregatorBySlot(ch, vectorType, cursor, col, kind == ReplacementKind.Max);
-                    case DataKind.R8:
+                    else if (vectorType.ItemType.RawType == typeof(double))
                         return new R8.MinMaxAggregatorBySlot(ch, vectorType, cursor, col, kind == ReplacementKind.Max);
-                    default:
-                        break;
-                    }
                 }
             }
             else
@@ -81,27 +61,17 @@ namespace Microsoft.ML.Transforms
                 // Imputation across slots.
                 if (kind == ReplacementKind.Mean)
                 {
-                    switch (vectorType.ItemType.RawKind)
-                    {
-                    case DataKind.R4:
+                    if (vectorType.ItemType.RawType == typeof(float))
                         return new R4.MeanAggregatorAcrossSlots(ch, cursor, col);
-                    case DataKind.R8:
+                    else if (vectorType.ItemType.RawType == typeof(double))
                         return new R8.MeanAggregatorAcrossSlots(ch, cursor, col);
-                    default:
-                        break;
-                    }
                 }
                 else if (kind == ReplacementKind.Min || kind == ReplacementKind.Max)
                 {
-                    switch (vectorType.ItemType.RawKind)
-                    {
-                    case DataKind.R4:
+                    if (vectorType.ItemType.RawType == typeof(float))
                         return new R4.MinMaxAggregatorAcrossSlots(ch, cursor, col, kind == ReplacementKind.Max);
-                    case DataKind.R8:
+                    else if (vectorType.ItemType.RawType == typeof(double))
                         return new R8.MinMaxAggregatorAcrossSlots(ch, cursor, col, kind == ReplacementKind.Max);
-                    default:
-                        break;
-                    }
                 }
             }
             ch.Assert(false);

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -680,7 +680,7 @@ namespace Microsoft.ML.Transforms.Projections
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if (col.ItemType.RawKind != DataKind.R4 || col.Kind != SchemaShape.Column.VectorKind.Vector)
+                if (col.ItemType.RawType != typeof(float) || col.Kind != SchemaShape.Column.VectorKind.Vector)
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
                 result[colInfo.Output] = new SchemaShape.Column(colInfo.Output, SchemaShape.Column.VectorKind.Vector, NumberType.R4, false);

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -1159,7 +1159,7 @@ namespace Microsoft.ML.Transforms.Text
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if (col.ItemType.RawKind != DataKind.R4 || col.Kind == SchemaShape.Column.VectorKind.Scalar)
+                if (col.ItemType.RawType != typeof(float) || col.Kind == SchemaShape.Column.VectorKind.Scalar)
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input, "a vector of floats", col.GetTypeString());
 
                 result[colInfo.Output] = new SchemaShape.Column(colInfo.Output, SchemaShape.Column.VectorKind.Vector, NumberType.R4, false);

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -1177,7 +1177,7 @@ namespace Microsoft.ML.Transforms.Text
             if (!(vectorType.ItemType is KeyType itemKeyType))
                 return false;
             // Can only accept key types that can be converted to U4.
-            if (itemKeyType.Count == 0 && itemKeyType.RawKind > DataKind.U4)
+            if (itemKeyType.Count == 0 && !NgramUtils.IsValidNgramRawType(itemKeyType.RawType))
                 return false;
             return true;
         }
@@ -1189,7 +1189,7 @@ namespace Microsoft.ML.Transforms.Text
             if (!col.IsKey)
                 return false;
             // Can only accept key types that can be converted to U4.
-            if (col.ItemType.RawKind > DataKind.U4)
+            if (!NgramUtils.IsValidNgramRawType(col.ItemType.RawType))
                 return false;
             return true;
         }

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -843,7 +843,7 @@ namespace Microsoft.ML.Transforms.Text
             if (!(vectorType.ItemType is KeyType itemKeyType))
                 return false;
             // Can only accept key types that can be converted to U4.
-            if (itemKeyType.Count == 0 && itemKeyType.RawKind > DataKind.U4)
+            if (itemKeyType.Count == 0 && !NgramUtils.IsValidNgramRawType(itemKeyType.RawType))
                 return false;
             return true;
         }
@@ -855,7 +855,7 @@ namespace Microsoft.ML.Transforms.Text
             if (!col.IsKey)
                 return false;
             // Can only accept key types that can be converted to U4.
-            if (col.ItemType.RawKind > DataKind.U4)
+            if (!NgramUtils.IsValidNgramRawType(col.ItemType.RawType))
                 return false;
             return true;
         }

--- a/src/Microsoft.ML.Transforms/Text/NgramUtils.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramUtils.cs
@@ -207,12 +207,7 @@ namespace Microsoft.ML.Data
         public static bool IsValidNgramRawType(Type rawType)
         {
             // Can only accept key types that can be converted to U4 (uint).
-            return rawType == typeof(sbyte)
-                || rawType == typeof(byte)
-                || rawType == typeof(short)
-                || rawType == typeof(ushort)
-                || rawType == typeof(int)
-                || rawType == typeof(uint);
+            return rawType != typeof(ulong);
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/Text/NgramUtils.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramUtils.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.ML.Internal.Utilities;
 using Float = System.Single;
 
@@ -198,6 +199,20 @@ namespace Microsoft.ML.Data
                     return false;
             }
             return more;
+        }
+    }
+
+    internal static class NgramUtils
+    {
+        public static bool IsValidNgramRawType(Type rawType)
+        {
+            // Can only accept key types that can be converted to U4 (uint).
+            return rawType == typeof(sbyte)
+                || rawType == typeof(byte)
+                || rawType == typeof(short)
+                || rawType == typeof(ushort)
+                || rawType == typeof(int)
+                || rawType == typeof(uint);
         }
     }
 }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/ScoreSchemaTest.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/ScoreSchemaTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.RunTests
             Assert.True(scoreColumn.Type is KeyType);
             Assert.Equal((scoreColumnType as KeyType).Min, (scoreColumn.Type as KeyType).Min);
             Assert.Equal((scoreColumnType as KeyType).Count, (scoreColumn.Type as KeyType).Count);
-            Assert.Equal((scoreColumnType as KeyType).RawKind, (scoreColumn.Type as KeyType).RawKind);
+            Assert.Equal((scoreColumnType as KeyType).RawType, (scoreColumn.Type as KeyType).RawType);
             Assert.Equal((scoreColumnType as KeyType).Contiguous, (scoreColumn.Type as KeyType).Contiguous);
 
             // Check metadata. Because keyNames is not empty, there should be three metadata fields.
@@ -105,7 +105,7 @@ namespace Microsoft.ML.RunTests
             Assert.True(scoreColumn.Type is KeyType);
             Assert.Equal((scoreColumnType as KeyType).Min, (scoreColumn.Type as KeyType).Min);
             Assert.Equal((scoreColumnType as KeyType).Count, (scoreColumn.Type as KeyType).Count);
-            Assert.Equal((scoreColumnType as KeyType).RawKind, (scoreColumn.Type as KeyType).RawKind);
+            Assert.Equal((scoreColumnType as KeyType).RawType, (scoreColumn.Type as KeyType).RawType);
             Assert.Equal((scoreColumnType as KeyType).Contiguous, (scoreColumn.Type as KeyType).Contiguous);
 
             // Check metadata. Because keyNames is not empty, there should be three metadata fields.

--- a/test/Microsoft.ML.Core.Tests/UnitTests/ScoreSchemaTest.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/ScoreSchemaTest.cs
@@ -30,10 +30,10 @@ namespace Microsoft.ML.RunTests
         public void SequencePredictorSchemaTest()
         {
             int keyCount = 10;
-            var scoreColumnType = new KeyType(DataKind.U4, 0, keyCount);
+            var expectedScoreColumnType = new KeyType(DataKind.U4, 0, keyCount);
             VBuffer<ReadOnlyMemory<char>> keyNames = GenerateKeyNames(keyCount);
 
-            var sequenceSchema = ScoreSchemaFactory.CreateSequencePredictionSchema(scoreColumnType,
+            var sequenceSchema = ScoreSchemaFactory.CreateSequencePredictionSchema(expectedScoreColumnType,
                 MetadataUtils.Const.ScoreColumnKind.SequenceClassification, keyNames);
 
             // Output schema should only contain one column, which is the predicted label.
@@ -44,11 +44,12 @@ namespace Microsoft.ML.RunTests
             Assert.Equal(MetadataUtils.Const.ScoreValueKind.PredictedLabel, scoreColumn.Name);
 
             // Check score column type.
-            Assert.True(scoreColumn.Type is KeyType);
-            Assert.Equal((scoreColumnType as KeyType).Min, (scoreColumn.Type as KeyType).Min);
-            Assert.Equal((scoreColumnType as KeyType).Count, (scoreColumn.Type as KeyType).Count);
-            Assert.Equal((scoreColumnType as KeyType).RawType, (scoreColumn.Type as KeyType).RawType);
-            Assert.Equal((scoreColumnType as KeyType).Contiguous, (scoreColumn.Type as KeyType).Contiguous);
+            var actualScoreColumnType = scoreColumn.Type as KeyType;
+            Assert.NotNull(actualScoreColumnType);
+            Assert.Equal(expectedScoreColumnType.Min, actualScoreColumnType.Min);
+            Assert.Equal(expectedScoreColumnType.Count, actualScoreColumnType.Count);
+            Assert.Equal(expectedScoreColumnType.RawType, actualScoreColumnType.RawType);
+            Assert.Equal(expectedScoreColumnType.Contiguous, actualScoreColumnType.Contiguous);
 
             // Check metadata. Because keyNames is not empty, there should be three metadata fields.
             var scoreMetadata = scoreColumn.Metadata;
@@ -88,10 +89,10 @@ namespace Microsoft.ML.RunTests
         public void SequencePredictorSchemaWithoutKeyNamesMetadataTest()
         {
             int keyCount = 10;
-            var scoreColumnType = new KeyType(DataKind.U4, 0, keyCount);
+            var expectedScoreColumnType = new KeyType(DataKind.U4, 0, keyCount);
             VBuffer<ReadOnlyMemory<char>> keyNames = GenerateKeyNames(0);
 
-            var sequenceSchema = ScoreSchemaFactory.CreateSequencePredictionSchema(scoreColumnType,
+            var sequenceSchema = ScoreSchemaFactory.CreateSequencePredictionSchema(expectedScoreColumnType,
                 MetadataUtils.Const.ScoreColumnKind.SequenceClassification, keyNames);
 
             // Output schema should only contain one column, which is the predicted label.
@@ -102,11 +103,12 @@ namespace Microsoft.ML.RunTests
             Assert.Equal(MetadataUtils.Const.ScoreValueKind.PredictedLabel, scoreColumn.Name);
 
             // Check score column type.
-            Assert.True(scoreColumn.Type is KeyType);
-            Assert.Equal((scoreColumnType as KeyType).Min, (scoreColumn.Type as KeyType).Min);
-            Assert.Equal((scoreColumnType as KeyType).Count, (scoreColumn.Type as KeyType).Count);
-            Assert.Equal((scoreColumnType as KeyType).RawType, (scoreColumn.Type as KeyType).RawType);
-            Assert.Equal((scoreColumnType as KeyType).Contiguous, (scoreColumn.Type as KeyType).Contiguous);
+            var actualScoreColumnType = scoreColumn.Type as KeyType;
+            Assert.NotNull(actualScoreColumnType);
+            Assert.Equal(expectedScoreColumnType.Min, actualScoreColumnType.Min);
+            Assert.Equal(expectedScoreColumnType.Count, actualScoreColumnType.Count);
+            Assert.Equal(expectedScoreColumnType.RawType, actualScoreColumnType.RawType);
+            Assert.Equal(expectedScoreColumnType.Contiguous, actualScoreColumnType.Contiguous);
 
             // Check metadata. Because keyNames is not empty, there should be three metadata fields.
             var scoreMetadata = scoreColumn.Metadata;

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -1024,93 +1024,95 @@ namespace Microsoft.ML.RunTests
         {
             if (!(type is VectorType vectorType))
             {
-                switch (type.RawKind)
+                Type rawType = type.RawType;
+                if (rawType == typeof(sbyte))
+                    return GetComparerOne<sbyte>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(byte))
+                    return GetComparerOne<byte>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(short))
+                    return GetComparerOne<short>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(ushort))
+                    return GetComparerOne<ushort>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(int))
+                    return GetComparerOne<int>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(uint))
+                    return GetComparerOne<uint>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(long))
+                    return GetComparerOne<long>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(ulong))
+                    return GetComparerOne<ulong>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(float))
+                    return GetComparerOne<float>(r1, r2, col, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
+                else if (rawType == typeof(double))
                 {
-                    case DataKind.I1:
-                        return GetComparerOne<sbyte>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.U1:
-                        return GetComparerOne<byte>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.I2:
-                        return GetComparerOne<short>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.U2:
-                        return GetComparerOne<ushort>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.I4:
-                        return GetComparerOne<int>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.U4:
-                        return GetComparerOne<uint>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.I8:
-                        return GetComparerOne<long>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.U8:
-                        return GetComparerOne<ulong>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.R4:
-                        return GetComparerOne<Single>(r1, r2, col, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
-                    case DataKind.R8:
-                        if (exactDoubles)
-                            return GetComparerOne<Double>(r1, r2, col, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
-                        else
-                            return GetComparerOne<Double>(r1, r2, col, EqualWithEpsDouble);
-                    case DataKind.Text:
-                        return GetComparerOne<ReadOnlyMemory<char>>(r1, r2, col, (a ,b) => a.Span.SequenceEqual(b.Span));
-                    case DataKind.Bool:
-                        return GetComparerOne<bool>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.TimeSpan:
-                        return GetComparerOne<TimeSpan>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.DT:
-                        return GetComparerOne<DateTime>(r1, r2, col, (x, y) => x == y);
-                    case DataKind.DZ:
-                        return GetComparerOne<DateTimeOffset>(r1, r2, col, (x, y) => x.Equals(y));
-                    case DataKind.UG:
-                        return GetComparerOne<RowId>(r1, r2, col, (x, y) => x.Equals(y));
-                    case (DataKind)0:
-                        // We cannot compare custom types (including image).
-                        return () => true;
+                    if (exactDoubles)
+                        return GetComparerOne<double>(r1, r2, col, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
+                    else
+                        return GetComparerOne<double>(r1, r2, col, EqualWithEpsDouble);
                 }
+                else if (rawType == typeof(ReadOnlyMemory<char>))
+                    return GetComparerOne<ReadOnlyMemory<char>>(r1, r2, col, (a, b) => a.Span.SequenceEqual(b.Span));
+                else if (rawType == typeof(bool))
+                    return GetComparerOne<bool>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(TimeSpan))
+                    return GetComparerOne<TimeSpan>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(DateTime))
+                    return GetComparerOne<DateTime>(r1, r2, col, (x, y) => x == y);
+                else if (rawType == typeof(DateTimeOffset))
+                    return GetComparerOne<DateTimeOffset>(r1, r2, col, (x, y) => x.Equals(y));
+                else if (rawType == typeof(RowId))
+                    return GetComparerOne<RowId>(r1, r2, col, (x, y) => x.Equals(y));
+                else
+                    return () => true;
             }
             else
             {
                 int size = vectorType.Size;
                 Contracts.Assert(size >= 0);
-                switch (vectorType.ItemType.RawKind)
+                Type itemType = vectorType.ItemType.RawType;
+
+                if (itemType == typeof(sbyte))
+                    return GetComparerVec<sbyte>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(byte))
+                    return GetComparerVec<byte>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(short))
+                    return GetComparerVec<short>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(ushort))
+                    return GetComparerVec<ushort>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(int))
+                    return GetComparerVec<int>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(uint))
+                    return GetComparerVec<uint>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(long))
+                    return GetComparerVec<long>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(ulong))
+                    return GetComparerVec<ulong>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(float))
                 {
-                    case DataKind.I1:
-                        return GetComparerVec<sbyte>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.U1:
-                        return GetComparerVec<byte>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.I2:
-                        return GetComparerVec<short>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.U2:
-                        return GetComparerVec<ushort>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.I4:
-                        return GetComparerVec<int>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.U4:
-                        return GetComparerVec<uint>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.I8:
-                        return GetComparerVec<long>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.U8:
-                        return GetComparerVec<ulong>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.R4:
-                        if (exactDoubles)
-                            return GetComparerVec<Single>(r1, r2, col, size, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
-                        else
-                            return GetComparerVec<Single>(r1, r2, col, size, EqualWithEpsSingle);
-                    case DataKind.R8:
-                        if (exactDoubles)
-                            return GetComparerVec<Double>(r1, r2, col, size, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
-                        else
-                            return GetComparerVec<Double>(r1, r2, col, size, EqualWithEpsDouble);
-                    case DataKind.Text:
-                        return GetComparerVec<ReadOnlyMemory<char>>(r1, r2, col, size, (a, b) => a.Span.SequenceEqual(b.Span));
-                    case DataKind.Bool:
-                        return GetComparerVec<bool>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.TimeSpan:
-                        return GetComparerVec<TimeSpan>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.DT:
-                        return GetComparerVec<DateTime>(r1, r2, col, size, (x, y) => x == y);
-                    case DataKind.DZ:
-                        return GetComparerVec<DateTimeOffset>(r1, r2, col, size, (x, y) => x.Equals(y));
-                    case DataKind.UG:
-                        return GetComparerVec<RowId>(r1, r2, col, size, (x, y) => x.Equals(y));
+                    if (exactDoubles)
+                        return GetComparerVec<float>(r1, r2, col, size, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
+                    else
+                        return GetComparerVec<float>(r1, r2, col, size, EqualWithEpsSingle);
                 }
+                else if (itemType == typeof(double))
+                {
+                    if (exactDoubles)
+                        return GetComparerVec<double>(r1, r2, col, size, (x, y) => FloatUtils.GetBits(x) == FloatUtils.GetBits(y));
+                    else
+                        return GetComparerVec<double>(r1, r2, col, size, EqualWithEpsDouble);
+                }
+                else if (itemType == typeof(ReadOnlyMemory<char>))
+                    return GetComparerVec<ReadOnlyMemory<char>>(r1, r2, col, size, (a, b) => a.Span.SequenceEqual(b.Span));
+                else if (itemType == typeof(bool))
+                    return GetComparerVec<bool>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(TimeSpan))
+                    return GetComparerVec<TimeSpan>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(DateTime))
+                    return GetComparerVec<DateTime>(r1, r2, col, size, (x, y) => x == y);
+                else if (itemType == typeof(DateTimeOffset))
+                    return GetComparerVec<DateTimeOffset>(r1, r2, col, size, (x, y) => x.Equals(y));
+                else if (itemType == typeof(RowId))
+                    return GetComparerVec<RowId>(r1, r2, col, size, (x, y) => x.Equals(y));
             }
 
 #if !CORECLR // REVIEW: Port Picture type to CoreTLC.


### PR DESCRIPTION
Remove all usages of RawKind that are outside of ML.Core and ML.Data assemblies. The next round will completely remove ColumnType.RawKind.

Part of the work necessary for #1860 and contributes to #1533.