### PR TITLE
Add analyzer for detecting BestFriend usages on public declarations

### DIFF
--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Code/BestFriendOnPublicDeclarationTest.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Code/BestFriendOnPublicDeclarationTest.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.ML.CodeAnalyzer.Tests.Helpers;
+using Xunit;
+
+namespace Microsoft.ML.InternalCodeAnalyzer.Tests
+{
+    public sealed class BestFriendOnPublicDeclarationTest : DiagnosticVerifier<BestFriendOnPublicDeclarationsAnalyzer>
+    {
+        private readonly Lazy<string> SourceAttribute = TestUtils.LazySource("BestFriendAttribute.cs");
+        private readonly Lazy<string> SourceDeclaration = TestUtils.LazySource("BestFriendOnPublicDeclaration.cs");
+
+        [Fact]
+        public void BestFriendOnPublicDeclaration()
+        {
+            Solution solution = null;
+            var projA = CreateProject("ProjectA", ref solution, SourceDeclaration.Value, SourceAttribute.Value);
+
+            var analyzer = new BestFriendOnPublicDeclarationsAnalyzer();
+
+            var refs = new List<MetadataReference> {
+                RefFromType<object>(), RefFromType<Attribute>(),
+                MetadataReference.CreateFromFile(Assembly.Load("netstandard, Version=2.0.0.0").Location),
+                MetadataReference.CreateFromFile(Assembly.Load("System.Runtime, Version=0.0.0.0").Location)
+            };
+
+            var comp = projA.GetCompilationAsync().Result.WithReferences(refs.ToArray());
+            var compilationWithAnalyzers = comp.WithAnalyzers(ImmutableArray.Create((DiagnosticAnalyzer)analyzer));
+            var allDiags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+
+            var projectTrees = new HashSet<SyntaxTree>(projA.Documents.Select(r => r.GetSyntaxTreeAsync().Result));
+            var diags = allDiags
+                .Where(d => d.Location == Location.None || d.Location.IsInMetadata || projectTrees.Contains(d.Location.SourceTree))
+                .OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+
+            var diag = analyzer.SupportedDiagnostics[0];
+            var expected = new DiagnosticResult[] {
+                diag.CreateDiagnosticResult(8, 6, "PublicClass"),
+                diag.CreateDiagnosticResult(11, 10, "PublicField"),
+                diag.CreateDiagnosticResult(14, 10, "PublicProperty"),
+                diag.CreateDiagnosticResult(20, 10, "PublicMethod"),
+                diag.CreateDiagnosticResult(26, 10, "PublicDelegate"),
+                diag.CreateDiagnosticResult(29, 10, "PublicClass"),
+                diag.CreateDiagnosticResult(35, 6, "PublicStruct"),
+                diag.CreateDiagnosticResult(40, 6, "PublicEnum"),
+                diag.CreateDiagnosticResult(47, 6, "PublicInterface")
+            };
+
+            VerifyDiagnosticResults(diags, analyzer, expected);
+        }
+    }
+}
+

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Code/BestFriendOnPublicDeclarationTest.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Code/BestFriendOnPublicDeclarationTest.cs
@@ -52,7 +52,8 @@ namespace Microsoft.ML.InternalCodeAnalyzer.Tests
                 diag.CreateDiagnosticResult(29, 10, "PublicClass"),
                 diag.CreateDiagnosticResult(35, 6, "PublicStruct"),
                 diag.CreateDiagnosticResult(40, 6, "PublicEnum"),
-                diag.CreateDiagnosticResult(47, 6, "PublicInterface")
+                diag.CreateDiagnosticResult(47, 6, "PublicInterface"),
+                diag.CreateDiagnosticResult(102, 10, "PublicMethod")
             };
 
             VerifyDiagnosticResults(diags, analyzer, expected);

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/BestFriendOnPublicDeclaration.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/BestFriendOnPublicDeclaration.cs
@@ -94,4 +94,14 @@ namespace TestNamespace
     internal interface InternalInterface
     {
     }
+
+    // this should fail the diagnostic
+    // a repro for https://github.com/dotnet/machinelearning/pull/2434#discussion_r254770946
+    internal class InternalClassWithPublicMember
+    {
+        [BestFriend]
+        public void PublicMethod()
+        {
+        }
+    }
 }

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/BestFriendOnPublicDeclaration.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/BestFriendOnPublicDeclaration.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.ML;
+
+namespace TestNamespace
+{
+    // all of the best friend declaration should fail the diagnostic
+
+    [BestFriend]
+    public class PublicClass
+    {
+        [BestFriend]
+        public int PublicField;
+
+        [BestFriend]
+        public string PublicProperty
+        {
+            get { return string.Empty; }
+        }
+
+        [BestFriend]
+        public bool PublicMethod()
+        {
+            return true;
+        }
+
+        [BestFriend]
+        public delegate string PublicDelegate();
+
+        [BestFriend]
+        public PublicClass()
+        {
+        }
+    }
+
+    [BestFriend]
+    public struct PublicStruct
+    {
+    }
+
+    [BestFriend]
+    public enum PublicEnum
+    {
+        EnumValue1,
+        EnumValue2
+    }
+
+    [BestFriend]
+    public interface PublicInterface
+    {
+    }
+
+    // these should work
+
+    [BestFriend]
+    internal class InternalClass
+    {
+        [BestFriend]
+        internal int InternalField;
+
+        [BestFriend]
+        internal string InternalProperty
+        {
+            get { return string.Empty; }
+        }
+
+        [BestFriend]
+        internal bool InternalMethod()
+        {
+            return true;
+        }
+
+        [BestFriend]
+        internal delegate string InternalDelegate();
+
+        [BestFriend]
+        internal InternalClass()
+        {
+        }
+    }
+
+    [BestFriend]
+    internal struct InternalStruct
+    {
+    }
+
+    [BestFriend]
+    internal enum InternalEnum
+    {
+        EnumValue1,
+        EnumValue2
+    }
+
+    [BestFriend]
+    internal interface InternalInterface
+    {
+    }
+}

--- a/tools-local/Microsoft.ML.InternalCodeAnalyzer/BestFriendOnPublicDeclarationsAnalyzer.cs
+++ b/tools-local/Microsoft.ML.InternalCodeAnalyzer/BestFriendOnPublicDeclarationsAnalyzer.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.ML.InternalCodeAnalyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class BestFriendOnPublicDeclarationsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string Category = "Access";
+        internal const string DiagnosticId = "MSML_BestFriendOnPublicDeclaration";
+
+        private const string Title = "Public declarations should not have " + AttributeName + " attribute.";
+        private const string Format = "The " + AttributeName + " should not be applied to publicly visible members.";
+
+        private const string Description =
+            "The " + AttributeName + " attribute is only valid on internal identifiers.";
+
+        private static DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, Format, Category,
+                DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+
+        private const string AttributeName = "Microsoft.ML.BestFriendAttribute";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSemanticModelAction(Analyze);
+        }
+
+        private void AnalyzeCore(SemanticModelAnalysisContext context, string attributeName)
+        {
+            var model = context.SemanticModel;
+            var comp = model.Compilation;
+
+            // Get the symbols of the key types we are analyzing. If we can't find it
+            // there is no point in going further.
+            var bestFriendAttributeType = comp.GetTypeByMetadataName(attributeName);
+            if (bestFriendAttributeType == null)
+                return;
+
+            foreach (var node in model.SyntaxTree.GetRoot().DescendantNodes(n => !n.IsKind(SyntaxKind.UsingDirective)))
+            {
+                switch (node.Kind())
+                {
+                    case SyntaxKind.ClassDeclaration:
+                    case SyntaxKind.StructDeclaration:
+                    case SyntaxKind.InterfaceDeclaration:
+                    case SyntaxKind.EnumDeclaration:
+                    case SyntaxKind.MethodDeclaration:
+                    case SyntaxKind.ConstructorDeclaration:
+                    case SyntaxKind.PropertyDeclaration:
+                    case SyntaxKind.DelegateDeclaration:
+                        var declaredSymbol = model.GetDeclaredSymbol(node);
+                        if (declaredSymbol == null)
+                            continue;
+
+                        VerifySymbol(context, declaredSymbol, bestFriendAttributeType);
+                        break;
+                    case SyntaxKind.FieldDeclaration: // field declaration is a little more complicated as it needs to be decomposed
+                        foreach (var variable in ((FieldDeclarationSyntax)node).Declaration.Variables)
+                        {
+                            var fieldSymbol = model.GetDeclaredSymbol(variable);
+                            VerifySymbol(context, fieldSymbol, bestFriendAttributeType);
+                        }
+                        break;
+                    default:
+                        continue;
+                }
+            }
+        }
+
+        private static void VerifySymbol(SemanticModelAnalysisContext context, ISymbol symbol,
+            INamedTypeSymbol bestFriendAttributeType)
+        {
+            if (symbol.DeclaredAccessibility != Accessibility.Public)
+                return;
+
+            var attribute = symbol.GetAttributes().FirstOrDefault(a => a.AttributeClass == bestFriendAttributeType);
+            if (attribute != null)
+            {
+                var diagnostic = Diagnostic.Create(Rule, attribute.ApplicationSyntaxReference.GetSyntax().GetLocation(), symbol.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private void Analyze(SemanticModelAnalysisContext context)
+        {
+            AnalyzeCore(context, "Microsoft.ML.BestFriendAttribute");
+            AnalyzeCore(context, "Microsoft.ML.Internal.CpuMath.Core.BestFriendAttribute");
+        }
+    }
+}


### PR DESCRIPTION
As proposed in #2415, the `BestFriend` attribute should never be applied to public declarations. While this is not a problem per se it still introduces unnecessary noise. I implemented a code analyzer that will flag these occurrences as errors whenever a `[BestFriend]` attribute is applied to a:

1. public class/struct/enum/interface
2. public method/property/field/delegate
3. public constructor

I didn't implement an automated code fix for this diagnostic as fixing the problem is trivial - either remove the attribute or make the declaration internal. If we still want a code fix to be created I'll gladly take care of that as well.

Fixes #2415.