### PR TITLE
Renaming .Train to .Fit in TrainerEstimators 

### DIFF
--- a/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
@@ -65,6 +65,10 @@ namespace Microsoft.ML.Training
         }
 
         /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
+        /// <remarks>
+        /// Derived class can overload this function.
+        /// For example, it could take an additional dataset to train with a separate validation set.
+        /// </remarks>
         public TTransformer Fit(IDataView input) => TrainTransformer(input);
 
         public SchemaShape GetOutputSchema(SchemaShape inputSchema)

--- a/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
@@ -64,6 +64,7 @@ namespace Microsoft.ML.Training
             WeightColumn = weight;
         }
 
+        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
         public TTransformer Fit(IDataView input) => TrainTransformer(input);
 
         public SchemaShape GetOutputSchema(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -278,7 +278,8 @@ namespace Microsoft.ML.Trainers.FastTree
             => new BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="FastTreeBinaryClassificationTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="FastTreeBinaryClassificationTrainer"/> using both training and validation data, returns
+        /// a <see cref="BinaryPredictionTransformer{CalibratedModelParametersBase}"/>.
         /// </summary>
         public BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.FastTree/FastTreeClassification.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeClassification.cs
@@ -277,7 +277,10 @@ namespace Microsoft.ML.Trainers.FastTree
             CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator> model, DataViewSchema trainSchema)
             => new BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="FastTreeBinaryClassificationTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<FastTreeBinaryModelParameters, PlattCalibrator>> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -457,7 +457,8 @@ namespace Microsoft.ML.Trainers.FastTree
         => new RankingPredictionTransformer<FastTreeRankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="FastTreeRankingTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="FastTreeRankingTrainer"/> using both training and validation data, returns
+        /// a <see cref="RankingPredictionTransformer{FastTreeRankingModelParameters}"/>.
         /// </summary>
         public RankingPredictionTransformer<FastTreeRankingModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.FastTree/FastTreeRanking.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRanking.cs
@@ -456,7 +456,10 @@ namespace Microsoft.ML.Trainers.FastTree
         protected override RankingPredictionTransformer<FastTreeRankingModelParameters> MakeTransformer(FastTreeRankingModelParameters model, DataViewSchema trainSchema)
         => new RankingPredictionTransformer<FastTreeRankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RankingPredictionTransformer<FastTreeRankingModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="FastTreeRankingTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RankingPredictionTransformer<FastTreeRankingModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -165,7 +165,8 @@ namespace Microsoft.ML.Trainers.FastTree
             => new RegressionPredictionTransformer<FastTreeRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="FastTreeRegressionTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="FastTreeRegressionTrainer"/> using both training and validation data, returns
+        /// a <see cref="RegressionPredictionTransformer{FastTreeRegressionModelParameters}"/>.
         /// </summary>
         public RegressionPredictionTransformer<FastTreeRegressionModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.FastTree/FastTreeRegression.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeRegression.cs
@@ -164,7 +164,10 @@ namespace Microsoft.ML.Trainers.FastTree
         protected override RegressionPredictionTransformer<FastTreeRegressionModelParameters> MakeTransformer(FastTreeRegressionModelParameters model, DataViewSchema trainSchema)
             => new RegressionPredictionTransformer<FastTreeRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<FastTreeRegressionModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="FastTreeRegressionTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RegressionPredictionTransformer<FastTreeRegressionModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -317,7 +317,10 @@ namespace Microsoft.ML.Trainers.FastTree
         protected override RegressionPredictionTransformer<FastTreeTweedieModelParameters> MakeTransformer(FastTreeTweedieModelParameters model, DataViewSchema trainSchema)
          => new RegressionPredictionTransformer<FastTreeTweedieModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<FastTreeTweedieModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="FastTreeTweedieTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RegressionPredictionTransformer<FastTreeTweedieModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
+++ b/src/Microsoft.ML.FastTree/FastTreeTweedie.cs
@@ -318,7 +318,8 @@ namespace Microsoft.ML.Trainers.FastTree
          => new RegressionPredictionTransformer<FastTreeTweedieModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="FastTreeTweedieTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="FastTreeTweedieTrainer"/> using both training and validation data, returns
+        /// a <see cref="RegressionPredictionTransformer{FastTreeTweedieModelParameters}"/>.
         /// </summary>
         public RegressionPredictionTransformer<FastTreeTweedieModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.FastTree/GamClassification.cs
+++ b/src/Microsoft.ML.FastTree/GamClassification.cs
@@ -143,7 +143,8 @@ namespace Microsoft.ML.Trainers.FastTree
             => new BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="BinaryClassificationGamTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="BinaryClassificationGamTrainer"/> using both training and validation data, returns
+        /// a <see cref="BinaryPredictionTransformer{CalibratedModelParametersBase}"/>.
         /// </summary>
         public BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.FastTree/GamClassification.cs
+++ b/src/Microsoft.ML.FastTree/GamClassification.cs
@@ -142,7 +142,10 @@ namespace Microsoft.ML.Trainers.FastTree
             MakeTransformer(CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator> model, DataViewSchema trainSchema)
             => new BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="BinaryClassificationGamTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<BinaryClassificationGamModelParameters, PlattCalibrator>> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/GamRegression.cs
+++ b/src/Microsoft.ML.FastTree/GamRegression.cs
@@ -91,7 +91,8 @@ namespace Microsoft.ML.Trainers.FastTree
             => new RegressionPredictionTransformer<RegressionGamModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="RegressionGamTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="RegressionGamTrainer"/> using both training and validation data, returns
+        /// a <see cref="RegressionPredictionTransformer{RegressionGamModelParameters}"/>.
         /// </summary>
         public RegressionPredictionTransformer<RegressionGamModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.FastTree/GamRegression.cs
+++ b/src/Microsoft.ML.FastTree/GamRegression.cs
@@ -90,7 +90,10 @@ namespace Microsoft.ML.Trainers.FastTree
         protected override RegressionPredictionTransformer<RegressionGamModelParameters> MakeTransformer(RegressionGamModelParameters model, DataViewSchema trainSchema)
             => new RegressionPredictionTransformer<RegressionGamModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<RegressionGamModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="RegressionGamTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RegressionPredictionTransformer<RegressionGamModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -214,7 +214,10 @@ namespace Microsoft.ML.Trainers.FastTree
         protected override BinaryPredictionTransformer<FastForestClassificationModelParameters> MakeTransformer(FastForestClassificationModelParameters model, DataViewSchema trainSchema)
          => new BinaryPredictionTransformer<FastForestClassificationModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<FastForestClassificationModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="FastForestClassification"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public BinaryPredictionTransformer<FastForestClassificationModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/RandomForestClassification.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestClassification.cs
@@ -215,7 +215,8 @@ namespace Microsoft.ML.Trainers.FastTree
          => new BinaryPredictionTransformer<FastForestClassificationModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="FastForestClassification"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="FastForestClassification"/> using both training and validation data, returns
+        /// a <see cref="BinaryPredictionTransformer{FastForestClassificationModelParameters}"/>.
         /// </summary>
         public BinaryPredictionTransformer<FastForestClassificationModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -224,7 +224,10 @@ namespace Microsoft.ML.Trainers.FastTree
         protected override RegressionPredictionTransformer<FastForestRegressionModelParameters> MakeTransformer(FastForestRegressionModelParameters model, DataViewSchema trainSchema)
          => new RegressionPredictionTransformer<FastForestRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<FastForestRegressionModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="FastForestRegression"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RegressionPredictionTransformer<FastForestRegressionModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.FastTree/RandomForestRegression.cs
+++ b/src/Microsoft.ML.FastTree/RandomForestRegression.cs
@@ -225,7 +225,8 @@ namespace Microsoft.ML.Trainers.FastTree
          => new RegressionPredictionTransformer<FastForestRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="FastForestRegression"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="FastForestRegression"/> using both training and validation data, returns
+        /// a <see cref="RegressionPredictionTransformer{FastForestRegressionModelParameters}"/>.
         /// </summary>
         public RegressionPredictionTransformer<FastForestRegressionModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -87,7 +87,10 @@ namespace Microsoft.ML.Trainers.HalLearners
         protected override RegressionPredictionTransformer<OlsLinearRegressionModelParameters> MakeTransformer(OlsLinearRegressionModelParameters model, DataViewSchema trainSchema)
              => new RegressionPredictionTransformer<OlsLinearRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<OlsLinearRegressionModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
+        /// <summary>
+        /// Continues the training of a <see cref="OlsLinearRegressionTrainer"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RegressionPredictionTransformer<OlsLinearRegressionModelParameters> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
+++ b/src/Microsoft.ML.HalLearners/OlsLinearRegression.cs
@@ -88,7 +88,8 @@ namespace Microsoft.ML.Trainers.HalLearners
              => new RegressionPredictionTransformer<OlsLinearRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Continues the training of a <see cref="OlsLinearRegressionTrainer"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// Continues the training of a <see cref="OlsLinearRegressionTrainer"/> using an initial predictor and returns
+        /// a <see cref="RegressionPredictionTransformer{OlsLinearRegressionModelParameters}"/>.
         /// </summary>
         public RegressionPredictionTransformer<OlsLinearRegressionModelParameters> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -212,7 +212,10 @@ namespace Microsoft.ML.Trainers.HalLearners
         protected override BinaryPredictionTransformer<TPredictor> MakeTransformer(TPredictor model, DataViewSchema trainSchema)
              => new BinaryPredictionTransformer<TPredictor>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<TPredictor> Train(IDataView trainData, TPredictor initialPredictor = null)
+        /// <summary>
+        /// Continues the training of a <see cref="SymSgdClassificationTrainer"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public BinaryPredictionTransformer<TPredictor> Fit(IDataView trainData, TPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         protected override SchemaShape.Column[] GetOutputColumnsCore(SchemaShape inputSchema)

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -213,7 +213,8 @@ namespace Microsoft.ML.Trainers.HalLearners
              => new BinaryPredictionTransformer<TPredictor>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Continues the training of a <see cref="SymSgdClassificationTrainer"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// Continues the training of a <see cref="SymSgdClassificationTrainer"/> using an initial predictor and returns
+        /// a <see cref="BinaryPredictionTransformer"/>.
         /// </summary>
         public BinaryPredictionTransformer<TPredictor> Fit(IDataView trainData, TPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -166,7 +166,8 @@ namespace Microsoft.ML.LightGBM
          => new BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="LightGbmBinaryTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="LightGbmBinaryTrainer"/> using both training and validation data, returns
+        /// a <see cref="BinaryPredictionTransformer{CalibratedModelParametersBase}"/>.
         /// </summary>
         public BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmBinaryTrainer.cs
@@ -165,7 +165,10 @@ namespace Microsoft.ML.LightGBM
             MakeTransformer(CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator> model, DataViewSchema trainSchema)
          => new BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="LightGbmBinaryTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<LightGbmBinaryModelParameters, PlattCalibrator>> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -222,7 +222,10 @@ namespace Microsoft.ML.LightGBM
         protected override MulticlassPredictionTransformer<OvaModelParameters> MakeTransformer(OvaModelParameters model, DataViewSchema trainSchema)
             => new MulticlassPredictionTransformer<OvaModelParameters>(Host, model, trainSchema, FeatureColumn.Name, LabelColumn.Name);
 
-        public MulticlassPredictionTransformer<OvaModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="LightGbmMulticlassTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public MulticlassPredictionTransformer<OvaModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmMulticlassTrainer.cs
@@ -223,7 +223,8 @@ namespace Microsoft.ML.LightGBM
             => new MulticlassPredictionTransformer<OvaModelParameters>(Host, model, trainSchema, FeatureColumn.Name, LabelColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="LightGbmMulticlassTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="LightGbmMulticlassTrainer"/> using both training and validation data, returns
+        /// a <see cref="MulticlassPredictionTransformer{OvaModelParameters}"/>.
         /// </summary>
         public MulticlassPredictionTransformer<OvaModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -177,7 +177,10 @@ namespace Microsoft.ML.LightGBM
         protected override RankingPredictionTransformer<LightGbmRankingModelParameters> MakeTransformer(LightGbmRankingModelParameters model, DataViewSchema trainSchema)
          => new RankingPredictionTransformer<LightGbmRankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RankingPredictionTransformer<LightGbmRankingModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="LightGbmRankingTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RankingPredictionTransformer<LightGbmRankingModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRankingTrainer.cs
@@ -178,7 +178,8 @@ namespace Microsoft.ML.LightGBM
          => new RankingPredictionTransformer<LightGbmRankingModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="LightGbmRankingTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="LightGbmRankingTrainer"/> using both training and validation data, returns
+        /// a <see cref="RankingPredictionTransformer{LightGbmRankingModelParameters}"/>.
         /// </summary>
         public RankingPredictionTransformer<LightGbmRankingModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -150,7 +150,10 @@ namespace Microsoft.ML.LightGBM
         protected override RegressionPredictionTransformer<LightGbmRegressionModelParameters> MakeTransformer(LightGbmRegressionModelParameters model, DataViewSchema trainSchema)
             => new RegressionPredictionTransformer<LightGbmRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<LightGbmRegressionModelParameters> Train(IDataView trainData, IDataView validationData = null)
+        /// <summary>
+        /// Trains a <see cref="LightGbmRegressorTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RegressionPredictionTransformer<LightGbmRegressionModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);
     }
 

--- a/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGBM/LightGbmRegressionTrainer.cs
@@ -151,7 +151,8 @@ namespace Microsoft.ML.LightGBM
             => new RegressionPredictionTransformer<LightGbmRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Trains a <see cref="LightGbmRegressorTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="LightGbmRegressorTrainer"/> using both training and validation data, returns
+        /// a <see cref="RegressionPredictionTransformer{LightGbmRegressionModelParameters}"/>.
         /// </summary>
         public RegressionPredictionTransformer<LightGbmRegressionModelParameters> Fit(IDataView trainData, IDataView validationData)
             => TrainTransformer(trainData, validationData);

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -505,7 +505,7 @@ namespace Microsoft.ML.Trainers
         /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
         /// </summary>
         /// <param name="input">The training data set.</param>
-        public MatrixFactorizationPredictionTransformer Fit(IDataView input) => Fit(input);
+        public MatrixFactorizationPredictionTransformer Fit(IDataView input) => Fit(input, null);
 
         /// <summary>
         /// Schema propagation for transformers. Returns the output schema of the data, if

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -478,7 +478,7 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// Trains a <see cref="MatrixFactorizationTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
+        /// Trains a <see cref="MatrixFactorizationTrainer"/> using both training and validation data, returns a <see cref="MatrixFactorizationPredictionTransformer"/>.
         /// </summary>
         /// <param name="trainData">The training data set.</param>
         /// <param name="validationData">The validation data set.</param>
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
+        /// <summary> Trains and returns a <see cref="MatrixFactorizationPredictionTransformer"/>.</summary>
         /// </summary>
         /// <param name="input">The training data set.</param>
         public MatrixFactorizationPredictionTransformer Fit(IDataView input) => Fit(input, null);

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -478,12 +478,11 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// Train a matrix factorization model based on the input <see cref="IDataView"/>
-        /// using the roles specified by <see cref="RecommenderUtils.MatrixColumnIndexKind"/> and <see cref="RecommenderUtils.MatrixRowIndexKind"/> in <see cref="MatrixFactorizationTrainer"/>.
+        /// Trains a <see cref="MatrixFactorizationTrainer"/> using both training and validation data, returns a <see cref="ITransformer"/>.
         /// </summary>
         /// <param name="trainData">The training data set.</param>
         /// <param name="validationData">The validation data set.</param>
-        public MatrixFactorizationPredictionTransformer Train(IDataView trainData, IDataView validationData = null)
+        public MatrixFactorizationPredictionTransformer Fit(IDataView trainData, IDataView validationData)
         {
             MatrixFactorizationModelParameters model = null;
 
@@ -503,11 +502,10 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// Train a matrix factorization model based on the input <see cref="IDataView"/>
-        /// using the roles specified by <see cref="RecommenderUtils.MatrixColumnIndexKind"/> and <see cref="RecommenderUtils.MatrixRowIndexKind"/> in <see cref="MatrixFactorizationTrainer"/>.
+        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
         /// </summary>
         /// <param name="input">The training data set.</param>
-        public MatrixFactorizationPredictionTransformer Fit(IDataView input) => Train(input);
+        public MatrixFactorizationPredictionTransformer Fit(IDataView input) => Fit(input);
 
         /// <summary>
         /// Schema propagation for transformers. Returns the output schema of the data, if

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -484,7 +484,7 @@ namespace Microsoft.ML.FactorizationMachine
 
         /// <summary>
         /// Continues the training of a <see cref="FieldAwareFactorizationMachineTrainer"/> using an initial predictor and/or validation data,
-        /// and returns a <see cref="ITransformer"/>.
+        /// and returns a <see cref="FieldAwareFactorizationMachinePredictionTransformer"/>.
         /// </summary>
         public FieldAwareFactorizationMachinePredictionTransformer Fit(IDataView trainData,
             IDataView validationData = null, FieldAwareFactorizationMachineModelParameters initialPredictor = null)
@@ -512,7 +512,7 @@ namespace Microsoft.ML.FactorizationMachine
             return new FieldAwareFactorizationMachinePredictionTransformer(Host, model, trainData.Schema, FeatureColumns.Select(x => x.Name).ToArray());
         }
 
-        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
+        /// <summary> Trains and returns a <see cref="FieldAwareFactorizationMachinePredictionTransformer"/>.</summary>
         public FieldAwareFactorizationMachinePredictionTransformer Fit(IDataView input) => Fit(input, null, null);
 
         /// <summary>

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -513,7 +513,7 @@ namespace Microsoft.ML.FactorizationMachine
         }
 
         /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
-        public FieldAwareFactorizationMachinePredictionTransformer Fit(IDataView input) => Fit(input);
+        public FieldAwareFactorizationMachinePredictionTransformer Fit(IDataView input) => Fit(input, null, null);
 
         /// <summary>
         /// Schema propagation for transformers. Returns the output schema of the data, if

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -482,7 +482,11 @@ namespace Microsoft.ML.FactorizationMachine
                 () => LearnerEntryPointsUtils.FindColumn(host, input.TrainingData.Schema, input.LabelColumn));
         }
 
-        public FieldAwareFactorizationMachinePredictionTransformer Train(IDataView trainData,
+        /// <summary>
+        /// Continues the training of a <see cref="FieldAwareFactorizationMachineTrainer"/> using an initial predictor and/or validation data,
+        /// and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public FieldAwareFactorizationMachinePredictionTransformer Fit(IDataView trainData,
             IDataView validationData = null, FieldAwareFactorizationMachineModelParameters initialPredictor = null)
         {
             FieldAwareFactorizationMachineModelParameters model = null;
@@ -508,7 +512,8 @@ namespace Microsoft.ML.FactorizationMachine
             return new FieldAwareFactorizationMachinePredictionTransformer(Host, model, trainData.Schema, FeatureColumns.Select(x => x.Name).ToArray());
         }
 
-        public FieldAwareFactorizationMachinePredictionTransformer Fit(IDataView input) => Train(input);
+        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
+        public FieldAwareFactorizationMachinePredictionTransformer Fit(IDataView input) => Fit(input);
 
         /// <summary>
         /// Schema propagation for transformers. Returns the output schema of the data, if

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -128,7 +128,8 @@ namespace Microsoft.ML.Trainers
             => new BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Continues the training of a <see cref="LogisticRegression"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// Continues the training of a <see cref="LogisticRegression"/> using an initial predictor and returns
+        /// a <see cref="BinaryPredictionTransformer{CalibratedModelParametersBase}"/>.
         /// </summary>
         public BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/LogisticRegression.cs
@@ -127,7 +127,10 @@ namespace Microsoft.ML.Trainers
             MakeTransformer(CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator> model, DataViewSchema trainSchema)
             => new BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>> Train(IDataView trainData, IPredictor initialPredictor = null)
+        /// <summary>
+        /// Continues the training of a <see cref="LogisticRegression"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public BinaryPredictionTransformer<CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         protected override float AccumulateOneGradient(in VBuffer<float> feat, float label, float weight,

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -325,7 +325,10 @@ namespace Microsoft.ML.Trainers
         protected override MulticlassPredictionTransformer<MulticlassLogisticRegressionModelParameters> MakeTransformer(MulticlassLogisticRegressionModelParameters model, DataViewSchema trainSchema)
             => new MulticlassPredictionTransformer<MulticlassLogisticRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name, LabelColumn.Name);
 
-        public MulticlassPredictionTransformer<MulticlassLogisticRegressionModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
+        /// <summary>
+        /// Continues the training of a <see cref="MulticlassLogisticRegression"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public MulticlassPredictionTransformer<MulticlassLogisticRegressionModelParameters> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
     }
 

--- a/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -326,7 +326,8 @@ namespace Microsoft.ML.Trainers
             => new MulticlassPredictionTransformer<MulticlassLogisticRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name, LabelColumn.Name);
 
         /// <summary>
-        /// Continues the training of a <see cref="MulticlassLogisticRegression"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// Continues the training of a <see cref="MulticlassLogisticRegression"/> using an initial predictor and returns
+        /// a <see cref="MulticlassPredictionTransformer{MulticlassLogisticRegressionModelParameters}"/>.
         /// </summary>
         public MulticlassPredictionTransformer<MulticlassLogisticRegressionModelParameters> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);

--- a/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/MultiClass/Ova.cs
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Trainers
             throw Host.ExceptNotSupp($"Label column type is not supported by OVA: {lab.Type}");
         }
 
-        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
+        /// <summary> Trains and returns a <see cref="MulticlassPredictionTransformer{OvaModelParameters}"/>.</summary>
         public override MulticlassPredictionTransformer<OvaModelParameters> Fit(IDataView input)
         {
             var roles = new KeyValuePair<CR, string>[1];

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -95,7 +95,8 @@ namespace Microsoft.ML.Trainers
             => new RegressionPredictionTransformer<PoissonRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Continues the training of a <see cref="PoissonRegression"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// Continues the training of a <see cref="PoissonRegression"/> using an initial predictor and returns
+        /// a <see cref="RegressionPredictionTransformer{PoissonRegressionModelParameters}"/>.
         /// </summary>
         public RegressionPredictionTransformer<PoissonRegressionModelParameters> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);

--- a/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/PoissonRegression/PoissonRegression.cs
@@ -94,7 +94,10 @@ namespace Microsoft.ML.Trainers
         protected override RegressionPredictionTransformer<PoissonRegressionModelParameters> MakeTransformer(PoissonRegressionModelParameters model, DataViewSchema trainSchema)
             => new RegressionPredictionTransformer<PoissonRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public RegressionPredictionTransformer<PoissonRegressionModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
+        /// <summary>
+        /// Continues the training of a <see cref="PoissonRegression"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public RegressionPredictionTransformer<PoissonRegressionModelParameters> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         protected override VBuffer<float> InitializeWeightsFromPredictor(PoissonRegressionModelParameters srcPredictor)

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -1876,7 +1876,10 @@ namespace Microsoft.ML.Trainers
         protected override BinaryPredictionTransformer<TScalarPredictor> MakeTransformer(TScalarPredictor model, DataViewSchema trainSchema)
             => new BinaryPredictionTransformer<TScalarPredictor>(Host, model, trainSchema, FeatureColumn.Name);
 
-        public BinaryPredictionTransformer<TScalarPredictor> Train(IDataView trainData, IPredictor initialPredictor = null)
+        /// <summary>
+        /// Continues the training of a <see cref="SdcaBinaryTrainer"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public BinaryPredictionTransformer<TScalarPredictor> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         //For complexity analysis, we assume that

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -1877,7 +1877,7 @@ namespace Microsoft.ML.Trainers
             => new BinaryPredictionTransformer<TScalarPredictor>(Host, model, trainSchema, FeatureColumn.Name);
 
         /// <summary>
-        /// Continues the training of a <see cref="SdcaBinaryTrainer"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// Continues the training of a <see cref="SdcaBinaryTrainer"/> using an initial predictor and returns a <see cref="BinaryPredictionTransformer"/>.
         /// </summary>
         public BinaryPredictionTransformer<TScalarPredictor> Fit(IDataView trainData, IPredictor initialPredictor)
             => TrainTransformer(trainData, initPredictor: initialPredictor);

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// Trains and returns a <see cref="ITransformer"/>.
+        /// Trains and returns a <see cref="BinaryPredictionTransformer{RandomModelParameters}"/>.
         /// </summary>
         public BinaryPredictionTransformer<RandomModelParameters> Fit(IDataView input)
         {
@@ -292,7 +292,7 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// Trains and returns a <see cref="ITransformer"/>.
+        /// Trains and returns a <see cref="BinaryPredictionTransformer{PriorModelParameters}"/>.
         /// </summary>
         public BinaryPredictionTransformer<PriorModelParameters> Fit(IDataView input)
         {

--- a/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
+++ b/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Sweeper
                         LabelColumn = DefaultColumnNames.Label,
                         FeatureColumn = DefaultColumnNames.Features,
                     });
-                var predictor = trainer.Train(view);
+                var predictor = trainer.Fit(view);
 
                 // Return random forest predictor.
                 return predictor.Model;

--- a/test/Microsoft.ML.Functional.Tests/Validation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Validation.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Functional.Tests
                     EarlyStoppingMetrics = 2,
                     EarlyStoppingRule = new GLEarlyStoppingCriterion.Arguments()
                 })
-                .Train(trainData: preprocessedTrainData, validationData: preprocessedValidData);
+                .Fit(trainData: preprocessedTrainData, validationData: preprocessedValidData);
 
             // Combine the model.
             var model = preprocessor.Append(trainedModel);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/FAFMEstimator.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/FAFMEstimator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             TestEstimatorCore(est, data);
             var model = est.Fit(data);
-            var anotherModel = est.Train(data, data, model.Model);
+            var anotherModel = est.Fit(data, data, model.Model);
 
             Done();
         }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/LbfgsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
             var model = trainer.Fit(transformedDataView);
-            trainer.Train(transformedDataView, model.Model);
+            trainer.Fit(transformedDataView, model.Model);
             Done();
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
             var model = trainer.Fit(transformedDataView);
-            trainer.Train(transformedDataView, model.Model);
+            trainer.Fit(transformedDataView, model.Model);
             Done();
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(trainer, dataView);
 
             var model = trainer.Fit(dataView);
-            trainer.Train(dataView, model.Model);
+            trainer.Fit(dataView, model.Model);
             Done();
         }
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 Assert.InRange(metrices.L2, expectedWindowsL2Error - tolerance, expectedWindowsL2Error + tolerance);
             }
 
-            var modelWithValidation = pipeline.Train(data, testData);
+            var modelWithValidation = pipeline.Fit(data, testData);
         }
 
         private TextLoader.Arguments GetLoaderArgs(string labelColumnName, string matrixColumnIndexColumnName, string matrixRowIndexColumnName)

--- a/test/Microsoft.ML.Tests/TrainerEstimators/OlsLinearRegressionTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/OlsLinearRegressionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(trainer, dataView);
 
             var model = trainer.Fit(dataView);
-            trainer.Train(dataView, model.Model);
+            trainer.Fit(dataView, model.Model);
             Done();
         }
     }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
             var model = trainer.Fit(transformedDataView);
-            trainer.Train(transformedDataView, model.Model);
+            trainer.Fit(transformedDataView, model.Model);
             Done();
         }
 
@@ -36,11 +36,11 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var initPredictor = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscent().Fit(transformedData);
             var data = initPredictor.Transform(transformedData);
 
-            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData,
+            var withInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Fit(transformedData,
                 initialPredictor: initPredictor.Model as CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>);
             var outInitData = withInitPredictor.Transform(transformedData);
 
-            var notInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Train(transformedData);
+            var notInitPredictor = new SymSgdClassificationTrainer(Env, new SymSgdClassificationTrainer.Options()).Fit(transformedData);
             var outNoInitData = notInitPredictor.Transform(transformedData);
 
             int numExamples = 10;

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
             var model = trainer.Fit(transformedDataView);
-            trainer.Train(transformedDataView, model.Model);
+            trainer.Fit(transformedDataView, model.Model);
             TestEstimatorCore(pipe, dataView);
             Done();
         }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(pipeWithTrainer, dataView);
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
-            var model = trainer.Train(transformedDataView, transformedDataView);
+            var model = trainer.Fit(transformedDataView, transformedDataView);
             Done();
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(pipeWithTrainer, dataView);
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
-            var model = trainer.Train(transformedDataView, transformedDataView);
+            var model = trainer.Fit(transformedDataView, transformedDataView);
             Done();
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(pipeWithTrainer, dataView);
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
-            var model = trainer.Train(transformedDataView, transformedDataView);
+            var model = trainer.Fit(transformedDataView, transformedDataView);
             Done();
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(pipeWithTrainer, dataView);
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
-            var model = trainer.Train(transformedDataView, transformedDataView);
+            var model = trainer.Fit(transformedDataView, transformedDataView);
             Done();
         }
 
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(pipeWithTrainer, dataView);
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
-            var model = trainer.Train(transformedDataView, transformedDataView);
+            var model = trainer.Fit(transformedDataView, transformedDataView);
             Done();
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(pipeWithTrainer, dataView);
 
             var transformedDataView = pipe.Fit(dataView).Transform(dataView);
-            var model = trainer.Train(transformedDataView, transformedDataView);
+            var model = trainer.Fit(transformedDataView, transformedDataView);
             Done();
         }
 
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 new FastTreeRegressionTrainer.Options { NumTrees = 10, NumThreads = 1, NumLeaves = 5 });
 
             TestEstimatorCore(trainer, dataView);
-            var model = trainer.Train(dataView, dataView);
+            var model = trainer.Fit(dataView, dataView);
             Done();
         }
 
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             });
 
             TestEstimatorCore(trainer, dataView);
-            var model = trainer.Train(dataView, dataView);
+            var model = trainer.Fit(dataView, dataView);
             Done();
         }
 
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             });
 
             TestEstimatorCore(trainer, dataView);
-            var model = trainer.Train(dataView, dataView);
+            var model = trainer.Fit(dataView, dataView);
             Done();
         }
 
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 });
 
             TestEstimatorCore(trainer, dataView);
-            var model = trainer.Train(dataView, dataView);
+            var model = trainer.Fit(dataView, dataView);
             Done();
         }
 
@@ -231,7 +231,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 });
 
             TestEstimatorCore(trainer, dataView);
-            var model = trainer.Train(dataView, dataView);
+            var model = trainer.Fit(dataView, dataView);
             Done();
         }
 


### PR DESCRIPTION
Fixes #2527.

As further explained in the issue, there were two methods with two different names to train a TrainerEstimator. I renamed one of them so that the additional functionalities come with an overload.

In particular the methods `Train(IDataView trainData, IDataView validData)`, and `Train(IDataView trainData, IPredictor initialPredictor)` have been renamed to `Fit(...`.

