### PR TITLE
[Tiny & Simple Change] Example classes should be static

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Calibrator.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Calibrator.cs
@@ -8,9 +8,9 @@ namespace Microsoft.ML.Samples.Dynamic
     /// <summary>
     /// This example first trains a StochasticDualCoordinateAscentBinary Classifier and then convert its output to probability via training a calibrator.  
     /// </summary>
-    public class CalibratorExample
+    public static class Calibrator
     {
-        public static void Calibration()
+        public static void Example()
         {
             // Downloading the dataset from github.com/dotnet/machinelearning.
             // This will create a sentiment.tsv file in the filesystem.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
@@ -4,7 +4,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public static class BootstrapSample
+    public static class Bootstrap
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FastTreeRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FastTreeRegression.cs
@@ -4,9 +4,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class FastTreeRegressionExample
+    public static class FastTreeRegression
     {
-        public static void FastTreeRegression()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -4,7 +4,7 @@ using Microsoft.ML.SamplesUtils;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class FeatureContributionCalculationTransform
+    public static class FeatureContributionCalculationTransform
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
@@ -4,9 +4,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class FeatureSelectionTransformExample
+    public static class FeatureSelectionTransform
     {
-        public static void FeatureSelectionTransform()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FieldAwareFactorizationMachine.cs
@@ -2,9 +2,9 @@
 using Microsoft.ML.Data;
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class FFM_BinaryClassificationExample
+    public static class FFMBinaryClassification
     {
-        public static void FFM_BinaryClassification()
+        public static void Example()
         {
             // Downloading the dataset from github.com/dotnet/machinelearning.
             // This will create a sentiment.tsv file in the filesystem.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/GeneralizedAdditiveModels.cs
@@ -4,9 +4,9 @@ using Microsoft.ML.SamplesUtils;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class GeneralizedAdditiveModels_RegressionExample
+    public static class GeneralizedAdditiveModelsRegression
     {
-        public static void RunExample()
+        public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/IidChangePointDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/IidChangePointDetectorTransform.cs
@@ -10,7 +10,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public partial class TransformSamples
+    public static partial class TransformSamples
     {
         class ChangePointPrediction
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/IidSpikeDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/IidSpikeDetectorTransform.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public partial class TransformSamples
+    public static partial class TransformSamples
     {
         class IidSpikeData
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ConvertToGrayScale.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ConvertToGrayScale.cs
@@ -3,10 +3,10 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ConvertToGrayscaleExample
+    public static class ConvertToGrayscale
     {
         // Sample that loads images from the file system, and converts them to grayscale. 
-        public static void ConvertToGrayscale()
+        public static void Example()
         {
             var mlContext = new MLContext();
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ExtractPixels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ExtractPixels.cs
@@ -3,11 +3,11 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ExtractPixelsExample
+    public static class ExtractPixels
     {
         // Sample that loads the images from the file system, resizes them (ExtractPixels requires a resizing operation), and extracts the 
         // values of the pixels as a vector. 
-        public static void ExtractPixels()
+        public static void Example()
         {
             var mlContext = new MLContext();
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/LoadImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/LoadImage.cs
@@ -3,10 +3,10 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class LoadImageExample
+    public static class LoadImage
     {
         // Loads the images of the imagesFolder into an IDataView. 
-        public static void LoadImage()
+        public static void Example()
         {
             var mlContext = new MLContext();
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImage.cs
@@ -3,10 +3,10 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ResizeImageExample
+    public static class ResizeImage
     {
         // Example on how to load the images from the file system, and resize them. 
-        public static void ResizeImage()
+        public static void Example()
         {
             var mlContext = new MLContext();
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KMeans.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KMeans.cs
@@ -3,9 +3,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class KMeans_example
+    public class KMeans
     {
-        public static void KMeans()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms.Conversions;
-using Microsoft.ML.Transforms.Text;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class KeyToValueValueToKeyExample
+    public class KeyToValueValueToKey
     {
-        public static void KeyToValueValueToKey()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
@@ -4,9 +4,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class LdaTransformExample
+    public static class LdaTransform
     {
-        public static void LdaTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/LogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/LogisticRegression.cs
@@ -4,9 +4,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class LogisticRegressionExample
+    public static class LogisticRegressionExample
     {
-        public static void LogisticRegression()
+        public static void Example()
         {
             var ml = new MLContext();
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
@@ -4,7 +4,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public partial class NgramTransformSamples
+    public static partial class TransformSamples
     {
         public static void NgramTransform()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
@@ -6,9 +6,9 @@ using Microsoft.ML.Transforms.Normalizers;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class NormalizerExample
+    public static class NormalizerTransform
     {
-        public static void Normalizer()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -6,12 +6,12 @@ using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    class OnnxTransformExample
+    public static class OnnxTransformExample
     {
         /// <summary>
         /// Example use of OnnxEstimator in an ML.NET pipeline
         /// </summary>
-        public static void OnnxTransformSample()
+        public static void Example()
         {
             // Download the squeeznet image model from ONNX model zoo, version 1.2
             // https://github.com/onnx/models/tree/master/squeezenet

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIHelper.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIHelper.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.Data.DataView;
-using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.SamplesUtils;
 using Microsoft.ML.Trainers.HalLearners;
 
 namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
 {
-    public class PfiHelper
+    public static class PfiHelper
     {
         public static IDataView GetHousingRegressionIDataView(MLContext mlContext, out string labelName, out string[] featureNames, bool binaryPrediction = false)
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIRegressionExample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIRegressionExample.cs
@@ -3,9 +3,9 @@ using System.Linq;
 
 namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
 {
-    public class PfiRegressionExample
+    public static class PfiRegression
     {
-        public static void RunExample()
+        public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
@@ -4,9 +4,9 @@ using Microsoft.ML.Trainers;
 
 namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
 {
-    public class PfiBinaryClassificationExample
+    public static class PfiBinaryClassification
     {
-        public static void RunExample()
+        public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
@@ -5,9 +5,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ProjectionTransformsExample
+    public static class ProjectionTransforms
     {
-        public static void ProjectionTransforms()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SDCARegression.cs
@@ -4,9 +4,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class SDCARegressionExample
+    public static class SDCARegression
     {
-        public static void SDCARegression()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SsaChangePointDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SsaChangePointDetectorTransform.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public partial class TransformSamples
+    public static partial class TransformSamples
     {
         class SsaChangePointData
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SsaSpikeDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SsaSpikeDetectorTransform.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public partial class TransformSamples
+    public static partial class TransformSamples
     {
         class SsaSpikeData
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/StopWordRemoverTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/StopWordRemoverTransform.cs
@@ -5,9 +5,9 @@ using Microsoft.ML.Transforms.Text;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class StopWordRemoverTransformExample
+    public static class StopWordRemoverTransform
     {
-        public static void StopWordRemoverTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/ImageClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/ImageClassification.cs
@@ -4,12 +4,12 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic.TensorFlow
 {
-    class ImageClassification
+    public static class ImageClassification
     {
         /// <summary>
         /// Example use of the TensorFlow image model in a ML.NET pipeline.
         /// </summary>
-        public static void ScoringWithImageClassificationModelSample()
+        public static void Example()
         {
             // Download the ResNet 101 model from the location below.
             // https://storage.googleapis.com/download.tensorflow.org/models/tflite_11_05_08/resnet_v2_101.tgz

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -1,18 +1,17 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms.TensorFlow;
 
 namespace Microsoft.ML.Samples.Dynamic.TensorFlow
 {
-    class TextClassification
+    public static class TextClassification
     {
         public const int MaxSentenceLenth = 600;
         /// <summary>
         /// Example use of the TensorFlow sentiment classification model.
         /// </summary>
-        public static void ScoringWithTextClassificationModelSample()
+        public static void Example()
         {
             string modelLocation = SamplesUtils.DatasetUtils.DownloadTensorFlowSentimentModel();
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
@@ -5,9 +5,9 @@ using Microsoft.ML.Transforms.Text;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class TextTransformExample
+    public static class TextTransform
     {
-        public static void TextTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SDCALogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SDCALogisticRegression.cs
@@ -5,7 +5,7 @@ using Microsoft.ML.Trainers;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class SDCALogisticRegression
+    public static class SDCALogisticRegression
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SDCASupportVectorMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SDCASupportVectorMachine.cs
@@ -4,7 +4,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class SDCASupportVectorMachine
+    public static class SDCASupportVectorMachine
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/PriorTrainerSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/PriorTrainerSample.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.ML.Data;
-using Microsoft.ML.Trainers;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class PriorTrainerSample
+    public class PriorTrainer
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/RandomTrainerSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/RandomTrainerSample.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.ML.Data;
-using Microsoft.ML.Trainers;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class RandomTrainerSample
+    public static class RandomTrainer
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
@@ -5,10 +5,10 @@ using static Microsoft.ML.SamplesUtils.DatasetUtils;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public partial class MatrixFactorizationExample
+    public static partial class MatrixFactorization
     {
         // This example first creates in-memory data and then use it to train a matrix factorization mode with default parameters. Afterward, quality metrics are reported.
-        public static void MatrixFactorization()
+        public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging,
             // as a catalog of available operations and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
@@ -6,11 +6,10 @@ using static Microsoft.ML.SamplesUtils.DatasetUtils;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public partial class MatrixFactorizationExample
+    public static partial class MatrixFactorization
     {
-
         // This example first creates in-memory data and then use it to train a matrix factorization model. Afterward, quality metrics are reported.
-        public static void MatrixFactorizationWithOptions()
+        public static void ExampleWithOptions()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging,
             // as a catalog of available operations and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Concatenate.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Concatenate.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.ML.Data;
-using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ConcatTransformExample
+    public static class ConcatTransform
     {
-        public static void ConcatTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CopyColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CopyColumns.cs
@@ -4,7 +4,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class CopyColumns
+    public static class CopyColumns
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CustomMappingSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CustomMappingSample.cs
@@ -3,7 +3,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class CustomMappingSample
+    public static class CustomMapping
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/DropColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/DropColumns.cs
@@ -4,7 +4,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class DropColumns
+    public static class DropColumns
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
@@ -3,7 +3,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class SelectColumns
+    public static class SelectColumns
     {
         public static void Example()
         {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMapping.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMapping.cs
@@ -5,7 +5,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ValueMappingExample
+    public static partial class ValueMapping
     {
         class SampleInfertDataWithFeatures
         {
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Samples.Dynamic
         ///   6-11yrs -> Postgraduate
         ///   12+yrs  -> Postgraduate
         /// Its possible to have multiple keys map to the same value.
-        public static void Run()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingFloatToString.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingFloatToString.cs
@@ -5,7 +5,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ValueMappingFloatToStringExample
+    public static class ValueMappingFloatToString
     {
         /// <summary>
         /// Helper class for retrieving the resulting data
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Samples.Dynamic
         /// This example demonstrates the use of ValueMappingEstimator by mapping float-to-string values. This is useful if the key
         /// data are floating point and need to be grouped into string values. In this example, the Induction value is mapped to 
         /// "T1", "T2", "T3", and "T4" groups.
-        public static void Run()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.Transforms.Conversions;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ValueMappingStringToArrayExample
+    public static class ValueMappingStringToArray
     {
         /// <summary>
         /// Helper class for retrieving the resulting data
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Samples.Dynamic
         ///     0-5yrs  -> 1, 2, 3
         ///     6-11yrs -> 5, 6, 7
         ///     12+yrs  -> 42,32,64
-        public static void Run()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.Transforms.Conversions;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public class ValueMappingStringToKeyTypeExample
+    public static class ValueMappingStringToKeyType
     {
         /// <summary>
         /// Helper class for retrieving the resulting data
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Samples.Dynamic
         /// 
         /// The KeyToValueEstimator is added to the pipeline to convert the KeyType back to the original value. Therefore the output of this example 
         /// results in the string value of 'Undergraduate' and 'Postgraduate'.
-        public static void Run()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/WordEmbeddingTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/WordEmbeddingTransform.cs
@@ -5,9 +5,9 @@ using Microsoft.ML.Data;
 using Microsoft.ML.Transforms.Text;
 namespace Microsoft.ML.Samples.Dynamic
 {
-    class WordEmbeddingTransform
+    public static class WordEmbeddingTransform
     {
-        public static void ExtractEmbeddings()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.


### PR DESCRIPTION
Polish DYNAMIC examples to fix #2549. This change is inspired by @TomFinley's good comment to #2506 and I sincerely want to address that.

- Example class should be static
- Example function should be called `Example()`
- Remove redundant `using` statements.

Please note that this PR only focuses on dynamic examples' `static` problem. I don't have much bandwidth to take care other cases.