### PR TITLE
Adding defaults for Label and GroupId to Ranking Evaluator

### DIFF
--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -623,7 +623,10 @@ namespace Microsoft.ML
         /// <param name="groupId">The name of the groupId column in <paramref name="data"/>.</param>
         /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these calibrated outputs.</returns>
-        public RankerMetrics Evaluate(IDataView data, string label, string groupId, string score = DefaultColumnNames.Score)
+        public RankerMetrics Evaluate(IDataView data,
+            string label = DefaultColumnNames.Label,
+            string groupId = DefaultColumnNames.GroupId,
+            string score = DefaultColumnNames.Score)
         {
             Environment.CheckValue(data, nameof(data));
             Environment.CheckNonEmpty(label, nameof(label));


### PR DESCRIPTION
This PR adds default column names for Label and GroupId for the Ranking `Evaluator`, in line with all other Evaluators.

Fixes #2633 