### PR TITLE
Add visibility for internal projects.

### DIFF
--- a/src/Microsoft.ML.HalLearners/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.HalLearners/Properties/AssemblyInfo.cs
@@ -10,5 +10,6 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.HalLearners.StaticPipe" + PublicKey.Value)]
 
 [assembly: InternalsVisibleTo(assemblyName: "RunTests" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Internal.MetaLinearLearner" + InternalPublicKey.Value)]
 
 [assembly: WantsToBeBestFriends]

--- a/src/Microsoft.ML.StandardLearners/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.StandardLearners/Properties/AssemblyInfo.cs
@@ -9,3 +9,7 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.StaticPipe" + PublicKey.Value)]
 
 [assembly: InternalsVisibleTo(assemblyName: "RunTests" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "RunTestsMore" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Internal.MetaLinearLearner" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "ParameterMixer" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Runtime.Sar" + InternalPublicKey.Value)]


### PR DESCRIPTION
We made constructors internal, and in internal repo I don't have mlcontext all the time. I don't want to create mlcontext, so I would prefer to make learners visible via [InternalVisible].