### PR TITLE
Revert "exclude test folder from codecov."

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,8 +9,6 @@ coverage:
       default: false
   fixes:
     - "build/::/"
-  ignore:
-    - "test"
 
 comment:
   layout: "diff"


### PR DESCRIPTION
Reverts dotnet/machinelearning#2227

Possibly blocked on tonerdo/coverlet#318 (though I would not personally block on that issue).