### PR TITLE
Microsoft.ML.Transforms assembly lockdown

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -136,7 +136,7 @@ namespace Microsoft.ML.Transforms.Conversions
         private readonly VBuffer<ReadOnlyMemory<char>>[] _keyValues;
         private readonly VectorType[] _kvTypes;
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             if (!HashingEstimator.IsColumnTypeValid(type))

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Transforms.Conversions
             return "key type of known cardinality";
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             string reason = TestIsKey(type);

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -561,7 +561,7 @@ namespace Microsoft.ML.Transforms.Normalizers
             }
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             const string expectedType = "scalar or known-size vector of R4";
 

--- a/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
@@ -78,7 +78,8 @@ namespace Microsoft.ML.Data
             CheckInputColumn(inputSchema, col, srcCol);
         }
 
-        protected virtual void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        [BestFriend]
+        private protected virtual void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             // By default, there are no extra checks.
         }

--- a/src/Microsoft.ML.HalLearners/VectorWhitening.cs
+++ b/src/Microsoft.ML.HalLearners/VectorWhitening.cs
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Transforms.Projections
         private static (string outputColumnName, string inputColumnName)[] GetColumnPairs(VectorWhiteningEstimator.ColumnInfo[] columns)
             => columns.Select(c => (c.Name, c.InputColumnName ?? c.Name)).ToArray();
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var inType = inputSchema[srcCol].Type;
             var reason = TestColumn(inType);

--- a/src/Microsoft.ML.ImageAnalytics/ImageGrayscale.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageGrayscale.cs
@@ -164,7 +164,7 @@ namespace Microsoft.ML.ImageAnalytics
 
         private protected override IRowMapper MakeRowMapper(DataViewSchema schema) => new Mapper(this, schema);
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             if (!(inputSchema[srcCol].Type is ImageType))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].inputColumnName, "image", inputSchema[srcCol].Type.ToString());

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.ImageAnalytics
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, DataViewSchema inputSchema)
             => Create(env, ctx).MakeRowMapper(inputSchema);
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             if (!(inputSchema[srcCol].Type is TextDataViewType))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", ColumnPairs[col].inputColumnName, TextDataViewType.Instance.ToString(), inputSchema[srcCol].Type.ToString());

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractor.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractor.cs
@@ -272,7 +272,7 @@ namespace Microsoft.ML.ImageAnalytics
 
         private protected override IRowMapper MakeRowMapper(DataViewSchema schema) => new Mapper(this, schema);
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var inputColName = _columns[col].InputColumnName;
             var imageType = inputSchema[srcCol].Type as ImageType;

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -265,7 +265,7 @@ namespace Microsoft.ML.ImageAnalytics
 
         private protected override IRowMapper MakeRowMapper(DataViewSchema schema) => new Mapper(this, schema);
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             if (!(inputSchema[srcCol].Type is ImageType))
                 throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _columns[col].InputColumnName, "image", inputSchema[srcCol].Type.ToString());

--- a/src/Microsoft.ML.PCA/PcaTransformer.cs
+++ b/src/Microsoft.ML.PCA/PcaTransformer.cs
@@ -499,7 +499,7 @@ namespace Microsoft.ML.Transforms.Projections
 
         private protected override IRowMapper MakeRowMapper(DataViewSchema schema) => new Mapper(this, schema);
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             ValidatePcaInput(Host, inputSchema[srcCol].Name, inputSchema[srcCol].Type);
         }

--- a/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
@@ -9,7 +9,7 @@ using Microsoft.ML.Transforms.Categorical;
 namespace Microsoft.ML
 {
     /// <summary>
-    /// Static extensions for categorical transforms.
+    /// The catalog of categorical transformations.
     /// </summary>
     public static class CategoricalCatalog
     {

--- a/src/Microsoft.ML.Transforms/CompositeTransformer.cs
+++ b/src/Microsoft.ML.Transforms/CompositeTransformer.cs
@@ -16,7 +16,7 @@ using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML.Transforms
 {
-    public static class CompositeTransformer
+    internal static class CompositeTransformer
     {
         private const string RegistrationName = "CompositeTransform";
 

--- a/src/Microsoft.ML.Transforms/FourierDistributionSampler.cs
+++ b/src/Microsoft.ML.Transforms/FourierDistributionSampler.cs
@@ -119,7 +119,7 @@ namespace Microsoft.ML.Transforms
             ctx.Writer.Write(_gamma);
         }
 
-        float IFourierDistributionSampler.Next(Random rand)
+        public float Next(Random rand)
         {
             return (float)Stats.SampleFromGaussian(rand) * MathUtils.Sqrt(2 * _gamma);
         }
@@ -201,7 +201,7 @@ namespace Microsoft.ML.Transforms
             ctx.Writer.Write(_a);
         }
 
-        float IFourierDistributionSampler.Next(Random rand)
+        public float Next(Random rand)
         {
             return _a * Stats.SampleFromCauchy(rand);
         }

--- a/src/Microsoft.ML.Transforms/FourierDistributionSampler.cs
+++ b/src/Microsoft.ML.Transforms/FourierDistributionSampler.cs
@@ -30,7 +30,8 @@ namespace Microsoft.ML.Transforms
     /// <summary>
     /// Signature for an IFourierDistributionSampler constructor.
     /// </summary>
-    public delegate void SignatureFourierDistributionSampler(float avgDist);
+    [BestFriend]
+    internal delegate void SignatureFourierDistributionSampler(float avgDist);
 
     public interface IFourierDistributionSampler : ICanSaveModel
     {
@@ -38,7 +39,7 @@ namespace Microsoft.ML.Transforms
     }
 
     [TlcModule.ComponentKind("FourierDistributionSampler")]
-    public interface IFourierDistributionSamplerFactory : IComponentFactory<float, IFourierDistributionSampler>
+    internal interface IFourierDistributionSamplerFactory : IComponentFactory<float, IFourierDistributionSampler>
     {
     }
 
@@ -51,10 +52,11 @@ namespace Microsoft.ML.Transforms
             [Argument(ArgumentType.AtMostOnce, HelpText = "gamma in the kernel definition: exp(-gamma*||x-y||^2 / r^2). r is an estimate of the average intra-example distance", ShortName = "g")]
             public float Gamma = 1;
 
-            public IFourierDistributionSampler CreateComponent(IHostEnvironment env, float avgDist) => new GaussianFourierSampler(env, this, avgDist);
+            IFourierDistributionSampler IComponentFactory<float, IFourierDistributionSampler>.CreateComponent(IHostEnvironment env, float avgDist)
+                => new GaussianFourierSampler(env, this, avgDist);
         }
 
-        public const string LoaderSignature = "RandGaussFourierExec";
+        internal const string LoaderSignature = "RandGaussFourierExec";
         private static VersionInfo GetVersionInfo()
         {
             return new VersionInfo(
@@ -66,7 +68,7 @@ namespace Microsoft.ML.Transforms
                 loaderAssemblyName: typeof(GaussianFourierSampler).Assembly.FullName);
         }
 
-        public const string LoadName = "GaussianRandom";
+        internal const string LoadName = "GaussianRandom";
 
         private readonly float _gamma;
 
@@ -79,7 +81,7 @@ namespace Microsoft.ML.Transforms
             _gamma = args.Gamma / avgDist;
         }
 
-        public static GaussianFourierSampler Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static GaussianFourierSampler Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
@@ -117,7 +119,7 @@ namespace Microsoft.ML.Transforms
             ctx.Writer.Write(_gamma);
         }
 
-        public float Next(Random rand)
+        float IFourierDistributionSampler.Next(Random rand)
         {
             return (float)Stats.SampleFromGaussian(rand) * MathUtils.Sqrt(2 * _gamma);
         }
@@ -130,7 +132,8 @@ namespace Microsoft.ML.Transforms
             [Argument(ArgumentType.AtMostOnce, HelpText = "a in the term exp(-a|x| / r). r is an estimate of the average intra-example L1 distance")]
             public float A = 1;
 
-            public IFourierDistributionSampler CreateComponent(IHostEnvironment env, float avgDist) => new LaplacianFourierSampler(env, this, avgDist);
+            IFourierDistributionSampler IComponentFactory<float, IFourierDistributionSampler>.CreateComponent(IHostEnvironment env, float avgDist)
+                => new LaplacianFourierSampler(env, this, avgDist);
         }
 
         private static VersionInfo GetVersionInfo()
@@ -144,8 +147,8 @@ namespace Microsoft.ML.Transforms
                 loaderAssemblyName: typeof(LaplacianFourierSampler).Assembly.FullName);
         }
 
-        public const string LoaderSignature = "RandLaplacianFourierExec";
-        public const string RegistrationName = "LaplacianRandom";
+        internal const string LoaderSignature = "RandLaplacianFourierExec";
+        internal const string RegistrationName = "LaplacianRandom";
 
         private readonly IHost _host;
         private readonly float _a;
@@ -159,7 +162,7 @@ namespace Microsoft.ML.Transforms
             _a = args.A / avgDist;
         }
 
-        public static LaplacianFourierSampler Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static LaplacianFourierSampler Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
@@ -198,7 +201,7 @@ namespace Microsoft.ML.Transforms
             ctx.Writer.Write(_a);
         }
 
-        public float Next(Random rand)
+        float IFourierDistributionSampler.Next(Random rand)
         {
             return _a * Stats.SampleFromCauchy(rand);
         }

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -202,7 +202,7 @@ namespace Microsoft.ML.Transforms.Projections
             return columns.Select(x => (x.Name, x.InputColumnName)).ToArray();
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var inType = inputSchema[srcCol].Type;
             if (!LpNormalizingEstimatorBase.IsColumnTypeValid(inType))

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Transforms.Conversions
             return "key type of known cardinality";
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             string reason = TestIsKey(type);

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Transforms
         private static (string outputColumnName, string inputColumnName)[] GetColumnPairs(Column[] columns)
             => columns.Select(c => (c.Name, c.Source ?? c.Name)).ToArray();
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var inType = inputSchema[srcCol].Type;
             if (!(inType is VectorType))

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -194,7 +194,7 @@ namespace Microsoft.ML.Transforms
         // REVIEW: Currently these arrays are constructed on load but could be changed to being constructed lazily.
         private readonly BitArray[] _repIsDefault;
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             string reason = TestType(type);

--- a/src/Microsoft.ML.Transforms/ProjectionCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ProjectionCatalog.cs
@@ -7,6 +7,9 @@ using Microsoft.ML.Transforms.Projections;
 
 namespace Microsoft.ML
 {
+    /// <summary>
+    /// The catalog of projection transformations.
+    /// </summary>
     public static class ProjectionCatalog
     {
         /// <summary>

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -240,7 +240,7 @@ namespace Microsoft.ML.Transforms.Projections
             return columns.Select(x => (x.Name, x.InputColumnName)).ToArray();
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             string reason = TestColumnType(type);

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -883,7 +883,7 @@ namespace Microsoft.ML.Transforms.Text
             public readonly int NgramLength;
             /// <summary>Maximum number of tokens to skip when constructing an ngram.</summary>
             public readonly int SkipLength;
-            /// <summary>Whether to store all ngram lengths up to ngramLength, or only ngramLength.</summary>
+            /// <summary>Whether to store all ngram lengths up to <see cref="NgramLength"/>, or only <see cref="NgramLength"/>.</summary>
             public readonly bool AllLengths;
             /// <summary>Number of bits to hash into. Must be between 1 and 31, inclusive.</summary>
             public readonly int HashBits;
@@ -893,7 +893,8 @@ namespace Microsoft.ML.Transforms.Text
             public readonly bool Ordered;
             /// <summary>
             /// During hashing we constuct mappings between original values and the produced hash values.
-            /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
+            /// Text representation of original values are stored in the slot names of the  metadata for the new column.
+            /// Hashing, as such, can map many initial values to one.
             /// <see cref="InvertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
             /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.
             /// </summary>
@@ -911,12 +912,13 @@ namespace Microsoft.ML.Transforms.Text
             /// <param name="inputColumnNames">Names of the columns to transform. </param>
             /// <param name="ngramLength">Maximum ngram length.</param>
             /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
-            /// <param name="allLengths">Whether to store all ngram lengths up to ngramLength, or only ngramLength.</param>
+            /// <param name="allLengths">Whether to store all ngram lengths up to <paramref name="ngramLength"/>, or only <paramref name="ngramLength"/>.</param>
             /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
             /// <param name="seed">Hashing seed.</param>
             /// <param name="ordered">Whether the position of each term should be included in the hash.</param>
             /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
-            /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
+            /// Text representation of original values are stored in the slot names of the metadata for the new column.
+            /// Hashing, as such, can map many initial values to one.
             /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
             /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
             /// <param name="rehashUnigrams">Whether to rehash unigrams.</param>

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -875,15 +875,30 @@ namespace Microsoft.ML.Transforms.Text
         /// </summary>
         public sealed class ColumnInfo
         {
+            /// <summary>Name of the column resulting from the transformation of <see cref="InputColumnNames"/>.</summary>
             public readonly string Name;
+            /// <summary>Names of the columns to transform.</summary>
             public readonly string[] InputColumnNames;
+            /// <summary>Maximum ngram length.</summary>
             public readonly int NgramLength;
+            /// <summary>Maximum number of tokens to skip when constructing an ngram.</summary>
             public readonly int SkipLength;
+            /// <summary>Whether to store all ngram lengths up to ngramLength, or only ngramLength.</summary>
             public readonly bool AllLengths;
+            /// <summary>Number of bits to hash into. Must be between 1 and 31, inclusive.</summary>
             public readonly int HashBits;
+            /// <summary>Hashing seed.</summary>
             public readonly uint Seed;
+            /// <summary>Whether the position of each term should be included in the hash.</summary>
             public readonly bool Ordered;
+            /// <summary>
+            /// During hashing we constuct mappings between original values and the produced hash values.
+            /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
+            /// <see cref="InvertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+            /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.
+            /// </summary>
             public readonly int InvertHash;
+            /// <summary>Whether to rehash unigrams.</summary>
             public readonly bool RehashUnigrams;
             // For all source columns, use these friendly names for the source
             // column names instead of the real column names.
@@ -893,10 +908,10 @@ namespace Microsoft.ML.Transforms.Text
             /// Describes how the transformer handles one column pair.
             /// </summary>
             /// <param name="name">Name of the column resulting from the transformation of <paramref name="inputColumnNames"/>.</param>
-            /// <param name="inputColumnNames">Name of the columns to transform. </param>
+            /// <param name="inputColumnNames">Names of the columns to transform. </param>
             /// <param name="ngramLength">Maximum ngram length.</param>
             /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
-            /// <param name="allLengths">"Whether to store all ngram lengths up to ngramLength, or only ngramLength.</param>
+            /// <param name="allLengths">Whether to store all ngram lengths up to ngramLength, or only ngramLength.</param>
             /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
             /// <param name="seed">Hashing seed.</param>
             /// <param name="ordered">Whether the position of each term should be included in the hash.</param>

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -676,7 +676,7 @@ namespace Microsoft.ML.Transforms.Text
     public sealed class NgramExtractingEstimator : IEstimator<NgramExtractingTransformer>
     {
         /// <summary>
-        /// Weighting criteria: a statistical measure used to evaluate how important a word is to a document in a corpus.
+        /// A statistical measure used to evaluate how important a word is to a document in a corpus.
         /// This enumeration is serialized.
         /// </summary>
         public enum WeightingCriteria
@@ -797,12 +797,18 @@ namespace Microsoft.ML.Transforms.Text
         /// </summary>
         public sealed class ColumnInfo
         {
+            /// <summary>Name of the column resulting from the transformation of <see cref="InputColumnName"/>.</summary>
             public readonly string Name;
+            /// <summary>Name of column to transform.</summary>
             public readonly string InputColumnName;
+            /// <summary>Maximum ngram length.</summary>
             public readonly int NgramLength;
+            /// <summary>Maximum number of tokens to skip when constructing an ngram.</summary>
             public readonly int SkipLength;
+            /// <summary>Whether to store all ngram lengths up to ngramLength, or only ngramLength.</summary>
             public readonly bool AllLengths;
-            public readonly NgramExtractingEstimator.WeightingCriteria Weighting;
+            /// <summary>The weighting criteria.</summary>
+            public readonly WeightingCriteria Weighting;
             /// <summary>
             /// Contains the maximum number of grams to store in the dictionary, for each level of ngrams,
             /// from 1 (in position 0) up to ngramLength (in position ngramLength-1)
@@ -816,15 +822,15 @@ namespace Microsoft.ML.Transforms.Text
             /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
             /// <param name="ngramLength">Maximum ngram length.</param>
             /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
-            /// <param name="allLengths">"Whether to store all ngram lengths up to ngramLength, or only ngramLength.</param>
+            /// <param name="allLengths">Whether to store all ngram lengths up to ngramLength, or only ngramLength.</param>
             /// <param name="weighting">The weighting criteria.</param>
             /// <param name="maxNumTerms">Maximum number of ngrams to store in the dictionary.</param>
             public ColumnInfo(string name, string inputColumnName = null,
-                int ngramLength = NgramExtractingEstimator.Defaults.NgramLength,
-                int skipLength = NgramExtractingEstimator.Defaults.SkipLength,
-                bool allLengths = NgramExtractingEstimator.Defaults.AllLengths,
-                NgramExtractingEstimator.WeightingCriteria weighting = NgramExtractingEstimator.Defaults.Weighting,
-                int maxNumTerms = NgramExtractingEstimator.Defaults.MaxNumTerms)
+                int ngramLength = Defaults.NgramLength,
+                int skipLength = Defaults.SkipLength,
+                bool allLengths = Defaults.AllLengths,
+                WeightingCriteria weighting = Defaults.Weighting,
+                int maxNumTerms = Defaults.MaxNumTerms)
                 : this(name, ngramLength, skipLength, allLengths, weighting, new int[] { maxNumTerms }, inputColumnName ?? name)
             {
             }
@@ -833,7 +839,7 @@ namespace Microsoft.ML.Transforms.Text
                 int ngramLength,
                 int skipLength,
                 bool allLengths,
-                NgramExtractingEstimator.WeightingCriteria weighting,
+                WeightingCriteria weighting,
                 int[] maxNumTerms,
                 string inputColumnName = null)
             {
@@ -854,13 +860,13 @@ namespace Microsoft.ML.Transforms.Text
                 {
                     Contracts.CheckUserArg(Utils.Size(maxNumTerms) == 0 ||
                         Utils.Size(maxNumTerms) == 1 && maxNumTerms[0] > 0, nameof(maxNumTerms));
-                    limits[ngramLength - 1] = Utils.Size(maxNumTerms) == 0 ? NgramExtractingEstimator.Defaults.MaxNumTerms : maxNumTerms[0];
+                    limits[ngramLength - 1] = Utils.Size(maxNumTerms) == 0 ? Defaults.MaxNumTerms : maxNumTerms[0];
                 }
                 else
                 {
                     Contracts.CheckUserArg(Utils.Size(maxNumTerms) <= ngramLength, nameof(maxNumTerms));
                     Contracts.CheckUserArg(Utils.Size(maxNumTerms) == 0 || maxNumTerms.All(i => i >= 0) && maxNumTerms[maxNumTerms.Length - 1] > 0, nameof(maxNumTerms));
-                    var extend = Utils.Size(maxNumTerms) == 0 ? NgramExtractingEstimator.Defaults.MaxNumTerms : maxNumTerms[maxNumTerms.Length - 1];
+                    var extend = Utils.Size(maxNumTerms) == 0 ? Defaults.MaxNumTerms : maxNumTerms[maxNumTerms.Length - 1];
                     limits = Utils.BuildArray(ngramLength, i => i < Utils.Size(maxNumTerms) ? maxNumTerms[i] : extend);
                 }
                 Limits = ImmutableArray.Create(limits);

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -197,7 +197,7 @@ namespace Microsoft.ML.Transforms.Text
             return columns.Select(x => (x.Name, x.InputColumnName)).ToArray();
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             if (!NgramExtractingEstimator.IsColumnTypeValid(type))

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Transforms.Text
             return columns.Select(x => (x.Name, x.InputColumnName)).ToArray();
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             if (!StopWordsRemovingEstimator.IsColumnTypeValid(type))

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -130,6 +130,9 @@ namespace Microsoft.ML.Transforms.Text
                 loaderAssemblyName: typeof(StopWordsRemovingTransformer).Assembly.FullName);
         }
 
+        /// <summary>
+        /// Defines the behavior of the transformer.
+        /// </summary>
         public IReadOnlyCollection<StopWordsRemovingEstimator.ColumnInfo> Columns => _columns.AsReadOnly();
 
         private readonly StopWordsRemovingEstimator.ColumnInfo[] _columns;
@@ -492,9 +495,13 @@ namespace Microsoft.ML.Transforms.Text
         /// </summary>
         public sealed class ColumnInfo
         {
+            /// <summary>Name of the column resulting from the transformation of <see cref="InputColumnName"/>.</summary>
             public readonly string Name;
+            /// <summary>Name of the column to transform.</summary>
             public readonly string InputColumnName;
-            public readonly StopWordsRemovingEstimator.Language Language;
+            /// <summary>Language-specific stop words list.</summary>
+            public readonly Language Language;
+            /// <summary>Optional column to use for languages. This overrides language value.</summary>
             public readonly string LanguageColumn;
 
             /// <summary>
@@ -506,7 +513,7 @@ namespace Microsoft.ML.Transforms.Text
             /// <param name="languageColumn">Optional column to use for languages. This overrides language value.</param>
             public ColumnInfo(string name,
                 string inputColumnName = null,
-                StopWordsRemovingEstimator.Language language = StopWordsRemovingEstimator.Defaults.DefaultLanguage,
+                Language language = Defaults.DefaultLanguage,
                 string languageColumn = null)
             {
                 Contracts.CheckNonWhiteSpace(name, nameof(name));
@@ -517,6 +524,7 @@ namespace Microsoft.ML.Transforms.Text
                 LanguageColumn = languageColumn;
             }
         }
+
         /// <summary>
         /// Stopwords language. This enumeration is serialized.
         /// </summary>

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -12,6 +12,9 @@ namespace Microsoft.ML
     using CharTokenizingDefaults = TokenizingByCharactersEstimator.Defaults;
     using TextNormalizeDefaults = TextNormalizingEstimator.Defaults;
 
+    /// <summary>
+    /// The catalog of text related transformations.
+    /// </summary>
     public static class TextCatalog
     {
         /// <summary>

--- a/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
@@ -320,7 +320,7 @@ namespace Microsoft.ML.Transforms.Text
         }
 
         /// <summary>
-        /// Trains and returns a <see cref="Transformer"/>.
+        /// Trains and returns a <see cref="ITransformer"/>.
         /// </summary>
         public ITransformer Fit(IDataView input)
         {

--- a/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
@@ -88,6 +88,10 @@ namespace Microsoft.ML.Transforms.Text
         }
 
         private const string RegistrationName = "TextNormalizer";
+
+        /// <summary>
+        /// The names of the output and input column pairs on which the transformation is applied.
+        /// </summary>
         public IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
 
         private readonly TextNormalizingEstimator.CaseNormalizationMode _textCase;

--- a/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Transforms.Text
 
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             if (!TextNormalizingEstimator.IsColumnTypeValid(type))

--- a/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
+++ b/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ML.Transforms.Text
         /// </summary>
         public IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             if (!TokenizingByCharactersEstimator.IsColumnTypeValid(type))

--- a/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
+++ b/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
@@ -112,6 +112,9 @@ namespace Microsoft.ML.Transforms.Text
             _useMarkerChars = useMarkerCharacters;
         }
 
+        /// <summary>
+        /// The names of the output and input column pairs on which the transformation is applied.
+        /// </summary>
         public IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
 
         protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
@@ -303,7 +303,7 @@ namespace Microsoft.ML.Transforms.Text
 
         private protected override IRowMapper MakeRowMapper(DataViewSchema schema) => new Mapper(this, schema);
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var colType = inputSchema[srcCol].Type;
             if (!(colType is VectorType vectorType && vectorType.ItemType is TextDataViewType))

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
@@ -93,6 +93,10 @@ namespace Microsoft.ML.Transforms.Text
         private readonly int _linesToSkip;
         private readonly Model _currentVocab;
         private static Dictionary<string, WeakReference<Model>> _vocab = new Dictionary<string, WeakReference<Model>>();
+
+        /// <summary>
+        /// The names of the output and input column pairs on which the transformation is applied.
+        /// </summary>
         public IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
 
         private sealed class Model
@@ -799,6 +803,9 @@ namespace Microsoft.ML.Transforms.Text
             _columns = columns;
         }
 
+        /// <summary>
+        /// Specifies which word embeddings to use.
+        /// </summary>
         public enum PretrainedModelKind
         {
             [TGUI(Label = "GloVe 50D")]

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Transforms.Text
             _columns = columns.ToArray();
         }
 
-        protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
+        private protected override void CheckInputColumn(DataViewSchema inputSchema, int col, int srcCol)
         {
             var type = inputSchema[srcCol].Type;
             if (!WordTokenizingEstimator.IsColumnTypeValid(type))

--- a/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
+++ b/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
@@ -105,6 +105,7 @@ namespace Microsoft.ML.Transforms.Text
             _weighting = weighting;
         }
 
+        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
         public override TransformWrapper Fit(IDataView input)
         {
             // Create arguments.
@@ -242,6 +243,7 @@ namespace Microsoft.ML.Transforms.Text
             _invertHash = invertHash;
         }
 
+        /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
         public override TransformWrapper Fit(IDataView input)
         {
             // Create arguments.


### PR DESCRIPTION
Fixes #2282.

This is a pull request in the assembly public surface lockdown series.
Besides internalization I also added some comments for public members. This is a relatively small PR as we have gone through the Transforms assembly many times already.

I made the method `CheckInputColumn` in `OneToOneTransformerBase` BestFriend private protected instead of just protected.