### PR TITLE
Allowing SelectColumns to take a bare list of columns

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
@@ -13,25 +13,31 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable and them read it as ML.NET's data type.
-            IEnumerable<SamplesUtils.DatasetUtils.SampleInfertData> data = SamplesUtils.DatasetUtils.GetInfertData();
-            var trainData = mlContext.Data.ReadFromEnumerable(data);
+            var enumerableData = SamplesUtils.DatasetUtils.GetInfertData();
+            var data = mlContext.Data.ReadFromEnumerable(enumerableData);
 
-            // Preview of the data.
-            //
-            // Age    Case  Education  induced     parity  pooled.stratum  row_num  ...
-            // 26.0   1.0   0-5yrs      1.0         6.0       3.0      1.0  ...
-            // 42.0   1.0   0-5yrs      1.0         1.0       1.0      2.0  ...
-            // 39.0   1.0   0-5yrs      2.0         6.0       4.0      3.0  ...
-            // 34.0   1.0   0-5yrs      2.0         4.0       2.0      4.0  ...
-            // 35.0   1.0   6-11yrs     1.0         3.0       32.0     5.0  ...
+            // Before transformation, take a look at the dataset
+            Console.WriteLine($"Age\tCase\tEducation\tInduced\tParity\tPooledStratum");
+            foreach (var row in enumerableData)
+            {
+                Console.WriteLine($"{row.Age}\t{row.Case}\t{row.Education}\t{row.Induced}\t{row.Parity}\t{row.PooledStratum}");
+            }
+            Console.WriteLine();
+            // Expected output:
+            //  Age     Case    Education       Induced Parity  PooledStratum
+            //  26      1       0 - 5yrs        1       6       3
+            //  42      1       0 - 5yrs        1       1       1
+            //  39      1       12 + yrs        2       6       4
+            //  34      1       0 - 5yrs        2       4       2
+            //  35      1       6 - 11yrs       1       3       32
 
             // Select a subset of columns to keep.
-            var pipeline = mlContext.Transforms.SelectColumns(new string[] { "Age", "Education" });
+            var pipeline = mlContext.Transforms.SelectColumns("Age", "Education");
 
             // Now we can transform the data and look at the output to confirm the behavior of CopyColumns.
             // Don't forget that this operation doesn't actually evaluate data until we read the data below,
             // as transformations are lazy in ML.NET.
-            var transformedData = pipeline.Fit(trainData).Transform(trainData);
+            var transformedData = pipeline.Fit(data).Transform(data);
 
             // Print the number of columns in the schema
             Console.WriteLine($"There are {transformedData.Schema.Count} columns in the dataset.");
@@ -51,11 +57,11 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Expected output:
             //  Age and Education columns obtained post-transformation.
-            //  Age: 26 Education: 0 - 5yrs
-            //  Age: 42 Education: 0 - 5yrs
-            //  Age: 39 Education: 0 - 5yrs
-            //  Age: 34 Education: 0 - 5yrs
-            //  Age: 35 Education: 6 - 11yrs
+            //  Age: 26 Education: 0-5yrs
+            //  Age: 42 Education: 0-5yrs
+            //  Age: 39 Education: 12+yrs
+            //  Age: 34 Education: 0-5yrs
+            //  Age: 35 Education: 6-11yrs
         }
 
         private class SampleInfertDataTransformed

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Data.DataView;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms;
 
@@ -67,9 +68,9 @@ namespace Microsoft.ML
         /// <remarks>
         /// <see cref="DropColumns"/> is commonly used to remove unwanted columns from the schema if the dataset is going to be serialized or
         /// written out to a file. It is not actually necessary to drop unused columns before training or
-        /// performing transforms, as IDataView's lazy evaluation won't actually materialize those columns.
+        /// performing transforms, as <see cref="IDataView"/>'s lazy evaluation won't actually materialize those columns.
         /// In the case of serialization, every column in the schema will be written out. If you have columns
-        /// that you don't want to save, you can use DropColumns to remove them from the schema.
+        /// that you don't want to save, you can use <see cref="DropColumns"/> to remove them from the schema.
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="columnsToDrop">The array of column names to drop.</param>
@@ -84,11 +85,11 @@ namespace Microsoft.ML
             => ColumnSelectingEstimator.DropColumns(CatalogUtils.GetEnvironment(catalog), columnsToDrop);
 
         /// <summary>
-        /// Select a list of columns that user wants to keep.
+        /// Select a list of columns to keep in a given <see cref="IDataView"/>.
         /// </summary>
         /// <remarks>
         /// <format type="text/markdown">
-        /// <see cref="SelectColumns(TransformsCatalog, string[], bool)"/> operates on the schema of an input IDataView,
+        /// <see cref="SelectColumns(TransformsCatalog, string[], bool)"/> operates on the schema of an input <see cref="IDataView"/>,
         /// either dropping unselected columns from the schema or keeping them but marking them as hidden in the schema. Keeping columns hidden
         /// is recommended when it is necessary to understand how the inputs of a pipeline map to outputs of the pipeline. This feature
         /// is useful, for example, in debugging a pipeline of transforms by allowing you to print out results from the middle of the pipeline.
@@ -112,11 +113,11 @@ namespace Microsoft.ML
                 keepColumns, null, keepHidden, ColumnSelectingTransformer.Defaults.IgnoreMissing);
 
         /// <summary>
-        /// ColumnSelectingEstimator is used to select a list of columns that user wants to keep from a given input.
+        /// Select a list of columns to keep in a given <see cref="IDataView"/>.
         /// </summary>
         /// <remarks>
         /// <format type="text/markdown">
-        /// <see cref="SelectColumns(TransformsCatalog, string[])"/> operates on the schema of an input IDataView, dropping unselected columns from the schema.
+        /// <see cref="SelectColumns(TransformsCatalog, string[])"/> operates on the schema of an input <see cref="IDataView"/>, dropping unselected columns from the schema.
         /// </format>
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -84,11 +84,11 @@ namespace Microsoft.ML
             => ColumnSelectingEstimator.DropColumns(CatalogUtils.GetEnvironment(catalog), columnsToDrop);
 
         /// <summary>
-        /// ColumnSelectingEstimator is used to select a list of columns that user wants to keep from a given input.
+        /// Select a list of columns that user wants to keep.
         /// </summary>
         /// <remarks>
         /// <format type="text/markdown">
-        /// <see cref="SelectColumns"/> operates on the schema of an input IDataView,
+        /// <see cref="SelectColumns(TransformsCatalog, string[], bool)"/> operates on the schema of an input IDataView,
         /// either dropping unselected columns from the schema or keeping them but marking them as hidden in the schema. Keeping columns hidden
         /// is recommended when it is necessary to understand how the inputs of a pipeline map to outputs of the pipeline. This feature
         /// is useful, for example, in debugging a pipeline of transforms by allowing you to print out results from the middle of the pipeline.
@@ -97,7 +97,7 @@ namespace Microsoft.ML
         /// </remarks>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="keepColumns">The array of column names to keep.</param>
-        /// <param name="keepHidden">If true will keep hidden columns and false will remove hidden columns.</param>
+        /// <param name="keepHidden">If <see langword="true"/> will keep hidden columns and <see langword="false"/> will remove hidden columns.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -107,8 +107,28 @@ namespace Microsoft.ML
         /// </example>
         public static ColumnSelectingEstimator SelectColumns(this TransformsCatalog catalog,
             string[] keepColumns,
-            bool keepHidden = ColumnSelectingTransformer.Defaults.KeepHidden)
+            bool keepHidden)
             => new ColumnSelectingEstimator(CatalogUtils.GetEnvironment(catalog),
                 keepColumns, null, keepHidden, ColumnSelectingTransformer.Defaults.IgnoreMissing);
+
+        /// <summary>
+        /// ColumnSelectingEstimator is used to select a list of columns that user wants to keep from a given input.
+        /// </summary>
+        /// <remarks>
+        /// <format type="text/markdown">
+        /// <see cref="SelectColumns(TransformsCatalog, string[])"/> operates on the schema of an input IDataView, dropping unselected columns from the schema.
+        /// </format>
+        /// </remarks>
+        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="keepColumns">The array of column names to keep.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[SelectColumns](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        public static ColumnSelectingEstimator SelectColumns(this TransformsCatalog catalog,
+            params string[] keepColumns) => catalog.SelectColumns(keepColumns, false);
     }
 }


### PR DESCRIPTION
This PR overloads `SelectColumns` so that it can be used with a bare list of columns. The original API is changed to remove `keepHidden`, as this new API has the default behavior.

The PR also cleans up the sample, which had mismatches between the actual and expected outputs.

Fixes: #2371 