### PR TITLE
ValueMappingEstimator documentation update

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/doc.xml
+++ b/src/Microsoft.ML.Data/Transforms/doc.xml
@@ -71,7 +71,7 @@
         Given a set of keys and values, the ValueMappingEstimator builds up a dictionary so that when given a specific key it will return a 
         specific value. The ValueMappingEstimator supports keys and values of different <see cref="System.Type"/> to support different data types.
         Examples for using a ValueMappingEstimator are:
-        <list>
+        <list type='bullet'>
           <item>
             <description>Converting a string value to a string value, this can be useful for grouping (i.e. 'cat', 'dog', 'horse' maps to 'mammals')</description>
           </item>


### PR DESCRIPTION
Adds a type='bullet' tag to the documentation for ValueMappingEstimator so that the bulleted list will render correctly.

Fixes #2447