### PR TITLE
Creating the MLNetCookBook_StaticApi.md and updating the current cookbook

### DIFF
--- a/docs/code/experimental/MlNetCookBook_StaticApi.md
+++ b/docs/code/experimental/MlNetCookBook_StaticApi.md
@@ -173,7 +173,6 @@ When the input file contains many columns of the same type, always intended to b
 
 Reading this file using `TextLoader`:
 ```csharp
-
 // Create the reader: define the data columns and where to find them in the text file.
 var reader = mlContext.Data.CreateTextReader(ctx => (
         // We read the first 11 values as a single float vector.
@@ -326,10 +325,6 @@ feature_0;feature_1;feature_2;feature_3;feature_4;feature_5;feature_6;feature_7;
 In the file above, the last column (12th) is label that we predict, and all the preceding ones are features.
 
 ```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
 var reader = mlContext.Data.CreateTextReader(ctx => (
@@ -427,10 +422,6 @@ For this case, ML.NET offers a convenient `PredictionEngine` component, that ess
 Here is the full example. Let's imagine that we have built a model for the famous Iris prediction dataset:
 
 ```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
 var reader = mlContext.Data.CreateTextReader(ctx => (
@@ -543,10 +534,6 @@ private class CustomerChurnInfo
 
 Given this information, here's how we turn this data into the ML.NET data view and train on it:
 ```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
 // Step one: read the data as an IDataView.
 // Let's assume that 'GetChurnData()' fetches and returns the training data from somewhere.
 IEnumerable<CustomerChurnInfo> churnData = GetChurnInfo();
@@ -686,10 +673,6 @@ It is a good practice to include the normalizer directly in the ML.NET learning 
 
 Here's a snippet of code that demonstrates normalization in learning pipelines. It assumes the Iris dataset:
 ```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
 // Define the reader: specify the data columns and where to find them in the text file.
 var reader = mlContext.Data.CreateTextReader(ctx => (
         // The four features of the Iris dataset will be grouped together as one Features column.
@@ -828,10 +811,6 @@ Sentiment   SentimentText
 ```
 
 ```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
 // Define the reader: specify the data columns and where to find them in the text file.
 var reader = mlContext.Data.CreateTextReader(ctx => (
         IsToxic: ctx.LoadBool(0),
@@ -895,10 +874,6 @@ ML.NET guards us against both these pitfalls: it will automatically apply the fe
 
 Here's an example of training on Iris dataset using randomized 90/10 train-test split, as well as a 5-fold cross-validation:
 ```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
 var reader = mlContext.Data.CreateTextReader(ctx => (
@@ -959,10 +934,6 @@ Transitioning from dynamic to static types is more costly: we have to formally d
 
 We can do this via `AssertStatic<T>` extensions, as demonstrated in the following example, where we mix and match static and dynamic pipelines.
 ```c#
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
 // Read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
 var reader = mlContext.Data.CreateTextReader(ctx => (

--- a/docs/code/experimental/MlNetCookBook_StaticApi.md
+++ b/docs/code/experimental/MlNetCookBook_StaticApi.md
@@ -1,14 +1,11 @@
 # ML.NET Cookbook
 
-This document is intended to provide essential samples for common usage patterns of ML.NET. 
-It is advisable to be at least minimally familiar with [high-level concepts of ML.NET](MlNetHighLevelConcepts.md), otherwise the terminology in this document may be foreign to you.
-The examples in this document make use of the dynamic API, currently the supported ML.Net api.
-In ML.Net there is also a static api, that operates on the schema of the data, strongly typing the data type. That version of the API is considered experimental.
-If you are loading an existing model from a stream, there's no need to use static types (and it's also pretty hard to do). 
-Also, if the data view's schema is only known at runtime, there is no way to use static types. 
-Using the static API gives you compiler support: it's more likely that, if your code compiles, it will also work as intended.
-A version of this cookbook containing the same samples in the static API samples can be found in the [MlNetCookBook_staticApi.md](experimental\MlNetCookBook_staticApi.md)
-We welcome feedback about it.  
+This document is intended to provide essential samples for common usage patterns of ML.NET, using examples from the experimental static API.
+The examples in this document make use of the static API, which at the time of writting is considered experimental.
+The supported way of composing pipelines in ML.NET is through the dynamic API. 
+You can find the same guide and examples on how to get started with ML.Net, dynamic API on the [cookbook reference for the dynamic API](..\MlNetCookBook.md)
+It is advisable to be at least minimally familiar with [high-level concepts of ML.NET](..\MlNetHighLevelConcepts.md), otherwise the terminology in this document may be foreign to you.
+We welcome feedback about the static API.  
 
 ## How to use this cookbook
 
@@ -41,7 +38,6 @@ Please feel free to search this page and use any code that suits your needs.
 - [How do I train my model on textual data?](#how-do-i-train-my-model-on-textual-data)
 - [How do I train using cross-validation?](#how-do-i-train-using-cross-validation)
 - [Can I mix and match static and dynamic pipelines?](#can-i-mix-and-match-static-and-dynamic-pipelines)
-- [How can I define my own transformation of data?](#how-can-i-define-my-own-transformation-of-data)
 
 ### General questions about the samples
 
@@ -52,9 +48,19 @@ This is because we rely on extension methods a lot, and they only become availab
 We are still re-organizing the namespaces, and trying to improve the story. In the meantime, the following namespaces prove useful for extension methods:
 ```csharp
 using Microsoft.ML.Data;
+using Microsoft.ML.StaticPipe;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Transforms;
 ```
+
+- *Why is there two ways of doing things? Which one is better, static or dynamic?*
+The static and dynamic are just two different APIs to compose the same pipelines, evaluate the models and generate predictions. 
+They create different developer experiences:the static API is typed over the schemaof the data, and the dynamic one is not, causing the errors to show up only at runtime. 
+
+If you are loading an existing model from a stream, there's no need to use static types (and it's also pretty hard to do). 
+Also, if the data view's schema is only known at runtime, there is no way to use static types. 
+You might prefer the static types, since this way gives you compiler support: it's more likely that, if your code compiles, it will also work as intended.
+The pipelines created, functionality and the model generated as the result of training are the same.  
 
 - *What is the [MLContext](https://docs.microsoft.com/en-us/dotnet/api/microsoft.ml.mlcontext?view=ml-dotnet)?*
 The MLContext is a starting point for all ML.NET operations. 
@@ -65,6 +71,17 @@ You will need one MlContext object for your pipelines or inference code.
 ```csharp
 // as a catalog of available operations and as the source of randomness.
 var mlContext = new MLContext();
+```
+
+- *Why do we call `reader.MakeNewEstimator` to create a pipeline?*
+In the static pipeline, we need to know the two 'schema' types: the input and the output to the pipeline.
+One of them is already known: typically, the output schema of `reader` (which is the same as the schema of `reader.Read()`) is also the input schema of the learning pipeline. 
+
+The call to `x.MakeNewEstimator` is only using the `x`'s *schema* to create an empty pipeline, it doesn't use anything else from `x`. So, the following three lines would create the exactly same (empty) pipeline:
+```csharp
+var p1 = reader.MakeNewEstimator();
+var p2 = reader.Read(dataLocation).MakeNewEstimator();
+var p3 = p1.MakeNewEstimator();
 ```
 
 - *Can we use `reader` to read more than one file?*
@@ -90,64 +107,20 @@ Label	Workclass	education	marital-status
 ```
 
 This is how you can read this data:
-```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
 
+```csharp
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.CreateTextReader(new[] {
-        // A boolean column depicting the 'label'.
-        new TextLoader.Column("IsOver50K", DataKind.BL, 0),
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // A boolean column depicting the 'target label'.
+        IsOver50K: ctx.LoadBool(0),
         // Three text columns.
-        new TextLoader.Column("Workclass", DataKind.TX, 1),
-        new TextLoader.Column("Education", DataKind.TX, 2),
-        new TextLoader.Column("MaritalStatus", DataKind.TX, 3)
-    },
-    // First line of the file is a header, not a data row.
-    hasHeader: true
-);
+        Workclass: ctx.LoadText(1),
+        Education: ctx.LoadText(2),
+        MaritalStatus: ctx.LoadText(3)),
+    hasHeader: true);
 
 // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
 var data = reader.Read(dataPath);
-```
-
-You can also create a data model class, and read the data based on this type. 
-
-```csharp
-// The data model. This type will be used through the document. 
-private class InspectedRow
-{
-    [LoadColumn(0)]
-    public bool IsOver50K { get; set; }
-
-    [LoadColumn(1)]
-    public string Workclass { get; set; }
-
-    [LoadColumn(2)]
-    public string Education { get; set; }
-
-    [LoadColumn(3)]
-    public string MaritalStatus { get; set; }
-
-    public string[] AllFeatures { get; set; }
-}
-
-private class InspectedRowWithAllFeatures : InspectedRow
-{
-    public string[] AllFeatures { get; set; }
-}
-
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
-// Read the data into a data view.
-var data = mlContext.Data.ReadFromTextFile<InspectedRow>(dataPath,
-    // First line of the file is a header, not a data row.
-    hasHeader: true
-)		
-        
 ```
 
 ## How do I load data from multiple files?
@@ -166,24 +139,22 @@ Label	Workclass	education	marital-status
 ```
 
 This is how you can read this data:
-
 ```csharp
 
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.CreateTextReader(new[] {
-        // A boolean column depicting the 'label'.
-        new TextLoader.Column("IsOver50K", DataKind.BL, 0),
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // A boolean column depicting the 'target label'.
+        IsOver50K: ctx.LoadBool(14),
         // Three text columns.
-        new TextLoader.Column("Workclass", DataKind.TX, 1),
-        new TextLoader.Column("Education", DataKind.TX, 2),
-        new TextLoader.Column("MaritalStatus", DataKind.TX, 3)
-    },
-    // First line of the file is a header, not a data row.
-    hasHeader: true
-);
+        Workclass: ctx.LoadText(1),
+        Education: ctx.LoadText(3),
+        MaritalStatus: ctx.LoadText(5)),
+    hasHeader: true);
 
+// Now read the files (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
 var data = reader.Read(exampleFile1, exampleFile2);
 ```
+
 ## How do I load data with many columns from a CSV?
 `TextLoader` is used to load data from text files. You will need to specify what are the data columns, what are their types, and where to find them in the text file. 
 
@@ -198,52 +169,29 @@ When the input file contains many columns of the same type, always intended to b
 ```
 
 Reading this file using `TextLoader`:
-
 ```csharp
+
 // Create the reader: define the data columns and where to find them in the text file.
-var reader = mlContext.Data.CreateTextReader(new[] {
-        // We read the first 10 values as a single float vector.
-        new TextLoader.Column("FeatureVector", DataKind.R4, new[] {new TextLoader.Range(0, 10)}),
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // We read the first 11 values as a single float vector.
+        FeatureVector: ctx.LoadFloat(0, 10),
         // Separately, read the target variable.
-        new TextLoader.Column("Target", DataKind.R4, 11)
-    },
+        Target: ctx.LoadFloat(11)
+    ),
     // Default separator is tab, but we need a comma.
     separatorChar: ',');
+
 
 // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
 var data = reader.Read(dataPath);
 ```
 
-Or by creating a data model for it:
-
-```csharp
-private class AdultData
-{
-    [LoadColumn(0, 10), ColumnName("Features")]
-    public float FeatureVector { get; set;}
-
-    [LoadColumn(11)]
-    public float Target { get; set;}
-}
-
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
-
-// Read the data into a data view.
-var data = mlContext.Data.ReadFromTextFile<AdultData>(dataPath,
-    // First line of the file is a header, not a data row.
-    separatorChar: ','
-);		
-
-```
-
 ## How do I debug my experiment or preview my pipeline?
 
-Most ML.NET operations are 'lazy': they are not actually processing data, they just validate that the operation is possible, and then defer execution until the output data is actually requested. 
+Most ML.NET operations are 'lazy': they are not actually processing data, they just validate that the operation is possible, and then defer execution until the output data is actually requested.
 This provides good efficiency, but makes it hard to step through and debug the experiment.
 
-In order to improve debug-ability, we have added a `Preview()` extension method to all data views, transformers, estimators and readers:
+The `Preview()` extension method is added to data views, transformers, estimators and readers:
 
 - `Preview` of a data view contains first 100 rows (configurable) of the data view, encoded as objects, in a single in-memory structure.
 - `Preview` of a transformer takes data as input, and outputs the preview of the transformed data.
@@ -253,25 +201,52 @@ We tried to make `Preview` debugger-friendly: our expectation is that, if you en
 
 Here is the code sample:
 ```csharp
-var mlContext = new MLContext();
-var estimator = mlContext.Transforms.Categorical.MapValueToKey("Label")
-    .Append(mlContext.MulticlassClassification.Trainers.StochasticDualCoordinateAscent())
-    .Append(mlContext.Transforms.Conversion.MapKeyToValue("PredictedLabel"));
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // We read the first 11 values as a single float vector.
+        FeatureVector: ctx.LoadFloat(0, 10),
+        // Separately, read the target variable.
+        Target: ctx.LoadFloat(11)
+    ),
+    // Default separator is tab, but we need a comma.
+    separatorChar: ',');
 
-var data = mlContext.Data.ReadFromTextFile(new TextLoader.Column[] {
-    new TextLoader.Column("Label", DataKind.Text, 0),
-    new TextLoader.Column("Features", DataKind.R4, 1, 4) }, filePath);
+
+// Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
+var data = reader.Read(dataPath);
 
 // Preview the data. 
 var dataPreview = data.Preview();
-
-// Preview the result of training and transformation.
-var transformationPreview = estimator.Preview(data);
 ```
+
+Similarly, if we wanted to preview the data resulting from the transformation, we would compose a pipeline, than call Preview():
+
+```csharp
+  var learningPipeline = reader.MakeNewEstimator()
+    // We add a step for caching data in memory so that the downstream iterative training
+    // algorithm can efficiently scan through the data multiple times.
+    .AppendCacheCheckpoint()
+    // Now we can add any 'training steps' to it. In our case we want to 'normalize' the data (rescale to be
+    // between -1 and 1 for all examples), and then train the model.
+    .Append(r => (
+        // Retain the 'Target' column for evaluation purposes.
+        r.Target,
+        // We choose the SDCA regression trainer. Note that we normalize the 'FeatureVector' right here in
+        // the the same call.
+        Prediction: mlContext.Regression.Trainers.Sdca(label: r.Target, features: r.FeatureVector.Normalize())));
+
+// Train the pipeline.
+var model = learningPipeline.Fit(trainData);
+
+// Preview
+var dataPreview = model.Preview();
+
+```
+
 
 ## How do I look at the intermediate data?
 
-Oftentimes, when we construct the experiment, we want to make sure that the data processing 'up to a certain moment' produces the results that we want. With ML.NET it is not very easy to do: since all ML.NET operations are lazy, the objects we construct are just 'promises' of data.
+Oftentimes, when we construct the experiment, we want to make sure that the data processing 'up to a certain moment' produces the results that we want. 
+With ML.NET it is not very easy to do: since all ML.NET operations are lazy, the objects we construct are just 'promises' of data.
 
 We will need to create the cursor and scan the data to obtain the actual values. One way to do this is to use [schema comprehension](SchemaComprehension.md) and map the data to an `IEnumerable` of user-defined objects.
 
@@ -290,33 +265,46 @@ Label	Workclass	education	marital-status
 ```
 
 ```csharp
-// Read the data into a data view.
-var data = mlContext.Data.ReadFromTextFile<InspectedRow>(dataPath,
-    // First line of the file is a header, not a data row.
-    hasHeader: true
-);
+// Create the reader: define the data columns and where to find them in the text file.
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // A boolean column depicting the 'target label'.
+        IsOver50K: ctx.LoadBool(0),
+        // Three text columns.
+        Workclass: ctx.LoadText(1),
+        Education: ctx.LoadText(2),
+        MaritalStatus: ctx.LoadText(3)),
+    hasHeader: true);
 
 // Start creating our processing pipeline. For now, let's just concatenate all the text columns
 // together into one.
-var dynamicPipeline = mlContext.Transforms.Concatenate("AllFeatures", "Education", "MaritalStatus");
+var dataPipeline = reader.MakeNewEstimator()
+    .Append(row => (
+            row.IsOver50K,
+            AllFeatures: row.Workclass.ConcatWith(row.Education, row.MaritalStatus)
+        ));
+
+// Let's verify that the data has been read correctly. 
+// First, we read the data file.
+var data = reader.Read(dataPath);
 
 // Fit our data pipeline and transform data with it.
-var transformedData = dynamicPipeline.Fit(data).Transform(data);
+var transformedData = dataPipeline.Fit(data).Transform(data);
 
 // 'transformedData' is a 'promise' of data. Let's actually read it.
 var someRows = mlContext
     // Convert to an enumerable of user-defined type. 
-    .CreateEnumerable<InspectedRowWithAllFeatures>(transformedData, reuseRowObject: false)
+    .CreateEnumerable<InspectedRow>(transformedData.AsDynamic, reuseRowObject: false)
     // Take a couple values as an array.
     .Take(4).ToArray();
 
 // Extract the 'AllFeatures' column.
 // This will give the entire dataset: make sure to only take several row
-// in case the dataset is huge. The is similar to the static API, except
-// you have to specify the column name and type.
-var featureColumns = transformedData.GetColumn<string[]>(mlContext, "AllFeatures")
+// in case the dataset is huge.
+var featureColumns = transformedData.GetColumn(r => r.AllFeatures)
     .Take(20).ToArray();
+
 ```
+
 ## How do I train a regression model?
 
 Generally, in order to train any model in ML.NET, you will go through three steps:
@@ -341,40 +329,52 @@ var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
 // First, we define the reader: specify the data columns and where to find them in the text file.
-// Read the data into a data view. Remember though, readers are lazy, so the actual reading will happen when the data is accessed.
-var trainData = mlContext.Data.ReadFromTextFile<AdultData>(dataPath,
-    // First line of the file is a header, not a data row.
-    separatorChar: ','
-);
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // We read the first 11 values as a single float vector.
+        FeatureVector: ctx.LoadFloat(0, 10),
+        // Separately, read the target variable.
+        Target: ctx.LoadFloat(11)
+    ),
+    // The data file has header.
+    hasHeader: true,
+    // Default separator is tab, but we need a semicolon.
+    separatorChar: ';');
+
+
+// Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
+var trainData = reader.Read(trainDataPath);
 
 // Sometime, caching data in-memory after its first access can save some loading time when the data is going to be used
 // several times somewhere. The caching mechanism is also lazy; it only caches things after being used.
 // User can replace all the subsequently uses of "trainData" with "cachedTrainData". We still use "trainData" because
-// a caching step, which provides the same caching function, will be inserted in the considered "dynamicPipeline."
-var cachedTrainData = mlContext.Data.Cache(trainData);
+// a caching step, which provides the same caching function, will be inserted in the considered "learningPipeline."
+var cachedTrainData = trainData.Cache();
 
 // Step two: define the learning pipeline. 
 
 // We 'start' the pipeline with the output of the reader.
-var dynamicPipeline =
-    // First 'normalize' the data (rescale to be
-    // between -1 and 1 for all examples)
-    mlContext.Transforms.Normalize("FeatureVector")
+var learningPipeline = reader.MakeNewEstimator()
     // We add a step for caching data in memory so that the downstream iterative training
     // algorithm can efficiently scan through the data multiple times. Otherwise, the following
     // trainer will read data from disk multiple times. The caching mechanism uses an on-demand strategy.
     // The data accessed in any downstream step will be cached since its first use. In general, you only
     // need to add a caching step before trainable step, because caching is not helpful if the data is
     // only scanned once. This step can be removed if user doesn't have enough memory to store the whole
-    // data set. Notice that in the upstream Transforms.Normalize step, we only scan through the data 
-    // once so adding a caching step before it is not helpful.
-    .AppendCacheCheckpoint(mlContext)
-    // Add the SDCA regression trainer.
-    .Append(mlContext.Regression.Trainers.StochasticDualCoordinateAscent(label: "Target", features: "FeatureVector"));
+    // data set.
+    .AppendCacheCheckpoint()
+    // Now we can add any 'training steps' to it. In our case we want to 'normalize' the data (rescale to be
+    // between -1 and 1 for all examples)
+    .Append(r => (
+        // Retain the 'Target' column for evaluation purposes.
+        r.Target,
+        // We choose the SDCA regression trainer. Note that we normalize the 'FeatureVector' right here in
+        // the the same call.
+        Prediction: mlContext.Regression.Trainers.Sdca(label: r.Target, features: r.FeatureVector.Normalize())));
 
 // Step three. Fit the pipeline to the training data.
-var model = dynamicPipeline.Fit(trainData);
+var model = learningPipeline.Fit(trainData);
 ```
+
 ## How do I verify the model quality?
 
 This is the first question that arises after you train the model: how good it actually is?
@@ -383,32 +383,25 @@ For each of the machine learning tasks, there is a set of 'metrics' that can des
 You can use the corresponding 'context' of the task to evaluate the model.
 
 Assuming the example above was used to train the model, here's how you calculate the metrics.
-
-Calculating the metrics with the dynamic API is as follows.
 ```csharp
 // Read the test dataset.
-var testData = mlContext.Data.ReadFromTextFile<AdultData>(testDataPath,
-    // First line of the file is a header, not a data row.
-    separatorChar: ','
-);
+var testData = reader.Read(testDataPath);
 // Calculate metrics of the model on the test data.
-var metrics = mlContext.Regression.Evaluate(model.Transform(testData), label: "Target");
+var metrics = mlContext.Regression.Evaluate(model.Transform(testData), label: r => r.Target, score: r => r.Prediction);
 ```
 
 ## How do I save and load the model?
 
-Assuming that the model metrics look good to you, it's time to 'operationalize' the model. This is where ML.NET really shines: the `model` object you just built is ready for immediate consumption, it will apply all the same steps that it has 'learned' during training, and it can be persisted and reused in different environments.
+Assuming that the model metrics look good to you, it's time to 'operationalize' the model. 
+This is where ML.NET really shines: the `model` object you just built is ready for immediate consumption, it will apply all the same steps that it has 'learned' during training, and it can be persisted and reused in different environments.
 
 Here's what you do to save the model to a file, and reload it (potentially in a different context).
 
 ```csharp
-
-You can use the dynamic API to achieve the same.
-```csharp
 using (var stream = File.Create(modelPath))
 {
-    // Saving and loading happens to 'dynamic' models.
-    mlContext.Model.Save(model, stream);
+    // Saving and loading happens to 'dynamic' models, so the static typing is lost in the process.
+    mlContext.Model.Save(model.AsDynamic, stream);
 }
 
 // Potentially, the lines below can be in a different process altogether.
@@ -418,44 +411,65 @@ ITransformer loadedModel;
 using (var stream = File.OpenRead(modelPath))
     loadedModel = mlContext.Model.Load(stream);
 ```
+
 ## How do I use the model to make one prediction?
 
 Since any ML.NET model is a transformer, you can of course use `model.Transform` to apply the model to the 'data view' and obtain predictions this way. 
 
-A more typical case, though, is when there is no 'dataset' that we want to predict on, but instead we receive one example at a time. For instance, we run the model as part of the ASP.NET website, and we need to make a prediction for an incoming HTTP request.
+A more typical case, though, is when there is no 'dataset' that we want to predict on, but instead we receive one example at a time. 
+For instance, we run the model as part of the ASP.NET website, and we need to make a prediction for an incoming HTTP request.
 
 For this case, ML.NET offers a convenient `PredictionEngine` component, that essentially runs one example at a time through the prediction pipeline. 
 
 Here is the full example. Let's imagine that we have built a model for the famous Iris prediction dataset:
 
-You can also use the dynamic API to create the equivalent of the previous pipeline. 
 ```csharp
 // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
 // as a catalog of available operations and as the source of randomness.
 var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
- //  Retrieve the training data.
-var trainData = mlContext.Data.ReadFromTextFile<IrisInput>(irisDataPath,
+// First, we define the reader: specify the data columns and where to find them in the text file.
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // The four features of the Iris dataset.
+        SepalLength: ctx.LoadFloat(0),
+        SepalWidth: ctx.LoadFloat(1),
+        PetalLength: ctx.LoadFloat(2),
+        PetalWidth: ctx.LoadFloat(3),
+        // Label: kind of iris.
+        Label: ctx.LoadText(4)
+    ),
     // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
-);
+    separatorChar: ',');
+
+// Retrieve the training data.
+var trainData = reader.Read(irisDataPath);
 
 // Build the training pipeline.
-var dynamicPipeline =
-    // Concatenate all the features together into one column 'Features'.
-    mlContext.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
-    // Note that the label is text, so it needs to be converted to key.
-    .Append(mlContext.Transforms.Categorical.MapValueToKey("Label"), TransformerScope.TrainTest)
-    // Cache data in memory for steps after the cache check point stage.
-    .AppendCacheCheckpoint(mlContext)
-    // Use the multi-class SDCA model to predict the label using features.
-    .Append(mlContext.MulticlassClassification.Trainers.StochasticDualCoordinateAscent())
-    // Apply the inverse conversion from 'PredictedLabel' column back to string value.
-    .Append(mlContext.Transforms.Conversion.MapKeyToValue(("PredictedLabel", "Data")));
+var learningPipeline = reader.MakeNewEstimator()
+    .Append(r => (
+        r.Label,
+        // Concatenate all the features together into one column 'Features'.
+        Features: r.SepalLength.ConcatWith(r.SepalWidth, r.PetalLength, r.PetalWidth)))
+    // We add a step for caching data in memory so that the downstream iterative training
+    // algorithm can efficiently scan through the data multiple times. Otherwise, the following
+    // trainer will read data from disk multiple times. The caching mechanism uses an on-demand strategy.
+    // The data accessed in any downstream step will be cached since its first use. In general, you only
+    // need to add a caching step before trainable step, because caching is not helpful if the data is
+    // only scanned once.
+    .AppendCacheCheckpoint()
+    .Append(r => (
+        r.Label,
+        // Train the multi-class SDCA model to predict the label using features.
+        // Note that the label is a text, so it needs to be converted to key using 'ToKey' estimator.
+        Predictions: mlContext.MulticlassClassification.Trainers.Sdca(r.Label.ToKey(), r.Features)))
+    // Apply the inverse conversion from 'predictedLabel' key back to string value.
+    // Note that the final output column is only one, and we didn't assign a name to it.
+    // In this case, ML.NET auto-assigns the name 'Data' to the produced column.
+    .Append(r => r.Predictions.predictedLabel.ToValue());
 
 // Train the model.
-var model = dynamicPipeline.Fit(trainData);
+var model = learningPipeline.Fit(trainData);
 ```
 
 Now, in order to use [schema comprehension](SchemaComprehension.md) for prediction, we define a pair of classes like following:
@@ -480,6 +494,9 @@ private class IrisPrediction
 
 The prediction code now looks as follows:
 ```csharp
+// 
+var model = learningPipeline.Fit(trainData).AsDynamic;
+
 // Use the model for one-time prediction.
 // Make the prediction function object. Note that, on average, this call takes around 200x longer
 // than one prediction, so you might want to cache and reuse the prediction function, instead of
@@ -536,27 +553,36 @@ IEnumerable<CustomerChurnInfo> churnData = GetChurnInfo();
 // or merely an IEnumerable.
 var trainData = mlContext.CreateStreamingDataView(churnData);
 
-// Now note that 'trainData' is just an IDataView, so we face a choice here: either declare the static type
-// and proceed in the statically typed fashion, or keep dynamic types and build a dynamic pipeline.
-// We demonstrate both below.
-
 // Build the learning pipeline. 
 // In our case, we will one-hot encode the demographic category, and concatenate that with the number of visits.
 // We apply our FastTree binary classifier to predict the 'HasChurned' label.
 
-var learningPipeline = mlContext.Transforms.Categorical.OneHotEncoding("DemographicCategory")
-    .Append(mlContext.Transforms.Concatenate("Features", "DemographicCategory", "LastVisits"))
-    .AppendCacheCheckpoint(mlContext) // FastTree will benefit from caching data in memory.
-    .Append(mlContext.BinaryClassification.Trainers.FastTree("HasChurned", "Features", numTrees: 20));
+// First, transition to the statically-typed data view.
+var staticData = trainData.AssertStatic(mlContext, c => (
+        HasChurned: c.Bool.Scalar,
+        DemographicCategory: c.Text.Scalar,
+        LastVisits: c.R4.Vector));
 
-var model = learningPipeline.Fit(trainData);
+// Build the pipeline, same as the one above.
+var staticLearningPipeline = staticData.MakeNewEstimator()
+    .Append(r => (
+        r.HasChurned,
+        Features: r.DemographicCategory.OneHotEncoding().ConcatWith(r.LastVisits)))
+    .AppendCacheCheckpoint() // FastTree will benefit from caching data in memory.
+    .Append(r => mlContext.BinaryClassification.Trainers.FastTree(r.HasChurned, r.Features, numTrees: 20));
+
+var staticModel = staticLearningPipeline.Fit(staticData);
+
+// Note that dynamicModel should be the same as staticModel.AsDynamic (give or take random variance from
+// the training procedure).
 ```
 
 ## I want to look at my model's coefficients
 
 Oftentimes, once a model is trained, we are also interested on 'what it has learned'. 
 
-For example, if the linear model assigned zero weight to a feature that we consider important, it could indicate some problem with modeling. The weights of the linear model can also be used as a poor man's estimation of 'feature importance'.
+For example, if the linear model assigned zero weight to a feature that we consider important, it could indicate some problem with modeling. 
+The weights of the linear model can also be used as a poor man's estimation of 'feature importance'.
 
 In the static pipeline API, we provide a set of `onFit` delegates that allow introspection of the individual transformers as they are trained.
 
@@ -564,51 +590,66 @@ This is how we can extract the learned parameters out of the model that we train
 ```csharp
 
 // Step one: read the data as an IDataView.
-//  Retrieve the training data.
-var trainData = mlContext.Data.ReadFromTextFile<IrisInput>(irisDataPath,
+// First, we define the reader: specify the data columns and where to find them in the text file.
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // The four features of the Iris dataset.
+        SepalLength: ctx.LoadFloat(0),
+        SepalWidth: ctx.LoadFloat(1),
+        PetalLength: ctx.LoadFloat(2),
+        PetalWidth: ctx.LoadFloat(3),
+        // Label: kind of iris.
+        Label: ctx.LoadText(4)
+    ),
     // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
-);
+    separatorChar: ',');
 
+// Retrieve the training data.
+var trainData = reader.Read(dataPath);
+
+// This is the predictor ('weights collection') that we will train.
+MulticlassLogisticRegressionPredictor predictor = null;
+// And these are the normalizer scales that we will learn.
+ImmutableArray<float> normScales;
 // Build the training pipeline.
-var dynamicPipeline =
-    // Concatenate all the features together into one column 'Features'.
-    mlContext.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
-    // Note that the label is text, so it needs to be converted to key.
-    .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"), TransformerScope.TrainTest)
-    // Cache data in memory for steps after the cache check point stage.
-    .AppendCacheCheckpoint(mlContext)
-    // Use the multi-class SDCA model to predict the label using features.
-    .Append(mlContext.MulticlassClassification.Trainers.StochasticDualCoordinateAscent());
+var learningPipeline = reader.MakeNewEstimator()
+    .Append(r => (
+        r.Label,
+        // Concatenate all the features together into one column 'Features'.
+        Features: r.SepalLength.ConcatWith(r.SepalWidth, r.PetalLength, r.PetalWidth)))
+    .Append(r => (
+        r.Label,
+        // Normalize (rescale) the features to be between -1 and 1. 
+        Features: r.Features.Normalize(
+            // When the normalizer is trained, the below delegate is going to be called.
+            // We use it to memorize the scales.
+            onFit: (scales, offsets) => normScales = scales)))
+    // Cache data used in memory because the subsequently trainer needs to access the data multiple times.
+    .AppendCacheCheckpoint()
+    .Append(r => (
+        r.Label,
+        // Train the multi-class SDCA model to predict the label using features.
+        // Note that the label is a text, so it needs to be converted to key using 'ToKey' estimator.
+        Predictions: mlContext.MulticlassClassification.Trainers.Sdca(r.Label.ToKey(), r.Features,
+            // When the model is trained, the below delegate is going to be called.
+            // We use that to memorize the predictor object.
+            onFit: p => predictor = p)));
 
-// Train the model.
-var trainedModel = dynamicPipeline.Fit(trainData);
+// Train the model. During this call our 'onFit' delegate will be invoked,
+// and our 'predictor' will be set.
+var model = learningPipeline.Fit(trainData);
 
-// Inspect the model parameters. 
-var modelParameters = trainedModel.LastTransformer.Model as MulticlassLogisticRegressionModelParameters;
-
-// Now we can use 'modelParameters' to look at the weights.
+// Now we can use 'predictor' to look at the weights.
 // 'weights' will be an array of weight vectors, one vector per class.
 // Our problem has 3 classes, so numClasses will be 3, and weights will contain
 // 3 vectors (of 4 values each).
-VBuffer<float>[] weights = default;
-modelParameters.GetWeights(ref weights, out int numClasses);
-
-// numClasses
-// 3
-// weights
-// {float[4]}       { float[4]}         { float[4]}
-// 2.45233274       0.181766108         -3.05772042
-// 4.61404276       0.0578986146        -4.85828352
-// - 6.934741       -0.0424297452       6.63682
-// - 3.64960361     -4.072106           7.55050659
+VBuffer<float>[] weights = null;
+predictor.GetWeights(ref weights, out int numClasses);
 
 // Similarly we can also inspect the biases for the 3 classes.
-var biases = modelParameters.GetBiases();
-// 		[0]	1.151999	float
-//      [1]	8.337694	float
-// 		[2]	-9.709775	float
+var biases = predictor.GetBiases();
 
+// Inspect the normalizer scales.
+Console.WriteLine(string.Join(" ", normScales));
 ```
 
 ## What is normalization and why do I need to care?
@@ -621,7 +662,8 @@ Most commonly, the assumptions are that
 - All the features have values roughly on the same scale;
 - Feature values are not too large, and not too small.
 
-Violating the first assumption above can cause the learner to train a sub-optimal model (or even a completely useless one). Violating the second assumption can cause arithmetic error accumulation, which typically breaks the training process altogether.
+Violating the first assumption above can cause the learner to train a sub-optimal model (or even a completely useless one). 
+Violating the second assumption can cause arithmetic error accumulation, which typically breaks the training process altogether.
 
 As a general rule, *if you use a parametric learner, you need to make sure your training data is correctly scaled*. 
 
@@ -640,41 +682,38 @@ It is a good practice to include the normalizer directly in the ML.NET learning 
 - is correctly applied to all the new incoming data, without the need for extra pre-processing at prediction time.
 
 Here's a snippet of code that demonstrates normalization in learning pipelines. It assumes the Iris dataset:
-
-You can achieve the same results using the dynamic API.
 ```csharp
-//data model for the Iris class
- private class IrisInputAllFeatures
-{
-    [ColumnName("Label"), LoadColumn(4)]
-    public string IgnoredLabel { get; set; }
-
-    [LoadColumn(0, 3)]
-    public float Features { get; set; }
-}
-
 // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
 // as a catalog of available operations and as the source of randomness.
 var mlContext = new MLContext();
 
-// Read the training data.
-var trainData = mlContext.Data.ReadFromTextFile<IrisInputAllFeatures>(dataPath,
+// Define the reader: specify the data columns and where to find them in the text file.
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // The four features of the Iris dataset will be grouped together as one Features column.
+        Features: ctx.LoadFloat(0, 3),
+        // Label: kind of iris.
+        Label: ctx.LoadText(4)
+    ),
     // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
-);
+    separatorChar: ',');
+
+// Read the training data.
+var trainData = reader.Read(dataPath);
 
 // Apply all kinds of standard ML.NET normalization to the raw features.
-var pipeline =
-    mlContext.Transforms.Normalize(
-        new NormalizingEstimator.MinMaxColumn("Features", "MinMaxNormalized", fixZero: true),
-        new NormalizingEstimator.MeanVarColumn("Features", "MeanVarNormalized", fixZero: true),
-        new NormalizingEstimator.BinningColumn("Features", "BinNormalized", numBins: 256));
+var pipeline = reader.MakeNewEstimator()
+    .Append(r => (
+        MinMaxNormalized: r.Features.Normalize(fixZero: true),
+        MeanVarNormalized: r.Features.NormalizeByMeanVar(fixZero: false),
+        CdfNormalized: r.Features.NormalizeByCumulativeDistribution(),
+        BinNormalized: r.Features.NormalizeByBinning(maxBins: 256)
+    ));
 
 // Let's train our pipeline of normalizers, and then apply it to the same data.
 var normalizedData = pipeline.Fit(trainData).Transform(trainData);
 
 // Inspect one column of the resulting dataset.
-var meanVarValues = normalizedData.GetColumn<float[]>(mlContext, "MeanVarNormalized").ToArray();
+var meanVarValues = normalizedData.GetColumn(r => r.MeanVarNormalized).ToArray();
 ```
 
 ## How do I train my model on categorical data?
@@ -686,7 +725,8 @@ If our data contains 'categorical' features (think 'enum'), we need to 'featuriz
 - Hash-based one-hot encoding
 - Binary encoding (convert category index into a bit sequence and use bits as features)
 
-If some of the categories are very high-cardinality (there's lots of different values, but only several are commonly occurring), a one-hot encoding can be wasteful. We can use count-based feature selection to trim down the number of slots that we encode.
+If some of the categories are very high-cardinality (there's lots of different values, but only several are commonly occurring), a one-hot encoding can be wasteful. 
+We can use count-based feature selection to trim down the number of slots that we encode.
 
 Same with normalization, it's a good practice to include categorical featurization directly in the ML.NET learning pipeline: this way you are sure that the categorical transformation
 - is only 'trained' on the training data, and not on your test data,
@@ -702,58 +742,58 @@ Label	Workclass	education	marital-status	occupation	relationship	ethnicity	sex	n
 ```
 
 ```csharp
-// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-// as a catalog of available operations and as the source of randomness.
-var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.CreateTextReader(new[] 
-    {
-        new TextLoader.Column("Label", DataKind.BL, 0),
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        Label: ctx.LoadBool(0),
         // We will load all the categorical features into one vector column of size 8.
-        new TextLoader.Column("CategoricalFeatures", DataKind.TX, 1, 8),
+        CategoricalFeatures: ctx.LoadText(1, 8),
         // Similarly, load all numerical features into one vector of size 6.
-        new TextLoader.Column("NumericalFeatures", DataKind.R4, 9, 14),
+        NumericalFeatures: ctx.LoadFloat(9, 14),
         // Let's also separately load the 'Workclass' column.
-        new TextLoader.Column("Workclass", DataKind.TX, 1),
-    },
-    hasHeader: true
-);
+        Workclass: ctx.LoadText(1)
+    ), hasHeader: true);
 
 // Read the data.
 var data = reader.Read(dataPath);
 
-// Inspect the first 10 records of the categorical columns to check that they are correctly read.
-var catColumns = data.GetColumn<string[]>(mlContext, "CategoricalFeatures").Take(10).ToArray();
+// Inspect the categorical columns to check that they are correctly read.
+var catColumns = data.GetColumn(r => r.CategoricalFeatures).Take(10).ToArray();
 
 // Build several alternative featurization pipelines.
-var dynamicPipeline =
-    // Convert each categorical feature into one-hot encoding independently.
-    mlContext.Transforms.Categorical.OneHotEncoding("CategoricalFeatures", "CategoricalOneHot")
-    // Convert all categorical features into indices, and build a 'word bag' of these.
-    .Append(mlContext.Transforms.Categorical.OneHotEncoding("CategoricalFeatures", "CategoricalBag", CategoricalTransform.OutputKind.Bag))
-    // One-hot encode the workclass column, then drop all the categories that have fewer than 10 instances in the train set.
-    .Append(mlContext.Transforms.Categorical.OneHotEncoding("Workclass", "WorkclassOneHot"))
-    .Append(mlContext.Transforms.FeatureSelection.CountFeatureSelectingEstimator("WorkclassOneHot", "WorkclassOneHotTrimmed", count: 10));
+var learningPipeline = reader.MakeNewEstimator()
+    // Cache data in memory in an on-demand manner. Columns used in any downstream step will be
+    // cached in memory at their first uses. This step can be removed if user's machine doesn't
+    // have enough memory.
+    .AppendCacheCheckpoint()
+    .Append(r => (
+        r.Label,
+        r.NumericalFeatures,
+        // Convert each categorical feature into one-hot encoding independently.
+        CategoricalOneHot: r.CategoricalFeatures.OneHotEncoding(outputKind: CategoricalStaticExtensions.OneHotVectorOutputKind.Ind),
+        // Convert all categorical features into indices, and build a 'word bag' of these.
+        CategoricalBag: r.CategoricalFeatures.OneHotEncoding(outputKind: CategoricalStaticExtensions.OneHotVectorOutputKind.Bag),
+        // One-hot encode the workclass column, then drop all the categories that have fewer than 10 instances in the train set.
+        WorkclassOneHotTrimmed: r.Workclass.OneHotEncoding().SelectFeaturesBasedOnCount(count: 10)
+    ));
 
 // Let's train our pipeline, and then apply it to the same data.
-var transformedData = dynamicPipeline.Fit(data).Transform(data);
+var transformedData = learningPipeline.Fit(data).Transform(data);
 
 // Inspect some columns of the resulting dataset.
-var categoricalBags = transformedData.GetColumn<float[]>(mlContext, "CategoricalBag").Take(10).ToArray();
-var workclasses = transformedData.GetColumn<float[]>(mlContext, "WorkclassOneHotTrimmed").Take(10).ToArray();
+var categoricalBags = transformedData.GetColumn(x => x.CategoricalBag).Take(10).ToArray();
+var workclasses = transformedData.GetColumn(x => x.WorkclassOneHotTrimmed).Take(10).ToArray();
 
 // Of course, if we want to train the model, we will need to compose a single float vector of all the features.
 // Here's how we could do this:
 
-var fullLearningPipeline = dynamicPipeline
-    // Concatenate two of the 3 categorical pipelines, and the numeric features.
-    .Append(mlContext.Transforms.Concatenate("Features", "NumericalFeatures", "CategoricalBag", "WorkclassOneHotTrimmed"))
-    // Cache data in memory so that the following trainer will be able to access training examples without
-    // reading them from disk multiple times.
-    .AppendCacheCheckpoint(mlContext)
+var fullLearningPipeline = learningPipeline
+    .Append(r => (
+        r.Label,
+        // Concatenate two of the 3 categorical pipelines, and the numeric features.
+        Features: r.NumericalFeatures.ConcatWith(r.CategoricalBag, r.WorkclassOneHotTrimmed)))
     // Now we're ready to train. We chose our FastTree trainer for this classification task.
-    .Append(mlContext.BinaryClassification.Trainers.FastTree(numTrees: 50));
+    .Append(r => mlContext.BinaryClassification.Trainers.FastTree(r.Label, r.Features, numTrees: 50));
 
 // Train the model.
 var model = fullLearningPipeline.Fit(data);
@@ -790,61 +830,63 @@ Sentiment   SentimentText
 var mlContext = new MLContext();
 
 // Define the reader: specify the data columns and where to find them in the text file.
-var reader = mlContext.Data.CreateTextReader(new[] 
-    {
-        new TextLoader.Column("IsToxic", DataKind.BL, 0),
-        new TextLoader.Column("Message", DataKind.TX, 1),
-    },
-    hasHeader: true
-);
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        IsToxic: ctx.LoadBool(0),
+        Message: ctx.LoadText(1)
+    ), hasHeader: true);
 
 // Read the data.
 var data = reader.Read(dataPath);
 
 // Inspect the message texts that are read from the file.
-var messageTexts = data.GetColumn<string>(mlContext, "Message").Take(20).ToArray();
+var messageTexts = data.GetColumn(x => x.Message).Take(20).ToArray();
 
 // Apply various kinds of text operations supported by ML.NET.
-var dynamicPipeline =
-    // One-stop shop to run the full text featurization.
-    mlContext.Transforms.Text.FeaturizeText("Message", "TextFeatures")
+var learningPipeline = reader.MakeNewEstimator()
+    // Cache data in memory in an on-demand manner. Columns used in any downstream step will be
+    // cached in memory at their first uses. This step can be removed if user's machine doesn't
+    // have enough memory.
+    .AppendCacheCheckpoint()
+    .Append(r => (
+        // One-stop shop to run the full text featurization.
+        TextFeatures: r.Message.FeaturizeText(),
 
-    // Normalize the message for later transforms
-    .Append(mlContext.Transforms.Text.NormalizeText("Message", "NormalizedMessage"))
+        // NLP pipeline 1: bag of words.
+        BagOfWords: r.Message.NormalizeText().ToBagofWords(),
 
-    // NLP pipeline 1: bag of words.
-    .Append(new WordBagEstimator(mlContext, "NormalizedMessage", "BagOfWords"))
+        // NLP pipeline 2: bag of bigrams, using hashes instead of dictionary indices.
+        BagOfBigrams: r.Message.NormalizeText().ToBagofHashedWords(ngramLength: 2, allLengths: false),
 
-    // NLP pipeline 2: bag of bigrams, using hashes instead of dictionary indices.
-    .Append(new WordHashBagEstimator(mlContext, "NormalizedMessage", "BagOfBigrams",
-                ngramLength: 2, allLengths: false))
+        // NLP pipeline 3: bag of tri-character sequences with TF-IDF weighting.
+        BagOfTrichar: r.Message.TokenizeIntoCharacters().ToNgrams(ngramLength: 3, weighting: NgramExtractingEstimator.WeightingCriteria.TfIdf),
 
-    // NLP pipeline 3: bag of tri-character sequences with TF-IDF weighting.
-    .Append(mlContext.Transforms.Text.TokenizeCharacters("Message", "MessageChars"))
-    .Append(new NgramExtractingEstimator(mlContext, "MessageChars", "BagOfTrichar",
-                ngramLength: 3, weighting: NgramExtractingEstimator.WeightingCriteria.TfIdf))
-
-    // NLP pipeline 4: word embeddings.
-    .Append(mlContext.Transforms.Text.TokenizeWords("NormalizedMessage", "TokenizedMessage"))
-    .Append(mlContext.Transforms.Text.ExtractWordEmbeedings("TokenizedMessage", "Embeddings",
-                WordEmbeddingsExtractorTransformer.PretrainedModelKind.GloVeTwitter25D));
+        // NLP pipeline 4: word embeddings.
+        Embeddings: r.Message.NormalizeText().TokenizeText().WordEmbeddings(WordEmbeddingsExtractorTransformer.PretrainedModelKind.GloVeTwitter25D)
+    ));
 
 // Let's train our pipeline, and then apply it to the same data.
 // Note that even on a small dataset of 70KB the pipeline above can take up to a minute to completely train.
-var transformedData = dynamicPipeline.Fit(data).Transform(data);
+var transformedData = learningPipeline.Fit(data).Transform(data);
 
 // Inspect some columns of the resulting dataset.
-var embeddings = transformedData.GetColumn<float[]>(mlContext, "Embeddings").Take(10).ToArray();
-var unigrams = transformedData.GetColumn<float[]>(mlContext, "BagOfWords").Take(10).ToArray();
+var embeddings = transformedData.GetColumn(x => x.Embeddings).Take(10).ToArray();
+var unigrams = transformedData.GetColumn(x => x.BagOfWords).Take(10).ToArray();
 ```
+
 ## How do I train using cross-validation?
 
-[Cross-validation](https://en.wikipedia.org/wiki/Cross-validation_(statistics)) is a useful technique for ML applications. It helps estimate the variance of the model quality from one run to another and also eliminates the need to extract a separate test set for evaluation.
+[Cross-validation](https://en.wikipedia.org/wiki/Cross-validation_(statistics)) is a useful technique for ML applications. 
+It helps estimate the variance of the model quality from one run to another and also eliminates the need to extract a separate test set for evaluation.
 
-There are a couple pitfalls that await us when we implement our own cross-validation. Essentially, if we are not careful, we may introduce label leakage in the process, so our metrics could become over-inflated.
+There are a couple pitfalls that await us when we implement our own cross-validation. 
+Essentially, if we are not careful, we may introduce label leakage in the process, so our metrics could become over-inflated.
 
-- It is tempting to apply the same pre-processing to the entire data, and then just cross-validate the final training of the model. If we do this for data-dependent, 'trainable' pre-processing (like text featurization, categorical handling and normalization/rescaling), we cause these processing steps to 'train' on the union of train subset and test subset, thus causing label leakage. The correct way is to apply pre-processing independently for each 'fold' of the cross-validation.
-- In many cases there is a natural 'grouping' of the data that needs to be respected. For example, if we are solving a click prediction problem, it's a good idea to group all examples pertaining to one URL to appear in one-fold of the data. If they end up separated, we can introduce label leakage.
+- It is tempting to apply the same pre-processing to the entire data, and then just cross-validate the final training of the model. 
+If we do this for data-dependent, 'trainable' pre-processing (like text featurization, categorical handling and normalization/rescaling), we cause these processing steps to 'train' on the union of train subset and test subset, thus causing label leakage. 
+The correct way is to apply pre-processing independently for each 'fold' of the cross-validation.
+- In many cases there is a natural 'grouping' of the data that needs to be respected. 
+For example, if we are solving a click prediction problem, it's a good idea to group all examples pertaining to one URL to appear in one-fold of the data.
+If they end up separated, we can introduce label leakage.
 
 ML.NET guards us against both these pitfalls: it will automatically apply the featurization correctly (as long as all of the preprocessing resides in one learning pipeline), and we can use the 'stratification column' concept to make sure that related examples don't get separated.
 
@@ -855,42 +897,55 @@ Here's an example of training on Iris dataset using randomized 90/10 train-test 
 var mlContext = new MLContext();
 
 // Step one: read the data as an IDataView.
-var data = mlContext.Data.ReadFromTextFile<IrisInput>(dataPath,
+// First, we define the reader: specify the data columns and where to find them in the text file.
+var reader = mlContext.Data.CreateTextReader(ctx => (
+        // The four features of the Iris dataset.
+        SepalLength: ctx.LoadFloat(0),
+        SepalWidth: ctx.LoadFloat(1),
+        PetalLength: ctx.LoadFloat(2),
+        PetalWidth: ctx.LoadFloat(3),
+        // Label: kind of iris.
+        Label: ctx.LoadText(4)
+    ),
     // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
-);
+    separatorChar: ',');
+
+// Read the data.
+var data = reader.Read(dataPath);
 
 // Build the training pipeline.
-var dynamicPipeline =
-    // Concatenate all the features together into one column 'Features'.
-    mlContext.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
-    // Note that the label is text, so it needs to be converted to key.
-    .Append(mlContext.Transforms.Conversions.MapValueToKey("Label"), TransformerScope.TrainTest)
-    // Cache data in memory so that SDCA trainer will be able to randomly access training examples without
-    // reading data from disk multiple times. Data will be cached at its first use in any downstream step.
-    // Notice that unused part in the data may not be cached.
-    .AppendCacheCheckpoint(mlContext)
-    // Use the multi-class SDCA model to predict the label using features.
-    .Append(mlContext.MulticlassClassification.Trainers.StochasticDualCoordinateAscent());
+var learningPipeline = reader.MakeNewEstimator()
+    .Append(r => (
+        // Convert string label to a key.
+        Label: r.Label.ToKey(),
+        // Concatenate all the features together into one column 'Features'.
+        Features: r.SepalLength.ConcatWith(r.SepalWidth, r.PetalLength, r.PetalWidth)))
+    // Add a step for caching data in memory so that the downstream iterative training
+    // algorithm can efficiently scan through the data multiple times.
+    .AppendCacheCheckpoint()
+    .Append(r => (
+        r.Label,
+        // Train the multi-class SDCA model to predict the label using features.
+        Predictions: mlContext.MulticlassClassification.Trainers.Sdca(r.Label, r.Features)));
 
 // Split the data 90:10 into train and test sets, train and evaluate.
 var (trainData, testData) = mlContext.MulticlassClassification.TrainTestSplit(data, testFraction: 0.1);
 
 // Train the model.
-var model = dynamicPipeline.Fit(trainData);
+var model = learningPipeline.Fit(trainData);
 // Compute quality metrics on the test set.
-var metrics = mlContext.MulticlassClassification.Evaluate(model.Transform(testData));
+var metrics = mlContext.MulticlassClassification.Evaluate(model.Transform(testData), r => r.Label, r => r.Predictions);
 Console.WriteLine(metrics.AccuracyMicro);
 
 // Now run the 5-fold cross-validation experiment, using the same pipeline.
-var cvResults = mlContext.MulticlassClassification.CrossValidate(data, dynamicPipeline, numFolds: 5);
+var cvResults = mlContext.MulticlassClassification.CrossValidate(data, learningPipeline, r => r.Label, numFolds: 5);
 
 // The results object is an array of 5 elements. For each of the 5 folds, we have metrics, model and scored test data.
 // Let's compute the average micro-accuracy.
 var microAccuracies = cvResults.Select(r => r.metrics.AccuracyMicro);
 Console.WriteLine(microAccuracies.Average());
-
 ```
+
 ## Can I mix and match static and dynamic pipelines?
 
 Yes, we can have both of them in our codebase. The static pipelines are just a statically-typed way to build dynamic pipelines.
@@ -930,8 +985,7 @@ var learningPipeline = reader.MakeNewEstimator()
         // Concatenate all the features together into one column 'Features'.
         Features: r.SepalLength.ConcatWith(r.SepalWidth, r.PetalLength, r.PetalWidth)));
 
-// Now, at the time of writing, there is no static pipeline for OVA (one-versus-all). So, let's
-// append the OVA learner to the dynamic pipeline.
+// Let's append the OVA learner to the dynamic pipeline.
 IEstimator<ITransformer> dynamicPipe = learningPipeline.AsDynamic;
 
 // Create a binary classification trainer.
@@ -969,109 +1023,4 @@ dynamicPipe = dynamicPipe.Append(new KeyToValueEstimator(mlContext, "PredictedLa
 var dynamicModel = dynamicPipe.Fit(data.AsDynamic);
 
 // Now 'dynamicModel', and 'model.AsDynamic' are equivalent.
-```
-
-## How can I define my own transformation of data?
-
-ML.NET has quite a lot of built-in transformers, but we can not possibly cover everything. Inevitably, you will need to perform custom user-defined operations.
-We added `MLContext.Transforms.CustomMapping` for this very purpose: it is a user-defined arbitrary *mapping* of the data.
-
-Suppose that we have the dataset with float 'Income' column, and we want to compute 'Label', that is equal to `true` if the income is more than 50000, and `false` otherwise.
-
-Here's how we can do this via a custom transformer:
-
-```csharp
-// Define a class for all the input columns that we intend to consume.
-class InputRow
-{
-    public float Income { get; set; }
-}
-
-// Define a class for all output columns that we intend to produce.
-class OutputRow
-{
-    public bool Label { get; set; }
-}
-
-public static IDataView PrepareData(MLContext mlContext, IDataView data)
-{
-    // Define the operation code.
-    Action<InputRow, OutputRow> mapping = (input, output) => output.Label = input.Income > 50000;
-    // Make a custom transformer and transform the data.
-    var transformer = mlContext.Transforms.CustomMappingTransformer(mapping, null);
-    return transformer.Transform(data);
-}
-```
-
-You can also insert a custom mapping inside an estimator pipeline:
-```csharp
-public static ITransformer TrainModel(MLContext mlContext, IDataView trainData)
-{
-    // Define the custom operation.
-    Action<InputRow, OutputRow> mapping = (input, output) => output.Label = input.Income > 50000;
-    // Construct the learning pipeline.
-    var estimator = mlContext.Transforms.CustomMapping(mapping, null)
-        .AppendCacheCheckpoint(mlContext)
-        .Append(mlContext.BinaryClassification.Trainers.FastTree(label: "Label"));
-
-    return estimator.Fit(trainData);
-}
-```
-
-Please note that you need to make your `mapping` operation into a 'pure function':
-- It should be reentrant (we will call it simultaneously from multiple threads)
-- It should not have side effects (we may call it arbitrarily at any time, or omit the call)
-
-One important caveat is: if you want your custom transformation to be part of your saved model, you will need to provide a `contractName` for it.
-At loading time, you will need to reconstruct the custom transformer and inject it into MLContext. 
-
-Here is a complete example that saves and loads a model with a custom mapping.
-```csharp
-/// <summary>
-/// One class that contains all custom mappings that we need for our model.
-/// </summary>
-public class CustomMappings
-{
-    // This is the custom mapping. We now separate it into a method, so that we can use it both in training and in loading.
-    public static void IncomeMapping(InputRow input, OutputRow output) => output.Label = input.Income > 50000;
-
-    // MLContext is needed to create a new transformer. We are using 'Import' to have ML.NET populate
-    // this property.
-    [Import]
-    public MLContext MLContext { get; set; }
-
-    // We are exporting the custom transformer by the name 'IncomeMapping'.
-    [Export(nameof(IncomeMapping))]
-    public ITransformer MyCustomTransformer 
-        => MLContext.Transforms.CustomMappingTransformer<InputRow, OutputRow>(IncomeMapping, nameof(IncomeMapping));
-}
-```
-
-```csharp
-// Construct the learning pipeline. Note that we are now providing a contract name for the custom mapping:
-// otherwise we will not be able to save the model.
-var estimator = mlContext.Transforms.CustomMapping<InputRow, OutputRow>(CustomMappings.IncomeMapping, nameof(CustomMappings.IncomeMapping))
-    .Append(mlContext.BinaryClassification.Trainers.FastTree(label: "Label"));
-
-// If memory is enough, we can cache the data in-memory to avoid reading them from file
-// when it will be accessed multiple times. 
-var cachedTrainData = mlContext.Data.Cache(trainData);
-
-// Train the model.
-var model = estimator.Fit(cachedTrainData);
-
-// Save the model.
-using (var fs = File.Create(modelPath))
-    mlContext.Model.Save(model, fs);
-
-// Now pretend we are in a different process.
-var newContext = new MLContext();
-
-// Create a custom composition container for all our custom mapping actions.
-newContext.CompositionContainer = new CompositionContainer(new TypeCatalog(typeof(CustomMappings)));
-
-// Now we can load the model.
-ITransformer loadedModel;
-using (var fs = File.OpenRead(modelPath))
-    loadedModel = newContext.Model.Load(fs);
 ```

--- a/docs/code/experimental/MlNetCookBook_StaticApi.md
+++ b/docs/code/experimental/MlNetCookBook_StaticApi.md
@@ -1,14 +1,14 @@
 # ML.NET Cookbook
 
-This document is intended to provide essential samples for common usage patterns of ML.NET, using examples from the experimental static API.
-The static api operates on the schema of the data, strongly typing the data type. 
+This document is intended to provide essential samples for common usage patterns of ML.NET, using examples from the experimental "Static API".
+The static api operates on the schema of the data, and strongly types the data columns.
 If you are loading an existing model from a stream, there's no need to use static types (and it's also pretty hard to do). 
-You should consider using the supported dynamic API. The same examples and content found through this cookbook is also available for the dynamic API in the  [MlNetCookBook.md](..\MlNetCookBook.md)
+You should consider using the supported dynamic API. The same examples and content found through this cookbook is also available for the dynamic API in the  [ML.NET CookBook.md](../MlNetCookBook.md)
 Also, if the data view's schema is only known at runtime, there is no way to use static types. 
-Using the static API gives you compiler support: it's more likely that, if your code compiles, it will also work as intended.
+Using the static API gives you compiler support: it's more likely that if your code compiles, it will also work as intended because the checks on the type compatibility between the data and the estimators are taken care at compile time. 
 
-To get started, it is advisable to be at least minimally familiar with [high-level concepts of ML.NET](..\MlNetHighLevelConcepts.md), otherwise the terminology in this document may be foreign to you.
-We welcome feedback about the static API.  
+To get started, it is helpful to be at least minimally familiar with [high-level concepts of ML.NET](../MlNetHighLevelConcepts.md), otherwise the terminology in this document may be foreign to you.
+As the static API is experimental and under development, we welcome feedback and examples where it gives an improved experience over the supported dynamic API.
 
 ## How to use this cookbook
 

--- a/docs/code/experimental/MlNetCookBook_StaticApi.md
+++ b/docs/code/experimental/MlNetCookBook_StaticApi.md
@@ -1,10 +1,13 @@
 # ML.NET Cookbook
 
 This document is intended to provide essential samples for common usage patterns of ML.NET, using examples from the experimental static API.
-The examples in this document make use of the static API, which at the time of writting is considered experimental.
-The supported way of composing pipelines in ML.NET is through the dynamic API. 
-You can find the same guide and examples on how to get started with ML.Net, dynamic API on the [cookbook reference for the dynamic API](..\MlNetCookBook.md)
-It is advisable to be at least minimally familiar with [high-level concepts of ML.NET](..\MlNetHighLevelConcepts.md), otherwise the terminology in this document may be foreign to you.
+The static api operates on the schema of the data, strongly typing the data type. 
+If you are loading an existing model from a stream, there's no need to use static types (and it's also pretty hard to do). 
+You should consider using the supported dynamic API. The same examples and content found through this cookbook is also available for the dynamic API in the  [MlNetCookBook.md](..\MlNetCookBook.md)
+Also, if the data view's schema is only known at runtime, there is no way to use static types. 
+Using the static API gives you compiler support: it's more likely that, if your code compiles, it will also work as intended.
+
+To get started, it is advisable to be at least minimally familiar with [high-level concepts of ML.NET](..\MlNetHighLevelConcepts.md), otherwise the terminology in this document may be foreign to you.
 We welcome feedback about the static API.  
 
 ## How to use this cookbook
@@ -564,14 +567,14 @@ var staticData = trainData.AssertStatic(mlContext, c => (
         LastVisits: c.R4.Vector));
 
 // Build the pipeline, same as the one above.
-var staticLearningPipeline = staticData.MakeNewEstimator()
+var staticPipeline = staticData.MakeNewEstimator()
     .Append(r => (
         r.HasChurned,
         Features: r.DemographicCategory.OneHotEncoding().ConcatWith(r.LastVisits)))
     .AppendCacheCheckpoint() // FastTree will benefit from caching data in memory.
     .Append(r => mlContext.BinaryClassification.Trainers.FastTree(r.HasChurned, r.Features, numTrees: 20));
 
-var staticModel = staticLearningPipeline.Fit(staticData);
+var staticModel = staticPipeline.Fit(staticData);
 
 // Note that dynamicModel should be the same as staticModel.AsDynamic (give or take random variance from
 // the training procedure).

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -197,15 +197,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // 		[2]	-9.709775	float
 
             // Apply the inverse conversion from 'PredictedLabel' column back to string value.
-<<<<<<< HEAD
-            var finalPipeline = dynamicPipeline.Append(mlContext.Transforms.Conversion.MapKeyToValue(("Data", "PredictedLabel")));
-=======
-            var finalPipeline = pipeline.Append(mlContext.Transforms.Conversion.MapKeyToValue(("PredictedLabel", "Data")));
-
-
+            var finalPipeline = pipeline.Append(mlContext.Transforms.Conversion.MapKeyToValue(("Data", "PredictedLabel")));
             dataPreview = finalPipeline.Preview(trainData);
-
->>>>>>> addressing PR comments, fixing links.
 
             return finalPipeline.Fit(trainData);
         }


### PR DESCRIPTION
Creating the MLNetCookBook_StaticApi.md. The document contains the same content and the MLNetCookBook.md, but the sample code uses the static API.

Updating the official cookbook to remove the static API samples, and leave just the dynamic API ones.

Fixes: #2210 
