### PR TITLE
MLContext catalog cleanup

### DIFF
--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML
     /// </summary>
     public abstract class TrainCatalogBase
     {
-        protected readonly IHost Host;
+        protected internal readonly IHost Host;
 
         [BestFriend]
         internal IHostEnvironment Environment => Host;
@@ -68,7 +68,7 @@ namespace Microsoft.ML
         /// Train the <paramref name="estimator"/> on <paramref name="numFolds"/> folds of the data sequentially.
         /// Return each model and each scored test dataset.
         /// </summary>
-        protected (IDataView scoredTestSet, ITransformer model)[] CrossValidateTrain(IDataView data, IEstimator<ITransformer> estimator,
+        protected internal (IDataView scoredTestSet, ITransformer model)[] CrossValidateTrain(IDataView data, IEstimator<ITransformer> estimator,
             int numFolds, string stratificationColumn, uint? seed = null)
         {
             Host.CheckValue(data, nameof(data));
@@ -111,7 +111,7 @@ namespace Microsoft.ML
             return result.ToArray();
         }
 
-        protected TrainCatalogBase(IHostEnvironment env, string registrationName)
+        protected internal TrainCatalogBase(IHostEnvironment env, string registrationName)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckNonEmpty(registrationName, nameof(registrationName));
@@ -174,7 +174,7 @@ namespace Microsoft.ML
             [BestFriend]
             internal TrainCatalogBase Owner { get; }
 
-            protected CatalogInstantiatorBase(TrainCatalogBase catalog)
+            internal protected CatalogInstantiatorBase(TrainCatalogBase catalog)
             {
                 Owner = catalog;
             }
@@ -182,16 +182,16 @@ namespace Microsoft.ML
     }
 
     /// <summary>
-    /// The central catalog for binary classification trainers.
+    /// The central catalog for binary classification tasks and trainers.
     /// </summary>
     public sealed class BinaryClassificationCatalog : TrainCatalogBase
     {
         /// <summary>
-        /// For trainers for performing binary classification.
+        /// The list of trainers for performing binary classification.
         /// </summary>
         public BinaryClassificationTrainers Trainers { get; }
 
-        public BinaryClassificationCatalog(IHostEnvironment env)
+        internal BinaryClassificationCatalog(IHostEnvironment env)
             : base(env, nameof(BinaryClassificationCatalog))
         {
             Trainers = new BinaryClassificationTrainers(this);
@@ -298,19 +298,19 @@ namespace Microsoft.ML
     }
 
     /// <summary>
-    /// The central catalog for clustering trainers.
+    /// The central catalog for clustering tasks and trainers.
     /// </summary>
     public sealed class ClusteringCatalog : TrainCatalogBase
     {
         /// <summary>
-        /// List of trainers for performing clustering.
+        /// The list of trainers for performing clustering.
         /// </summary>
         public ClusteringTrainers Trainers { get; }
 
         /// <summary>
         /// The clustering context.
         /// </summary>
-        public ClusteringCatalog(IHostEnvironment env)
+        internal ClusteringCatalog(IHostEnvironment env)
             : base(env, nameof(ClusteringCatalog))
         {
             Trainers = new ClusteringTrainers(this);
@@ -379,16 +379,16 @@ namespace Microsoft.ML
     }
 
     /// <summary>
-    /// The central catalog for multiclass classification trainers.
+    /// The central catalog for multiclass classification tasks and trainers.
     /// </summary>
     public sealed class MulticlassClassificationCatalog : TrainCatalogBase
     {
         /// <summary>
-        /// For trainers for performing multiclass classification.
+        /// The list of trainers for performing multiclass classification.
         /// </summary>
         public MulticlassClassificationTrainers Trainers { get; }
 
-        public MulticlassClassificationCatalog(IHostEnvironment env)
+        internal MulticlassClassificationCatalog(IHostEnvironment env)
             : base(env, nameof(MulticlassClassificationCatalog))
         {
             Trainers = new MulticlassClassificationTrainers(this);
@@ -455,16 +455,16 @@ namespace Microsoft.ML
     }
 
     /// <summary>
-    /// The central catalog for regression trainers.
+    /// The central catalog for regression tasks and trainers.
     /// </summary>
     public sealed class RegressionCatalog : TrainCatalogBase
     {
         /// <summary>
-        /// For trainers for performing regression.
+        /// The list of trainers for performing regression.
         /// </summary>
         public RegressionTrainers Trainers { get; }
 
-        public RegressionCatalog(IHostEnvironment env)
+        internal RegressionCatalog(IHostEnvironment env)
             : base(env, nameof(RegressionCatalog))
         {
             Trainers = new RegressionTrainers(this);
@@ -522,16 +522,16 @@ namespace Microsoft.ML
     }
 
     /// <summary>
-    /// The central catalog for ranking trainers.
+    /// The central catalog for ranking tasks and trainers.
     /// </summary>
     public sealed class RankingCatalog : TrainCatalogBase
     {
         /// <summary>
-        /// For trainers for performing regression.
+        /// The list of trainers for performing regression.
         /// </summary>
         public RankingTrainers Trainers { get; }
 
-        public RankingCatalog(IHostEnvironment env)
+        internal RankingCatalog(IHostEnvironment env)
             : base(env, nameof(RankingCatalog))
         {
             Trainers = new RankingTrainers(this);

--- a/src/Microsoft.ML.Data/Transforms/CatalogUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/CatalogUtils.cs
@@ -7,7 +7,8 @@ namespace Microsoft.ML.Data
     /// <summary>
     /// Set of extension methods to extract <see cref="IHostEnvironment"/> from various catalog classes.
     /// </summary>
-    public static class CatalogUtils
+    [BestFriend]
+    internal static class CatalogUtils
     {
         public static IHostEnvironment GetEnvironment(this TransformsCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
         public static IHostEnvironment GetEnvironment(this TransformsCatalog.SubCatalogBase subCatalog) => Contracts.CheckRef(subCatalog, nameof(subCatalog)).Environment;

--- a/src/Microsoft.ML.Data/Transforms/TransformsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformsCatalog.cs
@@ -12,10 +12,29 @@ namespace Microsoft.ML
     {
         internal IHostEnvironment Environment { get; }
 
+        /// <summary>
+        /// The list of operations over categorical data.
+        /// </summary>
         public CategoricalTransforms Categorical { get; }
+
+        /// <summary>
+        /// The list of operations for rescaling data.
+        /// </summary>
         public ConversionTransforms Conversion { get; }
+
+        /// <summary>
+        /// The list of operations for processing text data.
+        /// </summary>
         public TextTransforms Text { get; }
+
+        /// <summary>
+        /// The list of operations for data projection.
+        /// </summary>
         public ProjectionTransforms Projection { get; }
+
+        /// <summary>
+        /// The list of operations for selecting features based on some criteria.
+        /// </summary>
         public FeatureSelectionTransforms FeatureSelection { get; }
 
         internal TransformsCatalog(IHostEnvironment env)
@@ -56,7 +75,7 @@ namespace Microsoft.ML
         /// </summary>
         public sealed class ConversionTransforms : SubCatalogBase
         {
-            public ConversionTransforms(TransformsCatalog owner) : base(owner)
+            internal ConversionTransforms(TransformsCatalog owner) : base(owner)
             {
             }
         }
@@ -66,7 +85,7 @@ namespace Microsoft.ML
         /// </summary>
         public sealed class TextTransforms : SubCatalogBase
         {
-            public TextTransforms(TransformsCatalog owner) : base(owner)
+            internal TextTransforms(TransformsCatalog owner) : base(owner)
             {
             }
         }
@@ -76,7 +95,7 @@ namespace Microsoft.ML
         /// </summary>
         public sealed class ProjectionTransforms : SubCatalogBase
         {
-            public ProjectionTransforms(TransformsCatalog owner) : base(owner)
+            internal ProjectionTransforms(TransformsCatalog owner) : base(owner)
             {
             }
         }
@@ -86,7 +105,7 @@ namespace Microsoft.ML
         /// </summary>
         public sealed class FeatureSelectionTransforms : SubCatalogBase
         {
-            public FeatureSelectionTransforms(TransformsCatalog owner) : base(owner)
+            internal FeatureSelectionTransforms(TransformsCatalog owner) : base(owner)
             {
             }
         }

--- a/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
@@ -15,22 +15,22 @@ namespace Microsoft.ML
     {
 
         /// <summary>
-        /// Trainers and tasks specific to ranking problems.
+        /// Trainers and tasks specific to recommendation problems.
         /// </summary>
         public static RecommendationCatalog Recommendation(this MLContext ctx) => new RecommendationCatalog(ctx);
     }
 
     /// <summary>
-    /// The central catalog for recommendation trainers.
+    /// The central catalog for recommendation trainers and tasks.
     /// </summary>
     public sealed class RecommendationCatalog : TrainCatalogBase
     {
         /// <summary>
-        /// For trainers for performing recommendation.
+        /// The list of trainers for performing recommendation.
         /// </summary>
         public RecommendationTrainers Trainers { get; }
 
-        public RecommendationCatalog(IHostEnvironment env)
+        internal RecommendationCatalog(IHostEnvironment env)
             : base(env, nameof(RecommendationCatalog))
         {
             Trainers = new RecommendationTrainers(this);


### PR DESCRIPTION
End-users will use ML.NET mainly through MLContext. As part of documentation cleanup, I started from MLContext and cleaned up the top level catalogs as follows:

* Internal catalog constructors: All catalog constructors are made internal, since the user shouldn't be creating those objects.
* `protected internal` for some fields: doc.microsoft includes `protected` fields/methods (like [Host field here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.ml.binaryclassificationcontext?view=ml-dotnet#fields)). Since all our catalogs are sealed, I changed some `protected` fields/method to `protected internal` so that they don't get mentioned in the docs at all. 
* Xml cleanup: Fixed some incorrect/missing texts along the way.
