### PR TITLE
Improve exception message and make consistent with ExceptSchemaMismatch

### DIFF
--- a/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
+++ b/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
@@ -119,6 +119,8 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <returns>One intepretation is, the value at which the standard normal CDF evaluates to p.</returns>
         public static double Probit(double p)
         {
+            Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Input probability should be in range 0 to 1.");
+
             double q = p - 0.5;
             double r = 0.0;
             if (Math.Abs(q) <= 0.425)
@@ -134,8 +136,6 @@ namespace Microsoft.ML.Internal.CpuMath
                     r = p;
                 else
                     r = 1 - p;
-
-                Contracts.CheckParam(r >= 0, nameof(p), "Illegal input value");
 
                 r = Math.Sqrt(-Math.Log(r));
                 double retval = 0.0;

--- a/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ML
 
             var type = input.Schema[columnName].Type;
             if (type.GetKeyCount() == 0)
-                throw Environment.ExceptSchemaMismatch(nameof(columnName), "filter", columnName, "a known cardinality key", type.ToString());
+                throw Environment.ExceptSchemaMismatch(nameof(columnName), "filter", columnName, "a key", type.ToString());
             return new RangeFilter(Environment, input, columnName, lowerBound, upperBound, false);
         }
     }

--- a/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ML
 
             var type = input.Schema[columnName].Type;
             if (type.GetKeyCount() == 0)
-                throw Environment.ExceptSchemaMismatch(nameof(columnName), "filter", columnName, "a key", type.ToString());
+                throw Environment.ExceptSchemaMismatch(nameof(columnName), "filter", columnName, "KeyType", type.ToString());
             return new RangeFilter(Environment, input, columnName, lowerBound, upperBound, false);
         }
     }

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Data
                 {
                     if (ignoreMissingColumns)
                         continue;
-                    throw _host.Except("Column '{0}' not found in the data view", col.ColumnName);
+                    throw _host.ExceptSchemaMismatch(nameof(_data.Schema), "", col.ColumnName);
                 }
                 var realColType = _data.Schema[colIndex].Type;
                 if (!IsCompatibleType(realColType, col.MemberInfo))

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Data
             Host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.Float && t.GetKeyCount() != 2)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or a 2-value KeyType", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or a KeyType with cardinality 2", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
@@ -666,7 +666,7 @@ namespace Microsoft.ML.Data
 
             IDataView overall;
             if (!metrics.TryGetValue(MetricKinds.OverallMetrics, out overall))
-                throw Host.ExceptSchemaMismatch(nameof(overall.Schema), "overall metrics", MetricKinds.OverallMetrics);
+                throw Host.Except("No overall metrics found");
 
             // Find the number of anomalies, and the thresholds.
             int numAnomIndex;

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -96,11 +96,11 @@ namespace Microsoft.ML.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type;
             if (t != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type '{1}' but must be R4", score, t).MarkSensitive(MessageSensitivity.Schema);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "float", t.ToString());
             Host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.Float && t.GetKeyCount() != 2)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4 or a 2-value key", schema.Label.Value.Name, t).MarkSensitive(MessageSensitivity.Schema);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or a 2-value key", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
@@ -631,13 +631,13 @@ namespace Microsoft.ML.Data
             {
                 int index;
                 if (!top.Schema.TryGetColumnIndex(AnomalyDetectionEvaluator.TopKResultsColumns.Instance, out index))
-                    throw Host.Except("Data view does not contain the 'Instance' column");
+                    throw Host.ExceptSchemaMismatch(nameof(top.Schema), "instance", AnomalyDetectionEvaluator.TopKResultsColumns.Instance);
                 var instanceGetter = cursor.GetGetter<ReadOnlyMemory<char>>(index);
                 if (!top.Schema.TryGetColumnIndex(AnomalyDetectionEvaluator.TopKResultsColumns.AnomalyScore, out index))
-                    throw Host.Except("Data view does not contain the 'Anomaly Score' column");
+                    throw Host.ExceptSchemaMismatch(nameof(top.Schema), "anomaly score", AnomalyDetectionEvaluator.TopKResultsColumns.AnomalyScore);
                 var scoreGetter = cursor.GetGetter<Single>(index);
                 if (!top.Schema.TryGetColumnIndex(AnomalyDetectionEvaluator.TopKResultsColumns.Label, out index))
-                    throw Host.Except("Data view does not contain the 'Label' column");
+                    throw Host.ExceptSchemaMismatch(nameof(top.Schema), "label", AnomalyDetectionEvaluator.TopKResultsColumns.Label);
                 var labelGetter = cursor.GetGetter<Single>(index);
 
                 bool hasRows = false;
@@ -666,12 +666,12 @@ namespace Microsoft.ML.Data
 
             IDataView overall;
             if (!metrics.TryGetValue(MetricKinds.OverallMetrics, out overall))
-                throw Host.Except("No overall metrics found");
+                throw Host.ExceptSchemaMismatch(nameof(overall.Schema), "overall metrics", MetricKinds.OverallMetrics);
 
             // Find the number of anomalies, and the thresholds.
             int numAnomIndex;
             if (!overall.Schema.TryGetColumnIndex(AnomalyDetectionEvaluator.OverallMetrics.NumAnomalies, out numAnomIndex))
-                throw Host.Except("Could not find the 'NumAnomalies' column");
+                throw Host.ExceptSchemaMismatch(nameof(overall.Schema), "number of anomalies", AnomalyDetectionEvaluator.OverallMetrics.NumAnomalies);
 
             int stratCol;
             var hasStrat = overall.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratCol, out stratCol);

--- a/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AnomalyDetectionEvaluator.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Data
             Host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.Float && t.GetKeyCount() != 2)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or a 2-value key", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or a 2-value KeyType", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -129,11 +129,11 @@ namespace Microsoft.ML.Data
             var host = Host.SchemaSensitive();
             var t = score.Type;
             if (t != NumberType.Float)
-                throw host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "R4", t.ToString());
+                throw host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "float", t.ToString());
             host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.GetKeyCount() != 2)
-                throw host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "R4, R8, BL or a 2-value key", t.ToString());
+                throw host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float, double, bool, or a 2-value key", t.ToString());
         }
 
         private protected override void CheckCustomColumnTypesCore(RoleMappedSchema schema)
@@ -145,7 +145,7 @@ namespace Microsoft.ML.Data
                 host.CheckParam(prob.Count == 1, nameof(schema), "Cannot have multiple probability columns");
                 var probType = prob[0].Type;
                 if (probType != NumberType.Float)
-                    throw host.ExceptSchemaMismatch(nameof(schema), "probability", prob[0].Name, "R4", probType.ToString());
+                    throw host.ExceptSchemaMismatch(nameof(schema), "probability", prob[0].Name, "float", probType.ToString());
             }
             else if (!_useRaw)
             {

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Data
             host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.GetKeyCount() != 2)
-                throw host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float, double, bool, or a 2-value key", t.ToString());
+                throw host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float, double, bool, or a 2-value KeyType", t.ToString());
         }
 
         private protected override void CheckCustomColumnTypesCore(RoleMappedSchema schema)
@@ -1098,7 +1098,7 @@ namespace Microsoft.ML.Data
 
             var t = schema[(int)LabelIndex].Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.GetKeyCount() != 2)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float, double, bool or a 2-value key", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float, double, bool or a 2-value KeyType", t.ToString());
 
             t = schema[ScoreIndex].Type;
             if (t != NumberType.Float)

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Data
             host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.GetKeyCount() != 2)
-                throw host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float, double, bool, or a 2-value KeyType", t.ToString());
+                throw host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float, double, bool, or a KeyType with cardinality 2", t.ToString());
         }
 
         private protected override void CheckCustomColumnTypesCore(RoleMappedSchema schema)
@@ -1098,7 +1098,7 @@ namespace Microsoft.ML.Data
 
             var t = schema[(int)LabelIndex].Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.GetKeyCount() != 2)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float, double, bool or a 2-value KeyType", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float, double, bool or a KeyType with cardinality 2", t.ToString());
 
             t = schema[ScoreIndex].Type;
             if (t != NumberType.Float)

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -1098,18 +1098,18 @@ namespace Microsoft.ML.Data
 
             var t = schema[(int)LabelIndex].Type;
             if (t != NumberType.R4 && t != NumberType.R8 && t != BoolType.Instance && t.GetKeyCount() != 2)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4, R8, BL or a 2-value key", LabelCol, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float, double, bool or a 2-value key", t.ToString());
 
             t = schema[ScoreIndex].Type;
             if (t != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type '{1}' but must be R4", ScoreCol, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol, "float", t.ToString());
 
             if (_probIndex >= 0)
             {
                 Host.Assert(!string.IsNullOrEmpty(_probCol));
                 t = schema[_probIndex].Type;
                 if (t != NumberType.Float)
-                    throw Host.Except("Probability column '{0}' has type '{1}' but must be R4", _probCol, t);
+                    throw Host.ExceptSchemaMismatch(nameof(schema), "probability", _probCol, "float", t.ToString());
             }
             else if (!_useRaw)
                 throw Host.Except("Cannot compute the predicted label from the probability column because it does not exist");

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -754,7 +754,7 @@ namespace Microsoft.ML.Data
 
             var type = schema[(int) ScoreIndex].Type;
             if (!(type is VectorType vectorType) || !vectorType.IsKnownSize || vectorType.ItemType != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type {1}, but must be a float vector of known-size", ScoreCol, type);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol, "known-size vector of float", type.ToString());
         }
     }
 

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Data
             if (type != null && type != NumberType.Float && !(type is KeyType keyType && keyType.Count > 0))
             {
                 throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name,
-                    "float or key", type.ToString());
+                    "float or KeyType", type.ToString());
             }
 
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -100,13 +100,13 @@ namespace Microsoft.ML.Data
             if (type != null && type != NumberType.Float && !(type is KeyType keyType && keyType.Count > 0))
             {
                 throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name,
-                    "R4 or key of known cardinality", type.ToString());
+                    "float or key", type.ToString());
             }
 
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             type = score.Type;
             if (!(type is VectorType vectorType) || !vectorType.IsKnownSize || vectorType.ItemType != NumberType.Float)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "R4 vector of known size", type.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "known-size vector of float", type.ToString());
         }
 
         private protected override void CheckCustomColumnTypesCore(RoleMappedSchema schema)

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -486,9 +486,9 @@ namespace Microsoft.ML.Data
             LabelCol = labelCol;
 
             if (!string.IsNullOrEmpty(LabelCol) && !schema.TryGetColumnIndex(LabelCol, out LabelIndex))
-                throw Host.Except("Did not find the label column '{0}'", LabelCol);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol);
             if (!schema.TryGetColumnIndex(ScoreCol, out ScoreIndex))
-                throw Host.Except("Did not find column '{0}'", ScoreCol);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol);
         }
 
         protected PerInstanceEvaluatorBase(IHostEnvironment env, ModelLoadContext ctx,  Schema schema)
@@ -502,9 +502,9 @@ namespace Microsoft.ML.Data
             ScoreCol = ctx.LoadNonEmptyString();
             LabelCol = ctx.LoadStringOrNull();
             if (!string.IsNullOrEmpty(LabelCol) && !schema.TryGetColumnIndex(LabelCol, out LabelIndex))
-                throw Host.Except($"Did not find the label column '{LabelCol}'");
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol);
             if (!schema.TryGetColumnIndex(ScoreCol, out ScoreIndex))
-                throw Host.Except($"Did not find column '{ScoreCol}'");
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol);
         }
 
         public virtual void Save(ModelSaveContext ctx)

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -77,11 +77,11 @@ namespace Microsoft.ML.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var scoreType = score.Type as VectorType;
             if (scoreType == null || scoreType.Size < 2 || scoreType.ItemType != NumberType.Float)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "vector of two or more items of type R4", scoreType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "vector of two or more items of type float", scoreType.ToString());
             Host.CheckParam(schema.Label.HasValue, nameof(schema), "Could not find the label column");
             var labelType = schema.Label.Value.Type;
             if (labelType != NumberType.Float && labelType.GetKeyCount() <= 0)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or a known-cardinality key", labelType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float or KeyType", labelType.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)
@@ -818,7 +818,7 @@ namespace Microsoft.ML.Data
                 throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol, "vector of two or more items of type float", scoreType.ToString());
             var labelType = schema[LabelIndex].Type;
             if (labelType != NumberType.Float && labelType.GetKeyCount() <= 0)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float or key", labelType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float or KeyType", labelType.ToString());
         }
     }
 

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -815,10 +815,10 @@ namespace Microsoft.ML.Data
 
             var scoreType = schema[ScoreIndex].Type as VectorType;
             if (scoreType == null || scoreType.Size < 2 || scoreType.ItemType != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type '{1}' but must be a vector of two or more items of type R4", ScoreCol, scoreType);
+                throw Host.Except(nameof(schema), "score", "vector of two or more items of type float", ScoreCol, scoreType.ToString());
             var labelType = schema[LabelIndex].Type;
             if (labelType != NumberType.Float && labelType.GetKeyCount() <= 0)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be a float or a known-cardinality key", LabelCol, labelType);
+                throw Host.Except(nameof(schema), "label", LabelCol, "float or key", labelType.ToString());
         }
     }
 
@@ -1000,7 +1000,7 @@ namespace Microsoft.ML.Data
             // text file, since if there are different key counts the columns cannot be appended.
             string labelName = schema.Label.Value.Name;
             if (!perInst.Schema.TryGetColumnIndex(labelName, out int labelCol))
-                throw Host.Except("Could not find column '{0}'", labelName);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", labelName);
             var labelType = perInst.Schema[labelCol].Type;
             if (labelType is KeyType keyType && (!perInst.Schema[labelCol].HasKeyValues(keyType) || labelType.RawType != typeof(uint)))
             {

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -815,10 +815,10 @@ namespace Microsoft.ML.Data
 
             var scoreType = schema[ScoreIndex].Type as VectorType;
             if (scoreType == null || scoreType.Size < 2 || scoreType.ItemType != NumberType.Float)
-                throw Host.Except(nameof(schema), "score", "vector of two or more items of type float", ScoreCol, scoreType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol, "vector of two or more items of type float", scoreType.ToString());
             var labelType = schema[LabelIndex].Type;
             if (labelType != NumberType.Float && labelType.GetKeyCount() <= 0)
-                throw Host.Except(nameof(schema), "label", LabelCol, "float or key", labelType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float or key", labelType.ToString());
         }
     }
 

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -548,7 +548,7 @@ namespace Microsoft.ML.Data
 
             var t = schema[LabelIndex].Type as VectorType;
             if (t == null || !t.IsKnownSize || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
-                throw Host.Except("Label column '{0}' has type '{1}' but must be a known-size vector of R4 or R8", LabelCol, t);
+                throw Host.Except(nameof(schema), "label", LabelCol, "known-size vector of float or double", t.ToString());
             labelType = new VectorType((PrimitiveType)t.ItemType, t.Size);
             var slotNamesType = new VectorType(TextType.Instance, t.Size);
             var builder = new MetadataBuilder();
@@ -557,7 +557,7 @@ namespace Microsoft.ML.Data
 
             t = schema[ScoreIndex].Type as VectorType;
             if (t == null || !t.IsKnownSize || t.ItemType != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type '{1}' but must be a known length vector of type R4", ScoreCol, t);
+                throw Host.Except(nameof(schema), "score", ScoreCol, "known-size vector of float", t.ToString());
             scoreType = new VectorType((PrimitiveType)t.ItemType, t.Size);
             builder = new MetadataBuilder();
             builder.AddSlotNames(t.Size, CreateSlotNamesGetter(schema, ScoreIndex, scoreType.Size, "Predicted"));

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -60,11 +60,11 @@ namespace Microsoft.ML.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type as VectorType;
             if (t == null || !t.IsKnownSize || t.ItemType != NumberType.Float)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "known size vector of R4", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "known-size vector of float", t.ToString());
             Host.Check(schema.Label.HasValue, "Could not find the label column");
             t = schema.Label.Value.Type as VectorType;
             if (t == null || !t.IsKnownSize || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "known size vector of R4 or R8", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "known-size vector of float or double", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -548,7 +548,7 @@ namespace Microsoft.ML.Data
 
             var t = schema[LabelIndex].Type as VectorType;
             if (t == null || !t.IsKnownSize || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
-                throw Host.Except(nameof(schema), "label", LabelCol, "known-size vector of float or double", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "known-size vector of float or double", t.ToString());
             labelType = new VectorType((PrimitiveType)t.ItemType, t.Size);
             var slotNamesType = new VectorType(TextType.Instance, t.Size);
             var builder = new MetadataBuilder();
@@ -557,7 +557,7 @@ namespace Microsoft.ML.Data
 
             t = schema[ScoreIndex].Type as VectorType;
             if (t == null || !t.IsKnownSize || t.ItemType != NumberType.Float)
-                throw Host.Except(nameof(schema), "score", ScoreCol, "known-size vector of float", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol, "known-size vector of float", t.ToString());
             scoreType = new VectorType((PrimitiveType)t.ItemType, t.Size);
             builder = new MetadataBuilder();
             builder.AddSlotNames(t.Size, CreateSlotNamesGetter(schema, ScoreIndex, scoreType.Size, "Predicted"));

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -446,13 +446,13 @@ namespace Microsoft.ML.Data
 
             var t = schema[(int)LabelIndex].Type;
             if (t != NumberType.R4)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4", LabelCol, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float", t.ToString());
 
             VectorType scoreType = schema[ScoreIndex].Type as VectorType;
             if (scoreType == null || scoreType.Size == 0 || (scoreType.ItemType != NumberType.R4 && scoreType.ItemType != NumberType.R8))
             {
-                throw Host.Except(
-                    "Score column '{0}' has type '{1}' but must be a known length vector of type R4 or R8", ScoreCol, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol, "known-size vector of float or double", t.ToString());
+
             }
         }
     }

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -58,11 +58,11 @@ namespace Microsoft.ML.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type as VectorType;
             if (t == null || t.Size == 0 || (t.ItemType != NumberType.R4 && t.ItemType != NumberType.R8))
-                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "vector of type R4 or R8", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "vector of float or double", t.ToString());
             Host.CheckParam(schema.Label.HasValue, nameof(schema), "Must contain a label column");
             var labelType = schema.Label.Value.Type;
             if (labelType != NumberType.R4)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "R4", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -57,11 +57,11 @@ namespace Microsoft.ML.Data
             var score = schema.GetUniqueColumn(MetadataUtils.Const.ScoreValueKind.Score);
             var t = score.Type;
             if (t != NumberType.Float)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "R4", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", score.Name, "float", t.ToString());
             Host.CheckParam(schema.Label.HasValue, nameof(schema), "Could not find the label column");
             t = schema.Label.Value.Type;
             if (t != NumberType.R4)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "R4", t.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", schema.Label.Value.Name, "float", t.ToString());
         }
 
         private protected override Aggregator GetAggregatorCore(RoleMappedSchema schema, string stratName)

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -319,11 +319,11 @@ namespace Microsoft.ML.Data
 
             var t = schema[(int) LabelIndex].Type;
             if (t != NumberType.R4)
-                throw Host.Except("Label column '{0}' has type '{1}' but must be R4", LabelCol, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "label", LabelCol, "float", t.ToString());
 
             t = schema[ScoreIndex].Type;
             if (t != NumberType.Float)
-                throw Host.Except("Score column '{0}' has type '{1}' but must be R4", ScoreCol, t);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "score", ScoreCol, "float", t.ToString());
         }
     }
 

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -94,14 +94,14 @@ namespace Microsoft.ML.Calibrator
         /// <param name="inputSchema">The input <see cref="SchemaShape"/>.</param>
         SchemaShape IEstimator<CalibratorTransformer<TICalibrator>>.GetOutputSchema(SchemaShape inputSchema)
         {
-            Action<SchemaShape.Column, string> checkColumnValid = (SchemaShape.Column column, string expected) =>
+            Action<SchemaShape.Column, string> checkColumnValid = (SchemaShape.Column column, string columnRole) =>
             {
                 if (column.IsValid)
                 {
                     if (!inputSchema.TryFindColumn(column.Name, out var outCol))
-                        throw Host.Except($"{expected} column '{column.Name}' is not found");
+                        throw Host.ExceptSchemaMismatch(nameof(inputSchema), columnRole, column.Name);
                     if (!column.IsCompatibleWith(outCol))
-                        throw Host.Except($"{expected} column '{column.Name}' is not compatible");
+                        throw Host.ExceptSchemaMismatch(nameof(inputSchema), columnRole, column.Name, column.GetTypeString(), outCol.GetTypeString());
                 }
             };
 

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -177,7 +177,7 @@ namespace Microsoft.ML.Data
             if (featureColumn == null)
                 FeatureColumnType = null;
             else if (!trainSchema.TryGetColumnIndex(featureColumn, out int col))
-                throw Host.ExceptSchemaMismatch(nameof(featureColumn), RoleMappedSchema.ColumnRole.Feature.Value, featureColumn);
+                throw Host.ExceptSchemaMismatch(nameof(featureColumn), "feature", featureColumn);
             else
                 FeatureColumnType = trainSchema[col].Type;
 
@@ -192,7 +192,7 @@ namespace Microsoft.ML.Data
             if (FeatureColumn == null)
                 FeatureColumnType = null;
             else if (!TrainSchema.TryGetColumnIndex(FeatureColumn, out int col))
-                throw Host.ExceptSchemaMismatch(nameof(FeatureColumn), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumn);
+                throw Host.ExceptSchemaMismatch(nameof(FeatureColumn), "feature", FeatureColumn);
             else
                 FeatureColumnType = TrainSchema[col].Type;
 
@@ -206,9 +206,9 @@ namespace Microsoft.ML.Data
             if (FeatureColumn != null)
             {
                 if (!inputSchema.TryGetColumnIndex(FeatureColumn, out int col))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumn, FeatureColumnType.ToString(), null);
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "feature", FeatureColumn);
                 if (!inputSchema[col].Type.Equals(FeatureColumnType))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumn, FeatureColumnType.ToString(), inputSchema[col].Type.ToString());
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "feature", FeatureColumn, FeatureColumnType.ToString(), inputSchema[col].Type.ToString());
             }
 
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;

--- a/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
@@ -95,16 +95,18 @@ namespace Microsoft.ML.Training
         {
             // Verify that all required input columns are present, and are of the same type.
             if (!inputSchema.TryFindColumn(FeatureColumn.Name, out var featureCol))
-                throw Host.Except($"Feature column '{FeatureColumn.Name}' is not found");
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "feature", FeatureColumn.Name);
             if (!FeatureColumn.IsCompatibleWith(featureCol))
-                throw Host.Except($"Feature column '{FeatureColumn.Name}' is not compatible");
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "feature", FeatureColumn.Name,
+                    FeatureColumn.GetTypeString(), featureCol.GetTypeString());
 
             if (WeightColumn.IsValid)
             {
                 if (!inputSchema.TryFindColumn(WeightColumn.Name, out var weightCol))
-                    throw Host.Except($"Weight column '{WeightColumn.Name}' is not found");
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "weight", WeightColumn.Name);
                 if (!WeightColumn.IsCompatibleWith(weightCol))
-                    throw Host.Except($"Weight column '{WeightColumn.Name}' is not compatible");
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "weight", WeightColumn.Name,
+                        WeightColumn.GetTypeString(), weightCol.GetTypeString());
             }
 
             // Special treatment for label column: we allow different types of labels, so the trainers
@@ -112,7 +114,7 @@ namespace Microsoft.ML.Training
             if (LabelColumn.IsValid)
             {
                 if (!inputSchema.TryFindColumn(LabelColumn.Name, out var labelCol))
-                    throw Host.Except($"Label column '{LabelColumn.Name}' is not found");
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "label", LabelColumn.Name);
                 CheckLabelCompatible(labelCol);
             }
         }
@@ -123,7 +125,8 @@ namespace Microsoft.ML.Training
             Host.Assert(LabelColumn.IsValid);
 
             if (!LabelColumn.IsCompatibleWith(labelCol))
-                throw Host.Except($"Label column '{LabelColumn.Name}' is not compatible");
+                throw Host.ExceptSchemaMismatch(nameof(labelCol), "label", WeightColumn.Name,
+                    LabelColumn.GetTypeString(), labelCol.GetTypeString());
         }
 
         protected TTransformer TrainTransformer(IDataView trainSet,

--- a/src/Microsoft.ML.Data/Transforms/FeatureContributionCalculationTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/FeatureContributionCalculationTransform.cs
@@ -225,7 +225,7 @@ namespace Microsoft.ML.Data
                     throw Host.ExceptSchemaMismatch(nameof(schema), "input", _parent.ColumnPairs[0].inputColumnName);
                 _featureColumnType = schema[_featureColumnIndex].Type as VectorType;
                 if (_featureColumnType == null || _featureColumnType.ItemType != NumberType.R4)
-                    throw Host.ExceptSchemaMismatch(nameof(schema), "feature column", _parent.ColumnPairs[0].inputColumnName, "Expected type is vector of float.", _featureColumnType.ItemType.ToString());
+                    throw Host.ExceptSchemaMismatch(nameof(schema), "feature", _parent.ColumnPairs[0].inputColumnName, "vector of float.", _featureColumnType.ItemType.ToString());
 
                 if (InputSchema[_featureColumnIndex].HasSlotNames(_featureColumnType.Size))
                     InputSchema[_featureColumnIndex].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref _slotNames);
@@ -320,7 +320,7 @@ namespace Microsoft.ML.Data
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _featureColumn);
             // Check that the feature column is of the correct type: a vector of float.
             if (col.ItemType != NumberType.R4 || col.Kind != SchemaShape.Column.VectorKind.Vector)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "feature column", _featureColumn, "Expected type is vector of float.", col.GetTypeString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "column", _featureColumn, "vector of float.", col.GetTypeString());
 
             // Build output schemaShape.
             var result = inputSchema.ToDictionary(x => x.Name);

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -524,7 +524,7 @@ namespace Microsoft.ML.Transforms.Conversions
                 if (!inputSchema.TryFindColumn(colInfo.inputColumnName, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.inputColumnName);
                 if (!col.IsKey)
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.inputColumnName, "key type", col.GetTypeString());
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.inputColumnName, "KeyType", col.GetTypeString());
 
                 if (!col.Metadata.TryFindColumn(MetadataUtils.Kinds.KeyValues, out var keyMetaCol))
                     throw Host.ExceptParam(nameof(inputSchema), $"Input column '{colInfo.inputColumnName}' doesn't contain key values metadata");

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Transforms
 
                 var type = schema[index].Type;
                 if (!TestType(type))
-                    throw Host.ExceptSchemaMismatch(nameof(schema), "source", src, "scalar or vector of float, double or key", type.ToString());
+                    throw Host.ExceptSchemaMismatch(nameof(schema), "source", src, "scalar or vector of float, double or KeyType", type.ToString());
 
                 _infos[i] = new ColInfo(index, type);
                 _srcIndexToInfoIndex.Add(index, i);

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -146,13 +146,13 @@ namespace Microsoft.ML.Transforms
                 string src = ctx.LoadNonEmptyString();
                 int index;
                 if (!schema.TryGetColumnIndex(src, out index))
-                    throw Host.Except("Source column '{0}' not found", src);
+                    throw Host.ExceptSchemaMismatch(nameof(schema), "source", src);
                 if (_srcIndexToInfoIndex.ContainsKey(index))
                     throw Host.Except("Source column '{0}' specified multiple times", src);
 
                 var type = schema[index].Type;
                 if (!TestType(type))
-                    throw Host.Except($"Column '{src}' has type {type} which does not support missing values, so we cannot filter on them", src);
+                    throw Host.ExceptSchemaMismatch(nameof(schema), "source", src, "scalar or vector of float, double or key", type.ToString());
 
                 _infos[i] = new ColInfo(index, type);
                 _srcIndexToInfoIndex.Add(index, i);

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -255,10 +255,10 @@ namespace Microsoft.ML.Transforms.Normalizers
                 if (!inputSchema.TryFindColumn(colInfo.InputColumnName, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName);
                 if (col.Kind == SchemaShape.Column.VectorKind.VariableVector)
-                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName, "fixed-size vector or scalar", col.GetTypeString());
+                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName, "known-size vector or scalar", col.GetTypeString());
 
                 if (!col.ItemType.Equals(NumberType.R4) && !col.ItemType.Equals(NumberType.R8))
-                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName, "vector or scalar of R4 or R8", col.GetTypeString());
+                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName, "vector or scalar of float or double", col.GetTypeString());
 
                 var isNormalizedMeta = new SchemaShape.Column(MetadataUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar,
                     BoolType.Instance, false);

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -156,7 +156,7 @@ namespace Microsoft.ML.Transforms
 
             _type = schema[_index].Type;
             if (_type != NumberType.R4 && _type != NumberType.R8 && _type.GetKeyCount() == 0)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "source", column, "flaot, double or key", _type.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "source", column, "flaot, double or KeyType", _type.ToString());
 
             _min = ctx.Reader.ReadDouble();
             _max = ctx.Reader.ReadDouble();

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -152,11 +152,11 @@ namespace Microsoft.ML.Transforms
             var column = ctx.LoadNonEmptyString();
             var schema = Source.Schema;
             if (!schema.TryGetColumnIndex(column, out _index))
-                throw Host.Except("column", "Source column '{0}' not found", column);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "source", column);
 
             _type = schema[_index].Type;
             if (_type != NumberType.R4 && _type != NumberType.R8 && _type.GetKeyCount() == 0)
-                throw Host.Except("column", "Column '{0}' does not have compatible type", column);
+                throw Host.ExceptSchemaMismatch(nameof(schema), "source", column, "flaot, double or key", _type.ToString());
 
             _min = ctx.Reader.ReadDouble();
             _max = ctx.Reader.ReadDouble();

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -156,7 +156,7 @@ namespace Microsoft.ML.Transforms
 
             _type = schema[_index].Type;
             if (_type != NumberType.R4 && _type != NumberType.R8 && _type.GetKeyCount() == 0)
-                throw Host.ExceptSchemaMismatch(nameof(schema), "source", column, "flaot, double or KeyType", _type.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(schema), "source", column, "float, double or KeyType", _type.ToString());
 
             _min = ctx.Reader.ReadDouble();
             _max = ctx.Reader.ReadDouble();

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -373,7 +373,7 @@ namespace Microsoft.ML.Data
 
                     int colSrc;
                     if (!inputSchema.TryGetColumnIndex(src, out colSrc))
-                        throw host.Except("Source column '{0}' is required but not found", src);
+                        throw host.ExceptSchemaMismatch(nameof(inputSchema), "source", src);
                     var type = inputSchema[colSrc].Type;
                     if (testType != null)
                     {

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.EntryPoints
 
             var labelCol = input.Data.Schema.GetColumnOrNull(input.LabelColumn);
             if (!labelCol.HasValue)
-                throw host.ExceptSchemaMismatch(nameof(input), "Label", input.LabelColumn);
+                throw host.ExceptSchemaMismatch(nameof(input), "label", input.LabelColumn);
 
             var labelType = labelCol.Value.Type;
             if (labelType is KeyType || labelType is BoolType)
@@ -270,7 +270,7 @@ namespace Microsoft.ML.EntryPoints
 
             var predictedLabelCol = input.Data.Schema.GetColumnOrNull(input.PredictedLabelColumn);
             if (!predictedLabelCol.HasValue)
-                throw host.ExceptSchemaMismatch(nameof(input), "PredictedLabel",input.PredictedLabelColumn);
+                throw host.ExceptSchemaMismatch(nameof(input), "label", input.PredictedLabelColumn);
             var predictedLabelType = predictedLabelCol.Value.Type;
             if (predictedLabelType is NumberType || predictedLabelType is BoolType)
             {

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.EntryPoints
 
             var labelCol = input.Data.Schema.GetColumnOrNull(input.LabelColumn);
             if (!labelCol.HasValue)
-                throw host.ExceptSchemaMismatch(nameof(input), "label", input.LabelColumn);
+                throw host.ExceptSchemaMismatch(nameof(input), "predicted label", input.LabelColumn);
 
             var labelType = labelCol.Value.Type;
             if (labelType is KeyType || labelType is BoolType)

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML.Trainers.FastTree
             Contracts.Assert(labelCol.IsValid);
 
             Action error =
-                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), RoleMappedSchema.ColumnRole.Label.Value, labelCol.Name, "R4 or a Key", labelCol.GetTypeString());
+                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), "label", labelCol.Name, "float or KeyType", labelCol.GetTypeString());
 
             if (labelCol.Kind != SchemaShape.Column.VectorKind.Scalar)
                 error();

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -720,7 +720,7 @@ namespace Microsoft.ML.Data
 
             var col = input.Schema.GetColumnOrNull(labelName);
             if (!col.HasValue)
-                throw ch.ExceptSchemaMismatch(nameof(input), "Label", labelName);
+                throw ch.ExceptSchemaMismatch(nameof(input), "label", labelName);
 
             ColumnType labelType = col.Value.Type;
             if (!(labelType is KeyType))

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -141,7 +141,7 @@ namespace Microsoft.ML.LightGBM
             Contracts.Assert(labelCol.IsValid);
 
             Action error =
-                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), RoleMappedSchema.ColumnRole.Label.Value, labelCol.Name, "R4 or a Key", labelCol.GetTypeString());
+                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), "label", labelCol.Name, "float or KeyType", labelCol.GetTypeString());
 
             if (labelCol.Kind != SchemaShape.Column.VectorKind.Scalar)
                 error();

--- a/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransform/OnnxTransform.cs
@@ -559,7 +559,7 @@ namespace Microsoft.ML.Transforms
                 if (!inputSchema.TryFindColumn(input, out var col))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", input);
                 if (!(col.Kind == SchemaShape.Column.VectorKind.VariableVector || col.Kind == SchemaShape.Column.VectorKind.Vector))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", input, nameof(VectorType), col.GetTypeString());
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", input, "vector", col.GetTypeString());
 
                 var inputsInfo = Transformer.Model.ModelInfo.InputsInfo;
                 var idx = Transformer.Model.InputNames.IndexOf(input);

--- a/src/Microsoft.ML.PCA/PcaTransformer.cs
+++ b/src/Microsoft.ML.PCA/PcaTransformer.cs
@@ -551,7 +551,7 @@ namespace Microsoft.ML.Transforms.Projections
             string inputSchema; // just used for the excpections
 
             if (!(type is VectorType vectorType && vectorType.Size > 1 && vectorType.ItemType.Equals(NumberType.R4)))
-                throw ectx.ExceptSchemaMismatch(nameof(inputSchema), "input", name, "vector of floats with fixed size greater than 1", type.ToString());
+                throw ectx.ExceptSchemaMismatch(nameof(inputSchema), "input", name, "known-size vector of float of two or more items", type.ToString());
         }
 
         private sealed class Mapper : OneToOneMapperBase

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -407,10 +407,10 @@ namespace Microsoft.ML.Trainers.Recommender
             MatrixRowIndexColumnName = matrixRowIndexColumnName;
 
             if (!trainSchema.TryGetColumnIndex(MatrixColumnIndexColumnName, out int xCol))
-                throw Host.ExceptSchemaMismatch(nameof(MatrixColumnIndexColumnName), RecommenderUtils.MatrixColumnIndexKind.Value, MatrixColumnIndexColumnName);
+                throw Host.ExceptSchemaMismatch(nameof(MatrixColumnIndexColumnName), "matrixColumnIndex", MatrixColumnIndexColumnName);
             MatrixColumnIndexColumnType = trainSchema[xCol].Type;
             if (!trainSchema.TryGetColumnIndex(MatrixRowIndexColumnName, out int yCol))
-                throw Host.ExceptSchemaMismatch(nameof(yCol), RecommenderUtils.MatrixRowIndexKind.Value, MatrixRowIndexColumnName);
+                throw Host.ExceptSchemaMismatch(nameof(yCol), "matrixRowIndex", MatrixRowIndexColumnName);
             MatrixRowIndexColumnType = trainSchema[yCol].Type;
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, model);
@@ -445,11 +445,11 @@ namespace Microsoft.ML.Trainers.Recommender
             MatrixRowIndexColumnName = ctx.LoadString();
 
             if (!TrainSchema.TryGetColumnIndex(MatrixColumnIndexColumnName, out int xCol))
-                throw Host.ExceptSchemaMismatch(nameof(MatrixColumnIndexColumnName), RecommenderUtils.MatrixColumnIndexKind.Value, MatrixColumnIndexColumnName);
+                throw Host.ExceptSchemaMismatch(nameof(MatrixColumnIndexColumnName), "matrixColumnIndex", MatrixColumnIndexColumnName);
             MatrixColumnIndexColumnType = TrainSchema[xCol].Type;
 
             if (!TrainSchema.TryGetColumnIndex(MatrixRowIndexColumnName, out int yCol))
-                throw Host.ExceptSchemaMismatch(nameof(MatrixRowIndexColumnName), RecommenderUtils.MatrixRowIndexKind.Value, MatrixRowIndexColumnName);
+                throw Host.ExceptSchemaMismatch(nameof(MatrixRowIndexColumnName), "matrixRowIndex", MatrixRowIndexColumnName);
             MatrixRowIndexColumnType = TrainSchema[yCol].Type;
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, Model);
@@ -462,9 +462,9 @@ namespace Microsoft.ML.Trainers.Recommender
         public override Schema GetOutputSchema(Schema inputSchema)
         {
             if (!inputSchema.TryGetColumnIndex(MatrixColumnIndexColumnName, out int xCol))
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), RecommenderUtils.MatrixColumnIndexKind.Value, MatrixColumnIndexColumnName);
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "matrixColumnIndex", MatrixColumnIndexColumnName);
             if (!inputSchema.TryGetColumnIndex(MatrixRowIndexColumnName, out int yCol))
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), RecommenderUtils.MatrixRowIndexKind.Value, MatrixRowIndexColumnName);
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "matrixRowIndex", MatrixRowIndexColumnName);
 
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;
         }

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -431,24 +431,25 @@ namespace Microsoft.ML.Trainers
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
 
-            void CheckColumnsCompatible(SchemaShape.Column cachedColumn, string expectedColumnName)
+            void CheckColumnsCompatible(SchemaShape.Column cachedColumn, string columnRole)
             {
                 if (!inputSchema.TryFindColumn(cachedColumn.Name, out var col))
-                    throw Host.ExceptSchemaMismatch(nameof(col), expectedColumnName, expectedColumnName);
+                    throw Host.ExceptSchemaMismatch(nameof(col), columnRole, cachedColumn.Name);
 
                 if (!cachedColumn.IsCompatibleWith(col))
-                    throw Host.Except($"{expectedColumnName} column '{cachedColumn.Name}' is not compatible");
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), columnRole, cachedColumn.Name,
+                        cachedColumn.GetTypeString(), col.GetTypeString());
             }
 
             // Check if label column is good.
             var labelColumn = new SchemaShape.Column(LabelName, SchemaShape.Column.VectorKind.Scalar, NumberType.R4, false);
-            CheckColumnsCompatible(labelColumn, LabelName);
+            CheckColumnsCompatible(labelColumn, "label");
 
             // Check if columns of matrix's row and column indexes are good. Note that column of IDataView and column of matrix are two different things.
             var matrixColumnIndexColumn = new SchemaShape.Column(MatrixColumnIndexName, SchemaShape.Column.VectorKind.Scalar, NumberType.U4, true);
             var matrixRowIndexColumn = new SchemaShape.Column(MatrixRowIndexName, SchemaShape.Column.VectorKind.Scalar, NumberType.U4, true);
-            CheckColumnsCompatible(matrixColumnIndexColumn, MatrixColumnIndexName);
-            CheckColumnsCompatible(matrixRowIndexColumn, MatrixRowIndexName);
+            CheckColumnsCompatible(matrixColumnIndexColumn, "matrixColumnIndex");
+            CheckColumnsCompatible(matrixRowIndexColumn, "matrixRowIndex");
 
             // Input columns just pass through so that output column dictionary contains all input columns.
             var outColumns = inputSchema.ToDictionary(x => x.Name);

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -518,25 +518,26 @@ namespace Microsoft.ML.FactorizationMachine
 
             Host.CheckValue(inputSchema, nameof(inputSchema));
 
-            void CheckColumnsCompatible(SchemaShape.Column column, string defaultName)
+            void CheckColumnsCompatible(SchemaShape.Column column, string columnRole)
             {
 
                 if (!inputSchema.TryFindColumn(column.Name, out var col))
-                    throw Host.ExceptSchemaMismatch(nameof(col), defaultName, defaultName);
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), columnRole, column.Name);
 
                 if (!column.IsCompatibleWith(col))
-                    throw Host.Except($"{defaultName} column '{column.Name}' is not compatible");
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), columnRole, column.Name,
+                        column.GetTypeString(), col.GetTypeString());
             }
 
-            CheckColumnsCompatible(LabelColumn, DefaultColumnNames.Label);
+            CheckColumnsCompatible(LabelColumn, "label");
 
             foreach (var feat in FeatureColumns)
             {
-                CheckColumnsCompatible(feat, DefaultColumnNames.Features);
+                CheckColumnsCompatible(feat, "feature");
             }
 
             if (WeightColumn.IsValid)
-                CheckColumnsCompatible(WeightColumn, DefaultColumnNames.Weight);
+                CheckColumnsCompatible(WeightColumn, "weight");
 
             var outColumns = inputSchema.ToDictionary(x => x.Name);
             foreach (var col in GetOutputColumnsCore(inputSchema))

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineModelParameters.cs
@@ -321,7 +321,7 @@ namespace Microsoft.ML.FactorizationMachine
             foreach (var feat in featureColumns)
             {
                 if (!trainSchema.TryGetColumnIndex(feat, out int col))
-                    throw Host.ExceptSchemaMismatch(nameof(featureColumns), RoleMappedSchema.ColumnRole.Feature.Value, feat);
+                    throw Host.ExceptSchemaMismatch(nameof(featureColumns), "feature", feat);
                 FeatureColumnTypes[i++] = trainSchema[col].Type;
             }
 
@@ -351,7 +351,7 @@ namespace Microsoft.ML.FactorizationMachine
             {
                 FeatureColumns[i] = ctx.LoadString();
                 if (!TrainSchema.TryGetColumnIndex(FeatureColumns[i], out int col))
-                    throw Host.ExceptSchemaMismatch(nameof(FeatureColumns), RoleMappedSchema.ColumnRole.Feature.Value, FeatureColumns[i]);
+                    throw Host.ExceptSchemaMismatch(nameof(FeatureColumns), "feature", FeatureColumns[i]);
                 FeatureColumnTypes[i] = TrainSchema[col].Type;
             }
 
@@ -376,10 +376,10 @@ namespace Microsoft.ML.FactorizationMachine
             {
                 var feat = FeatureColumns[i];
                 if (!inputSchema.TryGetColumnIndex(feat, out int col))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, feat, FeatureColumnTypes[i].ToString(), null);
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "feature", feat, FeatureColumnTypes[i].ToString(), null);
 
                 if (!inputSchema[col].Type.Equals(FeatureColumnTypes[i]))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), RoleMappedSchema.ColumnRole.Feature.Value, feat, FeatureColumnTypes[i].ToString(), inputSchema[col].Type.ToString());
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "feature", feat, FeatureColumnTypes[i].ToString(), inputSchema[col].Type.ToString());
             }
 
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -153,10 +153,10 @@ namespace Microsoft.ML.Learners
             if (LabelColumn.IsValid)
             {
                 if (!inputSchema.TryFindColumn(LabelColumn.Name, out var labelCol))
-                    throw Host.ExceptSchemaMismatch(nameof(labelCol), DefaultColumnNames.PredictedLabel, DefaultColumnNames.PredictedLabel);
+                    throw Host.ExceptSchemaMismatch(nameof(labelCol), "label", LabelColumn.Name);
 
                 if (!LabelColumn.IsCompatibleWith(labelCol))
-                    throw Host.Except($"Label column '{LabelColumn.Name}' is not compatible");
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "label", LabelColumn.Name, LabelColumn.GetTypeString(), labelCol.GetTypeString());
             }
 
             var outColumns = inputSchema.ToDictionary(x => x.Name);

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
@@ -164,7 +164,7 @@ namespace Microsoft.ML.Trainers.Online
             Contracts.Assert(labelCol.IsValid);
 
             Action error =
-                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), RoleMappedSchema.ColumnRole.Label.Value, labelCol.Name, "BL, R8, R4 or a Key", labelCol.GetTypeString());
+                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), "label", labelCol.Name, "float, double, bool or KeyType", labelCol.GetTypeString());
 
             if (labelCol.Kind != SchemaShape.Column.VectorKind.Scalar)
                 error();

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -1538,7 +1538,7 @@ namespace Microsoft.ML.Trainers
             Contracts.Assert(labelCol.IsValid);
 
             Action error =
-                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), RoleMappedSchema.ColumnRole.Label.Value, labelCol.Name, "BL, R8, R4 or a Key", labelCol.GetTypeString());
+                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), "label", labelCol.Name, "float, double, bool or KeyType", labelCol.GetTypeString());
 
             if (labelCol.Kind != SchemaShape.Column.VectorKind.Scalar)
                 error();

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaMultiClass.cs
@@ -110,7 +110,7 @@ namespace Microsoft.ML.Trainers
             Contracts.Assert(labelCol.IsValid);
 
             Action error =
-                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), RoleMappedSchema.ColumnRole.Label.Value, labelCol.Name, "R8, R4 or a Key", labelCol.GetTypeString());
+                () => throw Host.ExceptSchemaMismatch(nameof(labelCol), "label", labelCol.Name, "float, double or KeyType", labelCol.GetTypeString());
 
             if (labelCol.Kind != SchemaShape.Column.VectorKind.Scalar)
                 error();

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -1135,7 +1135,7 @@ namespace Microsoft.ML.Transforms
                 if (!inputSchema.TryFindColumn(input, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", input);
                 if (!(col.Kind == SchemaShape.Column.VectorKind.Vector))
-                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", input, nameof(VectorType), col.GetTypeString());
+                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", input, "vector", col.GetTypeString());
                 var expectedType = TensorFlowUtils.Tf2MlNetType(_tfInputTypes[i]);
                 if (col.ItemType != expectedType)
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", input, expectedType.ToString(), col.ItemType.ToString());

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -818,7 +818,7 @@ namespace Microsoft.ML.Transforms
                 for (int i = 0; i < _parent.Inputs.Length; i++)
                 {
                     if (!inputSchema.TryGetColumnIndex(_parent.Inputs[i], out _inputColIndices[i]))
-                        throw Host.Except($"Column {_parent.Inputs[i]} doesn't exist");
+                        throw Host.ExceptSchemaMismatch(nameof(InputSchema), "source", _parent.Inputs[i]);
 
                     var type = inputSchema[_inputColIndices[i]].Type;
                     if (type is VectorType vecType && vecType.Size == 0)

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1230,7 +1230,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
             _host.CheckParam(data.Schema.Feature.HasValue, nameof(data), "Must have features column.");
             var featureCol = data.Schema.Feature.Value;
             if (featureCol.Type != NumberType.Float)
-                throw _host.ExceptSchemaMismatch(nameof(data), "feature", featureCol.Name, "R4", featureCol.Type.ToString());
+                throw _host.ExceptSchemaMismatch(nameof(data), "feature", featureCol.Name, "float", featureCol.Type.ToString());
 
             Single[] dataArray = new Single[_trainSize];
 

--- a/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
             var colType = inputSchema[col].Type;
             if (colType != NumberType.R4)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName, NumberType.R4.ToString(), colType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName, "float", colType.ToString());
 
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;
         }

--- a/src/Microsoft.ML.TimeSeries/IidChangePointDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/IidChangePointDetector.cs
@@ -247,7 +247,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
             if (!inputSchema.TryFindColumn(Transformer.InputColumnName, out var col))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", Transformer.InputColumnName);
             if (col.ItemType != NumberType.R4)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", Transformer.InputColumnName, NumberType.R4.ToString(), col.GetTypeString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", Transformer.InputColumnName, "float", col.GetTypeString());
 
             var metadata = new List<SchemaShape.Column>() {
                 new SchemaShape.Column(MetadataUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, TextType.Instance, false)

--- a/src/Microsoft.ML.TimeSeries/IidSpikeDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/IidSpikeDetector.cs
@@ -222,7 +222,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
             if (!inputSchema.TryFindColumn(Transformer.InputColumnName, out var col))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", Transformer.InputColumnName);
             if (col.ItemType != NumberType.R4)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", Transformer.InputColumnName, NumberType.R4.ToString(), col.GetTypeString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", Transformer.InputColumnName, "float", col.GetTypeString());
 
             var metadata = new List<SchemaShape.Column>() {
                 new SchemaShape.Column(MetadataUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, TextType.Instance, false)

--- a/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
@@ -594,7 +594,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
                 var colType = inputSchema[_inputColumnIndex].Type;
                 if (colType != NumberType.R4)
-                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", parent.InputColumnName, NumberType.R4.ToString(), colType.ToString());
+                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", parent.InputColumnName, "float", colType.ToString());
 
                 _parent = parent;
                 _parentSchema = inputSchema;

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -325,7 +325,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
             int colIndex;
             if (!_transform.Schema.TryGetColumnIndex(OutputColumnName, out colIndex))
-                throw Host.ExceptSchemaMismatch(nameof(_transform.Schema), "outputcolumn", OutputColumnName);
+                throw Host.ExceptSchemaMismatch(nameof(_transform.Schema), "output", OutputColumnName);
 
             bs.TryWriteTypeDescription(ctx.Writer.BaseStream, _transform.Schema[colIndex].Type, out byteWritten);
         }

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -325,7 +325,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
             int colIndex;
             if (!_transform.Schema.TryGetColumnIndex(OutputColumnName, out colIndex))
-                throw Host.Except(String.Format("The column {0} does not exist in the schema.", OutputColumnName));
+                throw Host.ExceptSchemaMismatch(nameof(_transform.Schema), "outputcolumn", OutputColumnName);
 
             bs.TryWriteTypeDescription(ctx.Writer.BaseStream, _transform.Schema[colIndex].Type, out byteWritten);
         }

--- a/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
@@ -171,7 +171,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
 
             var colType = inputSchema[col].Type;
             if (colType != NumberType.R4)
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName, NumberType.R4.ToString(), colType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", InputColumnName, "float", colType.ToString());
 
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;
         }

--- a/src/Microsoft.ML.TimeSeries/SsaChangePointDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaChangePointDetector.cs
@@ -283,7 +283,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
             if (!inputSchema.TryFindColumn(_args.Source, out var col))
                 throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", _args.Source);
             if (col.ItemType != NumberType.R4)
-                throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", _args.Source, NumberType.R4.ToString(), col.GetTypeString());
+                throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", _args.Source, "float", col.GetTypeString());
 
             var metadata = new List<SchemaShape.Column>() {
                 new SchemaShape.Column(MetadataUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, TextType.Instance, false)

--- a/src/Microsoft.ML.TimeSeries/SsaSpikeDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaSpikeDetector.cs
@@ -262,7 +262,7 @@ namespace Microsoft.ML.TimeSeriesProcessing
             if (!inputSchema.TryFindColumn(_args.Source, out var col))
                 throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", _args.Source);
             if (col.ItemType != NumberType.R4)
-                throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", _args.Source, NumberType.R4.ToString(), col.GetTypeString());
+                throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", _args.Source, "float", col.GetTypeString());
 
             var metadata = new List<SchemaShape.Column>() {
                 new SchemaShape.Column(MetadataUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, TextType.Instance, false)

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -105,7 +105,7 @@ namespace Microsoft.ML.Transforms
         {
             var inType = inputSchema[srcCol].Type;
             if (!(inType is VectorType))
-                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputSchema[srcCol].Name, "Vector", inType.ToString());
+                throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", inputSchema[srcCol].Name, "vector", inType.ToString());
         }
 
         // Factory method for SignatureLoadModel
@@ -377,7 +377,7 @@ namespace Microsoft.ML.Transforms
                 if (!inputSchema.TryFindColumn(colPair.inputColumnName, out var col) || !Data.Conversion.Conversions.Instance.TryGetIsNAPredicate(col.ItemType, out Delegate del))
                     throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colPair.inputColumnName);
                 if (!(col.Kind == SchemaShape.Column.VectorKind.Vector || col.Kind == SchemaShape.Column.VectorKind.VariableVector))
-                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colPair.inputColumnName, "Vector", col.GetTypeString());
+                    throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", colPair.inputColumnName, "known-size vector", col.GetTypeString());
                 var metadata = new List<SchemaShape.Column>();
                 if (col.Metadata.TryFindColumn(MetadataUtils.Kinds.KeyValues, out var keyMeta))
                     metadata.Add(keyMeta);

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -950,7 +950,7 @@ namespace Microsoft.ML.Transforms.Text
 
                 var srcColType = inputSchema[srcCol].Type as VectorType;
                 if (srcColType == null || !srcColType.IsKnownSize || !(srcColType.ItemType is NumberType))
-                    throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].inputColumnName, "known-size vector of float", srcColType.ToString());
+                    throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].InputColumnName, "known-size vector of float", srcColType.ToString());
 
                 srcCols[i] = srcCol;
                 activeColumns.Add(inputData.Schema[srcCol]);
@@ -1161,7 +1161,7 @@ namespace Microsoft.ML.Transforms.Text
                 if (!inputSchema.TryFindColumn(colInfo.InputColumnName, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName);
                 if (col.ItemType.RawType != typeof(float) || col.Kind == SchemaShape.Column.VectorKind.Scalar)
-                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.inputColumnName, "a vector of floats", col.GetTypeString());
+                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName, "vector of float", col.GetTypeString());
 
                 result[colInfo.Name] = new SchemaShape.Column(colInfo.Name, SchemaShape.Column.VectorKind.Vector, NumberType.R4, false);
             }

--- a/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/LdaTransform.cs
@@ -717,7 +717,7 @@ namespace Microsoft.ML.Transforms.Text
                     var srcCol = inputSchema[_srcCols[i]];
                     var srcType = srcCol.Type as VectorType;
                     if (srcType == null || !srcType.IsKnownSize || !(srcType.ItemType is NumberType))
-                        throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].inputColumnName, "a fixed vector of floats", srcCol.Type.ToString());
+                        throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.ColumnPairs[i].inputColumnName, "known-size vector of float", srcCol.Type.ToString());
                 }
             }
 
@@ -950,7 +950,7 @@ namespace Microsoft.ML.Transforms.Text
 
                 var srcColType = inputSchema[srcCol].Type as VectorType;
                 if (srcColType == null || !srcColType.IsKnownSize || !(srcColType.ItemType is NumberType))
-                    throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].InputColumnName, "a fixed vector of floats", srcColType.ToString());
+                    throw env.ExceptSchemaMismatch(nameof(inputSchema), "input", columns[i].inputColumnName, "known-size vector of float", srcColType.ToString());
 
                 srcCols[i] = srcCol;
                 activeColumns.Add(inputData.Schema[srcCol]);
@@ -1161,7 +1161,7 @@ namespace Microsoft.ML.Transforms.Text
                 if (!inputSchema.TryFindColumn(colInfo.InputColumnName, out var col))
                     throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName);
                 if (col.ItemType.RawType != typeof(float) || col.Kind == SchemaShape.Column.VectorKind.Scalar)
-                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.InputColumnName, "a vector of floats", col.GetTypeString());
+                    throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", colInfo.inputColumnName, "a vector of floats", col.GetTypeString());
 
                 result[colInfo.Name] = new SchemaShape.Column(colInfo.Name, SchemaShape.Column.VectorKind.Vector, NumberType.R4, false);
             }

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -406,7 +406,7 @@ namespace Microsoft.ML.Transforms.Text
                     if (!string.IsNullOrEmpty(_parent._columns[i].LanguageColumn))
                     {
                         if (!inputSchema.TryGetColumnIndex(_parent._columns[i].LanguageColumn, out int langCol))
-                            throw Host.ExceptSchemaMismatch(nameof(inputSchema), "language column", _parent._columns[i].LanguageColumn);
+                            throw Host.ExceptSchemaMismatch(nameof(inputSchema), "language", _parent._columns[i].LanguageColumn);
                         _languageColumns[i] = langCol;
                     }
                     else


### PR DESCRIPTION
Fixes #2044.

I make the exception message consistent using `ExceptSchemaMismatch` when possible. 
In particular, as mentioned in the issue #2044, I did it for the base class for TrainerEstimators.

