### PR TITLE
Enabling the tests to run on netcoreapp3.0 without Intrinsics

### DIFF
--- a/build/AfterCommonTargets.targets
+++ b/build/AfterCommonTargets.targets
@@ -2,12 +2,4 @@
   <PropertyGroup> 
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup> 
-
-  <!-- 
-  We use netcoreapp3.0 for C# intrinsics, but 3.0 isn't supported in CI or in normal development 
-  environments yet. So when we are targeting netcoreapp3.0, but aren't building for intrinsics, 
-  we need to skip the project. 
-  --> 
-  <Import Condition="'$(UseIntrinsics)' != 'true' and '$(TargetFramework)' == 'netcoreapp3.0'" 
-          Project="$(RepoRoot)build\Empty.targets" />
 </Project>

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/Microsoft.ML.CpuMath.PerformanceTests.csproj
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/Microsoft.ML.CpuMath.PerformanceTests.csproj
@@ -7,6 +7,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
+  <ItemGroup Condition="'$(UseIntrinsics)' != 'true'">
+    <Compile Remove="SsePerformanceTests.cs" />
+    <Compile Remove="AvxPerformanceTests.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="BenchmarkDotNet.Artifacts\**" />
     <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />


### PR DESCRIPTION
The 3.0 is supported on ci as well as local environments.

The change will enable people to run the tests with netcoreapp3.0 and have the possibility of using the native implementation of cpumath functions

It helps to distinguish between the regressions caused by netcoreapp3.0 or new Intrinsics