### PR TITLE
[One-line change] Internalize MamlEvaluatorBase

### DIFF
--- a/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MamlEvaluator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Data
     /// methods create a new <see cref="RoleMappedData"/> containing all the columns needed for evaluation, and call the corresponding
     /// methods on an <see cref="IEvaluator"/> of the appropriate type.
     /// </summary>
-    public abstract class MamlEvaluatorBase : IMamlEvaluator
+    internal abstract class MamlEvaluatorBase : IMamlEvaluator
     {
         public abstract class ArgumentsBase : EvaluateInputBase
         {


### PR DESCRIPTION
To fix #1976, the last missing piece is hiding 
```csharp
    public abstract class MamlEvaluatorBase : IMamlEvaluator
```
because we already have
```csharp
    [BestFriend]
    internal abstract partial class EvaluatorBase<TAgg> : IEvaluator
        where TAgg : EvaluatorBase<TAgg>.AggregatorBase

    [BestFriend]
    internal interface IMamlEvaluator : IEvaluator

    [BestFriend]
    internal interface IEvaluator
```