### PR TITLE
Typed Calibrated Predictors

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
             var linearPredictor = model.LastTransformer;
             // Linear models for binary classification are wrapped by a calibrator as a generic predictor
             //  To access it directly, we must extract it out and cast it to the proper class
-            var weights = PfiHelper.GetLinearModelWeights(linearPredictor.Model.SubModelParameters as LinearBinaryModelParameters);
+            var weights = PfiHelper.GetLinearModelWeights(linearPredictor.Model.SubModel as LinearBinaryModelParameters);
 
             // Compute the permutation metrics using the properly normalized data.
             var transformedData = model.Transform(data);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
             var linearPredictor = model.LastTransformer;
             // Linear models for binary classification are wrapped by a calibrator as a generic predictor
             //  To access it directly, we must extract it out and cast it to the proper class
-            var weights = PfiHelper.GetLinearModelWeights(linearPredictor.Model.SubPredictor as LinearBinaryModelParameters);
+            var weights = PfiHelper.GetLinearModelWeights(linearPredictor.Model.SubModelParameters as LinearBinaryModelParameters);
 
             // Compute the permutation metrics using the properly normalized data.
             var transformedData = model.Transform(data);

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -112,11 +112,11 @@ namespace Microsoft.ML.EntryPoints
         {
             Contracts.CheckValue(env, nameof(env));
             var predictor = Predictor;
-            var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubModelParameters;
-                calibrated = predictor as IWeaklyTypedCalibratedPredictor;
+                predictor = calibrated.WeeklyTypedSubModel;
+                calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             }
             var canGetTrainingLabelNames = predictor as ICanGetTrainingLabelNames;
             if (canGetTrainingLabelNames != null)

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -112,11 +112,11 @@ namespace Microsoft.ML.EntryPoints
         {
             Contracts.CheckValue(env, nameof(env));
             var predictor = Predictor;
-            var calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
+            var calibrated = predictor as IWeeklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
-                predictor = calibrated.SubPredictor;
-                calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
+                predictor = calibrated.WeeklyTypedSubModelParameters;
+                calibrated = predictor as IWeeklyTypedCalibratedPredictor;
             }
             var canGetTrainingLabelNames = predictor as ICanGetTrainingLabelNames;
             if (canGetTrainingLabelNames != null)

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Data.DataView;
+using Microsoft.ML.Calibrator;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Calibration;
 using Microsoft.ML.Internal.Internallearn;
@@ -111,11 +112,11 @@ namespace Microsoft.ML.EntryPoints
         {
             Contracts.CheckValue(env, nameof(env));
             var predictor = Predictor;
-            var calibrated = predictor as CalibratedPredictorBase;
+            var calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
             while (calibrated != null)
             {
                 predictor = calibrated.SubPredictor;
-                calibrated = predictor as CalibratedPredictorBase;
+                calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
             }
             var canGetTrainingLabelNames = predictor as ICanGetTrainingLabelNames;
             if (canGetTrainingLabelNames != null)

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -112,11 +112,11 @@ namespace Microsoft.ML.EntryPoints
         {
             Contracts.CheckValue(env, nameof(env));
             var predictor = Predictor;
-            var calibrated = predictor as IWeeklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
                 predictor = calibrated.WeeklyTypedSubModelParameters;
-                calibrated = predictor as IWeeklyTypedCalibratedPredictor;
+                calibrated = predictor as IWeaklyTypedCalibratedPredictor;
             }
             var canGetTrainingLabelNames = predictor as ICanGetTrainingLabelNames;
             if (canGetTrainingLabelNames != null)

--- a/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Text;
 using Microsoft.Data.DataView;
+using Microsoft.ML.Calibrator;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
@@ -48,11 +49,11 @@ namespace Microsoft.ML.EntryPoints
         [BestFriend]
         internal static IDataView GetSummaryAndStats(IHostEnvironment env, IPredictor predictor, RoleMappedSchema schema, out IDataView stats)
         {
-            var calibrated = predictor as CalibratedPredictorBase;
+            var calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
             while (calibrated != null)
             {
                 predictor = calibrated.SubPredictor;
-                calibrated = predictor as CalibratedPredictorBase;
+                calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
             }
 
             IDataView summary = null;

--- a/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
@@ -49,11 +49,11 @@ namespace Microsoft.ML.EntryPoints
         [BestFriend]
         internal static IDataView GetSummaryAndStats(IHostEnvironment env, IPredictor predictor, RoleMappedSchema schema, out IDataView stats)
         {
-            var calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
+            var calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
-                predictor = calibrated.SubPredictor;
-                calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
+                predictor = calibrated.WeeklyTypedSubPredictor;
+                calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
             }
 
             IDataView summary = null;

--- a/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
@@ -49,11 +49,11 @@ namespace Microsoft.ML.EntryPoints
         [BestFriend]
         internal static IDataView GetSummaryAndStats(IHostEnvironment env, IPredictor predictor, RoleMappedSchema schema, out IDataView stats)
         {
-            var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubModelParameters;
-                calibrated = predictor as IWeaklyTypedCalibratedPredictor;
+                predictor = calibrated.WeeklyTypedSubModel;
+                calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             }
 
             IDataView summary = null;

--- a/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
@@ -49,11 +49,11 @@ namespace Microsoft.ML.EntryPoints
         [BestFriend]
         internal static IDataView GetSummaryAndStats(IHostEnvironment env, IPredictor predictor, RoleMappedSchema schema, out IDataView stats)
         {
-            var calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeeklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubPredictor;
-                calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
+                predictor = calibrated.WeeklyTypedSubModelParameters;
+                calibrated = predictor as IWeeklyTypedCalibratedPredictor;
             }
 
             IDataView summary = null;

--- a/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
@@ -49,11 +49,11 @@ namespace Microsoft.ML.EntryPoints
         [BestFriend]
         internal static IDataView GetSummaryAndStats(IHostEnvironment env, IPredictor predictor, RoleMappedSchema schema, out IDataView stats)
         {
-            var calibrated = predictor as IWeeklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
                 predictor = calibrated.WeeklyTypedSubModelParameters;
-                calibrated = predictor as IWeeklyTypedCalibratedPredictor;
+                calibrated = predictor as IWeaklyTypedCalibratedPredictor;
             }
 
             IDataView summary = null;

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -117,14 +117,14 @@ namespace Microsoft.ML.Internal.Calibration
     }
 
     /// <summary>
-    /// <see cref="IWeeklyTypedCalibratedPredictor"/> provides a weekly-typed way to access strongly-typed
+    /// <see cref="IWeaklyTypedCalibratedPredictor"/> provides a weekly-typed way to access strongly-typed
     /// <see cref="CalibratedPredictorBase{TSubPredictor, TCalibrator}.SubModelParameters"/> and
     /// <see cref="CalibratedPredictorBase{TSubPredictor, TCalibrator}.Calibrator"/>.
-    /// <see cref="IWeeklyTypedCalibratedPredictor"/> is commonly used in weekly-typed expressions. The
+    /// <see cref="IWeaklyTypedCalibratedPredictor"/> is commonly used in weekly-typed expressions. The
     /// existence of this interface is just for supporting existing codebase, so we discourage its uses.
     /// </summary>
     [BestFriend]
-    internal interface IWeeklyTypedCalibratedPredictor
+    internal interface IWeaklyTypedCalibratedPredictor
     {
         IPredictorProducing<float> WeeklyTypedSubModelParameters { get; }
         ICalibrator WeeklyTypedCalibrator { get; }
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Internal.Calibration
         ICanSaveInSourceCode,
         ICanSaveSummary,
         ICanGetSummaryInKeyValuePairs,
-        IWeeklyTypedCalibratedPredictor
+        IWeaklyTypedCalibratedPredictor
         where TSubModelParameters : class, IPredictorProducing<float>
         where TCalibrator : class, ICalibrator
     {
@@ -148,8 +148,8 @@ namespace Microsoft.ML.Internal.Calibration
         public TCalibrator Calibrator { get; }
 
         // Type-unsafed accessors of strongly-typed members.
-        IPredictorProducing<float> IWeeklyTypedCalibratedPredictor.WeeklyTypedSubModelParameters => SubModelParameters;
-        ICalibrator IWeeklyTypedCalibratedPredictor.WeeklyTypedCalibrator => Calibrator;
+        IPredictorProducing<float> IWeaklyTypedCalibratedPredictor.WeeklyTypedSubModelParameters => SubModelParameters;
+        ICalibrator IWeaklyTypedCalibratedPredictor.WeeklyTypedCalibrator => Calibrator;
 
         public PredictionKind PredictionKind => SubModelParameters.PredictionKind;
 

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -132,12 +132,15 @@ namespace Microsoft.ML.Internal.Calibration
 
     /// <summary>
     /// Class for allowing a post-processing step, defined by <see cref="Calibrator"/>, to <see cref="SubModel"/>'s
-    /// output. For example, in binary classification, <see cref="Calibrator"/> can convert support vector machine's
-    /// output value to the probability of belonging to the positive (or negative) class. Detailed math materials
-    /// can be found at <a href="https://www.csie.ntu.edu.tw/~cjlin/papers/plattprob.pdf">this paper</a>.
+    /// output.
     /// </summary>
     /// <typeparam name="TSubModel">Type being calibrated.</typeparam>
     /// <typeparam name="TCalibrator">Type used to calibrate.</typeparam>
+    /// <remarks>
+    /// For example, in binary classification, <see cref="Calibrator"/> can convert support vector machine's
+    /// output value to the probability of belonging to the positive (or negative) class. Detailed math materials
+    /// can be found at <a href="https://www.csie.ntu.edu.tw/~cjlin/papers/plattprob.pdf">this paper</a>.
+    /// </remarks>
     public abstract class CalibratedModelParametersBase<TSubModel, TCalibrator> :
         IDistPredictorProducing<float, float>,
         ICanSaveInIniFormat,

--- a/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
@@ -141,7 +141,6 @@ namespace Microsoft.ML.Training
             return MakeTransformer(pred, trainSet.Schema);
         }
 
-        [BestFriend]
         private protected abstract TModel TrainModelCore(TrainContext trainContext);
 
         protected abstract TTransformer MakeTransformer(TModel model, Schema trainSchema);

--- a/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
@@ -36,11 +36,11 @@ namespace Microsoft.ML.Ensemble.EntryPoints
                 out RoleMappedData rmd, out IPredictor predictor
 );
 
-            var calibrated = predictor as CalibratedPredictorBase;
+            var calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>;
             while (calibrated != null)
             {
                 predictor = calibrated.SubPredictor;
-                calibrated = predictor as CalibratedPredictorBase;
+                calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>;
             }
             var ensemble = predictor as SchemaBindablePipelineEnsembleBase;
             host.CheckUserArg(ensemble != null, nameof(input.PredictorModel.Predictor), "Predictor is not a pipeline ensemble predictor");

--- a/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
@@ -35,11 +35,11 @@ namespace Microsoft.ML.Ensemble.EntryPoints
                 new EmptyDataView(host, input.PredictorModel.TransformModel.InputSchema),
                 out RoleMappedData rmd, out IPredictor predictor);
 
-            var calibrated = predictor as IWeeklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
                 predictor = calibrated.WeeklyTypedSubModelParameters;
-                calibrated = predictor as IWeeklyTypedCalibratedPredictor;
+                calibrated = predictor as IWeaklyTypedCalibratedPredictor;
             }
             var ensemble = predictor as SchemaBindablePipelineEnsembleBase;
             host.CheckUserArg(ensemble != null, nameof(input.PredictorModel.Predictor), "Predictor is not a pipeline ensemble predictor");

--- a/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
@@ -33,14 +33,13 @@ namespace Microsoft.ML.Ensemble.EntryPoints
 
             input.PredictorModel.PrepareData(host,
                 new EmptyDataView(host, input.PredictorModel.TransformModel.InputSchema),
-                out RoleMappedData rmd, out IPredictor predictor
-);
+                out RoleMappedData rmd, out IPredictor predictor);
 
-            var calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>;
+            var calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
-                predictor = calibrated.SubPredictor;
-                calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>;
+                predictor = calibrated.WeeklyTypedSubPredictor;
+                calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
             }
             var ensemble = predictor as SchemaBindablePipelineEnsembleBase;
             host.CheckUserArg(ensemble != null, nameof(input.PredictorModel.Predictor), "Predictor is not a pipeline ensemble predictor");

--- a/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
@@ -35,11 +35,11 @@ namespace Microsoft.ML.Ensemble.EntryPoints
                 new EmptyDataView(host, input.PredictorModel.TransformModel.InputSchema),
                 out RoleMappedData rmd, out IPredictor predictor);
 
-            var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubModelParameters;
-                calibrated = predictor as IWeaklyTypedCalibratedPredictor;
+                predictor = calibrated.WeeklyTypedSubModel;
+                calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             }
             var ensemble = predictor as SchemaBindablePipelineEnsembleBase;
             host.CheckUserArg(ensemble != null, nameof(input.PredictorModel.Predictor), "Predictor is not a pipeline ensemble predictor");

--- a/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
@@ -35,11 +35,11 @@ namespace Microsoft.ML.Ensemble.EntryPoints
                 new EmptyDataView(host, input.PredictorModel.TransformModel.InputSchema),
                 out RoleMappedData rmd, out IPredictor predictor);
 
-            var calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
+            var calibrated = predictor as IWeeklyTypedCalibratedPredictor;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubPredictor;
-                calibrated = predictor as IHasWeeklyTypedCalibratedPredictor;
+                predictor = calibrated.WeeklyTypedSubModelParameters;
+                calibrated = predictor as IWeeklyTypedCalibratedPredictor;
             }
             var ensemble = predictor as SchemaBindablePipelineEnsembleBase;
             host.CheckUserArg(ensemble != null, nameof(input.PredictorModel.Predictor), "Predictor is not a pipeline ensemble predictor");

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -92,11 +92,11 @@ namespace Microsoft.ML.Trainers.FastTree
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
             var predictor = new FastTreeBinaryModelParameters(env, ctx);
-            ICalibrator calibrator;
-            ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
+            PlattCalibrator calibrator;
+            ctx.LoadModelOrNull<PlattCalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor(env, predictor, calibrator);
+            return new SchemaBindableCalibratedPredictor<FastTreeBinaryModelParameters,PlattCalibrator>(env, predictor, calibrator);
         }
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
@@ -104,7 +104,9 @@ namespace Microsoft.ML.Trainers.FastTree
 
     /// <include file = 'doc.xml' path='doc/members/member[@name="FastTree"]/*' />
     public sealed partial class FastTreeBinaryClassificationTrainer :
-        BoostingFastTreeTrainerBase<FastTreeBinaryClassificationTrainer.Options, BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>>, IPredictorWithFeatureWeights<float>>
+        BoostingFastTreeTrainerBase<FastTreeBinaryClassificationTrainer.Options,
+        BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>>,
+        CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>>
     {
         /// <summary>
         /// The LoadName for the assembly containing the trainer.
@@ -156,7 +158,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        private protected override IPredictorWithFeatureWeights<float> TrainModelCore(TrainContext context)
+        private protected override CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator> TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -185,7 +187,7 @@ namespace Microsoft.ML.Trainers.FastTree
             // BinaryClassificationObjectiveFunction.GetGradientInOneQuery being consistent with the
             // description in section 6 of the paper.
             var cali = new PlattCalibrator(Host, -1 * _sigmoidParameter, 0);
-            return new FeatureWeightsCalibratedPredictor(Host, pred, cali);
+            return new FeatureWeightsCalibratedPredictor<FastTreeBinaryModelParameters,PlattCalibrator>(Host, pred, cali);
         }
 
         protected override ObjectiveFunctionBase ConstructObjFunc(IChannel ch)
@@ -273,10 +275,11 @@ namespace Microsoft.ML.Trainers.FastTree
             }
         }
 
-        protected override BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>> MakeTransformer(IPredictorWithFeatureWeights<float> model, Schema trainSchema)
-        => new BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> MakeTransformer(
+            CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator> model, Schema trainSchema)
+            => new BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor<FastTreeBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedModelParameters<FastTreeBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
         }
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
@@ -105,8 +105,8 @@ namespace Microsoft.ML.Trainers.FastTree
     /// <include file = 'doc.xml' path='doc/members/member[@name="FastTree"]/*' />
     public sealed partial class FastTreeBinaryClassificationTrainer :
         BoostingFastTreeTrainerBase<FastTreeBinaryClassificationTrainer.Options,
-        BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>>,
-        CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>>
+        BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>>,
+        CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>>
     {
         /// <summary>
         /// The LoadName for the assembly containing the trainer.
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        private protected override CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> TrainModelCore(TrainContext context)
+        private protected override CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator> TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Trainers.FastTree
             // BinaryClassificationObjectiveFunction.GetGradientInOneQuery being consistent with the
             // description in section 6 of the paper.
             var cali = new PlattCalibrator(Host, -1 * _sigmoidParameter, 0);
-            return new FeatureWeightsCalibratedPredictor<FastTreeBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
+            return new FeatureWeightsCalibratedModelParameters<FastTreeBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
         }
 
         protected override ObjectiveFunctionBase ConstructObjFunc(IChannel ch)
@@ -275,11 +275,11 @@ namespace Microsoft.ML.Trainers.FastTree
             }
         }
 
-        protected override BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> MakeTransformer(
-            CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
-            => new BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> MakeTransformer(
+            CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
+            => new BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -92,11 +92,11 @@ namespace Microsoft.ML.Trainers.FastTree
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
             var predictor = new FastTreeBinaryModelParameters(env, ctx);
-            PlattCalibrator calibrator;
-            ctx.LoadModelOrNull<PlattCalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
+            ICalibrator calibrator;
+            ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor<FastTreeBinaryModelParameters,PlattCalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedPredictor<FastTreeBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
         }
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
@@ -105,8 +105,8 @@ namespace Microsoft.ML.Trainers.FastTree
     /// <include file = 'doc.xml' path='doc/members/member[@name="FastTree"]/*' />
     public sealed partial class FastTreeBinaryClassificationTrainer :
         BoostingFastTreeTrainerBase<FastTreeBinaryClassificationTrainer.Options,
-        BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>>,
-        CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>>
+        BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>>,
+        CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>>
     {
         /// <summary>
         /// The LoadName for the assembly containing the trainer.
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         public override PredictionKind PredictionKind => PredictionKind.BinaryClassification;
 
-        private protected override CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator> TrainModelCore(TrainContext context)
+        private protected override CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Trainers.FastTree
             // BinaryClassificationObjectiveFunction.GetGradientInOneQuery being consistent with the
             // description in section 6 of the paper.
             var cali = new PlattCalibrator(Host, -1 * _sigmoidParameter, 0);
-            return new FeatureWeightsCalibratedPredictor<FastTreeBinaryModelParameters,PlattCalibrator>(Host, pred, cali);
+            return new FeatureWeightsCalibratedPredictor<FastTreeBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
         }
 
         protected override ObjectiveFunctionBase ConstructObjFunc(IChannel ch)
@@ -275,11 +275,11 @@ namespace Microsoft.ML.Trainers.FastTree
             }
         }
 
-        protected override BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> MakeTransformer(
-            CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator> model, Schema trainSchema)
-            => new BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> MakeTransformer(
+            CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
+            => new BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/GamClassification.cs
+++ b/src/Microsoft.ML.FastTree/GamClassification.cs
@@ -32,8 +32,8 @@ namespace Microsoft.ML.Trainers.FastTree
 {
     public sealed class BinaryClassificationGamTrainer :
         GamTrainerBase<BinaryClassificationGamTrainer.Options,
-        BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters,PlattCalibrator>>,
-        CalibratedPredictorBase<BinaryClassificationGamModelParameters,PlattCalibrator>>
+        BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>,
+        CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>
     {
         public sealed class Options : ArgumentsBase
         {
@@ -105,13 +105,13 @@ namespace Microsoft.ML.Trainers.FastTree
             Parallel.Invoke(new ParallelOptions { MaxDegreeOfParallelism = BlockingThreadPool.NumThreads }, actions);
             return boolArray;
         }
-        private protected override CalibratedPredictorBase<BinaryClassificationGamModelParameters,PlattCalibrator> TrainModelCore(TrainContext context)
+        private protected override CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator> TrainModelCore(TrainContext context)
         {
             TrainBase(context);
             var predictor = new BinaryClassificationGamModelParameters(Host,
                 BinUpperBounds, BinEffects, MeanEffect, InputLength, FeatureMap);
             var calibrator = new PlattCalibrator(Host, -1.0 * _sigmoidParameter, 0);
-            return new CalibratedPredictor<BinaryClassificationGamModelParameters,PlattCalibrator>(Host, predictor, calibrator);
+            return new CalibratedPredictor<BinaryClassificationGamModelParameters, PlattCalibrator>(Host, predictor, calibrator);
         }
 
         protected override ObjectiveFunctionBase CreateObjectiveFunction()
@@ -140,11 +140,11 @@ namespace Microsoft.ML.Trainers.FastTree
             PruningTest = new TestHistory(validTest, PruningLossIndex);
         }
 
-        protected override BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters,PlattCalibrator>>
-            MakeTransformer(CalibratedPredictorBase<BinaryClassificationGamModelParameters,PlattCalibrator> model, Schema trainSchema)
-            => new BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters,PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>
+            MakeTransformer(CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator> model, Schema trainSchema)
+            => new BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters,PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor<BinaryClassificationGamModelParameters,ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedPredictor<BinaryClassificationGamModelParameters, ICalibrator>(env, predictor, calibrator);
         }
 
         private protected override void SaveCore(ModelSaveContext ctx)

--- a/src/Microsoft.ML.FastTree/GamClassification.cs
+++ b/src/Microsoft.ML.FastTree/GamClassification.cs
@@ -32,8 +32,8 @@ namespace Microsoft.ML.Trainers.FastTree
 {
     public sealed class BinaryClassificationGamTrainer :
         GamTrainerBase<BinaryClassificationGamTrainer.Options,
-        BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>,
-        CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>
+        BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>>,
+        CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>>
     {
         public sealed class Options : ArgumentsBase
         {
@@ -105,13 +105,13 @@ namespace Microsoft.ML.Trainers.FastTree
             Parallel.Invoke(new ParallelOptions { MaxDegreeOfParallelism = BlockingThreadPool.NumThreads }, actions);
             return boolArray;
         }
-        private protected override CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator> TrainModelCore(TrainContext context)
+        private protected override CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator> TrainModelCore(TrainContext context)
         {
             TrainBase(context);
             var predictor = new BinaryClassificationGamModelParameters(Host,
                 BinUpperBounds, BinEffects, MeanEffect, InputLength, FeatureMap);
             var calibrator = new PlattCalibrator(Host, -1.0 * _sigmoidParameter, 0);
-            return new CalibratedPredictor<BinaryClassificationGamModelParameters, PlattCalibrator>(Host, predictor, calibrator);
+            return new ValueMapperCalibratedModelParameters<BinaryClassificationGamModelParameters, PlattCalibrator>(Host, predictor, calibrator);
         }
 
         protected override ObjectiveFunctionBase CreateObjectiveFunction()
@@ -140,11 +140,11 @@ namespace Microsoft.ML.Trainers.FastTree
             PruningTest = new TestHistory(validTest, PruningLossIndex);
         }
 
-        protected override BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>
-            MakeTransformer(CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator> model, Schema trainSchema)
-            => new BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>>
+            MakeTransformer(CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator> model, Schema trainSchema)
+            => new BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor<BinaryClassificationGamModelParameters, ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedModelParameters<BinaryClassificationGamModelParameters, ICalibrator>(env, predictor, calibrator);
         }
 
         private protected override void SaveCore(ModelSaveContext ctx)

--- a/src/Microsoft.ML.FastTree/GamModelParameters.cs
+++ b/src/Microsoft.ML.FastTree/GamModelParameters.cs
@@ -876,12 +876,17 @@ namespace Microsoft.ML.Trainers.FastTree
                 LoadModelObjects(ch, true, out rawPred, true, out schema, out loader);
                 bool hadCalibrator = false;
 
-                var calibrated = rawPred as CalibratedPredictorBase<GamModelParametersBase, ICalibrator>;
+                // The rawPred has two possible types:
+                //  1. CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>
+                //  2. RegressionGamModelParameters
+                // For (1), the trained model, GamModelParametersBase, is a field we need to extract. For (2),
+                // we don't need to do anything because RegressionGamModelParameters is derived from GamModelParametersBase.
+                var calibrated = rawPred as CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>;
                 while (calibrated != null)
                 {
                     hadCalibrator = true;
-                    rawPred = calibrated.SubPredictor;
-                    calibrated = rawPred as CalibratedPredictorBase<GamModelParametersBase, ICalibrator>;
+                    rawPred = calibrated.SubModelParameters;
+                    calibrated = rawPred as CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>;
                 }
                 var pred = rawPred as GamModelParametersBase;
                 ch.CheckUserArg(pred != null, nameof(Args.InputModelFile), "Predictor was not a " + nameof(GamModelParametersBase));

--- a/src/Microsoft.ML.FastTree/GamModelParameters.cs
+++ b/src/Microsoft.ML.FastTree/GamModelParameters.cs
@@ -881,12 +881,12 @@ namespace Microsoft.ML.Trainers.FastTree
                 //  2. RegressionGamModelParameters
                 // For (1), the trained model, GamModelParametersBase, is a field we need to extract. For (2),
                 // we don't need to do anything because RegressionGamModelParameters is derived from GamModelParametersBase.
-                var calibrated = rawPred as CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>;
+                var calibrated = rawPred as CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>;
                 while (calibrated != null)
                 {
                     hadCalibrator = true;
-                    rawPred = calibrated.SubModelParameters;
-                    calibrated = rawPred as CalibratedPredictorBase<BinaryClassificationGamModelParameters, PlattCalibrator>;
+                    rawPred = calibrated.SubModel;
+                    calibrated = rawPred as CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>;
                 }
                 var pred = rawPred as GamModelParametersBase;
                 ch.CheckUserArg(pred != null, nameof(Args.InputModelFile), "Predictor was not a " + nameof(GamModelParametersBase));

--- a/src/Microsoft.ML.FastTree/GamModelParameters.cs
+++ b/src/Microsoft.ML.FastTree/GamModelParameters.cs
@@ -876,12 +876,12 @@ namespace Microsoft.ML.Trainers.FastTree
                 LoadModelObjects(ch, true, out rawPred, true, out schema, out loader);
                 bool hadCalibrator = false;
 
-                var calibrated = rawPred as CalibratedPredictorBase;
+                var calibrated = rawPred as CalibratedPredictorBase<GamModelParametersBase, ICalibrator>;
                 while (calibrated != null)
                 {
                     hadCalibrator = true;
                     rawPred = calibrated.SubPredictor;
-                    calibrated = rawPred as CalibratedPredictorBase;
+                    calibrated = rawPred as CalibratedPredictorBase<GamModelParametersBase, ICalibrator>;
                 }
                 var pred = rawPred as GamModelParametersBase;
                 ch.CheckUserArg(pred != null, nameof(Args.InputModelFile), "Predictor was not a " + nameof(GamModelParametersBase));

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -105,7 +105,7 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor<FastForestClassificationModelParameters,ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedPredictor<FastForestClassificationModelParameters, ICalibrator>(env, predictor, calibrator);
         }
     }
 

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -105,7 +105,7 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor<FastForestClassificationModelParameters, ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedModelParameters<FastForestClassificationModelParameters, ICalibrator>(env, predictor, calibrator);
         }
     }
 

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -105,13 +105,13 @@ namespace Microsoft.ML.Trainers.FastTree
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new SchemaBindableCalibratedPredictor(env, predictor, calibrator);
+            return new SchemaBindableCalibratedPredictor<FastForestClassificationModelParameters,ICalibrator>(env, predictor, calibrator);
         }
     }
 
     /// <include file='doc.xml' path='doc/members/member[@name="FastForest"]/*' />
     public sealed partial class FastForestClassification :
-        RandomForestTrainerBase<FastForestClassification.Options, BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>>, IPredictorWithFeatureWeights<float>>
+        RandomForestTrainerBase<FastForestClassification.Options, BinaryPredictionTransformer<FastForestClassificationModelParameters>, FastForestClassificationModelParameters>
     {
         public sealed class Options : FastForestArgumentsBase
         {
@@ -170,7 +170,7 @@ namespace Microsoft.ML.Trainers.FastTree
         {
         }
 
-        private protected override IPredictorWithFeatureWeights<float> TrainModelCore(TrainContext context)
+        private protected override FastForestClassificationModelParameters TrainModelCore(TrainContext context)
         {
             Host.CheckValue(context, nameof(context));
             var trainData = context.TrainingSet;
@@ -213,10 +213,10 @@ namespace Microsoft.ML.Trainers.FastTree
             return new BinaryClassificationTest(ConstructScoreTracker(TrainSet), _trainSetLabels, 1);
         }
 
-        protected override BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>> MakeTransformer(IPredictorWithFeatureWeights<float> model, Schema trainSchema)
-         => new BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<FastForestClassificationModelParameters> MakeTransformer(FastForestClassificationModelParameters model, Schema trainSchema)
+         => new BinaryPredictionTransformer<FastForestClassificationModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<FastForestClassificationModelParameters> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                 var predictor = model;
                 _host.CheckValue(predictor, nameof(models), "One of the models is null");
 
-                var calibrated = predictor as IWeeklyTypedCalibratedPredictor;
+                var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
                 double paramA = 1;
                 if (calibrated != null)
                     _host.Check(calibrated.WeeklyTypedCalibrator is PlattCalibrator,

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
@@ -51,13 +51,13 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                 var predictor = model;
                 _host.CheckValue(predictor, nameof(models), "One of the models is null");
 
-                var calibrated = predictor as IWeaklyTypedCalibratedPredictor;
+                var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
                 double paramA = 1;
                 if (calibrated != null)
                     _host.Check(calibrated.WeeklyTypedCalibrator is PlattCalibrator,
                         "Combining FastTree models can only be done when the models are calibrated with Platt calibrator");
 
-                predictor = calibrated.WeeklyTypedSubModelParameters;
+                predictor = calibrated.WeeklyTypedSubModel;
                 paramA = -((PlattCalibrator)calibrated.WeeklyTypedCalibrator).Slope;
 
                 var tree = predictor as TreeEnsembleModelParameters;
@@ -107,7 +107,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
 
                     var cali = new PlattCalibrator(_host, -1, 0);
                     var fastTreeModel = new FastTreeBinaryModelParameters(_host, ensemble, featureCount, null);
-                    return new FeatureWeightsCalibratedPredictor<FastTreeBinaryModelParameters,PlattCalibrator>(_host, fastTreeModel, cali);
+                    return new FeatureWeightsCalibratedModelParameters<FastTreeBinaryModelParameters,PlattCalibrator>(_host, fastTreeModel, cali);
                 case PredictionKind.Regression:
                     return new FastTreeRegressionModelParameters(_host, ensemble, featureCount, null);
                 case PredictionKind.Ranking:

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
@@ -4,9 +4,11 @@
 
 using System.Collections.Generic;
 using Microsoft.ML;
+using Microsoft.ML.Calibrator;
 using Microsoft.ML.Data;
 using Microsoft.ML.Ensemble;
 using Microsoft.ML.Internal.Calibration;
+using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.Trainers.FastTree.Internal;
 
 [assembly: LoadableClass(typeof(TreeEnsembleCombiner), null, typeof(SignatureModelCombiner), "Fast Tree Model Combiner", "FastTreeCombiner")]
@@ -49,7 +51,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                 var predictor = model;
                 _host.CheckValue(predictor, nameof(models), "One of the models is null");
 
-                var calibrated = predictor as CalibratedPredictorBase;
+                var calibrated = predictor as CalibratedPredictorBase<IPredictorProducing<float>,ICalibrator>;
                 double paramA = 1;
                 if (calibrated != null)
                 {
@@ -103,7 +105,7 @@ namespace Microsoft.ML.Trainers.FastTree.Internal
                         return new FastTreeBinaryModelParameters(_host, ensemble, featureCount, null);
 
                     var cali = new PlattCalibrator(_host, -1, 0);
-                    return new FeatureWeightsCalibratedPredictor(_host, new FastTreeBinaryModelParameters(_host, ensemble, featureCount, null), cali);
+                    return new FeatureWeightsCalibratedPredictor<IPredictorWithFeatureWeights<float>,ICalibrator>(_host, new FastTreeBinaryModelParameters(_host, ensemble, featureCount, null), cali);
                 case PredictionKind.Regression:
                     return new FastTreeRegressionModelParameters(_host, ensemble, featureCount, null);
                 case PredictionKind.Ranking:

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -587,7 +587,7 @@ namespace Microsoft.ML.Data
                     Contracts.Assert(data.Schema.Feature.HasValue);
 
                     // Make sure that the given predictor has the correct number of input features.
-                    if (predictor is IWeeklyTypedCalibratedPredictor calibrated)
+                    if (predictor is IWeaklyTypedCalibratedPredictor calibrated)
                         predictor = calibrated.WeeklyTypedSubModelParameters;
                     // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                     // be non-null.

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -366,8 +366,8 @@ namespace Microsoft.ML.Data
             _host.CheckValue(args, nameof(args));
             _host.CheckValue(predictor, nameof(predictor));
 
-            if (predictor is CalibratedPredictorBase)
-                predictor = ((CalibratedPredictorBase)predictor).SubPredictor;
+            if (predictor is CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
+                predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubPredictor;
             _ensemble = predictor as TreeEnsembleModelParameters;
             _host.Check(_ensemble != null, "Predictor in model file does not have compatible type");
 
@@ -581,8 +581,8 @@ namespace Microsoft.ML.Data
                     Contracts.Assert(data.Schema.Feature.HasValue);
 
                     // Make sure that the given predictor has the correct number of input features.
-                    if (predictor is CalibratedPredictorBase)
-                        predictor = ((CalibratedPredictorBase)predictor).SubPredictor;
+                    if (predictor is CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
+                        predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubPredictor;
                     // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                     // be non-null.
                     var vm = predictor as IValueMapper;
@@ -646,8 +646,8 @@ namespace Microsoft.ML.Data
                 ch.Assert(predictor == predictor2);
 
                 // Make sure that the given predictor has the correct number of input features.
-                if (predictor is CalibratedPredictorBase)
-                    predictor = ((CalibratedPredictorBase)predictor).SubPredictor;
+                if (predictor is CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
+                    predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubPredictor;
                 // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                 // be non-null.
                 var vm = predictor as IValueMapper;

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -372,8 +372,8 @@ namespace Microsoft.ML.Data
             //  3. FastTreeRegressionModelParameters
             //  4. FastTreeTweedieModelParameters
             // Only (1) needs a special cast right below because all others are derived from TreeEnsembleModelParameters.
-            if (predictor is CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> calibrated)
-                predictor = calibrated.SubModelParameters;
+            if (predictor is CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator> calibrated)
+                predictor = calibrated.SubModel;
             _ensemble = predictor as TreeEnsembleModelParameters;
             _host.Check(_ensemble != null, "Predictor in model file does not have compatible type");
 
@@ -587,8 +587,8 @@ namespace Microsoft.ML.Data
                     Contracts.Assert(data.Schema.Feature.HasValue);
 
                     // Make sure that the given predictor has the correct number of input features.
-                    if (predictor is IWeaklyTypedCalibratedPredictor calibrated)
-                        predictor = calibrated.WeeklyTypedSubModelParameters;
+                    if (predictor is IWeaklyTypedCalibratedModelParameters calibrated)
+                        predictor = calibrated.WeeklyTypedSubModel;
                     // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                     // be non-null.
                     var vm = predictor as IValueMapper;
@@ -652,8 +652,8 @@ namespace Microsoft.ML.Data
                 ch.Assert(predictor == predictor2);
 
                 // Make sure that the given predictor has the correct number of input features.
-                if (predictor is CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
-                    predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubModelParameters;
+                if (predictor is CalibratedModelParametersBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
+                    predictor = ((CalibratedModelParametersBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubModel;
                 // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                 // be non-null.
                 var vm = predictor as IValueMapper;

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -366,8 +366,8 @@ namespace Microsoft.ML.Data
             _host.CheckValue(args, nameof(args));
             _host.CheckValue(predictor, nameof(predictor));
 
-            if (predictor is CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
-                predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubPredictor;
+            if (predictor is CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>)
+                predictor = ((CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>)predictor).SubPredictor;
             _ensemble = predictor as TreeEnsembleModelParameters;
             _host.Check(_ensemble != null, "Predictor in model file does not have compatible type");
 

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -366,8 +366,14 @@ namespace Microsoft.ML.Data
             _host.CheckValue(args, nameof(args));
             _host.CheckValue(predictor, nameof(predictor));
 
-            if (predictor is CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>)
-                predictor = ((CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>)predictor).SubPredictor;
+            // This function accepts models trained by FastTreeTrainer family. There are four types that "predictor" can be.
+            //  1. CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>
+            //  2. FastTreeRankingModelParameters
+            //  3. FastTreeRegressionModelParameters
+            //  4. FastTreeTweedieModelParameters
+            // Only (1) needs a special cast right below because all others are derived from TreeEnsembleModelParameters.
+            if (predictor is CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> calibrated)
+                predictor = calibrated.SubModelParameters;
             _ensemble = predictor as TreeEnsembleModelParameters;
             _host.Check(_ensemble != null, "Predictor in model file does not have compatible type");
 
@@ -581,8 +587,8 @@ namespace Microsoft.ML.Data
                     Contracts.Assert(data.Schema.Feature.HasValue);
 
                     // Make sure that the given predictor has the correct number of input features.
-                    if (predictor is CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
-                        predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubPredictor;
+                    if (predictor is IWeeklyTypedCalibratedPredictor calibrated)
+                        predictor = calibrated.WeeklyTypedSubModelParameters;
                     // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                     // be non-null.
                     var vm = predictor as IValueMapper;
@@ -647,7 +653,7 @@ namespace Microsoft.ML.Data
 
                 // Make sure that the given predictor has the correct number of input features.
                 if (predictor is CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)
-                    predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubPredictor;
+                    predictor = ((CalibratedPredictorBase<IPredictorProducing<float>, Calibrator.ICalibrator>)predictor).SubModelParameters;
                 // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                 // be non-null.
                 var vm = predictor as IValueMapper;
@@ -661,7 +667,7 @@ namespace Microsoft.ML.Data
 
                 ISchemaBindableMapper bindable = new TreeEnsembleFeaturizerBindableMapper(env, scorerArgs, predictor);
                 var bound = bindable.Bind(env, data.Schema);
-               return new GenericScorer(env, scorerArgs, data.Data, bound, data.Schema);
+                return new GenericScorer(env, scorerArgs, data.Data, bound, data.Schema);
             }
         }
 

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -31,7 +31,7 @@ using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML.Trainers.SymSgd
 {
-    using TPredictor = CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>;
+    using TPredictor = CalibratedModelParametersBase<LinearBinaryModelParameters,PlattCalibrator>;
 
     /// <include file='doc.xml' path='doc/members/member[@name="SymSGD"]/*' />
     public sealed class SymSgdClassificationTrainer : TrainerEstimatorBase<BinaryPredictionTransformer<TPredictor>, TPredictor>
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Trainers.SymSgd
                 var initPred = context.InitialPredictor;
                 var linearInitPred = initPred as LinearModelParameters;
                 if (linearInitPred == null)
-                    linearInitPred = ((initPred as IWeaklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters) as LinearModelParameters;
+                    linearInitPred = ((initPred as IWeaklyTypedCalibratedModelParameters)?.WeeklyTypedSubModel) as LinearModelParameters;
 
                 // If initial predictor is set, it must be a linear model or calibrated linear model. Otherwise, we throw.
                 // If initPred is null (i.e., not set), the following check will always be bypassed.
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Trainers.SymSgd
             VBufferUtils.CreateMaybeSparseCopy(in weights, ref maybeSparseWeights,
                 Conversions.Instance.GetIsDefaultPredicate<float>(NumberType.R4));
             var predictor = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias);
-            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
+            return new ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters,PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
         }
 
         protected override BinaryPredictionTransformer<TPredictor> MakeTransformer(TPredictor model, Schema trainSchema)

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Trainers.SymSgd
                 var initPred = context.InitialPredictor;
                 var linearInitPred = initPred as LinearModelParameters;
                 if (linearInitPred == null)
-                    linearInitPred = ((initPred as IWeeklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters) as LinearModelParameters;
+                    linearInitPred = ((initPred as IWeaklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters) as LinearModelParameters;
 
                 // If initial predictor is set, it must be a linear model or calibrated linear model. Otherwise, we throw.
                 // If initPred is null (i.e., not set), the following check will always be bypassed.

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -31,7 +31,7 @@ using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML.Trainers.SymSgd
 {
-    using TPredictor = IPredictorWithFeatureWeights<float>;
+    using TPredictor = CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>;
 
     /// <include file='doc.xml' path='doc/members/member[@name="SymSGD"]/*' />
     public sealed class SymSgdClassificationTrainer : TrainerEstimatorBase<BinaryPredictionTransformer<TPredictor>, TPredictor>
@@ -173,9 +173,9 @@ namespace Microsoft.ML.Trainers.SymSgd
                 var linearInitPred = initPred as LinearModelParameters;
                 if (initPred is CalibratedPredictorBase<LinearModelParameters,PlattCalibrator> calibrated)
                     linearInitPred = calibrated.SubPredictor;
-                else if (initPred is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> mixed)
+                else if (initPred is CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator> mixed)
                     linearInitPred = mixed.SubPredictor;
-                else
+
                 Host.CheckParam(context.InitialPredictor == null || linearInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");
                 return TrainCore(ch, preparedData, linearInitPred, weightSetCount);

--- a/src/Microsoft.ML.LightGBM.StaticPipe/LightGbmStaticExtensions.cs
+++ b/src/Microsoft.ML.LightGBM.StaticPipe/LightGbmStaticExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
+using Microsoft.ML.Internal.Calibration;
 using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.StaticPipe;
 using Microsoft.ML.StaticPipe.Runtime;
@@ -130,7 +131,7 @@ namespace Microsoft.ML.LightGBM.StaticPipe
             int? minDataPerLeaf = null,
             double? learningRate = null,
             int numBoostRound = Options.Defaults.NumBoostRound,
-            Action<IPredictorWithFeatureWeights<float>> onFit = null)
+            Action<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, minDataPerLeaf, learningRate, numBoostRound, onFit);
 
@@ -167,7 +168,7 @@ namespace Microsoft.ML.LightGBM.StaticPipe
         public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel) LightGbm(this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
             Scalar<bool> label, Vector<float> features, Scalar<float> weights,
             Options options,
-            Action<IPredictorWithFeatureWeights<float>> onFit = null)
+            Action<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             CheckUserValues(label, features, weights, options, onFit);
 

--- a/src/Microsoft.ML.LightGBM.StaticPipe/LightGbmStaticExtensions.cs
+++ b/src/Microsoft.ML.LightGBM.StaticPipe/LightGbmStaticExtensions.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.LightGBM.StaticPipe
             int? minDataPerLeaf = null,
             double? learningRate = null,
             int numBoostRound = Options.Defaults.NumBoostRound,
-            Action<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>> onFit = null)
+            Action<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, minDataPerLeaf, learningRate, numBoostRound, onFit);
 
@@ -168,7 +168,7 @@ namespace Microsoft.ML.LightGBM.StaticPipe
         public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel) LightGbm(this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
             Scalar<bool> label, Vector<float> features, Scalar<float> weights,
             Options options,
-            Action<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>> onFit = null)
+            Action<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             CheckUserValues(label, features, weights, options, onFit);
 

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -81,12 +81,14 @@ namespace Microsoft.ML.LightGBM
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new CalibratedPredictor<LightGbmBinaryModelParameters,ICalibrator>(env, predictor, calibrator);
+            return new CalibratedPredictor<LightGbmBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
         }
     }
 
     /// <include file='doc.xml' path='doc/members/member[@name="LightGBM"]/*' />
-    public sealed class LightGbmBinaryTrainer : LightGbmTrainerBase<float, BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>>, IPredictorWithFeatureWeights<float>>
+    public sealed class LightGbmBinaryTrainer : LightGbmTrainerBase<float,
+        BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>,
+        CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>
     {
         internal const string UserName = "LightGBM Binary Classifier";
         internal const string LoadNameValue = "LightGBMBinary";
@@ -123,13 +125,13 @@ namespace Microsoft.ML.LightGBM
         {
         }
 
-        private protected override IPredictorWithFeatureWeights<float> CreatePredictor()
+        private protected override CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator> CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);
             var pred = new LightGbmBinaryModelParameters(Host, TrainedEnsemble, FeatureCount, innerArgs);
             var cali = new PlattCalibrator(Host, -0.5, 0);
-            return new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters,PlattCalibrator>(Host, pred, cali);
+            return new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
         }
 
         private protected override void CheckDataValid(IChannel ch, RoleMappedData data)
@@ -162,10 +164,11 @@ namespace Microsoft.ML.LightGBM
             };
         }
 
-        protected override BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>> MakeTransformer(IPredictorWithFeatureWeights<float> model, Schema trainSchema)
-         => new BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>
+            MakeTransformer(CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
+         => new BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.LightGBM
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new CalibratedPredictor(env, predictor, calibrator);
+            return new CalibratedPredictor<LightGbmBinaryModelParameters,ICalibrator>(env, predictor, calibrator);
         }
     }
 
@@ -129,7 +129,7 @@ namespace Microsoft.ML.LightGBM
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);
             var pred = new LightGbmBinaryModelParameters(Host, TrainedEnsemble, FeatureCount, innerArgs);
             var cali = new PlattCalibrator(Host, -0.5, 0);
-            return new FeatureWeightsCalibratedPredictor(Host, pred, cali);
+            return new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters,PlattCalibrator>(Host, pred, cali);
         }
 
         private protected override void CheckDataValid(IChannel ch, RoleMappedData data)

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -81,14 +81,14 @@ namespace Microsoft.ML.LightGBM
             ctx.LoadModelOrNull<ICalibrator, SignatureLoadModel>(env, out calibrator, @"Calibrator");
             if (calibrator == null)
                 return predictor;
-            return new CalibratedPredictor<LightGbmBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
+            return new ValueMapperCalibratedModelParameters<LightGbmBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
         }
     }
 
     /// <include file='doc.xml' path='doc/members/member[@name="LightGBM"]/*' />
     public sealed class LightGbmBinaryTrainer : LightGbmTrainerBase<float,
-        BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>,
-        CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>
+        BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>>,
+        CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>>
     {
         internal const string UserName = "LightGBM Binary Classifier";
         internal const string LoadNameValue = "LightGBMBinary";
@@ -125,13 +125,13 @@ namespace Microsoft.ML.LightGBM
         {
         }
 
-        private protected override CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator> CreatePredictor()
+        private protected override CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator> CreatePredictor()
         {
             Host.Check(TrainedEnsemble != null, "The predictor cannot be created before training is complete");
             var innerArgs = LightGbmInterfaceUtils.JoinParameters(Options);
             var pred = new LightGbmBinaryModelParameters(Host, TrainedEnsemble, FeatureCount, innerArgs);
             var cali = new PlattCalibrator(Host, -0.5, 0);
-            return new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
+            return new FeatureWeightsCalibratedModelParameters<LightGbmBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
         }
 
         private protected override void CheckDataValid(IChannel ch, RoleMappedData data)
@@ -164,11 +164,11 @@ namespace Microsoft.ML.LightGBM
             };
         }
 
-        protected override BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>
-            MakeTransformer(CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
-         => new BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>>
+            MakeTransformer(CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
+         => new BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.LightGBM
             {
                 var pred = CreateBinaryPredictor(i, innerArgs);
                 var cali = new PlattCalibrator(Host, -0.5, 0);
-                predictors[i] = new FeatureWeightsCalibratedPredictor(Host, pred, cali);
+                predictors[i] = new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters,PlattCalibrator>(Host, pred, cali);
             }
             string obj = (string)GetGbmParameters()["objective"];
             if (obj == "multiclass")

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.LightGBM
             {
                 var pred = CreateBinaryPredictor(i, innerArgs);
                 var cali = new PlattCalibrator(Host, -0.5, 0);
-                predictors[i] = new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
+                predictors[i] = new FeatureWeightsCalibratedModelParameters<LightGbmBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
             }
             string obj = (string)GetGbmParameters()["objective"];
             if (obj == "multiclass")

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.LightGBM
             {
                 var pred = CreateBinaryPredictor(i, innerArgs);
                 var cali = new PlattCalibrator(Host, -0.5, 0);
-                predictors[i] = new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters,PlattCalibrator>(Host, pred, cali);
+                predictors[i] = new FeatureWeightsCalibratedPredictor<LightGbmBinaryModelParameters, PlattCalibrator>(Host, pred, cali);
             }
             string obj = (string)GetGbmParameters()["objective"];
             if (obj == "multiclass")

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
@@ -467,8 +467,8 @@ namespace Microsoft.ML.Learners
             if (calibrator == null)
                 return predictor;
             if (calibrator is IParameterMixer)
-                return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,ICalibrator>(env, predictor, calibrator);
-            return new SchemaBindableCalibratedPredictor<LinearBinaryModelParameters,ICalibrator>(env, predictor, calibrator);
+                return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedPredictor<LinearBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
         }
 
         private protected override void SaveCore(ModelSaveContext ctx)
@@ -546,8 +546,8 @@ namespace Microsoft.ML.Learners
 
     public abstract class RegressionModelParameters : LinearModelParameters
     {
-       public RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<float> weights, float bias)
-            : base(env, name, in weights, bias)
+        public RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<float> weights, float bias)
+             : base(env, name, in weights, bias)
         {
         }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
@@ -467,8 +467,8 @@ namespace Microsoft.ML.Learners
             if (calibrator == null)
                 return predictor;
             if (calibrator is IParameterMixer)
-                return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
-            return new SchemaBindableCalibratedPredictor<LinearBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
+                return new ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedModelParameters<LinearBinaryModelParameters, ICalibrator>(env, predictor, calibrator);
         }
 
         private protected override void SaveCore(ModelSaveContext ctx)

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
@@ -467,8 +467,8 @@ namespace Microsoft.ML.Learners
             if (calibrator == null)
                 return predictor;
             if (calibrator is IParameterMixer)
-                return new ParameterMixingCalibratedPredictor(env, predictor, calibrator);
-            return new SchemaBindableCalibratedPredictor(env, predictor, calibrator);
+                return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,ICalibrator>(env, predictor, calibrator);
+            return new SchemaBindableCalibratedPredictor<LinearBinaryModelParameters,ICalibrator>(env, predictor, calibrator);
         }
 
         private protected override void SaveCore(ModelSaveContext ctx)

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -32,8 +32,8 @@ namespace Microsoft.ML.Learners
     /// <include file='doc.xml' path='doc/members/member[@name="LBFGS"]/*' />
     /// <include file='doc.xml' path='docs/members/example[@name="LogisticRegressionBinaryClassifier"]/*' />
     public sealed partial class LogisticRegression : LbfgsTrainerBase<LogisticRegression.Options,
-        BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>,
-        CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>
+        BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>,
+        CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>
     {
         public const string LoadNameValue = "LogisticRegression";
         internal const string UserNameValue = "Logistic Regression";
@@ -124,11 +124,11 @@ namespace Microsoft.ML.Learners
             };
         }
 
-        protected override BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>
-            MakeTransformer(CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
-            => new BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>
+            MakeTransformer(CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> model, Schema trainSchema)
+            => new BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IPredictor initialPredictor = null)
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IPredictor initialPredictor = null)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         protected override float AccumulateOneGradient(in VBuffer<float> feat, float label, float weight,
@@ -381,16 +381,16 @@ namespace Microsoft.ML.Learners
             return opt;
         }
 
-        protected override VBuffer<float> InitializeWeightsFromPredictor(CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> srcPredictor)
+        protected override VBuffer<float> InitializeWeightsFromPredictor(CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> srcPredictor)
         {
             Contracts.AssertValue(srcPredictor);
 
-            var pred = srcPredictor.SubModelParameters as LinearBinaryModelParameters;
+            var pred = srcPredictor.SubModel as LinearBinaryModelParameters;
             Contracts.AssertValue(pred);
             return InitializeWeights(pred.Weights, new[] { pred.Bias });
         }
 
-        protected override CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> CreatePredictor()
+        protected override CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> CreatePredictor()
         {
             // Logistic regression is naturally calibrated to
             // output probabilities when transformed using
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Learners
             float bias = 0;
             CurrentWeights.GetItemOrDefault(0, ref bias);
             CurrentWeights.CopyTo(ref weights, 1, CurrentWeights.Length - 1);
-            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>(Host,
+            return new ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, PlattCalibrator>(Host,
                 new LinearBinaryModelParameters(Host, in weights, bias, _stats),
                 new PlattCalibrator(Host, -1, 0));
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -31,7 +31,9 @@ namespace Microsoft.ML.Learners
 
     /// <include file='doc.xml' path='doc/members/member[@name="LBFGS"]/*' />
     /// <include file='doc.xml' path='docs/members/example[@name="LogisticRegressionBinaryClassifier"]/*' />
-    public sealed partial class LogisticRegression : LbfgsTrainerBase<LogisticRegression.Options, BinaryPredictionTransformer<ParameterMixingCalibratedPredictor>, ParameterMixingCalibratedPredictor>
+    public sealed partial class LogisticRegression : LbfgsTrainerBase<LogisticRegression.Options,
+        BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>,
+        ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>
     {
         public const string LoadNameValue = "LogisticRegression";
         internal const string UserNameValue = "Logistic Regression";
@@ -122,10 +124,11 @@ namespace Microsoft.ML.Learners
             };
         }
 
-        protected override BinaryPredictionTransformer<ParameterMixingCalibratedPredictor> MakeTransformer(ParameterMixingCalibratedPredictor model, Schema trainSchema)
-            => new BinaryPredictionTransformer<ParameterMixingCalibratedPredictor>(Host, model, trainSchema, FeatureColumn.Name);
+        protected override BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>
+            MakeTransformer(ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> model, Schema trainSchema)
+            => new BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<ParameterMixingCalibratedPredictor> Train(IDataView trainData, IPredictor initialPredictor = null)
+        public BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>> Train(IDataView trainData, IPredictor initialPredictor = null)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         protected override float AccumulateOneGradient(in VBuffer<float> feat, float label, float weight,
@@ -378,7 +381,7 @@ namespace Microsoft.ML.Learners
             return opt;
         }
 
-        protected override VBuffer<float> InitializeWeightsFromPredictor(ParameterMixingCalibratedPredictor srcPredictor)
+        protected override VBuffer<float> InitializeWeightsFromPredictor(ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> srcPredictor)
         {
             Contracts.AssertValue(srcPredictor);
 
@@ -387,7 +390,7 @@ namespace Microsoft.ML.Learners
             return InitializeWeights(pred.Weights, new[] { pred.Bias });
         }
 
-        protected override ParameterMixingCalibratedPredictor CreatePredictor()
+        protected override ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> CreatePredictor()
         {
             // Logistic regression is naturally calibrated to
             // output probabilities when transformed using
@@ -397,7 +400,7 @@ namespace Microsoft.ML.Learners
             float bias = 0;
             CurrentWeights.GetItemOrDefault(0, ref bias);
             CurrentWeights.CopyTo(ref weights, 1, CurrentWeights.Length - 1);
-            return new ParameterMixingCalibratedPredictor(Host,
+            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>(Host,
                 new LinearBinaryModelParameters(Host, in weights, bias, _stats),
                 new PlattCalibrator(Host, -1, 0));
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -253,14 +253,19 @@ namespace Microsoft.ML.Trainers.Online
         {
             Host.CheckValue(context, nameof(context));
             var initPredictor = context.InitialPredictor;
-            LinearModelParameters initLinearPred = null;
-            if (initPredictor is LinearModelParameters)
-                initLinearPred = (LinearModelParameters)initPredictor;
-            else if (initPredictor is CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>)
-                initLinearPred = ((CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>)initPredictor).SubPredictor;
-            Host.CheckParam(initPredictor == null || initLinearPred != null, nameof(context), "Not a linear predictor.");
-            var data = context.TrainingSet;
 
+            if (initPredictor is LinearModelParameters initLinearPred)
+                initLinearPred = (LinearModelParameters)initPredictor;
+            else if (initPredictor is CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> calibrated)
+                initLinearPred = calibrated.SubModelParameters;
+            else
+            {
+                initLinearPred = null;
+                Host.CheckParam(initPredictor == null || initLinearPred != null, nameof(context),
+                    "Initial predictor was not a linear predictor.");
+            }
+
+            var data = context.TrainingSet;
             data.CheckFeatureFloatVector(out int numFeatures);
             CheckLabels(data);
 

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -256,8 +256,8 @@ namespace Microsoft.ML.Trainers.Online
 
             if (initPredictor is LinearModelParameters initLinearPred)
                 initLinearPred = (LinearModelParameters)initPredictor;
-            else if (initPredictor is CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> calibrated)
-                initLinearPred = calibrated.SubModelParameters;
+            else if (initPredictor is CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> calibrated)
+                initLinearPred = calibrated.SubModel;
             else
             {
                 initLinearPred = null;

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -253,7 +253,11 @@ namespace Microsoft.ML.Trainers.Online
         {
             Host.CheckValue(context, nameof(context));
             var initPredictor = context.InitialPredictor;
-            var initLinearPred = initPredictor as LinearModelParameters ?? (initPredictor as CalibratedPredictorBase<LinearModelParameters, Calibrator.ICalibrator>)?.SubPredictor;
+            LinearModelParameters initLinearPred = null;
+            if (initPredictor is LinearModelParameters)
+                initLinearPred = (LinearModelParameters)initPredictor;
+            else if (initPredictor is CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>)
+                initLinearPred = ((CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>)initPredictor).SubPredictor;
             Host.CheckParam(initPredictor == null || initLinearPred != null, nameof(context), "Not a linear predictor.");
             var data = context.TrainingSet;
 

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -253,7 +253,7 @@ namespace Microsoft.ML.Trainers.Online
         {
             Host.CheckValue(context, nameof(context));
             var initPredictor = context.InitialPredictor;
-            var initLinearPred = initPredictor as LinearModelParameters ?? (initPredictor as CalibratedPredictorBase)?.SubPredictor as LinearModelParameters;
+            var initLinearPred = initPredictor as LinearModelParameters ?? (initPredictor as CalibratedPredictorBase<LinearModelParameters, Calibrator.ICalibrator>)?.SubPredictor;
             Host.CheckParam(initPredictor == null || initLinearPred != null, nameof(context), "Not a linear predictor.");
             var data = context.TrainingSet;
 

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Trainers
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as CalibratedPredictorBase<LinearModelParameters,PlattCalibrator>)?.SubPredictor as LinearModelParameters;
+                var linInitPred = (initPred as IHasWeeklyTypedCalibratedPredictor)?.WeeklyTypedSubPredictor as LinearModelParameters;
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Trainers
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as IWeeklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
+                var linInitPred = (initPred as IWeaklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Trainers
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as IWeaklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
+                var linInitPred = (initPred as IWeaklyTypedCalibratedModelParameters)?.WeeklyTypedSubModel as LinearModelParameters;
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");
@@ -1561,7 +1561,7 @@ namespace Microsoft.ML.Trainers
             var predictor = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias[0]);
             if (Info.NeedCalibration)
                 return predictor;
-            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
+            return new ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
         }
 
         private protected override float GetInstanceWeight(FloatLabelCursor cursor)
@@ -1931,7 +1931,7 @@ namespace Microsoft.ML.Trainers
             var pred = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias);
             if (!(_loss is LogLoss))
                 return pred;
-            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>(Host, pred, new PlattCalibrator(Host, -1, 0));
+            return new ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, PlattCalibrator>(Host, pred, new PlattCalibrator(Host, -1, 0));
         }
 
         private protected override void CheckLabel(RoleMappedData examples, out int weightSetCount)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Trainers
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearModelParameters;
+                var linInitPred = (initPred as CalibratedPredictorBase<LinearModelParameters,PlattCalibrator>)?.SubPredictor as LinearModelParameters;
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");
@@ -1561,7 +1561,7 @@ namespace Microsoft.ML.Trainers
             var predictor = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias[0]);
             if (Info.NeedCalibration)
                 return predictor;
-            return new ParameterMixingCalibratedPredictor(Host, predictor, new PlattCalibrator(Host, -1, 0));
+            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
         }
 
         private protected override float GetInstanceWeight(FloatLabelCursor cursor)
@@ -1931,7 +1931,7 @@ namespace Microsoft.ML.Trainers
             var pred = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias);
             if (!(_loss is LogLoss))
                 return pred;
-            return new ParameterMixingCalibratedPredictor(Host, pred, new PlattCalibrator(Host, -1, 0));
+            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>(Host, pred, new PlattCalibrator(Host, -1, 0));
         }
 
         private protected override void CheckLabel(RoleMappedData examples, out int weightSetCount)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Trainers
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as IHasWeeklyTypedCalibratedPredictor)?.WeeklyTypedSubPredictor as LinearModelParameters;
+                var linInitPred = (initPred as IWeeklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");
@@ -1561,7 +1561,7 @@ namespace Microsoft.ML.Trainers
             var predictor = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias[0]);
             if (Info.NeedCalibration)
                 return predictor;
-            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
+            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>(Host, predictor, new PlattCalibrator(Host, -1, 0));
         }
 
         private protected override float GetInstanceWeight(FloatLabelCursor cursor)
@@ -1931,7 +1931,7 @@ namespace Microsoft.ML.Trainers
             var pred = new LinearBinaryModelParameters(Host, in maybeSparseWeights, bias);
             if (!(_loss is LogLoss))
                 return pred;
-            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>(Host, pred, new PlattCalibrator(Host, -1, 0));
+            return new ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>(Host, pred, new PlattCalibrator(Host, -1, 0));
         }
 
         private protected override void CheckLabel(RoleMappedData examples, out int weightSetCount)

--- a/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Learners
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
                 // Try extract linear model from calibrated predictor.
-                var linInitPred = (initPred as IWeaklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
+                var linInitPred = (initPred as IWeaklyTypedCalibratedModelParameters)?.WeeklyTypedSubModel as LinearModelParameters;
                 // If the initial predictor is not calibrated, it should be a linear model.
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),

--- a/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
@@ -36,7 +36,9 @@ namespace Microsoft.ML.Learners
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as CalibratedPredictorBase<LinearModelParameters, Calibrator.ICalibrator>)?.SubPredictor;
+                // Try extract linear model from calibrated predictor.
+                var linInitPred = (initPred as IWeeklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
+                // If the initial predictor is not calibrated, it should be a linear model.
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");

--- a/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Learners
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
                 // Try extract linear model from calibrated predictor.
-                var linInitPred = (initPred as IWeeklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
+                var linInitPred = (initPred as IWeaklyTypedCalibratedPredictor)?.WeeklyTypedSubModelParameters as LinearModelParameters;
                 // If the initial predictor is not calibrated, it should be a linear model.
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),

--- a/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Learners
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as CalibratedPredictorBase)?.SubPredictor as LinearModelParameters;
+                var linInitPred = (initPred as CalibratedPredictorBase<LinearModelParameters, Calibrator.ICalibrator>)?.SubPredictor;
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");

--- a/src/Microsoft.ML.StaticPipe/LbfgsStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/LbfgsStatic.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.StaticPipe
             float optimizationTolerance = Options.Defaults.OptTol,
             int memorySize = Options.Defaults.MemorySize,
             bool enoforceNoNegativity = Options.Defaults.EnforceNonNegativity,
-            Action<CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
+            Action<CalibratedModelParametersBase<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             LbfgsStaticUtils.ValidateParams(label, features, weights, l1Weight, l2Weight, optimizationTolerance, memorySize, enoforceNoNegativity, onFit);
 
@@ -84,7 +84,7 @@ namespace Microsoft.ML.StaticPipe
             Vector<float> features,
             Scalar<float> weights,
             Options options,
-            Action<CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
+            Action<CalibratedModelParametersBase<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));

--- a/src/Microsoft.ML.StaticPipe/LbfgsStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/LbfgsStatic.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.StaticPipe
             float optimizationTolerance = Options.Defaults.OptTol,
             int memorySize = Options.Defaults.MemorySize,
             bool enoforceNoNegativity = Options.Defaults.EnforceNonNegativity,
-            Action<ParameterMixingCalibratedPredictor> onFit = null)
+            Action<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             LbfgsStaticUtils.ValidateParams(label, features, weights, l1Weight, l2Weight, optimizationTolerance, memorySize, enoforceNoNegativity, onFit);
 
@@ -84,7 +84,7 @@ namespace Microsoft.ML.StaticPipe
             Vector<float> features,
             Scalar<float> weights,
             Options options,
-            Action<ParameterMixingCalibratedPredictor> onFit = null)
+            Action<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));

--- a/src/Microsoft.ML.StaticPipe/LbfgsStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/LbfgsStatic.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.StaticPipe
             float optimizationTolerance = Options.Defaults.OptTol,
             int memorySize = Options.Defaults.MemorySize,
             bool enoforceNoNegativity = Options.Defaults.EnforceNonNegativity,
-            Action<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
+            Action<CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             LbfgsStaticUtils.ValidateParams(label, features, weights, l1Weight, l2Weight, optimizationTolerance, memorySize, enoforceNoNegativity, onFit);
 
@@ -84,7 +84,7 @@ namespace Microsoft.ML.StaticPipe
             Vector<float> features,
             Scalar<float> weights,
             Options options,
-            Action<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
+            Action<CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));

--- a/src/Microsoft.ML.StaticPipe/SdcaStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/SdcaStaticExtensions.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ML.StaticPipe
                     float? l2Const = null,
                     float? l1Threshold = null,
                     int? maxIterations = null,
-                    Action<LinearBinaryModelParameters, ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
+                    Action<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -161,10 +161,8 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             // Under the default log-loss we assume a calibrated predictor.
-                            var model = trans.Model;
-                            var cali = (ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>)model;
-                            var pred = cali.SubPredictor;
-                            onFit(pred, cali);
+                            var pred = trans.Model;
+                            onFit((CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>)pred);
                         });
                     }
                     return trainer;
@@ -198,7 +196,7 @@ namespace Microsoft.ML.StaticPipe
                     this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
                     Scalar<bool> label, Vector<float> features, Scalar<float> weights,
                     SdcaBinaryTrainer.Options options,
-                    Action<LinearBinaryModelParameters, ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
+                    Action<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -218,10 +216,8 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             // Under the default log-loss we assume a calibrated predictor.
-                            var model = trans.Model;
-                            var cali = (ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>)model;
-                            var pred = cali.SubPredictor;
-                            onFit(pred, cali);
+                            var pred = trans.Model;
+                            onFit((ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>)pred);
                         });
                     }
                     return trainer;
@@ -281,8 +277,8 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             var model = trans.Model;
-                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, Calibrator.ICalibrator> cali)
-                                onFit(cali.SubPredictor);
+                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator> cali)
+                                onFit(cali.SubModelParameters);
                             else
                                 onFit((LinearBinaryModelParameters)model);
                         });
@@ -340,8 +336,8 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             var model = trans.Model;
-                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> cali)
-                                onFit((LinearBinaryModelParameters)cali.SubPredictor);
+                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator> cali)
+                                onFit(cali.SubModelParameters);
                             else
                                 onFit((LinearBinaryModelParameters)model);
                         });

--- a/src/Microsoft.ML.StaticPipe/SdcaStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/SdcaStaticExtensions.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ML.StaticPipe
                     float? l2Const = null,
                     float? l1Threshold = null,
                     int? maxIterations = null,
-                    Action<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
+                    Action<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -162,7 +162,7 @@ namespace Microsoft.ML.StaticPipe
                         {
                             // Under the default log-loss we assume a calibrated predictor.
                             var pred = trans.Model;
-                            onFit((CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>)pred);
+                            onFit((CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>)pred);
                         });
                     }
                     return trainer;
@@ -196,7 +196,7 @@ namespace Microsoft.ML.StaticPipe
                     this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
                     Scalar<bool> label, Vector<float> features, Scalar<float> weights,
                     SdcaBinaryTrainer.Options options,
-                    Action<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
+                    Action<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -217,7 +217,7 @@ namespace Microsoft.ML.StaticPipe
                         {
                             // Under the default log-loss we assume a calibrated predictor.
                             var pred = trans.Model;
-                            onFit((ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>)pred);
+                            onFit((ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, PlattCalibrator>)pred);
                         });
                     }
                     return trainer;
@@ -277,8 +277,8 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             var model = trans.Model;
-                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator> cali)
-                                onFit(cali.SubModelParameters);
+                            if (model is ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, PlattCalibrator> cali)
+                                onFit(cali.SubModel);
                             else
                                 onFit((LinearBinaryModelParameters)model);
                         });
@@ -336,8 +336,8 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             var model = trans.Model;
-                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator> cali)
-                                onFit(cali.SubModelParameters);
+                            if (model is ParameterMixingCalibratedModelParameters<LinearBinaryModelParameters, PlattCalibrator> cali)
+                                onFit(cali.SubModel);
                             else
                                 onFit((LinearBinaryModelParameters)model);
                         });

--- a/src/Microsoft.ML.StaticPipe/SdcaStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/SdcaStaticExtensions.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ML.StaticPipe
                     float? l2Const = null,
                     float? l1Threshold = null,
                     int? maxIterations = null,
-                    Action<LinearBinaryModelParameters, ParameterMixingCalibratedPredictor> onFit = null)
+                    Action<LinearBinaryModelParameters, ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -162,8 +162,8 @@ namespace Microsoft.ML.StaticPipe
                         {
                             // Under the default log-loss we assume a calibrated predictor.
                             var model = trans.Model;
-                            var cali = (ParameterMixingCalibratedPredictor)model;
-                            var pred = (LinearBinaryModelParameters)cali.SubPredictor;
+                            var cali = (ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>)model;
+                            var pred = cali.SubPredictor;
                             onFit(pred, cali);
                         });
                     }
@@ -198,7 +198,7 @@ namespace Microsoft.ML.StaticPipe
                     this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
                     Scalar<bool> label, Vector<float> features, Scalar<float> weights,
                     SdcaBinaryTrainer.Options options,
-                    Action<LinearBinaryModelParameters, ParameterMixingCalibratedPredictor> onFit = null)
+                    Action<LinearBinaryModelParameters, ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValue(label, nameof(label));
             Contracts.CheckValue(features, nameof(features));
@@ -219,8 +219,8 @@ namespace Microsoft.ML.StaticPipe
                         {
                             // Under the default log-loss we assume a calibrated predictor.
                             var model = trans.Model;
-                            var cali = (ParameterMixingCalibratedPredictor)model;
-                            var pred = (LinearBinaryModelParameters)cali.SubPredictor;
+                            var cali = (ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>)model;
+                            var pred = cali.SubPredictor;
                             onFit(pred, cali);
                         });
                     }
@@ -281,8 +281,8 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             var model = trans.Model;
-                            if (model is ParameterMixingCalibratedPredictor cali)
-                                onFit((LinearBinaryModelParameters)cali.SubPredictor);
+                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters, Calibrator.ICalibrator> cali)
+                                onFit(cali.SubPredictor);
                             else
                                 onFit((LinearBinaryModelParameters)model);
                         });
@@ -340,7 +340,7 @@ namespace Microsoft.ML.StaticPipe
                         return trainer.WithOnFitDelegate(trans =>
                         {
                             var model = trans.Model;
-                            if (model is ParameterMixingCalibratedPredictor cali)
+                            if (model is ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> cali)
                                 onFit((LinearBinaryModelParameters)cali.SubPredictor);
                             else
                                 onFit((LinearBinaryModelParameters)model);

--- a/src/Microsoft.ML.StaticPipe/TreeTrainersStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/TreeTrainersStatic.cs
@@ -6,7 +6,6 @@ using System;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
 using Microsoft.ML.Internal.Calibration;
-using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.StaticPipe.Runtime;
 using Microsoft.ML.Trainers.FastTree;
 
@@ -140,7 +139,7 @@ namespace Microsoft.ML.StaticPipe
             int numTrees = Defaults.NumTrees,
             int minDatapointsInLeaves = Defaults.MinDocumentsInLeaves,
             double learningRate = Defaults.LearningRates,
-            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> onFit = null)
+            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, numTrees, minDatapointsInLeaves, learningRate, onFit);
 
@@ -184,7 +183,7 @@ namespace Microsoft.ML.StaticPipe
         public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel) FastTree(this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
             Scalar<bool> label, Vector<float> features, Scalar<float> weights,
             FastTreeBinaryClassificationTrainer.Options options,
-            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> onFit = null)
+            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValueOrNull(options);
             CheckUserValues(label, features, weights, onFit);

--- a/src/Microsoft.ML.StaticPipe/TreeTrainersStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/TreeTrainersStatic.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
+using Microsoft.ML.Internal.Calibration;
 using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.StaticPipe.Runtime;
 using Microsoft.ML.Trainers.FastTree;
@@ -139,7 +140,7 @@ namespace Microsoft.ML.StaticPipe
             int numTrees = Defaults.NumTrees,
             int minDatapointsInLeaves = Defaults.MinDocumentsInLeaves,
             double learningRate = Defaults.LearningRates,
-            Action<IPredictorWithFeatureWeights<float>> onFit = null)
+            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, numTrees, minDatapointsInLeaves, learningRate, onFit);
 
@@ -183,7 +184,7 @@ namespace Microsoft.ML.StaticPipe
         public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel) FastTree(this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
             Scalar<bool> label, Vector<float> features, Scalar<float> weights,
             FastTreeBinaryClassificationTrainer.Options options,
-            Action<IPredictorWithFeatureWeights<float>> onFit = null)
+            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValueOrNull(options);
             CheckUserValues(label, features, weights, onFit);

--- a/src/Microsoft.ML.StaticPipe/TreeTrainersStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/TreeTrainersStatic.cs
@@ -139,7 +139,7 @@ namespace Microsoft.ML.StaticPipe
             int numTrees = Defaults.NumTrees,
             int minDatapointsInLeaves = Defaults.MinDocumentsInLeaves,
             double learningRate = Defaults.LearningRates,
-            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> onFit = null)
+            Action<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             CheckUserValues(label, features, weights, numLeaves, numTrees, minDatapointsInLeaves, learningRate, onFit);
 
@@ -183,7 +183,7 @@ namespace Microsoft.ML.StaticPipe
         public static (Scalar<float> score, Scalar<float> probability, Scalar<bool> predictedLabel) FastTree(this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
             Scalar<bool> label, Vector<float> features, Scalar<float> weights,
             FastTreeBinaryClassificationTrainer.Options options,
-            Action<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> onFit = null)
+            Action<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> onFit = null)
         {
             Contracts.CheckValueOrNull(options);
             CheckUserValues(label, features, weights, onFit);

--- a/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
+++ b/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Benchmarks
         private readonly string _dataPath = BaseTestClass.GetDataPath("adult.tiny.with-schema.txt");
 
         [Benchmark]
-        public ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> TrainKMeansAndLR()
+        public CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> TrainKMeansAndLR()
         {
             var ml = new MLContext(seed: 1);
             // Pipeline

--- a/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
+++ b/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Benchmarks
         private readonly string _dataPath = BaseTestClass.GetDataPath("adult.tiny.with-schema.txt");
 
         [Benchmark]
-        public CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> TrainKMeansAndLR()
+        public CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> TrainKMeansAndLR()
         {
             var ml = new MLContext(seed: 1);
             // Pipeline

--- a/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
+++ b/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Benchmarks
         private readonly string _dataPath = BaseTestClass.GetDataPath("adult.tiny.with-schema.txt");
 
         [Benchmark]
-        public ParameterMixingCalibratedPredictor TrainKMeansAndLR()
+        public ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> TrainKMeansAndLR()
         {
             var ml = new MLContext(seed: 1);
             // Pipeline

--- a/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
@@ -580,7 +580,7 @@ namespace Microsoft.ML.RunTests
                 new KeyValuePair<RoleMappedSchema.ColumnRole, string>(RoleMappedSchema.ColumnRole.Feature, "Features"),
                 new KeyValuePair<RoleMappedSchema.ColumnRole, string>(RoleMappedSchema.ColumnRole.Label, "Label"));
 
-            var calibratedPredictor = model.LastTransformer.Model as CalibratedPredictor;
+            var calibratedPredictor = model.LastTransformer.Model;
             var predictor = calibratedPredictor.SubPredictor as ICanSaveInIniFormat;
             string modelIniPath = GetOutputPath(FullTestName + "-model.ini");
 

--- a/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
@@ -581,7 +581,7 @@ namespace Microsoft.ML.RunTests
                 new KeyValuePair<RoleMappedSchema.ColumnRole, string>(RoleMappedSchema.ColumnRole.Label, "Label"));
 
             var calibratedPredictor = model.LastTransformer.Model;
-            var predictor = calibratedPredictor.SubModelParameters as ICanSaveInIniFormat;
+            var predictor = calibratedPredictor.SubModel as ICanSaveInIniFormat;
             string modelIniPath = GetOutputPath(FullTestName + "-model.ini");
 
             using (Stream iniStream = File.Create(modelIniPath))

--- a/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestIniModels.cs
@@ -581,7 +581,7 @@ namespace Microsoft.ML.RunTests
                 new KeyValuePair<RoleMappedSchema.ColumnRole, string>(RoleMappedSchema.ColumnRole.Label, "Label"));
 
             var calibratedPredictor = model.LastTransformer.Model;
-            var predictor = calibratedPredictor.SubPredictor as ICanSaveInIniFormat;
+            var predictor = calibratedPredictor.SubModelParameters as ICanSaveInIniFormat;
             string modelIniPath = GetOutputPath(FullTestName + "-model.ini");
 
             using (Stream iniStream = File.Create(modelIniPath))

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -119,7 +119,7 @@ namespace Microsoft.ML.StaticPipelineTesting
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
             LinearBinaryModelParameters pred = null;
-            ParameterMixingCalibratedPredictor cali = null;
+            ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> cali = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.Sdca(r.label, r.features, null,
@@ -384,7 +384,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            IPredictorWithFeatureWeights<float> pred = null;
+            CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.FastTree(r.label, r.features,
@@ -400,7 +400,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // 9 input features, so we ought to have 9 weights.
             VBuffer<float> weights = new VBuffer<float>();
-            pred.GetFeatureWeights(ref weights);
+            ((IPredictorWithFeatureWeights<float>)pred).GetFeatureWeights(ref weights);
             Assert.Equal(9, weights.Length);
 
             var data = model.Read(dataSource);

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML;
@@ -118,23 +117,20 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            LinearBinaryModelParameters pred = null;
-            ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator> cali = null;
+            CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.Sdca(r.label, r.features, null,
                     new SdcaBinaryTrainer.Options { MaxIterations = 2, NumThreads = 1 },
-                    onFit: (p, c) => { pred = p; cali = c; })));
+                    onFit: (p) => { pred = p; })));
 
             var pipe = reader.Append(est);
 
             Assert.Null(pred);
-            Assert.Null(cali);
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
-            Assert.NotNull(cali);
             // 9 input features, so we ought to have 9 weights.
-            Assert.Equal(9, pred.Weights.Count);
+            Assert.Equal(9, pred.SubModelParameters.Weights.Count);
 
             var data = model.Read(dataSource);
 
@@ -384,7 +380,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator> pred = null;
+            CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.FastTree(r.label, r.features,
@@ -465,7 +461,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            IPredictorWithFeatureWeights<float> pred = null;
+            CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.LightGbm(r.label, r.features,
@@ -482,7 +478,7 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             // 9 input features, so we ought to have 9 weights.
             VBuffer<float> weights = new VBuffer<float>();
-            pred.GetFeatureWeights(ref weights);
+            ((IHaveFeatureWeights)pred).GetFeatureWeights(ref weights);
             Assert.Equal(9, weights.Length);
 
             var data = model.Read(dataSource);
@@ -588,7 +584,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            IPredictorWithFeatureWeights<float> pred = null;
+            CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.LogisticRegressionBinaryClassifier(r.label, r.features, null,
@@ -601,9 +597,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.NotNull(pred);
 
             // 9 input features, so we ought to have 9 weights.
-            VBuffer<float> weights = new VBuffer<float>();
-            pred.GetFeatureWeights(ref weights);
-            Assert.Equal(9, weights.Length);
+            Assert.Equal(9, pred.SubModelParameters.Weights.Count);
 
             var data = model.Read(dataSource);
 

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> pred = null;
+            CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.Sdca(r.label, r.features, null,
@@ -130,7 +130,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
             // 9 input features, so we ought to have 9 weights.
-            Assert.Equal(9, pred.SubModelParameters.Weights.Count);
+            Assert.Equal(9, pred.SubModel.Weights.Count);
 
             var data = model.Read(dataSource);
 
@@ -380,7 +380,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator> pred = null;
+            CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.FastTree(r.label, r.features,
@@ -461,7 +461,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            CalibratedPredictorBase<LightGbmBinaryModelParameters, PlattCalibrator> pred = null;
+            CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.LightGbm(r.label, r.features,
@@ -584,7 +584,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var reader = TextLoaderStatic.CreateReader(env,
                 c => (label: c.LoadBool(0), features: c.LoadFloat(1, 9)));
 
-            CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator> pred = null;
+            CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> pred = null;
 
             var est = reader.MakeNewEstimator()
                 .Append(r => (r.label, preds: catalog.Trainers.LogisticRegressionBinaryClassifier(r.label, r.features, null,
@@ -597,7 +597,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.NotNull(pred);
 
             // 9 input features, so we ought to have 9 weights.
-            Assert.Equal(9, pred.SubModelParameters.Weights.Count);
+            Assert.Equal(9, pred.SubModel.Weights.Count);
 
             var data = model.Read(dataSource);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Calibration;
-using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.RunTests;
 using Microsoft.ML.SamplesUtils;
 using Microsoft.ML.Trainers;
@@ -56,7 +55,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var trainer = ml.BinaryClassification.Trainers.FastTree(numLeaves: 5, numTrees: 3);
 
-            BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> pred = null;
+            BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> pred = null;
 
             var pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(ml)
@@ -66,7 +65,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data);
 
             // Extract the learned GBDT model.
-            var treeCollection = pred.Model.SubPredictor.TrainedTreeEnsemble;
+            var treeCollection = pred.Model.SubModelParameters.TrainedTreeEnsemble;
 
             // Inspect properties in the extracted model.
             Assert.Equal(3, treeCollection.Trees.Count);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Data;
+using Microsoft.ML.Internal.Calibration;
 using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.RunTests;
 using Microsoft.ML.SamplesUtils;
@@ -55,7 +56,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var trainer = ml.BinaryClassification.Trainers.FastTree(numLeaves: 5, numTrees: 3);
 
-            BinaryPredictionTransformer<IPredictorWithFeatureWeights<float>> pred = null;
+            BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters,PlattCalibrator>> pred = null;
 
             var pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(ml)
@@ -65,7 +66,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data);
 
             // Extract the learned GBDT model.
-            var treeCollection = ((FastTreeBinaryModelParameters)((Internal.Calibration.FeatureWeightsCalibratedPredictor)pred.Model).SubPredictor).TrainedTreeEnsemble;
+            var treeCollection = pred.Model.SubPredictor.TrainedTreeEnsemble;
 
             // Inspect properties in the extracted model.
             Assert.Equal(3, treeCollection.Trees.Count);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             var trainer = ml.BinaryClassification.Trainers.FastTree(numLeaves: 5, numTrees: 3);
 
-            BinaryPredictionTransformer<CalibratedPredictorBase<FastTreeBinaryModelParameters, PlattCalibrator>> pred = null;
+            BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> pred = null;
 
             var pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(ml)
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data);
 
             // Extract the learned GBDT model.
-            var treeCollection = pred.Model.SubModelParameters.TrainedTreeEnsemble;
+            var treeCollection = pred.Model.SubModel.TrainedTreeEnsemble;
 
             // Inspect properties in the extracted model.
             Assert.Equal(3, treeCollection.Trees.Count);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
@@ -61,9 +61,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             (IEstimator<ITransformer> pipe, IDataView dataView) = GetBinaryClassificationPipeline();
 
             pipe = pipe.Append(ML.BinaryClassification.Trainers.LogisticRegression(new LogisticRegression.Options { ShowTrainingStats = true }));
-            var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>>;
+            var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>>;
 
-            var linearModel = transformerChain.LastTransformer.Model.SubPredictor as LinearBinaryModelParameters;
+            var linearModel = transformerChain.LastTransformer.Model.SubModelParameters as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;
             LinearModelStatistics.TryGetBiasStatistics(stats, 2, out float stdError, out float zScore, out float pValue);
 
@@ -77,14 +77,15 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             (IEstimator<ITransformer> pipe, IDataView dataView) = GetBinaryClassificationPipeline();
 
             pipe = pipe.Append(ML.BinaryClassification.Trainers.LogisticRegression(
-                new LogisticRegression.Options { 
+                new LogisticRegression.Options
+                {
                     ShowTrainingStats = true,
                     StdComputer = new ComputeLRTrainingStdThroughHal(),
-            }));
+                }));
 
-            var transformer = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>>;
+            var transformer = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>>;
 
-            var linearModel = transformer.LastTransformer.Model.SubPredictor as LinearBinaryModelParameters;
+            var linearModel = transformer.LastTransformer.Model.SubModelParameters as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;
             LinearModelStatistics.TryGetBiasStatistics(stats, 2, out float stdError, out float zScore, out float pValue);
 
@@ -93,11 +94,11 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var scoredData = transformer.Transform(dataView);
 
-            var coeffcients  = stats.GetCoefficientStatistics(linearModel, scoredData.Schema["Features"], 100);
+            var coeffcients = stats.GetCoefficientStatistics(linearModel, scoredData.Schema["Features"], 100);
 
             Assert.Equal(19, coeffcients.Length);
 
-            foreach(var coefficient in coeffcients)
+            foreach (var coefficient in coeffcients)
                 Assert.True(coefficient.StandardError < 1.0);
 
         }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             (IEstimator<ITransformer> pipe, IDataView dataView) = GetBinaryClassificationPipeline();
 
             pipe = pipe.Append(ML.BinaryClassification.Trainers.LogisticRegression(new LogisticRegression.Options { ShowTrainingStats = true }));
-            var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor>>;
+            var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>>;
 
             var linearModel = transformerChain.LastTransformer.Model.SubPredictor as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                     StdComputer = new ComputeLRTrainingStdThroughHal(),
             }));
 
-            var transformer = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor>>;
+            var transformer = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<ParameterMixingCalibratedPredictor<LinearBinaryModelParameters,PlattCalibrator>>>;
 
             var linearModel = transformer.LastTransformer.Model.SubPredictor as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;

--- a/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
@@ -61,9 +61,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             (IEstimator<ITransformer> pipe, IDataView dataView) = GetBinaryClassificationPipeline();
 
             pipe = pipe.Append(ML.BinaryClassification.Trainers.LogisticRegression(new LogisticRegression.Options { ShowTrainingStats = true }));
-            var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>>;
+            var transformerChain = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>>;
 
-            var linearModel = transformerChain.LastTransformer.Model.SubModelParameters as LinearBinaryModelParameters;
+            var linearModel = transformerChain.LastTransformer.Model.SubModel as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;
             LinearModelStatistics.TryGetBiasStatistics(stats, 2, out float stdError, out float zScore, out float pValue);
 
@@ -83,9 +83,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                     StdComputer = new ComputeLRTrainingStdThroughHal(),
                 }));
 
-            var transformer = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>>>;
+            var transformer = pipe.Fit(dataView) as TransformerChain<BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>>;
 
-            var linearModel = transformer.LastTransformer.Model.SubModelParameters as LinearBinaryModelParameters;
+            var linearModel = transformer.LastTransformer.Model.SubModel as LinearBinaryModelParameters;
             var stats = linearModel.Statistics;
             LinearModelStatistics.TryGetBiasStatistics(stats, 2, out float stdError, out float zScore, out float pValue);
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var initPredictor = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscent().Fit(transformedData);
             var data = initPredictor.Transform(transformedData);
 
-            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData, initialPredictor: initPredictor.Model as CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>);
+            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData, initialPredictor: initPredictor.Model as CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>);
             var outInitData = withInitPredictor.Transform(transformedData);
 
             var notInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -4,6 +4,8 @@
 
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Internal.Calibration;
+using Microsoft.ML.Learners;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.SymSgd;
 using Xunit;
@@ -35,7 +37,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var initPredictor = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscent().Fit(transformedData);
             var data = initPredictor.Transform(transformedData);
 
-            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData, initialPredictor: initPredictor.Model);
+            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData, initialPredictor: initPredictor.Model as CalibratedPredictorBase<LinearBinaryModelParameters,PlattCalibrator>);
             var outInitData = withInitPredictor.Transform(transformedData);
 
             var notInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -37,7 +37,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var initPredictor = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscent().Fit(transformedData);
             var data = initPredictor.Transform(transformedData);
 
-            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData, initialPredictor: initPredictor.Model as CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>);
+            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData,
+                initialPredictor: initPredictor.Model as CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>);
             var outInitData = withInitPredictor.Transform(transformedData);
 
             var notInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var initPredictor = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscent().Fit(transformedData);
             var data = initPredictor.Transform(transformedData);
 
-            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData, initialPredictor: initPredictor.Model as CalibratedPredictorBase<LinearBinaryModelParameters, PlattCalibrator>);
+            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData, initialPredictor: initPredictor.Model as CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>);
             var outInitData = withInitPredictor.Transform(transformedData);
 
             var notInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData);


### PR DESCRIPTION
There are some [problems ](https://github.com/dotnet/machinelearning/issues/2378)around weekly-typed calibrated predictor, if we want to expose those trained calibrated predictor to users. To expose trained predictor in a type-safe manner, this PR adds two type parameters to `CalibratedPredictorBase`; that is,
```csharp
    /// <summary>
    /// <see cref="IWeeklyTypedCalibratedPredictor"/> provides a weekly-typed way to access strongly-typed
    /// <see cref="CalibratedPredictorBase{TSubPredictor, TCalibrator}.SubModelParameters"/> and
    /// <see cref="CalibratedPredictorBase{TSubPredictor, TCalibrator}.Calibrator"/>.
    /// <see cref="IWeeklyTypedCalibratedPredictor"/> is commonly used in weekly-typed expressions. The
    /// existence of this interface is just for supporting existing codebase, so we discourage its uses.
    /// </summary>
    [BestFriend]
    internal interface IWeeklyTypedCalibratedPredictor
    {
        IPredictorProducing<float> WeeklyTypedSubModelParameters { get; }
        ICalibrator WeeklyTypedCalibrator { get; }
    }

    public abstract class CalibratedPredictorBase<TSubModelParameters, TCalibrator> :
        IDistPredictorProducing<float, float>,
        ICanSaveInIniFormat,
        ICanSaveInTextFormat,
        ICanSaveInSourceCode,
        ICanSaveSummary,
        ICanGetSummaryInKeyValuePairs,
        IWeeklyTypedCalibratedPredictor
        where TSubModelParameters : class, IPredictorProducing<float>
        where TCalibrator : class, ICalibrator
    {
        ...
        // Strongly-typed members.
        public TSubModelParameters SubModelParameters { get; }
        public TCalibrator Calibrator { get; }

        // Type-unsafed accessors of strongly-typed members.
        IPredictorProducing<float> IWeeklyTypedCalibratedPredictor.WeeklyTypedSubModelParameters => SubModelParameters;
        ICalibrator IWeeklyTypedCalibratedPredictor.WeeklyTypedCalibrator => Calibrator
        ...
    }
```
and make changes making the code complied. This PR doesn't make every use of `CalibratedPredictorBase` type-safe, because there are some functionalities built upon C# interface.

Fix #2378, Fix #1307.