### PR TITLE
Minimum Vector size check added

### DIFF
--- a/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/AvxIntrinsics.cs
@@ -466,22 +466,6 @@ namespace Microsoft.ML.Internal.CpuMath
                 int length = dst.Length;
                 Vector256<float> scaleVector256 = Vector256.Create(scale);
 
-                if (length < 8)
-                {
-                    // Handle cases where we have less than 256-bits total and can't ever use SIMD acceleration.
-                    switch (length)
-                    {
-                        case 7: dst[6] *= scale; goto case 6;
-                        case 6: dst[5] *= scale; goto case 5;
-                        case 5: dst[4] *= scale; goto case 4;
-                        case 4: dst[3] *= scale; goto case 3;
-                        case 3: dst[2] *= scale; goto case 2;
-                        case 2: dst[1] *= scale; goto case 1;
-                        case 1: dst[0] *= scale; break;
-                    }
-                    return;
-                }
-
                 nuint address = (nuint)(pd);
                 int misalignment = (int)(address % 32);
                 int remainder = 0;
@@ -993,27 +977,6 @@ namespace Microsoft.ML.Internal.CpuMath
             {
                 float* pValues = pSrc;
                 int length = src.Length;
-
-                if (length < 8)
-                {
-                    // Handle cases where we have less than 256-bits total and can't ever use SIMD acceleration.
-
-                    float res = 0;
-
-                    switch (length)
-                    {
-                        case 7: res += pValues[6]; goto case 6;
-                        case 6: res += pValues[5]; goto case 5;
-                        case 5: res += pValues[4]; goto case 4;
-                        case 4: res += pValues[3]; goto case 3;
-                        case 3: res += pValues[2]; goto case 2;
-                        case 2: res += pValues[1]; goto case 1;
-                        case 1: res += pValues[0]; break;
-                    }
-
-                    return res;
-                }
-
                 Vector256<float> result = Vector256<float>.Zero;
 
                 nuint address = (nuint)(pValues);

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -163,14 +163,14 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (destination.Length < MinInputSize || (!Avx.IsSupported && !Sse.IsSupported))
+            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < destination.Length; i++)
                 {
                     destination[i] += value;
                 }
             }
-            if (Avx.IsSupported)
+            else if (Avx.IsSupported)
             {
                 AvxIntrinsics.AddScalarU(value, destination);
             }
@@ -190,20 +190,20 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (Avx.IsSupported)
-            {
-                AvxIntrinsics.Scale(value, destination);
-            }
-            else if (Sse.IsSupported)
-            {
-                SseIntrinsics.Scale(value, destination);
-            }
-            else
+            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < destination.Length; i++)
                 {
                     destination[i] *= value;
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.Scale(value, destination);
+            }
+            else
+            {
+                SseIntrinsics.Scale(value, destination);
             }
         }
 
@@ -491,15 +491,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported)
-            {
-                return AvxIntrinsics.Sum(source);
-            }
-            else if (Sse.IsSupported)
-            {
-                return SseIntrinsics.Sum(source);
-            }
-            else
+            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float sum = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -507,6 +499,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     sum += source[i];
                 }
                 return sum;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.Sum(source);
+            }
+            else
+            {
+                return SseIntrinsics.Sum(source);
             }
         }
 

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -163,7 +163,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (destination.Length < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < destination.Length; i++)
                 {
@@ -190,7 +190,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (destination.Length < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < destination.Length; i++)
                 {
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (destination.Length < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -255,7 +255,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (destination.Length < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < destination.Length; i++)
                 {
@@ -288,7 +288,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (destination.Length < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -324,7 +324,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -361,7 +361,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= destination.Length);
             Contracts.Assert(count <= result.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -393,7 +393,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -428,7 +428,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -464,7 +464,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -491,7 +491,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (source.Length < MinInputSize || !Sse.IsSupported)
             {
                 float sum = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -520,7 +520,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (source.Length < MinInputSize || !Sse.IsSupported)
             {
                 float result = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -550,7 +550,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (source.Length < MinInputSize || !Sse.IsSupported)
             {
                 float result = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -579,7 +579,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (source.Length < MinInputSize || !Sse.IsSupported)
             {
                 float sum = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -609,7 +609,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (source.Length < MinInputSize || !Sse.IsSupported)
             {
                 float sum = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -638,7 +638,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (source.Length < MinInputSize || !Sse.IsSupported)
             {
                 float max = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -672,7 +672,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (source.Length < MinInputSize || !Sse.IsSupported)
             {
                 float max = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -711,7 +711,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(left.Length >= count);
             Contracts.Assert(right.Length >= count);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 float result = 0;
                 for (int i = 0; i < count; i++)
@@ -749,7 +749,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= indices.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 float result = 0;
                 for (int i = 0; i < count; i++)
@@ -785,7 +785,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= left.Length);
             Contracts.Assert(count <= right.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 float norm = 0;
                 for (int i = 0; i < count; i++)
@@ -897,7 +897,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -939,7 +939,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
+            if (count < MinInputSize || !Sse.IsSupported)
             {
                 for (int i = 0; i < count; i++)
                 {

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -20,6 +20,8 @@ namespace Microsoft.ML.Internal.CpuMath
         // The count of bytes in a 32-bit float, corresponding to _cbAlign in AlignedArray
         private const int FloatAlignment = 4;
 
+        private const int MinVectorSize = 16;
+
         // If neither AVX nor SSE is supported, return basic alignment for a 4-byte float.
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         public static int GetVectorAlignment()
@@ -160,11 +162,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && destination.Length >= MinVectorSize)
             {
                 AvxIntrinsics.AddScalarU(value, destination);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && destination.Length >= MinVectorSize)
             {
                 SseIntrinsics.AddScalarU(value, destination);
             }
@@ -249,11 +251,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && destination.Length >= MinVectorSize)
             {
                 AvxIntrinsics.ScaleAddU(scale, addend, destination);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && destination.Length >= MinVectorSize)
             {
                 SseIntrinsics.ScaleAddU(scale, addend, destination);
             }
@@ -281,11 +283,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.AddScaleU(scale, source, destination, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.AddScaleU(scale, source, destination, count);
             }
@@ -316,11 +318,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.AddScaleSU(scale, source, indices, destination, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.AddScaleSU(scale, source, indices, destination, count);
             }
@@ -352,11 +354,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= destination.Length);
             Contracts.Assert(count <= result.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
             }
@@ -383,11 +385,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.AddU(source, destination, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.AddU(source, destination, count);
             }
@@ -417,11 +419,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.AddSU(source, indices, destination, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.AddSU(source, indices, destination, count);
             }
@@ -452,11 +454,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.MulElementWiseU(left, right, destination, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.MulElementWiseU(left, right, destination, count);
             }
@@ -506,11 +508,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && source.Length >= MinVectorSize)
             {
                 return AvxIntrinsics.SumSqU(source);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && source.Length >= MinVectorSize)
             {
                 return SseIntrinsics.SumSqU(source);
             }
@@ -535,11 +537,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && source.Length >= MinVectorSize)
             {
                 return (mean == 0) ? AvxIntrinsics.SumSqU(source) : AvxIntrinsics.SumSqDiffU(mean, source);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && source.Length >= MinVectorSize)
             {
                 return (mean == 0) ? SseIntrinsics.SumSqU(source) : SseIntrinsics.SumSqDiffU(mean, source);
             }
@@ -563,11 +565,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && source.Length >= MinVectorSize)
             {
                 return AvxIntrinsics.SumAbsU(source);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && source.Length >= MinVectorSize)
             {
                 return SseIntrinsics.SumAbsU(source);
             }
@@ -592,11 +594,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && source.Length >= MinVectorSize)
             {
                 return (mean == 0) ? AvxIntrinsics.SumAbsU(source) : AvxIntrinsics.SumAbsDiffU(mean, source);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && source.Length >= MinVectorSize)
             {
                 return (mean == 0) ? SseIntrinsics.SumAbsU(source) : SseIntrinsics.SumAbsDiffU(mean, source);
             }
@@ -620,11 +622,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && source.Length >= MinVectorSize)
             {
                 return AvxIntrinsics.MaxAbsU(source);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && source.Length >= MinVectorSize)
             {
                 return SseIntrinsics.MaxAbsU(source);
             }
@@ -653,11 +655,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && source.Length >= MinVectorSize)
             {
                 return AvxIntrinsics.MaxAbsDiffU(mean, source);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && source.Length >= MinVectorSize)
             {
                 return SseIntrinsics.MaxAbsDiffU(mean, source);
             }
@@ -691,11 +693,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(left.Length >= count);
             Contracts.Assert(right.Length >= count);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 return AvxIntrinsics.DotU(left, right, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 return SseIntrinsics.DotU(left, right, count);
             }
@@ -728,11 +730,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= indices.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 return AvxIntrinsics.DotSU(left, right, indices, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 return SseIntrinsics.DotSU(left, right, indices, count);
             }
@@ -763,11 +765,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= left.Length);
             Contracts.Assert(count <= right.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 return AvxIntrinsics.Dist2(left, right, count);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 return SseIntrinsics.Dist2(left, right, count);
             }
@@ -874,11 +876,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
             }
@@ -915,11 +917,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (Avx.IsSupported)
+            if (Avx.IsSupported && count >= MinVectorSize)
             {
                 AvxIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
             }
-            else if (Sse.IsSupported)
+            else if (Sse.IsSupported && count >= MinVectorSize)
             {
                 SseIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
             }

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -158,6 +158,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// </summary>
         /// <param name="value">The value to add.</param>
         /// <param name="destination">The destination to add the value to.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Add(float value, Span<float> destination)
         {
             Contracts.AssertNonEmpty(destination);
@@ -184,6 +185,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// </summary>
         /// <param name="value">The value to add.</param>
         /// <param name="destination">The destination to add the value to.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Scale(float value, Span<float> destination)
         {
             Contracts.AssertNonEmpty(destination);
@@ -213,6 +215,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="source">The source values.</param>
         /// <param name="destination">The destination.</param>
         /// <param name="count">The count of items.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Scale(float value, ReadOnlySpan<float> source, Span<float> destination, int count)
         {
             Contracts.AssertNonEmpty(source);
@@ -247,6 +250,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="scale">The scale to add by.</param>
         /// <param name="addend">The added value.</param>
         /// <param name="destination">The destination.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ScaleAdd(float scale, float addend, Span<float> destination)
         {
             Contracts.AssertNonEmpty(destination);
@@ -275,6 +279,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="source">The source values.</param>
         /// <param name="destination">The destination values.</param>
         /// <param name="count">The count of items.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AddScale(float scale, ReadOnlySpan<float> source, Span<float> destination, int count)
         {
             Contracts.AssertNonEmpty(source);
@@ -308,6 +313,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="indices">The indices of value collection.</param>
         /// <param name="destination">The destination values.</param>
         /// <param name="count">The count of items.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AddScale(float scale, ReadOnlySpan<float> source, ReadOnlySpan<int> indices, Span<float> destination, int count)
         {
             Contracts.AssertNonEmpty(source);
@@ -344,6 +350,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="destination">The destination values.</param>
         /// <param name="result">A new collection of values to be returned.</param>
         /// <param name="count">The count of items.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AddScaleCopy(float scale, ReadOnlySpan<float> source, ReadOnlySpan<float> destination, Span<float> result, int count)
         {
             Contracts.AssertNonEmpty(source);
@@ -377,6 +384,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="source">The source values.</param>
         /// <param name="destination">The destination values.</param>
         /// <param name="count">The count of items.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Add(ReadOnlySpan<float> source, Span<float> destination, int count)
         {
             Contracts.AssertNonEmpty(source);
@@ -409,6 +417,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="indices"></param>
         /// <param name="destination">The destination values.</param>
         /// <param name="count">The count of items.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Add(ReadOnlySpan<float> source, ReadOnlySpan<int> indices, Span<float> destination, int count)
         {
             Contracts.AssertNonEmpty(source);
@@ -444,6 +453,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="right">The right element.</param>
         /// <param name="destination">The destination values.</param>
         /// <param name="count">The count of items.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MulElementWise(ReadOnlySpan<float> left, ReadOnlySpan<float> right, Span<float> destination, int count)
         {
             Contracts.AssertNonEmpty(left);
@@ -476,6 +486,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// </summary>
         /// <param name="source">The source values.</param>
         /// <returns>The sum of all items in <paramref name="source"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Sum(ReadOnlySpan<float> source)
         {
             Contracts.AssertNonEmpty(source);
@@ -504,6 +515,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// </summary>
         /// <param name="source">The source values.</param>
         /// <returns>The sum of the squares of all items in <paramref name="source"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float SumSq(ReadOnlySpan<float> source)
         {
             Contracts.AssertNonEmpty(source);
@@ -533,6 +545,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="mean">The mean value.</param>
         /// <param name="source">The source values.</param>
         /// <returns>The sum of all items in <paramref name="source"/> by <paramref name="mean"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float SumSq(float mean, ReadOnlySpan<float> source)
         {
             Contracts.AssertNonEmpty(source);
@@ -561,6 +574,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// </summary>
         /// <param name="source">The source values.</param>
         /// <returns>The sum of all absolute value of the items in <paramref name="source"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float SumAbs(ReadOnlySpan<float> source)
         {
             Contracts.AssertNonEmpty(source);
@@ -590,6 +604,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="mean">The mean value.</param>
         /// <param name="source">The source values.</param>
         /// <returns>The sum of all items by absolute value in <paramref name="source"/> subtracted by <paramref name="mean"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float SumAbs(float mean, ReadOnlySpan<float> source)
         {
             Contracts.AssertNonEmpty(source);
@@ -618,6 +633,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// </summary>
         /// <param name="source">The source values.</param>
         /// <returns>The max of all absolute value items in <paramref name="source"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float MaxAbs(ReadOnlySpan<float> source)
         {
             Contracts.AssertNonEmpty(source);
@@ -651,6 +667,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="mean">The mean value.</param>
         /// <param name="source">The source values.</param>
         /// <returns>The sum of all absolute value items in <paramref name="source"/> subtracted by <paramref name="mean"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float MaxAbsDiff(float mean, ReadOnlySpan<float> source)
         {
             Contracts.AssertNonEmpty(source);
@@ -685,6 +702,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="right">The right span.</param>
         /// <param name="count">The count of items.</param>
         /// <returns>The dot product.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float DotProductDense(ReadOnlySpan<float> left, ReadOnlySpan<float> right, int count)
         {
             Contracts.AssertNonEmpty(left);
@@ -720,6 +738,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="indices">The indicies of the left span.</param>
         /// <param name="count">The count of items.</param>
         /// <returns>The dot product.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float DotProductSparse(ReadOnlySpan<float> left, ReadOnlySpan<float> right, ReadOnlySpan<int> indices, int count)
         {
             Contracts.AssertNonEmpty(left);
@@ -757,6 +776,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="right">The right span.</param>
         /// <param name="count">The count of items.</param>
         /// <returns>The squared distance value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float L2DistSquared(ReadOnlySpan<float> left, ReadOnlySpan<float> right, int count)
         {
             Contracts.AssertNonEmpty(left);
@@ -866,6 +886,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="threshold">The threshold value.</param>
         /// <param name="v">The v span.</param>
         /// <param name="w">The w span.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SdcaL1UpdateDense(float primalUpdate, int count, ReadOnlySpan<float> source, float threshold, Span<float> v, Span<float> w)
         {
             Contracts.AssertNonEmpty(source);
@@ -905,6 +926,7 @@ namespace Microsoft.ML.Internal.CpuMath
         /// <param name="threshold">The threshold.</param>
         /// <param name="v">The v span.</param>
         /// <param name="w">The w span.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SdcaL1UpdateSparse(float primalUpdate, int count, ReadOnlySpan<float> source, ReadOnlySpan<int> indices, float threshold, Span<float> v, Span<float> w)
         {
             Contracts.AssertNonEmpty(source);

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Internal.CpuMath
         // The count of bytes in a 32-bit float, corresponding to _cbAlign in AlignedArray
         private const int FloatAlignment = 4;
 
-        private const int MinVectorSize = 16;
+        private const int MinInputSize = 16;
 
         // If neither AVX nor SSE is supported, return basic alignment for a 4-byte float.
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
@@ -163,11 +163,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (Avx.IsSupported && destination.Length >= MinVectorSize)
+            if (Avx.IsSupported && destination.Length >= MinInputSize)
             {
                 AvxIntrinsics.AddScalarU(value, destination);
             }
-            else if (Sse.IsSupported && destination.Length >= MinVectorSize)
+            else if (Sse.IsSupported && destination.Length >= MinInputSize)
             {
                 SseIntrinsics.AddScalarU(value, destination);
             }
@@ -255,11 +255,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (Avx.IsSupported && destination.Length >= MinVectorSize)
+            if (Avx.IsSupported && destination.Length >= MinInputSize)
             {
                 AvxIntrinsics.ScaleAddU(scale, addend, destination);
             }
-            else if (Sse.IsSupported && destination.Length >= MinVectorSize)
+            else if (Sse.IsSupported && destination.Length >= MinInputSize)
             {
                 SseIntrinsics.ScaleAddU(scale, addend, destination);
             }
@@ -288,11 +288,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.AddScaleU(scale, source, destination, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.AddScaleU(scale, source, destination, count);
             }
@@ -324,11 +324,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.AddScaleSU(scale, source, indices, destination, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.AddScaleSU(scale, source, indices, destination, count);
             }
@@ -361,11 +361,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= destination.Length);
             Contracts.Assert(count <= result.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
             }
@@ -393,11 +393,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.AddU(source, destination, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.AddU(source, destination, count);
             }
@@ -428,11 +428,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.AddSU(source, indices, destination, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.AddSU(source, indices, destination, count);
             }
@@ -464,11 +464,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.MulElementWiseU(left, right, destination, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.MulElementWiseU(left, right, destination, count);
             }
@@ -520,11 +520,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinVectorSize)
+            if (Avx.IsSupported && source.Length >= MinInputSize)
             {
                 return AvxIntrinsics.SumSqU(source);
             }
-            else if (Sse.IsSupported && source.Length >= MinVectorSize)
+            else if (Sse.IsSupported && source.Length >= MinInputSize)
             {
                 return SseIntrinsics.SumSqU(source);
             }
@@ -550,11 +550,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinVectorSize)
+            if (Avx.IsSupported && source.Length >= MinInputSize)
             {
                 return (mean == 0) ? AvxIntrinsics.SumSqU(source) : AvxIntrinsics.SumSqDiffU(mean, source);
             }
-            else if (Sse.IsSupported && source.Length >= MinVectorSize)
+            else if (Sse.IsSupported && source.Length >= MinInputSize)
             {
                 return (mean == 0) ? SseIntrinsics.SumSqU(source) : SseIntrinsics.SumSqDiffU(mean, source);
             }
@@ -579,11 +579,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinVectorSize)
+            if (Avx.IsSupported && source.Length >= MinInputSize)
             {
                 return AvxIntrinsics.SumAbsU(source);
             }
-            else if (Sse.IsSupported && source.Length >= MinVectorSize)
+            else if (Sse.IsSupported && source.Length >= MinInputSize)
             {
                 return SseIntrinsics.SumAbsU(source);
             }
@@ -609,11 +609,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinVectorSize)
+            if (Avx.IsSupported && source.Length >= MinInputSize)
             {
                 return (mean == 0) ? AvxIntrinsics.SumAbsU(source) : AvxIntrinsics.SumAbsDiffU(mean, source);
             }
-            else if (Sse.IsSupported && source.Length >= MinVectorSize)
+            else if (Sse.IsSupported && source.Length >= MinInputSize)
             {
                 return (mean == 0) ? SseIntrinsics.SumAbsU(source) : SseIntrinsics.SumAbsDiffU(mean, source);
             }
@@ -638,11 +638,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinVectorSize)
+            if (Avx.IsSupported && source.Length >= MinInputSize)
             {
                 return AvxIntrinsics.MaxAbsU(source);
             }
-            else if (Sse.IsSupported && source.Length >= MinVectorSize)
+            else if (Sse.IsSupported && source.Length >= MinInputSize)
             {
                 return SseIntrinsics.MaxAbsU(source);
             }
@@ -672,11 +672,11 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinVectorSize)
+            if (Avx.IsSupported && source.Length >= MinInputSize)
             {
                 return AvxIntrinsics.MaxAbsDiffU(mean, source);
             }
-            else if (Sse.IsSupported && source.Length >= MinVectorSize)
+            else if (Sse.IsSupported && source.Length >= MinInputSize)
             {
                 return SseIntrinsics.MaxAbsDiffU(mean, source);
             }
@@ -711,11 +711,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(left.Length >= count);
             Contracts.Assert(right.Length >= count);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 return AvxIntrinsics.DotU(left, right, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 return SseIntrinsics.DotU(left, right, count);
             }
@@ -749,11 +749,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= indices.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 return AvxIntrinsics.DotSU(left, right, indices, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 return SseIntrinsics.DotSU(left, right, indices, count);
             }
@@ -785,11 +785,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= left.Length);
             Contracts.Assert(count <= right.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 return AvxIntrinsics.Dist2(left, right, count);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 return SseIntrinsics.Dist2(left, right, count);
             }
@@ -897,11 +897,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
             }
@@ -939,11 +939,11 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (Avx.IsSupported && count >= MinVectorSize)
+            if (Avx.IsSupported && count >= MinInputSize)
             {
                 AvxIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
             }
-            else if (Sse.IsSupported && count >= MinVectorSize)
+            else if (Sse.IsSupported && count >= MinInputSize)
             {
                 SseIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
             }

--- a/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
+++ b/src/Microsoft.ML.CpuMath/CpuMathUtils.netcoreapp.cs
@@ -163,20 +163,20 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (Avx.IsSupported && destination.Length >= MinInputSize)
-            {
-                AvxIntrinsics.AddScalarU(value, destination);
-            }
-            else if (Sse.IsSupported && destination.Length >= MinInputSize)
-            {
-                SseIntrinsics.AddScalarU(value, destination);
-            }
-            else
+            if (destination.Length < MinInputSize || (!Avx.IsSupported && !Sse.IsSupported))
             {
                 for (int i = 0; i < destination.Length; i++)
                 {
                     destination[i] += value;
                 }
+            }
+            if (Avx.IsSupported)
+            {
+                AvxIntrinsics.AddScalarU(value, destination);
+            }
+            else
+            {
+                SseIntrinsics.AddScalarU(value, destination);
             }
         }
 
@@ -224,20 +224,20 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported)
-            {
-                AvxIntrinsics.ScaleSrcU(value, source, destination, count);
-            }
-            else if (Sse.IsSupported)
-            {
-                SseIntrinsics.ScaleSrcU(value, source, destination, count);
-            }
-            else
+            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
                     destination[i] = value * source[i];
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.ScaleSrcU(value, source, destination, count);
+            }
+            else
+            {
+                SseIntrinsics.ScaleSrcU(value, source, destination, count);
             }
         }
 
@@ -255,20 +255,20 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(destination);
 
-            if (Avx.IsSupported && destination.Length >= MinInputSize)
-            {
-                AvxIntrinsics.ScaleAddU(scale, addend, destination);
-            }
-            else if (Sse.IsSupported && destination.Length >= MinInputSize)
-            {
-                SseIntrinsics.ScaleAddU(scale, addend, destination);
-            }
-            else
+            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < destination.Length; i++)
                 {
                     destination[i] = scale * (destination[i] + addend);
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.ScaleAddU(scale, addend, destination);
+            }
+            else
+            {
+                SseIntrinsics.ScaleAddU(scale, addend, destination);
             }
         }
 
@@ -288,20 +288,20 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.AddScaleU(scale, source, destination, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.AddScaleU(scale, source, destination, count);
-            }
-            else
+            if (destination.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
                     destination[i] += scale * source[i];
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.AddScaleU(scale, source, destination, count);
+            }
+            else
+            {
+                SseIntrinsics.AddScaleU(scale, source, destination, count);
             }
         }
 
@@ -324,21 +324,21 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.AddScaleSU(scale, source, indices, destination, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.AddScaleSU(scale, source, indices, destination, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
                     int index = indices[i];
                     destination[index] += scale * source[i];
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.AddScaleSU(scale, source, indices, destination, count);
+            }
+            else
+            {
+                SseIntrinsics.AddScaleSU(scale, source, indices, destination, count);
             }
         }
 
@@ -361,20 +361,20 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= destination.Length);
             Contracts.Assert(count <= result.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
                     result[i] = scale * source[i] + destination[i];
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
+            }
+            else
+            {
+                SseIntrinsics.AddScaleCopyU(scale, source, destination, result, count);
             }
         }
 
@@ -393,20 +393,20 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= source.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.AddU(source, destination, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.AddU(source, destination, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
                     destination[i] += source[i];
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.AddU(source, destination, count);
+            }
+            else
+            {
+                SseIntrinsics.AddU(source, destination, count);
             }
         }
 
@@ -428,21 +428,21 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= indices.Length);
             Contracts.Assert(count < destination.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.AddSU(source, indices, destination, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.AddSU(source, indices, destination, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
                     int index = indices[i];
                     destination[index] += source[i];
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.AddSU(source, indices, destination, count);
+            }
+            else
+            {
+                SseIntrinsics.AddSU(source, indices, destination, count);
             }
         }
 
@@ -464,20 +464,20 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= destination.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.MulElementWiseU(left, right, destination, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.MulElementWiseU(left, right, destination, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
                     destination[i] = left[i] * right[i];
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.MulElementWiseU(left, right, destination, count);
+            }
+            else
+            {
+                SseIntrinsics.MulElementWiseU(left, right, destination, count);
             }
         }
 
@@ -520,15 +520,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinInputSize)
-            {
-                return AvxIntrinsics.SumSqU(source);
-            }
-            else if (Sse.IsSupported && source.Length >= MinInputSize)
-            {
-                return SseIntrinsics.SumSqU(source);
-            }
-            else
+            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float result = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -536,6 +528,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     result += source[i] * source[i];
                 }
                 return result;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.SumSqU(source);
+            }
+            else
+            {
+                return SseIntrinsics.SumSqU(source);
             }
         }
 
@@ -550,15 +550,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinInputSize)
-            {
-                return (mean == 0) ? AvxIntrinsics.SumSqU(source) : AvxIntrinsics.SumSqDiffU(mean, source);
-            }
-            else if (Sse.IsSupported && source.Length >= MinInputSize)
-            {
-                return (mean == 0) ? SseIntrinsics.SumSqU(source) : SseIntrinsics.SumSqDiffU(mean, source);
-            }
-            else
+            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float result = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -566,6 +558,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     result += (source[i] - mean) * (source[i] - mean);
                 }
                 return result;
+            }
+            else if (Avx.IsSupported)
+            {
+                return (mean == 0) ? AvxIntrinsics.SumSqU(source) : AvxIntrinsics.SumSqDiffU(mean, source);
+            }
+            else
+            {
+                return (mean == 0) ? SseIntrinsics.SumSqU(source) : SseIntrinsics.SumSqDiffU(mean, source);
             }
         }
 
@@ -579,15 +579,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinInputSize)
-            {
-                return AvxIntrinsics.SumAbsU(source);
-            }
-            else if (Sse.IsSupported && source.Length >= MinInputSize)
-            {
-                return SseIntrinsics.SumAbsU(source);
-            }
-            else
+            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float sum = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -595,6 +587,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     sum += Math.Abs(source[i]);
                 }
                 return sum;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.SumAbsU(source);
+            }
+            else
+            {
+                return SseIntrinsics.SumAbsU(source);
             }
         }
 
@@ -609,15 +609,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinInputSize)
-            {
-                return (mean == 0) ? AvxIntrinsics.SumAbsU(source) : AvxIntrinsics.SumAbsDiffU(mean, source);
-            }
-            else if (Sse.IsSupported && source.Length >= MinInputSize)
-            {
-                return (mean == 0) ? SseIntrinsics.SumAbsU(source) : SseIntrinsics.SumAbsDiffU(mean, source);
-            }
-            else
+            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float sum = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -625,6 +617,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     sum += Math.Abs(source[i] - mean);
                 }
                 return sum;
+            }
+            else if (Avx.IsSupported)
+            {
+                return (mean == 0) ? AvxIntrinsics.SumAbsU(source) : AvxIntrinsics.SumAbsDiffU(mean, source);
+            }
+            else
+            {
+                return (mean == 0) ? SseIntrinsics.SumAbsU(source) : SseIntrinsics.SumAbsDiffU(mean, source);
             }
         }
 
@@ -638,15 +638,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinInputSize)
-            {
-                return AvxIntrinsics.MaxAbsU(source);
-            }
-            else if (Sse.IsSupported && source.Length >= MinInputSize)
-            {
-                return SseIntrinsics.MaxAbsU(source);
-            }
-            else
+            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float max = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -658,6 +650,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     }
                 }
                 return max;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.MaxAbsU(source);
+            }
+            else
+            {
+                return SseIntrinsics.MaxAbsU(source);
             }
         }
 
@@ -672,15 +672,7 @@ namespace Microsoft.ML.Internal.CpuMath
         {
             Contracts.AssertNonEmpty(source);
 
-            if (Avx.IsSupported && source.Length >= MinInputSize)
-            {
-                return AvxIntrinsics.MaxAbsDiffU(mean, source);
-            }
-            else if (Sse.IsSupported && source.Length >= MinInputSize)
-            {
-                return SseIntrinsics.MaxAbsDiffU(mean, source);
-            }
-            else
+            if (source.Length < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float max = 0;
                 for (int i = 0; i < source.Length; i++)
@@ -692,6 +684,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     }
                 }
                 return max;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.MaxAbsDiffU(mean, source);
+            }
+            else
+            {
+                return SseIntrinsics.MaxAbsDiffU(mean, source);
             }
         }
 
@@ -711,15 +711,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(left.Length >= count);
             Contracts.Assert(right.Length >= count);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                return AvxIntrinsics.DotU(left, right, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                return SseIntrinsics.DotU(left, right, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float result = 0;
                 for (int i = 0; i < count; i++)
@@ -727,6 +719,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     result += left[i] * right[i];
                 }
                 return result;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.DotU(left, right, count);
+            }
+            else
+            {
+                return SseIntrinsics.DotU(left, right, count);
             }
         }
 
@@ -749,15 +749,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= right.Length);
             Contracts.Assert(count <= indices.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                return AvxIntrinsics.DotSU(left, right, indices, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                return SseIntrinsics.DotSU(left, right, indices, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float result = 0;
                 for (int i = 0; i < count; i++)
@@ -766,6 +758,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     result += left[index] * right[i];
                 }
                 return result;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.DotSU(left, right, indices, count);
+            }
+            else
+            {
+                return SseIntrinsics.DotSU(left, right, indices, count);
             }
         }
 
@@ -785,15 +785,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= left.Length);
             Contracts.Assert(count <= right.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                return AvxIntrinsics.Dist2(left, right, count);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                return SseIntrinsics.Dist2(left, right, count);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 float norm = 0;
                 for (int i = 0; i < count; i++)
@@ -802,6 +794,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     norm += distance * distance;
                 }
                 return norm;
+            }
+            else if (Avx.IsSupported)
+            {
+                return AvxIntrinsics.Dist2(left, right, count);
+            }
+            else
+            {
+                return SseIntrinsics.Dist2(left, right, count);
             }
         }
 
@@ -897,15 +897,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -913,6 +905,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     float value = v[i];
                     w[i] = Math.Abs(value) > threshold ? (value > 0 ? value - threshold : value + threshold) : 0;
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
+            }
+            else
+            {
+                SseIntrinsics.SdcaL1UpdateU(primalUpdate, count, source, threshold, v, w);
             }
         }
 
@@ -939,15 +939,7 @@ namespace Microsoft.ML.Internal.CpuMath
             Contracts.Assert(count <= v.Length);
             Contracts.Assert(count <= w.Length);
 
-            if (Avx.IsSupported && count >= MinInputSize)
-            {
-                AvxIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
-            }
-            else if (Sse.IsSupported && count >= MinInputSize)
-            {
-                SseIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
-            }
-            else
+            if (count < MinInputSize || !(Avx.IsSupported || Sse.IsSupported))
             {
                 for (int i = 0; i < count; i++)
                 {
@@ -956,6 +948,14 @@ namespace Microsoft.ML.Internal.CpuMath
                     float value = v[index];
                     w[index] = Math.Abs(value) > threshold ? (value > 0 ? value - threshold : value + threshold) : 0;
                 }
+            }
+            else if (Avx.IsSupported)
+            {
+                AvxIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
+            }
+            else
+            {
+                SseIntrinsics.SdcaL1UpdateSU(primalUpdate, count, source, indices, threshold, v, w);
             }
         }
     }

--- a/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
+++ b/src/Microsoft.ML.CpuMath/SseIntrinsics.cs
@@ -390,18 +390,6 @@ namespace Microsoft.ML.Internal.CpuMath
                 int length = dst.Length;
                 Vector128<float> scaleVector128 = Vector128.Create(scale);
 
-                if (length < 4)
-                {
-                    // Handle cases where we have less than 128-bits total and can't ever use SIMD acceleration.
-                    switch (length)
-                    {
-                        case 3: dst[2] *= scale; goto case 2;
-                        case 2: dst[1] *= scale; goto case 1;
-                        case 1: dst[0] *= scale; break;
-                    }
-                    return;
-                }
-
                 nuint address = (nuint)(pd);
                 int misalignment = (int)(address % 16);
                 int remainder = 0;
@@ -809,23 +797,6 @@ namespace Microsoft.ML.Internal.CpuMath
             {
                 float* pValues = pSrc;
                 int length = src.Length;
-
-                if (length < 4)
-                {
-                    // Handle cases where we have less than 128-bits total and can't ever use SIMD acceleration.
-
-                    float res = 0;
-
-                    switch (length)
-                    {
-                        case 3: res += pValues[2]; goto case 2;
-                        case 2: res += pValues[1]; goto case 1;
-                        case 1: res += pValues[0]; break;
-                    }
-
-                    return res;
-                }
-
                 Vector128<float> result = Vector128<float>.Zero;
 
                 nuint address = (nuint)(pValues);

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -3383,8 +3383,8 @@ namespace Microsoft.ML.RunTests
                     DataSaverUtils.SaveDataView(ch, saver, mcOutput.Stats, file);
             }
 
-            CheckEquality(@"../Common/EntryPoints", "lr-weights.txt", digitsOfPrecision: 6);
-            CheckEquality(@"../Common/EntryPoints", "lr-stats.txt", digitsOfPrecision: 6);
+            CheckEquality(@"../Common/EntryPoints", "lr-weights.txt", digitsOfPrecision: 4);
+            CheckEquality(@"../Common/EntryPoints", "lr-stats.txt", digitsOfPrecision: 3);
             CheckEquality(@"../Common/EntryPoints", "mc-lr-weights.txt", digitsOfPrecision: 3);
             CheckEquality(@"../Common/EntryPoints", "mc-lr-stats.txt", digitsOfPrecision: 5);
             Done();

--- a/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
@@ -36,7 +36,9 @@ namespace Microsoft.ML.CpuMath.UnitTests
             float[] testArray1 = new float[32] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f, 11f, 12f, 13f, 14f, 15f, 16f };
             // Unpadded array whose length is not a multiple of 4.
             float[] testArray2 = new float[30] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f, 11f, 12f, 13f, 14f, 15f };
-            _testArrays = new float[][] { testArray1, testArray2 };
+            // Small Input Size Array
+            float[] testArray3 = new float[15] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f };
+            _testArrays = new float[][] { testArray1, testArray2, testArray3 };
             _testIndexArray = new int[18] { 0, 2, 5, 6, 8, 11, 12, 13, 14, 16, 18, 21, 22, 24, 26, 27, 28, 29};
             _comparer = new FloatEqualityComparer();
             _matMulComparer = new FloatEqualityComparerForMatMul();
@@ -125,7 +127,7 @@ namespace Microsoft.ML.CpuMath.UnitTests
         {
             {  defaultMode, "0", null },
             {  defaultMode, "1", null },
-
+            {  defaultMode, "2", null },
 #if NETCOREAPP3_0
             { disableAvx, "0", DisableAvxEnvironmentVariables },
             { disableAvx, "1", DisableAvxEnvironmentVariables },
@@ -139,9 +141,10 @@ namespace Microsoft.ML.CpuMath.UnitTests
         {
             {  defaultMode, "0", "1.7", null },
             {  defaultMode, "1", "1.7", null },
+            {  defaultMode, "2", "1.7", null },
             {  defaultMode, "0", "-1.7", null },
             {  defaultMode, "1", "-1.7", null },
-
+            {  defaultMode, "2", "-1.7", null },
 #if NETCOREAPP3_0
             {  disableAvx, "0", "1.7", DisableAvxEnvironmentVariables },
             {  disableAvx, "1", "1.7", DisableAvxEnvironmentVariables },
@@ -394,10 +397,11 @@ namespace Microsoft.ML.CpuMath.UnitTests
                 float[] src = (float[])_testArrays[int.Parse(arg1)].Clone();
                 float[] dst = (float[])src.Clone();
                 int[] idx = _testIndexArray;
+                int limit = int.Parse(arg1) == 2 ? 9 : 18;
                 float[] expected = (float[])dst.Clone();
 
-                CpuMathUtils.AddScale(defaultScale, src, idx, dst, idx.Length);
-                for (int i = 0; i < idx.Length; i++)
+                CpuMathUtils.AddScale(defaultScale, src, idx, dst, limit);
+                for (int i = 0; i < limit; i++)
                 {
                     int index = idx[i];
                     expected[index] += defaultScale * src[i];
@@ -472,15 +476,16 @@ namespace Microsoft.ML.CpuMath.UnitTests
                 float[] src = (float[])_testArrays[int.Parse(arg1)].Clone();
                 float[] dst = (float[])src.Clone();
                 int[] idx = _testIndexArray;
+                int limit = int.Parse(arg1) == 2 ? 9 : 18;
                 float[] expected = (float[])dst.Clone();
 
-                for (int i = 0; i < idx.Length; i++)
+                for (int i = 0; i < limit; i++)
                 {
                     int index = idx[i];
                     expected[index] += src[i];
                 }
 
-                CpuMathUtils.Add(src, idx, dst, idx.Length);
+                CpuMathUtils.Add(src, idx, dst, limit);
                 var actual = dst;
                 Assert.Equal(expected, actual, _comparer);
                 return RemoteExecutor.SuccessExitCode;
@@ -709,6 +714,7 @@ namespace Microsoft.ML.CpuMath.UnitTests
                 float[] src = (float[])_testArrays[int.Parse(arg1)].Clone();
                 float[] dst = (float[])src.Clone();
                 int[] idx = _testIndexArray;
+                int limit = int.Parse(arg1) == 2 ? 9 : 18;
 
                 // Ensures src and dst are different arrays
                 for (int i = 0; i < dst.Length; i++)
@@ -717,13 +723,13 @@ namespace Microsoft.ML.CpuMath.UnitTests
                 }
 
                 float expected = 0;
-                for (int i = 0; i < idx.Length; i++)
+                for (int i = 0; i < limit; i++)
                 {
                     int index = idx[i];
                     expected += src[index] * dst[i];
                 }
 
-                var actual = CpuMathUtils.DotProductSparse(src, dst, idx, idx.Length);
+                var actual = CpuMathUtils.DotProductSparse(src, dst, idx, limit);
                 Assert.Equal(expected, actual, 2);
                 return RemoteExecutor.SuccessExitCode;
             }, mode, test, new RemoteInvokeOptions(environmentVariables));
@@ -825,16 +831,17 @@ namespace Microsoft.ML.CpuMath.UnitTests
                 float[] v = (float[])src.Clone();
                 float[] w = (float[])src.Clone();
                 int[] idx = _testIndexArray;
+                int limit = int.Parse(arg1) == 2 ? 9 : 18;
                 float[] expected = (float[])w.Clone();
 
-                for (int i = 0; i < idx.Length; i++)
+                for (int i = 0; i < limit; i++)
                 {
                     int index = idx[i];
                     float value = v[index] + src[i] * defaultScale;
                     expected[index] = Math.Abs(value) > defaultScale ? (value > 0 ? value - defaultScale : value + defaultScale) : 0;
                 }
 
-                CpuMathUtils.SdcaL1UpdateSparse(defaultScale, idx.Length, src, idx, defaultScale, v, w);
+                CpuMathUtils.SdcaL1UpdateSparse(defaultScale, limit, src, idx, defaultScale, v, w);
                 var actual = w;
                 Assert.Equal(expected, actual, _comparer);
                 return RemoteExecutor.SuccessExitCode;

--- a/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
+++ b/test/Microsoft.ML.CpuMath.UnitTests.netcoreapp/UnitTests.cs
@@ -33,11 +33,11 @@ namespace Microsoft.ML.CpuMath.UnitTests
         static CpuMathUtilsUnitTests()
         {
             // Padded array whose length is a multiple of 4
-            float[] testArray1 = new float[16] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f };
+            float[] testArray1 = new float[32] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f, 11f, 12f, 13f, 14f, 15f, 16f };
             // Unpadded array whose length is not a multiple of 4.
-            float[] testArray2 = new float[15] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f };
+            float[] testArray2 = new float[30] { 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 3.29f, 1.96f, -2.38f, -9.76f, 13.84f, -106.37f, -26.93f, 32.45f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f, 11f, 12f, 13f, 14f, 15f };
             _testArrays = new float[][] { testArray1, testArray2 };
-            _testIndexArray = new int[9] { 0, 2, 5, 6, 8, 11, 12, 13, 14 };
+            _testIndexArray = new int[18] { 0, 2, 5, 6, 8, 11, 12, 13, 14, 16, 18, 21, 22, 24, 26, 27, 28, 29};
             _comparer = new FloatEqualityComparer();
             _matMulComparer = new FloatEqualityComparerForMatMul();
 
@@ -474,15 +474,11 @@ namespace Microsoft.ML.CpuMath.UnitTests
                 int[] idx = _testIndexArray;
                 float[] expected = (float[])dst.Clone();
 
-                expected[0] = 3.92f;
-                expected[2] = -12.14f;
-                expected[5] = -36.69f;
-                expected[6] = 46.29f;
-                expected[8] = -104.41f;
-                expected[11] = -13.09f;
-                expected[12] = -73.92f;
-                expected[13] = -23.64f;
-                expected[14] = 34.41f;
+                for (int i = 0; i < idx.Length; i++)
+                {
+                    int index = idx[i];
+                    expected[index] += src[i];
+                }
 
                 CpuMathUtils.Add(src, idx, dst, idx.Length);
                 var actual = dst;
@@ -579,7 +575,7 @@ namespace Microsoft.ML.CpuMath.UnitTests
                     expected += (src[i] - defaultScale) * (src[i] - defaultScale);
                 }
 
-                Assert.Equal(expected, actual, 2);
+                Assert.Equal(expected, actual, 1);
                 return RemoteExecutor.SuccessExitCode;
             }, mode, test, scale, new RemoteInvokeOptions(environmentVariables));
         }

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -237,9 +237,9 @@ namespace Microsoft.ML.RunTests
         [TestCategory("Multiclass")]
         public void MulticlassReductionTest()
         {
-            RunOneAllTests(TestLearners.Ova, TestDatasets.iris);
-            RunOneAllTests(TestLearners.OvaWithFastForest, TestDatasets.iris);
-            RunOneAllTests(TestLearners.Pkpd, TestDatasets.iris);
+            RunOneAllTests(TestLearners.Ova, TestDatasets.iris, digitsOfPrecision: 6);
+            RunOneAllTests(TestLearners.OvaWithFastForest, TestDatasets.iris, digitsOfPrecision: 6);
+            RunOneAllTests(TestLearners.Pkpd, TestDatasets.iris, digitsOfPrecision: 6);
 
             Done();
         }

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -1033,7 +1033,7 @@ namespace Microsoft.ML.RunTests
                 new[]
                 {
                     "loader=Text{sparse+} xf=TrainScore{tr=AP{shuf-} scorer=fcc{str+}}"
-                }, digitsOfPrecision: 5);
+                }, digitsOfPrecision: 4);
 
             Done();
         }

--- a/test/Microsoft.ML.TestFramework/TestCommandBase.cs
+++ b/test/Microsoft.ML.TestFramework/TestCommandBase.cs
@@ -441,6 +441,11 @@ namespace Microsoft.ML.RunTests
             return TestCoreCore(ctx, cmdName, dataPath, PathArgument.Usage.Loader, modelPath, null, null, extraArgs, toCompare);
         }
 
+        protected bool TestInCore(RunContextBase ctx, string cmdName, string dataPath, OutputPath modelPath, string extraArgs, int digitsOfPrecision = DigitsOfPrecision, params PathArgument[] toCompare)
+        {
+            return TestCoreCore(ctx, cmdName, dataPath, PathArgument.Usage.Loader, modelPath, null, null, extraArgs, digitsOfPrecision, toCompare);
+        }
+
         /// <summary>
         /// Run one command loading the datafile loaded as defined by a model file, and comparing
         /// against standard output. This utility method will both load and save a model.
@@ -649,6 +654,11 @@ namespace Microsoft.ML.RunTests
         protected bool TestInCore(string cmdName, string dataPath, OutputPath modelPath, string extraArgs, params PathArgument[] toCompare)
         {
             return TestInCore(Params, cmdName, dataPath, modelPath, extraArgs, toCompare);
+        }
+
+        protected bool TestInCore(string cmdName, string dataPath, OutputPath modelPath, string extraArgs, int digitsOfPrecision = DigitsOfPrecision, params PathArgument[] toCompare)
+        {
+            return TestInCore(Params, cmdName, dataPath, modelPath, extraArgs, digitsOfPrecision, toCompare);
         }
 
         protected bool TestInOutCore(string cmdName, string dataPath, OutputPath modelPath, string extraArgs, params PathArgument[] toCompare)
@@ -1082,12 +1092,12 @@ namespace Microsoft.ML.RunTests
 
             string trainData = GetDataPath("adult.tiny.with-schema.txt");
             OutputPath trainModel = ModelPath();
-            TestCore("train", trainData, loaderArgs, extraArgs);
+            TestCore("train", trainData, loaderArgs, extraArgs, digitsOfPrecision: 5);
 
             _step++;
             // Save model summary.
             OutputPath modelSummary = CreateOutputPath("summary.txt");
-            TestInCore("savemodel", null, trainModel, "", modelSummary.Arg("sum"));
+            TestInCore("savemodel", null, trainModel, "", digitsOfPrecision: 4, modelSummary.Arg("sum"));
 
             Done();
         }

--- a/test/Microsoft.ML.Tests/FeatureContributionTests.cs
+++ b/test/Microsoft.ML.Tests/FeatureContributionTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Tests
         public void TestSDCABinary()
         {
             TestFeatureContribution(ML.BinaryClassification.Trainers.StochasticDualCoordinateAscentNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { NumThreads = 1, }), GetSparseDataset(TaskType.BinaryClassification, 100), "SDCABinary");
+                new SdcaNonCalibratedBinaryTrainer.Options { NumThreads = 1, }), GetSparseDataset(TaskType.BinaryClassification, 100), "SDCABinary", precision: 5);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/2253

The new c# implementation is slower for inputs of smaller size, so adding a size constraint for using these new c# apis

