### PR TITLE
Stop using System.ComponentModel.Composition

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -8,7 +8,6 @@
     <SystemMemoryVersion>4.5.1</SystemMemoryVersion>
     <SystemReflectionEmitLightweightPackageVersion>4.3.0</SystemReflectionEmitLightweightPackageVersion>
     <SystemThreadingTasksDataflowPackageVersion>4.8.0</SystemThreadingTasksDataflowPackageVersion>
-    <SystemComponentModelCompositionVersion>4.5.0</SystemComponentModelCompositionVersion>
   </PropertyGroup>
 
   <!-- Other/Non-Core Product Dependencies -->

--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -970,27 +970,27 @@ Please note that you need to make your `mapping` operation into a 'pure function
 - It should not have side effects (we may call it arbitrarily at any time, or omit the call)
 
 One important caveat is: if you want your custom transformation to be part of your saved model, you will need to provide a `contractName` for it.
-At loading time, you will need to reconstruct the custom transformer and inject it into MLContext. 
+At loading time, you will need to register the custom transformer with the MLContext. 
 
 Here is a complete example that saves and loads a model with a custom mapping.
 ```csharp
 /// <summary>
-/// One class that contains all custom mappings that we need for our model.
+/// One class that contains the custom mapping functionality that we need for our model.
+/// 
+/// It has a [CustomMappingTransformerFactoryAttribute] on it and
+/// derives from CustomMappingTransformerFactory{TSrc, TDst}.
 /// </summary>
-public class CustomMappings
+[CustomMappingTransformerFactory(nameof(CustomMappings.IncomeMapping))]
+public class CustomMappings : CustomMappingTransformerFactory<InputRow, OutputRow>
 {
     // This is the custom mapping. We now separate it into a method, so that we can use it both in training and in loading.
     public static void IncomeMapping(InputRow input, OutputRow output) => output.Label = input.Income > 50000;
 
-    // MLContext is needed to create a new transformer. We are using 'Import' to have ML.NET populate
-    // this property.
-    [Import]
-    public MLContext MLContext { get; set; }
-
-    // We are exporting the custom transformer by the name 'IncomeMapping'.
-    [Export(nameof(IncomeMapping))]
-    public ITransformer MyCustomTransformer 
-        => MLContext.Transforms.CustomMappingTransformer<InputRow, OutputRow>(IncomeMapping, nameof(IncomeMapping));
+    // This factory method will be called when loading the model to get the mapping operation.
+    public override Action<InputRow, OutputRow> GetTransformer()
+    {
+        return IncomeMapping;
+    }
 }
 ```
 
@@ -1013,8 +1013,9 @@ using (var fs = File.Create(modelPath))
 
 // Now pretend we are in a different process.
 
-// Create a custom composition container for all our custom mapping actions.
-newContext.CompositionContainer = new CompositionContainer(new TypeCatalog(typeof(CustomMappings)));
+// Register the assembly that contains 'CustomMappings' with the ComponentCatalog
+// so it can be found when loading the model.
+newContext.ComponentCatalog.RegisterAssembly(typeof(CustomMappings).Assembly);
 
 // Now we can load the model.
 ITransformer loadedModel;

--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -977,17 +977,17 @@ Here is a complete example that saves and loads a model with a custom mapping.
 /// <summary>
 /// One class that contains the custom mapping functionality that we need for our model.
 /// 
-/// It has a [CustomMappingTransformerFactoryAttribute] on it and
-/// derives from CustomMappingTransformerFactory{TSrc, TDst}.
+/// It has a <see cref="CustomMappingFactoryAttributeAttribute"/> on it and
+/// derives from <see cref="CustomMappingFactory{TSrc, TDst}"/>.
 /// </summary>
-[CustomMappingTransformerFactory(nameof(CustomMappings.IncomeMapping))]
-public class CustomMappings : CustomMappingTransformerFactory<InputRow, OutputRow>
+[CustomMappingFactoryAttribute(nameof(CustomMappings.IncomeMapping))]
+public class CustomMappings : CustomMappingFactory<InputRow, OutputRow>
 {
     // This is the custom mapping. We now separate it into a method, so that we can use it both in training and in loading.
     public static void IncomeMapping(InputRow input, OutputRow output) => output.Label = input.Income > 50000;
 
     // This factory method will be called when loading the model to get the mapping operation.
-    public override Action<InputRow, OutputRow> GetTransformer()
+    public override Action<InputRow, OutputRow> GetMapping()
     {
         return IncomeMapping;
     }

--- a/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
+++ b/pkg/Microsoft.ML/Microsoft.ML.nupkgproj
@@ -15,7 +15,6 @@
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.Core/ComponentModel/ExtensionBaseAttribute.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/ExtensionBaseAttribute.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.ML
+{
+    /// <summary>
+    /// The base attribute type for all attributes used for extensibility purposes.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public abstract class ExtensionBaseAttribute : Attribute
+    {
+        public string ContractName { get; }
+
+        [BestFriend]
+        private protected ExtensionBaseAttribute(string contractName)
+        {
+            ContractName = contractName;
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
+++ b/src/Microsoft.ML.Core/Data/IHostEnvironment.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ComponentModel.Composition.Hosting;
 
 namespace Microsoft.ML
 {
@@ -92,12 +91,6 @@ namespace Microsoft.ML
         [Obsolete("The host environment is not disposable, so it is inappropriate to use this method. " +
             "Please handle your own temporary files within the component yourself, including their proper disposal and deletion.")]
         IFileHandle CreateTempFile(string suffix = null, string prefix = null);
-
-        /// <summary>
-        /// Get the MEF composition container. This can be used to instantiate user-provided 'parts' when the model
-        /// is being loaded, or the components are otherwise created via dependency injection.
-        /// </summary>
-        CompositionContainer GetCompositionContainer();
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
+++ b/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel.Composition.Hosting;
 using System.IO;
 
 namespace Microsoft.ML.Data
@@ -632,7 +631,5 @@ namespace Microsoft.ML.Data
             else if (!removeLastNewLine)
                 writer.WriteLine();
         }
-
-        public virtual CompositionContainer GetCompositionContainer() => new CompositionContainer();
     }
 }

--- a/src/Microsoft.ML.Core/Microsoft.ML.Core.csproj
+++ b/src/Microsoft.ML.Core/Microsoft.ML.Core.csproj
@@ -12,7 +12,6 @@
     <ProjectReference Include="..\Microsoft.Data.DataView\Microsoft.Data.DataView.csproj" />
     
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.ML.Data/Utilities/LocalEnvironment.cs
+++ b/src/Microsoft.ML.Data/Utilities/LocalEnvironment.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ComponentModel.Composition.Hosting;
 
 namespace Microsoft.ML.Data
 {
@@ -14,8 +13,6 @@ namespace Microsoft.ML.Data
     /// </summary>
     internal sealed class LocalEnvironment : HostEnvironmentBase<LocalEnvironment>
     {
-        private readonly Func<CompositionContainer> _compositionContainerFactory;
-
         private sealed class Channel : ChannelBase
         {
             public readonly Stopwatch Watch;
@@ -49,11 +46,9 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="seed">Random seed. Set to <c>null</c> for a non-deterministic environment.</param>
         /// <param name="conc">Concurrency level. Set to 1 to run single-threaded. Set to 0 to pick automatically.</param>
-        /// <param name="compositionContainerFactory">The function to retrieve the composition container</param>
-        public LocalEnvironment(int? seed = null, int conc = 0, Func<CompositionContainer> compositionContainerFactory = null)
+        public LocalEnvironment(int? seed = null, int conc = 0)
             : base(RandomUtils.Create(seed), verbose: false, conc)
         {
-            _compositionContainerFactory = compositionContainerFactory;
         }
 
         /// <summary>
@@ -94,13 +89,6 @@ namespace Microsoft.ML.Data
             Contracts.Assert(parent is LocalEnvironment);
             Contracts.AssertNonEmpty(name);
             return new Pipe<TMessage>(parent, name, GetDispatchDelegate<TMessage>());
-        }
-
-        public override CompositionContainer GetCompositionContainer()
-        {
-            if (_compositionContainerFactory != null)
-                return _compositionContainerFactory();
-            return base.GetCompositionContainer();
         }
 
         private sealed class Host : HostBase

--- a/src/Microsoft.ML.Transforms/CustomMappingFactory.cs
+++ b/src/Microsoft.ML.Transforms/CustomMappingFactory.cs
@@ -8,36 +8,39 @@ using Microsoft.Data.DataView;
 namespace Microsoft.ML.Transforms
 {
     /// <summary>
-    /// Place this attribute onto a type to cause it to be considered a custom mapping transformer factory.
+    /// Place this attribute onto a type to cause it to be considered a custom mapping factory.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class CustomMappingTransformerFactoryAttribute : ExtensionBaseAttribute
+    public sealed class CustomMappingFactoryAttributeAttribute : ExtensionBaseAttribute
     {
-        public CustomMappingTransformerFactoryAttribute(string contractName)
+        public CustomMappingFactoryAttributeAttribute(string contractName)
             : base(contractName)
         {
         }
     }
 
-    internal interface ICustomMappingTransformerFactory
+    internal interface ICustomMappingFactory
     {
-        ITransformer CreateTransformerObject(IHostEnvironment env, string contractName);
+        ITransformer CreateTransformer(IHostEnvironment env, string contractName);
     }
 
     /// <summary>
-    /// The base type for custom mapping transformer factories.
+    /// The base type for custom mapping factories.
     /// </summary>
     /// <typeparam name="TSrc">The type that describes what 'source' columns are consumed from the input <see cref="IDataView"/>.</typeparam>
     /// <typeparam name="TDst">The type that describes what new columns are added by this transform.</typeparam>
-    public abstract class CustomMappingTransformerFactory<TSrc, TDst> : ICustomMappingTransformerFactory
+    public abstract class CustomMappingFactory<TSrc, TDst> : ICustomMappingFactory
         where TSrc : class, new()
         where TDst : class, new()
     {
-        public abstract Action<TSrc, TDst> GetTransformer();
+        /// <summary>
+        /// Returns the mapping delegate that maps from <typeparamref name="TSrc"/> inputs to <typeparamref name="TDst"/> outputs.
+        /// </summary>
+        public abstract Action<TSrc, TDst> GetMapping();
 
-        ITransformer ICustomMappingTransformerFactory.CreateTransformerObject(IHostEnvironment env, string contractName)
+        ITransformer ICustomMappingFactory.CreateTransformer(IHostEnvironment env, string contractName)
         {
-            Action<TSrc, TDst> mapAction = GetTransformer();
+            Action<TSrc, TDst> mapAction = GetMapping();
             return new CustomMappingTransformer<TSrc, TDst>(env, mapAction, contractName);
         }
     }

--- a/src/Microsoft.ML.Transforms/CustomMappingTransformerFactory.cs
+++ b/src/Microsoft.ML.Transforms/CustomMappingTransformerFactory.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Data.DataView;
+
+namespace Microsoft.ML.Transforms
+{
+    /// <summary>
+    /// Place this attribute onto a type to cause it to be considered a custom mapping transformer factory.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class CustomMappingTransformerFactoryAttribute : ExtensionBaseAttribute
+    {
+        public CustomMappingTransformerFactoryAttribute(string contractName)
+            : base(contractName)
+        {
+        }
+    }
+
+    internal interface ICustomMappingTransformerFactory
+    {
+        ITransformer CreateTransformerObject(IHostEnvironment env, string contractName);
+    }
+
+    /// <summary>
+    /// The base type for custom mapping transformer factories.
+    /// </summary>
+    /// <typeparam name="TSrc">The type that describes what 'source' columns are consumed from the input <see cref="IDataView"/>.</typeparam>
+    /// <typeparam name="TDst">The type that describes what new columns are added by this transform.</typeparam>
+    public abstract class CustomMappingTransformerFactory<TSrc, TDst> : ICustomMappingTransformerFactory
+        where TSrc : class, new()
+        where TDst : class, new()
+    {
+        public abstract Action<TSrc, TDst> GetTransformer();
+
+        ITransformer ICustomMappingTransformerFactory.CreateTransformerObject(IHostEnvironment env, string contractName)
+        {
+            Action<TSrc, TDst> mapAction = GetTransformer();
+            return new CustomMappingTransformer<TSrc, TDst>(env, mapAction, contractName);
+        }
+    }
+}

--- a/src/Microsoft.ML.Transforms/LambdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/LambdaTransform.cs
@@ -68,13 +68,13 @@ namespace Microsoft.ML.Transforms
 
             var contractName = ctx.LoadString();
 
-            object factoryObject = env.ComponentCatalog.GetExtensionValue(env, typeof(CustomMappingTransformerFactoryAttribute), contractName);
-            if (!(factoryObject is ICustomMappingTransformerFactory transformerFactory))
+            object factoryObject = env.ComponentCatalog.GetExtensionValue(env, typeof(CustomMappingFactoryAttributeAttribute), contractName);
+            if (!(factoryObject is ICustomMappingFactory mappingFactory))
             {
-                throw env.Except($"The class with contract '{contractName}' must derive from '{typeof(CustomMappingTransformerFactory<,>).FullName}'.");
+                throw env.Except($"The class with contract '{contractName}' must derive from '{typeof(CustomMappingFactory<,>).FullName}'.");
             }
 
-            return transformerFactory.CreateTransformerObject(env, contractName);
+            return mappingFactory.CreateTransformer(env, contractName);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Transforms/LambdaTransform.cs
+++ b/src/Microsoft.ML.Transforms/LambdaTransform.cs
@@ -68,11 +68,13 @@ namespace Microsoft.ML.Transforms
 
             var contractName = ctx.LoadString();
 
-            var composition = env.GetCompositionContainer();
-            if (composition == null)
-                throw Contracts.Except("Unable to get the MEF composition container");
-            ITransformer transformer = composition.GetExportedValue<ITransformer>(contractName);
-            return transformer;
+            object factoryObject = env.ComponentCatalog.GetExtensionValue(env, typeof(CustomMappingTransformerFactoryAttribute), contractName);
+            if (!(factoryObject is ICustomMappingTransformerFactory transformerFactory))
+            {
+                throw env.Except($"The class with contract '{contractName}' must derive from '{typeof(CustomMappingTransformerFactory<,>).FullName}'.");
+            }
+
+            return transformerFactory.CreateTransformerObject(env, contractName);
         }
 
         /// <summary>

--- a/test/Microsoft.ML.FSharp.Tests/SmokeTests.fs
+++ b/test/Microsoft.ML.FSharp.Tests/SmokeTests.fs
@@ -38,7 +38,6 @@
 #r @"../../bin/AnyCPU.Debug/Microsoft.ML.FSharp.Tests/net461/xunit.core.dll" 
 #r @"../../bin/AnyCPU.Debug/Microsoft.ML.FSharp.Tests/net461/xunit.assert.dll" 
 #r "System" 
-#r "System.ComponentModel.Composition" 
 #r "System.Core" 
 #r "System.Xml.Linq" 
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -492,17 +492,17 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         /// <summary>
         /// One class that contains the custom mapping functionality that we need for our model.
         /// 
-        /// It has a <see cref="CustomMappingTransformerFactoryAttribute"/> on it and
-        /// derives from <see cref="CustomMappingTransformerFactory{TSrc, TDst}"/>.
+        /// It has a <see cref="CustomMappingFactoryAttributeAttribute"/> on it and
+        /// derives from <see cref="CustomMappingFactory{TSrc, TDst}"/>.
         /// </summary>
-        [CustomMappingTransformerFactory(nameof(CustomMappings.IncomeMapping))]
-        public class CustomMappings : CustomMappingTransformerFactory<InputRow, OutputRow>
+        [CustomMappingFactoryAttribute(nameof(CustomMappings.IncomeMapping))]
+        public class CustomMappings : CustomMappingFactory<InputRow, OutputRow>
         {
             // This is the custom mapping. We now separate it into a method, so that we can use it both in training and in loading.
             public static void IncomeMapping(InputRow input, OutputRow output) => output.Label = input.Income > 50000;
 
             // This factory method will be called when loading the model to get the mapping operation.
-            public override Action<InputRow, OutputRow> GetTransformer()
+            public override Action<InputRow, OutputRow> GetMapping()
             {
                 return IncomeMapping;
             }

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Linq;
 using Microsoft.Data.DataView;
@@ -13,6 +11,7 @@ using Microsoft.ML.Data;
 using Microsoft.ML.RunTests;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.Trainers;
+using Microsoft.ML.Transforms;
 using Microsoft.ML.Transforms.Categorical;
 using Microsoft.ML.Transforms.Normalizers;
 using Microsoft.ML.Transforms.Text;
@@ -491,22 +490,22 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         /// <summary>
-        /// One class that contains all custom mappings that we need for our model.
+        /// One class that contains the custom mapping functionality that we need for our model.
+        /// 
+        /// It has a <see cref="CustomMappingTransformerFactoryAttribute"/> on it and
+        /// derives from <see cref="CustomMappingTransformerFactory{TSrc, TDst}"/>.
         /// </summary>
-        public class CustomMappings
+        [CustomMappingTransformerFactory(nameof(CustomMappings.IncomeMapping))]
+        public class CustomMappings : CustomMappingTransformerFactory<InputRow, OutputRow>
         {
             // This is the custom mapping. We now separate it into a method, so that we can use it both in training and in loading.
             public static void IncomeMapping(InputRow input, OutputRow output) => output.Label = input.Income > 50000;
 
-            // MLContext is needed to create a new transformer. We are using 'Import' to have ML.NET populate
-            // this property.
-            [Import]
-            public MLContext MLContext { get; set; }
-
-            // We are exporting the custom transformer by the name 'IncomeMapping'.
-            [Export(nameof(IncomeMapping))]
-            public ITransformer MyCustomTransformer 
-                => MLContext.Transforms.CustomMappingTransformer<InputRow, OutputRow>(IncomeMapping, nameof(IncomeMapping));
+            // This factory method will be called when loading the model to get the mapping operation.
+            public override Action<InputRow, OutputRow> GetTransformer()
+            {
+                return IncomeMapping;
+            }
         }
 
         private static void RunEndToEnd(MLContext mlContext, IDataView trainData, string modelPath)
@@ -530,8 +529,9 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Now pretend we are in a different process.
             var newContext = new MLContext();
 
-            // Create a custom composition container for all our custom mapping actions.
-            newContext.CompositionContainer = new CompositionContainer(new TypeCatalog(typeof(CustomMappings)));
+            // Register the assembly that contains 'CustomMappings' with the ComponentCatalog
+            // so it can be found when loading the model.
+            newContext.ComponentCatalog.RegisterAssembly(typeof(CustomMappings).Assembly);
 
             // Now we can load the model.
             ITransformer loadedModel;

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ComponentModel.Composition;
-using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML.Data;
@@ -32,17 +30,17 @@ namespace Microsoft.ML.Tests.Transformers
             public string Together { get; set; }
         }
 
-        public class MyLambda
+        [CustomMappingTransformerFactory("MyLambda")]
+        public class MyLambda : CustomMappingTransformerFactory<MyInput, MyOutput>
         {
-            [Export("MyLambda")]
-            public ITransformer MyTransformer => ML.Transforms.CustomMappingTransformer<MyInput, MyOutput>(MyAction, "MyLambda");
-
-            [Import]
-            public MLContext ML { get; set; }
-
             public static void MyAction(MyInput input, MyOutput output)
             {
                 output.Together = $"{input.Float1} + {string.Join(", ", input.Float4)}";
+            }
+
+            public override Action<MyInput, MyOutput> GetTransformer()
+            {
+                return MyAction;
             }
         }
 
@@ -67,14 +65,14 @@ namespace Microsoft.ML.Tests.Transformers
             try
             {
                 TestEstimatorCore(customEst, data);
-                Assert.True(false, "Cannot work without MEF injection");
+                Assert.True(false, "Cannot work without RegisterAssembly");
             }
             catch (InvalidOperationException ex)
             {
                 if (!ex.IsMarked())
                     throw;
             }
-            ML.CompositionContainer = new CompositionContainer(new TypeCatalog(typeof(MyLambda)));
+            ML.ComponentCatalog.RegisterAssembly(typeof(MyLambda).Assembly);
             TestEstimatorCore(customEst, data);
             transformedData = customEst.Fit(data).Transform(data);
 

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -30,15 +30,15 @@ namespace Microsoft.ML.Tests.Transformers
             public string Together { get; set; }
         }
 
-        [CustomMappingTransformerFactory("MyLambda")]
-        public class MyLambda : CustomMappingTransformerFactory<MyInput, MyOutput>
+        [CustomMappingFactoryAttribute("MyLambda")]
+        public class MyLambda : CustomMappingFactory<MyInput, MyOutput>
         {
             public static void MyAction(MyInput input, MyOutput output)
             {
                 output.Together = $"{input.Float1} + {string.Join(", ", input.Float4)}";
             }
 
-            public override Action<MyInput, MyOutput> GetTransformer()
+            public override Action<MyInput, MyOutput> GetMapping()
             {
                 return MyAction;
             }


### PR DESCRIPTION
Replace our MEF usage, which is only used by custom mapping transforms, with the ComponentCatalog class.

Fix #1595
Fix #2422
