### PR TITLE
Fix a bug in `ColumnTypeExtensions.SameSizeAndItemType()`

### DIFF
--- a/src/Microsoft.ML.Core/Data/ColumnTypeExtensions.cs
+++ b/src/Microsoft.ML.Core/Data/ColumnTypeExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Data
                 return false;
             if (!vectorType.ItemType.Equals(otherVectorType.ItemType))
                 return false;
-            return otherVectorType.Size == otherVectorType.Size;
+            return vectorType.Size == otherVectorType.Size;
         }
     }
 }


### PR DESCRIPTION
Hi,

I came across this when looking at the alerts for this project on LGTM.com (full disclosure: I work on the C# analysis there). It appears to have been introduced recently on https://github.com/dotnet/machinelearning/pull/2131.

You can see the original alert on LGTM.com here: https://lgtm.com/projects/g/dotnet/machinelearning/alerts/?mode=tree&lang=csharp&ruleFocus=1506097706076

Best regards,
Tom

(I will leave these bits below unfilled until you've determined whether this is actually a bug fix or not...)

- [ ] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [ ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

