### PR TITLE
Update calibrator estimators to be more suitable.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Calibrator.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Calibrator.cs
@@ -1,8 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
 using System.Linq;
 using Microsoft.ML.Calibrator;
 using Microsoft.ML.Data;

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Calibrator.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Calibrator.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Linq;
 using Microsoft.ML.Calibrator;
 using Microsoft.ML.Data;
@@ -75,7 +79,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Let's train a calibrator estimator on this scored dataset. The trained calibrator estimator produces a transformer
             // that can transform the scored data by adding a new column names "Probability". 
-            var calibratorEstimator = new PlattCalibratorEstimator(mlContext, model, "Sentiment", "Features");
+            var calibratorEstimator = new PlattCalibratorEstimator(mlContext, "Sentiment", "Score");
             var calibratorTransformer = calibratorEstimator.Fit(scoredData);
 
             // Transform the scored data with a calibrator transfomer by adding a new column names "Probability". 

--- a/src/Microsoft.ML.Core/BestFriendAttribute.cs
+++ b/src/Microsoft.ML.Core/BestFriendAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ML
 #endif
 {
     /// <summary>
-    /// Intended to be applied to types and members marked as internal to indicate that friend access of this
+    /// Intended to be applied to types and members with internal scope to indicate that friend access of this
     /// internal item is OK from another assembly. This restriction applies only to assemblies that declare the
     /// <see cref="WantsToBeBestFriendsAttribute"/> assembly level attribute. Note that this attribute is not
     /// transferrable: an internal member with this attribute does not somehow make a containing internal type

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -12,6 +12,7 @@ using Microsoft.Data.DataView;
 using Microsoft.ML;
 using Microsoft.ML.Calibrator;
 using Microsoft.ML.CommandLine;
+using Microsoft.ML.Core.Data;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
 using Microsoft.ML.Internal.Calibration;
@@ -85,14 +86,24 @@ namespace Microsoft.ML.Internal.Calibration
     /// <summary>
     /// Signature for the loaders of calibrators.
     /// </summary>
-    public delegate void SignatureCalibrator();
+    [BestFriend]
+    internal delegate void SignatureCalibrator();
 
+    [BestFriend]
     [TlcModule.ComponentKind("CalibratorTrainer")]
-    public interface ICalibratorTrainerFactory : IComponentFactory<ICalibratorTrainer>
+    internal interface ICalibratorTrainerFactory : IComponentFactory<ICalibratorTrainer>
     {
     }
 
-    public interface ICalibratorTrainer
+    /// <summary>
+    /// This is a legacy interface still used for the command line and entry-points. All applications should transition away
+    /// from this interface and still work instead via <see cref="IEstimator{TTransformer}"/> of <see cref="CalibratorTransformer{TICalibrator}"/>,
+    /// for example, the subclasses of <see cref="CalibratorEstimatorBase{TICalibrator}"/>. However for now we retain this
+    /// until such time as those components making use of it can transition to the new way. No public surface should use
+    /// this, and even new internal code should avoid its use if possible.
+    /// </summary>
+    [BestFriend]
+    internal interface ICalibratorTrainer
     {
         /// <summary>
         /// True if the calibrator needs training, false otherwise.
@@ -105,6 +116,17 @@ namespace Microsoft.ML.Internal.Calibration
 
         /// <summary> Finish up training after seeing all examples </summary>
         ICalibrator FinishTraining(IChannel ch);
+    }
+
+    /// <summary>
+    /// This is a shim interface implemented only by <see cref="CalibratorEstimatorBase{TICalibrator}"/> to enable
+    /// access to the underlying legacy <see cref="ICalibratorTrainer"/> interface for those components that use
+    /// that old mechanism that we do not care to change right now.
+    /// </summary>
+    [BestFriend]
+    internal interface IHaveCalibratorTrainer
+    {
+        ICalibratorTrainer CalibratorTrainer { get; }
     }
 
     /// <summary>
@@ -842,6 +864,64 @@ namespace Microsoft.ML.Internal.Calibration
             return CreateCalibratedPredictor(env, (IPredictorProducing<float>)predictor, trainedCalibrator);
         }
 
+        public static ICalibrator TrainCalibrator(IHostEnvironment env, IChannel ch, ICalibratorTrainer caliTrainer, IDataView scored, string labelColumn, string scoreColumn, string weightColumn = null, int maxRows = _maxCalibrationExamples)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            env.CheckValue(ch, nameof(ch));
+            ch.CheckValue(scored, nameof(scored));
+            ch.CheckValue(caliTrainer, nameof(caliTrainer));
+            ch.CheckParam(!caliTrainer.NeedsTraining || !string.IsNullOrWhiteSpace(labelColumn), nameof(labelColumn),
+                "If " + nameof(caliTrainer) + " requires training, then " + nameof(labelColumn) + " must have a value.");
+            ch.CheckNonWhiteSpace(scoreColumn, nameof(scoreColumn));
+
+            if (!caliTrainer.NeedsTraining)
+                return caliTrainer.FinishTraining(ch);
+
+            var labelCol = scored.Schema[labelColumn];
+            var scoreCol = scored.Schema[scoreColumn];
+
+            var weightCol = weightColumn == null ? null : scored.Schema.GetColumnOrNull(weightColumn);
+            if (weightColumn != null && !weightCol.HasValue)
+                throw ch.ExceptSchemaMismatch(nameof(weightColumn), "weight", weightColumn);
+
+            ch.Info("Training calibrator.");
+
+            var cols = weightCol.HasValue ?
+                new Schema.Column[] { labelCol, scoreCol, weightCol.Value } :
+                new Schema.Column[] { labelCol, scoreCol };
+
+            using (var cursor = scored.GetRowCursor(cols))
+            {
+                var labelGetter = RowCursorUtils.GetLabelGetter(cursor, labelCol.Index);
+                var scoreGetter = RowCursorUtils.GetGetterAs<Single>(NumberType.R4, cursor, scoreCol.Index);
+                ValueGetter<Single> weightGetter = !weightCol.HasValue ? (ref float dst) => dst = 1 :
+                    RowCursorUtils.GetGetterAs<Single>(NumberType.R4, cursor, weightCol.Value.Index);
+
+                int num = 0;
+                while (cursor.MoveNext())
+                {
+                    Single label = 0;
+                    labelGetter(ref label);
+                    if (!FloatUtils.IsFinite(label))
+                        continue;
+                    Single score = 0;
+                    scoreGetter(ref score);
+                    if (!FloatUtils.IsFinite(score))
+                        continue;
+                    Single weight = 0;
+                    weightGetter(ref weight);
+                    if (!FloatUtils.IsFinite(weight))
+                        continue;
+
+                    caliTrainer.ProcessTrainingExample(score, label > 0, weight);
+
+                    if (maxRows > 0 && ++num >= maxRows)
+                        break;
+                }
+            }
+            return caliTrainer.FinishTraining(ch);
+        }
+
         /// <summary>
         /// Trains a calibrator.
         /// </summary>
@@ -857,60 +937,14 @@ namespace Microsoft.ML.Internal.Calibration
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ch, nameof(ch));
+            ch.CheckValue(caliTrainer, nameof(caliTrainer));
             ch.CheckValue(predictor, nameof(predictor));
             ch.CheckValue(data, nameof(data));
             ch.CheckParam(data.Schema.Label.HasValue, nameof(data), "data must have a Label column");
 
             var scored = ScoreUtils.GetScorer(predictor, data, env, null);
-
-            if (caliTrainer.NeedsTraining)
-            {
-                int labelCol;
-                if (!scored.Schema.TryGetColumnIndex(data.Schema.Label.Value.Name, out labelCol))
-                    throw ch.Except("No label column found");
-                int scoreCol;
-                if (!scored.Schema.TryGetColumnIndex(MetadataUtils.Const.ScoreValueKind.Score, out scoreCol))
-                    throw ch.Except("No score column found");
-                int weightCol = -1;
-                if (data.Schema.Weight?.Name is string weightName && scored.Schema.GetColumnOrNull(weightName)?.Index is int weightIdx)
-                    weightCol = weightIdx;
-                ch.Info("Training calibrator.");
-
-                var cols = weightCol > -1 ?
-                    new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol], scored.Schema[weightCol] } :
-                    new Schema.Column[] { scored.Schema[labelCol], scored.Schema[scoreCol] };
-
-                using (var cursor = scored.GetRowCursor(cols))
-                {
-                    var labelGetter = RowCursorUtils.GetLabelGetter(cursor, labelCol);
-                    var scoreGetter = RowCursorUtils.GetGetterAs<Single>(NumberType.R4, cursor, scoreCol);
-                    ValueGetter<Single> weightGetter = weightCol == -1 ? (ref float dst) => dst = 1 :
-                        RowCursorUtils.GetGetterAs<Single>(NumberType.R4, cursor, weightCol);
-
-                    int num = 0;
-                    while (cursor.MoveNext())
-                    {
-                        Single label = 0;
-                        labelGetter(ref label);
-                        if (!FloatUtils.IsFinite(label))
-                            continue;
-                        Single score = 0;
-                        scoreGetter(ref score);
-                        if (!FloatUtils.IsFinite(score))
-                            continue;
-                        Single weight = 0;
-                        weightGetter(ref weight);
-                        if (!FloatUtils.IsFinite(weight))
-                            continue;
-
-                        caliTrainer.ProcessTrainingExample(score, label > 0, weight);
-
-                        if (maxRows > 0 && ++num >= maxRows)
-                            break;
-                    }
-                }
-            }
-            return caliTrainer.FinishTraining(ch);
+            var scoreColumn = scored.Schema[DefaultColumnNames.Score];
+            return TrainCalibrator(env, ch, caliTrainer, scored, data.Schema.Label.Value.Name, DefaultColumnNames.Score, data.Schema.Weight?.Name, maxRows);
         }
 
         public static IPredictorProducing<float> CreateCalibratedPredictor<TSubPredictor, TCalibrator>(IHostEnvironment env, TSubPredictor predictor, TCalibrator cali)
@@ -953,7 +987,8 @@ namespace Microsoft.ML.Internal.Calibration
     /// The probability of belonging to a particular class, for example class 1, is the number of class 1 instances in the bin, divided by the total number
     /// of instances in that bin.
     /// </summary>
-    public sealed class NaiveCalibratorTrainer : ICalibratorTrainer
+    [BestFriend]
+    internal sealed class NaiveCalibratorTrainer : ICalibratorTrainer
     {
         private readonly IHost _host;
 
@@ -1181,7 +1216,8 @@ namespace Microsoft.ML.Internal.Calibration
     /// <summary>
     /// Base class for calibrator trainers.
     /// </summary>
-    public abstract class CalibratorTrainerBase : ICalibratorTrainer
+    [BestFriend]
+    internal abstract class CalibratorTrainerBase : ICalibratorTrainer
     {
         protected readonly IHost Host;
         protected CalibrationDataStore Data;
@@ -1230,7 +1266,8 @@ namespace Microsoft.ML.Internal.Calibration
         }
     }
 
-    public sealed class PlattCalibratorTrainer : CalibratorTrainerBase
+    [BestFriend]
+    internal sealed class PlattCalibratorTrainer : CalibratorTrainerBase
     {
         internal const string UserName = "Sigmoid Calibration";
         internal const string LoadName = "PlattCalibration";
@@ -1389,7 +1426,8 @@ namespace Microsoft.ML.Internal.Calibration
         }
     }
 
-    public sealed class FixedPlattCalibratorTrainer : ICalibratorTrainer
+    [BestFriend]
+    internal sealed class FixedPlattCalibratorTrainer : ICalibratorTrainer
     {
         [TlcModule.Component(Name = "FixedPlattCalibrator", FriendlyName = "Fixed Platt Calibrator", Aliases = new[] { "FixedPlatt", "FixedSigmoid" })]
         public sealed class Arguments : ICalibratorTrainerFactory
@@ -1591,7 +1629,8 @@ namespace Microsoft.ML.Internal.Calibration
         }
     }
 
-    public class PavCalibratorTrainer : CalibratorTrainerBase
+    [BestFriend]
+    internal sealed class PavCalibratorTrainer : CalibratorTrainerBase
     {
         // a piece of the piecwise function
         private readonly struct Piece

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -1703,6 +1703,7 @@ namespace Microsoft.ML.Internal.Calibration
     }
 
     /// <summary>
+    /// The pair-adjacent violators calibrator.
     /// The function that is implemented by this calibrator is:
     /// f(x) = v_i, if minX_i &lt;= x &lt;= maxX_i
     ///      = linear interpolate between v_i and v_i+1, if maxX_i &lt; x &lt; minX_i+1

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Calibrator
     }
 
     /// <summary>
-    /// The PlattCalibratorEstimator.
+    /// The Platt calibrator estimator.
     /// </summary>
     /// <remarks>
     /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TICalibrator}"/>.
@@ -291,6 +291,8 @@ namespace Microsoft.ML.Calibrator
 
     /// <summary>
     /// Obtains the probability values by applying the sigmoid:  f(x) = 1 / (1 + exp(-slope * x + offset).
+    /// Note that unlike, say, <see cref="PlattCalibratorEstimator"/>, the fit function here is trivial
+    /// and just "fits" a calibrator with the provided parameters.
     /// </summary>
     /// <remarks>
     /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TICalibrator}"/>.
@@ -347,7 +349,7 @@ double slope = 1,
     }
 
     /// <summary>
-    /// The naive binning-based calibratorEstimator.
+    /// The naive binning-based calbirator estimator.
     /// </summary>
     /// <remarks>
     /// It divides the range of the outputs into equally sized bins. In each bin,
@@ -399,7 +401,7 @@ double slope = 1,
     }
 
     /// <summary>
-    /// The PavCalibratorEstimator.
+    /// The pair-adjacent violators calibrator estimator.
     /// </summary>
     /// <remarks>
     /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TICalibrator}"/>.

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML;
@@ -36,7 +35,7 @@ namespace Microsoft.ML.Calibrator
     }
 
     /// <summary>
-    /// Base class for CalibratorEstimators.
+    /// Base class for calibrator estimators.
     /// </summary>
     /// <remarks>
     /// CalibratorEstimators take an <see cref="IDataView"/> (the output of a <see cref="BinaryClassifierScorer"/>)
@@ -49,39 +48,35 @@ namespace Microsoft.ML.Calibrator
     ///  [!code-csharp[Calibrators](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Calibrator.cs)]
     /// ]]></format>
     /// </example>
-    public abstract class CalibratorEstimatorBase<TCalibratorTrainer, TICalibrator> : IEstimator<CalibratorTransformer<TICalibrator>>
-        where TCalibratorTrainer : ICalibratorTrainer
+    public abstract class CalibratorEstimatorBase<TICalibrator> : IEstimator<CalibratorTransformer<TICalibrator>>, IHaveCalibratorTrainer
         where TICalibrator : class, ICalibrator
     {
-        protected readonly IHostEnvironment Host;
-        protected readonly TCalibratorTrainer CalibratorTrainer;
+        [BestFriend]
+        private protected readonly IHostEnvironment Host;
+        private readonly ICalibratorTrainer _calibratorTrainer;
+        ICalibratorTrainer IHaveCalibratorTrainer.CalibratorTrainer => _calibratorTrainer;
 
-        protected readonly IPredictor Predictor;
-        protected readonly SchemaShape.Column ScoreColumn;
-        protected readonly SchemaShape.Column FeatureColumn;
-        protected readonly SchemaShape.Column LabelColumn;
-        protected readonly SchemaShape.Column WeightColumn;
-        protected readonly SchemaShape.Column PredictedLabel;
+        [BestFriend]
+        private protected readonly SchemaShape.Column ScoreColumn;
+        [BestFriend]
+        private protected readonly SchemaShape.Column LabelColumn;
+        [BestFriend]
+        private protected readonly SchemaShape.Column WeightColumn;
+        [BestFriend]
+        private protected readonly SchemaShape.Column PredictedLabel;
 
-        protected CalibratorEstimatorBase(IHostEnvironment env,
-            TCalibratorTrainer calibratorTrainer,
-            IPredictor predictor = null,
-            string labelColumn = DefaultColumnNames.Label,
-            string featureColumn = DefaultColumnNames.Features,
-            string weightColumn = null)
+        [BestFriend]
+        private protected CalibratorEstimatorBase(IHostEnvironment env,
+            ICalibratorTrainer calibratorTrainer, string labelColumn, string scoreColumn, string weightColumn)
         {
             Host = env;
-            Predictor = predictor;
-            CalibratorTrainer = calibratorTrainer;
+            _calibratorTrainer = calibratorTrainer;
 
-            ScoreColumn = TrainerUtils.MakeR4ScalarColumn(DefaultColumnNames.Score); // Do we fantom this being named anything else (renaming column)? Complete metadata?
-            LabelColumn = TrainerUtils.MakeBoolScalarLabel(labelColumn);
-            FeatureColumn = TrainerUtils.MakeR4VecFeature(featureColumn);
-            PredictedLabel = new SchemaShape.Column(DefaultColumnNames.PredictedLabel,
-                SchemaShape.Column.VectorKind.Scalar,
-                BoolType.Instance,
-                false,
-                new SchemaShape(MetadataUtils.GetTrainerOutputMetadata()));
+            if (!string.IsNullOrWhiteSpace(labelColumn))
+                LabelColumn = TrainerUtils.MakeBoolScalarLabel(labelColumn);
+            else
+                env.CheckParam(!calibratorTrainer.NeedsTraining, nameof(labelColumn), "For trained calibrators, " + nameof(labelColumn) + " must be specified.");
+            ScoreColumn = TrainerUtils.MakeR4ScalarColumn(scoreColumn); // Do we fanthom this being named anything else (renaming column)? Complete metadata?
 
             if (weightColumn != null)
                 WeightColumn = TrainerUtils.MakeR4ScalarWeightColumn(weightColumn);
@@ -105,14 +100,12 @@ namespace Microsoft.ML.Calibrator
                 }
             };
 
-            // check the input schema
-            checkColumnValid(ScoreColumn, DefaultColumnNames.Score);
-            checkColumnValid(WeightColumn, DefaultColumnNames.Weight);
-            checkColumnValid(LabelColumn, DefaultColumnNames.Label);
-            checkColumnValid(FeatureColumn, DefaultColumnNames.Features);
-            checkColumnValid(PredictedLabel, DefaultColumnNames.PredictedLabel);
+            // Check the input schema.
+            checkColumnValid(ScoreColumn, "score");
+            checkColumnValid(WeightColumn, "weight");
+            checkColumnValid(LabelColumn, "label");
 
-            //create the new Probability column
+            // Create the new Probability column.
             var outColumns = inputSchema.ToDictionary(x => x.Name);
             outColumns[DefaultColumnNames.Probability] = new SchemaShape.Column(DefaultColumnNames.Probability,
                 SchemaShape.Column.VectorKind.Scalar,
@@ -132,35 +125,27 @@ namespace Microsoft.ML.Calibrator
         /// <see cref="DefaultColumnNames.Probability"/> column.</returns>
         public CalibratorTransformer<TICalibrator> Fit(IDataView input)
         {
-            TICalibrator calibrator = null;
-
-            var roles = new List<KeyValuePair<RoleMappedSchema.ColumnRole, string>>();
-            roles.Add(RoleMappedSchema.CreatePair(MetadataUtils.Const.ScoreValueKind.Score, DefaultColumnNames.Score));
-            roles.Add(RoleMappedSchema.ColumnRole.Label.Bind(LabelColumn.Name));
-            roles.Add(RoleMappedSchema.ColumnRole.Feature.Bind(FeatureColumn.Name));
-            if (WeightColumn.IsValid)
-                roles.Add(RoleMappedSchema.ColumnRole.Weight.Bind(WeightColumn.Name));
-
-            var roleMappedData = new RoleMappedData(input, opt: false, roles.ToArray());
-
             using (var ch = Host.Start("Creating calibrator."))
-                calibrator = (TICalibrator)CalibratorUtils.TrainCalibrator(Host, ch, CalibratorTrainer, Predictor, roleMappedData);
-
-            return Create(Host, calibrator);
+            {
+                var calibrator = (TICalibrator)CalibratorUtils.TrainCalibrator(Host, ch,
+                    _calibratorTrainer, input, LabelColumn.Name, ScoreColumn.Name, WeightColumn.Name);
+                return Create(Host, calibrator);
+            }
         }
 
         /// <summary>
         /// Implemented by deriving classes that create a concrete calibrator.
         /// </summary>
-        protected abstract CalibratorTransformer<TICalibrator> Create(IHostEnvironment env, TICalibrator calibrator);
+        [BestFriend]
+        private protected abstract CalibratorTransformer<TICalibrator> Create(IHostEnvironment env, TICalibrator calibrator);
     }
 
     /// <summary>
-    /// CalibratorTransfomers, the artifact of calling Fit on a <see cref="CalibratorEstimatorBase{TCalibratorTrainer, TICalibrator}"/>.
+    /// An instance of this class is the result of calling <see cref="CalibratorEstimatorBase{TICalibrator}.Fit(IDataView)"/>.
     /// If you pass a scored data, to the <see cref="CalibratorTransformer{TICalibrator}"/> Transform method, it will add the Probability column
     /// to the dataset. The Probability column is the value of the Score normalized to be a valid probability.
-    /// The CalibratorTransformer is an instance of <see cref="ISingleFeaturePredictionTransformer{TModel}"/> where score can be viewed as a feature
-    /// while probability is treated as the label.
+    /// The <see cref="CalibratorTransformer{TICalibrator}"/> is an instance of <see cref="ISingleFeaturePredictionTransformer{TModel}"/>
+    /// where score can be viewed as a feature while probability is treated as the label.
     /// </summary>
     /// <typeparam name="TICalibrator">The <see cref="ICalibrator"/> used to transform the data.</typeparam>
     public abstract class CalibratorTransformer<TICalibrator> : RowToRowTransformerBase, ISingleFeaturePredictionTransformer<TICalibrator>
@@ -172,8 +157,6 @@ namespace Microsoft.ML.Calibrator
         internal CalibratorTransformer(IHostEnvironment env, TICalibrator calibrator, string loaderSignature)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(CalibratorTransformer<TICalibrator>)))
         {
-            Host.CheckRef(calibrator, nameof(calibrator));
-
             _loaderSignature = loaderSignature;
             _calibrator = calibrator;
         }
@@ -189,7 +172,7 @@ namespace Microsoft.ML.Calibrator
 
             // *** Binary format ***
             // model: _calibrator
-            ctx.LoadModel<TICalibrator, SignatureLoadModel>(env, out _calibrator, @"Calibrator");
+            ctx.LoadModel<TICalibrator, SignatureLoadModel>(env, out _calibrator, "Calibrator");
         }
 
         string ISingleFeaturePredictionTransformer<TICalibrator>.FeatureColumn => DefaultColumnNames.Score;
@@ -224,8 +207,8 @@ namespace Microsoft.ML.Calibrator
                 loaderAssemblyName: typeof(CalibratorTransformer<>).Assembly.FullName);
         }
 
-    private sealed class Mapper<TCalibrator> : MapperBase
-        where TCalibrator : class, ICalibrator
+        private sealed class Mapper<TCalibrator> : MapperBase
+            where TCalibrator : class, ICalibrator
         {
             private TCalibrator _calibrator;
             private int _scoreColIndex;
@@ -280,65 +263,67 @@ namespace Microsoft.ML.Calibrator
     /// The PlattCalibratorEstimator.
     /// </summary>
     /// <remarks>
-    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TCalibratorTrainer, TICalibrator}"/>.
+    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TICalibrator}"/>.
     /// </remarks>
-    public sealed class PlattCalibratorEstimator : CalibratorEstimatorBase<PlattCalibratorTrainer, PlattCalibrator>
+    public sealed class PlattCalibratorEstimator : CalibratorEstimatorBase<PlattCalibrator>
     {
         /// <summary>
         /// Initializes a new instance of <see cref="PlattCalibratorEstimator"/>
         /// </summary>
         /// <param name="env">The environment to use.</param>
-        /// <param name="predictor">The predictor used to train the data.</param>
-        /// <param name="labelColumn">The label column name.</param>
-        /// <param name="featureColumn">The feature column name.</param>
-        /// <param name="weightColumn">The weight column name.</param>
+        /// <param name="labelColumn">The label column name. This is consumed when this estimator is fit,
+        /// but not consumed by the resulting transformer.</param>
+        /// <param name="scoreColumn">The score column name. This is consumed both when this estimator
+        /// is fit and when the estimator is consumed.</param>
+        /// <param name="weightColumn">The optional weight column name. Note that if specified this is
+        /// consumed when this estimator is fit, but not consumed by the resulting transformer.</param>
         public PlattCalibratorEstimator(IHostEnvironment env,
-            IPredictor predictor,
             string labelColumn = DefaultColumnNames.Label,
-            string featureColumn = DefaultColumnNames.Features,
-            string weightColumn = null) : base(env, new PlattCalibratorTrainer(env), predictor, labelColumn, featureColumn, weightColumn)
+            string scoreColumn = DefaultColumnNames.Score,
+            string weightColumn = null) : base(env, new PlattCalibratorTrainer(env), labelColumn, scoreColumn, weightColumn)
         {
-
         }
 
-        protected override CalibratorTransformer<PlattCalibrator> Create(IHostEnvironment env, PlattCalibrator calibrator)
-        => new PlattCalibratorTransformer(env, calibrator);
+        [BestFriend]
+        private protected override CalibratorTransformer<PlattCalibrator> Create(IHostEnvironment env, PlattCalibrator calibrator)
+            => new PlattCalibratorTransformer(env, calibrator);
     }
 
     /// <summary>
-    /// Obtains the probability values by fitting the sigmoid:  f(x) = 1 / (1 + exp(-slope * x + offset).
+    /// Obtains the probability values by applying the sigmoid:  f(x) = 1 / (1 + exp(-slope * x + offset).
     /// </summary>
     /// <remarks>
-    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TCalibratorTrainer, TICalibrator}"/>.
+    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TICalibrator}"/>.
     /// </remarks>
-    public sealed class FixedPlattCalibratorEstimator : CalibratorEstimatorBase<FixedPlattCalibratorTrainer, PlattCalibrator>
+    public sealed class FixedPlattCalibratorEstimator : CalibratorEstimatorBase<PlattCalibrator>
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="FixedPlattCalibratorEstimator"/>
+        /// Initializes a new instance of <see cref="FixedPlattCalibratorEstimator"/>.
         /// </summary>
+        /// <remarks>
+        /// Note that unlike many other calibrator estimators this one has the parameters pre-specified.
+        /// This means that it does not have a label or weight column specified as an input during training.
+        /// </remarks>
         /// <param name="env">The environment to use.</param>
-        /// <param name="predictor">The predictor used to train the data.</param>
         /// <param name="slope">The slope in the function of the exponent of the sigmoid.</param>
         /// <param name="offset">The offset in the function of the exponent of the sigmoid.</param>
-        /// <param name="labelColumn">The label column name.</param>
-        /// <param name="featureColumn">The feature column name.</param>
-        /// <param name="weightColumn">The weight column name.</param>
+        /// <param name="scoreColumn">The score column name. This is consumed both when this estimator
+        /// is fit and when the estimator is consumed.</param>
         public FixedPlattCalibratorEstimator(IHostEnvironment env,
-            IPredictor predictor,
-            double slope = 1,
+double slope = 1,
             double offset = 0,
-            string labelColumn = DefaultColumnNames.Label,
-            string featureColumn = DefaultColumnNames.Features,
-            string weightColumn = null) : base(env, new FixedPlattCalibratorTrainer(env, new FixedPlattCalibratorTrainer.Arguments()
+            string scoreColumn = DefaultColumnNames.Score)
+            : base(env, new FixedPlattCalibratorTrainer(env, new FixedPlattCalibratorTrainer.Arguments()
             {
                 Slope = slope,
                 Offset = offset
-            }), predictor, labelColumn, featureColumn, weightColumn)
+            }), null, scoreColumn, null)
         {
 
         }
 
-        protected override CalibratorTransformer<PlattCalibrator> Create(IHostEnvironment env, PlattCalibrator calibrator)
+        [BestFriend]
+        private protected override CalibratorTransformer<PlattCalibrator> Create(IHostEnvironment env, PlattCalibrator calibrator)
             => new PlattCalibratorTransformer(env, calibrator);
     }
 
@@ -352,14 +337,12 @@ namespace Microsoft.ML.Calibrator
         internal PlattCalibratorTransformer(IHostEnvironment env, PlattCalibrator calibrator)
           : base(env, calibrator, LoadName)
         {
-
         }
 
         // Factory method for SignatureLoadModel.
         internal PlattCalibratorTransformer(IHostEnvironment env, ModelLoadContext ctx)
-            :base(env, ctx, LoadName)
+            : base(env, ctx, LoadName)
         {
-
         }
     }
 
@@ -370,29 +353,30 @@ namespace Microsoft.ML.Calibrator
     /// It divides the range of the outputs into equally sized bins. In each bin,
     /// the probability of belonging to class 1, is the number of class 1 instances in the bin, divided by the total number
     /// of instances in the bin.
-    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TCalibratorTrainer, TICalibrator}"/>.
+    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TICalibrator}"/>.
     /// </remarks>
-    public sealed class NaiveCalibratorEstimator : CalibratorEstimatorBase<NaiveCalibratorTrainer, NaiveCalibrator>
+    public sealed class NaiveCalibratorEstimator : CalibratorEstimatorBase<NaiveCalibrator>
     {
         /// <summary>
         /// Initializes a new instance of <see cref="NaiveCalibratorEstimator"/>
         /// </summary>
         /// <param name="env">The environment to use.</param>
-        /// <param name="predictor">The predictor used to train the data.</param>
-        /// <param name="labelColumn">The label column name.</param>
-        /// <param name="featureColumn">The feature column name.</param>
-        /// <param name="weightColumn">The weight column name.</param>
+        /// <param name="labelColumn">The label column name. This is consumed when this estimator is fit,
+        /// but not consumed by the resulting transformer.</param>
+        /// <param name="scoreColumn">The score column name. This is consumed both when this estimator
+        /// is fit and when the estimator is consumed.</param>
+        /// <param name="weightColumn">The optional weight column name. Note that if specified this is
+        /// consumed when this estimator is fit, but not consumed by the resulting transformer.</param>
         public NaiveCalibratorEstimator(IHostEnvironment env,
-            IPredictor predictor,
             string labelColumn = DefaultColumnNames.Label,
-            string featureColumn = DefaultColumnNames.Features,
-            string weightColumn = null) : base(env, new NaiveCalibratorTrainer(env), predictor, labelColumn, featureColumn, weightColumn)
+            string scoreColumn = DefaultColumnNames.Score,
+            string weightColumn = null) : base(env, new NaiveCalibratorTrainer(env), labelColumn, scoreColumn, weightColumn)
         {
-
         }
 
-        protected override CalibratorTransformer<NaiveCalibrator> Create(IHostEnvironment env, NaiveCalibrator calibrator)
-        => new NaiveCalibratorTransformer(env, calibrator);
+        [BestFriend]
+        private protected override CalibratorTransformer<NaiveCalibrator> Create(IHostEnvironment env, NaiveCalibrator calibrator)
+            => new NaiveCalibratorTransformer(env, calibrator);
     }
 
     /// <summary>
@@ -405,14 +389,12 @@ namespace Microsoft.ML.Calibrator
         internal NaiveCalibratorTransformer(IHostEnvironment env, NaiveCalibrator calibrator)
           : base(env, calibrator, LoadName)
         {
-
         }
 
         // Factory method for SignatureLoadModel.
         internal NaiveCalibratorTransformer(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, ctx, LoadName)
         {
-
         }
     }
 
@@ -420,28 +402,29 @@ namespace Microsoft.ML.Calibrator
     /// The PavCalibratorEstimator.
     /// </summary>
     /// <remarks>
-    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TCalibratorTrainer, TICalibrator}"/>.
+    /// For the usage pattern see the example in <see cref="CalibratorEstimatorBase{TICalibrator}"/>.
     /// </remarks>
-    public sealed class PavCalibratorEstimator : CalibratorEstimatorBase<PavCalibratorTrainer, PavCalibrator>
+    public sealed class PavCalibratorEstimator : CalibratorEstimatorBase<PavCalibrator>
     {
         /// <summary>
         /// Initializes a new instance of <see cref="PavCalibratorEstimator"/>
         /// </summary>
         /// <param name="env">The environment to use.</param>
-        /// <param name="predictor">The predictor used to train the data.</param>
-        /// <param name="labelColumn">The label column name.</param>
-        /// <param name="featureColumn">The feature column name.</param>
-        /// <param name="weightColumn">The weight column name.</param>
+        /// <param name="labelColumn">The label column name. This is consumed when this estimator is fit,
+        /// but not consumed by the resulting transformer.</param>
+        /// <param name="scoreColumn">The score column name. This is consumed both when this estimator
+        /// is fit and when the estimator is consumed.</param>
+        /// <param name="weightColumn">The optional weight column name. Note that if specified this is
+        /// consumed when this estimator is fit, but not consumed by the resulting transformer.</param>
         public PavCalibratorEstimator(IHostEnvironment env,
-            IPredictor predictor,
             string labelColumn = DefaultColumnNames.Label,
-            string featureColumn = DefaultColumnNames.Features,
-            string weightColumn = null) : base(env, new PavCalibratorTrainer(env), predictor, labelColumn, featureColumn, weightColumn)
+            string scoreColumn = DefaultColumnNames.Score,
+            string weightColumn = null) : base(env, new PavCalibratorTrainer(env), labelColumn, scoreColumn, weightColumn)
         {
-
         }
 
-        protected override CalibratorTransformer<PavCalibrator> Create(IHostEnvironment env, PavCalibrator calibrator)
+        [BestFriend]
+        private protected override CalibratorTransformer<PavCalibrator> Create(IHostEnvironment env, PavCalibrator calibrator)
             => new PavCalibratorTransformer(env, calibrator);
 
     }
@@ -456,14 +439,12 @@ namespace Microsoft.ML.Calibrator
         internal PavCalibratorTransformer(IHostEnvironment env, PavCalibrator calibrator)
           : base(env, calibrator, LoadName)
         {
-
         }
 
         // Factory method for SignatureLoadModel.
         private PavCalibratorTransformer(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, ctx, LoadName)
         {
-
         }
     }
 }

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML.Core.Data;
@@ -20,7 +19,8 @@ namespace Microsoft.ML
     /// </summary>
     public abstract class TrainCatalogBase
     {
-        protected internal readonly IHost Host;
+        [BestFriend]
+        private protected readonly IHost Host;
 
         [BestFriend]
         internal IHostEnvironment Environment => Host;
@@ -192,7 +192,8 @@ namespace Microsoft.ML
             return result;
         }
 
-        protected internal TrainCatalogBase(IHostEnvironment env, string registrationName)
+        [BestFriend]
+        private protected TrainCatalogBase(IHostEnvironment env, string registrationName)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckNonEmpty(registrationName, nameof(registrationName));

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -118,10 +118,10 @@ namespace Microsoft.ML.Trainers.FastTree
             public Double MaxTreeOutput = 100;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The calibrator kind to apply to the predictor. Specify null for no calibration", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
+            internal ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The maximum number of examples to use when training the calibrator", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public int MaxCalibrationExamples = 1000000;
+            internal int MaxCalibrationExamples = 1000000;
         }
 
         internal const string LoadNameValue = "FastForestClassification";

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/MetaMulticlassTrainer.cs
@@ -29,10 +29,10 @@ namespace Microsoft.ML.Trainers
             internal IComponentFactory<TScalarTrainer> PredictorType;
 
             [Argument(ArgumentType.Multiple, HelpText = "Output calibrator", ShortName = "cali", SortOrder = 150, NullName = "<None>", SignatureType = typeof(SignatureCalibrator))]
-            public IComponentFactory<ICalibratorTrainer> Calibrator = new PlattCalibratorTrainerFactory();
+            internal IComponentFactory<ICalibratorTrainer> Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.LastOccurenceWins, HelpText = "Number of instances to train the calibrator", SortOrder = 150, ShortName = "numcali")]
-            public int MaxCalibrationExamples = 1000000000;
+            internal int MaxCalibrationExamples = 1000000000;
 
             [Argument(ArgumentType.Multiple, HelpText = "Whether to treat missing labels as having negative labels, instead of keeping them missing", SortOrder = 150, ShortName = "missNeg")]
             public bool ImputeMissingLabelsAsNegative;

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
@@ -45,10 +45,10 @@ namespace Microsoft.ML.Trainers.Online
             public ISupportClassificationLossFactory LossFunction = new HingeLoss.Arguments();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The calibrator kind to apply to the predictor. Specify null for no calibration", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
+            internal ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The maximum number of examples to use when training the calibrator", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public int MaxCalibrationExamples = 1000000;
+            internal int MaxCalibrationExamples = 1000000;
 
             internal override IComponentFactory<IScalarOutputLoss> LossFunctionFactory => LossFunction;
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -61,10 +61,10 @@ namespace Microsoft.ML.Trainers.Online
             public bool NoBias = false;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The calibrator kind to apply to the predictor. Specify null for no calibration", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
+            internal ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The maximum number of examples to use when training the calibrator", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public int MaxCalibrationExamples = 1000000;
+            internal int MaxCalibrationExamples = 1000000;
         }
 
         private sealed class TrainState : TrainStateBase

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -1408,10 +1408,10 @@ namespace Microsoft.ML.Trainers
             public float PositiveInstanceWeight = 1;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The calibrator kind to apply to the predictor. Specify null for no calibration", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
+            internal ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The maximum number of examples to use when training the calibrator", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public int MaxCalibrationExamples = 1000000;
+            internal int MaxCalibrationExamples = 1000000;
 
             internal override void Check(IHostEnvironment env)
             {
@@ -1624,10 +1624,10 @@ namespace Microsoft.ML.Trainers
             public int? CheckFrequency;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The calibrator kind to apply to the predictor. Specify null for no calibration", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
+            internal ICalibratorTrainerFactory Calibrator = new PlattCalibratorTrainerFactory();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The maximum number of examples to use when training the calibrator", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public int MaxCalibrationExamples = 1000000;
+            internal int MaxCalibrationExamples = 1000000;
 
             internal void Check(IHostEnvironment env)
             {

--- a/src/Microsoft.ML.StandardLearners/StandardLearnersCatalog.cs
+++ b/src/Microsoft.ML.StandardLearners/StandardLearnersCatalog.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Microsoft.ML.Calibrator;
+using Microsoft.ML.Core.Data;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Calibration;
 using Microsoft.ML.Trainers;
@@ -438,6 +440,26 @@ namespace Microsoft.ML
         }
 
         /// <summary>
+        /// Works via the <see cref="IHaveCalibratorTrainer"/> shim interface to extract from the calibrating training
+        /// estimator the internal <see cref="ICalibratorTrainer"/> object. Note that this should be a temporary measure,
+        /// since the trainers should really be changed to actually work over estimators.
+        /// </summary>
+        /// <param name="ectx">The exception context.</param>
+        /// <param name="calibratorEstimator">The estimator out of which we should try to extract the calibrator trainer.</param>
+        /// <returns>The calibrator trainer.</returns>
+        private static ICalibratorTrainer GetCalibratorTrainerOrThrow(IExceptionContext ectx, IEstimator<ISingleFeaturePredictionTransformer<ICalibrator>> calibratorEstimator)
+        {
+            Contracts.AssertValue(ectx);
+            ectx.AssertValueOrNull(calibratorEstimator);
+            if (calibratorEstimator == null)
+                return null;
+            if (calibratorEstimator is IHaveCalibratorTrainer haveCalibratorTrainer)
+                return haveCalibratorTrainer.CalibratorTrainer;
+            throw ectx.ExceptParam(nameof(calibratorEstimator),
+                "Calibrator estimator was not of a type usable in this context.");
+        }
+
+        /// <summary>
         /// Predicts a target using a linear multiclass classification model trained with the <see cref="Ova"/>.
         /// </summary>
         /// <remarks>
@@ -459,7 +481,7 @@ namespace Microsoft.ML
             ITrainerEstimator<ISingleFeaturePredictionTransformer<TModel>, TModel> binaryEstimator,
             string labelColumn = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
-            ICalibratorTrainer calibrator = null,
+            IEstimator<ISingleFeaturePredictionTransformer<ICalibrator>> calibrator = null,
             int maxCalibrationExamples = 1000000000,
             bool useProbabilities = true)
             where TModel : class
@@ -468,7 +490,7 @@ namespace Microsoft.ML
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new Ova(env, est, labelColumn, imputeMissingLabelsAsNegative, calibrator, maxCalibrationExamples, useProbabilities);
+            return new Ova(env, est, labelColumn, imputeMissingLabelsAsNegative, GetCalibratorTrainerOrThrow(env, calibrator), maxCalibrationExamples, useProbabilities);
         }
 
         /// <summary>
@@ -492,7 +514,7 @@ namespace Microsoft.ML
             ITrainerEstimator<ISingleFeaturePredictionTransformer<TModel>, TModel> binaryEstimator,
             string labelColumn = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
-            ICalibratorTrainer calibrator = null,
+            IEstimator<ISingleFeaturePredictionTransformer<ICalibrator>> calibrator = null,
             int maxCalibrationExamples = 1_000_000_000)
             where TModel : class
         {
@@ -500,7 +522,7 @@ namespace Microsoft.ML
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new Pkpd(env, est, labelColumn, imputeMissingLabelsAsNegative, calibrator, maxCalibrationExamples);
+            return new Pkpd(env, est, labelColumn, imputeMissingLabelsAsNegative, GetCalibratorTrainerOrThrow(env, calibrator), maxCalibrationExamples);
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Scenarios
 
             // Pipeline
             var ap = mlContext.BinaryClassification.Trainers.AveragedPerceptron(
-                    new AveragedPerceptronTrainer.Options { Shuffle = true, Calibrator = null });
+                    new AveragedPerceptronTrainer.Options { Shuffle = true });
             var pipeline = mlContext.MulticlassClassification.Trainers.OneVersusAll(ap, useProbabilities: false);
 
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/CalibratorEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/CalibratorEstimators.cs
@@ -21,15 +21,15 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         {
             var calibratorTestData = GetCalibratorTestData();
 
-            // platCalibrator
-            var platCalibratorEstimator = new PlattCalibratorEstimator(Env, calibratorTestData.transformer.Model, "Label", "Features");
-            var platCalibratorTransformer = platCalibratorEstimator.Fit(calibratorTestData.scoredData);
+            // plattCalibrator
+            var plattCalibratorEstimator = new PlattCalibratorEstimator(Env);
+            var plattCalibratorTransformer = plattCalibratorEstimator.Fit(calibratorTestData.ScoredData);
 
             //testData
-            checkValidCalibratedData(calibratorTestData.scoredData, platCalibratorTransformer);
+            CheckValidCalibratedData(calibratorTestData.ScoredData, plattCalibratorTransformer);
 
             //test estimator
-            TestEstimatorCore(platCalibratorEstimator, calibratorTestData.scoredData);
+            TestEstimatorCore(plattCalibratorEstimator, calibratorTestData.ScoredData);
 
             Done();
         }
@@ -38,18 +38,18 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         /// OVA and calibrators
         /// </summary>
         [Fact]
-        public void FixedPlatCalibratorEstimator()
+        public void FixedPlattCalibratorEstimator()
         {
             var calibratorTestData = GetCalibratorTestData();
 
-            // fixedPlatCalibrator
-            var fixedPlatCalibratorEstimator = new FixedPlattCalibratorEstimator(Env, calibratorTestData.transformer.Model, labelColumn: "Label", featureColumn: "Features");
-            var fixedPlatCalibratorTransformer = fixedPlatCalibratorEstimator.Fit(calibratorTestData.scoredData);
+            // fixedPlattCalibrator
+            var fixedPlattCalibratorEstimator = new FixedPlattCalibratorEstimator(Env);
+            var fixedPlattCalibratorTransformer = fixedPlattCalibratorEstimator.Fit(calibratorTestData.ScoredData);
 
-            checkValidCalibratedData(calibratorTestData.scoredData, fixedPlatCalibratorTransformer);
+            CheckValidCalibratedData(calibratorTestData.ScoredData, fixedPlattCalibratorTransformer);
 
             //test estimator
-            TestEstimatorCore(calibratorTestData.pipeline, calibratorTestData.data);
+            TestEstimatorCore(calibratorTestData.Pipeline, calibratorTestData.Data);
 
             Done();
         }
@@ -63,14 +63,14 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var calibratorTestData = GetCalibratorTestData();
 
             // naive calibrator
-            var naiveCalibratorEstimator = new NaiveCalibratorEstimator(Env, calibratorTestData.transformer.Model, "Label", "Features");
-            var naiveCalibratorTransformer = naiveCalibratorEstimator.Fit(calibratorTestData.scoredData);
+            var naiveCalibratorEstimator = new NaiveCalibratorEstimator(Env);
+            var naiveCalibratorTransformer = naiveCalibratorEstimator.Fit(calibratorTestData.ScoredData);
 
             // check data
-            checkValidCalibratedData(calibratorTestData.scoredData, naiveCalibratorTransformer);
+            CheckValidCalibratedData(calibratorTestData.ScoredData, naiveCalibratorTransformer);
 
             //test estimator
-            TestEstimatorCore(calibratorTestData.pipeline, calibratorTestData.data);
+            TestEstimatorCore(calibratorTestData.Pipeline, calibratorTestData.Data);
 
             Done();
         }
@@ -83,14 +83,14 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var calibratorTestData = GetCalibratorTestData();
 
             // pav calibrator
-            var pavCalibratorEstimator = new PavCalibratorEstimator(Env, calibratorTestData.transformer.Model, "Label", "Features");
-            var pavCalibratorTransformer = pavCalibratorEstimator.Fit(calibratorTestData.scoredData);
+            var pavCalibratorEstimator = new PavCalibratorEstimator(Env);
+            var pavCalibratorTransformer = pavCalibratorEstimator.Fit(calibratorTestData.ScoredData);
 
             //check data
-            checkValidCalibratedData(calibratorTestData.scoredData, pavCalibratorTransformer);
+            CheckValidCalibratedData(calibratorTestData.ScoredData, pavCalibratorTransformer);
 
             //test estimator
-            TestEstimatorCore(calibratorTestData.pipeline, calibratorTestData.data);
+            TestEstimatorCore(calibratorTestData.Pipeline, calibratorTestData.Data);
 
             Done();
         }
@@ -109,24 +109,24 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             return new CalibratorTestData
             {
-                data = data,
-                scoredData = scoredData,
-                pipeline = pipeline,
-                transformer = ((TransformerChain<BinaryPredictionTransformer<LinearBinaryModelParameters>>)transformer).LastTransformer as BinaryPredictionTransformer<LinearBinaryModelParameters>,
+                Data = data,
+                ScoredData = scoredData,
+                Pipeline = pipeline,
+                Transformer = ((TransformerChain<BinaryPredictionTransformer<LinearBinaryModelParameters>>)transformer).LastTransformer as BinaryPredictionTransformer<LinearBinaryModelParameters>,
             };
         }
 
-        private class CalibratorTestData
+        private sealed class CalibratorTestData
         {
-            internal IDataView data { get; set; }
-            internal IDataView scoredData { get; set; }
-            internal IEstimator<ITransformer> pipeline { get; set; }
+            public IDataView Data { get; set; }
+            public IDataView ScoredData { get; set; }
+            public IEstimator<ITransformer> Pipeline { get; set; }
 
-            internal BinaryPredictionTransformer<LinearBinaryModelParameters> transformer { get; set; }
+            public BinaryPredictionTransformer<LinearBinaryModelParameters> Transformer { get; set; }
         }
 
 
-        void checkValidCalibratedData (IDataView scoredData, ITransformer transformer){
+        private void CheckValidCalibratedData(IDataView scoredData, ITransformer transformer){
 
             var calibratedData = transformer.Transform(scoredData).Preview();
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Calibrator;
 using Microsoft.ML.Data;
-using Microsoft.ML.Internal.Calibration;
 using Microsoft.ML.RunTests;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.Online;
@@ -22,9 +22,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         public void OVAWithAllConstructorArgs()
         {
             var (pipeline, data) = GetMultiClassPipeline();
-            var calibrator = new PlattCalibratorTrainer(Env);
+            var calibrator = new PlattCalibratorEstimator(Env);
             var averagePerceptron = ML.BinaryClassification.Trainers.AveragedPerceptron(
-                new AveragedPerceptronTrainer.Options { Shuffle = true, Calibrator = null });
+                new AveragedPerceptronTrainer.Options { Shuffle = true });
 
             var ova = ML.MulticlassClassification.Trainers.OneVersusAll(averagePerceptron, imputeMissingLabelsAsNegative: true,
                 calibrator: calibrator, maxCalibrationExamples: 10000, useProbabilities: true);
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         {
             var (pipeline, data) = GetMultiClassPipeline();
             var sdcaTrainer = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscent(
-                new SdcaBinaryTrainer.Options { MaxIterations = 100, Shuffle = true, NumThreads = 1, Calibrator = null });
+                new SdcaBinaryTrainer.Options { MaxIterations = 100, Shuffle = true, NumThreads = 1 });
 
             pipeline = pipeline.Append(ML.MulticlassClassification.Trainers.OneVersusAll(sdcaTrainer, useProbabilities: false))
                     .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));


### PR DESCRIPTION
Fixes #2515, contributes towards #1871 and indirectly towards #2251.

* Internalize infrastructure only interface ICalibratorTrainer.
* Update calibrator estimators so they are a suitable replacement for calibrator trainers in the public surface, e.g., no longer take IPredictor.

Note that I did not add a calibrator catalog, since:

1. I believe @sfilipi already has assigned herself the issue #1871 to do so, and
2. Real reason, I am lazy! 😄

Calibrator estimators now are configured by the score/label/optionally weight column, *except* for the fixed Platt estimator, which only takes score (since it is not trained).

Note that ultimately the trainer estimator constructors *will* be internal, pending #1871.