### PR TITLE
Simple fix to make error message more clear

### DIFF
--- a/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
+++ b/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
@@ -119,6 +119,8 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <returns>One intepretation is, the value at which the standard normal CDF evaluates to p.</returns>
         public static double Probit(double p)
         {
+            Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Input probability should be in range 0 to 1.");
+
             double q = p - 0.5;
             double r = 0.0;
             if (Math.Abs(q) <= 0.425)
@@ -134,8 +136,6 @@ namespace Microsoft.ML.Internal.CpuMath
                     r = p;
                 else
                     r = 1 - p;
-
-                Contracts.CheckParam(r >= 0, nameof(p), "Illegal input value");
 
                 r = Math.Sqrt(-Math.Log(r));
                 double retval = 0.0;

--- a/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
+++ b/src/Microsoft.ML.CpuMath/ProbabilityFunctions.cs
@@ -119,8 +119,6 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <returns>One intepretation is, the value at which the standard normal CDF evaluates to p.</returns>
         public static double Probit(double p)
         {
-            Contracts.CheckParam(0 <= p && p <= 1, nameof(p), "Input probability should be in range 0 to 1.");
-
             double q = p - 0.5;
             double r = 0.0;
             if (Math.Abs(q) <= 0.425)
@@ -136,6 +134,8 @@ namespace Microsoft.ML.Internal.CpuMath
                     r = p;
                 else
                     r = 1 - p;
+
+                Contracts.CheckParam(r >= 0, nameof(p), "Input probability should be in range 0 to 1.");
 
                 r = Math.Sqrt(-Math.Log(r));
                 double retval = 0.0;


### PR DESCRIPTION
Fixes #966.

First, I further investigated and we don't use short names in error messages.
The issue #966 was pointing to an internal utility function that calculates the `probit`. The error message was not particularly useful which probably led to this concern.

In this PR, I change the error message to make the error a bit more clear and close the issue.