### PR TITLE
Remove ColumnType.RawKind usages Round 2.

### DIFF
--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -120,6 +120,22 @@ namespace Microsoft.ML.Data
                 return DateTimeOffsetType.Instance;
             return NumberType.FromKind(kind);
         }
+
+        [BestFriend]
+        internal static PrimitiveType FromType(Type type)
+        {
+            if (type == typeof(ReadOnlyMemory<char>) || type == typeof(string))
+                return TextType.Instance;
+            if (type == typeof(bool))
+                return BoolType.Instance;
+            if (type == typeof(TimeSpan))
+                return TimeSpanType.Instance;
+            if (type == typeof(DateTime))
+                return DateTimeType.Instance;
+            if (type == typeof(DateTimeOffset))
+                return DateTimeOffsetType.Instance;
+            return NumberType.FromType(type);
+        }
     }
 
     /// <summary>
@@ -325,7 +341,7 @@ namespace Microsoft.ML.Data
         }
 
         [BestFriend]
-        internal static NumberType FromType(Type type)
+        internal static new NumberType FromType(Type type)
         {
             DataKind kind;
             if (type.TryGetDataKind(out kind))
@@ -339,7 +355,7 @@ namespace Microsoft.ML.Data
         {
             if (other == this)
                 return true;
-            Contracts.Assert(other == null || !(other is NumberType) || other.RawKind != RawKind);
+            Contracts.Assert(other == null || !(other is NumberType) || other.RawType != RawType);
             return false;
         }
 
@@ -589,9 +605,8 @@ namespace Microsoft.ML.Data
 
             if (!(other is KeyType tmp))
                 return false;
-            if (RawKind != tmp.RawKind)
+            if (RawType != tmp.RawType)
                 return false;
-            Contracts.Assert(RawType == tmp.RawType);
             if (Contiguous != tmp.Contiguous)
                 return false;
             if (Min != tmp.Min)

--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Data
         [BestFriend]
         internal static PrimitiveType FromType(Type type)
         {
-            if (type == typeof(ReadOnlyMemory<char>) || type == typeof(string))
+            if (type == typeof(ReadOnlyMemory<char>))
                 return TextType.Instance;
             if (type == typeof(bool))
                 return BoolType.Instance;

--- a/src/Microsoft.ML.Core/Data/DataKind.cs
+++ b/src/Microsoft.ML.Core/Data/DataKind.cs
@@ -227,6 +227,41 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
+        /// Returns true if type is a valid DataKind type. Otherwise, false.
+        /// </summary>
+        public static bool IsValidDataKindType(this Type type)
+        {
+            Contracts.CheckValueOrNull(type);
+
+            return type == typeof(sbyte)
+                || type == typeof(byte)
+                || type == typeof(short)
+                || type == typeof(ushort)
+                || type == typeof(int)
+                || type == typeof(uint)
+                || type == typeof(long)
+                || type == typeof(ulong)
+                || type == typeof(float)
+                || type == typeof(double)
+                || type == typeof(ReadOnlyMemory<char>) || type == typeof(string)
+                || type == typeof(bool)
+                || type == typeof(TimeSpan)
+                || type == typeof(DateTime)
+                || type == typeof(DateTimeOffset)
+                || type == typeof(RowId);
+        }
+
+        /// <summary>
+        /// Returns true if the types are compatible with each other.
+        /// </summary>
+        public static bool AreDataKindCompatibleTypes(Type left, Type right)
+        {
+            return left == right
+                || (left == typeof(ReadOnlyMemory<char>) && right == typeof(string))
+                || (left == typeof(string) && right == typeof(ReadOnlyMemory<char>));
+        }
+
+        /// <summary>
         /// Get the canonical string for a DataKind. Note that using DataKind.ToString() is not stable
         /// and is also slow, so use this instead.
         /// </summary>

--- a/src/Microsoft.ML.Core/Data/DataKind.cs
+++ b/src/Microsoft.ML.Core/Data/DataKind.cs
@@ -227,41 +227,6 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Returns true if type is a valid DataKind type. Otherwise, false.
-        /// </summary>
-        public static bool IsValidDataKindType(this Type type)
-        {
-            Contracts.CheckValueOrNull(type);
-
-            return type == typeof(sbyte)
-                || type == typeof(byte)
-                || type == typeof(short)
-                || type == typeof(ushort)
-                || type == typeof(int)
-                || type == typeof(uint)
-                || type == typeof(long)
-                || type == typeof(ulong)
-                || type == typeof(float)
-                || type == typeof(double)
-                || type == typeof(ReadOnlyMemory<char>) || type == typeof(string)
-                || type == typeof(bool)
-                || type == typeof(TimeSpan)
-                || type == typeof(DateTime)
-                || type == typeof(DateTimeOffset)
-                || type == typeof(RowId);
-        }
-
-        /// <summary>
-        /// Returns true if the types are compatible with each other.
-        /// </summary>
-        public static bool AreDataKindCompatibleTypes(Type left, Type right)
-        {
-            return left == right
-                || (left == typeof(ReadOnlyMemory<char>) && right == typeof(string))
-                || (left == typeof(string) && right == typeof(ReadOnlyMemory<char>));
-        }
-
-        /// <summary>
         /// Get the canonical string for a DataKind. Note that using DataKind.ToString() is not stable
         /// and is also slow, so use this instead.
         /// </summary>

--- a/src/Microsoft.ML.Core/Data/IEstimator.cs
+++ b/src/Microsoft.ML.Core/Data/IEstimator.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Core.Data
                 Contracts.CheckValueOrNull(metadata);
                 Contracts.CheckParam(!(itemType is KeyType), nameof(itemType), "Item type cannot be a key");
                 Contracts.CheckParam(!(itemType is VectorType), nameof(itemType), "Item type cannot be a vector");
-                Contracts.CheckParam(!isKey || KeyType.IsValidDataKind(itemType.RawKind), nameof(itemType), "The item type must be valid for a key");
+                Contracts.CheckParam(!isKey || KeyType.IsValidDataType(itemType.RawType), nameof(itemType), "The item type must be valid for a key");
 
                 Name = name;
                 Kind = vecKind;
@@ -167,7 +167,7 @@ namespace Microsoft.ML.Core.Data
 
             isKey = itemType is KeyType;
             if (isKey)
-                itemType = PrimitiveType.FromKind(itemType.RawKind);
+                itemType = PrimitiveType.FromType(itemType.RawType);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -238,7 +238,7 @@ namespace Microsoft.ML.Data
             for (int col = 0; col < schema.Count; col++)
             {
                 var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
-                if (columnType == null || !(columnType is KeyType) || columnType.RawKind != DataKind.U4)
+                if (columnType == null || !(columnType is KeyType) || columnType.RawType != typeof(uint))
                     continue;
                 if (filterFunc != null && !filterFunc(schema, col))
                     continue;
@@ -263,7 +263,7 @@ namespace Microsoft.ML.Data
             for (int col = 0; col < schema.Count; col++)
             {
                 var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
-                if (columnType != null && columnType is KeyType && columnType.RawKind == DataKind.U4)
+                if (columnType != null && columnType is KeyType && columnType.RawType == typeof(uint))
                 {
                     uint val = 0;
                     schema[col].Metadata.GetValue(metadataKind, ref val);

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -238,7 +238,7 @@ namespace Microsoft.ML.Data
             for (int col = 0; col < schema.Count; col++)
             {
                 var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
-                if (columnType == null || !(columnType is KeyType) || columnType.RawType != typeof(uint))
+                if (!(columnType is KeyType) || columnType.RawType != typeof(uint))
                     continue;
                 if (filterFunc != null && !filterFunc(schema, col))
                     continue;
@@ -263,7 +263,7 @@ namespace Microsoft.ML.Data
             for (int col = 0; col < schema.Count; col++)
             {
                 var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
-                if (columnType != null && columnType is KeyType && columnType.RawType == typeof(uint))
+                if (columnType is KeyType && columnType.RawType == typeof(uint))
                 {
                     uint val = 0;
                     schema[col].Metadata.GetValue(metadataKind, ref val);
@@ -283,7 +283,7 @@ namespace Microsoft.ML.Data
             for (int col = 0; col < schema.Count; col++)
             {
                 var columnType = schema[col].Metadata.Schema.GetColumnOrNull(metadataKind)?.Type;
-                if (columnType != null && columnType is TextType)
+                if (columnType is TextType)
                 {
                     ReadOnlyMemory<char> val = default;
                     schema[col].Metadata.GetValue(metadataKind, ref val);

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -436,7 +436,7 @@ namespace Microsoft.ML.Data.Conversion
                     // Technically there is no standard conversion from a key type to an unsigned integer type,
                     // but it's very convenient for client code, so we allow it here. Note that ConvertTransform
                     // does not allow this.
-                    if (!KeyType.IsValidDataKind(typeDst.RawKind))
+                    if (!KeyType.IsValidDataType(typeDst.RawType))
                         return false;
                     if (keySrc.RawKind > typeDst.RawKind)
                     {
@@ -460,8 +460,8 @@ namespace Microsoft.ML.Data.Conversion
             else if (!typeDst.IsStandardScalar())
                 return false;
 
-            Contracts.Assert(typeSrc.RawKind != 0);
-            Contracts.Assert(typeDst.RawKind != 0);
+            Contracts.Assert(typeSrc.RawType.IsValidDataKindType());
+            Contracts.Assert(typeDst.RawType.IsValidDataKindType());
 
             int key = GetKey(typeSrc.RawKind, typeDst.RawKind);
             identity = typeSrc.RawKind == typeDst.RawKind;

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -460,8 +460,8 @@ namespace Microsoft.ML.Data.Conversion
             else if (!typeDst.IsStandardScalar())
                 return false;
 
-            Contracts.Assert(typeSrc.RawType.IsValidDataKindType());
-            Contracts.Assert(typeDst.RawType.IsValidDataKindType());
+            Contracts.Assert(typeSrc.RawKind != 0);
+            Contracts.Assert(typeDst.RawKind != 0);
 
             int key = GetKey(typeSrc.RawKind, typeDst.RawKind);
             identity = typeSrc.RawKind == typeDst.RawKind;

--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -386,18 +386,18 @@ namespace Microsoft.ML.Data
                 if (!colNames.Add(name))
                     throw Contracts.ExceptParam(nameof(userType), "Duplicate column name '{0}' detected, this is disallowed", name);
 
-                InternalSchemaDefinition.GetVectorAndKind(memberInfo, out bool isVector, out DataKind kind);
+                InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type dataType);
 
                 PrimitiveType itemType;
                 var keyAttr = memberInfo.GetCustomAttribute<KeyTypeAttribute>();
                 if (keyAttr != null)
                 {
-                    if (!KeyType.IsValidDataKind(kind))
+                    if (!KeyType.IsValidDataType(dataType))
                         throw Contracts.ExceptParam(nameof(userType), "Member {0} marked with KeyType attribute, but does not appear to be a valid kind of data for a key type", memberInfo.Name);
-                    itemType = new KeyType(kind, keyAttr.Min, keyAttr.Count, keyAttr.Contiguous);
+                    itemType = new KeyType(dataType, keyAttr.Min, keyAttr.Count, keyAttr.Contiguous);
                 }
                 else
-                    itemType = PrimitiveType.FromKind(kind);
+                    itemType = PrimitiveType.FromType(dataType);
 
                 // Get the column type.
                 ColumnType columnType;

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/CodecFactory.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/CodecFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Data.IO
         // Or maybe not. That may depend on how much flexibility we really need from this.
         private readonly Dictionary<string, GetCodecFromStreamDelegate> _loadNameToCodecCreator;
         // The non-vector non-generic types can have a very simple codec mapping.
-        private readonly Dictionary<DataKind, IValueCodec> _simpleCodecTypeMap;
+        private readonly Dictionary<Type, IValueCodec> _simpleCodecTypeMap;
         // A shared object pool of memory buffers. Objects returned to the memory stream pool
         // should be cleared and have position set to 0. Use the ReturnMemoryStream helper method.
         private readonly MemoryStreamPool _memPool;
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Data.IO
             _encoding = Encoding.UTF8;
 
             _loadNameToCodecCreator = new Dictionary<string, GetCodecFromStreamDelegate>();
-            _simpleCodecTypeMap = new Dictionary<DataKind, IValueCodec>();
+            _simpleCodecTypeMap = new Dictionary<Type, IValueCodec>();
             // Register the current codecs.
             RegisterSimpleCodec(new UnsafeTypeCodec<sbyte>(this));
             RegisterSimpleCodec(new UnsafeTypeCodec<byte>(this));
@@ -84,9 +84,9 @@ namespace Microsoft.ML.Data.IO
         private void RegisterSimpleCodec<T>(SimpleCodec<T> codec)
         {
             Contracts.Assert(!_loadNameToCodecCreator.ContainsKey(codec.LoadName));
-            Contracts.Assert(!_simpleCodecTypeMap.ContainsKey(codec.Type.RawKind));
+            Contracts.Assert(!_simpleCodecTypeMap.ContainsKey(codec.Type.RawType));
             _loadNameToCodecCreator.Add(codec.LoadName, codec.GetCodec);
-            _simpleCodecTypeMap.Add(codec.Type.RawKind, codec);
+            _simpleCodecTypeMap.Add(codec.Type.RawType, codec);
         }
 
         private void RegisterOtherCodec(string name, GetCodecFromStreamDelegate fn)
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Data.IO
                 return GetKeyCodec(type, out codec);
             if (type is VectorType vectorType)
                 return GetVBufferCodec(vectorType, out codec);
-            return _simpleCodecTypeMap.TryGetValue(type.RawKind, out codec);
+            return _simpleCodecTypeMap.TryGetValue(type.RawType, out codec);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -154,27 +154,6 @@ namespace Microsoft.ML.Data.IO
 
             private readonly UnsafeTypeOps<T> _ops;
 
-            public override string LoadName
-            {
-                get
-                {
-                    switch (Type.RawKind)
-                    {
-                        case DataKind.I1:
-                            return typeof(sbyte).Name;
-                        case DataKind.I2:
-                            return typeof(short).Name;
-                        case DataKind.I4:
-                            return typeof(int).Name;
-                        case DataKind.I8:
-                            return typeof(long).Name;
-                        case DataKind.TS:
-                            return typeof(TimeSpan).Name;
-                    }
-                    return base.LoadName;
-                }
-            }
-
             // Gatekeeper to ensure T is a type that is supported by UnsafeTypeCodec.
             // Throws an exception if T is neither a TimeSpan nor a NumberType.
             private static ColumnType UnsafeColumnType(Type type)
@@ -1207,7 +1186,7 @@ namespace Microsoft.ML.Data.IO
                 Contracts.AssertValue(type);
                 Contracts.AssertValue(innerCodec);
                 Contracts.Assert(type.RawType == typeof(T));
-                Contracts.Assert(innerCodec.Type.RawKind == type.RawKind);
+                Contracts.Assert(innerCodec.Type.RawType == type.RawType);
                 _factory = factory;
                 _type = type;
                 _innerCodec = innerCodec;
@@ -1262,7 +1241,7 @@ namespace Microsoft.ML.Data.IO
             // Construct the key type.
             var itemType = innerCodec.Type as PrimitiveType;
             Contracts.CheckDecode(itemType != null);
-            Contracts.CheckDecode(KeyType.IsValidDataKind(itemType.RawKind));
+            Contracts.CheckDecode(KeyType.IsValidDataType(itemType.RawType));
             KeyType type;
             using (BinaryReader reader = OpenBinaryReader(definitionStream))
             {
@@ -1276,7 +1255,7 @@ namespace Microsoft.ML.Data.IO
                 Contracts.CheckDecode((ulong)count <= itemType.RawKind.ToMaxInt());
                 Contracts.CheckDecode(contiguous || count == 0);
 
-                type = new KeyType(itemType.RawKind, min, count, contiguous);
+                type = new KeyType(itemType.RawType, min, count, contiguous);
             }
             // Next create the key codec.
             Type codecType = typeof(KeyCodec<>).MakeGenericType(itemType.RawType);
@@ -1290,7 +1269,7 @@ namespace Microsoft.ML.Data.IO
                 throw Contracts.ExceptParam(nameof(type), "type must be a key type");
             // Create the internal codec the key codec will use to do the actual reading/writing.
             IValueCodec innerCodec;
-            if (!TryGetCodec(NumberType.FromKind(type.RawKind), out innerCodec))
+            if (!TryGetCodec(NumberType.FromType(type.RawType), out innerCodec))
             {
                 codec = default(IValueCodec);
                 return false;

--- a/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Data.DataLoadSave
         {
             ColumnType curType = column.ItemType;
             if (column.IsKey)
-                curType = new KeyType(((PrimitiveType)curType).RawKind, 0, AllKeySizes);
+                curType = new KeyType(((PrimitiveType)curType).RawType, 0, AllKeySizes);
             if (column.Kind == SchemaShape.Column.VectorKind.VariableVector)
                 curType = new VectorType((PrimitiveType)curType, 0);
             else if (column.Kind == SchemaShape.Column.VectorKind.Vector)

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -845,14 +845,14 @@ namespace Microsoft.ML.Data
         {
             Contracts.Assert(value != null);
             bool isVector;
-            DataKind dataKind;
-            InternalSchemaDefinition.GetVectorAndKind(typeof(T), "metadata value", out isVector, out dataKind);
+            Type itemType;
+            InternalSchemaDefinition.GetVectorAndItemType(typeof(T), "metadata value", out isVector, out itemType);
 
             if (metadataType == null)
             {
                 // Infer a type as best we can.
-                var itemType = PrimitiveType.FromKind(dataKind);
-                metadataType = isVector ? new VectorType(itemType) : (ColumnType)itemType;
+                var primitiveItemType = PrimitiveType.FromType(itemType);
+                metadataType = isVector ? new VectorType(primitiveItemType) : (ColumnType)primitiveItemType;
             }
             else
             {
@@ -866,11 +866,11 @@ namespace Microsoft.ML.Data
                 }
 
                 ColumnType metadataItemType = metadataVectorType?.ItemType ?? metadataType;
-                if (dataKind != metadataItemType.RawKind)
+                if (!DataKindExtensions.AreDataKindCompatibleTypes(itemType, metadataItemType.RawType))
                 {
                     throw Contracts.Except(
-                        "Value inputted is supposed to have dataKind {0}, but type of Metadatainfo has {1}",
-                        dataKind.ToString(), metadataItemType.RawKind.ToString());
+                        "Value inputted is supposed to have Type {0}, but type of Metadatainfo has {1}",
+                        itemType.ToString(), metadataItemType.RawType.ToString());
                 }
             }
             MetadataType = metadataType;

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -866,7 +866,7 @@ namespace Microsoft.ML.Data
                 }
 
                 ColumnType metadataItemType = metadataVectorType?.ItemType ?? metadataType;
-                if (!DataKindExtensions.AreDataKindCompatibleTypes(itemType, metadataItemType.RawType))
+                if (itemType != metadataItemType.RawType)
                 {
                     throw Contracts.Except(
                         "Value inputted is supposed to have Type {0}, but type of Metadatainfo has {1}",

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -119,11 +119,10 @@ namespace Microsoft.ML.Data
                 Contracts.Assert(Generator.GetMethodInfo().ReturnType == typeof(void));
 
                 // Checks that the return type of the generator is compatible with ColumnType.
-                GetVectorAndKind(ComputedReturnType, "return type", out bool isVector, out DataKind datakind);
+                GetVectorAndItemType(ComputedReturnType, "return type", out bool isVector, out Type itemType);
                 Contracts.Assert(isVector == ColumnType is VectorType);
-                Contracts.Assert(datakind == ColumnType.GetItemType().RawKind);
+                Contracts.Assert(DataKindExtensions.AreDataKindCompatibleTypes(itemType, ColumnType.GetItemType().RawType));
             }
-
         }
 
         private InternalSchemaDefinition(Column[] columns)
@@ -139,18 +138,21 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="memberInfo">The field or property info to inspect.</param>
         /// <param name="isVector">Whether this appears to be a vector type.</param>
-        /// <param name="kind">The data kind of the type, or items of this type if vector.</param>
-        public static void GetVectorAndKind(MemberInfo memberInfo, out bool isVector, out DataKind kind)
+        /// <param name="itemType">
+        /// For non-vectors, this is set to the member's type.
+        /// For vectors, this is set to the type of the items stored as values in the vector.
+        /// </param>
+        public static void GetVectorAndItemType(MemberInfo memberInfo, out bool isVector, out Type itemType)
         {
             Contracts.AssertValue(memberInfo);
             switch (memberInfo)
             {
                 case FieldInfo fieldInfo:
-                    GetVectorAndKind(fieldInfo.FieldType, fieldInfo.Name, out isVector, out kind);
+                    GetVectorAndItemType(fieldInfo.FieldType, fieldInfo.Name, out isVector, out itemType);
                     break;
 
                 case PropertyInfo propertyInfo:
-                    GetVectorAndKind(propertyInfo.PropertyType, propertyInfo.Name, out isVector, out kind);
+                    GetVectorAndItemType(propertyInfo.PropertyType, propertyInfo.Name, out isVector, out itemType);
                     break;
 
                 default:
@@ -160,49 +162,32 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Given a parameter info on a type, returns whether this appears to be a vector type,
-        /// and also the associated data kind for this type. If a data kind could not
-        /// be determined, this will throw.
-        /// </summary>
-        /// <param name="parameterInfo">The parameter info to inspect.</param>
-        /// <param name="isVector">Whether this appears to be a vector type.</param>
-        /// <param name="kind">The data kind of the type, or items of this type if vector.</param>
-        public static void GetVectorAndKind(ParameterInfo parameterInfo, out bool isVector, out DataKind kind)
-        {
-            Contracts.AssertValue(parameterInfo);
-            Type rawParameterType = parameterInfo.ParameterType;
-            var name = parameterInfo.Name;
-            GetVectorAndKind(rawParameterType, name, out isVector, out kind);
-        }
-
-        /// <summary>
         /// Given a type and name for a variable, returns whether this appears to be a vector type,
-        /// and also the associated data kind for this type. If a data kind could not
+        /// and also the associated data type for this type. If a valid data type could not
         /// be determined, this will throw.
         /// </summary>
         /// <param name="rawType">The type of the variable to inspect.</param>
         /// <param name="name">The name of the variable to inspect.</param>
         /// <param name="isVector">Whether this appears to be a vector type.</param>
-        /// <param name="kind">The data kind of the type, or items of this type if vector.</param>
-        public static void GetVectorAndKind(Type rawType, string name, out bool isVector, out DataKind kind)
+        /// <param name="itemType">
+        /// For non-vectors, this is set to <paramref name="rawType"/>.
+        /// For vectors, this is set to the type of the items stored as values in the vector.
+        /// </param>
+        public static void GetVectorAndItemType(Type rawType, string name, out bool isVector, out Type itemType)
         {
             // Determine whether this is a vector, and also determine the raw item type.
-            Type rawItemType;
             isVector = true;
             if (rawType.IsArray)
-                rawItemType = rawType.GetElementType();
+                itemType = rawType.GetElementType();
             else if (rawType.IsGenericType && rawType.GetGenericTypeDefinition() == typeof(VBuffer<>))
-                rawItemType = rawType.GetGenericArguments()[0];
+                itemType = rawType.GetGenericArguments()[0];
             else
             {
-                rawItemType = rawType;
+                itemType = rawType;
                 isVector = false;
             }
 
-            // Get the data kind, and the item's column type.
-            if (rawItemType == typeof(string))
-                kind = DataKind.Text;
-            else if (!rawItemType.TryGetDataKind(out kind))
+            if (!itemType.IsValidDataKindType())
                 throw Contracts.ExceptParam(nameof(rawType), "Could not determine an IDataView type for member {0}", name);
         }
 
@@ -229,7 +214,7 @@ namespace Microsoft.ML.Data
                     throw Contracts.ExceptParam(nameof(userSchemaDefinition), "Null field name detected in schema definition");
 
                 bool isVector;
-                DataKind kind;
+                Type dataItemType;
                 MemberInfo memberInfo = null;
 
                 if (!col.IsComputed)
@@ -250,14 +235,14 @@ namespace Microsoft.ML.Data
                         (memberInfo is PropertyInfo && (memberInfo as PropertyInfo).PropertyType == typeof(IChannel)))
                         continue;
 
-                    GetVectorAndKind(memberInfo, out isVector, out kind);
+                    GetVectorAndItemType(memberInfo, out isVector, out dataItemType);
                 }
                 else
                 {
                     var parameterType = col.ReturnType;
                     if (parameterType == null)
                         throw Contracts.ExceptParam(nameof(userSchemaDefinition), "No return parameter found in computed column.");
-                    GetVectorAndKind(parameterType, "returnType", out isVector, out kind);
+                    GetVectorAndItemType(parameterType, "returnType", out isVector, out dataItemType);
                 }
                 // Infer the column name.
                 var colName = string.IsNullOrEmpty(col.ColumnName) ? col.MemberName : col.ColumnName;
@@ -269,7 +254,7 @@ namespace Microsoft.ML.Data
                 if (col.ColumnType == null)
                 {
                     // Infer a type as best we can.
-                    PrimitiveType itemType = PrimitiveType.FromKind(kind);
+                    PrimitiveType itemType = PrimitiveType.FromType(dataItemType);
                     colType = isVector ? new VectorType(itemType) : (ColumnType)itemType;
                 }
                 else
@@ -283,10 +268,10 @@ namespace Microsoft.ML.Data
                             colName, columnVectorType != null ? "vector" : "scalar", col.MemberName, isVector ? "vector" : "scalar");
                     }
                     ColumnType itemType = columnVectorType?.ItemType ?? col.ColumnType;
-                    if (kind != itemType.RawKind)
+                    if (!DataKindExtensions.AreDataKindCompatibleTypes(itemType.RawType, dataItemType))
                     {
-                        throw Contracts.ExceptParam(nameof(userSchemaDefinition), "Column '{0}' is supposed to have item kind {1}, but associated field has kind {2}",
-                            colName, itemType.RawKind, kind);
+                        throw Contracts.ExceptParam(nameof(userSchemaDefinition), "Column '{0}' is supposed to have item type {1}, but associated field has type {2}",
+                            colName, itemType.RawType, dataItemType);
                     }
                     colType = col.ColumnType;
                 }

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -139,9 +139,9 @@ namespace Microsoft.ML.Data
         {
             InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type itemType);
             if (isVector)
-                return colType is VectorType vectorType && DataKindExtensions.AreDataKindCompatibleTypes(vectorType.ItemType.RawType, itemType);
+                return colType is VectorType vectorType && vectorType.ItemType.RawType == itemType;
             else
-                return !(colType is VectorType) && DataKindExtensions.AreDataKindCompatibleTypes(colType.RawType, itemType);
+                return !(colType is VectorType) && colType.RawType == itemType;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -137,11 +137,11 @@ namespace Microsoft.ML.Data
         /// </summary>
         private static bool IsCompatibleType(ColumnType colType, MemberInfo memberInfo)
         {
-            InternalSchemaDefinition.GetVectorAndKind(memberInfo, out bool isVector, out DataKind kind);
+            InternalSchemaDefinition.GetVectorAndItemType(memberInfo, out bool isVector, out Type itemType);
             if (isVector)
-                return colType is VectorType vectorType && vectorType.ItemType.RawKind == kind;
+                return colType is VectorType vectorType && DataKindExtensions.AreDataKindCompatibleTypes(vectorType.ItemType.RawType, itemType);
             else
-                return !(colType is VectorType) && colType.RawKind == kind;
+                return !(colType is VectorType) && DataKindExtensions.AreDataKindCompatibleTypes(colType.RawType, itemType);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Data
 
             // Get the score column set id from colScore.
             var type = schema[colScore].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnSetId)?.Type;
-            if (type == null || !(type is KeyType) || type.RawKind != DataKind.U4)
+            if (type == null || !(type is KeyType) || type.RawType != typeof(uint))
             {
                 // scoreCol is not part of a score column set, so can't determine an aux column.
                 return null;
@@ -573,7 +573,7 @@ namespace Microsoft.ML.Data
                 if (keyValueItemType == null || keyValueItemType.RawType != typeof(T))
                     throw Contracts.Except($"Column '{columnName}' in schema number {i} does not have the correct type of key values");
                 ColumnType typeItemType = vectorType?.ItemType ?? type;
-                if (!(typeItemType is KeyType itemKeyType) || typeItemType.RawKind != DataKind.U4)
+                if (!(typeItemType is KeyType itemKeyType) || typeItemType.RawType != typeof(uint))
                     throw Contracts.Except($"Column '{columnName}' must be a U4 key type, but is '{typeItemType}'");
 
                 schema[indices[i]].Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keyNamesCur);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Data
 
             // Get the score column set id from colScore.
             var type = schema[colScore].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.ScoreColumnSetId)?.Type;
-            if (type == null || !(type is KeyType) || type.RawType != typeof(uint))
+            if (!(type is KeyType) || type.RawType != typeof(uint))
             {
                 // scoreCol is not part of a score column set, so can't determine an aux column.
                 return null;

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -1001,7 +1001,7 @@ namespace Microsoft.ML.Data
             if (!perInst.Schema.TryGetColumnIndex(labelName, out int labelCol))
                 throw Host.Except("Could not find column '{0}'", labelName);
             var labelType = perInst.Schema[labelCol].Type;
-            if (labelType is KeyType keyType && (!(bool)perInst.Schema[labelCol].HasKeyValues(keyType.Count) || labelType.RawKind != DataKind.U4))
+            if (labelType is KeyType keyType && (!(bool)perInst.Schema[labelCol].HasKeyValues(keyType.Count) || labelType.RawType != typeof(uint)))
             {
                 perInst = LambdaColumnMapper.Create(Host, "ConvertToDouble", perInst, labelName,
                     labelName, perInst.Schema[labelCol].Type, NumberType.R8,

--- a/src/Microsoft.ML.Data/Model/Pfa/PfaUtils.cs
+++ b/src/Microsoft.ML.Data/Model/Pfa/PfaUtils.cs
@@ -180,36 +180,45 @@ namespace Microsoft.ML.Model.Pfa
                 {
                     // Keys will retain the property that they are just numbers,
                     // with 0 representing missing.
-                    if (keyType.Count > 0 || itemType.RawKind != DataKind.U8)
+                    if (keyType.Count > 0 || keyType.RawType != typeof(ulong))
                         return Int;
                     return Long;
                 }
 
-                switch (itemType.RawKind)
+                System.Type rawType = itemType.RawType;
+                if (rawType == typeof(sbyte)
+                    || rawType == typeof(byte)
+                    || rawType == typeof(short)
+                    || rawType == typeof(ushort)
+                    || rawType == typeof(int))
                 {
-                    case DataKind.I1:
-                    case DataKind.U1:
-                    case DataKind.I2:
-                    case DataKind.U2:
-                    case DataKind.I4:
-                        return Int;
-                    case DataKind.U4:
-                    case DataKind.I8:
-                    case DataKind.U8:
-                        return Long;
-                    case DataKind.R4:
-                    // REVIEW: This should really be float. But, for the
+                    return Int;
+                }
+                else if (rawType == typeof(uint)
+                    || rawType == typeof(long)
+                    || rawType == typeof(ulong))
+                {
+                    return Long;
+                }
+                else if(rawType == typeof(float)
+                    // REVIEW: The above should really be float. But, for the
                     // sake of the POC, we use double since all the PFA convenience
                     // libraries operate over doubles.
-                    case DataKind.R8:
-                        return Double;
-                    case DataKind.BL:
-                        return Bool;
-                    case DataKind.TX:
-                        return String;
-                    default:
-                        return null;
+                    || rawType == typeof(double))
+                {
+                    return Double;
                 }
+                else if (rawType == typeof(bool))
+                {
+                    return Bool;
+                }
+                else if (rawType == typeof(System.ReadOnlyMemory<char>)
+                    || rawType == typeof(string))
+                {
+                    return String;
+                }
+
+                return null;
             }
 
             public static JToken DefaultTokenOrNull(PrimitiveType itemType)
@@ -219,30 +228,37 @@ namespace Microsoft.ML.Model.Pfa
                 if (itemType is KeyType)
                     return 0;
 
-                switch (itemType.RawKind)
+                System.Type rawType = itemType.RawType;
+                if (rawType == typeof(sbyte)
+                    || rawType == typeof(byte)
+                    || rawType == typeof(short)
+                    || rawType == typeof(ushort)
+                    || rawType == typeof(int)
+                    || rawType == typeof(uint)
+                    || rawType == typeof(long)
+                    || rawType == typeof(ulong))
                 {
-                    case DataKind.I1:
-                    case DataKind.U1:
-                    case DataKind.I2:
-                    case DataKind.U2:
-                    case DataKind.I4:
-                    case DataKind.U4:
-                    case DataKind.I8:
-                    case DataKind.U8:
-                        return 0;
-                    case DataKind.R4:
-                    // REVIEW: This should really be float. But, for the
+                    return 0;
+                }
+                else if (rawType == typeof(float)
+                    // REVIEW: The above should really be float. But, for the
                     // sake of the POC, we use double since all the PFA convenience
                     // libraries operate over doubles.
-                    case DataKind.R8:
-                        return 0.0;
-                    case DataKind.BL:
-                        return false;
-                    case DataKind.TX:
-                        return String("");
-                    default:
-                        return null;
+                    || rawType == typeof(double))
+                {
+                    return 0.0;
                 }
+                else if (rawType == typeof(bool))
+                {
+                    return false;
+                }
+                else if (rawType == typeof(System.ReadOnlyMemory<char>)
+                    || rawType == typeof(string))
+                {
+                    return String("");
+                }
+
+                return null;
             }
         }
 

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -409,18 +409,32 @@ namespace Microsoft.ML.Transforms.Conversions
 
             if (srcType is KeyType)
             {
-                if (srcType.RawType == typeof(byte))
-                    return MakeScalarHashGetter<byte, HashKey1>(input, srcCol, seed, mask);
+                if (srcType.RawType == typeof(uint))
+                    return MakeScalarHashGetter<uint, HashKey4>(input, srcCol, seed, mask);
+                else if (srcType.RawType == typeof(ulong))
+                    return MakeScalarHashGetter<ulong, HashKey8>(input, srcCol, seed, mask);
                 else if (srcType.RawType == typeof(ushort))
                     return MakeScalarHashGetter<ushort, HashKey2>(input, srcCol, seed, mask);
-                else if (srcType.RawType == typeof(uint))
-                    return MakeScalarHashGetter<uint, HashKey4>(input, srcCol, seed, mask);
 
-                Host.Assert(srcType.RawType == typeof(ulong));
-                return MakeScalarHashGetter<ulong, HashKey8>(input, srcCol, seed, mask);
+                Host.Assert(srcType.RawType == typeof(byte));
+                return MakeScalarHashGetter<byte, HashKey1>(input, srcCol, seed, mask);
             }
 
-            if (srcType.RawType == typeof(byte))
+            if (srcType.RawType == typeof(ReadOnlyMemory<char>))
+                return MakeScalarHashGetter<ReadOnlyMemory<char>, HashText>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(float))
+                return MakeScalarHashGetter<float, HashFloat>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(double))
+                return MakeScalarHashGetter<double, HashDouble>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(sbyte))
+                return MakeScalarHashGetter<sbyte, HashI1>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(short))
+                return MakeScalarHashGetter<short, HashI2>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(int))
+                return MakeScalarHashGetter<int, HashI4>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(long))
+                return MakeScalarHashGetter<long, HashI8>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(byte))
                 return MakeScalarHashGetter<byte, HashU1>(input, srcCol, seed, mask);
             else if (srcType.RawType == typeof(ushort))
                 return MakeScalarHashGetter<ushort, HashU2>(input, srcCol, seed, mask);
@@ -429,24 +443,10 @@ namespace Microsoft.ML.Transforms.Conversions
             else if (srcType.RawType == typeof(ulong))
                 return MakeScalarHashGetter<ulong, HashU8>(input, srcCol, seed, mask);
             else if (srcType.RawType == typeof(RowId))
-                    return MakeScalarHashGetter<RowId, HashU16>(input, srcCol, seed, mask);
-            else if (srcType.RawType == typeof(sbyte))
-                    return MakeScalarHashGetter<sbyte, HashI1>(input, srcCol, seed, mask);
-            else if (srcType.RawType == typeof(short))
-                    return MakeScalarHashGetter<short, HashI2>(input, srcCol, seed, mask);
-            else if (srcType.RawType == typeof(int))
-                    return MakeScalarHashGetter<int, HashI4>(input, srcCol, seed, mask);
-            else if (srcType.RawType == typeof(long))
-                    return MakeScalarHashGetter<long, HashI8>(input, srcCol, seed, mask);
-            else if (srcType.RawType == typeof(float))
-                    return MakeScalarHashGetter<float, HashFloat>(input, srcCol, seed, mask);
-            else if (srcType.RawType == typeof(double))
-                    return MakeScalarHashGetter<double, HashDouble>(input, srcCol, seed, mask);
-            else if (srcType.RawType == typeof(bool))
-                    return MakeScalarHashGetter<bool, HashBool>(input, srcCol, seed, mask);
+                return MakeScalarHashGetter<RowId, HashU16>(input, srcCol, seed, mask);
 
-            Host.Assert(srcType == TextType.Instance);
-            return MakeScalarHashGetter<ReadOnlyMemory<char>, HashText>(input, srcCol, seed, mask);
+            Host.Assert(srcType.RawType == typeof(bool));
+            return MakeScalarHashGetter<bool, HashBool>(input, srcCol, seed, mask);
         }
 
         private ValueGetter<VBuffer<uint>> ComposeGetterVec(Row input, int iinfo, int srcCol, VectorType srcType)

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -409,102 +409,91 @@ namespace Microsoft.ML.Transforms.Conversions
 
             if (srcType is KeyType)
             {
-                switch (srcType.RawKind)
-                {
-                    case DataKind.U1:
-                        return MakeScalarHashGetter<byte, HashKey1>(input, srcCol, seed, mask);
-                    case DataKind.U2:
-                        return MakeScalarHashGetter<ushort, HashKey2>(input, srcCol, seed, mask);
-                    case DataKind.U4:
-                        return MakeScalarHashGetter<uint, HashKey4>(input, srcCol, seed, mask);
-                    default:
-                        Host.Assert(srcType.RawKind == DataKind.U8);
-                        return MakeScalarHashGetter<ulong, HashKey8>(input, srcCol, seed, mask);
-                }
+                if (srcType.RawType == typeof(byte))
+                    return MakeScalarHashGetter<byte, HashKey1>(input, srcCol, seed, mask);
+                else if (srcType.RawType == typeof(ushort))
+                    return MakeScalarHashGetter<ushort, HashKey2>(input, srcCol, seed, mask);
+                else if (srcType.RawType == typeof(uint))
+                    return MakeScalarHashGetter<uint, HashKey4>(input, srcCol, seed, mask);
+
+                Host.Assert(srcType.RawType == typeof(ulong));
+                return MakeScalarHashGetter<ulong, HashKey8>(input, srcCol, seed, mask);
             }
 
-            switch (srcType.RawKind)
-            {
-                case DataKind.U1:
-                    return MakeScalarHashGetter<byte, HashU1>(input, srcCol, seed, mask);
-                case DataKind.U2:
-                    return MakeScalarHashGetter<ushort, HashU2>(input, srcCol, seed, mask);
-                case DataKind.U4:
-                    return MakeScalarHashGetter<uint, HashU4>(input, srcCol, seed, mask);
-                case DataKind.U8:
-                    return MakeScalarHashGetter<ulong, HashU8>(input, srcCol, seed, mask);
-                case DataKind.U16:
+            if (srcType.RawType == typeof(byte))
+                return MakeScalarHashGetter<byte, HashU1>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(ushort))
+                return MakeScalarHashGetter<ushort, HashU2>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(uint))
+                return MakeScalarHashGetter<uint, HashU4>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(ulong))
+                return MakeScalarHashGetter<ulong, HashU8>(input, srcCol, seed, mask);
+            else if (srcType.RawType == typeof(RowId))
                     return MakeScalarHashGetter<RowId, HashU16>(input, srcCol, seed, mask);
-                case DataKind.I1:
+            else if (srcType.RawType == typeof(sbyte))
                     return MakeScalarHashGetter<sbyte, HashI1>(input, srcCol, seed, mask);
-                case DataKind.I2:
+            else if (srcType.RawType == typeof(short))
                     return MakeScalarHashGetter<short, HashI2>(input, srcCol, seed, mask);
-                case DataKind.I4:
+            else if (srcType.RawType == typeof(int))
                     return MakeScalarHashGetter<int, HashI4>(input, srcCol, seed, mask);
-                case DataKind.I8:
+            else if (srcType.RawType == typeof(long))
                     return MakeScalarHashGetter<long, HashI8>(input, srcCol, seed, mask);
-                case DataKind.R4:
+            else if (srcType.RawType == typeof(float))
                     return MakeScalarHashGetter<float, HashFloat>(input, srcCol, seed, mask);
-                case DataKind.R8:
+            else if (srcType.RawType == typeof(double))
                     return MakeScalarHashGetter<double, HashDouble>(input, srcCol, seed, mask);
-                case DataKind.BL:
+            else if (srcType.RawType == typeof(bool))
                     return MakeScalarHashGetter<bool, HashBool>(input, srcCol, seed, mask);
-                default:
-                    Host.Assert(srcType.RawKind == DataKind.Text);
-                    return MakeScalarHashGetter<ReadOnlyMemory<char>, HashText>(input, srcCol, seed, mask);
-            }
+
+            Host.Assert(srcType == TextType.Instance);
+            return MakeScalarHashGetter<ReadOnlyMemory<char>, HashText>(input, srcCol, seed, mask);
         }
 
         private ValueGetter<VBuffer<uint>> ComposeGetterVec(Row input, int iinfo, int srcCol, VectorType srcType)
         {
             Host.Assert(HashingEstimator.IsColumnTypeValid(srcType.ItemType));
 
+            Type rawType = srcType.ItemType.RawType;
             if (srcType.ItemType is KeyType)
             {
-                switch (srcType.ItemType.RawKind)
-                {
-                    case DataKind.U1:
-                        return ComposeGetterVecCore<byte, HashKey1>(input, iinfo, srcCol, srcType);
-                    case DataKind.U2:
-                        return ComposeGetterVecCore<ushort, HashKey2>(input, iinfo, srcCol, srcType);
-                    case DataKind.U4:
-                        return ComposeGetterVecCore<uint, HashKey4>(input, iinfo, srcCol, srcType);
-                    default:
-                        Host.Assert(srcType.ItemType.RawKind == DataKind.U8);
-                        return ComposeGetterVecCore<ulong, HashKey8>(input, iinfo, srcCol, srcType);
-                }
+                if (rawType == typeof(byte))
+                    return ComposeGetterVecCore<byte, HashKey1>(input, iinfo, srcCol, srcType);
+                else if (rawType == typeof(ushort))
+                    return ComposeGetterVecCore<ushort, HashKey2>(input, iinfo, srcCol, srcType);
+                else if (rawType == typeof(uint))
+                    return ComposeGetterVecCore<uint, HashKey4>(input, iinfo, srcCol, srcType);
+
+                Host.Assert(rawType == typeof(ulong));
+                return ComposeGetterVecCore<ulong, HashKey8>(input, iinfo, srcCol, srcType);
             }
 
-            switch (srcType.ItemType.RawKind)
-            {
-                case DataKind.U1:
-                    return ComposeGetterVecCore<byte, HashU1>(input, iinfo, srcCol, srcType);
-                case DataKind.U2:
-                    return ComposeGetterVecCore<ushort, HashU2>(input, iinfo, srcCol, srcType);
-                case DataKind.U4:
-                    return ComposeGetterVecCore<uint, HashU4>(input, iinfo, srcCol, srcType);
-                case DataKind.U8:
-                    return ComposeGetterVecCore<ulong, HashU8>(input, iinfo, srcCol, srcType);
-                case DataKind.U16:
-                    return ComposeGetterVecCore<RowId, HashU16>(input, iinfo, srcCol, srcType);
-                case DataKind.I1:
-                    return ComposeGetterVecCore<sbyte, HashI1>(input, iinfo, srcCol, srcType);
-                case DataKind.I2:
-                    return ComposeGetterVecCore<short, HashI2>(input, iinfo, srcCol, srcType);
-                case DataKind.I4:
-                    return ComposeGetterVecCore<int, HashI4>(input, iinfo, srcCol, srcType);
-                case DataKind.I8:
-                    return ComposeGetterVecCore<long, HashI8>(input, iinfo, srcCol, srcType);
-                case DataKind.R4:
-                    return ComposeGetterVecCore<float, HashFloat>(input, iinfo, srcCol, srcType);
-                case DataKind.R8:
-                    return ComposeGetterVecCore<double, HashDouble>(input, iinfo, srcCol, srcType);
-                case DataKind.BL:
-                    return ComposeGetterVecCore<bool, HashBool>(input, iinfo, srcCol, srcType);
-                default:
-                    Host.Assert(srcType.ItemType.RawKind == DataKind.TX);
-                    return ComposeGetterVecCore<ReadOnlyMemory<char>, HashText>(input, iinfo, srcCol, srcType);
-            }
+            if (rawType == typeof(byte))
+                return ComposeGetterVecCore<byte, HashU1>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(ushort))
+                return ComposeGetterVecCore<ushort, HashU2>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(uint))
+                return ComposeGetterVecCore<uint, HashU4>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(ulong))
+                return ComposeGetterVecCore<ulong, HashU8>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(RowId))
+                return ComposeGetterVecCore<RowId, HashU16>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(sbyte))
+                return ComposeGetterVecCore<sbyte, HashI1>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(short))
+                return ComposeGetterVecCore<short, HashI2>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(int))
+                return ComposeGetterVecCore<int, HashI4>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(long))
+                return ComposeGetterVecCore<long, HashI8>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(float))
+                return ComposeGetterVecCore<float, HashFloat>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(double))
+                return ComposeGetterVecCore<double, HashDouble>(input, iinfo, srcCol, srcType);
+            else if (rawType == typeof(bool))
+                return ComposeGetterVecCore<bool, HashBool>(input, iinfo, srcCol, srcType);
+
+            Host.Assert(srcType.ItemType == TextType.Instance);
+            return ComposeGetterVecCore<ReadOnlyMemory<char>, HashText>(input, iinfo, srcCol, srcType);
         }
 
         private ValueGetter<VBuffer<uint>> ComposeGetterVecCore<T, THash>(Row input, int iinfo, int srcCol, VectorType srcType)

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -767,7 +767,7 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if (!col.ItemType.GetItemType().RawType.IsValidDataKindType() || !(col.ItemType is VectorType || col.ItemType is PrimitiveType))
+                if (!col.ItemType.IsStandardScalar())
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
                 var metadata = new List<SchemaShape.Column>();

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -767,7 +767,7 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
-                if ((col.ItemType.GetItemType().RawKind == default) || !(col.ItemType is VectorType || col.ItemType is PrimitiveType))
+                if (!col.ItemType.GetItemType().RawType.IsValidDataKindType() || !(col.ItemType is VectorType || col.ItemType is PrimitiveType))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
                 var metadata = new List<SchemaShape.Column>();

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -352,7 +352,7 @@ namespace Microsoft.ML.Transforms.Normalizers
                 ctx.Writer.Write(vectorType?.Size ?? 0);
 
                 ColumnType itemType = vectorType?.ItemType ?? type;
-                var itemKind = itemType.RawKind;
+                itemType.RawType.TryGetDataKind(out DataKind itemKind);
                 Contracts.Assert(itemKind == DataKind.R4 || itemKind == DataKind.R8);
                 ctx.Writer.Write((byte)itemKind);
             }

--- a/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
+++ b/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
@@ -377,7 +377,7 @@ namespace Microsoft.ML.Transforms.Conversions
             }
             else
             {
-                ectx.Assert(KeyType.IsValidDataKind(key.RawKind));
+                ectx.Assert(KeyType.IsValidDataType(key.RawType));
                 int count = key.Count;
                 // Technically, it's an error for the counts not to match, but we'll let the Conversions
                 // code return false below. There's a possibility we'll change the standard conversions to

--- a/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueMappingTransformer.cs
@@ -204,12 +204,12 @@ namespace Microsoft.ML.Transforms.Conversions
                 // Key Values are treated in one of two ways:
                 // If the values are of type uint or ulong, these values are used directly as the keys types and no new keys are created.
                 // If the values are not of uint or ulong, then key values are generated as uints starting from 1, since 0 is missing key.
-                if (valueType.RawKind == DataKind.U4)
+                if (valueType.RawType == typeof(uint))
                 {
                     uint[] indices = values.Select((x) => Convert.ToUInt32(x)).ToArray();
                     dataViewBuilder.AddColumn(valueColumnName, GetKeyValueGetter(metaKeys), 0, metaKeys.Length, indices);
                 }
-                else if (valueType.RawKind == DataKind.U8)
+                else if (valueType.RawType == typeof(ulong))
                 {
                     ulong[] indices = values.Select((x) => Convert.ToUInt64(x)).ToArray();
                     dataViewBuilder.AddColumn(valueColumnName, GetKeyValueGetter(metaKeys), 0, metaKeys.Length, indices);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
-                if (!col.ItemType.GetItemType().RawType.IsValidDataKindType() || !(col.ItemType is VectorType || col.ItemType is PrimitiveType))
+                if (!col.ItemType.IsStandardScalar())
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
                 SchemaShape metadata;
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 if (!inputSchema.TryFindColumn(colInfo.Input, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
 
-                if ((col.ItemType.GetItemType().RawKind == default) || !(col.ItemType is VectorType || col.ItemType is PrimitiveType))
+                if (!col.ItemType.GetItemType().RawType.IsValidDataKindType() || !(col.ItemType is VectorType || col.ItemType is PrimitiveType))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.Input);
                 SchemaShape metadata;
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -261,12 +261,12 @@ namespace Microsoft.ML.Transforms.Conversions
             return columns.Select(x => (x.Input, x.Output)).ToArray();
         }
 
-        internal string TestIsKnownDataKind(ColumnType type)
+        private string TestIsKnownDataKind(ColumnType type)
         {
             VectorType vectorType = type as VectorType;
             ColumnType itemType = vectorType?.ItemType ?? type;
 
-            if (itemType.RawKind != default && (vectorType != null || type is PrimitiveType))
+            if (itemType.RawType.IsValidDataKindType() && (vectorType != null || type is PrimitiveType))
                 return null;
             return "standard type or a vector of standard type";
         }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -266,7 +266,7 @@ namespace Microsoft.ML.Transforms.Conversions
             VectorType vectorType = type as VectorType;
             ColumnType itemType = vectorType?.ItemType ?? type;
 
-            if (itemType.RawType.IsValidDataKindType() && (vectorType != null || type is PrimitiveType))
+            if (itemType.IsStandardScalar())
                 return null;
             return "standard type or a vector of standard type";
         }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -266,7 +266,7 @@ namespace Microsoft.ML.Transforms.Conversions
             VectorType vectorType = type as VectorType;
             ColumnType itemType = vectorType?.ItemType ?? type;
 
-            if (itemType.IsStandardScalar())
+            if (itemType is KeyType || itemType.IsStandardScalar())
                 return null;
             return "standard type or a vector of standard type";
         }


### PR DESCRIPTION
Removes the "easy" usages of ColumnType.RawKind.

Part of the work necessary for #1860 and contributes to #1533.

There are still about 38 usages of ColumnType.RawKind left, but they are a little more involved, and needs refactoring. I will fully remove them in the next PR.