### PR TITLE
Fix an initial-value problem caused by unseen row/column

### DIFF
--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -528,5 +528,78 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Negative example (i.e., examples can not be found in dataMatrix) is close to 0.15 (specified by s.C = 0.15 in the trainer).
             CompareNumbersWithTolerance(0.141411, testResults[1].Score, digitsOfPrecision: 5);
         }
+
+        [MatrixFactorizationFact]
+        public void OneClassMatrixFactorizationWithUnseenRow()
+        {
+            // Create an in-memory matrix as a list of tuples (column index, row index, value). For one-class matrix
+            // factorization problem, unspecified matrix elements are all a constant provided by user. If that constant is 0.15,
+            // the following list means a 3-by-2 training matrix with elements:
+            //   (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 0.15), (0, 2, 0.15), (1, 2, 0.15).
+            // because matrix elements at (0, 1), (0, 2), and (1, 2) are not specified. Below is a visualization of the training matrix.
+            //   [1, 1]
+            //   |?, 1| where ? will be set to 0.15 by user when creating the trainer.
+            //   [?, ?]
+            // Note that the third row is an unseen row because it contains no training elements (i.e., all its values are "?"s).
+            var dataMatrix = new List<OneClassMatrixElementZeroBased>();
+            dataMatrix.Add(new OneClassMatrixElementZeroBased() { MatrixColumnIndex = 0, MatrixRowIndex = 0, Value = 1 });
+            dataMatrix.Add(new OneClassMatrixElementZeroBased() { MatrixColumnIndex = 1, MatrixRowIndex = 0, Value = 1 });
+            dataMatrix.Add(new OneClassMatrixElementZeroBased() { MatrixColumnIndex = 1, MatrixRowIndex = 1, Value = 1 });
+
+            // Convert the in-memory matrix into an IDataView so that ML.NET components can consume it.
+            var dataView = ML.Data.ReadFromEnumerable(dataMatrix);
+
+            // Create a matrix factorization trainer which may consume "Value" as the training label, "MatrixColumnIndex" as the
+            // matrix's column index, and "MatrixRowIndex" as the matrix's row index.
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            var options = new MatrixFactorizationTrainer.Options
+            {
+                MatrixColumnIndexColumnName = nameof(MatrixElement.MatrixColumnIndex),
+                MatrixRowIndexColumnName = nameof(MatrixElement.MatrixRowIndex),
+                LabelColumnName = nameof(MatrixElement.Value),
+                LossFunction = MatrixFactorizationTrainer.LossFunctionType.SquareLossOneClass,
+                NumIterations = 100,
+                NumThreads = 1, // To eliminate randomness, # of threads must be 1.
+                Lambda = 0.025, // Let's test non-default regularization coefficient.
+                ApproximationRank = 16,
+                Alpha = 0.01, // Importance coefficient of loss function over matrix elements not specified in the input matrix.
+                C = 0.15, // Desired value for matrix elements not specified in the input matrix.
+            };
+
+            var pipeline = mlContext.Recommendation().Trainers.MatrixFactorization(options);
+
+            // Train a matrix factorization model.
+            var model = pipeline.Fit(dataView);
+
+            // Apply the trained model to the training set.
+            var prediction = model.Transform(dataView);
+
+            // Calculate regression matrices for the prediction result.
+            var metrics = mlContext.Recommendation().Evaluate(prediction, label: "Value", score: "Score");
+
+            // Make sure the prediction error is not too large.
+            Assert.InRange(metrics.L2, 0, 0.0016);
+
+            // Create data for testing.
+            var testDataMatrix = new List<OneClassMatrixElementZeroBasedForScore>();
+            testDataMatrix.Add(new OneClassMatrixElementZeroBasedForScore() { MatrixColumnIndex = 0, MatrixRowIndex = 0, Value = 0, Score = 0 });
+            testDataMatrix.Add(new OneClassMatrixElementZeroBasedForScore() { MatrixColumnIndex = 0, MatrixRowIndex = 1, Value = 0, Score = 0 });
+            testDataMatrix.Add(new OneClassMatrixElementZeroBasedForScore() { MatrixColumnIndex = 1, MatrixRowIndex = 2, Value = 0, Score = 0 });
+
+            // Convert the in-memory matrix into an IDataView so that ML.NET components can consume it.
+            var testDataView = ML.Data.ReadFromEnumerable(testDataMatrix);
+
+            // Apply the trained model to the test data.
+            var testPrediction = model.Transform(testDataView);
+
+            var testResults = mlContext.CreateEnumerable<OneClassMatrixElementZeroBasedForScore>(testPrediction, false).ToList();
+            // Positive example (i.e., examples can be found in dataMatrix) is close to 1.
+            CompareNumbersWithTolerance(0.975457132, testResults[0].Score, digitsOfPrecision: 5);
+            // Negative examples' scores (i.e., examples can not be found in dataMatrix) are closer
+            // to 0.15 (specified by s.C = 0.15 in the trainer) than positive example's score.
+            CompareNumbersWithTolerance(0.6217553, testResults[1].Score, digitsOfPrecision: 5);
+            CompareNumbersWithTolerance(0.06734055, testResults[2].Score, digitsOfPrecision: 5);
+        }
     }
 }


### PR DESCRIPTION
Update LIBMF to have this [fix](https://github.com/cjlin1/libmf/pull/25). The problem is that when the largest row index in the training set doesn't match the number of rows in the specified matrix shape, rows' starting addresses may look like `[ptr_to_first_element_in_row_1, ptr_to_first_element_in_row_8, ptr_to_the_end_of_element_array, nullptr, nullptr]` but the correct value should be `[ptr_to_first_element_in_row_1, ptr_to_first_element_in_row_8, ptr_to_the_end_of_element_array, ptr_to_the_end_of_element_array, ptr_to_the_end_of_element_array]`.

Fixes https://github.com/dotnet/machinelearning/issues/2488