### PR TITLE
Explicit implementation for IsRowToRowMapper and GetRowToRowMapper

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -33,7 +33,6 @@ namespace Microsoft.ML.Data
             _host.CheckValue(xf, nameof(xf));
             _xf = xf;
             _allowSave = allowSave;
-            IsRowToRowMapper = IsChainRowToRowMapper(_xf);
         }
 
         public DataViewSchema GetOutputSchema(DataViewSchema inputSchema)
@@ -108,7 +107,6 @@ namespace Microsoft.ML.Data
             }
 
             _xf = data;
-            IsRowToRowMapper = IsChainRowToRowMapper(_xf);
         }
 
         public IDataView Transform(IDataView input) => ApplyTransformUtils.ApplyAllTransformsToData(_host, _xf, input);
@@ -123,9 +121,9 @@ namespace Microsoft.ML.Data
             return true;
         }
 
-        public bool IsRowToRowMapper { get; }
+        bool ITransformer.IsRowToRowMapper => IsChainRowToRowMapper(_xf);
 
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
         {
             _host.CheckValue(inputSchema, nameof(inputSchema));
             var input = new EmptyDataView(_host, inputSchema);

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -25,6 +25,7 @@ namespace Microsoft.ML.Data
         private readonly IHost _host;
         private readonly IDataView _xf;
         private readonly bool _allowSave;
+        private readonly bool _isRowToRowMapper;
 
         public TransformWrapper(IHostEnvironment env, IDataView xf, bool allowSave = false)
         {
@@ -33,6 +34,7 @@ namespace Microsoft.ML.Data
             _host.CheckValue(xf, nameof(xf));
             _xf = xf;
             _allowSave = allowSave;
+            _isRowToRowMapper = IsChainRowToRowMapper(_xf);
         }
 
         public DataViewSchema GetOutputSchema(DataViewSchema inputSchema)
@@ -107,6 +109,7 @@ namespace Microsoft.ML.Data
             }
 
             _xf = data;
+            _isRowToRowMapper = IsChainRowToRowMapper(_xf);
         }
 
         public IDataView Transform(IDataView input) => ApplyTransformUtils.ApplyAllTransformsToData(_host, _xf, input);
@@ -121,7 +124,7 @@ namespace Microsoft.ML.Data
             return true;
         }
 
-        bool ITransformer.IsRowToRowMapper => IsChainRowToRowMapper(_xf);
+        bool ITransformer.IsRowToRowMapper => _isRowToRowMapper;
 
         IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
         {

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Data
 
         private const string TransformDirTemplate = "Transform_{0:000}";
 
-        public bool IsRowToRowMapper => _transformers.All(t => t.IsRowToRowMapper);
+        bool ITransformer.IsRowToRowMapper => _transformers.All(t => t.IsRowToRowMapper);
 
         ITransformer[] ITransformerChainAccessor.Transformers => _transformers;
 
@@ -216,10 +216,11 @@ namespace Microsoft.ML.Data
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
         {
             Contracts.CheckValue(inputSchema, nameof(inputSchema));
-            Contracts.Check(IsRowToRowMapper, nameof(GetRowToRowMapper) + " method called despite " + nameof(IsRowToRowMapper) + " being false.");
+            Contracts.Check(((ITransformer)this).IsRowToRowMapper, nameof(ITransformer.GetRowToRowMapper) + " method called despite " +
+                nameof(ITransformer.IsRowToRowMapper) + " being false.");
 
             IRowToRowMapper[] mappers = new IRowToRowMapper[_transformers.Length];
             DataViewSchema schema = inputSchema;

--- a/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
+++ b/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
@@ -116,8 +116,8 @@ namespace Microsoft.ML
             {
                 var pipe = DataViewConstructionUtils.LoadPipeWithPredictor(env, modelStream, new EmptyDataView(env, schema));
                 var transformer = new TransformWrapper(env, pipe);
-                env.CheckParam(transformer.IsRowToRowMapper, nameof(transformer), "Must be a row to row mapper");
-                return transformer.GetRowToRowMapper(schema);
+                env.CheckParam(((ITransformer)transformer).IsRowToRowMapper, nameof(transformer), "Must be a row to row mapper");
+                return ((ITransformer)transformer).GetRowToRowMapper(schema);
             };
         }
 

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -55,10 +55,10 @@ namespace Microsoft.ML.Data
         protected DataViewSchema TrainSchema;
 
         /// <summary>
-        /// Whether a call to <see cref="GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
+        /// Whether a call to <see cref="ITransformer.GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
         /// appropriate schema.
         /// </summary>
-        public bool IsRowToRowMapper => true;
+        bool ITransformer.IsRowToRowMapper => true;
 
         /// <summary>
         /// This class is more or less a thin wrapper over the <see cref="IDataScorerTransform"/> implementing
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="inputSchema"></param>
         /// <returns></returns>
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
             return (IRowToRowMapper)Scorer.ApplyToData(Host, new EmptyDataView(Host, inputSchema));

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -138,7 +138,7 @@ namespace Microsoft.ML.Transforms
         private readonly IHost _host;
         private string[] _selectedColumns;
 
-        public bool IsRowToRowMapper => true;
+        bool ITransformer.IsRowToRowMapper => true;
 
         public IEnumerable<string> SelectColumns => _selectedColumns.AsReadOnly();
 
@@ -458,13 +458,13 @@ namespace Microsoft.ML.Transforms
         }
 
         /// <summary>
-        /// Constructs a row-to-row mapper based on an input schema. If <see cref="IsRowToRowMapper"/>
+        /// Constructs a row-to-row mapper based on an input schema. If <see cref="ITransformer.IsRowToRowMapper"/>
         /// is <c>false</c>, then an exception is thrown. If the input schema is in any way
         /// unsuitable for constructing the mapper, an exception should likewise be thrown.
         /// </summary>
         /// <param name="inputSchema">The input schema for which we should get the mapper.</param>
         /// <returns>The row to row mapper.</returns>
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
         {
             _host.CheckValue(inputSchema, nameof(inputSchema));
             if (!IgnoreMissing && !IsSchemaValid(inputSchema.Select(x => x.Name),

--- a/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
@@ -26,9 +26,9 @@ namespace Microsoft.ML.Data
 
         private protected abstract void SaveModel(ModelSaveContext ctx);
 
-        public bool IsRowToRowMapper => true;
+        bool ITransformer.IsRowToRowMapper => true;
 
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
             return new RowToRowMapperTransform(Host, new EmptyDataView(Host, inputSchema), MakeRowMapper(inputSchema), MakeRowMapper);

--- a/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/IidAnomalyDetectionBase.cs
@@ -18,10 +18,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
     public class IidAnomalyDetectionBaseWrapper : IStatefulTransformer, ICanSaveModel
     {
         /// <summary>
-        /// Whether a call to <see cref="GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
+        /// Whether a call to <see cref="ITransformer.GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
         /// appropriate schema.
         /// </summary>
-        public bool IsRowToRowMapper => InternalTransform.IsRowToRowMapper;
+        bool ITransformer.IsRowToRowMapper => ((ITransformer)InternalTransform).IsRowToRowMapper;
 
         /// <summary>
         /// Creates a clone of the transfomer. Used for taking the snapshot of the state.
@@ -36,20 +36,22 @@ namespace Microsoft.ML.Transforms.TimeSeries
         public DataViewSchema GetOutputSchema(DataViewSchema inputSchema) => InternalTransform.GetOutputSchema(inputSchema);
 
         /// <summary>
-        /// Constructs a row-to-row mapper based on an input schema. If <see cref="IsRowToRowMapper"/>
+        /// Constructs a row-to-row mapper based on an input schema. If <see cref="ITransformer.IsRowToRowMapper"/>
         /// is <c>false</c>, then an exception should be thrown. If the input schema is in any way
         /// unsuitable for constructing the mapper, an exception should likewise be thrown.
         /// </summary>
         /// <param name="inputSchema">The input schema for which we should get the mapper.</param>
         /// <returns>The row to row mapper.</returns>
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema) => InternalTransform.GetRowToRowMapper(inputSchema);
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
+            => ((ITransformer)InternalTransform).GetRowToRowMapper(inputSchema);
 
         /// <summary>
         /// Same as <see cref="ITransformer.GetRowToRowMapper(DataViewSchema)"/> but also supports mechanism to save the state.
         /// </summary>
         /// <param name="inputSchema">The input schema for which we should get the mapper.</param>
         /// <returns>The row to row mapper.</returns>
-        public IRowToRowMapper GetStatefulRowToRowMapper(DataViewSchema inputSchema) => ((IStatefulTransformer)InternalTransform).GetStatefulRowToRowMapper(inputSchema);
+        public IRowToRowMapper GetStatefulRowToRowMapper(DataViewSchema inputSchema)
+            => ((IStatefulTransformer)InternalTransform).GetStatefulRowToRowMapper(inputSchema);
 
         /// <summary>
         /// Take the data in, make transformations, output the data.
@@ -60,7 +62,9 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <summary>
         /// For saving a model into a repository.
         /// </summary>
-        public virtual void Save(ModelSaveContext ctx)
+        void ICanSaveModel.Save(ModelSaveContext ctx) => SaveModel(ctx);
+
+        private protected virtual void SaveModel(ModelSaveContext ctx)
         {
             InternalTransform.SaveThis(ctx);
         }
@@ -129,7 +133,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
             private protected override void SaveModel(ModelSaveContext ctx)
             {
-                Parent.Save(ctx);
+                ((ICanSaveModel)Parent).Save(ctx);
             }
 
             internal void SaveThis(ModelSaveContext ctx)

--- a/src/Microsoft.ML.TimeSeries/IidChangePointDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/IidChangePointDetector.cs
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         {
         }
 
-        public override void Save(ModelSaveContext ctx)
+        private protected override void SaveModel(ModelSaveContext ctx)
         {
             InternalTransform.Host.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel();
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             // *** Binary format ***
             // <base>
 
-            base.Save(ctx);
+            base.SaveModel(ctx);
         }
 
         // Factory method for SignatureLoadRowMapper.

--- a/src/Microsoft.ML.TimeSeries/IidSpikeDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/IidSpikeDetector.cs
@@ -153,7 +153,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         {
         }
 
-        public override void Save(ModelSaveContext ctx)
+        private protected override void SaveModel(ModelSaveContext ctx)
         {
             InternalTransform.Host.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel();
@@ -164,7 +164,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             // *** Binary format ***
             // <base>
 
-            base.Save(ctx);
+            base.SaveModel(ctx);
         }
 
         // Factory method for SignatureLoadRowMapper.

--- a/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
@@ -348,7 +348,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                         return col => false;
                 }
 
-                public void Save(ModelSaveContext ctx) => _parent.SaveModel(ctx);
+                void ICanSaveModel.Save(ModelSaveContext ctx) => _parent.SaveModel(ctx);
 
                 public Delegate[] CreateGetters(DataViewRow input, Func<int, bool> activeOutput, out Action disposer)
                 {

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -269,7 +269,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
         internal readonly string OutputColumnName;
         private protected DataViewType OutputColumnType;
 
-        public bool IsRowToRowMapper => false;
+        bool ITransformer.IsRowToRowMapper => false;
 
         internal TState StateRef { get; set; }
 

--- a/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaAnomalyDetectionBase.cs
@@ -87,10 +87,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
     public class SsaAnomalyDetectionBaseWrapper : IStatefulTransformer, ICanSaveModel
     {
         /// <summary>
-        /// Whether a call to <see cref="GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
+        /// Whether a call to <see cref="ITransformer.GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
         /// appropriate schema.
         /// </summary>
-        public bool IsRowToRowMapper => InternalTransform.IsRowToRowMapper;
+        bool ITransformer.IsRowToRowMapper => ((ITransformer)InternalTransform).IsRowToRowMapper;
 
         /// <summary>
         /// Creates a clone of the transfomer. Used for taking the snapshot of the state.
@@ -105,20 +105,22 @@ namespace Microsoft.ML.Transforms.TimeSeries
         public DataViewSchema GetOutputSchema(DataViewSchema inputSchema) => InternalTransform.GetOutputSchema(inputSchema);
 
         /// <summary>
-        /// Constructs a row-to-row mapper based on an input schema. If <see cref="IsRowToRowMapper"/>
+        /// Constructs a row-to-row mapper based on an input schema. If <see cref="ITransformer.IsRowToRowMapper"/>
         /// is <c>false</c>, then an exception should be thrown. If the input schema is in any way
         /// unsuitable for constructing the mapper, an exception should likewise be thrown.
         /// </summary>
         /// <param name="inputSchema">The input schema for which we should get the mapper.</param>
         /// <returns>The row to row mapper.</returns>
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema) => InternalTransform.GetRowToRowMapper(inputSchema);
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
+            => ((ITransformer)InternalTransform).GetRowToRowMapper(inputSchema);
 
         /// <summary>
         /// Same as <see cref="ITransformer.GetRowToRowMapper(DataViewSchema)"/> but also supports mechanism to save the state.
         /// </summary>
         /// <param name="inputSchema">The input schema for which we should get the mapper.</param>
         /// <returns>The row to row mapper.</returns>
-        public IRowToRowMapper GetStatefulRowToRowMapper(DataViewSchema inputSchema) => ((IStatefulTransformer)InternalTransform).GetStatefulRowToRowMapper(inputSchema);
+        public IRowToRowMapper GetStatefulRowToRowMapper(DataViewSchema inputSchema)
+            => ((IStatefulTransformer)InternalTransform).GetStatefulRowToRowMapper(inputSchema);
 
         /// <summary>
         /// Take the data in, make transformations, output the data.
@@ -129,7 +131,9 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <summary>
         /// For saving a model into a repository.
         /// </summary>
-        public virtual void Save(ModelSaveContext ctx) => InternalTransform.SaveThis(ctx);
+        void ICanSaveModel.Save(ModelSaveContext ctx) => SaveModel(ctx);
+
+        private protected virtual void SaveModel(ModelSaveContext ctx) => InternalTransform.SaveThis(ctx);
 
         /// <summary>
         /// Creates a row mapper from Schema.
@@ -255,7 +259,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
             private protected override void SaveModel(ModelSaveContext ctx)
             {
-                Parent.Save(ctx);
+                ((ICanSaveModel)Parent).Save(ctx);
             }
 
             internal void SaveThis(ModelSaveContext ctx)

--- a/src/Microsoft.ML.TimeSeries/SsaChangePointDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaChangePointDetector.cs
@@ -180,7 +180,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             InternalTransform.Host.CheckDecode(InternalTransform.IsAdaptive == false);
         }
 
-        public override void Save(ModelSaveContext ctx)
+        private protected override void SaveModel(ModelSaveContext ctx)
         {
             InternalTransform.Host.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel();
@@ -194,7 +194,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             // *** Binary format ***
             // <base>
 
-            base.Save(ctx);
+            base.SaveModel(ctx);
         }
 
         // Factory method for SignatureLoadRowMapper.

--- a/src/Microsoft.ML.TimeSeries/SsaSpikeDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaSpikeDetector.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             InternalTransform.Host.CheckDecode(InternalTransform.IsAdaptive == false);
         }
 
-        public override void Save(ModelSaveContext ctx)
+        private protected override void SaveModel(ModelSaveContext ctx)
         {
             InternalTransform.Host.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel();
@@ -175,7 +175,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             // *** Binary format ***
             // <base>
 
-            base.Save(ctx);
+            base.SaveModel(ctx);
         }
 
         // Factory method for SignatureLoadRowMapper.

--- a/src/Microsoft.ML.Transforms/CustomMappingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/CustomMappingTransformer.cs
@@ -30,10 +30,10 @@ namespace Microsoft.ML.Transforms
         internal SchemaDefinition InputSchemaDefinition { get; }
 
         /// <summary>
-        /// Whether a call to <see cref="GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
+        /// Whether a call to <see cref="ITransformer.GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
         /// appropriate schema.
         /// </summary>
-        public bool IsRowToRowMapper => true;
+        bool ITransformer.IsRowToRowMapper => true;
 
         /// <summary>
         /// Create a custom mapping of input columns to output columns.
@@ -95,11 +95,11 @@ namespace Microsoft.ML.Transforms
         }
 
         /// <summary>
-        /// Constructs a row-to-row mapper based on an input schema. If <see cref="IsRowToRowMapper"/>
+        /// Constructs a row-to-row mapper based on an input schema. If <see cref="ITransformer.IsRowToRowMapper"/>
         /// is <c>false</c>, then an exception is thrown. If the <paramref name="inputSchema"/> is in any way
         /// unsuitable for constructing the mapper, an exception is likewise thrown.
         /// </summary>
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
         {
             _host.CheckValue(inputSchema, nameof(inputSchema));
             var simplerMapper = MakeRowMapper(inputSchema);

--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -166,9 +166,9 @@ namespace Microsoft.ML.Transforms.Categorical
 
         void ICanSaveModel.Save(ModelSaveContext ctx) => (_transformer as ICanSaveModel).Save(ctx);
 
-        public bool IsRowToRowMapper => _transformer.IsRowToRowMapper;
+        bool ITransformer.IsRowToRowMapper => ((ITransformer)_transformer).IsRowToRowMapper;
 
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema) => _transformer.GetRowToRowMapper(inputSchema);
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema) => ((ITransformer)_transformer).GetRowToRowMapper(inputSchema);
     }
     /// <summary>
     /// Estimator which takes set of columns and produce for each column indicator array.

--- a/src/Microsoft.ML.Transforms/OneHotHashEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotHashEncoding.cs
@@ -191,14 +191,14 @@ namespace Microsoft.ML.Transforms.Categorical
         void ICanSaveModel.Save(ModelSaveContext ctx) => (_transformer as ICanSaveModel).Save(ctx);
 
         /// <summary>
-        /// Whether a call to <see cref="GetRowToRowMapper"/> should succeed, on an appropriate schema.
+        /// Whether a call to <see cref="ITransformer.GetRowToRowMapper"/> should succeed, on an appropriate schema.
         /// </summary>
-        public bool IsRowToRowMapper => _transformer.IsRowToRowMapper;
+        bool ITransformer.IsRowToRowMapper => ((ITransformer)_transformer).IsRowToRowMapper;
 
         /// <summary>
         /// Constructs a row-to-row mapper based on an input schema.
         /// </summary>
-        public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema) => _transformer.GetRowToRowMapper(inputSchema);
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema) => ((ITransformer)_transformer).GetRowToRowMapper(inputSchema);
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
@@ -586,9 +586,9 @@ namespace Microsoft.ML.Transforms.Text
                 return ApplyTransformUtils.ApplyAllTransformsToData(_host, _xf, input);
             }
 
-            public bool IsRowToRowMapper => true;
+            bool ITransformer.IsRowToRowMapper => true;
 
-            public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+            IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
             {
                 _host.CheckValue(inputSchema, nameof(inputSchema));
                 var input = new EmptyDataView(_host, inputSchema);

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -75,7 +75,7 @@ namespace Microsoft.ML.Benchmarks
             // One million features is a nice, typical number.
             var info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: hashBits);
             var xf = new HashingTransformer(_env, new[] { info });
-            var mapper = xf.GetRowToRowMapper(_inRow.Schema);
+            var mapper = ((ITransformer)xf).GetRowToRowMapper(_inRow.Schema);
             var column = mapper.OutputSchema["Bar"];
             var outRow = mapper.GetRow(_inRow, c => c == column.Index);
             if (type is VectorType)

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Tests.Transformers
             // First do an unordered hash.
             var info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits);
             var xf = new HashingTransformer(Env, new[] { info });
-            var mapper = xf.GetRowToRowMapper(inRow.Schema);
+            var mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out int outCol);
             var outRow = mapper.GetRow(inRow, c => c == outCol);
 
@@ -147,7 +147,7 @@ namespace Microsoft.ML.Tests.Transformers
             // Next do an ordered hash.
             info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits, ordered: true);
             xf = new HashingTransformer(Env, new[] { info });
-            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
             outRow = mapper.GetRow(inRow, c => c == outCol);
 
@@ -165,7 +165,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits, ordered: false);
             xf = new HashingTransformer(Env, new[] { info });
-            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
             outRow = mapper.GetRow(inRow, c => c == outCol);
 
@@ -180,7 +180,7 @@ namespace Microsoft.ML.Tests.Transformers
             // Now do ordered with the dense vector.
             info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits, ordered: true);
             xf = new HashingTransformer(Env, new[] { info });
-            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
             outRow = mapper.GetRow(inRow, c => c == outCol);
             vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits, ordered: false);
             xf = new HashingTransformer(Env, new[] { info });
-            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
             outRow = mapper.GetRow(inRow, c => c == outCol);
             vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
@@ -212,7 +212,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits, ordered: true);
             xf = new HashingTransformer(Env, new[] { info });
-            mapper = xf.GetRowToRowMapper(inRow.Schema);
+            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
             mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
             outRow = mapper.GetRow(inRow, c => c == outCol);
             vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);


### PR DESCRIPTION
Fixes #2540.

As explained in the issue I make the implementations of two methods of the`ITransformer` interface `IsRowToRowMapper` and `GetRowToRowMapper` explicit.

In a previous PR #2431 I made the implementation of `ICanSaveModel.Save` explicit. `Save` is part of `ITransformer` as it derives from `ICanSaveModel`. I found a few instances that have been changed since my last PR in the TimeSeries assembly and that still had a regular implementation for `Save. I made their implementation explicit in this PR as it is very similar in spirit.