### PR TITLE
Metadata utils internalization, migration of few useful methods

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Samples.Dynamic
            };
             // Preview of the CharsUnigrams column obtained after processing the input.
             VBuffer<ReadOnlyMemory<char>> slotNames = default;
-            transformedData_onechars.Schema["CharsUnigrams"].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slotNames);
+            transformedData_onechars.Schema["CharsUnigrams"].GetSlotNames(ref slotNames);
             var charsOneGramColumn = transformedData_onechars.GetColumn<VBuffer<float>>(ml, "CharsUnigrams");
             printHelper("CharsUnigrams", charsOneGramColumn, slotNames);
 
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // 'B' - 0 'e' - 6 's' - 3 't' - 6 '<?>' - 9 'g' - 2 'a' - 2 'm' - 2 'I' - 0 ''' - 0 'v' - 0 ...
             // Preview of the CharsTwoGrams column obtained after processing the input.
             var charsTwoGramColumn = transformedData_twochars.GetColumn<VBuffer<float>>(ml, "CharsTwograms");
-            transformedData_twochars.Schema["CharsTwograms"].Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slotNames);
+            transformedData_twochars.Schema["CharsTwograms"].GetSlotNames(ref slotNames);
             printHelper("CharsTwograms", charsTwoGramColumn, slotNames);
 
             // CharsTwograms column obtained post-transformation.

--- a/src/Microsoft.ML.Core/Data/MetadataBuilderExtensions.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataBuilderExtensions.cs
@@ -7,7 +7,8 @@ using Microsoft.Data.DataView;
 
 namespace Microsoft.ML.Data
 {
-    public static class MetadataBuilderExtensions
+    [BestFriend]
+    internal static class MetadataBuilderExtensions
     {
         /// <summary>
         /// Add slot names metadata.

--- a/src/Microsoft.ML.Core/Data/MetadataUtils.cs
+++ b/src/Microsoft.ML.Core/Data/MetadataUtils.cs
@@ -14,7 +14,8 @@ namespace Microsoft.ML.Data
     /// <summary>
     /// Utilities for implementing and using the metadata API of <see cref="DataViewSchema"/>.
     /// </summary>
-    public static class MetadataUtils
+    [BestFriend]
+    internal static class MetadataUtils
     {
         /// <summary>
         /// This class lists the canonical metadata kinds
@@ -114,20 +115,17 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Returns a standard exception for responding to an invalid call to GetMetadata.
         /// </summary>
-        [BestFriend]
-        internal static Exception ExceptGetMetadata() => Contracts.Except("Invalid call to GetMetadata");
+        public static Exception ExceptGetMetadata() => Contracts.Except("Invalid call to GetMetadata");
 
         /// <summary>
         /// Returns a standard exception for responding to an invalid call to GetMetadata.
         /// </summary>
-        [BestFriend]
-        internal static Exception ExceptGetMetadata(this IExceptionContext ctx) => ctx.Except("Invalid call to GetMetadata");
+        public static Exception ExceptGetMetadata(this IExceptionContext ctx) => ctx.Except("Invalid call to GetMetadata");
 
         /// <summary>
         /// Helper to marshal a call to GetMetadata{TValue} to a specific type.
         /// </summary>
-        [BestFriend]
-        internal static void Marshal<THave, TNeed>(this MetadataGetter<THave> getter, int col, ref TNeed dst)
+        public static void Marshal<THave, TNeed>(this MetadataGetter<THave> getter, int col, ref TNeed dst)
         {
             Contracts.CheckValue(getter, nameof(getter));
 
@@ -141,8 +139,7 @@ namespace Microsoft.ML.Data
         /// Returns a vector type with item type text and the given size. The size must be positive.
         /// This is a standard type for metadata consisting of multiple text values, eg SlotNames.
         /// </summary>
-        [BestFriend]
-        internal static VectorType GetNamesType(int size)
+        public static VectorType GetNamesType(int size)
         {
             Contracts.CheckParam(size > 0, nameof(size), "must be known size");
             return new VectorType(TextDataViewType.Instance, size);
@@ -154,8 +151,7 @@ namespace Microsoft.ML.Data
         /// This is a standard type for metadata consisting of multiple int values that represent
         /// categorical slot ranges with in a column.
         /// </summary>
-        [BestFriend]
-        internal static VectorType GetCategoricalType(int rangeCount)
+        public static VectorType GetCategoricalType(int rangeCount)
         {
             Contracts.CheckParam(rangeCount > 0, nameof(rangeCount), "must be known size");
             return new VectorType(NumberDataViewType.Int32, rangeCount, 2);
@@ -166,8 +162,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// The type of the ScoreColumnSetId metadata.
         /// </summary>
-        [BestFriend]
-        internal static KeyType ScoreColumnSetIdType
+        public static KeyType ScoreColumnSetIdType
         {
             get
             {
@@ -180,8 +175,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Returns a key-value pair useful when implementing GetMetadataTypes(col).
         /// </summary>
-        [BestFriend]
-        internal static KeyValuePair<string, DataViewType> GetSlotNamesPair(int size)
+        public static KeyValuePair<string, DataViewType> GetSlotNamesPair(int size)
         {
             return GetNamesType(size).GetPair(Kinds.SlotNames);
         }
@@ -190,8 +184,7 @@ namespace Microsoft.ML.Data
         /// Returns a key-value pair useful when implementing GetMetadataTypes(col). This assumes
         /// that the values of the key type are Text.
         /// </summary>
-        [BestFriend]
-        internal static KeyValuePair<string, DataViewType> GetKeyNamesPair(int size)
+        public static KeyValuePair<string, DataViewType> GetKeyNamesPair(int size)
         {
             return GetNamesType(size).GetPair(Kinds.KeyValues);
         }
@@ -200,8 +193,7 @@ namespace Microsoft.ML.Data
         /// Given a type and metadata kind string, returns a key-value pair. This is useful when
         /// implementing GetMetadataTypes(col).
         /// </summary>
-        [BestFriend]
-        internal static KeyValuePair<string, DataViewType> GetPair(this DataViewType type, string kind)
+        public static KeyValuePair<string, DataViewType> GetPair(this DataViewType type, string kind)
         {
             Contracts.CheckValue(type, nameof(type));
             return new KeyValuePair<string, DataViewType>(kind, type);
@@ -212,8 +204,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Prepends a params array to an enumerable. Useful when implementing GetMetadataTypes.
         /// </summary>
-        [BestFriend]
-        internal static IEnumerable<T> Prepend<T>(this IEnumerable<T> tail, params T[] head)
+        public static IEnumerable<T> Prepend<T>(this IEnumerable<T> tail, params T[] head)
         {
             return head.Concat(tail);
         }
@@ -252,8 +243,7 @@ namespace Microsoft.ML.Data
         /// Returns the set of column ids which match the value of specified metadata kind.
         /// The metadata type should be a KeyType with raw type U4.
         /// </summary>
-        [BestFriend]
-        internal static IEnumerable<int> GetColumnSet(this DataViewSchema schema, string metadataKind, uint value)
+        public static IEnumerable<int> GetColumnSet(this DataViewSchema schema, string metadataKind, uint value)
         {
             for (int col = 0; col < schema.Count; col++)
             {
@@ -272,8 +262,7 @@ namespace Microsoft.ML.Data
         /// Returns the set of column ids which match the value of specified metadata kind.
         /// The metadata type should be of type text.
         /// </summary>
-        [BestFriend]
-        internal static IEnumerable<int> GetColumnSet(this DataViewSchema schema, string metadataKind, string value)
+        public static IEnumerable<int> GetColumnSet(this DataViewSchema schema, string metadataKind, string value)
         {
             for (int col = 0; col < schema.Count; col++)
             {
@@ -293,8 +282,7 @@ namespace Microsoft.ML.Data
         ///  * has a SlotNames metadata
         ///  * metadata type is VBuffer&lt;ReadOnlyMemory&lt;char&gt;&gt; of length <paramref name="vectorSize"/>.
         /// </summary>
-        [BestFriend]
-        internal static bool HasSlotNames(this DataViewSchema.Column column, int vectorSize)
+        public static bool HasSlotNames(this DataViewSchema.Column column, int vectorSize)
         {
             if (vectorSize == 0)
                 return false;
@@ -307,8 +295,7 @@ namespace Microsoft.ML.Data
                 && vectorType.ItemType is TextDataViewType;
         }
 
-        [BestFriend]
-        internal static void GetSlotNames(RoleMappedSchema schema, RoleMappedSchema.ColumnRole role, int vectorSize, ref VBuffer<ReadOnlyMemory<char>> slotNames)
+        public static void GetSlotNames(RoleMappedSchema schema, RoleMappedSchema.ColumnRole role, int vectorSize, ref VBuffer<ReadOnlyMemory<char>> slotNames)
         {
             Contracts.CheckValueOrNull(schema);
             Contracts.CheckParam(vectorSize >= 0, nameof(vectorSize));
@@ -320,8 +307,7 @@ namespace Microsoft.ML.Data
                 schema.Schema[list[0].Index].Metadata.GetValue(Kinds.SlotNames, ref slotNames);
         }
 
-        [BestFriend]
-        internal static bool HasKeyValues(this SchemaShape.Column col)
+        public static bool HasKeyValues(this SchemaShape.Column col)
         {
             return col.Metadata.TryFindColumn(Kinds.KeyValues, out var metaCol)
                 && metaCol.Kind == SchemaShape.Column.VectorKind.Vector
@@ -369,8 +355,7 @@ namespace Microsoft.ML.Data
         /// <param name="col">The column</param>
         /// <param name="value">The value to return, if successful</param>
         /// <returns>True if the metadata of the right type exists, false otherwise</returns>
-        [BestFriend]
-        internal static bool TryGetMetadata<T>(this DataViewSchema schema, PrimitiveDataViewType type, string kind, int col, ref T value)
+        public static bool TryGetMetadata<T>(this DataViewSchema schema, PrimitiveDataViewType type, string kind, int col, ref T value)
         {
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.CheckValue(type, nameof(type));
@@ -390,8 +375,7 @@ namespace Microsoft.ML.Data
         /// The way to interpret that is: feature with indices 0, 1, and 2 are one categorical
         /// Features with indices 3 and 4 are another categorical. Features 5 and 6 don't appear there, so they are not categoricals.
         /// </summary>
-        [BestFriend]
-        internal static bool TryGetCategoricalFeatureIndices(DataViewSchema schema, int colIndex, out int[] categoricalFeatures)
+        public static bool TryGetCategoricalFeatureIndices(DataViewSchema schema, int colIndex, out int[] categoricalFeatures)
         {
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.Check(colIndex >= 0, nameof(colIndex));
@@ -438,8 +422,7 @@ namespace Microsoft.ML.Data
         /// Produces sequence of columns that are generated by trainer estimators.
         /// </summary>
         /// <param name="isNormalized">whether we should also append 'IsNormalized' (typically for probability column)</param>
-        [BestFriend]
-        internal static IEnumerable<SchemaShape.Column> GetTrainerOutputMetadata(bool isNormalized = false)
+        public static IEnumerable<SchemaShape.Column> GetTrainerOutputMetadata(bool isNormalized = false)
         {
             var cols = new List<SchemaShape.Column>();
             cols.Add(new SchemaShape.Column(Kinds.ScoreColumnSetId, SchemaShape.Column.VectorKind.Scalar, NumberDataViewType.UInt32, true));
@@ -455,8 +438,7 @@ namespace Microsoft.ML.Data
         /// If input LabelColumn is not available it produces slotnames metadata by default.
         /// </summary>
         /// <param name="labelColumn">Label column.</param>
-        [BestFriend]
-        internal static IEnumerable<SchemaShape.Column> MetadataForMulticlassScoreColumn(SchemaShape.Column? labelColumn = null)
+        public static IEnumerable<SchemaShape.Column> MetadataForMulticlassScoreColumn(SchemaShape.Column? labelColumn = null)
         {
             var cols = new List<SchemaShape.Column>();
             if (labelColumn != null && labelColumn.Value.IsKey && HasKeyValues(labelColumn.Value))

--- a/src/Microsoft.ML.Data/Data/SchemaAnnotationsExtensions.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaAnnotationsExtensions.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Data.DataView;
+
+namespace Microsoft.ML.Data
+{
+    /// <summary>
+    /// Extension methods to facilitate easy consumption of popular contents of <see cref="DataViewSchema.Column.Metadata"/>.
+    /// </summary>
+    public static class SchemaAnnotationsExtensions
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> if the input column is of <see cref="VectorType"/>, and that has
+        /// <c>SlotNames</c> metadata of a <see cref="VectorType"/> whose <see cref="VectorType.ItemType"/>
+        /// is of <see cref="TextDataViewType"/>, and further whose <see cref="VectorType.Size"/> matches
+        /// this input vector size.
+        /// </summary>
+        /// <param name="column">The column whose <see cref="DataViewSchema.Column.Metadata"/> will be queried.</param>
+        /// <seealso cref="GetSlotNames(DataViewSchema.Column, ref VBuffer{ReadOnlyMemory{char}})"/>
+        public static bool HasSlotNames(this DataViewSchema.Column column)
+            => column.Type is VectorType vectorType
+                && vectorType.Size > 0
+                && column.HasSlotNames(vectorType.Size);
+
+        /// <summary>
+        /// Stores the slots names of the input column into the provided buffer, if there are slot names.
+        /// Otherwise it will throw an exception.
+        /// </summary>
+        /// <seealso cref="HasSlotNames(DataViewSchema.Column)"/>
+        /// <param name="column">The column whose <see cref="DataViewSchema.Column.Metadata"/> will be queried.</param>
+        /// <param name="slotNames">The <see cref="VBuffer{T}"/> into which the slot names will be stored.</param>
+        public static void GetSlotNames(this DataViewSchema.Column column, ref VBuffer<ReadOnlyMemory<char>> slotNames)
+            => column.Metadata.GetValue(MetadataUtils.Kinds.SlotNames, ref slotNames);
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the input column is of <see cref="VectorType"/>, and that has
+        /// <c>SlotNames</c> metadata of a <see cref="VectorType"/> whose <see cref="VectorType.ItemType"/>
+        /// is of <see cref="TextDataViewType"/>, and further whose <see cref="VectorType.Size"/> matches
+        /// this input vector size.
+        /// </summary>
+        /// <param name="column">The column whose <see cref="DataViewSchema.Column.Metadata"/> will be queried.</param>
+        /// <param name="keyValueItemType">The type of the individual key-values to query. A common,
+        /// though not universal, type to provide is <see cref="TextDataViewType.Instance"/>, so if left unspecified
+        /// this will be assumed to have the value <see cref="TextDataViewType.Instance"/>.</param>
+        /// <seealso cref="GetKeyValues{TValue}(DataViewSchema.Column, ref VBuffer{TValue})"/>
+        public static bool HasKeyValues(this DataViewSchema.Column column, PrimitiveDataViewType keyValueItemType = null)
+        {
+            // False if type is neither a key type, or a vector of key types.
+            if (!(column.Type.GetItemType() is KeyType keyType))
+                return false;
+
+            if (keyValueItemType == null)
+                keyValueItemType = TextDataViewType.Instance;
+
+            var metaColumn = column.Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues);
+            return
+                metaColumn != null
+                && metaColumn.Value.Type is VectorType vectorType
+                && keyType.Count == (ulong)vectorType.Size
+                && keyValueItemType.Equals(vectorType.ItemType);
+        }
+
+        /// <summary>
+        /// Stores the key values of the input colum into the provided buffer, if this is of key type and whose
+        /// key values are of <see cref="VectorType.ItemType"/> whose <see cref="DataViewType.RawType"/> matches
+        /// <typeparamref name="TValue"/>. If there is no matching key valued metadata this will throw an exception.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the key values.</typeparam>
+        /// <param name="column">The column whose <see cref="DataViewSchema.Column.Metadata"/> will be queried.</param>
+        /// <param name="keyValues">The <see cref="VBuffer{T}"/> into which the key values will be stored.</param>
+        public static void GetKeyValues<TValue>(this DataViewSchema.Column column, ref VBuffer<TValue> keyValues)
+            => column.Metadata.GetValue(MetadataUtils.Kinds.KeyValues, ref keyValues);
+
+        /// <summary>
+        /// Returns <see langword="true"/> if and only if <paramref name="column"/> has <c>IsNormalized</c> metadata
+        /// set to <see langword="true"/>.
+        /// </summary>
+        public static bool IsNormalized(this DataViewSchema.Column column)
+        {
+            var metaColumn = column.Metadata.Schema.GetColumnOrNull((MetadataUtils.Kinds.IsNormalized));
+            if (metaColumn == null || !(metaColumn.Value.Type is BooleanDataViewType))
+                return false;
+
+            bool value = default;
+            column.Metadata.GetValue(MetadataUtils.Kinds.IsNormalized, ref value);
+            return value;
+        }
+    }
+}

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -127,7 +127,7 @@ namespace Microsoft.ML.EntryPoints
             if (trainRms.Label != null)
             {
                 labelType = trainRms.Label.Value.Type;
-                if (trainRms.Label.Value.HasKeyValues(labelType))
+                if (trainRms.Label.Value.HasKeyValues())
                 {
                     VBuffer<ReadOnlyMemory<char>> keyValues = default;
                     trainRms.Label.Value.GetKeyValues(ref keyValues);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -837,7 +837,7 @@ namespace Microsoft.ML.Data
                     {
                         if (dvNumber == 0)
                         {
-                            if (dv.Schema[i].HasKeyValues(type.GetItemType()))
+                            if (dv.Schema[i].HasKeyValues())
                                 firstDvVectorKeyColumns.Add(name);
                             // Store the slot names of the 1st idv and use them as baseline.
                             if (dv.Schema[i].HasSlotNames(vectorType.Size))
@@ -866,9 +866,9 @@ namespace Microsoft.ML.Data
                         // The label column can be a key. Reconcile the key values, and wrap with a KeyToValue transform.
                         labelColKeyValuesType = dv.Schema[i].Metadata.Schema.GetColumnOrNull(MetadataUtils.Kinds.KeyValues)?.Type;
                     }
-                    else if (dvNumber == 0 && dv.Schema[i].HasKeyValues(type))
+                    else if (dvNumber == 0 && dv.Schema[i].HasKeyValues())
                         firstDvKeyWithNamesColumns.Add(name);
-                    else if (type.GetKeyCount() > 0 && name != labelColName && !dv.Schema[i].HasKeyValues(type))
+                    else if (type.GetKeyCount() > 0 && name != labelColName && !dv.Schema[i].HasKeyValues())
                     {
                         // For any other key column (such as GroupId) we do not reconcile the key values, we only convert to U4.
                         if (!firstDvKeyNoNamesColumns.ContainsKey(name))

--- a/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/InvertHashUtils.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Data
 
             bool identity;
             // Second choice: if key, utilize the KeyValues metadata for that key, if it has one and is text.
-            if (schema[col].HasKeyValues(keyType))
+            if (schema[col].HasKeyValues())
             {
                 // REVIEW: Non-textual KeyValues are certainly possible. Should we handle them?
                 // Get the key names.

--- a/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
+++ b/src/Microsoft.ML.Data/Transforms/MetadataDispatcher.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ML.Data
     /// <summary>
     /// Base class for handling the schema metadata API.
     /// </summary>
-    public abstract class MetadataDispatcherBase
+    internal abstract class MetadataDispatcherBase
     {
         private bool _sealed;
 
@@ -304,7 +304,8 @@ namespace Microsoft.ML.Data
     /// a builder for a particular column. Wrap the return in a using statement. Disposing the builder
     /// records the metadata for the column. Call Seal() once all metadata is constructed.
     /// </summary>
-    public sealed class MetadataDispatcher : MetadataDispatcherBase
+    [BestFriend]
+    internal sealed class MetadataDispatcher : MetadataDispatcherBase
     {
         public MetadataDispatcher(int colCount)
             : base(colCount)

--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -509,7 +509,7 @@ namespace Microsoft.ML.Transforms.Text
 
             private void AddMetadata(int iinfo, MetadataBuilder builder)
             {
-                if (InputSchema[_srcCols[iinfo]].HasKeyValues(_srcTypes[iinfo].GetItemType()))
+                if (InputSchema[_srcCols[iinfo]].HasKeyValues())
                 {
                     ValueGetter<VBuffer<ReadOnlyMemory<char>>> getter = (ref VBuffer<ReadOnlyMemory<char>> dst) =>
                     {
@@ -525,7 +525,7 @@ namespace Microsoft.ML.Transforms.Text
             {
                 var itemType = _srcTypes[iinfo].GetItemType();
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
-                Host.Assert(InputSchema[_srcCols[iinfo]].HasKeyValues(itemType));
+                Host.Assert(InputSchema[_srcCols[iinfo]].HasKeyValues());
 
                 var unigramNames = new VBuffer<ReadOnlyMemory<char>>();
 


### PR DESCRIPTION
Fixes #2622 by limiting the public surface area of metadata/annotations conveniences to a few places.

Note that that migrated methods are not exactly the same as the existing methods in the case of querying whether a key column type exists, since the existing methods predated the schema column type and therefore had some unnecessary parameters. Though I decided to expand it a bit so as to allow checks on whether other types of key values are present. Not sure if that's necessary or helpful.

Also internalized the rather innocuous but nonetheless probably unnecessary metadata builder extensions.

Commits structured incrementally as usual for the small steps.