### PR TITLE
Hide InitialWeights in OnlineLinear trainers

### DIFF
--- a/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/AveragedPerceptron.cs
@@ -98,7 +98,6 @@ namespace Microsoft.ML.Trainers.Online
         /// <param name="lossFunction">The classification loss function. </param>
         /// <param name="labelColumn">The name of the label column. </param>
         /// <param name="featureColumn">The name of the feature column.</param>
-        /// <param name="weights">The optional name of the weights column.</param>
         /// <param name="learningRate">The learning rate. </param>
         /// <param name="decreaseLearningRate">Wheather to decrease learning rate as iterations progress.</param>
         /// <param name="l2RegularizerWeight">L2 Regularization Weight.</param>
@@ -106,7 +105,6 @@ namespace Microsoft.ML.Trainers.Online
         internal AveragedPerceptronTrainer(IHostEnvironment env,
             string labelColumn = DefaultColumnNames.Label,
             string featureColumn = DefaultColumnNames.Features,
-            string weights = null,
             IClassificationLoss lossFunction = null,
             float learningRate = Options.AveragedDefaultArgs.LearningRate,
             bool decreaseLearningRate = Options.AveragedDefaultArgs.DecreaseLearningRate,
@@ -116,7 +114,6 @@ namespace Microsoft.ML.Trainers.Online
             {
                 LabelColumn = labelColumn,
                 FeatureColumn = featureColumn,
-                InitialWeights = weights,
                 LearningRate = learningRate,
                 DecreaseLearningRate = decreaseLearningRate,
                 L2RegularizerWeight = l2RegularizerWeight,
@@ -179,9 +176,6 @@ namespace Microsoft.ML.Trainers.Online
 
         protected override BinaryPredictionTransformer<LinearBinaryModelParameters> MakeTransformer(LinearBinaryModelParameters model, Schema trainSchema)
         => new BinaryPredictionTransformer<LinearBinaryModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
-
-        public BinaryPredictionTransformer<LinearBinaryModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
-            => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         [TlcModule.EntryPoint(Name = "Trainers.AveragedPerceptronBinaryClassifier",
              Desc = Summary,

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/LinearSvm.cs
@@ -65,6 +65,12 @@ namespace Microsoft.ML.Trainers.Online
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "The maximum number of examples to use when training the calibrator", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
             internal int MaxCalibrationExamples = 1000000;
+
+            /// <summary>
+            /// Column to use for example weight.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Column to use for example weight", ShortName = "weight", SortOrder = 4, Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
+            public Optional<string> WeightColumn = Optional<string>.Implicit(DefaultColumnNames.Weight);
         }
 
         private sealed class TrainState : TrainStateBase
@@ -226,19 +232,19 @@ namespace Microsoft.ML.Trainers.Online
         /// <param name="env">The environment to use.</param>
         /// <param name="labelColumn">The name of the label column. </param>
         /// <param name="featureColumn">The name of the feature column.</param>
-        /// <param name="weightsColumn">The optional name of the weights column.</param>
+         /// <param name="weightColumn">The optional name of the weight column.</param>
         /// <param name="numIterations">The number of training iteraitons.</param>
         [BestFriend]
         internal LinearSvmTrainer(IHostEnvironment env,
             string labelColumn = DefaultColumnNames.Label,
             string featureColumn = DefaultColumnNames.Features,
-            string weightsColumn = null,
+            string weightColumn = null,
             int numIterations = Options.OnlineDefaultArgs.NumIterations)
             : this(env, new Options
             {
                 LabelColumn = labelColumn,
                 FeatureColumn = featureColumn,
-                InitialWeights = weightsColumn,
+                WeightColumn = weightColumn,
                 NumIterations = numIterations,
             })
         {
@@ -289,8 +295,5 @@ namespace Microsoft.ML.Trainers.Online
 
         protected override BinaryPredictionTransformer<LinearBinaryModelParameters> MakeTransformer(LinearBinaryModelParameters model, Schema trainSchema)
             => new BinaryPredictionTransformer<LinearBinaryModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
-
-        public BinaryPredictionTransformer<LinearBinaryModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
-            => TrainTransformer(trainData, initPredictor: initialPredictor);
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineGradientDescent.cs
@@ -98,7 +98,6 @@ namespace Microsoft.ML.Trainers.Online
         /// <param name="decreaseLearningRate">Decrease learning rate as iterations progress.</param>
         /// <param name="l2RegularizerWeight">L2 Regularization Weight.</param>
         /// <param name="numIterations">Number of training iterations through the data.</param>
-        /// <param name="weightsColumn">The name of the weights column.</param>
         /// <param name="lossFunction">The custom loss functions. Defaults to <see cref="SquaredLoss"/> if not provided.</param>
         internal OnlineGradientDescentTrainer(IHostEnvironment env,
             string labelColumn = DefaultColumnNames.Label,
@@ -107,7 +106,6 @@ namespace Microsoft.ML.Trainers.Online
             bool decreaseLearningRate = Options.OgdDefaultArgs.DecreaseLearningRate,
             float l2RegularizerWeight = Options.OgdDefaultArgs.L2RegularizerWeight,
             int numIterations = Options.OgdDefaultArgs.NumIterations,
-            string weightsColumn = null,
             IRegressionLoss lossFunction = null)
             : this(env, new Options
             {
@@ -117,7 +115,6 @@ namespace Microsoft.ML.Trainers.Online
                 NumIterations = numIterations,
                 LabelColumn = labelColumn,
                 FeatureColumn = featureColumn,
-                InitialWeights = weightsColumn,
                 LossFunction = new TrivialFactory(lossFunction ?? new SquaredLoss())
             })
         {
@@ -179,8 +176,5 @@ namespace Microsoft.ML.Trainers.Online
 
         protected override RegressionPredictionTransformer<LinearRegressionModelParameters> MakeTransformer(LinearRegressionModelParameters model, Schema trainSchema)
         => new RegressionPredictionTransformer<LinearRegressionModelParameters>(Host, model, trainSchema, FeatureColumn.Name);
-
-        public RegressionPredictionTransformer<LinearRegressionModelParameters> Train(IDataView trainData, IPredictor initialPredictor = null)
-            => TrainTransformer(trainData, initPredictor: initialPredictor);
     }
 }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Data.DataView;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Core.Data;
 using Microsoft.ML.Data;
@@ -16,7 +17,6 @@ using Microsoft.ML.Training;
 
 namespace Microsoft.ML.Trainers.Online
 {
-
     public abstract class OnlineLinearArguments : LearnerInputBaseWithLabel
     {
         [Argument(ArgumentType.AtMostOnce, HelpText = "Number of iterations", ShortName = "iter", SortOrder = 50)]
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Trainers.Online
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "Initial Weights and bias, comma-separated", ShortName = "initweights")]
         [TGUI(NoSweep = true)]
-        public string InitialWeights;
+        internal string InitialWeights;
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "Init weights diameter", ShortName = "initwts", SortOrder = 140)]
         [TGUI(Label = "Initial Weights Scale", SuggestedSweeps = "0,0.1,0.5,1")]
@@ -280,6 +280,12 @@ namespace Microsoft.ML.Trainers.Online
                 return state.CreatePredictor();
             }
         }
+
+        /// <summary>
+        /// Continues the training of a <see cref="OnlineLinearTrainer{TTransformer, TModel}"/> using an initial predictor and returns a <see cref="ITransformer"/>.
+        /// </summary>
+        public TTransformer Fit(IDataView trainData, IPredictor initialPredictor)
+            => TrainTransformer(trainData, initPredictor: initialPredictor);
 
         private protected abstract void CheckLabels(RoleMappedData data);
 

--- a/src/Microsoft.ML.StandardLearners/StandardLearnersCatalog.cs
+++ b/src/Microsoft.ML.StandardLearners/StandardLearnersCatalog.cs
@@ -198,7 +198,6 @@ namespace Microsoft.ML
         /// <param name="labelColumn">The name of the label column, or dependent variable.</param>
         /// <param name="featureColumn">The features, or independent variables.</param>
         /// <param name="lossFunction">The custom loss.</param>
-        /// <param name="weights">The optional example weights.</param>
         /// <param name="learningRate">The learning Rate.</param>
         /// <param name="decreaseLearningRate">Decrease learning rate as iterations progress.</param>
         /// <param name="l2RegularizerWeight">L2 regularization weight.</param>
@@ -207,7 +206,6 @@ namespace Microsoft.ML
             this BinaryClassificationCatalog.BinaryClassificationTrainers catalog,
             string labelColumn = DefaultColumnNames.Label,
             string featureColumn = DefaultColumnNames.Features,
-            string weights = null,
             IClassificationLoss lossFunction = null,
             float learningRate = AveragedLinearArguments.AveragedDefaultArgs.LearningRate,
             bool decreaseLearningRate = AveragedLinearArguments.AveragedDefaultArgs.DecreaseLearningRate,
@@ -217,7 +215,7 @@ namespace Microsoft.ML
             Contracts.CheckValue(catalog, nameof(catalog));
 
             var env = CatalogUtils.GetEnvironment(catalog);
-            return new AveragedPerceptronTrainer(env, labelColumn, featureColumn, weights, lossFunction ?? new LogLoss(), learningRate, decreaseLearningRate, l2RegularizerWeight, numIterations);
+            return new AveragedPerceptronTrainer(env, labelColumn, featureColumn, lossFunction ?? new LogLoss(), learningRate, decreaseLearningRate, l2RegularizerWeight, numIterations);
         }
 
         /// <summary>
@@ -256,7 +254,6 @@ namespace Microsoft.ML
         /// <param name="catalog">The regression catalog trainer object.</param>
         /// <param name="labelColumn">The name of the label, or dependent variable.</param>
         /// <param name="featureColumn">The features, or independent variables.</param>
-        /// <param name="weights">The optional example weights.</param>
         /// <param name="lossFunction">The custom loss. Defaults to <see cref="SquaredLoss"/> if not provided.</param>
         /// <param name="learningRate">The learning Rate.</param>
         /// <param name="decreaseLearningRate">Decrease learning rate as iterations progress.</param>
@@ -265,7 +262,6 @@ namespace Microsoft.ML
         public static OnlineGradientDescentTrainer OnlineGradientDescent(this RegressionCatalog.RegressionTrainers catalog,
             string labelColumn = DefaultColumnNames.Label,
             string featureColumn = DefaultColumnNames.Features,
-            string weights = null,
             IRegressionLoss lossFunction = null,
             float learningRate = OnlineGradientDescentTrainer.Options.OgdDefaultArgs.LearningRate,
             bool decreaseLearningRate = OnlineGradientDescentTrainer.Options.OgdDefaultArgs.DecreaseLearningRate,
@@ -275,7 +271,7 @@ namespace Microsoft.ML
             Contracts.CheckValue(catalog, nameof(catalog));
             var env = CatalogUtils.GetEnvironment(catalog);
             return new OnlineGradientDescentTrainer(env, labelColumn, featureColumn, learningRate, decreaseLearningRate, l2RegularizerWeight,
-                numIterations, weights, lossFunction);
+                numIterations, lossFunction);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StaticPipe/OnlineLearnerStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/OnlineLearnerStatic.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.StaticPipe
                 (env, labelName, featuresName, weightsName) =>
                 {
 
-                    var trainer = new AveragedPerceptronTrainer(env, labelName, featuresName, weightsName, lossFunction,
+                    var trainer = new AveragedPerceptronTrainer(env, labelName, featuresName, lossFunction,
                         learningRate, decreaseLearningRate, l2RegularizerWeight, numIterations);
 
                     if (onFit != null)
@@ -120,7 +120,6 @@ namespace Microsoft.ML.StaticPipe
                 {
                     options.LabelColumn = labelName;
                     options.FeatureColumn = featuresName;
-                    options.InitialWeights = weightsName;
 
                     var trainer = new AveragedPerceptronTrainer(env, options);
 
@@ -179,7 +178,7 @@ namespace Microsoft.ML.StaticPipe
                 (env, labelName, featuresName, weightsName) =>
                 {
                     var trainer = new OnlineGradientDescentTrainer(env, labelName, featuresName, learningRate,
-                        decreaseLearningRate, l2RegularizerWeight, numIterations, weightsName, lossFunction);
+                        decreaseLearningRate, l2RegularizerWeight, numIterations, lossFunction);
 
                     if (onFit != null)
                         return trainer.WithOnFitDelegate(trans => onFit(trans.Model));
@@ -225,7 +224,6 @@ namespace Microsoft.ML.StaticPipe
                 {
                     options.LabelColumn = labelName;
                     options.FeatureColumn = featuresName;
-                    options.InitialWeights = weightsName;
 
                     var trainer = new OnlineGradientDescentTrainer(env, options);
 
@@ -239,7 +237,8 @@ namespace Microsoft.ML.StaticPipe
         }
     }
 
-    internal static class OnlineLinearStaticUtils{
+    internal static class OnlineLinearStaticUtils
+    {
 
         internal static void CheckUserParams(PipelineColumn label,
             PipelineColumn features,

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -13169,6 +13169,18 @@
           "Default": "Label"
         },
         {
+          "Name": "WeightColumn",
+          "Type": "String",
+          "Desc": "Column to use for example weight",
+          "Aliases": [
+            "weight"
+          ],
+          "Required": false,
+          "SortOrder": 4.0,
+          "IsNullable": false,
+          "Default": "Weight"
+        },
+        {
           "Name": "NormalizeFeatures",
           "Type": {
             "Kind": "Enum",

--- a/test/Microsoft.ML.Tests/TrainerEstimators/OnlineLinearTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/OnlineLinearTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var ogdTrainer = ML.Regression.Trainers.OnlineGradientDescent();
             TestEstimatorCore(ogdTrainer, regressionTrainData);
             var ogdModel = ogdTrainer.Fit(regressionTrainData);
-            ogdTrainer.Train(regressionTrainData, ogdModel.Model);
+            ogdTrainer.Fit(regressionTrainData, ogdModel.Model);
 
             var binaryData = TextLoaderStatic.CreateReader(ML, ctx => (Label: ctx.LoadBool(0), Features: ctx.LoadFloat(1, 10)))
                .Read(dataPath);
@@ -41,13 +41,13 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             TestEstimatorCore(apTrainer, binaryTrainData);
 
             var apModel = apTrainer.Fit(binaryTrainData);
-            apTrainer.Train(binaryTrainData, apModel.Model);
+            apTrainer.Fit(binaryTrainData, apModel.Model);
 
             var svmTrainer = ML.BinaryClassification.Trainers.LinearSupportVectorMachines();
             TestEstimatorCore(svmTrainer, binaryTrainData);
 
             var svmModel = svmTrainer.Fit(binaryTrainData);
-            svmTrainer.Train(binaryTrainData, apModel.Model);
+            svmTrainer.Fit(binaryTrainData, apModel.Model);
 
             Done();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/2519
Related to https://github.com/dotnet/machinelearning/issues/2527
Also fixes mess with Weights columns for OnlineLinear trainers. Only LinearSVM uses it, so all other trainers shouldn't accept weight as column