### PR TITLE
Remove OpenInputFile and CreateOutputFile methods from IHostEnvironment

### DIFF
--- a/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
+++ b/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
@@ -34,6 +34,8 @@ namespace Microsoft.ML
         /// </summary>
         public static IFileHandle OpenInputFile(this IHostEnvironment env, string path)
         {
+            Contracts.AssertValue(env);
+            Contracts.CheckNonWhiteSpace(path, nameof(path));
             return new SimpleFileHandle(env, path, needsWrite: false, autoDelete: false);
         }
 
@@ -42,6 +44,8 @@ namespace Microsoft.ML
         /// </summary>
         public static IFileHandle CreateOutputFile(this IHostEnvironment env, string path)
         {
+            Contracts.AssertValue(env);
+            Contracts.CheckNonWhiteSpace(path, nameof(path));
             return new SimpleFileHandle(env, path, needsWrite: true, autoDelete: false);
         }
     }

--- a/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
+++ b/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
@@ -24,6 +24,29 @@ namespace Microsoft.ML
     }
 
     /// <summary>
+    /// Utility class for IHostEnvironment
+    /// </summary>
+    [BestFriend]
+    internal static class HostEnvironmentExtensions
+    {
+        /// <summary>
+        /// Return a file handle for an input "file".
+        /// </summary>
+        public static IFileHandle OpenInputFile(this IHostEnvironment env, string path)
+        {
+            return new SimpleFileHandle(env, path, needsWrite: false, autoDelete: false);
+        }
+
+        /// <summary>
+        /// Create an output "file" and return a handle to it.
+        /// </summary>
+        public static IFileHandle CreateOutputFile(this IHostEnvironment env, string path)
+        {
+            return new SimpleFileHandle(env, path, needsWrite: true, autoDelete: false);
+        }
+    }
+
+    /// <summary>
     /// The host environment interface creates hosts for components. Note that the methods of
     /// this interface should be called from the main thread for the environment. To get an environment
     /// to service another thread, call Fork and pass the return result to that thread.
@@ -51,16 +74,6 @@ namespace Microsoft.ML
         /// The catalog of loadable components (<see cref="LoadableClassAttribute"/>) that are available in this host.
         /// </summary>
         ComponentCatalog ComponentCatalog { get; }
-
-        /// <summary>
-        /// Return a file handle for an input "file".
-        /// </summary>
-        IFileHandle OpenInputFile(string path);
-
-        /// <summary>
-        /// Create an output "file" and return a handle to it.
-        /// </summary>
-        IFileHandle CreateOutputFile(string path);
 
         /// <summary>
         /// Create a temporary "file" and return a handle to it. Generally temp files are expected to be

--- a/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
+++ b/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
@@ -439,14 +439,6 @@ namespace Microsoft.ML.Data
         protected abstract IHost RegisterCore(HostEnvironmentBase<TEnv> source, string shortName,
             string parentFullName, Random rand, bool verbose, int? conc);
 
-        public IFileHandle OpenInputFile(string path)
-        {
-
-            if (Master != null)
-                return Master.OpenInputFileCore(this, path);
-            return OpenInputFileCore(this, path);
-        }
-
         public IProgressChannel StartProgressChannel(string name)
         {
             Contracts.CheckNonEmpty(name, nameof(name));
@@ -458,41 +450,6 @@ namespace Microsoft.ML.Data
             Contracts.AssertNonEmpty(name);
             Contracts.AssertValueOrNull(host);
             return new ProgressReporting.ProgressChannel(this, ProgressTracker, name);
-        }
-
-        /// <summary>
-        /// This "opens" the input file handle. The default implementation assumes the file resides in the
-        /// file system and it does not access the physical file until a read stream is opened on the returned
-        /// file handle.
-        /// </summary>
-        protected virtual IFileHandle OpenInputFileCore(IHostEnvironment env, string path)
-        {
-            this.AssertValue(env);
-            this.CheckNonWhiteSpace(path, nameof(path));
-            if (Master != null)
-                return Master.OpenInputFileCore(env, path);
-            return new SimpleFileHandle(env, path, needsWrite: false, autoDelete: false);
-        }
-
-        public IFileHandle CreateOutputFile(string path)
-        {
-            if (Master != null)
-                return Master.CreateOutputFileCore(this, path);
-            return CreateOutputFileCore(this, path);
-        }
-
-        /// <summary>
-        /// This "creates" the output file handle. The default implementation assumes the file resides in the
-        /// file system and it does not create the physical file until a write stream is opened on the returned
-        /// file handle.
-        /// </summary>
-        protected virtual IFileHandle CreateOutputFileCore(IHostEnvironment env, string path)
-        {
-            this.AssertValue(env);
-            this.CheckNonWhiteSpace(path, nameof(path));
-            if (Master != null)
-                return Master.CreateOutputFileCore(env, path);
-            return new SimpleFileHandle(env, path, needsWrite: true, autoDelete: false);
         }
 
         public IFileHandle CreateTempFile(string suffix = null, string prefix = null)

--- a/src/Microsoft.ML.Data/MLContext.cs
+++ b/src/Microsoft.ML.Data/MLContext.cs
@@ -116,9 +116,7 @@ namespace Microsoft.ML
         bool IHostEnvironment.IsCancelled => _env.IsCancelled;
         ComponentCatalog IHostEnvironment.ComponentCatalog => _env.ComponentCatalog;
         string IExceptionContext.ContextDescription => _env.ContextDescription;
-        IFileHandle IHostEnvironment.CreateOutputFile(string path) => _env.CreateOutputFile(path);
         IFileHandle IHostEnvironment.CreateTempFile(string suffix, string prefix) => _env.CreateTempFile(suffix, prefix);
-        IFileHandle IHostEnvironment.OpenInputFile(string path) => _env.OpenInputFile(path);
         TException IExceptionContext.Process<TException>(TException ex) => _env.Process(ex);
         IHost IHostEnvironment.Register(string name, int? seed, bool? verbose, int? conc) => _env.Register(name, seed, verbose, conc);
         IChannel IChannelProvider.Start(string name) => _env.Start(name);


### PR DESCRIPTION
Didn't add new tests since the implementation is just moved from HostEnvironmentBase to HostEnvironmentUtils class.

On a separate PR will remove CreateTempFile which still part of IHostEnvironment interface.

Related to: #1287
cc: @eerhardt 

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

