### PR TITLE
Increase build timeout for code coverage CI.

### DIFF
--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -15,9 +15,9 @@ phases:
       _codeCoverage: ${{ parameters.codeCoverage }}
     queue:
       ${{ if eq(variables._codeCoverage, 'false') }}:
-        timeoutInMinutes: 45
+        timeoutInMinutes: 30
       ${{ if eq(variables._codeCoverage, 'true') }}:
-        timeoutInMinutes: 90
+        timeoutInMinutes: 60
       parallel: 99
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -14,7 +14,10 @@ phases:
       _arch: ${{ parameters.architecture }}
       _codeCoverage: ${{ parameters.codeCoverage }}
     queue:
-      timeoutInMinutes: 45
+      ${{ if eq(variables._codeCoverage, 'false') }}:
+        timeoutInMinutes: 45
+      ${{ if eq(variables._codeCoverage, 'true') }}:
+        timeoutInMinutes: 90
       parallel: 99
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:


### PR DESCRIPTION
Recently it seems the code coverage build times have increased, the exact reason is unclear but it could be because of added tests. Since code coverage CI does not interfere with the main CI so its ok to increase the build timeouts for code coverage CI to prevent build failures due to [timeouts.](https://dev.azure.com/dnceng/public/_build/results?buildId=100301)
