### PR TITLE
Remove ColumnType.RawKind Round 3 (and final)

### DIFF
--- a/src/Microsoft.ML.Core/Data/ColumnType.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnType.cs
@@ -25,24 +25,6 @@ namespace Microsoft.ML.Data
         {
             Contracts.CheckValue(rawType, nameof(rawType));
             RawType = rawType;
-            RawType.TryGetDataKind(out var rawKind);
-            RawKind = rawKind;
-        }
-
-        /// <summary>
-        /// Internal sub types can pass both the <paramref name="rawType"/> and <paramref name="rawKind"/> values.
-        /// This asserts that they are consistent.
-        /// </summary>
-        private protected ColumnType(Type rawType, DataKind rawKind)
-        {
-            Contracts.AssertValue(rawType);
-#if DEBUG
-            DataKind tmp;
-            rawType.TryGetDataKind(out tmp);
-            Contracts.Assert(tmp == rawKind);
-#endif
-            RawType = rawType;
-            RawKind = rawKind;
         }
 
         /// <summary>
@@ -54,20 +36,11 @@ namespace Microsoft.ML.Data
         /// </summary>
         public Type RawType { get; }
 
-        /// <summary>
-        /// The <see cref="DataKind"/> corresponding to <see cref="RawType"/>, if there is one (<c>default</c> otherwise).
-        /// It is equivalent to the result produced by <see cref="DataKindExtensions.TryGetDataKind(Type, out DataKind)"/>.
-        /// For external code it would be preferable to operate over <see cref="RawType"/>.
-        /// </summary>
-        [BestFriend]
-        internal DataKind RawKind { get; }
-
         // IEquatable<T> interface recommends also to override base class implementations of
         // Object.Equals(Object) and GetHashCode. In classes below where Equals(ColumnType other)
         // is effectively a referencial comparison, there is no need to override base class implementations
         // of Object.Equals(Object) (and GetHashCode) since its also a referencial comparison.
         public abstract bool Equals(ColumnType other);
-
     }
 
     /// <summary>
@@ -77,11 +50,6 @@ namespace Microsoft.ML.Data
     {
         protected StructuredType(Type rawType)
             : base(rawType)
-        {
-        }
-
-        private protected StructuredType(Type rawType, DataKind rawKind)
-            : base(rawType, rawKind)
         {
         }
     }
@@ -97,12 +65,6 @@ namespace Microsoft.ML.Data
         {
             Contracts.CheckParam(!typeof(IDisposable).IsAssignableFrom(RawType), nameof(rawType),
                 "A " + nameof(PrimitiveType) + " cannot have a disposable " + nameof(RawType));
-        }
-
-        private protected PrimitiveType(Type rawType, DataKind rawKind)
-            : base(rawType, rawKind)
-        {
-            Contracts.Assert(!typeof(IDisposable).IsAssignableFrom(RawType));
         }
 
         [BestFriend]
@@ -155,7 +117,7 @@ namespace Microsoft.ML.Data
         }
 
         private TextType()
-            : base(typeof(ReadOnlyMemory<char>), DataKind.TX)
+            : base(typeof(ReadOnlyMemory<char>))
         {
         }
 
@@ -177,8 +139,8 @@ namespace Microsoft.ML.Data
     {
         private readonly string _name;
 
-        private NumberType(DataKind kind, string name)
-            : base(kind.ToType(), kind)
+        private NumberType(Type rawType, string name)
+            : base(rawType)
         {
             Contracts.AssertNonEmpty(name);
             _name = name;
@@ -190,7 +152,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instI1 == null)
-                    Interlocked.CompareExchange(ref _instI1, new NumberType(DataKind.I1, "I1"), null);
+                    Interlocked.CompareExchange(ref _instI1, new NumberType(typeof(sbyte), "I1"), null);
                 return _instI1;
             }
         }
@@ -201,7 +163,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instU1 == null)
-                    Interlocked.CompareExchange(ref _instU1, new NumberType(DataKind.U1, "U1"), null);
+                    Interlocked.CompareExchange(ref _instU1, new NumberType(typeof(byte), "U1"), null);
                 return _instU1;
             }
         }
@@ -212,7 +174,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instI2 == null)
-                    Interlocked.CompareExchange(ref _instI2, new NumberType(DataKind.I2, "I2"), null);
+                    Interlocked.CompareExchange(ref _instI2, new NumberType(typeof(short), "I2"), null);
                 return _instI2;
             }
         }
@@ -223,7 +185,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instU2 == null)
-                    Interlocked.CompareExchange(ref _instU2, new NumberType(DataKind.U2, "U2"), null);
+                    Interlocked.CompareExchange(ref _instU2, new NumberType(typeof(ushort), "U2"), null);
                 return _instU2;
             }
         }
@@ -234,7 +196,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instI4 == null)
-                    Interlocked.CompareExchange(ref _instI4, new NumberType(DataKind.I4, "I4"), null);
+                    Interlocked.CompareExchange(ref _instI4, new NumberType(typeof(int), "I4"), null);
                 return _instI4;
             }
         }
@@ -245,7 +207,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instU4 == null)
-                    Interlocked.CompareExchange(ref _instU4, new NumberType(DataKind.U4, "U4"), null);
+                    Interlocked.CompareExchange(ref _instU4, new NumberType(typeof(uint), "U4"), null);
                 return _instU4;
             }
         }
@@ -256,7 +218,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instI8 == null)
-                    Interlocked.CompareExchange(ref _instI8, new NumberType(DataKind.I8, "I8"), null);
+                    Interlocked.CompareExchange(ref _instI8, new NumberType(typeof(long), "I8"), null);
                 return _instI8;
             }
         }
@@ -267,7 +229,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instU8 == null)
-                    Interlocked.CompareExchange(ref _instU8, new NumberType(DataKind.U8, "U8"), null);
+                    Interlocked.CompareExchange(ref _instU8, new NumberType(typeof(ulong), "U8"), null);
                 return _instU8;
             }
         }
@@ -278,7 +240,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instUG == null)
-                    Interlocked.CompareExchange(ref _instUG, new NumberType(DataKind.UG, "UG"), null);
+                    Interlocked.CompareExchange(ref _instUG, new NumberType(typeof(RowId), "UG"), null);
                 return _instUG;
             }
         }
@@ -289,7 +251,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instR4 == null)
-                    Interlocked.CompareExchange(ref _instR4, new NumberType(DataKind.R4, "R4"), null);
+                    Interlocked.CompareExchange(ref _instR4, new NumberType(typeof(float), "R4"), null);
                 return _instR4;
             }
         }
@@ -300,7 +262,7 @@ namespace Microsoft.ML.Data
             get
             {
                 if (_instR8 == null)
-                    Interlocked.CompareExchange(ref _instR8, new NumberType(DataKind.R8, "R8"), null);
+                    Interlocked.CompareExchange(ref _instR8, new NumberType(typeof(double), "R8"), null);
                 return _instR8;
             }
         }
@@ -379,7 +341,7 @@ namespace Microsoft.ML.Data
         }
 
         private BoolType()
-            : base(typeof(bool), DataKind.BL)
+            : base(typeof(bool))
         {
         }
 
@@ -411,7 +373,7 @@ namespace Microsoft.ML.Data
         }
 
         private DateTimeType()
-            : base(typeof(DateTime), DataKind.DT)
+            : base(typeof(DateTime))
         {
         }
 
@@ -440,7 +402,7 @@ namespace Microsoft.ML.Data
         }
 
         private DateTimeOffsetType()
-            : base(typeof(DateTimeOffset), DataKind.DZ)
+            : base(typeof(DateTimeOffset))
         {
         }
 
@@ -472,7 +434,7 @@ namespace Microsoft.ML.Data
         }
 
         private TimeSpanType()
-            : base(typeof(TimeSpan), DataKind.TS)
+            : base(typeof(TimeSpan))
         {
         }
 
@@ -506,7 +468,7 @@ namespace Microsoft.ML.Data
     public sealed class KeyType : PrimitiveType
     {
         private KeyType(Type type, DataKind kind, ulong min, int count, bool contiguous)
-            : base(type, kind)
+            : base(type)
         {
             Contracts.AssertValue(type);
             Contracts.Assert(kind.ToType() == type);
@@ -623,17 +585,18 @@ namespace Microsoft.ML.Data
 
         public override int GetHashCode()
         {
-            return Hashing.CombinedHash(RawKind.GetHashCode(), Contiguous, Min, Count);
+            return Hashing.CombinedHash(RawType.GetHashCode(), Contiguous, Min, Count);
         }
 
         public override string ToString()
         {
+            DataKind rawKind = this.GetRawKind();
             if (Count > 0)
-                return string.Format("Key<{0}, {1}-{2}>", RawKind.GetString(), Min, Min + (ulong)Count - 1);
+                return string.Format("Key<{0}, {1}-{2}>", rawKind.GetString(), Min, Min + (ulong)Count - 1);
             if (Contiguous)
-                return string.Format("Key<{0}, {1}-*>", RawKind.GetString(), Min);
+                return string.Format("Key<{0}, {1}-*>", rawKind.GetString(), Min);
             // This is the non-contiguous case - simply show the Min.
-            return string.Format("Key<{0}, Min:{1}>", RawKind.GetString(), Min);
+            return string.Format("Key<{0}, Min:{1}>", rawKind.GetString(), Min);
         }
     }
 
@@ -642,7 +605,7 @@ namespace Microsoft.ML.Data
     /// </summary>
     public sealed class VectorType : StructuredType
     {
-        /// <summary>b
+        /// <summary>
         /// The dimensions. This will always have at least one item. All values will be non-negative.
         /// As with <see cref="Size"/>, a zero value indicates that the vector type is considered to have
         /// unknown length along that dimension.
@@ -655,7 +618,7 @@ namespace Microsoft.ML.Data
         /// <param name="itemType">The type of the items contained in the vector.</param>
         /// <param name="size">The size of the single dimension.</param>
         public VectorType(PrimitiveType itemType, int size = 0)
-            : base(GetRawType(itemType), 0)
+            : base(GetRawType(itemType))
         {
             Contracts.CheckParam(size >= 0, nameof(size));
 
@@ -672,7 +635,7 @@ namespace Microsoft.ML.Data
         /// non-negative values. Also, because <see cref="Size"/> is the product of <see cref="Dimensions"/>, the result of
         /// multiplying all these values together must not overflow <see cref="int"/>.</param>
         public VectorType(PrimitiveType itemType, params int[] dimensions)
-            : base(GetRawType(itemType), default)
+            : base(GetRawType(itemType))
         {
             Contracts.CheckParam(Utils.Size(dimensions) > 0, nameof(dimensions));
             Contracts.CheckParam(dimensions.All(d => d >= 0), nameof(dimensions));
@@ -687,7 +650,7 @@ namespace Microsoft.ML.Data
         /// </summary>
         [BestFriend]
         internal VectorType(PrimitiveType itemType, VectorType template)
-            : base(GetRawType(itemType), default)
+            : base(GetRawType(itemType))
         {
             Contracts.CheckValue(template, nameof(template));
 
@@ -702,7 +665,7 @@ namespace Microsoft.ML.Data
         /// </summary>
         [BestFriend]
         internal VectorType(PrimitiveType itemType, VectorType template, params int[] dims)
-            : base(GetRawType(itemType), default)
+            : base(GetRawType(itemType))
         {
             Contracts.CheckValue(template, nameof(template));
             Contracts.CheckParam(Utils.Size(dims) > 0, nameof(dims));

--- a/src/Microsoft.ML.Core/Data/ColumnTypeExtensions.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnTypeExtensions.cs
@@ -47,6 +47,17 @@ namespace Microsoft.ML.Data
         public static bool IsKnownSizeVector(this ColumnType columnType) => columnType.GetVectorSize() > 0;
 
         /// <summary>
+        /// Gets the equivalent <see cref="DataKind"/> for the <paramref name="columnType"/>'s RawType.
+        /// This can return default(<see cref="DataKind"/>) if the RawType doesn't have a corresponding
+        /// <see cref="DataKind"/>.
+        /// </summary>
+        public static DataKind GetRawKind(this ColumnType columnType)
+        {
+            columnType.RawType.TryGetDataKind(out DataKind result);
+            return result;
+        }
+
+        /// <summary>
         /// Equivalent to calling Equals(ColumnType) for non-vector types. For vector type,
         /// returns true if current and other vector types have the same size and item type.
         /// </summary>

--- a/src/Microsoft.ML.Core/Data/DataKind.cs
+++ b/src/Microsoft.ML.Core/Data/DataKind.cs
@@ -105,6 +105,32 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
+        /// For integer Types, this returns the maximum legal value. For un-supported Types,
+        /// it returns zero.
+        /// </summary>
+        public static ulong ToMaxInt(this Type type)
+        {
+            if (type == typeof(sbyte))
+                return (ulong)sbyte.MaxValue;
+            else if (type == typeof(byte))
+                return byte.MaxValue;
+            else if (type == typeof(short))
+                return (ulong)short.MaxValue;
+            else if (type == typeof(ushort))
+                return ushort.MaxValue;
+            else if (type == typeof(int))
+                return int.MaxValue;
+            else if (type == typeof(uint))
+                return uint.MaxValue;
+            else if (type == typeof(long))
+                return long.MaxValue;
+            else if (type == typeof(ulong))
+                return ulong.MaxValue;
+
+            return 0;
+        }
+
+        /// <summary>
         /// For integer DataKinds, this returns the minimum legal value. For un-supported kinds,
         /// it returns one.
         /// </summary>

--- a/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
+++ b/src/Microsoft.ML.Data/Commands/TypeInfoCommand.cs
@@ -96,18 +96,18 @@ namespace Microsoft.ML.Data.Commands
                     for (int j = 0; j < types.Length; ++j)
                     {
                         if (conv.TryGetStandardConversion(types[i], types[j], out del, out isIdentity))
-                            dstKinds.Add(types[j].RawKind);
+                            dstKinds.Add(types[j].GetRawKind());
                     }
                     if (!conv.TryGetStandardConversion(types[i], types[i], out del, out isIdentity))
-                        Utils.Add(ref nonIdentity, types[i].RawKind);
+                        Utils.Add(ref nonIdentity, types[i].GetRawKind());
                     else
                         ch.Assert(isIdentity);
 
-                    srcToDstMap[types[i].RawKind] = dstKinds;
+                    srcToDstMap[types[i].GetRawKind()] = dstKinds;
                     HashSet<DataKind> srcKinds;
                     if (!dstToSrcMap.TryGetValue(dstKinds, out srcKinds))
                         dstToSrcMap[dstKinds] = srcKinds = new HashSet<DataKind>();
-                    srcKinds.Add(types[i].RawKind);
+                    srcKinds.Add(types[i].GetRawKind());
                 }
 
                 // Now perform the final outputs.

--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -62,57 +62,43 @@ namespace Microsoft.ML.Data.Conversion
             }
         }
 
-        private const DataKind _kindStringBuilder = (DataKind)100;
-        private readonly Dictionary<Type, DataKind> _kinds;
+        // Maps from {src,dst} pair of DataKind to ValueMapper. The {src,dst} pair is
+        // the two byte values packed into the low two bytes of an int, with src the lsb.
+        private readonly Dictionary<(Type src, Type dst), Delegate> _delegatesStd;
 
         // Maps from {src,dst} pair of DataKind to ValueMapper. The {src,dst} pair is
         // the two byte values packed into the low two bytes of an int, with src the lsb.
-        private readonly Dictionary<int, Delegate> _delegatesStd;
-
-        // Maps from {src,dst} pair of DataKind to ValueMapper. The {src,dst} pair is
-        // the two byte values packed into the low two bytes of an int, with src the lsb.
-        private readonly Dictionary<int, Delegate> _delegatesAll;
+        private readonly Dictionary<(Type src, Type dst), Delegate> _delegatesAll;
 
         // This has RefPredicate<T> delegates for determining whether a value is NA.
-        private readonly Dictionary<DataKind, Delegate> _isNADelegates;
+        private readonly Dictionary<Type, Delegate> _isNADelegates;
 
         // This has RefPredicate<VBuffer<T>> delegates for determining whether a buffer contains any NA values.
-        private readonly Dictionary<DataKind, Delegate> _hasNADelegates;
+        private readonly Dictionary<Type, Delegate> _hasNADelegates;
 
         // This has RefPredicate<T> delegates for determining whether a value is default.
-        private readonly Dictionary<DataKind, Delegate> _isDefaultDelegates;
+        private readonly Dictionary<Type, Delegate> _isDefaultDelegates;
 
         // This has RefPredicate<VBuffer<T>> delegates for determining whether a buffer contains any zero values.
         // The supported types are unsigned signed integer values (for determining whether a key type is NA).
-        private readonly Dictionary<DataKind, Delegate> _hasZeroDelegates;
+        private readonly Dictionary<Type, Delegate> _hasZeroDelegates;
 
         // This has ValueGetter<T> delegates for producing an NA value of the given type.
-        private readonly Dictionary<DataKind, Delegate> _getNADelegates;
+        private readonly Dictionary<Type, Delegate> _getNADelegates;
 
         // This has TryParseMapper<T> delegates for parsing values from text.
-        private readonly Dictionary<DataKind, Delegate> _tryParseDelegates;
+        private readonly Dictionary<Type, Delegate> _tryParseDelegates;
 
         private Conversions()
         {
-            // We fabricate a DataKind value for StringBuilder.
-            Contracts.Assert(!Enum.IsDefined(typeof(DataKind), _kindStringBuilder));
-
-            _kinds = new Dictionary<Type, DataKind>();
-            for (DataKind kind = DataKindExtensions.KindMin; kind < DataKindExtensions.KindLim; kind++)
-                _kinds.Add(kind.ToType(), kind);
-
-            // We don't put StringBuilder in _kinds, but there are conversions to StringBuilder.
-            Contracts.Assert(!_kinds.ContainsKey(typeof(StringBuilder)));
-            Contracts.Assert(_kinds.Count == 16);
-
-            _delegatesStd = new Dictionary<int, Delegate>();
-            _delegatesAll = new Dictionary<int, Delegate>();
-            _isNADelegates = new Dictionary<DataKind, Delegate>();
-            _hasNADelegates = new Dictionary<DataKind, Delegate>();
-            _isDefaultDelegates = new Dictionary<DataKind, Delegate>();
-            _hasZeroDelegates = new Dictionary<DataKind, Delegate>();
-            _getNADelegates = new Dictionary<DataKind, Delegate>();
-            _tryParseDelegates = new Dictionary<DataKind, Delegate>();
+            _delegatesStd = new Dictionary<(Type src, Type dst), Delegate>();
+            _delegatesAll = new Dictionary<(Type src, Type dst), Delegate>();
+            _isNADelegates = new Dictionary<Type, Delegate>();
+            _hasNADelegates = new Dictionary<Type, Delegate>();
+            _isDefaultDelegates = new Dictionary<Type, Delegate>();
+            _hasZeroDelegates = new Dictionary<Type, Delegate>();
+            _getNADelegates = new Dictionary<Type, Delegate>();
+            _tryParseDelegates = new Dictionary<Type, Delegate>();
 
             // !!! WARNING !!!: Do NOT add any standard conversions without clearing from the IDV Type System
             // design committee. Any changes also require updating the IDV Type System Specification.
@@ -291,20 +277,10 @@ namespace Microsoft.ML.Data.Conversion
             AddTryParse<DZ>(TryParse);
         }
 
-        private static int GetKey(DataKind kindSrc, DataKind kindDst)
-        {
-            Contracts.Assert(Enum.IsDefined(typeof(DataKind), kindSrc));
-            Contracts.Assert(Enum.IsDefined(typeof(DataKind), kindDst) || kindDst == _kindStringBuilder);
-            Contracts.Assert(0 <= _kindStringBuilder && (int)_kindStringBuilder < (1 << 8));
-            return ((int)kindSrc << 8) | (int)kindDst;
-        }
-
         // Add a standard conversion to the lookup tables.
         private void AddStd<TSrc, TDst>(ValueMapper<TSrc, TDst> fn)
         {
-            var kindSrc = _kinds[typeof(TSrc)];
-            var kindDst = _kinds[typeof(TDst)];
-            var key = GetKey(kindSrc, kindDst);
+            var key = (typeof(TSrc), typeof(TDst));
             _delegatesStd.Add(key, fn);
             _delegatesAll.Add(key, fn);
         }
@@ -312,45 +288,38 @@ namespace Microsoft.ML.Data.Conversion
         // Add a non-standard conversion to the lookup table.
         private void AddAux<TSrc, TDst>(ValueMapper<TSrc, TDst> fn)
         {
-            var kindSrc = _kinds[typeof(TSrc)];
-            var kindDst = typeof(TDst) == typeof(SB) ? _kindStringBuilder : _kinds[typeof(TDst)];
-            _delegatesAll.Add(GetKey(kindSrc, kindDst), fn);
+            var key = (typeof(TSrc), typeof(TDst));
+            _delegatesAll.Add(key, fn);
         }
 
         private void AddIsNA<T>(InPredicate<T> fn)
         {
-            var kind = _kinds[typeof(T)];
-            _isNADelegates.Add(kind, fn);
+            _isNADelegates.Add(typeof(T), fn);
         }
 
         private void AddGetNA<T>(ValueGetter<T> fn)
         {
-            var kind = _kinds[typeof(T)];
-            _getNADelegates.Add(kind, fn);
+            _getNADelegates.Add(typeof(T), fn);
         }
 
         private void AddHasNA<T>(InPredicate<VBuffer<T>> fn)
         {
-            var kind = _kinds[typeof(T)];
-            _hasNADelegates.Add(kind, fn);
+            _hasNADelegates.Add(typeof(T), fn);
         }
 
         private void AddIsDef<T>(InPredicate<T> fn)
         {
-            var kind = _kinds[typeof(T)];
-            _isDefaultDelegates.Add(kind, fn);
+            _isDefaultDelegates.Add(typeof(T), fn);
         }
 
         private void AddHasZero<T>(InPredicate<VBuffer<T>> fn)
         {
-            var kind = _kinds[typeof(T)];
-            _hasZeroDelegates.Add(kind, fn);
+            _hasZeroDelegates.Add(typeof(T), fn);
         }
 
         private void AddTryParse<T>(TryParseMapper<T> fn)
         {
-            var kind = _kinds[typeof(T)];
-            _tryParseDelegates.Add(kind, fn);
+            _tryParseDelegates.Add(typeof(T), fn);
         }
 
         /// <summary>
@@ -460,11 +429,11 @@ namespace Microsoft.ML.Data.Conversion
             else if (!typeDst.IsStandardScalar())
                 return false;
 
-            Contracts.Assert(typeSrc.RawKind != 0);
-            Contracts.Assert(typeDst.RawKind != 0);
+            Contracts.Assert(typeSrc is KeyType || typeSrc.IsStandardScalar());
+            Contracts.Assert(typeDst is KeyType || typeDst.IsStandardScalar());
 
-            int key = GetKey(typeSrc.RawKind, typeDst.RawKind);
-            identity = typeSrc.RawKind == typeDst.RawKind;
+            identity = typeSrc.RawType == typeDst.RawType;
+            var key = (typeSrc.RawType, typeDst.RawType);
             return _delegatesStd.TryGetValue(key, out conv);
         }
 
@@ -500,13 +469,7 @@ namespace Microsoft.ML.Data.Conversion
 
         private bool TryGetStringConversion<TSrc>(out ValueMapper<TSrc, SB> conv)
         {
-            DataKind kindSrc;
-            if (!_kinds.TryGetValue(typeof(TSrc), out kindSrc))
-            {
-                conv = null;
-                return false;
-            }
-            int key = GetKey(kindSrc, _kindStringBuilder);
+            var key = (typeof(TSrc), typeof(SB));
             Delegate del;
             if (_delegatesAll.TryGetValue(key, out del))
             {
@@ -574,8 +537,8 @@ namespace Microsoft.ML.Data.Conversion
             if (typeDst is KeyType keyType)
                 return GetKeyTryParse<TDst>(keyType);
 
-            Contracts.Assert(_tryParseDelegates.ContainsKey(typeDst.RawKind));
-            return (TryParseMapper<TDst>)_tryParseDelegates[typeDst.RawKind];
+            Contracts.Assert(_tryParseDelegates.ContainsKey(typeDst.RawType));
+            return (TryParseMapper<TDst>)_tryParseDelegates[typeDst.RawType];
         }
 
         private TryParseMapper<TDst> GetKeyTryParse<TDst>(KeyType key)
@@ -676,7 +639,7 @@ namespace Microsoft.ML.Data.Conversion
 
             var t = type;
             Delegate del;
-            if (!t.IsStandardScalar() && !(t is KeyType) || !_isDefaultDelegates.TryGetValue(t.RawKind, out del))
+            if (!t.IsStandardScalar() && !(t is KeyType) || !_isDefaultDelegates.TryGetValue(t.RawType, out del))
                 throw Contracts.Except("No IsDefault predicate for '{0}'", type);
 
             return (InPredicate<T>)del;
@@ -716,10 +679,10 @@ namespace Microsoft.ML.Data.Conversion
             if (t is KeyType)
             {
                 // REVIEW: Should we test for out of range when KeyCount > 0?
-                Contracts.Assert(_isDefaultDelegates.ContainsKey(t.RawKind));
-                del = _isDefaultDelegates[t.RawKind];
+                Contracts.Assert(_isDefaultDelegates.ContainsKey(t.RawType));
+                del = _isDefaultDelegates[t.RawType];
             }
-            else if (!t.IsStandardScalar() || !_isNADelegates.TryGetValue(t.RawKind, out del))
+            else if (!t.IsStandardScalar() || !_isNADelegates.TryGetValue(t.RawType, out del))
             {
                 del = null;
                 return false;
@@ -739,10 +702,10 @@ namespace Microsoft.ML.Data.Conversion
             if (t is KeyType)
             {
                 // REVIEW: Should we test for out of range when KeyCount > 0?
-                Contracts.Assert(_hasZeroDelegates.ContainsKey(t.RawKind));
-                del = _hasZeroDelegates[t.RawKind];
+                Contracts.Assert(_hasZeroDelegates.ContainsKey(t.RawType));
+                del = _hasZeroDelegates[t.RawType];
             }
-            else if (!t.IsStandardScalar() || !_hasNADelegates.TryGetValue(t.RawKind, out del))
+            else if (!t.IsStandardScalar() || !_hasNADelegates.TryGetValue(t.RawType, out del))
                 throw Contracts.Except("No HasMissing predicate for '{0}'", type);
 
             return (InPredicate<VBuffer<T>>)del;
@@ -759,7 +722,7 @@ namespace Microsoft.ML.Data.Conversion
             Contracts.CheckParam(type.RawType == typeof(T), nameof(type));
 
             Delegate del;
-            if (!_getNADelegates.TryGetValue(type.RawKind, out del))
+            if (!_getNADelegates.TryGetValue(type.RawType, out del))
                 return default(T);
             T res = default(T);
             ((ValueGetter<T>)del)(ref res);
@@ -777,7 +740,7 @@ namespace Microsoft.ML.Data.Conversion
             Contracts.CheckParam(type.RawType == typeof(T), nameof(type));
 
             Delegate del;
-            if (!_getNADelegates.TryGetValue(type.RawKind, out del))
+            if (!_getNADelegates.TryGetValue(type.RawType, out del))
             {
                 isDefault = true;
                 return default(T);
@@ -789,7 +752,7 @@ namespace Microsoft.ML.Data.Conversion
 
 #if DEBUG
             Delegate isDefPred;
-            if (_isDefaultDelegates.TryGetValue(type.RawKind, out isDefPred))
+            if (_isDefaultDelegates.TryGetValue(type.RawType, out isDefPred))
                 Contracts.Assert(!((InPredicate<T>)isDefPred)(in res));
 #endif
 
@@ -807,7 +770,7 @@ namespace Microsoft.ML.Data.Conversion
             Contracts.CheckParam(type.RawType == typeof(T), nameof(type));
 
             Delegate del;
-            if (!_getNADelegates.TryGetValue(type.RawKind, out del))
+            if (!_getNADelegates.TryGetValue(type.RawType, out del))
                 return (ref T res) => res = default(T);
             return (ValueGetter<T>)del;
         }

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/Codecs.cs
@@ -1252,7 +1252,7 @@ namespace Microsoft.ML.Data.IO
                 Contracts.CheckDecode(min >= 0);
                 Contracts.CheckDecode(0 <= count);
                 Contracts.CheckDecode((ulong)count <= ulong.MaxValue - min);
-                Contracts.CheckDecode((ulong)count <= itemType.RawKind.ToMaxInt());
+                Contracts.CheckDecode((ulong)count <= itemType.GetRawKind().ToMaxInt());
                 Contracts.CheckDecode(contiguous || count == 0);
 
                 type = new KeyType(itemType.RawType, min, count, contiguous);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -461,7 +461,7 @@ namespace Microsoft.ML.Data
                 Contracts.Assert(isegVar >= -1);
 
                 Name = name;
-                Kind = colType.GetItemType().RawKind;
+                Kind = colType.GetItemType().GetRawKind();
                 Contracts.Assert(Kind != 0);
                 ColType = colType;
                 Segments = segs;
@@ -850,8 +850,9 @@ namespace Microsoft.ML.Data
                     var info = Infos[iinfo];
                     ctx.SaveNonEmptyString(info.Name);
                     var type = info.ColType.GetItemType();
-                    Contracts.Assert((DataKind)(byte)type.RawKind == type.RawKind);
-                    ctx.Writer.Write((byte)type.RawKind);
+                    DataKind rawKind = type.GetRawKind();
+                    Contracts.Assert((DataKind)(byte)rawKind == rawKind);
+                    ctx.Writer.Write((byte)rawKind);
                     ctx.Writer.WriteBoolByte(type is KeyType);
                     if (type is KeyType key)
                     {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -675,8 +675,7 @@ namespace Microsoft.ML.Data
                     }
 
                     ColumnType itemType = vectorType?.ItemType ?? info.ColType;
-                    DataKind kind = itemType.RawKind;
-                    Contracts.Assert(kind != 0);
+                    Contracts.Assert(itemType is KeyType || itemType.IsStandardScalar());
                     var map = vectorType != null ? mapVec : mapOne;
                     if (!map.TryGetValue(info.Kind, out _creator[i]))
                     {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -388,7 +388,8 @@ namespace Microsoft.ML.Data.IO
             for (int i = 0; i < cols.Length; i++)
             {
                 ch.Check(0 <= cols[i] && cols[i] < data.Schema.Count);
-                ch.Check(data.Schema[cols[i]].Type.GetItemType().RawKind != 0);
+                ColumnType itemType = data.Schema[cols[i]].Type.GetItemType();
+                ch.Check(itemType is KeyType || itemType.IsStandardScalar());
                 activeCols.Add(data.Schema[cols[i]]);
             }
 
@@ -486,7 +487,6 @@ namespace Microsoft.ML.Data.IO
 
         private TextLoader.Column GetColumn(string name, ColumnType type, int? start)
         {
-            DataKind? kind;
             KeyRange keyRange = null;
             VectorType vectorType = type as VectorType;
             ColumnType itemType = vectorType?.ItemType ?? type;
@@ -501,10 +501,9 @@ namespace Microsoft.ML.Data.IO
                     Contracts.Assert(key.Count >= 1);
                     keyRange = new KeyRange(key.Min, key.Min + (ulong)(key.Count - 1));
                 }
-                kind = key.RawKind;
             }
-            else
-                kind = itemType.RawKind;
+
+            DataKind kind = itemType.GetRawKind();
 
             TextLoader.Range[] source = null;
 

--- a/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/DataView/InternalSchemaDefinition.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// Given a field or property info on a type, returns whether this appears to be a vector type,
-        /// and also the associated data kind for this type. If a data kind could not
+        /// and also the associated data kind for this type. If a valid data type could not
         /// be determined, this will throw.
         /// </summary>
         /// <param name="memberInfo">The field or property info to inspect.</param>

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// Returns whether the column type <paramref name="colType"/> can be bound to field <paramref name="memberInfo"/>.
-        /// They must both be vectors or scalars, and the raw data kind should match.
+        /// They must both be vectors or scalars, and the raw data type should match.
         /// </summary>
         private static bool IsCompatibleType(ColumnType colType, MemberInfo memberInfo)
         {

--- a/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
+++ b/src/Microsoft.ML.Data/Transforms/TypeConverting.cs
@@ -313,7 +313,6 @@ namespace Microsoft.ML.Transforms.Conversions
             {
                 var item = args.Column[i];
                 var tempResultType = item.ResultType ?? args.ResultType;
-                DataKind kind;
                 KeyRange range = null;
                 // If KeyRange or Range are defined on this column, set range to the appropriate value.
                 if (item.KeyRange != null)
@@ -330,6 +329,7 @@ namespace Microsoft.ML.Transforms.Conversions
                         range = KeyRange.Parse(args.Range);
                 }
 
+                DataKind kind;
                 if (tempResultType == null)
                 {
                     if (range == null)
@@ -337,7 +337,7 @@ namespace Microsoft.ML.Transforms.Conversions
                     else
                     {
                         var srcType = input.Schema[item.Source ?? item.Name].Type;
-                        kind = srcType is KeyType ? srcType.RawKind : DataKind.U4;
+                        kind = srcType is KeyType ? srcType.GetRawKind() : DataKind.U4;
                     }
                 }
                 else

--- a/src/Microsoft.ML.Transforms/MissingValueHandlingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueHandlingTransformer.cs
@@ -177,7 +177,13 @@ namespace Microsoft.ML.Transforms
 
                 // Add a ConvertTransform column if necessary.
                 if (!identity)
-                    naConvCols.Add(new TypeConvertingTransformer.ColumnInfo(tmpIsMissingColName, tmpIsMissingColName, replaceItemType.RawKind));
+                {
+                    if (!replaceItemType.RawType.TryGetDataKind(out DataKind replaceItemTypeKind))
+                    {
+                        throw h.Except("Cannot get a DataKind for type '{0}'", replaceItemType.RawType);
+                    }
+                    naConvCols.Add(new TypeConvertingTransformer.ColumnInfo(tmpIsMissingColName, tmpIsMissingColName, replaceItemTypeKind));
+                }
 
                 // Add the NAReplaceTransform column.
                 replaceCols.Add(new MissingValueReplacingTransformer.ColumnInfo(column.Source, tmpReplacementColName, (MissingValueReplacingTransformer.ColumnInfo.ReplacementMode)(column.Kind ?? args.ReplaceWith), column.ImputeBySlot ?? args.ImputeBySlot));


### PR DESCRIPTION
Completely removes `ColumnType.RawKind`.

Part of the work necessary for #1860. 

Fix #1533.