### PR TITLE
ResNet Tests corrected for netfx

### DIFF
--- a/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AlexNetExtension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AlexNetExtension.cs
@@ -22,7 +22,9 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> AlexNet(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            return AlexNet(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DnnImageModels"));
+            // Substring is  removing initial "file:///" from the codebase string.
+            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
+            return AlexNet(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AlexNetExtension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AlexNetExtension.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Reflection;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Transforms
@@ -22,9 +21,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> AlexNet(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            // Substring is  removing initial "file:///" from the codebase string.
-            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
-            return AlexNet(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
+            return AlexNet(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(AssemblyPathHelpers.GetExecutingAssemblyLocation(), "DnnImageModels"));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AssemblyPathHelpers.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AssemblyPathHelpers.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.ML.Transforms
+{
+    internal static class AssemblyPathHelpers
+    {
+        public static string GetExecutingAssemblyLocation()
+        {
+            string codeBaseUri = Assembly.GetExecutingAssembly().CodeBase;
+            string path = new Uri(codeBaseUri).AbsolutePath;
+            return Directory.GetParent(path).FullName;
+        }
+    }
+}

--- a/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AssemblyPathHelpers.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.AlexNet/AssemblyPathHelpers.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Reflection;
 
 namespace Microsoft.ML.Transforms
 {
@@ -12,7 +11,7 @@ namespace Microsoft.ML.Transforms
     {
         public static string GetExecutingAssemblyLocation()
         {
-            string codeBaseUri = Assembly.GetExecutingAssembly().CodeBase;
+            string codeBaseUri = typeof(AssemblyPathHelpers).Assembly.CodeBase;
             string path = new Uri(codeBaseUri).AbsolutePath;
             return Directory.GetParent(path).FullName;
         }

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/Microsoft.ML.DnnImageFeaturizer.ResNet101.csproj
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/Microsoft.ML.DnnImageFeaturizer.ResNet101.csproj
@@ -6,6 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Microsoft.ML.DnnImageFeaturizer.AlexNet\AssemblyPathHelpers.cs" />
+    <None Include="**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.ML.OnnxTransform\Microsoft.ML.OnnxTransform.csproj" />
   </ItemGroup>
   

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/Microsoft.ML.DnnImageFeaturizer.ResNet101.csproj
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/Microsoft.ML.DnnImageFeaturizer.ResNet101.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.ML.DnnImageFeaturizer.AlexNet\AssemblyPathHelpers.cs" />
-    <None Include="**/*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/ResNet101Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/ResNet101Extension.cs
@@ -22,7 +22,9 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet101(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            return ResNet101(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DnnImageModels"));
+            // Substring is  removing initial "file:///" from the codebase string.
+            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
+            return ResNet101(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/ResNet101Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet101/ResNet101Extension.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Reflection;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Transforms
@@ -22,9 +21,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet101(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            // Substring is  removing initial "file:///" from the codebase string.
-            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
-            return ResNet101(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
+            return ResNet101(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(AssemblyPathHelpers.GetExecutingAssemblyLocation(), "DnnImageModels"));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/Microsoft.ML.DnnImageFeaturizer.ResNet18.csproj
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/Microsoft.ML.DnnImageFeaturizer.ResNet18.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.ML.DnnImageFeaturizer.AlexNet\AssemblyPathHelpers.cs" />
-    <None Include="**/*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/Microsoft.ML.DnnImageFeaturizer.ResNet18.csproj
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/Microsoft.ML.DnnImageFeaturizer.ResNet18.csproj
@@ -6,6 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Microsoft.ML.DnnImageFeaturizer.AlexNet\AssemblyPathHelpers.cs" />
+    <None Include="**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.ML.OnnxTransform\Microsoft.ML.OnnxTransform.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/ResNet18Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/ResNet18Extension.cs
@@ -22,13 +22,8 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet18(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-#if NETFRAMEWORK
             // Substring is  removing initial "file:///" from the codebase string.
-            var executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
-
-#else
-            var executingAssemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-#endif
+            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
             return ResNet18(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
         }
 

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/ResNet18Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/ResNet18Extension.cs
@@ -22,7 +22,14 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet18(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            return ResNet18(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DnnImageModels"));
+#if NETFRAMEWORK
+            // Substring is  removing initial "file:///" from the codebase string.
+            var executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
+
+#else
+            var executingAssemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+#endif
+            return ResNet18(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/ResNet18Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet18/ResNet18Extension.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Reflection;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Transforms
@@ -22,9 +21,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet18(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            // Substring is  removing initial "file:///" from the codebase string.
-            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
-            return ResNet18(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
+            return ResNet18(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(AssemblyPathHelpers.GetExecutingAssemblyLocation(), "DnnImageModels"));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/Microsoft.ML.DnnImageFeaturizer.ResNet50.csproj
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/Microsoft.ML.DnnImageFeaturizer.ResNet50.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.ML.DnnImageFeaturizer.AlexNet\AssemblyPathHelpers.cs" />
-    <None Include="**/*.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/Microsoft.ML.DnnImageFeaturizer.ResNet50.csproj
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/Microsoft.ML.DnnImageFeaturizer.ResNet50.csproj
@@ -6,6 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Microsoft.ML.DnnImageFeaturizer.AlexNet\AssemblyPathHelpers.cs" />
+    <None Include="**/*.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.ML.OnnxTransform\Microsoft.ML.OnnxTransform.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/ResNet50Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/ResNet50Extension.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Reflection;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Transforms
@@ -22,9 +21,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet50(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            // Substring is  removing initial "file:///" from the codebase string.
-            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
-            return ResNet50(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
+            return ResNet50(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(AssemblyPathHelpers.GetExecutingAssemblyLocation(), "DnnImageModels"));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/ResNet50Extension.cs
+++ b/src/Microsoft.ML.DnnImageFeaturizer.ResNet50/ResNet50Extension.cs
@@ -22,7 +22,9 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         public static EstimatorChain<ColumnCopyingTransformer> ResNet50(this DnnImageModelSelector dnnModelContext, IHostEnvironment env, string outputColumnName, string inputColumnName)
         {
-            return ResNet50(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DnnImageModels"));
+            // Substring is  removing initial "file:///" from the codebase string.
+            string executingAssemblyLocation = Directory.GetParent(Assembly.GetExecutingAssembly().CodeBase.Substring(8)).FullName;
+            return ResNet50(dnnModelContext, env, outputColumnName, inputColumnName, Path.Combine(executingAssemblyLocation, "DnnImageModels"));
         }
 
         /// <summary>

--- a/test/Microsoft.ML.TestFramework/BaseTestClass.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestClass.cs
@@ -52,8 +52,9 @@ namespace Microsoft.ML.TestFramework
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 
 #if NETFRAMEWORK
-            // Substring is  removing initial "file:///" from the codebase string.
-            var currentAssemblyLocation = new FileInfo(Directory.GetParent(typeof(BaseTestClass).Assembly.CodeBase.Substring(8)).FullName);
+            string codeBaseUri = typeof(BaseTestClass).Assembly.CodeBase;
+            string path = new Uri(codeBaseUri).AbsolutePath;
+            var currentAssemblyLocation = new FileInfo(Directory.GetParent(path).FullName);
 #else
             // There is an extra folder in the netfx path representing the runtime identifier.
             var currentAssemblyLocation = new FileInfo(typeof(BaseTestClass).Assembly.Location);


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/2373

The behavior of GetExecutingAssembly is different on netFramework. It return a temp path on .netFramework

This problem also occurred while enabling tests for netfx.
