### PR TITLE
Fix loading type problem for netfx

### DIFF
--- a/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformTest/OnnxTransformTests.cs
@@ -245,7 +245,6 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         void TestCommandLine()
         {
-            var env = new MLContext();
             var x = Maml.Main(new[] { @"showschema loader=Text{col=data_0:R4:0-150527} xf=Onnx{InputColumns={data_0} OutputColumns={softmaxout_1} model={squeezenet/00000001/model.onnx}}" });
             Assert.Equal(0, x);
         }

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -135,9 +135,8 @@ namespace Microsoft.ML.Tests
         [ConditionalFact(typeof(Environment), nameof(Environment.Is64BitProcess))] // x86 output differs from Baseline
         void TestCommandLine()
         {
-            IHostEnvironment environment = new MLContext();
-            environment.ComponentCatalog.RegisterAssembly(typeof(TensorFlowTransformer).Assembly);
-
+            // typeof helps to load the TensorFlowTransformer type.
+            Type type = typeof(TensorFlowTransformer);
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=a:R4:0-3 col=b:R4:0-3} xf=TFTransform{inputs=a inputs=b outputs=c modellocation={model_matmul/frozen_saved_model.pb}}" }), (int)0);
         }
 

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -135,8 +135,7 @@ namespace Microsoft.ML.Tests
         [ConditionalFact(typeof(Environment), nameof(Environment.Is64BitProcess))] // x86 output differs from Baseline
         void TestCommandLine()
         {
-            var env = new MLContext();
-            IHostEnvironment environment = env;
+            IHostEnvironment environment = new MLContext();
             environment.ComponentCatalog.RegisterAssembly(typeof(TensorFlowTransformer).Assembly);
 
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=a:R4:0-3 col=b:R4:0-3} xf=TFTransform{inputs=a inputs=b outputs=c modellocation={model_matmul/frozen_saved_model.pb}}" }), (int)0);

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -136,6 +136,9 @@ namespace Microsoft.ML.Tests
         void TestCommandLine()
         {
             var env = new MLContext();
+            IHostEnvironment environment = env;
+            environment.ComponentCatalog.RegisterAssembly(typeof(TensorFlowTransformer).Assembly);
+
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=a:R4:0-3 col=b:R4:0-3} xf=TFTransform{inputs=a inputs=b outputs=c modellocation={model_matmul/frozen_saved_model.pb}}" }), (int)0);
         }
 

--- a/test/Microsoft.ML.Tests/TermEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TermEstimatorTests.cs
@@ -154,7 +154,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         void TestCommandLine()
         {
-            var env = new MLContext();
             Assert.Equal(0, Maml.Main(new[] { @"showschema loader=Text{col=A:R4:0} xf=Term{col=B:A} in=f:\2.txt" }));
         }
 

--- a/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
@@ -153,7 +153,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         void TestCommandLine()
         {
-            var env = new MLContext();
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=A:R4:0} xf=copy{col=B:A} in=f:\1.txt" }), (int)0);
         }
 

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -325,9 +325,13 @@ namespace Microsoft.ML.Tests.Transformers
             Done();
         }
 
-        [ConditionalFact(typeof(BaseTestBaseline), nameof(BaseTestBaseline.NotFullFramework))] // Tracked by https://github.com/dotnet/machinelearning/issues/2104
+        [Fact]
         public void TestWhiteningCommandLine()
         {
+            MLContext env = new MLContext();
+            IHostEnvironment environment = env;
+            environment.ComponentCatalog.RegisterAssembly(typeof(VectorWhiteningTransformer).Assembly);
+
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=A:R4:0-10} xf=whitening{col=B:A} in=f:\2.txt" }), (int)0);
         }
 

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.Data.DataView;
@@ -328,9 +329,8 @@ namespace Microsoft.ML.Tests.Transformers
         [Fact]
         public void TestWhiteningCommandLine()
         {
-            IHostEnvironment environment = new MLContext();
-            environment.ComponentCatalog.RegisterAssembly(typeof(VectorWhiteningTransformer).Assembly);
-
+            // typeof helps to load the VectorWhiteningTransformer type.
+            Type type = typeof(VectorWhiteningTransformer);
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=A:R4:0-10} xf=whitening{col=B:A} in=f:\2.txt" }), (int)0);
         }
 

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -328,8 +328,7 @@ namespace Microsoft.ML.Tests.Transformers
         [Fact]
         public void TestWhiteningCommandLine()
         {
-            MLContext env = new MLContext();
-            IHostEnvironment environment = env;
+            IHostEnvironment environment = new MLContext();
             environment.ComponentCatalog.RegisterAssembly(typeof(VectorWhiteningTransformer).Assembly);
 
             Assert.Equal(Maml.Main(new[] { @"showschema loader=Text{col=A:R4:0-10} xf=whitening{col=B:A} in=f:\2.txt" }), (int)0);


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/2104

A couple of types doesn't get loaded properly by Maml commands on netfx. So we have to register them manually.
We are doing a similar things for maml commands in our benchmarks.
These tests fail on netfx and are being enabled in https://github.com/dotnet/machinelearning/pull/2402
