### PR TITLE
WIP: Making TrivialEstimator an ITransformer

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Data
     /// Concrete implementations still have to provide the schema propagation mechanism, since
     /// there is no easy way to infer it from the transformer.
     /// </summary>
-    public abstract class TrivialEstimator<TTransformer> : IEstimator<TTransformer>
+    public abstract class TrivialEstimator<TTransformer> : IEstimator<TTransformer>, ITransformer
         where TTransformer : class, ITransformer
     {
         protected readonly IHost Host;
@@ -38,5 +38,10 @@ namespace Microsoft.ML.Data
         }
 
         public abstract SchemaShape GetOutputSchema(SchemaShape inputSchema);
+
+        public bool IsRowToRowMapper => Transformer.IsRowToRowMapper;
+        public Schema GetOutputSchema(Schema inputSchema) => Transformer.GetOutputSchema(inputSchema);
+        public IRowToRowMapper GetRowToRowMapper(Schema inputSchema) => Transformer.GetRowToRowMapper(inputSchema);
+        public IDataView Transform(IDataView input) => Transformer.Transform(input);
     }
 }


### PR DESCRIPTION
Fixes #2354.

As elaborated in the issue, it can be unintuitive to a `.Fit()` step for non trainable estimators/transformers. 
In this PR, I make the base class of most trivial estimators an `ITransformer`.

Next steps for the PR:
1. Identify the trivial estimators that don't implement `TrivialEstimator` and make them derive from that.
2. Consider whether it is worth it to rename the trivial estimators, including "Transformer" in their name. Something like "ActionPerformingTransformerEstimator".
3. Add some tests.


