### PR TITLE
Hide much of Microsoft.ML.Model namespace.

### DIFF
--- a/src/Microsoft.ML.Core/Data/ModelHeader.cs
+++ b/src/Microsoft.ML.Core/Data/ModelHeader.cs
@@ -621,7 +621,8 @@ namespace Microsoft.ML.Model
     /// This is used to simplify version checking boiler-plate code. It is an optional
     /// utility type.
     /// </summary>
-    public readonly struct VersionInfo
+    [BestFriend]
+    internal readonly struct VersionInfo
     {
         public readonly ulong ModelSignature;
         public readonly uint VerWrittenCur;

--- a/src/Microsoft.ML.Core/Data/ModelLoadContext.cs
+++ b/src/Microsoft.ML.Core/Data/ModelLoadContext.cs
@@ -15,7 +15,8 @@ namespace Microsoft.ML.Model
     /// amount of boiler plate code. It can also be used when loading from a single stream,
     /// for implementors of ICanSaveInBinaryFormat.
     /// </summary>
-    public sealed partial class ModelLoadContext : IDisposable
+    [BestFriend]
+    internal sealed partial class ModelLoadContext : IDisposable
     {
         /// <summary>
         /// When in repository mode, this is the repository we're reading from. It is null when

--- a/src/Microsoft.ML.Core/Data/ModelLoading.cs
+++ b/src/Microsoft.ML.Core/Data/ModelLoading.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Model
     [BestFriend]
     internal delegate void SignatureLoadModel(ModelLoadContext ctx);
 
-    public sealed partial class ModelLoadContext : IDisposable
+    internal sealed partial class ModelLoadContext : IDisposable
     {
         public const string ModelStreamName = "Model.key";
         internal const string NameBinary = "Model.bin";

--- a/src/Microsoft.ML.Core/Data/ModelSaveContext.cs
+++ b/src/Microsoft.ML.Core/Data/ModelSaveContext.cs
@@ -21,18 +21,21 @@ namespace Microsoft.ML.Model
         /// When in repository mode, this is the repository we're writing to. It is null when
         /// in single-stream mode.
         /// </summary>
-        public readonly RepositoryWriter Repository;
+        [BestFriend]
+        internal readonly RepositoryWriter Repository;
 
         /// <summary>
         /// When in repository mode, this is the directory we're reading from. Null means the root
         /// of the repository. It is always null in single-stream mode.
         /// </summary>
-        public readonly string Directory;
+        [BestFriend]
+        internal readonly string Directory;
 
         /// <summary>
         /// The main stream writer.
         /// </summary>
-        public readonly BinaryWriter Writer;
+        [BestFriend]
+        internal readonly BinaryWriter Writer;
 
         /// <summary>
         /// The strings that will be saved in the main stream's string table.
@@ -49,7 +52,8 @@ namespace Microsoft.ML.Model
         /// <summary>
         /// The min file position of the main stream.
         /// </summary>
-        public readonly long FpMin;
+        [BestFriend]
+        internal readonly long FpMin;
 
         /// <summary>
         /// The wrapped entry.
@@ -69,7 +73,8 @@ namespace Microsoft.ML.Model
         /// <summary>
         /// Returns whether this context is in repository mode (true) or single-stream mode (false).
         /// </summary>
-        public bool InRepository { get { return Repository != null; } }
+        [BestFriend]
+        internal bool InRepository => Repository != null;
 
         /// <summary>
         /// Create a <see cref="ModelSaveContext"/> supporting saving to a repository, for implementors of <see cref="ICanSaveModel"/>.
@@ -125,7 +130,8 @@ namespace Microsoft.ML.Model
             ModelHeader.BeginWrite(Writer, out FpMin, out Header);
         }
 
-        public void CheckAtModel()
+        [BestFriend]
+        internal void CheckAtModel()
         {
             _ectx.Check(Writer.BaseStream.Position == FpMin + Header.FpModel);
         }
@@ -142,7 +148,8 @@ namespace Microsoft.ML.Model
             _loaderAssemblyName = ver.LoaderAssemblyName;
         }
 
-        public void SaveTextStream(string name, Action<TextWriter> action)
+        [BestFriend]
+        internal void SaveTextStream(string name, Action<TextWriter> action)
         {
             _ectx.Check(InRepository, "Can't save a text stream when writing to a single stream");
             _ectx.CheckNonEmpty(name, nameof(name));
@@ -157,7 +164,8 @@ namespace Microsoft.ML.Model
             }
         }
 
-        public void SaveBinaryStream(string name, Action<BinaryWriter> action)
+        [BestFriend]
+        internal void SaveBinaryStream(string name, Action<BinaryWriter> action)
         {
             _ectx.Check(InRepository, "Can't save a text stream when writing to a single stream");
             _ectx.CheckNonEmpty(name, nameof(name));
@@ -176,7 +184,8 @@ namespace Microsoft.ML.Model
         /// Puts a string into the context pool, and writes the integer code of the string ID
         /// to the write stream. If str is null, this writes -1 and doesn't add it to the pool.
         /// </summary>
-        public void SaveStringOrNull(string str)
+        [BestFriend]
+        internal void SaveStringOrNull(string str)
         {
             if (str == null)
                 Writer.Write(-1);
@@ -188,13 +197,15 @@ namespace Microsoft.ML.Model
         /// Puts a string into the context pool, and writes the integer code of the string ID
         /// to the write stream. Checks that str is not null.
         /// </summary>
-        public void SaveString(string str)
+        [BestFriend]
+        internal void SaveString(string str)
         {
             _ectx.CheckValue(str, nameof(str));
             Writer.Write(Strings.Add(str).Id);
         }
 
-        public void SaveString(ReadOnlyMemory<char> str)
+        [BestFriend]
+        internal void SaveString(ReadOnlyMemory<char> str)
         {
             Writer.Write(Strings.Add(str).Id);
         }
@@ -203,13 +214,15 @@ namespace Microsoft.ML.Model
         /// Puts a string into the context pool, and writes the integer code of the string ID
         /// to the write stream.
         /// </summary>
-        public void SaveNonEmptyString(string str)
+        [BestFriend]
+        internal void SaveNonEmptyString(string str)
         {
             _ectx.CheckParam(!string.IsNullOrEmpty(str), nameof(str));
             Writer.Write(Strings.Add(str).Id);
         }
 
-        public void SaveNonEmptyString(ReadOnlyMemory<Char> str)
+        [BestFriend]
+        internal void SaveNonEmptyString(ReadOnlyMemory<char> str)
         {
             Writer.Write(Strings.Add(str).Id);
         }
@@ -218,7 +231,8 @@ namespace Microsoft.ML.Model
         /// Commit the save operation. This completes writing of the main stream. When in repository
         /// mode, it disposes <see cref="Writer"/> (but not <see cref="Repository"/>).
         /// </summary>
-        public void Done()
+        [BestFriend]
+        internal void Done()
         {
             _ectx.Check(Header.ModelSignature != 0, "ModelSignature not specified!");
             ModelHeader.EndWrite(Writer, FpMin, ref Header, Strings, _loaderAssemblyName);

--- a/src/Microsoft.ML.Core/Data/ModelSaveContext.cs
+++ b/src/Microsoft.ML.Core/Data/ModelSaveContext.cs
@@ -135,7 +135,8 @@ namespace Microsoft.ML.Model
         /// <see cref="Done"/> is called.
         /// </summary>
         /// <param name="ver"></param>
-        public void SetVersionInfo(VersionInfo ver)
+        [BestFriend]
+        internal void SetVersionInfo(VersionInfo ver)
         {
             ModelHeader.SetVersionInfo(ref Header, ver);
             _loaderAssemblyName = ver.LoaderAssemblyName;

--- a/src/Microsoft.ML.Core/Data/ModelSaving.cs
+++ b/src/Microsoft.ML.Core/Data/ModelSaving.cs
@@ -11,9 +11,10 @@ namespace Microsoft.ML.Model
     public sealed partial class ModelSaveContext : IDisposable
     {
         /// <summary>
-        /// Save a sub model to the given sub directory. This requires InRepository to be true.
+        /// Save a sub model to the given sub directory. This requires <see cref="InRepository"/> to be <see langword="true"/>.
         /// </summary>
-        public void SaveModel<T>(T value, string name)
+        [BestFriend]
+        internal void SaveModel<T>(T value, string name)
             where T : class
         {
             _ectx.Check(InRepository, "Can't save a sub-model when writing to a single stream");
@@ -23,7 +24,8 @@ namespace Microsoft.ML.Model
         /// <summary>
         /// Save the object by calling TrySaveModel then falling back to .net serialization.
         /// </summary>
-        public static void SaveModel<T>(RepositoryWriter rep, T value, string path)
+        [BestFriend]
+        internal static void SaveModel<T>(RepositoryWriter rep, T value, string path)
             where T : class
         {
             if (value == null)
@@ -55,7 +57,8 @@ namespace Microsoft.ML.Model
         /// <summary>
         /// Save to a single-stream by invoking the given action.
         /// </summary>
-        public static void Save(BinaryWriter writer, Action<ModelSaveContext> fn)
+        [BestFriend]
+        internal static void Save(BinaryWriter writer, Action<ModelSaveContext> fn)
         {
             Contracts.CheckValue(writer, nameof(writer));
             Contracts.CheckValue(fn, nameof(fn));
@@ -68,9 +71,11 @@ namespace Microsoft.ML.Model
         }
 
         /// <summary>
-        /// Save to the given sub directory by invoking the given action. This requires InRepository to be true.
+        /// Save to the given sub directory by invoking the given action. This requires
+        /// <see cref="InRepository"/> to be <see langword="true"/>.
         /// </summary>
-        public void SaveSubModel(string dir, Action<ModelSaveContext> fn)
+        [BestFriend]
+        internal void SaveSubModel(string dir, Action<ModelSaveContext> fn)
         {
             _ectx.Check(InRepository, "Can't save a sub-model when writing to a single stream");
             _ectx.CheckNonEmpty(dir, nameof(dir));

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -32,9 +32,10 @@ namespace Microsoft.ML.Model
     }
 
     /// <summary>
-    /// Abstraction around a ZipArchive or other hierarchical storage.
+    /// Abstraction around a <see cref="ZipArchive"/> or other hierarchical storage.
     /// </summary>
-    public abstract class Repository : IDisposable
+    [BestFriend]
+    internal abstract class Repository : IDisposable
     {
         public sealed class Entry : IDisposable
         {
@@ -289,7 +290,8 @@ namespace Microsoft.ML.Model
         }
     }
 
-    public sealed class RepositoryWriter : Repository
+    [BestFriend]
+    internal sealed class RepositoryWriter : Repository
     {
         private const string DirTrainingInfo = "TrainingInfo";
 
@@ -429,7 +431,8 @@ namespace Microsoft.ML.Model
         }
     }
 
-    public sealed class RepositoryReader : Repository
+    [BestFriend]
+    internal sealed class RepositoryReader : Repository
     {
         private ZipArchive _archive;
 

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Data
         }
 
         // Factory for SignatureLoadModel.
-        public TransformWrapper(IHostEnvironment env, ModelLoadContext ctx)
+        private TransformWrapper(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(nameof(TransformWrapper));

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
@@ -239,7 +239,7 @@ namespace Microsoft.ML.Data
     {
         public const string LoaderSignature = "TransformerChain";
 
-        public static TransformerChain<ITransformer> Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static TransformerChain<ITransformer> Create(IHostEnvironment env, ModelLoadContext ctx)
             => new TransformerChain<ITransformer>(env, ctx);
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Dirty/ModelParametersBase.cs
+++ b/src/Microsoft.ML.Data/Dirty/ModelParametersBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Internal.Internallearn
     /// </summary>
     public abstract class ModelParametersBase<TOutput> : ICanSaveModel, IPredictorProducing<TOutput>
     {
-        public const string NormalizerWarningFormat =
+        private const string NormalizerWarningFormat =
             "Ignoring integrated normalizer while loading a predictor of type {0}.{1}" +
             "   Please refer to https://aka.ms/MLNetIssue for assistance with converting legacy models.";
 

--- a/src/Microsoft.ML.Data/Dirty/ModelParametersBase.cs
+++ b/src/Microsoft.ML.Data/Dirty/ModelParametersBase.cs
@@ -18,16 +18,19 @@ namespace Microsoft.ML.Internal.Internallearn
             "Ignoring integrated normalizer while loading a predictor of type {0}.{1}" +
             "   Please refer to https://aka.ms/MLNetIssue for assistance with converting legacy models.";
 
-        protected readonly IHost Host;
+        [BestFriend]
+        private protected readonly IHost Host;
 
-        protected ModelParametersBase(IHostEnvironment env, string name)
+        [BestFriend]
+        private protected ModelParametersBase(IHostEnvironment env, string name)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckNonWhiteSpace(name, nameof(name));
             Host = env.Register(name);
         }
 
-        protected ModelParametersBase(IHostEnvironment env, string name, ModelLoadContext ctx)
+        [BestFriend]
+        private protected ModelParametersBase(IHostEnvironment env, string name, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckNonWhiteSpace(name, nameof(name));

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -998,7 +998,7 @@ namespace Microsoft.ML.Data
         // Multi-class evaluator adds four per-instance columns: "Assigned", "Top scores", "Top classes" and "Log-loss".
         private protected override IDataView GetPerInstanceMetricsCore(IDataView perInst, RoleMappedSchema schema)
         {
-            // If the label column is a key without text key values, convert it to I8, just for saving the per-instance
+            // If the label column is a key without text key values, convert it to double, just for saving the per-instance
             // text file, since if there are different key counts the columns cannot be appended.
             string labelName = schema.Label.Value.Name;
             if (!perInst.Schema.TryGetColumnIndex(labelName, out int labelColIndex))

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Calibrator
         private TICalibrator _calibrator;
         private readonly string _loaderSignature;
 
-        internal CalibratorTransformer(IHostEnvironment env, TICalibrator calibrator, string loaderSignature)
+        private protected CalibratorTransformer(IHostEnvironment env, TICalibrator calibrator, string loaderSignature)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(CalibratorTransformer<TICalibrator>)))
         {
             _loaderSignature = loaderSignature;
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Calibrator
         }
 
         // Factory method for SignatureLoadModel.
-        internal CalibratorTransformer(IHostEnvironment env, ModelLoadContext ctx, string loaderSignature)
+        private protected CalibratorTransformer(IHostEnvironment env, ModelLoadContext ctx, string loaderSignature)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(CalibratorTransformer<TICalibrator>)))
         {
             Contracts.AssertValue(ctx);
@@ -195,7 +195,7 @@ namespace Microsoft.ML.Calibrator
 
         private protected override IRowMapper MakeRowMapper(DataViewSchema schema) => new Mapper<TICalibrator>(this, _calibrator, schema);
 
-        protected VersionInfo GetVersionInfo()
+        private protected VersionInfo GetVersionInfo()
         {
             return new VersionInfo(
                 modelSignature: "CALTRANS",

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -321,7 +321,8 @@ namespace Microsoft.ML.Data
     /// Simple utility class for saving a <see cref="VBuffer{T}"/> of ReadOnlyMemory
     /// as a model, both in a binary and more easily human readable form.
     /// </summary>
-    public static class TextModelHelper
+    [BestFriend]
+    internal static class TextModelHelper
     {
         private const string LoaderSignature = "TextSpanBuffer";
 

--- a/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
@@ -32,7 +32,8 @@ namespace Microsoft.ML.Data
             ColumnPairs = columns;
         }
 
-        protected OneToOneTransformerBase(IHost host, ModelLoadContext ctx) : base(host)
+        [BestFriend]
+        private protected OneToOneTransformerBase(IHost host, ModelLoadContext ctx) : base(host)
         {
             // *** Binary format ***
             // int: number of added columns

--- a/src/Microsoft.ML.Data/Transforms/ValueMapping.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueMapping.cs
@@ -666,7 +666,7 @@ namespace Microsoft.ML.Transforms.Conversions
             }
         }
 
-        protected static ValueMappingTransformer Create(IHostEnvironment env, ModelLoadContext ctx)
+        private protected static ValueMappingTransformer Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Trainers
                 _weightsDenseLock = new object();
         }
 
-        protected LinearModelParameters(IHostEnvironment env, string name, ModelLoadContext ctx)
+        private protected LinearModelParameters(IHostEnvironment env, string name, ModelLoadContext ctx)
             : base(env, name, ctx)
         {
             // *** Binary format ***
@@ -547,12 +547,14 @@ namespace Microsoft.ML.Trainers
 
     public abstract class RegressionModelParameters : LinearModelParameters
     {
-        public RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<float> weights, float bias)
+        [BestFriend]
+        private protected RegressionModelParameters(IHostEnvironment env, string name, in VBuffer<float> weights, float bias)
              : base(env, name, in weights, bias)
         {
         }
 
-        protected RegressionModelParameters(IHostEnvironment env, string name, ModelLoadContext ctx)
+        [BestFriend]
+        private protected RegressionModelParameters(IHostEnvironment env, string name, ModelLoadContext ctx)
             : base(env, name, ctx)
         {
         }

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Code/ContractsCheckTest.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Code/ContractsCheckTest.cs
@@ -39,9 +39,6 @@ namespace Microsoft.ML.InternalCodeAnalyzer.Tests
                 VerifyCS.Diagnostic(ContractsCheckAnalyzer.SimpleMessageDiagnostic.Rule).WithLocation(basis + 32, 35).WithArguments("Check", "\"Less fine: \" + env.GetType().Name"),
                 VerifyCS.Diagnostic(ContractsCheckAnalyzer.NameofDiagnostic.Rule).WithLocation(basis + 34, 17).WithArguments("CheckUserArg", "name", "\"p\""),
                 VerifyCS.Diagnostic(ContractsCheckAnalyzer.DecodeMessageWithLoadContextDiagnostic.Rule).WithLocation(basis + 39, 41).WithArguments("CheckDecode", "\"This message is suspicious\""),
-                new DiagnosticResult("CS0117", DiagnosticSeverity.Error).WithLocation("Test1.cs", 220, 70).WithMessage("'MessageSensitivity' does not contain a definition for 'UserData'"),
-                new DiagnosticResult("CS0117", DiagnosticSeverity.Error).WithLocation("Test1.cs", 231, 70).WithMessage("'MessageSensitivity' does not contain a definition for 'Schema'"),
-                new DiagnosticResult("CS1061", DiagnosticSeverity.Error).WithLocation("Test1.cs", 747, 21).WithMessage("'IHostEnvironment' does not contain a definition for 'IsCancelled' and no accessible extension method 'IsCancelled' accepting a first argument of type 'IHostEnvironment' could be found (are you missing a using directive or an assembly reference?)"),
             };
 
             var test = new VerifyCS.Test

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/ContractsCheckResource.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Resources/ContractsCheckResource.cs
@@ -65,7 +65,17 @@ namespace Microsoft.ML
     internal enum MessageSensitivity
     {
         None = 0,
-        Unknown = ~None
+        Unknown = ~None,
+        UserData,
+        Schema
     }
-    internal interface IHostEnvironment : IExceptionContext { }
+    internal interface IHostEnvironment : IExceptionContext
+    {
+        bool IsCancelled { get; }
+    }
+}
+
+namespace Microsoft.ML.Model
+{
+    public sealed class ModelLoadContext { }
 }


### PR DESCRIPTION
Fixes #2640. Per usual commits are logically ordered to reflect the natural order in which structures are internalized, etc.