### PR TITLE
Exclude files not authored by ML.NET from code coverage

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -44,7 +44,7 @@
       -->
       <Exclude>[*]Microsoft.ML.*Contracts*,[*]Microsoft.ML.Internal.Utilities*,[*]Microsoft.ML.Data.VBuffer*</Exclude>
       <ExcludeByAttribute>Obsolete,ExcludeFromCodeCoverage</ExcludeByAttribute>
-      <ExcludeByFile>$(BaseOutputPath)..\src\Microsoft.ML.Onnx\OnnxMl.cs</ExcludeByFile>
+      <ExcludeByFile>$(BaseOutputPath)..\src\Microsoft.ML.Onnx\OnnxMl.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Buffer.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Tensor.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\TensorGeneric.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Tensorflow.cs</ExcludeByFile>
   </PropertyGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -43,6 +43,8 @@
            but they need to be migrated. Excluding these classes should have very minimal effect on code coverage.
       -->
       <Exclude>[*]Microsoft.ML.*Contracts*,[*]Microsoft.ML.Internal.Utilities*,[*]Microsoft.ML.Data.VBuffer*</Exclude>
+      <ExcludeByAttribute>Obsolete,ExcludeFromCodeCoverage</ExcludeByAttribute>
+      <ExcludeByFile>$(BaseOutputPath)..\src\Microsoft.ML.Onnx\OnnxMl.cs</ExcludeByFile>
   </PropertyGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -44,7 +44,7 @@
       -->
       <Exclude>[*]Microsoft.ML.*Contracts*,[*]Microsoft.ML.Internal.Utilities*,[*]Microsoft.ML.Data.VBuffer*</Exclude>
       <ExcludeByAttribute>Obsolete,ExcludeFromCodeCoverage</ExcludeByAttribute>
-      <ExcludeByFile>$(BaseOutputPath)..\src\Microsoft.ML.Onnx\OnnxMl.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Buffer.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Tensor.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\TensorGeneric.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Tensorflow.cs</ExcludeByFile>
+      <ExcludeByFile>$(BaseOutputPath)..\src\Microsoft.ML.Onnx\OnnxMl.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Buffer.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Tensor.cs,$(BaseOutputPath)..\src\Microsoft.ML.TensorFlow\TensorFlow\Tensorflow.cs</ExcludeByFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Doesn't make sense to include ONNX ML autogenerated C# to protobuf file generator and Tensorflow sharp files as part of code coverage. 

