### PR TITLE
Remove exception due to supportsSparse:true in ReadFromTextLoader

### DIFF
--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -1585,6 +1585,17 @@ namespace Microsoft.ML.Data.Conversion
         {
             value = ParseI4(in span);
         }
+        public bool TryConvert(in TX span, ref I4 value)
+        {
+            TryParseSigned(I4.MaxValue, in span, out long? res);
+            if (res.HasValue)
+            {
+                value = (I4)res.GetValueOrDefault();
+                return true;
+            }
+
+            return false;
+        }
         public void Convert(in TX span, ref U4 value)
         {
             value = ParseU4(in span);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderParser.cs
@@ -1016,18 +1016,8 @@ namespace Microsoft.ML.Data
                                 }
                                 var spanT = Fields.Spans[Fields.Count - 1];
 
-                                // Note that Convert throws exception the text is unparsable.
-                                int csrc = default;
-                                try
-                                {
-                                    Conversions.Instance.Convert(in spanT, ref csrc);
-                                }
-                                catch
-                                {
-                                    Contracts.Assert(csrc == default);
-                                }
-
-                                if (csrc <= 0)
+                                int csrc = 0;
+                                if (!Conversions.Instance.TryConvert(in spanT, ref csrc) || csrc <= 0)
                                 {
                                     _stats.LogBadFmt(ref scan, "Bad dimensionality or ambiguous sparse item. Use sparse=- for non-sparse file, and/or quote the value.");
                                     break;


### PR DESCRIPTION
In the GitHubLabeler sample, for example, there are ~450 InvalidOperationExceptions getting thrown and caught internally, as the implementation tries to parse some text as an int and fails.  There's no need for an exception here; the implementation is already using a TryParse method, which it then turns into an exception and then immediately catches and ignores... we can just cut out the middle man and not throw.

Related to https://github.com/dotnet/machinelearning-samples/pull/257
Related to https://github.com/dotnet/machinelearning/issues/2576