### PR TITLE
Rename Resize Transform to ResizeImages

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ExtractPixels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ExtractPixels.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
             var pipeline = mlContext.Transforms.LoadImages(imagesFolder, ("ImageObject", "ImagePath"))
-                          .Append(mlContext.Transforms.Resize("ImageObject",imageWidth: 100 , imageHeight: 100 ))
+                          .Append(mlContext.Transforms.ResizeImages("ImageObject",imageWidth: 100 , imageHeight: 100 ))
                           .Append(mlContext.Transforms.ExtractPixels("Pixels", "ImageObject"));
 
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/LoadImages.cs
@@ -3,9 +3,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public static class ResizeImage
+    public static class LoadImages
     {
-        // Example on how to load the images from the file system, and resize them. 
+        // Loads the images of the imagesFolder into an IDataView. 
         public static void Example()
         {
             var mlContext = new MLContext();
@@ -29,15 +29,12 @@ namespace Microsoft.ML.Samples.Dynamic
                 {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
                         new TextLoader.Column("Name", DataKind.TX, 1),
-                }
+                    }
             }).Read(imagesDataFile);
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, ("ImageReal", "ImagePath"))
-                        .Append(mlContext.Transforms.Resize("ImageReal", imageWidth: 100, imageHeight: 100));
-                                
-
+            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, ("ImageReal", "ImagePath"));
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // The transformedData IDataView contains the loaded images now

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImages.cs
@@ -3,9 +3,9 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
-    public static class LoadImage
+    public static class ResizeImages
     {
-        // Loads the images of the imagesFolder into an IDataView. 
+        // Example on how to load the images from the file system, and resize them. 
         public static void Example()
         {
             var mlContext = new MLContext();
@@ -29,12 +29,15 @@ namespace Microsoft.ML.Samples.Dynamic
                 {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
                         new TextLoader.Column("Name", DataKind.TX, 1),
-                    }
+                }
             }).Read(imagesDataFile);
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, ("ImageReal", "ImagePath"));
+            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, ("ImageReal", "ImagePath"))
+                        .Append(mlContext.Transforms.ResizeImages("ImageReal", imageWidth: 100, imageHeight: 100));
+                                
+
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // The transformedData IDataView contains the loaded images now

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[Resize](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImage.cs)]
         /// ]]></format>
         /// </example>
-        public static ImageResizingEstimator Resize(this TransformsCatalog catalog,
+        public static ImageResizingEstimator ResizeImages(this TransformsCatalog catalog,
             string outputColumnName,
             int imageWidth,
             int imageHeight,

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        ///  [!code-csharp[LoadImage](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/LoadImage.cs)]
+        ///  [!code-csharp[LoadImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/LoadImages.cs)]
         /// ]]></format>
         /// </example>
         public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string imageFolder, params (string outputColumnName, string inputColumnName)[] columnPairs)
@@ -98,7 +98,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        ///  [!code-csharp[Resize](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImage.cs)]
+        ///  [!code-csharp[ResizeImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImages.cs)]
         /// ]]></format>
         /// </example>
         public static ImageResizingEstimator ResizeImages(this TransformsCatalog catalog,
@@ -128,10 +128,10 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        ///  [!code-csharp[Resize](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImage.cs)]
+        ///  [!code-csharp[ResizeImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ImageAnalytics/ResizeImages.cs)]
         /// ]]></format>
         /// </example>
-        public static ImageResizingEstimator Resize(this TransformsCatalog catalog, params ImageResizingEstimator.ColumnInfo[] columns)
+        public static ImageResizingEstimator ResizeImages(this TransformsCatalog catalog, params ImageResizingEstimator.ColumnInfo[] columns)
             => new ImageResizingEstimator(CatalogUtils.GetEnvironment(catalog), columns);
     }
 }

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.ImageAnalytics
     /// </summary>
     /// <remarks>
     /// Calling <see cref="ITransformer.Transform(IDataView)"/> resizes the images to a new height and width.
-    /// <seealso cref = "ImageEstimatorsCatalog.Resize(TransformsCatalog, ImageResizingEstimator.ColumnInfo[])" />
+    /// <seealso cref = "ImageEstimatorsCatalog.ResizeImages(TransformsCatalog, ImageResizingEstimator.ColumnInfo[])" />
     /// <seealso cref = "ImageEstimatorsCatalog.ResizeImages(TransformsCatalog, string, int, int, string, ImageResizingEstimator.ResizingKind, ImageResizingEstimator.Anchor)" />
     /// <seealso cref = "ImageEstimatorsCatalog" />
     /// </remarks >
@@ -415,7 +415,7 @@ namespace Microsoft.ML.ImageAnalytics
     /// </summary>
     /// <remarks>
     /// Calling <see cref="IEstimator{TTransformer}.Fit(IDataView)"/> in this estimator, produces an <see cref="ImageResizingTransformer"/>.
-    /// <seealso cref = "ImageEstimatorsCatalog.Resize(TransformsCatalog, ImageResizingEstimator.ColumnInfo[])" />
+    /// <seealso cref = "ImageEstimatorsCatalog.ResizeImages(TransformsCatalog, ImageResizingEstimator.ColumnInfo[])" />
     /// <seealso cref = "ImageEstimatorsCatalog.ResizeImages(TransformsCatalog, string, int, int, string, ResizingKind, Anchor)" />
     /// <seealso cref = "ImageEstimatorsCatalog" />
     /// </remarks >

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.ImageAnalytics
     /// <remarks>
     /// Calling <see cref="ITransformer.Transform(IDataView)"/> resizes the images to a new height and width.
     /// <seealso cref = "ImageEstimatorsCatalog.Resize(TransformsCatalog, ImageResizingEstimator.ColumnInfo[])" />
-    /// <seealso cref = "ImageEstimatorsCatalog.Resize(TransformsCatalog, string, int, int, string, ImageResizingEstimator.ResizingKind, ImageResizingEstimator.Anchor)" />
+    /// <seealso cref = "ImageEstimatorsCatalog.ResizeImages(TransformsCatalog, string, int, int, string, ImageResizingEstimator.ResizingKind, ImageResizingEstimator.Anchor)" />
     /// <seealso cref = "ImageEstimatorsCatalog" />
     /// </remarks >
     public sealed class ImageResizingTransformer : OneToOneTransformerBase
@@ -416,7 +416,7 @@ namespace Microsoft.ML.ImageAnalytics
     /// <remarks>
     /// Calling <see cref="IEstimator{TTransformer}.Fit(IDataView)"/> in this estimator, produces an <see cref="ImageResizingTransformer"/>.
     /// <seealso cref = "ImageEstimatorsCatalog.Resize(TransformsCatalog, ImageResizingEstimator.ColumnInfo[])" />
-    /// <seealso cref = "ImageEstimatorsCatalog.Resize(TransformsCatalog, string, int, int, string, ResizingKind, Anchor)" />
+    /// <seealso cref = "ImageEstimatorsCatalog.ResizeImages(TransformsCatalog, string, int, int, string, ResizingKind, Anchor)" />
     /// <seealso cref = "ImageEstimatorsCatalog" />
     /// </remarks >
     public sealed class ImageResizingEstimator : TrivialEstimator<ImageResizingTransformer>

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -389,7 +389,7 @@ namespace Microsoft.ML.Scenarios
             var imageFolder = Path.GetDirectoryName(dataFile);
             var data = mlContext.CreateLoader("Text{col=ImagePath:TX:0 col=Name:TX:1}", new MultiFileSource(dataFile));
             var images = mlContext.Transforms.LoadImages(imageFolder, ("ImageReal", "ImagePath")).Fit(data).Transform(data);
-            var cropped = mlContext.Transforms.Resize("ImageCropped", 224, 224 , "ImageReal").Fit(images).Transform(images);
+            var cropped = mlContext.Transforms.ResizeImages("ImageCropped", 224, 224 , "ImageReal").Fit(images).Transform(images);
             var pixels = mlContext.Transforms.ExtractPixels("input","ImageCropped").Fit(cropped).Transform(cropped);
             var tf = mlContext.Transforms.ScoreTensorFlowModel(modelLocation, "softmax2_pre_activation", "input").Fit(pixels).Transform(pixels);
 
@@ -902,7 +902,7 @@ namespace Microsoft.ML.Scenarios
                 }
             );
             var images = mlContext.Transforms.LoadImages(imageFolder, ("ImageReal", "ImagePath")).Fit(data).Transform(data);
-            var cropped = mlContext.Transforms.Resize("ImageCropped", imageWidth, imageHeight, "ImageReal").Fit(images).Transform(images);
+            var cropped = mlContext.Transforms.ResizeImages("ImageCropped", imageWidth, imageHeight, "ImageReal").Fit(images).Transform(images);
             var pixels = mlContext.Transforms.ExtractPixels("Input", "ImageCropped", interleave: true).Fit(cropped).Transform(cropped);
             IDataView trans = mlContext.Transforms.ScoreTensorFlowModel(tensorFlowModel, "Output", "Input").Fit(pixels).Transform(pixels);
 


### PR DESCRIPTION
This PR changes the catalog entry for the `ImageResizer` to be `ResizeImages` from `Resize`.

This PR also does a quick fix to rename the `LoadImages` sample to `LoadImages` from `LoadImage`.

Fixes #2550 