### PR TITLE
Textloader internalizations, documentation, and Arguments refactoring

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/DataReaderExtensions.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataReaderExtensions.cs
@@ -9,14 +9,12 @@ namespace Microsoft.ML
 {
     public static class DataReaderExtensions
     {
-        public static IDataView Read(this IDataReader<IMultiStreamSource> reader, string path)
-        {
-            return reader.Read(new MultiFileSource(path));
-        }
-
+        /// <summary>
+        /// Reads data from one or more file <paramref name="path"/> into an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="reader">The reader to use.</param>
+        /// <param name="path">One or more paths from which to load data.</param>
         public static IDataView Read(this IDataReader<IMultiStreamSource> reader, params string[] path)
-        {
-            return reader.Read(new MultiFileSource(path));
-        }
+            => reader.Read(new MultiFileSource(path));
     }
 }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1413,6 +1413,10 @@ namespace Microsoft.ML.Data
 
         public DataViewSchema GetOutputSchema() => _bindings.OutputSchema;
 
+        /// <summary>
+        /// Reads data from <paramref name="source"/> into an <see cref="IDataView"/>.
+        /// </summary>
+        /// <param name="source">The source from which to load data.</param>
         public IDataView Read(IMultiStreamSource source) => new BoundLoader(this, source);
 
         internal static TextLoader CreateTextReader<TInput>(IHostEnvironment host,

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1223,9 +1223,17 @@ namespace Microsoft.ML.Data
 #pragma warning restore 649 // never assigned
         }
 
-        // See if we can extract valid arguments from the first data file.
-        // If so, update options and set cols to the combined set of columns.
-        // If not, set error to true if there was an error condition.
+        /// <summary>
+        /// See if we can extract valid arguments from the first data file. If so, update options and set cols to the combined set of columns.
+        /// If not, set error to true if there was an error condition.
+        /// </summary>
+        /// <remarks>
+        /// Not all arguments are extracted from the data file. There are three arguments that can vary from iteration to iteration and that are set
+        /// directly by the user in the options class. These three arguments are:
+        /// <see cref="Options.UseThreads"/>,
+        /// <see cref="Options.HeaderFile"/>,
+        /// <see cref="Options.MaxRows"/>
+        /// </remarks>
         private static bool TryParseSchema(IHost host, IMultiStreamSource files,
             ref Options options, out Column[] cols, out bool error)
         {
@@ -1237,10 +1245,11 @@ namespace Microsoft.ML.Data
             error = false;
 
             // Verify that the current schema-defining arguments are default.
-            // Get settings just for core arguments, not everything.
+            // Get a string representation of the settings for all the fields of the Options class besides the following three
+            // UseThreads, HeaderFile, MaxRows, which are set by the user directly.
             string tmp = CmdParser.GetSettings(host, options, new Options()
             {
-                // It's fine if the user sets the following three arguments that are not considered core arguments.
+                // It's fine if the user sets the following three arguments, as they are instance specific.
                 // Setting the defaults to the user provided values will avoid these in the output of the call CmdParser.GetSettings.
                 UseThreads = options.UseThreads,
                 HeaderFile = options.HeaderFile,
@@ -1281,11 +1290,11 @@ namespace Microsoft.ML.Data
                     goto LDone;
 
                 var optionsNew = new Options();
-                // Copy the core arguments to the new options.
+                // Set the fields of optionsNew to the arguments parsed from the file.
                 if (!CmdParser.ParseArguments(host, loader.GetSettingsString(), optionsNew, typeof(Options), msg => ch.Error(msg)))
                     goto LDone;
 
-                // Set the non core arguments in the new options.
+                // Overwrite the three arguments that vary from iteration to iteration with the values specified by the user in the options class.
                 optionsNew.UseThreads = options.UseThreads;
                 optionsNew.HeaderFile = options.HeaderFile;
                 optionsNew.MaxRows = options.MaxRows;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1237,18 +1237,16 @@ namespace Microsoft.ML.Data
             cols = null;
             error = false;
 
-            // It's fine if the user sets the following three arguments that are not considered core arguments.
-            // Setting the defaults to the user provided values will avoid these in the output of the call CmdParser.GetSettings.
-            var optionsCoreDefault = new Options()
+            // Verify that the current schema-defining arguments are default.
+            // Get settings just for core arguments, not everything.
+            string tmp = CmdParser.GetSettings(host, options, new Options()
             {
+                // It's fine if the user sets the following three arguments that are not considered core arguments.
+                // Setting the defaults to the user provided values will avoid these in the output of the call CmdParser.GetSettings.
                 UseThreads = options.UseThreads,
                 HeaderFile = options.HeaderFile,
                 MaxRows = options.MaxRows
-            };
-
-            // Verify that the current schema-defining arguments are default.
-            // Get settings just for core arguments, not everything.
-            string tmp = CmdParser.GetSettings(host, options, optionsCoreDefault);
+            });
 
             // Try to get the schema information from the file.
             string str = Cursor.GetEmbeddedArgs(files);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1303,7 +1303,7 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Checks whether the source contains the valid TextLoader.Arguments depiction.
+        /// Checks whether the source contains the valid TextLoader.Options depiction.
         /// </summary>
         internal static bool FileContainsValidSchema(IHostEnvironment env, IMultiStreamSource files, out Options options)
         {
@@ -1425,6 +1425,9 @@ namespace Microsoft.ML.Data
             _bindings.Save(ctx);
         }
 
+        /// <summary>
+        /// The output <see cref="DataViewSchema"/> that will be produced by the reader.
+        /// </summary>
         public DataViewSchema GetOutputSchema() => _bindings.OutputSchema;
 
         /// <summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -24,10 +24,13 @@ using Float = System.Single;
 namespace Microsoft.ML.Data
 {
     /// <summary>
-    /// Loads a text file into an IDataView. Supports basic mapping from input columns to IDataView columns.
+    /// Loads a text file into an IDataView. Supports basic mapping from input columns to <see cref="IDataView"/> columns.
     /// </summary>
     public sealed partial class TextLoader : IDataReader<IMultiStreamSource>, ICanSaveModel
     {
+        /// <summary>
+        /// Describes how an input column should be mapped to an <see cref="IDataView"/> column.
+        /// </summary>
         /// <example>
         /// Scalar column of <seealso cref="DataKind"/> I4 sourced from 2nd column
         ///      col=ColumnName:I4:1
@@ -40,16 +43,39 @@ namespace Microsoft.ML.Data
         /// </example>
         public sealed class Column
         {
+            /// <summary>
+            /// Describes how an input column should be mapped to an <see cref="IDataView"/> column.
+            /// </summary>
             public Column() { }
 
+            /// <summary>
+            /// Describes how an input column should be mapped to an <see cref="IDataView"/> column.
+            /// </summary>
+            /// <param name="name">Name of the column.</param>
+            /// <param name="type">Type of the items in the column.</param>
+            /// <param name="index">Index of the column.</param>
             public Column(string name, DataKind? type, int index)
                : this(name, type, new[] { new Range(index) }) { }
 
+            /// <summary>
+            /// Describes how an input column should be mapped to an <see cref="IDataView"/> column.
+            /// </summary>
+            /// <param name="name">Name of the column.</param>
+            /// <param name="type">Type of the items in the column.</param>
+            /// <param name="minIndex">The minimum inclusive index of the column.</param>
+            /// <param name="maxIndex">The maximum-inclusive index of the column.</param>
             public Column(string name, DataKind? type, int minIndex, int maxIndex)
                 : this(name, type, new[] { new Range(minIndex, maxIndex) })
             {
             }
 
+            /// <summary>
+            /// Describes how an input column should be mapped to an <see cref="IDataView"/> column.
+            /// </summary>
+            /// <param name="name">Name of the column.</param>
+            /// <param name="type">Type of the items in the column.</param>
+            /// <param name="source">Source index range(s) of the column.</param>
+            /// <param name="keyCount">For a key column, this defines the range of values.</param>
             public Column(string name, DataKind? type, Range[] source, KeyCount keyCount = null)
             {
                 Contracts.CheckValue(name, nameof(name));
@@ -61,15 +87,27 @@ namespace Microsoft.ML.Data
                 KeyCount = keyCount;
             }
 
+            /// <summary>
+            /// Name of the column.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Name of the column")]
             public string Name;
 
+            /// <summary>
+            /// Type of the items in the column.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Type of the items in the column")]
             public DataKind? Type;
 
+            /// <summary>
+            /// Source index range(s) of the column.
+            /// </summary>
             [Argument(ArgumentType.Multiple, HelpText = "Source index range(s) of the column", ShortName = "src")]
             public Range[] Source;
 
+            /// <summary>
+            /// For a key column, this defines the range of values.
+            /// </summary>
             [Argument(ArgumentType.Multiple, HelpText = "For a key column, this defines the range of values", ShortName = "key")]
             public KeyCount KeyCount;
 
@@ -108,7 +146,7 @@ namespace Microsoft.ML.Data
 
             private bool TryParseSource(string str) => TryParseSourceEx(str, out Source);
 
-            public static bool TryParseSourceEx(string str, out Range[] ranges)
+            internal static bool TryParseSourceEx(string str, out Range[] ranges)
             {
                 ranges = null;
                 var strs = str.Split(',');
@@ -198,6 +236,9 @@ namespace Microsoft.ML.Data
             }
         }
 
+        /// <summary>
+        /// Specifies the range of indices of input columns that should be mapped to an output column.
+        /// </summary>
         public sealed class Range
         {
             public Range() { }
@@ -219,7 +260,7 @@ namespace Microsoft.ML.Data
             /// <param name="min">The minimum inclusive index of the column.</param>
             /// <param name="max">The maximum-inclusive index of the column. If <c>null</c>
             /// indicates that the <see cref="TextLoader"/> should auto-detect the legnth
-            /// of the lines, and read till the end.</param>
+            /// of the lines, and read untill the end.</param>
             public Range(int min, int? max)
             {
                 Contracts.CheckParam(min >= 0, nameof(min), "Must be non-negative");
@@ -233,27 +274,49 @@ namespace Microsoft.ML.Data
                 AutoEnd = max == null;
             }
 
+            /// <summary>
+            /// The minimum inclusive index of the column.
+            /// </summary>
             [Argument(ArgumentType.Required, HelpText = "First index in the range")]
             public int Min;
 
-            // If max is specified, the fields autoEnd and variableEnd are ignored.
-            // Otherwise, if autoEnd is true, then variableEnd is ignored.
+            /// <summary>
+            /// The maximum-inclusive index of the column. If <see langword="null"/>
+            /// indicates that the <see cref="TextLoader"/> should auto-detect the legnth
+            /// of the lines, and read untill the end.
+            /// If max is specified, the fields <see cref="AutoEnd"/> and <see cref="VariableEnd"/> are ignored.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Last index in the range")]
             public int? Max;
 
+            /// <summary>
+            /// Whether this range extends to the end of the line, but should be a fixed number of items.
+            /// If <see cref="Max"/> is specified, the fields <see cref="AutoEnd"/> and <see cref="VariableEnd"/> are ignored.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "This range extends to the end of the line, but should be a fixed number of items",
                 ShortName = "auto")]
             public bool AutoEnd;
 
+            /// <summary>
+            /// Whether this range extends to the end of the line, which can vary from line to line.
+            /// If <see cref="Max"/> is specified, the fields <see cref="AutoEnd"/> and <see cref="VariableEnd"/> are ignored.
+            /// If <see cref="AutoEnd"/> is <see langword="true"/>, then <see cref="VariableEnd"/> is ignored.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "This range extends to the end of the line, which can vary from line to line",
                 ShortName = "var")]
             public bool VariableEnd;
 
+            /// <summary>
+            /// Whether this range includes only other indices not specified.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "This range includes only other indices not specified", ShortName = "other")]
             public bool AllOther;
 
+            /// <summary>
+            /// Force scalar columns to be treated as vectors of length one.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Force scalar columns to be treated as vectors of length one", ShortName = "vector")]
             public bool ForceVector;
 
@@ -333,8 +396,16 @@ namespace Microsoft.ML.Data
             }
         }
 
-        public class ArgumentsCore
+        /// <summary>
+        /// The settings for <see cref="TextLoader"/>
+        /// </summary>
+        public class Options
         {
+            /// <summary>
+            /// Whether the input may include quoted values, which can contain separator characters, colons,
+            /// and distinguish empty values from missing values. When true, consecutive separators denote a
+            /// missing value and an empty value is denoted by \"\". When false, consecutive separators denote an empty value.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce,
                 HelpText =
                     "Whether the input may include quoted values, which can contain separator characters, colons," +
@@ -342,11 +413,17 @@ namespace Microsoft.ML.Data
                     " missing value and an empty value is denoted by \"\". When false, consecutive separators" +
                     " denote an empty value.",
                 ShortName = "quote")]
-            public bool AllowQuoting = DefaultArguments.AllowQuoting;
+            public bool AllowQuoting = Defaults.AllowQuoting;
 
+            /// <summary>
+            /// Whether the input may include sparse representations.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Whether the input may include sparse representations", ShortName = "sparse")]
-            public bool AllowSparse = DefaultArguments.AllowSparse;
+            public bool AllowSparse = Defaults.AllowSparse;
 
+            /// <summary>
+            /// Number of source columns in the text data. Default is that sparse rows contain their size information.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Number of source columns in the text data. Default is that sparse rows contain their size information.",
                 ShortName = "size")]
@@ -354,45 +431,63 @@ namespace Microsoft.ML.Data
 
             [Argument(ArgumentType.AtMostOnce, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly, HelpText = "Source column separator. Options: tab, space, comma, single character", ShortName = "sep")]
             // this is internal as it only serves the command line interface
-            internal string Separator = DefaultArguments.Separator.ToString();
+            internal string Separator = Defaults.Separator.ToString();
 
+            /// <summary>
+            /// The characters that should be used as separators column separator.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, Name = nameof(Separator), Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly, HelpText = "Source column separator.", ShortName = "sep")]
-            public char[] Separators = new[] { DefaultArguments.Separator };
+            public char[] Separators = new[] { Defaults.Separator };
 
+            /// <summary>
+            /// Specifies the input columns that should be mapped to <see cref="IDataView"/> columns.
+            /// </summary>
             [Argument(ArgumentType.Multiple, HelpText = "Column groups. Each group is specified as name:type:numeric-ranges, eg, col=Features:R4:1-17,26,35-40",
                 Name = "Column", ShortName = "col", SortOrder = 1)]
             public Column[] Columns;
 
+            /// <summary>
+            /// Wheter to remove trailing whitespace from lines.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Remove trailing whitespace from lines", ShortName = "trim")]
-            public bool TrimWhitespace = DefaultArguments.TrimWhitespace;
+            public bool TrimWhitespace = Defaults.TrimWhitespace;
 
+            /// <summary>
+            /// Whether the data file has a header with feature names.
+            /// </summary>
             [Argument(ArgumentType.AtMostOnce, ShortName = "header",
                 HelpText = "Data file has header with feature names. Header is read only if options 'hs' and 'hf' are not specified.")]
             public bool HasHeader;
 
             /// <summary>
+            /// Whether to use separate parsing threads.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Use separate parsing threads?", ShortName = "threads", Hide = true)]
+            public bool UseThreads = true;
+
+            /// <summary>
+            /// File containing a header with feature names. If specified, the header defined in the data file is ignored regardless of <see cref="HasHeader"/>.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "File containing a header with feature names. If specified, header defined in the data file (header+) is ignored.",
+                ShortName = "hf", IsInputFileName = true)]
+            public string HeaderFile;
+
+            /// <summary>
+            /// Maximum number of rows to produce.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of rows to produce", ShortName = "rows", Hide = true)]
+            public long? MaxRows;
+
+            /// <summary>
             /// Checks that all column specifications are valid (that is, ranges are disjoint and have min&lt;=max).
             /// </summary>
-            public bool IsValid()
+            internal bool IsValid()
             {
                 return Utils.Size(Columns) == 0 || Columns.All(x => x.IsValid());
             }
         }
 
-        public sealed class Options : ArgumentsCore
-        {
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Use separate parsing threads?", ShortName = "threads", Hide = true)]
-            public bool UseThreads = true;
-
-            [Argument(ArgumentType.AtMostOnce, HelpText = "File containing a header with feature names. If specified, header defined in the data file (header+) is ignored.",
-                ShortName = "hf", IsInputFileName = true)]
-            public string HeaderFile;
-
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of rows to produce", ShortName = "rows", Hide = true)]
-            public long? MaxRows;
-        }
-
-        internal static class DefaultArguments
+        internal static class Defaults
         {
             internal const bool AllowQuoting = true;
             internal const bool AllowSparse = true;
@@ -532,7 +627,7 @@ namespace Microsoft.ML.Data
             /// </summary>
             private readonly VBuffer<ReadOnlyMemory<char>>[] _slotNames;
             /// <summary>
-            /// Empty if <see cref="ArgumentsCore.HasHeader"/> is <see langword="false"/>, no header presents, or upon load
+            /// Empty if <see cref="Options.HasHeader"/> is <see langword="false"/>, no header presents, or upon load
             /// there was no header stored in the model.
             /// </summary>
             private readonly ReadOnlyMemory<char> _header;
@@ -975,7 +1070,7 @@ namespace Microsoft.ML.Data
         /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
-        public TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null)
+        internal TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null)
             : this(env, MakeArgs(columns, hasHeader, new[] { separatorChar }), dataSample)
         {
         }
@@ -993,7 +1088,7 @@ namespace Microsoft.ML.Data
         /// <param name="env">The environment to use.</param>
         /// <param name="options">Defines the settings of the load operation.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
-        public TextLoader(IHostEnvironment env, Options options = null, IMultiStreamSource dataSample = null)
+        internal TextLoader(IHostEnvironment env, Options options = null, IMultiStreamSource dataSample = null)
         {
             options = options ?? new Options();
 
@@ -1049,7 +1144,7 @@ namespace Microsoft.ML.Data
 
             _host.CheckNonEmpty(options.Separator, nameof(options.Separator), "Must specify a separator");
 
-            //Default arg.Separator is tab and default args.Separators is also a '\t'.
+            //Default arg.Separator is tab and default options. Separators is also a '\t'.
             //At a time only one default can be different and whichever is different that will
             //be used.
             if (options.Separators.Length > 1 || options.Separators[0] != '\t')
@@ -1131,7 +1226,7 @@ namespace Microsoft.ML.Data
         }
 
         // See if we can extract valid arguments from the first data file.
-        // If so, update args and set cols to the combined set of columns.
+        // If so, update options and set cols to the combined set of columns.
         // If not, set error to true if there was an error condition.
         private static bool TryParseSchema(IHost host, IMultiStreamSource files,
             ref Options options, out Column[] cols, out bool error)
@@ -1144,7 +1239,7 @@ namespace Microsoft.ML.Data
 
             // Verify that the current schema-defining arguments are default.
             // Get settings just for core arguments, not everything.
-            string tmp = CmdParser.GetSettings(host, options, new ArgumentsCore());
+            string tmp = CmdParser.GetSettings(host, options, new Options());
 
             // Try to get the schema information from the file.
             string str = Cursor.GetEmbeddedArgs(files);
@@ -1179,20 +1274,20 @@ namespace Microsoft.ML.Data
                 if (info.Type != typeof(IDataLoader) || info.ArgType != typeof(Options))
                     goto LDone;
 
-                var argsNew = new Options();
-                // Copy the non-core arguments to the new args (we already know that all the core arguments are default).
-                var parsed = CmdParser.ParseArguments(host, CmdParser.GetSettings(host, options, new Options()), argsNew);
+                var optionsNew = new Options();
+                // Copy the non-core arguments to the new options (we already know that all the core arguments are default).
+                var parsed = CmdParser.ParseArguments(host, CmdParser.GetSettings(host, options, new Options()), optionsNew);
                 ch.Assert(parsed);
-                // Copy the core arguments to the new args.
-                if (!CmdParser.ParseArguments(host, loader.GetSettingsString(), argsNew, typeof(ArgumentsCore), msg => ch.Error(msg)))
+                // Copy the core arguments to the new options.
+                if (!CmdParser.ParseArguments(host, loader.GetSettingsString(), optionsNew, typeof(Options), msg => ch.Error(msg)))
                     goto LDone;
 
-                cols = argsNew.Columns;
+                cols = optionsNew.Columns;
                 if (Utils.Size(cols) == 0)
                     goto LDone;
 
                 error = false;
-                options = argsNew;
+                options = optionsNew;
 
             LDone:
                 return !error;
@@ -1312,11 +1407,11 @@ namespace Microsoft.ML.Data
         public IDataView Read(IMultiStreamSource source) => new BoundLoader(this, source);
 
         internal static TextLoader CreateTextReader<TInput>(IHostEnvironment host,
-           bool hasHeader = DefaultArguments.HasHeader,
-           char separator = DefaultArguments.Separator,
-           bool allowQuotedStrings = DefaultArguments.AllowQuoting,
-           bool supportSparse = DefaultArguments.AllowSparse,
-           bool trimWhitespace = DefaultArguments.TrimWhitespace)
+           bool hasHeader = Defaults.HasHeader,
+           char separator = Defaults.Separator,
+           bool allowQuotedStrings = Defaults.AllowQuoting,
+           bool supportSparse = Defaults.AllowSparse,
+           bool trimWhitespace = Defaults.TrimWhitespace)
         {
             var userType = typeof(TInput);
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1231,6 +1231,7 @@ namespace Microsoft.ML.Data
         {
             host.AssertValue(host);
             host.AssertValue(files);
+            host.CheckValue(options, nameof(options));
 
             cols = null;
             error = false;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1317,21 +1317,6 @@ namespace Microsoft.ML.Data
             return found && !error && options.IsValid();
         }
 
-        /// <summary>
-        /// Checks whether the source contains the valid TextLoader.Arguments depiction.
-        /// </summary>
-        public static bool FileContainsValidSchema(IHostEnvironment env, IMultiStreamSource files, out Options options)
-        {
-            Contracts.CheckValue(env, nameof(env));
-            var h = env.Register(RegistrationName);
-            h.CheckValue(files, nameof(files));
-            options = new Options();
-            Column[] cols;
-            bool error;
-            bool found = TryParseSchema(h, files, ref options, out cols, out error);
-            return found && !error && options.IsValid();
-        }
-
         private TextLoader(IHost host, ModelLoadContext ctx)
         {
             Contracts.AssertValue(host, "host");

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -21,8 +21,8 @@ namespace Microsoft.ML
         /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
         public static TextLoader CreateTextLoader(this DataOperationsCatalog catalog,
             TextLoader.Column[] columns,
-            bool hasHeader = TextLoader.DefaultArguments.HasHeader,
-            char separatorChar = TextLoader.DefaultArguments.Separator,
+            bool hasHeader = TextLoader.Defaults.HasHeader,
+            char separatorChar = TextLoader.Defaults.Separator,
             IMultiStreamSource dataSample = null)
             => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample);
 
@@ -53,11 +53,11 @@ namespace Microsoft.ML
         /// except for 3rd and 5th columns which have values 6 and 3</param>
         /// <param name="trimWhitespace">Remove trailing whitespace from lines</param>
         public static TextLoader CreateTextLoader<TInput>(this DataOperationsCatalog catalog,
-            bool hasHeader = TextLoader.DefaultArguments.HasHeader,
-            char separatorChar = TextLoader.DefaultArguments.Separator,
-            bool allowQuotedStrings = TextLoader.DefaultArguments.AllowQuoting,
-            bool supportSparse = TextLoader.DefaultArguments.AllowSparse,
-            bool trimWhitespace = TextLoader.DefaultArguments.TrimWhitespace)
+            bool hasHeader = TextLoader.Defaults.HasHeader,
+            char separatorChar = TextLoader.Defaults.Separator,
+            bool allowQuotedStrings = TextLoader.Defaults.AllowQuoting,
+            bool supportSparse = TextLoader.Defaults.AllowSparse,
+            bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)
             => TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar, allowQuotedStrings, supportSparse, trimWhitespace);
 
         /// <summary>
@@ -72,8 +72,8 @@ namespace Microsoft.ML
         public static IDataView ReadFromTextFile(this DataOperationsCatalog catalog,
             string path,
             TextLoader.Column[] columns,
-            bool hasHeader = TextLoader.DefaultArguments.HasHeader,
-            char separatorChar = TextLoader.DefaultArguments.Separator)
+            bool hasHeader = TextLoader.Defaults.HasHeader,
+            char separatorChar = TextLoader.Defaults.Separator)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 
@@ -104,11 +104,11 @@ namespace Microsoft.ML
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile<TInput>(this DataOperationsCatalog catalog,
             string path,
-            bool hasHeader = TextLoader.DefaultArguments.HasHeader,
-            char separatorChar = TextLoader.DefaultArguments.Separator,
-            bool allowQuotedStrings = TextLoader.DefaultArguments.AllowQuoting,
-            bool supportSparse = TextLoader.DefaultArguments.AllowSparse,
-            bool trimWhitespace = TextLoader.DefaultArguments.TrimWhitespace)
+            bool hasHeader = TextLoader.Defaults.HasHeader,
+            char separatorChar = TextLoader.Defaults.Separator,
+            bool allowQuotedStrings = TextLoader.Defaults.AllowQuoting,
+            bool supportSparse = TextLoader.Defaults.AllowSparse,
+            bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 
@@ -147,8 +147,8 @@ namespace Microsoft.ML
         public static void SaveAsText(this DataOperationsCatalog catalog,
             IDataView data,
             Stream stream,
-            char separatorChar = TextLoader.DefaultArguments.Separator,
-            bool headerRow = TextLoader.DefaultArguments.HasHeader,
+            char separatorChar = TextLoader.Defaults.Separator,
+            bool headerRow = TextLoader.Defaults.HasHeader,
             bool schema = true,
             bool keepHidden = false)
         {

--- a/src/Microsoft.ML.StaticPipe/LocalPathReader.cs
+++ b/src/Microsoft.ML.StaticPipe/LocalPathReader.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Data;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.StaticPipe
 {
     public static class LocalPathReader
     {
-        public static DataView<TShape> Read<TShape>(this DataReader<IMultiStreamSource, TShape> reader, string path)
-        {
-            return reader.Read(new MultiFileSource(path));
-        }
 
+        /// <summary>
+        /// Reads data from one or more file <paramref name="path"/> into an <see cref="DataView"/>.
+        /// </summary>
+        /// <param name="reader">The reader to use.</param>
+        /// <param name="path">One or more paths from which to load data.</param>
         public static DataView<TShape> Read<TShape>(this DataReader<IMultiStreamSource, TShape> reader, params string[] path)
-        {
-            return reader.Read(new MultiFileSource(path));
-        }
+            => reader.Read(new MultiFileSource(path));
     }
 }

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -317,42 +317,6 @@
                 "Default": null
               },
               {
-                "Name": "UseThreads",
-                "Type": "Bool",
-                "Desc": "Use separate parsing threads?",
-                "Aliases": [
-                  "threads"
-                ],
-                "Required": false,
-                "SortOrder": 150.0,
-                "IsNullable": false,
-                "Default": true
-              },
-              {
-                "Name": "HeaderFile",
-                "Type": "String",
-                "Desc": "File containing a header with feature names. If specified, header defined in the data file (header+) is ignored.",
-                "Aliases": [
-                  "hf"
-                ],
-                "Required": false,
-                "SortOrder": 150.0,
-                "IsNullable": false,
-                "Default": null
-              },
-              {
-                "Name": "MaxRows",
-                "Type": "Int",
-                "Desc": "Maximum number of rows to produce",
-                "Aliases": [
-                  "rows"
-                ],
-                "Required": false,
-                "SortOrder": 150.0,
-                "IsNullable": true,
-                "Default": null
-              },
-              {
                 "Name": "AllowQuoting",
                 "Type": "Bool",
                 "Desc": "Whether the input may include quoted values, which can contain separator characters, colons, and distinguish empty values from missing values. When true, consecutive separators denote a missing value and an empty value is denoted by \"\". When false, consecutive separators denote an empty value.",
@@ -428,6 +392,42 @@
                 "SortOrder": 150.0,
                 "IsNullable": false,
                 "Default": false
+              },
+              {
+                "Name": "UseThreads",
+                "Type": "Bool",
+                "Desc": "Use separate parsing threads?",
+                "Aliases": [
+                  "threads"
+                ],
+                "Required": false,
+                "SortOrder": 150.0,
+                "IsNullable": false,
+                "Default": true
+              },
+              {
+                "Name": "HeaderFile",
+                "Type": "String",
+                "Desc": "File containing a header with feature names. If specified, header defined in the data file (header+) is ignored.",
+                "Aliases": [
+                  "hf"
+                ],
+                "Required": false,
+                "SortOrder": 150.0,
+                "IsNullable": false,
+                "Default": null
+              },
+              {
+                "Name": "MaxRows",
+                "Type": "Int",
+                "Desc": "Maximum number of rows to produce",
+                "Aliases": [
+                  "rows"
+                ],
+                "Required": false,
+                "SortOrder": 150.0,
+                "IsNullable": true,
+                "Default": null
               }
             ]
           },

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -463,7 +463,7 @@ namespace Microsoft.ML.RunTests
                      MetadataUtils.Const.ScoreValueKind.Score)
                     ).Transform(individualScores[i]);
 
-                individualScores[i] = ColumnSelectingTransformer.CreateDrop(Env, individualScores[i], MetadataUtils.Const.ScoreValueKind.Score);
+                individualScores[i] = new ColumnSelectingTransformer(Env, null, new[] { MetadataUtils.Const.ScoreValueKind.Score }).Transform(individualScores[i]);
             }
 
             var avgEnsembleInput = new EnsembleCreator.ClassifierInput { Models = predictorModels, ModelCombiner = EnsembleCreator.ClassifierCombiner.Average };

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -1806,7 +1806,7 @@ output Out [3] from H all;
         {
             using (var env = new LocalEnvironment(1, conc: 1))
             {
-                IDataView trainView = new TextLoader(env, new TextLoader.Arguments(), new MultiFileSource(GetDataPath(TestDatasets.mnistOneClass.trainFilename)));
+                IDataView trainView = new TextLoader(env, new TextLoader.Options(), new MultiFileSource(GetDataPath(TestDatasets.mnistOneClass.trainFilename)));
                 trainView =
                     NormalizeTransform.Create(env,
                         new NormalizeTransform.MinMaxArguments()
@@ -1815,7 +1815,7 @@ output Out [3] from H all;
                         },
                      trainView);
                 var trainData = new RoleMappedData(trainView, "Label", "Features");
-                IDataView testView = new TextLoader(env, new TextLoader.Arguments(), new MultiFileSource(GetDataPath(TestDatasets.mnistOneClass.testFilename)));
+                IDataView testView = new TextLoader(env, new TextLoader.Options(), new MultiFileSource(GetDataPath(TestDatasets.mnistOneClass.testFilename)));
                 ApplyTransformUtils.ApplyAllTransformsToData(env, trainView, testView);
                 var testData = new RoleMappedData(testView, "Label", "Features");
 


### PR DESCRIPTION
Fixes #2046.
Related to #1798.

This PR does the following:

1. Addresses the problem raised by #2046 by creating a single `Arguments` class from the original two classes `Arguments` and `ArgumentsCore`. The issue suggested the first approach out of two possible ways to do this, which is the one I followed in this PR.
2. Renames `Arguments` to `Options`.
3. Internalizes the constructors and other fields that should not be in the public API.
4. Adds comments for all public fields and methods. 
