### PR TITLE
Adding functional tests for explainability

### DIFF
--- a/test/Microsoft.ML.Functional.Tests/Common.cs
+++ b/test/Microsoft.ML.Functional.Tests/Common.cs
@@ -164,13 +164,38 @@ namespace Microsoft.ML.Functional.Tests
         /// Check that a <see cref="RegressionMetrics"/> object is valid.
         /// </summary>
         /// <param name="metrics">The metrics object.</param>
-        public static void CheckMetrics(RegressionMetrics metrics)
+        public static void AssertMetrics(RegressionMetrics metrics)
         {
             // Perform sanity checks on the metrics.
             Assert.True(metrics.Rms >= 0);
             Assert.True(metrics.L1 >= 0);
             Assert.True(metrics.L2 >= 0);
             Assert.True(metrics.RSquared <= 1);
+        }
+
+        /// <summary>
+        /// Check that a <see cref="MetricStatistics"/> object is valid.
+        /// </summary>
+        /// <param name="metric">The <see cref="MetricStatistics"/> object.</param>
+        public static void AssertMetricStatistics(MetricStatistics metric)
+        {
+            // Perform sanity checks on the metrics.
+            Assert.True(metric.StandardDeviation >= 0);
+            Assert.True(metric.StandardError >= 0);
+        }
+
+        /// <summary>
+        /// Check that a <see cref="RegressionMetricsStatistics"/> object is valid.
+        /// </summary>
+        /// <param name="metrics">The metrics object.</param>
+        public static void AssertMetricsStatistics(RegressionMetricsStatistics metrics)
+        {
+            // The mean can be any float; the standard deviation and error must be >=0.
+            AssertMetricStatistics(metrics.Rms);
+            AssertMetricStatistics(metrics.L1);
+            AssertMetricStatistics(metrics.L2);
+            AssertMetricStatistics(metrics.RSquared);
+            AssertMetricStatistics(metrics.LossFn);
         }
     }
 }

--- a/test/Microsoft.ML.Functional.Tests/Datasets/FeatureContributionOutput.cs
+++ b/test/Microsoft.ML.Functional.Tests/Datasets/FeatureContributionOutput.cs
@@ -7,7 +7,7 @@ using Microsoft.ML.Data;
 namespace Microsoft.ML.Functional.Tests.Datasets
 {
     /// <summary>
-    /// A schematized class for loading the HousingRegression dataset.
+    /// A class to hold the output of FeatureContributionCalculator
     /// </summary>
     internal sealed class FeatureContributionOutput
     {

--- a/test/Microsoft.ML.Functional.Tests/Datasets/FeatureContributionOutput.cs
+++ b/test/Microsoft.ML.Functional.Tests/Datasets/FeatureContributionOutput.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Functional.Tests.Datasets
+{
+    /// <summary>
+    /// A schematized class for loading the HousingRegression dataset.
+    /// </summary>
+    internal sealed class FeatureContributionOutput
+    {
+        public float[] FeatureContributions { get; set; }
+    }
+}

--- a/test/Microsoft.ML.Functional.Tests/Datasets/HousingRegression.cs
+++ b/test/Microsoft.ML.Functional.Tests/Datasets/HousingRegression.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Functional.Tests.Datasets
+{
+    /// <summary>
+    /// A schematized class for loading the HousingRegression dataset.
+    /// </summary>
+    internal sealed class HousingRegression
+    {
+        [LoadColumn(0), ColumnName("Label")]
+        public float MedianHomeValue { get; set; }
+
+        [LoadColumn(1)]
+        public float CrimesPerCapita { get; set; }
+
+        [LoadColumn(2)]
+        public float PercentResidental { get; set; }
+
+        [LoadColumn(3)]
+        public float PercentNonRetail { get; set; }
+
+        [LoadColumn(4)]
+        public float CharlesRiver { get; set; }
+
+        [LoadColumn(5)]
+        public float NitricOxides { get; set; }
+
+        [LoadColumn(6)]
+        public float RoomsPerDwelling { get; set; }
+
+        [LoadColumn(7)]
+        public float PercentPre40s { get; set; }
+
+        [LoadColumn(8)]
+        public float EmploymentDistance { get; set; }
+
+        [LoadColumn(9)]
+        public float HighwayDistance { get; set; }
+
+        [LoadColumn(10)]
+        public float TaxRate { get; set; }
+
+        [LoadColumn(11)]
+        public float TeacherRatio { get; set; }
+
+        /// <summary>
+        /// The list of columns commonly used as features
+        /// </summary>
+        public static readonly string[] Features = new string[] {"CrimesPerCapita", "PercentResidental", "PercentNonRetail", "CharlesRiver", "NitricOxides",
+                "RoomsPerDwelling", "PercentPre40s", "EmploymentDistance", "HighwayDistance", "TaxRate", "TeacherRatio"};
+    }
+}

--- a/test/Microsoft.ML.Functional.Tests/Explainability.cs
+++ b/test/Microsoft.ML.Functional.Tests/Explainability.cs
@@ -1,0 +1,277 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Data.DataView;
+using Microsoft.ML.Data;
+using Microsoft.ML.Functional.Tests.Datasets;
+using Microsoft.ML.RunTests;
+using Microsoft.ML.TestFramework;
+using Microsoft.ML.Trainers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ML.Functional.Tests
+{
+    /// <summary>
+    /// Test explainability features.
+    /// </summary>
+    public class Explainability : BaseTestClass
+    {
+        public Explainability(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /// <summary>
+        /// GlobalFeatureImportance: PFI can be used to compute global feature importance.
+        /// </summary>
+        [Fact]
+        public void GlobalFeatureImportanceWithPermutationFeatureImportance()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.StochasticDualCoordinateAscent());
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var transformedData = model.Transform(data);
+
+            // Compute the permutation feature importance to look at global feature importance.
+            var permutationMetrics = mlContext.Regression.PermutationFeatureImportance(model.LastTransformer, transformedData);
+
+            // Make sure the correct number of features came back
+            Assert.Equal(HousingRegression.Features.Length, permutationMetrics.Length);
+            foreach (var metricsStatistics in permutationMetrics)
+                Common.AssertMetricsStatistics(metricsStatistics);
+        }
+
+        /// <summary>
+        /// GlobalFeatureImportance: A linear model's feature importance can be viewed through its weight coefficients.
+        /// </summary>
+        /// <remarks>
+        /// Note that this isn't recommended, as there are quite a few statistical issues with interpreting coefficients
+        /// as weights, but it's common practice, so it's a supported scenario.
+        /// </remarks>
+        [Fact]
+        public void GlobalFeatureImportanceForLinearModelThroughWeights()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.StochasticDualCoordinateAscent());
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var linearModel = model.LastTransformer.Model;
+
+            var weights = linearModel.Weights;
+
+            Assert.Equal(HousingRegression.Features.Length, weights.Count);
+        }
+
+        /// <summary>
+        /// GlobalFeatureImportance: A FastTree model can give back global feature importance through feature gain.
+        /// </summary>
+        [Fact]
+        public void GlobalFeatureImportanceForFastTreeThroughFeatureGain()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.FastTree());
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var treeModel = model.LastTransformer.Model;
+
+            // Get the feature gain
+            var weights = new VBuffer<float>();
+            treeModel.GetFeatureWeights(ref weights);
+
+            Assert.Equal(HousingRegression.Features.Length, weights.Length);
+        }
+
+        /// <summary>
+        /// GlobalFeatureImportance: A FastForest model can give back global feature importance through feature gain.
+        /// </summary>
+        [Fact]
+        public void GlobalFeatureImportanceForFastForestThroughFeatureGain()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.FastForest());
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var treeModel = model.LastTransformer.Model;
+
+            // Get the feature gain
+            var weights = new VBuffer<float>();
+            treeModel.GetFeatureWeights(ref weights);
+
+            Assert.Equal(HousingRegression.Features.Length, weights.Length);
+        }
+
+        /// <summary>
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a linear model.
+        /// </summary>
+        [Fact]
+        public void LocalFeatureImportanceForLinearModel()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.StochasticDualCoordinateAscent());
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var scoredData = model.Transform(data);
+
+            // Create a Feature Contribution Calculator
+            var predictor = model.LastTransformer;
+            var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
+
+            // Compute the contributions
+            var outputData = featureContributions.Fit(scoredData).Transform(scoredData);
+
+            // Validate that the contributions are there
+            var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
+            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+
+            foreach (var row in scoringEnumerator)
+            {
+                Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);
+            }
+        }
+
+        /// <summary>
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a linear model.
+        /// </summary>
+        [Fact]
+        public void LocalFeatureImportanceForFastTreeModel()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.FastTree());
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var scoredData = model.Transform(data);
+
+            // Create a Feature Contribution Calculator
+            var predictor = model.LastTransformer;
+            var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
+
+            // Compute the contributions
+            var outputData = featureContributions.Fit(scoredData).Transform(scoredData);
+
+            // Validate that the contributions are there
+            var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
+            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+
+            foreach (var row in scoringEnumerator)
+            {
+                Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);
+            }
+        }
+
+        /// <summary>
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a linear model.
+        /// </summary>
+        [Fact]
+        public void LocalFeatureImportanceForFastForestModel()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.FastForest());
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var scoredData = model.Transform(data);
+
+            // Create a Feature Contribution Calculator
+            var predictor = model.LastTransformer;
+            var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
+
+            // Compute the contributions
+            var outputData = featureContributions.Fit(scoredData).Transform(scoredData);
+
+            // Validate that the contributions are there
+            var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
+            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+
+            foreach (var row in scoringEnumerator)
+            {
+                Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);
+            }
+        }
+
+        /// <summary>
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a linear model.
+        /// </summary>
+        [Fact]
+        public void LocalFeatureImportanceForGamModel()
+        {
+            var mlContext = new MLContext(seed: 1, conc: 1);
+
+            // Get the dataset
+            var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
+
+            // Create a pipeline to train on the housing data.
+            var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
+                .Append(mlContext.Regression.Trainers.GeneralizedAdditiveModels(numIterations: 2));
+
+            // Fit the pipeline and transform the data.
+            var model = pipeline.Fit(data);
+            var scoredData = model.Transform(data);
+
+            // Create a Feature Contribution Calculator
+            var predictor = model.LastTransformer;
+            var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
+
+            // Compute the contributions
+            var outputData = featureContributions.Fit(scoredData).Transform(scoredData);
+
+            // Validate that the contributions are there
+            var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
+            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+
+            foreach (var row in scoringEnumerator)
+            {
+                Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);
+            }
+        }
+    }
+}

--- a/test/Microsoft.ML.Functional.Tests/Explainability.cs
+++ b/test/Microsoft.ML.Functional.Tests/Explainability.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Functional.Tests
         {
             var mlContext = new MLContext(seed: 1, conc: 1);
 
-            // Get the dataset
+            // Get the dataset.
             var data = mlContext.Data.ReadFromTextFile<HousingRegression>(GetDataPath(TestDatasets.housing.trainFilename), hasHeader: true);
 
             // Create a pipeline to train on the housing data.
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Functional.Tests
             var model = pipeline.Fit(data);
             var scoredData = model.Transform(data);
 
-            // Create a Feature Contribution Calculator
+            // Create a Feature Contribution Calculator.
             var predictor = model.LastTransformer;
             var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
 
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Functional.Tests
         }
 
         /// <summary>
-        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a FastTree model.
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a <see cref="FastTree"/> model.
         /// </summary>
         [Fact]
         public void LocalFeatureImportanceForFastTreeModel()
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Functional.Tests
             var model = pipeline.Fit(data);
             var scoredData = model.Transform(data);
 
-            // Create a Feature Contribution Calculator
+            // Create a Feature Contribution Calculator.
             var predictor = model.LastTransformer;
             var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
 
@@ -208,7 +208,7 @@ namespace Microsoft.ML.Functional.Tests
         }
 
         /// <summary>
-        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a FastForest model.
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a <see cref="FastForest"/>model.
         /// </summary>
         [Fact]
         public void LocalFeatureImportanceForFastForestModel()
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Functional.Tests
             var model = pipeline.Fit(data);
             var scoredData = model.Transform(data);
 
-            // Create a Feature Contribution Calculator
+            // Create a Feature Contribution Calculator.
             var predictor = model.LastTransformer;
             var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
 
@@ -245,7 +245,8 @@ namespace Microsoft.ML.Functional.Tests
         }
 
         /// <summary>
-        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a Generalized Additive Models model.
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a <see cref="GamModelParametersBase" />
+        /// (Generalized Additive Model) model.
         /// </summary>
         [Fact]
         public void LocalFeatureImportanceForGamModel()
@@ -263,7 +264,7 @@ namespace Microsoft.ML.Functional.Tests
             var model = pipeline.Fit(data);
             var scoredData = model.Transform(data);
 
-            // Create a Feature Contribution Calculator
+            // Create a Feature Contribution Calculator.
             var predictor = model.LastTransformer;
             var featureContributions = mlContext.Model.Explainability.FeatureContributionCalculation(predictor.Model, predictor.FeatureColumn, normalize: false);
 

--- a/test/Microsoft.ML.Functional.Tests/Explainability.cs
+++ b/test/Microsoft.ML.Functional.Tests/Explainability.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Functional.Tests
             // Compute the permutation feature importance to look at global feature importance.
             var permutationMetrics = mlContext.Regression.PermutationFeatureImportance(model.LastTransformer, transformedData);
 
-            // Make sure the correct number of features came back
+            // Make sure the correct number of features came back.
             Assert.Equal(HousingRegression.Features.Length, permutationMetrics.Length);
             foreach (var metricsStatistics in permutationMetrics)
                 Common.AssertMetricsStatistics(metricsStatistics);
@@ -74,8 +74,8 @@ namespace Microsoft.ML.Functional.Tests
             var model = pipeline.Fit(data);
             var linearModel = model.LastTransformer.Model;
 
+            // Make sure the number of model weights returned matches the length of the input feature vector.
             var weights = linearModel.Weights;
-
             Assert.Equal(HousingRegression.Features.Length, weights.Count);
         }
 
@@ -98,10 +98,11 @@ namespace Microsoft.ML.Functional.Tests
             var model = pipeline.Fit(data);
             var treeModel = model.LastTransformer.Model;
 
-            // Get the feature gain
+            // Get the feature gain.
             var weights = new VBuffer<float>();
             treeModel.GetFeatureWeights(ref weights);
 
+            // Make sure the number of feature gains returned matches the length of the input feature vector.
             Assert.Equal(HousingRegression.Features.Length, weights.Length);
         }
 
@@ -128,6 +129,7 @@ namespace Microsoft.ML.Functional.Tests
             var weights = new VBuffer<float>();
             treeModel.GetFeatureWeights(ref weights);
 
+            // Make sure the number of feature gains returned matches the length of the input feature vector.
             Assert.Equal(HousingRegression.Features.Length, weights.Length);
         }
 
@@ -161,6 +163,7 @@ namespace Microsoft.ML.Functional.Tests
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
             var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
+            // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)
             {
                 Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);
@@ -197,6 +200,7 @@ namespace Microsoft.ML.Functional.Tests
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
             var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
+            // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)
             {
                 Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);
@@ -233,6 +237,7 @@ namespace Microsoft.ML.Functional.Tests
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
             var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
+            // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)
             {
                 Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);
@@ -269,6 +274,7 @@ namespace Microsoft.ML.Functional.Tests
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
             var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
+            // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)
             {
                 Assert.Equal(HousingRegression.Features.Length, row.FeatureContributions.Length);

--- a/test/Microsoft.ML.Functional.Tests/Explainability.cs
+++ b/test/Microsoft.ML.Functional.Tests/Explainability.cs
@@ -8,6 +8,7 @@ using Microsoft.ML.Functional.Tests.Datasets;
 using Microsoft.ML.RunTests;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.Trainers;
+using Microsoft.ML.Trainers.FastTree;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -167,7 +168,7 @@ namespace Microsoft.ML.Functional.Tests
         }
 
         /// <summary>
-        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a linear model.
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a FastTree model.
         /// </summary>
         [Fact]
         public void LocalFeatureImportanceForFastTreeModel()
@@ -203,7 +204,7 @@ namespace Microsoft.ML.Functional.Tests
         }
 
         /// <summary>
-        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a linear model.
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a FastForest model.
         /// </summary>
         [Fact]
         public void LocalFeatureImportanceForFastForestModel()
@@ -239,7 +240,7 @@ namespace Microsoft.ML.Functional.Tests
         }
 
         /// <summary>
-        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a linear model.
+        /// LocalFeatureImportance: Per-row feature importance can be computed through FeatureContributionCalculator for a Generalized Additive Models model.
         /// </summary>
         [Fact]
         public void LocalFeatureImportanceForGamModel()

--- a/test/Microsoft.ML.Functional.Tests/Prediction.cs
+++ b/test/Microsoft.ML.Functional.Tests/Prediction.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Functional.Tests
             var scoredTest = model.Transform(split.TestSet);
             var metrics = mlContext.Regression.Evaluate(scoredTest);
 
-            Common.CheckMetrics(metrics);
+            Common.AssertMetrics(metrics);
 
             // Todo #2465: Allow the setting of threshold and thresholdColumn for scoring.
             // This is no longer possible in the API

--- a/test/Microsoft.ML.Functional.Tests/Validation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Validation.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Functional.Tests
 
             // And validate the metrics.
             foreach (var result in cvResult)
-                Common.CheckMetrics(result.Metrics);
+                Common.AssertMetrics(result.Metrics);
         }
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Microsoft.ML.Functional.Tests
             var trainMetrics = mlContext.Regression.Evaluate(scoredTrainData);
             var validMetrics = mlContext.Regression.Evaluate(scoredValidData);
 
-            Common.CheckMetrics(trainMetrics);
-            Common.CheckMetrics(validMetrics);
+            Common.AssertMetrics(trainMetrics);
+            Common.AssertMetrics(validMetrics);
         }
     }
 }


### PR DESCRIPTION
This PR adds functional tests for Explainability features. Namely, it tests the following scenarios:

* I can get near-free (local) feature importance for scored examples (Feature Contributions)
* I can view the overall importance of each feature (Permutation Feature Importance, GetFeatureWeights)
* I can train interpretable models (linear model, GAM)
* I can view how much each feature contributed to each prediction for trees and linear models (Feature Contributions)

Fixes #2573 