### PR TITLE
Make KeyToValueMapping API consistent

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -62,15 +62,16 @@ namespace Microsoft.ML
         /// Convert the key types back to their original values.
         /// </summary>
         /// <param name="catalog">The categorical transform's catalog.</param>
-        /// <param name="inputColumnName">Name of the column to transform.</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
         ///  [!code-csharp[KeyToValueMappingEstimator](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs)]
         /// ]]></format>
         /// </example>
-        public static KeyToValueMappingEstimator MapKeyToValue(this TransformsCatalog.ConversionTransforms catalog, string inputColumnName)
-            => new KeyToValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), inputColumnName);
+        public static KeyToValueMappingEstimator MapKeyToValue(this TransformsCatalog.ConversionTransforms catalog, string outputColumnName, string inputColumnName = null)
+            => new KeyToValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName);
 
         /// <summary>
         ///  Convert the key types (name of the column specified in the first item of the tuple) back to their original values

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -87,8 +87,8 @@ namespace Microsoft.ML.Transforms.Conversions
         /// <summary>
         /// Create a <see cref="KeyToValueMappingTransformer"/> that takes and transforms one column.
         /// </summary>
-        internal KeyToValueMappingTransformer(IHostEnvironment env, string columnName)
-            : this(env, (columnName, columnName))
+        internal KeyToValueMappingTransformer(IHostEnvironment env, string outputColumnName, string inputColumnName = null)
+            : this(env, (outputColumnName, inputColumnName ?? outputColumnName))
         {
         }
 
@@ -507,8 +507,8 @@ namespace Microsoft.ML.Transforms.Conversions
 
     public sealed class KeyToValueMappingEstimator : TrivialEstimator<KeyToValueMappingTransformer>
     {
-        internal KeyToValueMappingEstimator(IHostEnvironment env, string columnName)
-            : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(KeyToValueMappingEstimator)), new KeyToValueMappingTransformer(env, columnName))
+        internal KeyToValueMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null)
+            : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(KeyToValueMappingEstimator)), new KeyToValueMappingTransformer(env, outputColumnName, inputColumnName ?? outputColumnName))
         {
         }
 


### PR DESCRIPTION
Fixes #2376 

Makes KeyToValueMapping API consistent with the rest by using the `string outputColumnName, string inputColumnName = null` signature in the `MapKeyToValue` method in `ConversionsExtensionsCatalog` and the associated `KeyToValueMappingEstimator` and `KeyToValueMappingTransformer` constructors.