### PR TITLE
Change Default Settings in TextLoader

### DIFF
--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -219,10 +219,10 @@ private class AdultData
 
 // Read the data into a data view.
 var trainData = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                // First line of the file is a header, not a data row.
-                hasHeader: true,
                 // Default separator is tab, but we need a semicolon.
-                separatorChar: ';'
+                separatorChar: ';',
+                // First line of the file is a header, not a data row.
+                hasHeader: true
 );		
 
 ```
@@ -328,7 +328,7 @@ In the file above, the last column (12th) is label that we predict, and all the 
 // First, we define the reader: specify the data columns and where to find them in the text file.
 // Read the data into a data view. Remember though, readers are lazy, so the actual reading will happen when the data is accessed.
 var trainData = mlContext.Data.ReadFromTextFile<AdultData>(dataPath,
-    // First line of the file is a header, not a data row.
+    // Default separator is tab, but the dataset has comma.
     separatorChar: ','
 );
 
@@ -372,7 +372,7 @@ Assuming the example above was used to train the model, here's how you calculate
 ```csharp
 // Read the test dataset.
 var testData = mlContext.Data.ReadFromTextFile<AdultData>(testDataPath,
-    // First line of the file is a header, not a data row.
+    // Default separator is tab, but the dataset has comma.
     separatorChar: ','
 );
 // Calculate metrics of the model on the test data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -34,12 +34,12 @@ namespace Microsoft.ML.Samples.Dynamic.TensorFlow
 
             // This is the dictionary to convert words into the integer indexes.
             var lookupMap = mlContext.Data.ReadFromTextFile(Path.Combine(modelLocation, "imdb_word_index.csv"),
-                   columns: new[]
+                columns: new[]
                    {
                         new TextLoader.Column("Words", DataKind.TX, 0),
                         new TextLoader.Column("Ids", DataKind.I4, 1),
                    },
-                   separatorChar: ','
+                separatorChar: ','
                );
 
             // Load the TensorFlow model once.

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -488,7 +488,7 @@ namespace Microsoft.ML.Data
 
         internal static class Defaults
         {
-            internal const bool AllowQuoting = true;
+            internal const bool AllowQuoting = false;
             internal const bool AllowSparse = false;
             internal const char Separator = '\t';
             internal const bool HasHeader = false;
@@ -1070,15 +1070,16 @@ namespace Microsoft.ML.Data
         /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
-        internal TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null, bool allowSparse = false)
-            : this(env, MakeArgs(columns, hasHeader, new[] { separatorChar }, allowSparse), dataSample)
+        /// <param name="allowQuoting">Whether the file can contain numerical vectors in sparse format.</param>
+        internal TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null, bool allowSparse = false, bool allowQuoting = false)
+            : this(env, MakeArgs(columns, hasHeader, new[] { separatorChar }, allowSparse, allowQuoting), dataSample)
         {
         }
 
-        private static Options MakeArgs(Column[] columns, bool hasHeader, char[] separatorChars, bool allowSparse)
+        private static Options MakeArgs(Column[] columns, bool hasHeader, char[] separatorChars, bool allowSparse, bool allowQuoting)
         {
             Contracts.AssertValue(separatorChars);
-            var result = new Options { Columns = columns, HasHeader = hasHeader, Separators = separatorChars, AllowSparse = allowSparse };
+            var result = new Options { Columns = columns, HasHeader = hasHeader, Separators = separatorChars, AllowSparse = allowSparse, AllowQuoting = allowQuoting };
             return result;
         }
 
@@ -1257,7 +1258,7 @@ namespace Microsoft.ML.Data
                 HeaderFile = options.HeaderFile,
                 MaxRows = options.MaxRows
             });
-            tmp = Regex.Replace(tmp, @"[(sparse=\+)]", "");
+            tmp = Regex.Replace(tmp, @"[(sparse=\+)|(quote\+)]", "");
 
             // Try to get the schema information from the file.
             string str = Cursor.GetEmbeddedArgs(files);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1071,7 +1071,9 @@ namespace Microsoft.ML.Data
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         /// <param name="allowQuoting">Whether the file can contain numerical vectors in sparse format.</param>
-        internal TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = false, char separatorChar = '\t', IMultiStreamSource dataSample = null, bool allowSparse = false, bool allowQuoting = false)
+        internal TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = Defaults.HasHeader,
+            char separatorChar = Defaults.Separator, IMultiStreamSource dataSample = null,
+            bool allowSparse = Defaults.AllowSparse, bool allowQuoting = Defaults.AllowQuoting)
             : this(env, MakeArgs(columns, hasHeader, new[] { separatorChar }, allowSparse, allowQuoting), dataSample)
         {
         }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1064,14 +1064,14 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
-        /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
-        /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
+        /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         /// <param name="allowQuoting">Whether the content of a column can be parsed from a string starting and ending with quote.</param>
-        internal TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = Defaults.HasHeader,
-            char separatorChar = Defaults.Separator, IMultiStreamSource dataSample = null,
-            bool allowSparse = Defaults.AllowSparse, bool allowQuoting = Defaults.AllowQuoting)
+        /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
+        internal TextLoader(IHostEnvironment env, Column[] columns, char separatorChar = Defaults.Separator,
+            bool hasHeader = Defaults.HasHeader, bool allowSparse = Defaults.AllowSparse,
+            bool allowQuoting = Defaults.AllowQuoting, IMultiStreamSource dataSample = null)
             : this(env, MakeArgs(columns, hasHeader, new[] { separatorChar }, allowSparse, allowQuoting), dataSample)
         {
         }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1260,7 +1260,6 @@ namespace Microsoft.ML.Data
                 HeaderFile = options.HeaderFile,
                 MaxRows = options.MaxRows
             });
-            tmp = Regex.Replace(tmp, @"[(sparse=\+)|(quote\+)]", "");
 
             // Try to get the schema information from the file.
             string str = Cursor.GetEmbeddedArgs(files);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -7,14 +7,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.Data.DataView;
 using Microsoft.ML;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Model;
-using Float = System.Single;
 
 [assembly: LoadableClass(TextLoader.Summary, typeof(IDataLoader), typeof(TextLoader), typeof(TextLoader.Options), typeof(SignatureDataLoader),
     "Text Loader", "TextLoader", "Text", DocName = "loader/TextLoader.md")]
@@ -1070,7 +1068,7 @@ namespace Microsoft.ML.Data
         /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
-        /// <param name="allowQuoting">Whether the file can contain numerical vectors in sparse format.</param>
+        /// <param name="allowQuoting">Whether the content of a column can be parsed from a string starting and ending with quote.</param>
         internal TextLoader(IHostEnvironment env, Column[] columns, bool hasHeader = Defaults.HasHeader,
             char separatorChar = Defaults.Separator, IMultiStreamSource dataSample = null,
             bool allowSparse = Defaults.AllowSparse, bool allowQuoting = Defaults.AllowQuoting)
@@ -1350,7 +1348,7 @@ namespace Microsoft.ML.Data
             // char[]: separators
             // bindings
             int cbFloat = ctx.Reader.ReadInt32();
-            host.CheckDecode(cbFloat == sizeof(Float));
+            host.CheckDecode(cbFloat == sizeof(float));
             _maxRows = ctx.Reader.ReadInt64();
             host.CheckDecode(_maxRows > 0);
             _flags = (OptionFlags)ctx.Reader.ReadUInt32();
@@ -1413,7 +1411,7 @@ namespace Microsoft.ML.Data
             // int: number of separators
             // char[]: separators
             // bindings
-            ctx.Writer.Write(sizeof(Float));
+            ctx.Writer.Write(sizeof(float));
             ctx.Writer.Write(_maxRows);
             _host.Assert((_flags & ~OptionFlags.All) == 0);
             ctx.Writer.Write((uint)_flags);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -16,19 +16,19 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="columns">Array of columns <see cref="TextLoader.Column"/> defining the schema.</param>
-        /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
-        /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
+        /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         /// <param name="allowQuoting">Whether the file can contain column defined by a quoted string.</param>
+        /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
         public static TextLoader CreateTextLoader(this DataOperationsCatalog catalog,
             TextLoader.Column[] columns,
-            bool hasHeader = TextLoader.Defaults.HasHeader,
             char separatorChar = TextLoader.Defaults.Separator,
-            IMultiStreamSource dataSample = null,
+            bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
-            bool allowQuoting = TextLoader.Defaults.AllowQuoting)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample, allowSparse, allowQuoting);
+            bool allowQuoting = TextLoader.Defaults.AllowQuoting,
+            IMultiStreamSource dataSample = null)
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, separatorChar, hasHeader, allowSparse, allowQuoting, dataSample);
 
         /// <summary>
         /// Create a text loader <see cref="TextLoader"/>.
@@ -45,8 +45,8 @@ namespace Microsoft.ML
         /// Create a text loader <see cref="TextLoader"/> by inferencing the dataset schema from a data model type.
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
-        /// <param name="hasHeader">Does the file contains header?</param>
         /// <param name="separatorChar">Column separator character. Default is '\t'</param>
+        /// <param name="hasHeader">Does the file contains header?</param>
         /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
         /// and distinguish empty values from missing values. When true, consecutive separators
@@ -57,8 +57,8 @@ namespace Microsoft.ML
         /// except for 3rd and 5th columns which have values 6 and 3</param>
         /// <param name="trimWhitespace">Remove trailing whitespace from lines</param>
         public static TextLoader CreateTextLoader<TInput>(this DataOperationsCatalog catalog,
-            bool hasHeader = TextLoader.Defaults.HasHeader,
             char separatorChar = TextLoader.Defaults.Separator,
+            bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)
@@ -76,8 +76,8 @@ namespace Microsoft.ML
         public static IDataView ReadFromTextFile(this DataOperationsCatalog catalog,
             string path,
             TextLoader.Column[] columns,
-            bool hasHeader = TextLoader.Defaults.HasHeader,
-            char separatorChar = TextLoader.Defaults.Separator)
+            char separatorChar = TextLoader.Defaults.Separator,
+            bool hasHeader = TextLoader.Defaults.HasHeader)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 
@@ -85,7 +85,7 @@ namespace Microsoft.ML
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            var reader = new TextLoader(env, columns, hasHeader, separatorChar, dataSample: null);
+            var reader = new TextLoader(env, columns, separatorChar, hasHeader, dataSample: null);
             return reader.Read(new MultiFileSource(path));
         }
 
@@ -108,8 +108,8 @@ namespace Microsoft.ML
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile<TInput>(this DataOperationsCatalog catalog,
             string path,
-            bool hasHeader = TextLoader.Defaults.HasHeader,
             char separatorChar = TextLoader.Defaults.Separator,
+            bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -47,22 +47,22 @@ namespace Microsoft.ML
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="hasHeader">Does the file contains header?</param>
         /// <param name="separatorChar">Column separator character. Default is '\t'</param>
-        /// <param name="allowQuotedStrings">Whether the input may include quoted values,
+        /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
         /// and distinguish empty values from missing values. When true, consecutive separators
         /// denote a missing value and an empty value is denoted by \"\".
         /// When false, consecutive separators denote an empty value.</param>
-        /// <param name="supportSparse">Whether the input may include sparse representations for example,
+        /// <param name="allowSparse">Whether the input may include sparse representations for example,
         /// if one of the row contains "5 2:6 4:3" that's mean there are 5 columns all zero
         /// except for 3rd and 5th columns which have values 6 and 3</param>
         /// <param name="trimWhitespace">Remove trailing whitespace from lines</param>
         public static TextLoader CreateTextLoader<TInput>(this DataOperationsCatalog catalog,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             char separatorChar = TextLoader.Defaults.Separator,
-            bool allowQuotedStrings = TextLoader.Defaults.AllowQuoting,
-            bool supportSparse = TextLoader.Defaults.AllowSparse,
+            bool allowQuoting = TextLoader.Defaults.AllowQuoting,
+            bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)
-            => TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar, allowQuotedStrings, supportSparse, trimWhitespace);
+            => TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar, allowQuoting, allowSparse, trimWhitespace);
 
         /// <summary>
         /// Read a data view from a text file using <see cref="TextLoader"/>.
@@ -95,12 +95,12 @@ namespace Microsoft.ML
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="hasHeader">Does the file contains header?</param>
         /// <param name="separatorChar">Column separator character. Default is '\t'</param>
-        /// <param name="allowQuotedStrings">Whether the input may include quoted values,
+        /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
         /// and distinguish empty values from missing values. When true, consecutive separators
         /// denote a missing value and an empty value is denoted by \"\".
         /// When false, consecutive separators denote an empty value.</param>
-        /// <param name="supportSparse">Whether the input may include sparse representations for example,
+        /// <param name="allowSparse">Whether the input may include sparse representations for example,
         /// if one of the row contains "5 2:6 4:3" that's mean there are 5 columns all zero
         /// except for 3rd and 5th columns which have values 6 and 3</param>
         /// <param name="trimWhitespace">Remove trailing whitespace from lines</param>
@@ -110,15 +110,15 @@ namespace Microsoft.ML
             string path,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             char separatorChar = TextLoader.Defaults.Separator,
-            bool allowQuotedStrings = TextLoader.Defaults.AllowQuoting,
-            bool supportSparse = TextLoader.Defaults.AllowSparse,
+            bool allowQuoting = TextLoader.Defaults.AllowQuoting,
+            bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            return TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar, allowQuotedStrings, supportSparse, trimWhitespace)
+            return TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar, allowQuoting, allowSparse, trimWhitespace)
                              .Read(new MultiFileSource(path));
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -148,20 +148,22 @@ namespace Microsoft.ML
         /// <param name="headerRow">Whether to write the header row.</param>
         /// <param name="schema">Whether to write the header comment with the schema.</param>
         /// <param name="keepHidden">Whether to keep hidden columns in the dataset.</param>
+        /// <param name="forceDense">Whether to save columns in dense format even if they are sparse vectors.</param>
         public static void SaveAsText(this DataOperationsCatalog catalog,
             IDataView data,
             Stream stream,
             char separatorChar = TextLoader.Defaults.Separator,
-            bool headerRow = TextLoader.Defaults.HasHeader,
-            bool schema = true,
-            bool keepHidden = false)
+            bool headerRow = TextSaver.Defaults.OutputHeader,
+            bool schema = TextSaver.Defaults.OutputSchema,
+            bool keepHidden = false,
+            bool forceDense = TextSaver.Defaults.ForceDense)
         {
             Contracts.CheckValue(catalog, nameof(catalog));
             Contracts.CheckValue(data, nameof(data));
             Contracts.CheckValue(stream, nameof(stream));
 
             var env = catalog.GetEnvironment();
-            var saver = new TextSaver(env, new TextSaver.Arguments { Separator = separatorChar.ToString(), OutputHeader = headerRow, OutputSchema = schema });
+            var saver = new TextSaver(env, new TextSaver.Arguments { Dense = forceDense, Separator = separatorChar.ToString(), OutputHeader = headerRow, OutputSchema = schema });
 
             using (var ch = env.Start("Saving data"))
                 DataSaverUtils.SaveDataView(ch, saver, data, stream, keepHidden);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -20,13 +20,15 @@ namespace Microsoft.ML
         /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
+        /// <param name="allowQuoting">Whether the file can contain column defined by a quoted string.</param>
         public static TextLoader CreateTextLoader(this DataOperationsCatalog catalog,
             TextLoader.Column[] columns,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             char separatorChar = TextLoader.Defaults.Separator,
             IMultiStreamSource dataSample = null,
-            bool allowSparse = TextLoader.Defaults.AllowSparse)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample, allowSparse);
+            bool allowSparse = TextLoader.Defaults.AllowSparse,
+            bool allowQuoting = TextLoader.Defaults.AllowQuoting)
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample, allowSparse, allowQuoting);
 
         /// <summary>
         /// Create a text loader <see cref="TextLoader"/>.

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -19,12 +19,14 @@ namespace Microsoft.ML
         /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
         /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
+        /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         public static TextLoader CreateTextLoader(this DataOperationsCatalog catalog,
             TextLoader.Column[] columns,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             char separatorChar = TextLoader.Defaults.Separator,
-            IMultiStreamSource dataSample = null)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample);
+            IMultiStreamSource dataSample = null,
+            bool allowSparse = TextLoader.Defaults.AllowSparse)
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, hasHeader, separatorChar, dataSample, allowSparse);
 
         /// <summary>
         /// Create a text loader <see cref="TextLoader"/>.

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ML
         public static void SaveAsText(this DataOperationsCatalog catalog,
             IDataView data,
             Stream stream,
-            char separatorChar = TextLoader.Defaults.Separator,
+            char separatorChar = TextSaver.Defaults.Separator,
             bool headerRow = TextSaver.Defaults.OutputHeader,
             bool schema = TextSaver.Defaults.OutputSchema,
             bool keepHidden = false,

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Data.IO
     {
         internal static class DefaultArguments
         {
-            internal const char Separator = '\t';
+            internal const string Separator = "tab";
             internal const bool ForceDense = false;
             internal const bool OutputSchema = true;
             internal const bool OutputHeader = true;
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Data.IO
         public sealed class Arguments
         {
             [Argument(ArgumentType.AtMostOnce, HelpText = "Separator", ShortName = "sep")]
-            public string Separator = DefaultArguments.Separator.ToString();
+            public string Separator = DefaultArguments.Separator;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Force dense format", ShortName = "dense")]
             public bool Dense = DefaultArguments.ForceDense;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -22,14 +22,22 @@ namespace Microsoft.ML.Data.IO
     [BestFriend]
     internal sealed class TextSaver : IDataSaver
     {
+        internal static class DefaultArguments
+        {
+            internal const char Separator = '\t';
+            internal const bool ForceDense = false;
+            internal const bool OutputSchema = true;
+            internal const bool OutputHeader = true;
+        }
+
         // REVIEW: consider saving a command line in a separate file.
         public sealed class Arguments
         {
             [Argument(ArgumentType.AtMostOnce, HelpText = "Separator", ShortName = "sep")]
-            public string Separator = "tab";
+            public string Separator = DefaultArguments.Separator.ToString();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Force dense format", ShortName = "dense")]
-            public bool Dense;
+            public bool Dense = DefaultArguments.ForceDense;
 
             // REVIEW: This and the corresponding BinarySaver option should be removed,
             // with the silence being handled, somehow, at the environment level. (Task 6158846.)
@@ -37,10 +45,10 @@ namespace Microsoft.ML.Data.IO
             public bool Silent;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Output the comment containing the loader settings", ShortName = "schema")]
-            public bool OutputSchema = true;
+            public bool OutputSchema = DefaultArguments.OutputSchema;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Output the header", ShortName = "header")]
-            public bool OutputHeader = true;
+            public bool OutputHeader = DefaultArguments.OutputHeader;
         }
 
         internal const string Summary = "Writes data into a text file.";

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -22,9 +22,9 @@ namespace Microsoft.ML.Data.IO
     [BestFriend]
     internal sealed class TextSaver : IDataSaver
     {
-        internal static class DefaultArguments
+        internal static class Defaults
         {
-            internal const string Separator = "tab";
+            internal const char Separator = '\t';
             internal const bool ForceDense = false;
             internal const bool OutputSchema = true;
             internal const bool OutputHeader = true;
@@ -34,10 +34,10 @@ namespace Microsoft.ML.Data.IO
         public sealed class Arguments
         {
             [Argument(ArgumentType.AtMostOnce, HelpText = "Separator", ShortName = "sep")]
-            public string Separator = DefaultArguments.Separator;
+            public string Separator = Defaults.Separator.ToString();
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Force dense format", ShortName = "dense")]
-            public bool Dense = DefaultArguments.ForceDense;
+            public bool Dense = Defaults.ForceDense;
 
             // REVIEW: This and the corresponding BinarySaver option should be removed,
             // with the silence being handled, somehow, at the environment level. (Task 6158846.)
@@ -45,10 +45,10 @@ namespace Microsoft.ML.Data.IO
             public bool Silent;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Output the comment containing the loader settings", ShortName = "schema")]
-            public bool OutputSchema = DefaultArguments.OutputSchema;
+            public bool OutputSchema = Defaults.OutputSchema;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Output the header", ShortName = "header")]
-            public bool OutputHeader = DefaultArguments.OutputHeader;
+            public bool OutputHeader = Defaults.OutputHeader;
         }
 
         internal const string Summary = "Writes data into a text file.";

--- a/src/Microsoft.ML.StaticPipe/DataLoadSaveOperationsExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/DataLoadSaveOperationsExtensions.cs
@@ -36,6 +36,6 @@ namespace Microsoft.ML.StaticPipe
             this DataOperationsCatalog catalog, Func<Context, TShape> func, IMultiStreamSource files = null,
             bool hasHeader = false, char separator = '\t', bool allowQuoting = true, bool allowSparse = true,
             bool trimWhitspace = false)
-         => CreateReader(catalog.Environment, func, files, hasHeader, separator, allowQuoting, allowSparse, trimWhitspace);
+         => CreateReader(catalog.Environment, func, files, separator, hasHeader, allowQuoting, allowSparse, trimWhitspace);
     }
 }

--- a/src/Microsoft.ML.StaticPipe/TextLoaderStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/TextLoaderStatic.cs
@@ -26,8 +26,8 @@ namespace Microsoft.ML.StaticPipe
         /// <param name="files">Input files. If <c>null</c> then no files are read, but this means that options or
         /// configurations that require input data for initialization (for example, <paramref name="hasHeader"/> or
         /// <see cref="Context.LoadFloat(int, int?)"/>) with a <c>null</c> second argument.</param>
-        /// <param name="hasHeader">Data file has header with feature names.</param>
         /// <param name="separator">Text field separator.</param>
+        /// <param name="hasHeader">Data file has header with feature names.</param>
         /// <param name="allowQuoting">Whether the input -may include quoted values, which can contain separator
         /// characters, colons, and distinguish empty values from missing values. When true, consecutive separators
         /// denote a missing value and an empty value is denoted by <c>""</c>. When false, consecutive separators
@@ -36,8 +36,8 @@ namespace Microsoft.ML.StaticPipe
         /// <param name="trimWhitspace">Remove trailing whitespace from lines.</param>
         /// <returns>A configured statically-typed reader for text files.</returns>
         public static DataReader<IMultiStreamSource, TShape> CreateReader<[IsShape] TShape>(
-            IHostEnvironment env,  Func<Context, TShape> func, IMultiStreamSource files = null,
-            bool hasHeader = false, char separator = '\t', bool allowQuoting = true, bool allowSparse = true,
+            IHostEnvironment env, Func<Context, TShape> func, IMultiStreamSource files = null,
+            char separator = '\t', bool hasHeader = false, bool allowQuoting = true, bool allowSparse = true,
             bool trimWhitspace = false)
         {
             Contracts.CheckValue(env, nameof(env));
@@ -114,7 +114,7 @@ namespace Microsoft.ML.StaticPipe
         /// <summary>
         /// Context object by which a user can indicate what fields they want to read from a text file, and what data type they ought to have.
         /// Instances of this class are never made but the user, but rather are fed into the delegate in
-        /// <see cref="CreateReader{TShape}(IHostEnvironment, Func{Context, TShape}, IMultiStreamSource, bool, char, bool, bool, bool)"/>.
+        /// <see cref="CreateReader{TShape}(IHostEnvironment, Func{Context, TShape}, IMultiStreamSource, char, bool, bool, bool, bool)"/>.
         /// </summary>
         public sealed class Context
         {

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -326,7 +326,7 @@
                 "Required": false,
                 "SortOrder": 150.0,
                 "IsNullable": false,
-                "Default": true
+                "Default": false
               },
               {
                 "Name": "AllowSparse",

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -338,7 +338,7 @@
                 "Required": false,
                 "SortOrder": 150.0,
                 "IsNullable": false,
-                "Default": true
+                "Default": false
               },
               {
                 "Name": "InputSize",

--- a/test/BaselineOutput/Common/pcaAnomaly/Default-TrainTest-mnistOneClass-out.txt
+++ b/test/BaselineOutput/Common/pcaAnomaly/Default-TrainTest-mnistOneClass-out.txt
@@ -1,4 +1,4 @@
-maml.exe TrainTest test=%Data% tr=pcaAnomaly dout=%Output% data=%Data% out=%Output% seed=1
+maml.exe TrainTest test=%Data% tr=pcaAnomaly dout=%Output% loader=text{sparse+} data=%Data% out=%Output% seed=1
 Automatically adding a MinMax normalization transform, use 'norm=Warn' or 'norm=No' to turn this behavior off.
 Not training a calibrator because it is not needed.
 50 Top-scored Results

--- a/test/BaselineOutput/Common/pcaAnomaly/Default-TrainTest-mnistOneClass-rp.txt
+++ b/test/BaselineOutput/Common/pcaAnomaly/Default-TrainTest-mnistOneClass-rp.txt
@@ -1,4 +1,4 @@
 pcaAnomaly
 AUC	DR @K FP	DR @P FPR	DR @NumPos	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-0.95619	0.9	0.1	0.5	pcaAnomaly	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=pcaAnomaly dout=%Output% data=%Data% out=%Output% seed=1		
+0.95619	0.9	0.1	0.5	pcaAnomaly	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=pcaAnomaly dout=%Output% loader=text{sparse+} data=%Data% out=%Output% seed=1		
 

--- a/test/BaselineOutput/Common/pcaAnomaly/NoNorm-TrainTest-mnistOneClass-out.txt
+++ b/test/BaselineOutput/Common/pcaAnomaly/NoNorm-TrainTest-mnistOneClass-out.txt
@@ -1,4 +1,4 @@
-maml.exe TrainTest test=%Data% tr=pcaAnomaly norm=No dout=%Output% data=%Data% out=%Output% seed=1
+maml.exe TrainTest test=%Data% tr=pcaAnomaly norm=No dout=%Output% loader=text{sparse+} data=%Data% out=%Output% seed=1
 Not adding a normalizer.
 Not training a calibrator because it is not needed.
 50 Top-scored Results

--- a/test/BaselineOutput/Common/pcaAnomaly/NoNorm-TrainTest-mnistOneClass-rp.txt
+++ b/test/BaselineOutput/Common/pcaAnomaly/NoNorm-TrainTest-mnistOneClass-rp.txt
@@ -1,4 +1,4 @@
 pcaAnomaly
 AUC	DR @K FP	DR @P FPR	DR @NumPos	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-0.989524	1	0.9	0.9	pcaAnomaly	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=pcaAnomaly norm=No dout=%Output% data=%Data% out=%Output% seed=1		
+0.989524	1	0.9	0.9	pcaAnomaly	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=pcaAnomaly norm=No dout=%Output% loader=text{sparse+} data=%Data% out=%Output% seed=1		
 

--- a/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
+++ b/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Benchmarks
 
             var env = new MLContext(seed: 1, conc: 1);
             var reader = new TextLoader(env,
-                    columns: new[]
+                columns: new[]
                     {
                             new TextLoader.Column("Label", DataKind.R4, 0),
                             new TextLoader.Column("SepalLength", DataKind.R4, 1),
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Benchmarks
                             new TextLoader.Column("PetalLength", DataKind.R4, 3),
                             new TextLoader.Column("PetalWidth", DataKind.R4, 4),
                     },
-                    hasHeader: true
+                hasHeader: true
                 );
 
             IDataView data = reader.Read(_irisDataPath);
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Benchmarks
                             new TextLoader.Column("Label", DataKind.BL, 0),
                             new TextLoader.Column("SentimentText", DataKind.Text, 1)
                         },
-                        hasHeader: true                        
+                hasHeader: true
                     );
 
             IDataView data = reader.Read(_sentimentDataPath);
@@ -107,8 +107,8 @@ namespace Microsoft.ML.Benchmarks
                         {
                             new TextLoader.Column("Label", DataKind.BL, 0),
                             new TextLoader.Column("Features", DataKind.R4, new[] { new TextLoader.Range(1, 9) })
-                        }, 
-                        hasHeader: false
+                        },
+                hasHeader: false
                     );
 
             IDataView data = reader.Read(_breastCancerDataPath);

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Benchmarks
         private TransformerChain<MulticlassPredictionTransformer<MulticlassLogisticRegressionModelParameters>> Train(string dataPath)
         {
             var reader = new TextLoader(mlContext,
-                    columns: new[]
+                columns: new[]
                     {
                             new TextLoader.Column("Label", DataKind.R4, 0),
                             new TextLoader.Column("SepalLength", DataKind.R4, 1),
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Benchmarks
                             new TextLoader.Column("PetalLength", DataKind.R4, 3),
                             new TextLoader.Column("PetalWidth", DataKind.R4, 4),
                     },
-                    hasHeader: true
+                hasHeader: true
                 );
 
             IDataView data = reader.Read(dataPath);
@@ -128,7 +128,7 @@ namespace Microsoft.ML.Benchmarks
             _consumer.Consume(_predictionEngine.Predict(_example));
 
             var reader = new TextLoader(mlContext,
-                    columns: new[]
+                columns: new[]
                     {
                             new TextLoader.Column("Label", DataKind.R4, 0),
                             new TextLoader.Column("SepalLength", DataKind.R4, 1),
@@ -136,7 +136,7 @@ namespace Microsoft.ML.Benchmarks
                             new TextLoader.Column("PetalLength", DataKind.R4, 3),
                             new TextLoader.Column("PetalWidth", DataKind.R4, 4),
                     },
-                    hasHeader: true
+                hasHeader: true
                 );
 
             IDataView testData = reader.Read(_dataPath);

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -2411,7 +2411,7 @@ namespace Microsoft.ML.RunTests
                     'model' : '{1}'
                   }}
                 }}", EscapePath(dataPath), EscapePath(outputPath), trainerName,
-                string.IsNullOrWhiteSpace(loader) ? "" : string.Format(",'CustomSchema': '{0}'", loader),
+                string.IsNullOrWhiteSpace(loader) ? "" : string.Format(",'CustomSchema': 'sparse+ {0}'", loader),
                 string.IsNullOrWhiteSpace(trainerArgs) ? "" : trainerArgs
                 );
 
@@ -3403,6 +3403,7 @@ namespace Microsoft.ML.RunTests
                 {
                     Arguments =
                 {
+                    AllowSparse = true,
                     Separators = new []{'\t' },
                     HasHeader = false,
                     Columns = new[]

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -3859,8 +3859,8 @@ namespace Microsoft.ML.RunTests
                                 'UseThreads': true,
                                 'HeaderFile': null,
                                 'MaxRows': null,
-                                'AllowQuoting': true,
-                                'AllowSparse': true,
+                                'AllowQuoting': false,
+                                'AllowSparse': false,
                                 'InputSize': null,
                                 'Separator': [
                                     '\t'
@@ -3922,8 +3922,8 @@ namespace Microsoft.ML.RunTests
                                 'UseThreads': true,
                                 'HeaderFile': null,
                                 'MaxRows': null,
-                                'AllowQuoting': true,
-                                'AllowSparse': true,
+                                'AllowQuoting': false,
+                                'AllowSparse': false,
                                 'InputSize': null,
                                 'Separator': [
                                     '\t'

--- a/test/Microsoft.ML.FSharp.Tests/SmokeTests.fs
+++ b/test/Microsoft.ML.FSharp.Tests/SmokeTests.fs
@@ -76,7 +76,7 @@ module SmokeTest1 =
         let testDataPath = __SOURCE_DIRECTORY__ + @"/../data/wikipedia-detox-250-line-data.tsv"
 
         let ml = MLContext(seed = new System.Nullable<int>(1), conc = 1)
-        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true)
+        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuotedStrings = true)
 
         let pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText") 
                         .Append(ml.BinaryClassification.Trainers.FastTree(numLeaves = 5, numTrees = 5))      
@@ -116,7 +116,7 @@ module SmokeTest2 =
         let testDataPath = __SOURCE_DIRECTORY__ + @"/../data/wikipedia-detox-250-line-data.tsv"
         
         let ml = MLContext(seed = new System.Nullable<int>(1), conc = 1)
-        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true)
+        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuotedStrings = true)
 
         let pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText") 
                         .Append(ml.BinaryClassification.Trainers.FastTree(numLeaves = 5, numTrees = 5))
@@ -153,7 +153,7 @@ module SmokeTest3 =
         let testDataPath = __SOURCE_DIRECTORY__ + @"/../data/wikipedia-detox-250-line-data.tsv"
 
         let ml = MLContext(seed = new System.Nullable<int>(1), conc = 1)
-        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true)
+        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuotedStrings = true)
 
         let pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText") 
                         .Append(ml.BinaryClassification.Trainers.FastTree(numLeaves = 5, numTrees = 5))

--- a/test/Microsoft.ML.FSharp.Tests/SmokeTests.fs
+++ b/test/Microsoft.ML.FSharp.Tests/SmokeTests.fs
@@ -76,7 +76,7 @@ module SmokeTest1 =
         let testDataPath = __SOURCE_DIRECTORY__ + @"/../data/wikipedia-detox-250-line-data.tsv"
 
         let ml = MLContext(seed = new System.Nullable<int>(1), conc = 1)
-        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuotedStrings = true)
+        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuoting = true)
 
         let pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText") 
                         .Append(ml.BinaryClassification.Trainers.FastTree(numLeaves = 5, numTrees = 5))      
@@ -116,7 +116,7 @@ module SmokeTest2 =
         let testDataPath = __SOURCE_DIRECTORY__ + @"/../data/wikipedia-detox-250-line-data.tsv"
         
         let ml = MLContext(seed = new System.Nullable<int>(1), conc = 1)
-        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuotedStrings = true)
+        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuoting = true)
 
         let pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText") 
                         .Append(ml.BinaryClassification.Trainers.FastTree(numLeaves = 5, numTrees = 5))
@@ -153,7 +153,7 @@ module SmokeTest3 =
         let testDataPath = __SOURCE_DIRECTORY__ + @"/../data/wikipedia-detox-250-line-data.tsv"
 
         let ml = MLContext(seed = new System.Nullable<int>(1), conc = 1)
-        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuotedStrings = true)
+        let data = ml.Data.ReadFromTextFile<SentimentData>(testDataPath, hasHeader = true, allowQuoting = true)
 
         let pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText") 
                         .Append(ml.BinaryClassification.Trainers.FastTree(numLeaves = 5, numTrees = 5))

--- a/test/Microsoft.ML.Functional.Tests/DataIO.cs
+++ b/test/Microsoft.ML.Functional.Tests/DataIO.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Functional.Tests
             {
                 // Serialize a dataset with a known schema to a file.
                 var filePath = SerializeDatasetToFile(mlContext, dataBefore, separator);
-                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, hasHeader: true, separatorChar: separator, allowQuoting: true);
+                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, separatorChar: separator, hasHeader: true, allowQuoting: true);
                 Common.AssertTestTypeDatasetsAreEqual(mlContext, dataBefore, dataAfter);
             }
         }

--- a/test/Microsoft.ML.Functional.Tests/DataIO.cs
+++ b/test/Microsoft.ML.Functional.Tests/DataIO.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Functional.Tests
             {
                 // Serialize a dataset with a known schema to a file.
                 var filePath = SerializeDatasetToFile(mlContext, dataBefore, separator);
-                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, hasHeader: true, separatorChar: separator, allowQuotedStrings: true);
+                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, hasHeader: true, separatorChar: separator, allowQuoting: true);
                 Common.AssertTestTypeDatasetsAreEqual(mlContext, dataBefore, dataAfter);
             }
         }

--- a/test/Microsoft.ML.Functional.Tests/DataIO.cs
+++ b/test/Microsoft.ML.Functional.Tests/DataIO.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Functional.Tests
             {
                 // Serialize a dataset with a known schema to a file.
                 var filePath = SerializeDatasetToFile(mlContext, dataBefore, separator);
-                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, hasHeader: true, separatorChar: separator);
+                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, hasHeader: true, separatorChar: separator, allowQuotedStrings: true);
                 Common.AssertTestTypeDatasetsAreEqual(mlContext, dataBefore, dataAfter);
             }
         }

--- a/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
+++ b/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
@@ -100,8 +100,8 @@ namespace Microsoft.ML.Functional.Tests.Datasets
                         new TextLoader.Column("Ug", DataKind.UG, 15),
                         new TextLoader.Column("Features", DataKind.R4, 16, 16 + _numFeatures-1),
                     },
-                    hasHeader: true,
                     separatorChar: separator,
+                    hasHeader: true,
                     allowQuoting: true);
         }
 

--- a/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
+++ b/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
@@ -101,7 +101,8 @@ namespace Microsoft.ML.Functional.Tests.Datasets
                         new TextLoader.Column("Features", DataKind.R4, 16, 16 + _numFeatures-1),
                     },
                     hasHeader: true,
-                    separatorChar: separator);
+                    separatorChar: separator,
+                    allowQuoting: true);
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -1755,8 +1755,8 @@ output Out [3] from H all;
         [TestCategory("Anomaly")]
         public void PcaAnomalyTest()
         {
-            Run_TrainTest(TestLearners.PCAAnomalyDefault, TestDatasets.mnistOneClass, digitsOfPrecision: 5);
-            Run_TrainTest(TestLearners.PCAAnomalyNoNorm, TestDatasets.mnistOneClass, digitsOfPrecision: 5);
+            Run_TrainTest(TestLearners.PCAAnomalyDefault, TestDatasets.mnistOneClass, extraSettings: new[] { "loader=text{sparse+}" }, digitsOfPrecision: 5);
+            Run_TrainTest(TestLearners.PCAAnomalyNoNorm, TestDatasets.mnistOneClass, extraSettings: new[] { "loader=text{sparse+}" }, digitsOfPrecision: 5);
 
             // REVIEW: This next test was misbehaving in a strange way that seems to have gone away
             // mysteriously (bad build?).

--- a/test/Microsoft.ML.TestFramework/BaseTestPredictorsMaml.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestPredictorsMaml.cs
@@ -233,6 +233,7 @@ namespace Microsoft.ML.RunTests
                 removeArgs.Add("xf=");
                 removeArgs.Add("cache-");
                 removeArgs.Add("sf=");
+                removeArgs.Add("loader=");
 
                 for (int i = 0; i < args.Count; ++i)
                 {

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -274,7 +274,7 @@ namespace Microsoft.ML.RunTests
         {
             TestCore(null, true,
                 new[] {
-                    "loader=Text{sparse+ col=Label:Num:0 col=Text:TX:1-9}",
+                    "loader=Text{quote+ sparse+ col=Label:Num:0 col=Text:TX:1-9}",
                     "xf=Cat{max=5 col={name=Key src=Text kind=key}}",
                     "xf=Ngram{ngram=3 skips=1 col={name=Ngrams1 src=Key max=10}}",
                     "xf=Ngram{skips=2 col={name=Ngrams2 src=Key ngram=4 max=10:20:30} col={name=Ngrams3 src=Key ngram=3 max=10:15}}",
@@ -301,7 +301,7 @@ namespace Microsoft.ML.RunTests
 
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{sparse+ col=Text:TX:0-20}",
+                    "loader=Text{quote+ sparse+ col=Text:TX:0-20}",
                     "xf=Cat{col={name=Key src=Text kind=key}}",
                     "xf=Ngram{ngram=3 skips=2 col={name=Ngrams src=Key max=100}}",
                 });
@@ -412,7 +412,7 @@ namespace Microsoft.ML.RunTests
         {
             TestCore(null, false,
                 new[] {
-                    "loader=Text{sparse+ col=Text:TX:1-9 col=OneText:TX:1 col=Label:0}",
+                    "loader=Text{quote+ sparse+ col=Text:TX:1-9 col=OneText:TX:1 col=Label:0}",
                     "xf=Cat{max=5 col={name=Bag src=Text kind=bag} col=One:ind:OneText}",
                     "xf=Cat{max=7 col=Hot:Text}",
                     "xf=Cat{max=8 col=Key:kEY:Text col=KeyOne:KeY:OneText}",
@@ -455,7 +455,7 @@ namespace Microsoft.ML.RunTests
         {
             TestCore(null, false,
                 new[] {
-                    "loader=Text{sparse+ col=One:TX:1 col=Num:R4:2-* col=Key:U1[0-10]:1}",
+                    "loader=Text{quote+ sparse+ col=One:TX:1 col=Num:R4:2-* col=Key:U1[0-10]:1}",
                     // Create a lot of unused slots.
                     "xf=CatHash{col=OneInd:One bits=10}",
                     // One is for the non-vector case and OneInd is reduced to a small size.
@@ -661,7 +661,7 @@ namespace Microsoft.ML.RunTests
                     "an angry ant\t3\t3\t\tbob bowled badly",
                     "\t10\t\t\t\"\""
                 });
-            const string loader = "loader=Text{sparse+ col=A:TX:0 col=K:U4[11]:1-2 col=KS:U4[11]:2 col=B:TX:4 col=E:TX:3}";
+            const string loader = "loader=Text{quote+ sparse+ col=A:TX:0 col=K:U4[11]:1-2 col=KS:U4[11]:2 col=B:TX:4 col=E:TX:3}";
             TestCore(pathData, true,
                 new[] {
                     loader,

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -175,7 +175,7 @@ namespace Microsoft.ML.RunTests
             string pathData = GetDataPath("adult.tiny.with-schema.txt");
             TestCore(pathData, false,
                 new[] {
-                    "loader=Text{header+ col=Label:0 col=Age:9 col=Gender:TX:7 col=Mar:TX:3 col=Race:TX:6 col=Num:10-14 col=Txt:TX:~}",
+                    "loader=Text{sparse+ header+ col=Label:0 col=Age:9 col=Gender:TX:7 col=Mar:TX:3 col=Race:TX:6 col=Num:10-14 col=Txt:TX:~}",
                     "xf=Cat{col=Race2:Key:Race data={" + pathTerms + "} termCol=Whatever}",
                     "xf=Cat{col=Gender2:Gender terms=Male,Female}",
                     "xf=Cat{col=Mar2:Mar col={name=Race3 src=Race terms=Other,White,Black,Asian-Pac-Islander,Amer-Indian-Inuit}}",
@@ -198,7 +198,7 @@ namespace Microsoft.ML.RunTests
             string pathData = GetDataPath("adult.tiny.with-schema.txt");
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{header+ col=Mar:TX:3 col=Race:TX:6 col=Gen:TX:7~8}",
+                    "loader=Text{sparse+ header+ col=Mar:TX:3 col=Race:TX:6 col=Gen:TX:7~8}",
                     "xf=Concat{col=Comb:Race,Gen,Race}",
                     "xf=Cat{kind=Key col=MarKey:Mar}",
                     "xf=Cat{kind=Key col={name=CombKey src=Comb} data={" + pathTerms + "}}",
@@ -254,7 +254,7 @@ namespace Microsoft.ML.RunTests
 
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{col=Known:I4:0-2 col=Single:I4:3 col=Text:TX:4 col=Unknown:I4:~** sep=comma}",
+                    "loader=Text{sparse+ col=Known:I4:0-2 col=Single:I4:3 col=Text:TX:4 col=Unknown:I4:~** sep=comma}",
                     // Tokenize Text, then run it through Categorical to get key values, then through KeyToVector.
                     // Then convert everything to R8 and concatenate it all.
                     "xf=WordToken{col=Tokens:Text}",
@@ -274,7 +274,7 @@ namespace Microsoft.ML.RunTests
         {
             TestCore(null, true,
                 new[] {
-                    "loader=Text{col=Label:Num:0 col=Text:TX:1-9}",
+                    "loader=Text{sparse+ col=Label:Num:0 col=Text:TX:1-9}",
                     "xf=Cat{max=5 col={name=Key src=Text kind=key}}",
                     "xf=Ngram{ngram=3 skips=1 col={name=Ngrams1 src=Key max=10}}",
                     "xf=Ngram{skips=2 col={name=Ngrams2 src=Key ngram=4 max=10:20:30} col={name=Ngrams3 src=Key ngram=3 max=10:15}}",
@@ -301,7 +301,7 @@ namespace Microsoft.ML.RunTests
 
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{col=Text:TX:0-20}",
+                    "loader=Text{sparse+ col=Text:TX:0-20}",
                     "xf=Cat{col={name=Key src=Text kind=key}}",
                     "xf=Ngram{ngram=3 skips=2 col={name=Ngrams src=Key max=100}}",
                 });
@@ -412,7 +412,7 @@ namespace Microsoft.ML.RunTests
         {
             TestCore(null, false,
                 new[] {
-                    "loader=Text{col=Text:TX:1-9 col=OneText:TX:1 col=Label:0}",
+                    "loader=Text{sparse+ col=Text:TX:1-9 col=OneText:TX:1 col=Label:0}",
                     "xf=Cat{max=5 col={name=Bag src=Text kind=bag} col=One:ind:OneText}",
                     "xf=Cat{max=7 col=Hot:Text}",
                     "xf=Cat{max=8 col=Key:kEY:Text col=KeyOne:KeY:OneText}",
@@ -435,7 +435,7 @@ namespace Microsoft.ML.RunTests
 
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{col=Text:TX:0-2 col=CatU1:U1[0-2]:0-2 col=CatU2:U2[0-4]:0-2 col=CatU8:U8[]:0-2 col=OneU1:U1[]:0 col=OneU2:U2[]:1 col=OneU4:U4[]:1 col=OneU8:U8[]:2 col=Single:TX:0 col=VarU1:U1[]:3-** col=VarU2:U2[]:3-** col=VarU4:U4[]:3-** col=VarU8:U8[]:3-** col=Variable:TX:3-**}",
+                    "loader=Text{sparse+ col=Text:TX:0-2 col=CatU1:U1[0-2]:0-2 col=CatU2:U2[0-4]:0-2 col=CatU8:U8[]:0-2 col=OneU1:U1[]:0 col=OneU2:U2[]:1 col=OneU4:U4[]:1 col=OneU8:U8[]:2 col=Single:TX:0 col=VarU1:U1[]:3-** col=VarU2:U2[]:3-** col=VarU4:U4[]:3-** col=VarU8:U8[]:3-** col=Variable:TX:3-**}",
                     "xf=Cat{col=Cat:Key:Text col=VarCat:Key:Variable}",
                     "xf=Hash{bits=6 ordered+ col={name=Hash0 src=Text bits=4} col={name=Hash1 src=Text ord- bits=4} col={name=Hash2 src=Cat} col=Hash3:CatU8}",
                     "xf=Hash{col={name=Hash4 bits=5 src=CatU1} col={name=Hash5 src=CatU2 bits=6 ord+} col={name=Hash6 src=CatU2 bits=6} col={name=Hash7 src=CatU8 bits=6} col={name=Hash8 src=Cat bits=6}}",
@@ -455,7 +455,7 @@ namespace Microsoft.ML.RunTests
         {
             TestCore(null, false,
                 new[] {
-                    "loader=Text{col=One:TX:1 col=Num:R4:2-* col=Key:U1[0-10]:1}",
+                    "loader=Text{sparse+ col=One:TX:1 col=Num:R4:2-* col=Key:U1[0-10]:1}",
                     // Create a lot of unused slots.
                     "xf=CatHash{col=OneInd:One bits=10}",
                     // One is for the non-vector case and OneInd is reduced to a small size.
@@ -515,7 +515,7 @@ namespace Microsoft.ML.RunTests
             string pathData = GetDataPath("lm.sample.txt");
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{header+ col=Label:TX:0 col=Attrs:TX:1-2 col=TextFeatures:TX:3-4 rows=100}",
+                    "loader=Text{sparse+ header+ col=Label:TX:0 col=Attrs:TX:1-2 col=TextFeatures:TX:3-4 rows=100}",
                     "xf=WordToken{col={name=Tokens src=TextFeatures}}",
                     "xf=Cat{max=10 col={name=Cat src=Tokens kind=key}}",
                     "xf=Hash{col={name=Hash src=Tokens bits=10} col={name=HashBig src=Tokens bits=31}}",
@@ -559,7 +559,7 @@ namespace Microsoft.ML.RunTests
             string pathData = GetDataPath(@"lm.sample.txt");
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{header+ col=One:TX:4 col=Two:TX:3 rows=101}",
+                    "loader=Text{sparse+ header+ col=One:TX:4 col=Two:TX:3 rows=101}",
                     "xf=WordHashBag{bits=5",
                     "  col=F11:5:One col={name=F12 src=One ngram=4} col={name=F13 src=Two ngram=3 skips=2 bits=15}",
                     "  col=F21:Two,One col={name=F22 src=Two src=One ngram=4} col={name=F23 src=Two src=One bits=15 ngram=3 skips=2}",
@@ -609,7 +609,7 @@ namespace Microsoft.ML.RunTests
             string pathData = GetDataPath(@"lm.sample.txt");
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{header+ col=One:TX:4 col=Two:TX:3 rows=101}",
+                    "loader=Text{sparse+ header+ col=One:TX:4 col=Two:TX:3 rows=101}",
                     "xf=WordHashBag{bits=5 ord=- col=F1:One col=F2:One,One}",
                     "xf=SelectColumns{keepcol=F1 keepcol=F2}",
                 },
@@ -661,7 +661,7 @@ namespace Microsoft.ML.RunTests
                     "an angry ant\t3\t3\t\tbob bowled badly",
                     "\t10\t\t\t\"\""
                 });
-            const string loader = "loader=Text{col=A:TX:0 col=K:U4[11]:1-2 col=KS:U4[11]:2 col=B:TX:4 col=E:TX:3}";
+            const string loader = "loader=Text{sparse+ col=A:TX:0 col=K:U4[11]:1-2 col=KS:U4[11]:2 col=B:TX:4 col=E:TX:3}";
             TestCore(pathData, true,
                 new[] {
                     loader,
@@ -720,7 +720,7 @@ namespace Microsoft.ML.RunTests
             string pathData = GetDataPath(@"lm.sample.txt");
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{header+ col=Label:TX:0 col=One:TX:4 col=Vec:TX:3,4 rows=101}",
+                    "loader=Text{sparse+ header+ col=Label:TX:0 col=One:TX:4 col=Vec:TX:3,4 rows=101}",
                     "xf=AutoLabel{col=Label}",
                     "xf=WordBag{max=10",
                     "  col=F11:One col={name=F12 src=One ngram=4 max=3 max=4 max=5} col={name=F13 src=One ngram=3 skips=2}",
@@ -749,7 +749,7 @@ namespace Microsoft.ML.RunTests
 
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{header=+ col=Text:TX:0}",
+                    "loader=Text{sparse+ header=+ col=Text:TX:0}",
                     "xf=WordBag{col={name=TfIdf src=Text max=5 ngram=3 weighting=TfIdf}}",
                     "xf=SelectColumns{keepCol=TfIdf}",
                 });
@@ -763,7 +763,7 @@ namespace Microsoft.ML.RunTests
             string pathData = GetDataPath(@"lm.sample.txt");
             TestCore(pathData, true,
                 new[] {
-                    "loader=Text{header+ col=One:TX:4 col=Vec:TX:3,4 rows=101}",
+                    "loader=Text{sparse+ header+ col=One:TX:4 col=Vec:TX:3,4 rows=101}",
                     "xf=WordBag{col={name=WB1 src=One max=10 ngram=3 skips=2} col={name=WB2 src=One src=One max=10 ngram=3 skips=2}}",
                     "xf=SelectColumns{keepCol=WB1 keepCol=WB2}"
                 },
@@ -1016,7 +1016,7 @@ namespace Microsoft.ML.RunTests
             RunMTAThread(() => TestCore(null, false,
                 new[]
                 {
-                    "loader=Text",
+                    "loader=Text{sparse+}",
                     "xf=TrainScore{tr=FT scorer=fcc{top=4 bottom=2 str+}}",
                     "xf=Copy{col=ContributionsStr:FeatureContributions}",
                     "xf=TrainScore{tr=FT scorer=fcc{top=3 bottom=3}}"
@@ -1032,7 +1032,7 @@ namespace Microsoft.ML.RunTests
             TestCore(null, false,
                 new[]
                 {
-                    "loader=Text xf=TrainScore{tr=AP{shuf-} scorer=fcc{str+}}"
+                    "loader=Text{sparse+} xf=TrainScore{tr=AP{shuf-} scorer=fcc{str+}}"
                 }, digitsOfPrecision: 5);
 
             Done();

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -403,7 +403,7 @@ namespace Microsoft.ML.RunTests
                 view = new ChooseColumnsByIndexTransform(env, chooseargs, view);
             }
 
-            var args = new TextLoader.Options();
+            var args = new TextLoader.Options() { AllowSparse = true };
             if (!CmdParser.ParseArguments(Env, argsLoader, args))
             {
                 Fail("Couldn't parse the args '{0}' in '{1}'", argsLoader, pathData);
@@ -412,7 +412,7 @@ namespace Microsoft.ML.RunTests
 
             // Note that we don't pass in "args", but pass in a default args so we test
             // the auto-schema parsing.
-            var loadedData = ML.Data.ReadFromTextFile(pathData);
+            var loadedData = ML.Data.ReadFromTextFile(pathData, options: args);
             if (!CheckMetadataTypes(loadedData.Schema))
                 Failed();
 

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -403,7 +403,7 @@ namespace Microsoft.ML.RunTests
                 view = new ChooseColumnsByIndexTransform(env, chooseargs, view);
             }
 
-            var args = new TextLoader.Options() { AllowSparse = true };
+            var args = new TextLoader.Options() { AllowSparse = true, AllowQuoting = true};
             if (!CmdParser.ParseArguments(Env, argsLoader, args))
             {
                 Fail("Couldn't parse the args '{0}' in '{1}'", argsLoader, pathData);

--- a/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
+++ b/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
@@ -40,7 +40,8 @@ namespace Microsoft.ML.Tests
                 {
                     new TextLoader.Column("Label", DataKind.R4, 0),
                     new TextLoader.Column(featureColumn, DataKind.R4, new [] { new TextLoader.Range(1, 784) })
-                }
+                },
+                AllowSparse = true
             });
 
             var trainData = reader.Read(GetDataPath(TestDatasets.mnistOneClass.trainFilename));

--- a/test/Microsoft.ML.Tests/BinaryLoaderSaverTests.cs
+++ b/test/Microsoft.ML.Tests/BinaryLoaderSaverTests.cs
@@ -25,12 +25,11 @@ namespace Microsoft.ML.Tests
             // dotnet MML.dll savedata loader=text{col=A:U4[0-2]:0 col=B:U4[0-5]:0 col=C:U1[0-10]:0 col=D:U2[0-*]:0 col=E:U4[0-*]:0 col=F:U8[0-*]:0} dout=codectest.idv
             var data = ML.Data.ReadFromBinary(GetDataPath("schema-codec-test.idv"));
 
-            var saver = new TextSaver(ML, new TextSaver.Arguments { Silent = true });
             var outputPath = GetOutputPath("BinaryLoaderSaver", "OldKeyTypeCodecTest.txt");
             using (var ch = Env.Start("save"))
             {
                 using (var fs = File.Create(outputPath))
-                    ML.Data.SaveAsText(data, fs);
+                    ML.Data.SaveAsText(data, fs, headerRow: false);
             }
             CheckEquality("BinaryLoaderSaver", "OldKeyTypeCodecTest.txt");
             Done();

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -51,9 +51,9 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                hasHeader: true,
                 separatorChar: ';'
-            );
+,
+                hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
                 mlContext.Transforms.Normalize("FeatureVector")
@@ -129,8 +129,8 @@ namespace Microsoft.ML.Tests
             string dataPath = GetDataPath("breast-cancer.txt");
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var data = mlContext.Data.ReadFromTextFile<BreastCancerFeatureVector>(dataPath,
-                hasHeader: true,
-                separatorChar: '\t');
+                separatorChar: '\t',
+                hasHeader: true);
 
             var pipeline = mlContext.Transforms.Normalize("Features").
                 Append(mlContext.Clustering.Trainers.KMeans(new Trainers.KMeans.KMeansPlusPlusTrainer.Options
@@ -207,8 +207,8 @@ namespace Microsoft.ML.Tests
             string dataPath = GetDataPath("breast-cancer.txt");
 
             var data = mlContext.Data.ReadFromTextFile<BreastCancerCatFeatureExample>(dataPath,
-                hasHeader: true,
-                separatorChar: '\t');
+                separatorChar: '\t',
+                hasHeader: true);
 
             var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.Categorical.OneHotEncodingTransformer.OutputKind.Bag)
             .Append(mlContext.Transforms.ReplaceMissingValues(new MissingValueReplacingEstimator.ColumnInfo("F2")))
@@ -305,9 +305,9 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                hasHeader: true,
                 separatorChar: ';'
-            );
+,
+                hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
                 mlContext.Transforms.Normalize("FeatureVector")
@@ -338,9 +338,9 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                hasHeader: true,
                 separatorChar: ';'
-            );
+,
+                hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
                 mlContext.Transforms.Normalize("FeatureVector")
@@ -371,8 +371,8 @@ namespace Microsoft.ML.Tests
 
             string dataPath = GetDataPath("breast-cancer.txt");
             var data = mlContext.Data.ReadFromTextFile<BreastCancerMulticlassExample>(dataPath,
-                hasHeader: true,
-                separatorChar: '\t');
+                separatorChar: '\t',
+                hasHeader: true);
 
             var pipeline = mlContext.Transforms.Normalize("Features").
                 Append(mlContext.Transforms.Conversion.MapValueToKey("Label")).
@@ -401,8 +401,8 @@ namespace Microsoft.ML.Tests
 
             string dataPath = GetDataPath("breast-cancer.txt");
             var data = mlContext.Data.ReadFromTextFile<BreastCancerCatFeatureExample>(dataPath,
-                hasHeader: true,
-                separatorChar: '\t');
+                separatorChar: '\t',
+                hasHeader: true);
 
             var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.Categorical.OneHotEncodingTransformer.OutputKind.Bag)
             .Append(mlContext.Transforms.ReplaceMissingValues(new MissingValueReplacingEstimator.ColumnInfo("F2")))
@@ -452,7 +452,7 @@ namespace Microsoft.ML.Tests
             var mlContext = new MLContext(seed: 1, conc: 1);
             var dataPath = GetDataPath(@"small-sentiment-test.tsv");
             var embedNetworkPath = GetDataPath(@"shortsentiment.emd");
-            var data = mlContext.Data.ReadFromTextFile<SmallSentimentExample>(dataPath, hasHeader: false, separatorChar: '\t');
+            var data = mlContext.Data.ReadFromTextFile<SmallSentimentExample>(dataPath, separatorChar: '\t', hasHeader: false);
 
             var pipeline = mlContext.Transforms.Text.ExtractWordEmbeddings("Embed", embedNetworkPath, "Tokens");
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -78,11 +78,11 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Step one: read the data as an IDataView.
             // Read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var trainData = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                // First line of the file is a header, not a data row.
-                hasHeader: true,
                 // Default separator is tab, but we need a semicolon.
                 separatorChar: ';'
-            );
+,
+                // First line of the file is a header, not a data row.
+                hasHeader: true);
 
             // Sometime, caching data in-memory after its first access can save some loading time when the data is going to be used
             // several times somewhere. The caching mechanism is also lazy; it only caches things after being used.
@@ -114,11 +114,11 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
 
             // Read the test dataset.
             var testData = mlContext.Data.ReadFromTextFile<AdultData>(testDataPath,
-                // First line of the file is a header, not a data row.
-                hasHeader: true,
                 // Default separator is tab, but we need a semicolon.
                 separatorChar: ';'
-            );
+,
+                // First line of the file is a header, not a data row.
+                hasHeader: true);
 
             // Calculate metrics of the model on the test data.
             var metrics = mlContext.Regression.Evaluate(model.Transform(testData), label: "Target");
@@ -277,7 +277,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.CreateTextLoader(new[] 
+            var reader = mlContext.Data.CreateTextLoader(new[]
                 {
                     new TextLoader.Column("IsToxic", DataKind.BL, 0),
                     new TextLoader.Column("Message", DataKind.TX, 1),
@@ -344,7 +344,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var mlContext = new MLContext();
 
             // Define the reader: specify the data columns and where to find them in the text file.
-            var reader = mlContext.Data.CreateTextLoader(new[] 
+            var reader = mlContext.Data.CreateTextLoader(new[]
                 {
                     new TextLoader.Column("Label", DataKind.BL, 0),
                     // We will load all the categorical features into one vector column of size 8.
@@ -458,7 +458,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var reader = mlContext.Data.ReadFromTextFile<AdultData>(dataPath,
                 // Default separator is tab, but we need a comma.
-                separatorChar: ',' );
+                separatorChar: ',');
         }
 
         // Define a class for all the input columns that we intend to consume.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), hasHeader: true, separatorChar: ',');
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',', hasHeader: true);
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void IntrospectiveTraining()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true);
+            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true, allowQuotedStrings: true);
 
             var pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(ml)
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void FastTreeClassificationIntrospectiveTraining()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true);
+            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true, allowQuotedStrings: true);
 
             var trainer = ml.BinaryClassification.Trainers.FastTree(numLeaves: 5, numTrees: 3);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void IntrospectiveTraining()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true, allowQuotedStrings: true);
+            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true, allowQuoting: true);
 
             var pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(ml)
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void FastTreeClassificationIntrospectiveTraining()
         {
             var ml = new MLContext(seed: 1, conc: 1);
-            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true, allowQuotedStrings: true);
+            var data = ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.trainFilename), hasHeader: true, allowQuoting: true);
 
             var trainer = ml.BinaryClassification.Trainers.FastTree(numLeaves: 5, numTrees: 3);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPredictionNotCasted>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), hasHeader: true, separatorChar: ',');
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',', hasHeader: true);
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             
             // During prediction we will get Score column with 3 float values.

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -497,8 +497,8 @@ namespace Microsoft.ML.Scenarios
                         new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
 
                     },
-                    hasHeader: true,
-                    allowSparse: true
+                hasHeader: true,
+                allowSparse: true
                 );
 
             var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
@@ -539,7 +539,7 @@ namespace Microsoft.ML.Scenarios
                             new TextLoader.Column("Label", DataKind.I8, 0),
                             new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
                         },
-                        allowSparse: true
+                    allowSparse: true
                     );
 
                 var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
@@ -855,7 +855,7 @@ namespace Microsoft.ML.Scenarios
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
             var data = mlContext.Data.ReadFromTextFile(dataFile,
-                    columns: new[]
+                columns: new[]
                     {
                         new TextLoader.Column("ImagePath", DataKind.TX, 0),
                         new TextLoader.Column("Name", DataKind.TX, 1),
@@ -993,12 +993,12 @@ namespace Microsoft.ML.Scenarios
             var dataView = mlContext.Data.ReadFromEnumerable(data);
 
             var lookupMap = mlContext.Data.ReadFromTextFile(@"sentiment_model/imdb_word_index.csv",
-                   columns: new[]
+                columns: new[]
                    {
                         new TextLoader.Column("Words", DataKind.TX, 0),
                         new TextLoader.Column("Ids", DataKind.I4, 1),
                    },
-                   separatorChar: ','
+                separatorChar: ','
                );
 
             // We cannot resize variable length vector to fixed length vector in ML.NET

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -497,7 +497,8 @@ namespace Microsoft.ML.Scenarios
                         new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
 
                     },
-                    hasHeader: true
+                    hasHeader: true,
+                    allowSparse: true
                 );
 
             var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
@@ -537,7 +538,8 @@ namespace Microsoft.ML.Scenarios
                         {
                             new TextLoader.Column("Label", DataKind.I8, 0),
                             new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
-                        }
+                        },
+                        allowSparse: true
                     );
 
                 var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
@@ -631,7 +633,8 @@ namespace Microsoft.ML.Scenarios
                         new TextLoader.Column("Label", DataKind.U4, new []{ new TextLoader.Range(0) }, new KeyCount(10)),
                         new TextLoader.Column("TfLabel", DataKind.I8, 0),
                         new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
-                    }
+                    },
+                    allowSparse: true
                 );
 
                 var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
@@ -725,7 +728,8 @@ namespace Microsoft.ML.Scenarios
                     new TextLoader.Column("Label", DataKind.U4 , new [] { new TextLoader.Range(0) }, new KeyCount(10)),
                     new TextLoader.Column("Placeholder", DataKind.R4, new []{ new TextLoader.Range(1, 784) })
                 },
-                hasHeader: true
+                hasHeader: true,
+                allowSparse: true
             );
 
             var trainData = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -149,9 +149,9 @@ namespace Microsoft.ML.EntryPoints.Tests
             Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt"));
             Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: true));
             Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: false));
-            Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: false, supportSparse: false, trimWhitespace: false));
-            Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: false, supportSparse: false));
-            Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: false, allowQuotedStrings: false));
+            Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: false, allowSparse: false, trimWhitespace: false));
+            Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: false, allowSparse: false));
+            Assert.NotNull(mlContext.Data.ReadFromTextFile<Input>("fakeFile.txt", hasHeader: false, allowQuoting: false));
             Assert.NotNull(mlContext.Data.ReadFromTextFile<InputWithUnderscore>("fakeFile.txt"));
         }
 

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var data = TestCore(pathData, true,
                 new[] {
-                "loader=Text{col=DvInt1:I1:0 col=DvInt2:I2:1 col=DvInt4:I4:2 col=DvInt8:I8:3 sep=comma}",
+                "loader=Text{quote+ col=DvInt1:I1:0 col=DvInt2:I2:1 col=DvInt4:I4:2 col=DvInt8:I8:3 sep=comma}",
                 }, logCurs: true);
 
             using (var cursor = data.GetRowCursorForAllColumns())

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
@@ -163,6 +163,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var data = new TextLoader(Env,
                     new TextLoader.Options()
                     {
+                        AllowQuoting = true,
                         Separator = "\t",
                         HasHeader = true,
                         Columns = new[]

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TrainerEstimators.cs
@@ -35,7 +35,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 Columns = new[]
                 {
                     new TextLoader.Column(featureColumn, DataKind.R4, new [] { new TextLoader.Range(1, 784) })
-                }
+                },
+                AllowSparse = true
             });
             var data = reader.Read(GetDataPath(TestDatasets.mnistOneClass.trainFilename));
 
@@ -64,7 +65,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 {
                     new TextLoader.Column(featureColumn, DataKind.R4, new [] { new TextLoader.Range(1, 784) }),
                     new TextLoader.Column(weights, DataKind.R4, 0)
-                }
+                },
+                AllowSparse = true
             });
             var data = reader.Read(GetDataPath(TestDatasets.mnistTiny28.trainFilename));
 

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new TextLoader.Column("Float1", DataKind.R4, 0),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(0), new TextLoader.Range(2), new TextLoader.Range(4), new TextLoader.Range(10) }),
                     new TextLoader.Column("Text1", DataKind.Text, 0)
-            }, hasHeader: true, separatorChar: ',' );
+            }, separatorChar: ',', hasHeader: true);
 
             var data = loader.Read(source);
 

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.RunTests
         {
             TestCore(GetDataPath(Path.Combine("Timeseries", "real_1.csv")),
                 true,
-                    new[]{"loader=TextLoader{sep=, col=Features:R4:1 header=+}",
+                    new[]{"loader=TextLoader{sparse+ sep=, col=Features:R4:1 header=+}",
                     "xf=IidSpikeDetector{src=Features name=Anomaly cnf=99.5 wnd=200 side=Positive}",
                     "xf=Convert{col=fAnomaly:R4:Anomaly}",
                     "xf=IidSpikeDetector{src=Features name=Anomaly2 cnf=99.5 wnd=200 side=Negative}",

--- a/test/data/adult.tiny.with-schema.txt
+++ b/test/data/adult.tiny.with-schema.txt
@@ -1,6 +1,5 @@
 #@ TextLoader{
 #@   header+
-#@   sparse+
 #@   sep=tab
 #@   col=Label:R4:0
 #@   col=Workclass:TX:1

--- a/test/data/adult.tiny.with-schema.txt
+++ b/test/data/adult.tiny.with-schema.txt
@@ -1,5 +1,6 @@
 #@ TextLoader{
 #@   header+
+#@   sparse+
 #@   sep=tab
 #@   col=Label:R4:0
 #@   col=Workclass:TX:1


### PR DESCRIPTION
To fix #2576, this PR makes the default to `sparse-` everywhere including both of command line and public APIs.

- [x] Make `sparse-` as default
- [x] Make `quote-` as default
- [x] Fix #2452, which is about TextSaver.

