### PR TITLE
Upload coverage files only when all tests pass.

### DIFF
--- a/build/Codecoverage.proj
+++ b/build/Codecoverage.proj
@@ -13,7 +13,7 @@
     <PropertyGroup>
       <_CodecovPath>$(RestorePackagesPath)codecov\$(CodecovVersion)\tools\Codecov.exe</_CodecovPath>
       <_ReportGeneratorPath>$(RestorePackagesPath)reportgenerator\$(ReportGeneratorVersion)\tools\net47\ReportGenerator.exe</_ReportGeneratorPath>
-      <_BranchName Condition="'$(_BranchName)' == ''">$(SYSTEM_PULLREQUEST_TARGETBRANCH)</_BranchName>
+      <_BranchName Condition="'$(_BranchName)' == ''">$(SYSTEM_PULLREQUEST_SOURCEBRANCH)</_BranchName>
       <_BranchName Condition="'$(_BranchName)' == ''">$(BUILD_SOURCEBRANCHNAME)</_BranchName>
     </PropertyGroup>
 

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -41,7 +41,7 @@ phases:
       displayName: Run Tests.
     - script: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet msbuild build/Codecoverage.proj /p:CodeCovToken=$(CODECOV_TOKEN)
       displayName: Upload coverage to codecov.io
-      condition: eq(variables._codeCoverage, 'true')
+      condition: and(succeeded(), eq(variables._codeCoverage, 'true'))
     - task: PublishTestResults@2
       displayName: Publish Test Results
       condition: succeededOrFailed()


### PR DESCRIPTION
Sometimes not all tests pass and coverage files with missing data is uploaded to codecov and this changes the baseline of the master repo and causes all sorts of fluctuations in the coverage report both in PR and on the main page.
