### PR TITLE
Make separator char[] everywhere (previous type is char sometime)

### DIFF
--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -198,8 +198,8 @@ var reader = mlContext.Data.CreateTextReader(new[] {
         // Separately, read the target variable.
         new TextLoader.Column("Target", DataKind.R4, 11)
     },
-    // Default separator is tab, but we need a comma.
-    separatorChar: ',');
+    // Default separator list only contains a tab, but we need a comma.
+    separators: new[] { ',' });
 
 // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
 var data = reader.Read(dataPath);
@@ -219,8 +219,8 @@ private class AdultData
 
 // Read the data into a data view.
 var trainData = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                // Default separator is tab, but we need a semicolon.
-                separatorChar: ';',
+                // Default separator list only contains a tab, but we need a semicolon.
+                separators: new[] { ';' },
                 // First line of the file is a header, not a data row.
                 hasHeader: true
 );		
@@ -328,8 +328,8 @@ In the file above, the last column (12th) is label that we predict, and all the 
 // First, we define the reader: specify the data columns and where to find them in the text file.
 // Read the data into a data view. Remember though, readers are lazy, so the actual reading will happen when the data is accessed.
 var trainData = mlContext.Data.ReadFromTextFile<AdultData>(dataPath,
-    // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
+    // Default separator list only contains a tab, but the dataset has comma.
+    separators: new[] { ',' }
 );
 
 // Sometime, caching data in-memory after its first access can save some loading time when the data is going to be used
@@ -372,8 +372,8 @@ Assuming the example above was used to train the model, here's how you calculate
 ```csharp
 // Read the test dataset.
 var testData = mlContext.Data.ReadFromTextFile<AdultData>(testDataPath,
-    // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
+    // Default separator list only contains a tab, but the dataset has comma.
+    separators: new[] { ',' }
 );
 // Calculate metrics of the model on the test data.
 var metrics = mlContext.Regression.Evaluate(model.Transform(testData), label: "Target");
@@ -410,8 +410,8 @@ Here is the full example. Let's imagine that we have built a model for the famou
 // Step one: read the data as an IDataView.
  //  Retrieve the training data.
 var trainData = mlContext.Data.ReadFromTextFile<IrisInput>(irisDataPath,
-    // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
+    // Default separator list only contains a tab, but the dataset has comma.
+    separators: new[] { ',' }
 );
 
 // Build the training pipeline.
@@ -534,8 +534,8 @@ This is how we can extract the learned parameters out of the model that we train
 // Step one: read the data as an IDataView.
 //  Retrieve the training data.
 var trainData = mlContext.Data.ReadFromTextFile<IrisInput>(irisDataPath,
-    // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
+    // Default separator list only contains a tab, but the dataset has comma.
+    separators: new[] { ',' }
 );
 
 // Build the training pipeline.
@@ -622,8 +622,8 @@ Here's a snippet of code that demonstrates normalization in learning pipelines. 
 
 // Read the training data.
 var trainData = mlContext.Data.ReadFromTextFile<IrisInputAllFeatures>(dataPath,
-    // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
+    // Default separator list only contains a tab, but the dataset has comma.
+    separators: new[] { ',' }
 );
 
 // Apply all kinds of standard ML.NET normalization to the raw features.
@@ -807,8 +807,8 @@ Here's an example of training on Iris dataset using randomized 90/10 train-test 
 ```csharp
 // Step one: read the data as an IDataView.
 var data = mlContext.Data.ReadFromTextFile<IrisInput>(dataPath,
-    // Default separator is tab, but the dataset has comma.
-    separatorChar: ','
+    // Default separator list only contains a tab, but the dataset has comma.
+    separators: ','
 );
 
 // Build the training pipeline.
@@ -863,8 +863,8 @@ var reader = mlContext.Data.CreateTextReader(ctx => (
         // Label: kind of iris.
         Label: ctx.LoadText(4)
     ),
-    // Default separator is tab, but the dataset has comma.
-    separatorChar: ',');
+    // Default separator list only contains a tab, but the dataset has comma.
+    separators: new[] { ',' });
 
 // Read the data.
 var data = reader.Read(dataPath);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Samples.Dynamic.TensorFlow
                         new TextLoader.Column("Words", DataKind.TX, 0),
                         new TextLoader.Column("Ids", DataKind.I4, 1),
                    },
-                separatorChar: new[] { ',' }
+                separators: new[] { ',' }
                );
 
             // Load the TensorFlow model once.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Samples.Dynamic.TensorFlow
                         new TextLoader.Column("Words", DataKind.TX, 0),
                         new TextLoader.Column("Ids", DataKind.I4, 1),
                    },
-                separatorChar: ','
+                separatorChar: new[] { ',' }
                );
 
             // Load the TensorFlow model once.

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -428,13 +428,13 @@ namespace Microsoft.ML.Data
 
             [Argument(ArgumentType.AtMostOnce, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly, HelpText = "Source column separator. Options: tab, space, comma, single character", ShortName = "sep")]
             // this is internal as it only serves the command line interface
-            internal string Separator = "\t";
+            internal string Separator = Defaults.Separator;
 
             /// <summary>
             /// The characters that should be used as separators column separator.
             /// </summary>
             [Argument(ArgumentType.AtMostOnce, Name = nameof(Separator), Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly, HelpText = "Source column separator.", ShortName = "sep")]
-            public char[] Separators = Defaults.Separator;
+            public char[] Separators = Defaults.Separators;
 
             /// <summary>
             /// Specifies the input columns that should be mapped to <see cref="IDataView"/> columns.
@@ -488,7 +488,8 @@ namespace Microsoft.ML.Data
         {
             internal const bool AllowQuoting = false;
             internal const bool AllowSparse = false;
-            internal static char[] Separator => new[] { '\t' };
+            internal static char[] Separators => new[] { '\t' };
+            internal const string Separator = "\t";
             internal const bool HasHeader = false;
             internal const bool TrimWhitespace = false;
         }
@@ -1064,15 +1065,15 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
-        /// <param name="separatorChar"> The character used as separator between data points in a row. By default the tab character is used as separator.</param>
+        /// <param name="separators"> The character used as separator between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         /// <param name="allowQuoting">Whether the content of a column can be parsed from a string starting and ending with quote.</param>
         /// <param name="dataSample">Allows to expose items that can be used for reading.</param>
-        internal TextLoader(IHostEnvironment env, Column[] columns, char[] separatorChar = null,
+        internal TextLoader(IHostEnvironment env, Column[] columns, char[] separators = null,
             bool hasHeader = Defaults.HasHeader, bool allowSparse = Defaults.AllowSparse,
             bool allowQuoting = Defaults.AllowQuoting, IMultiStreamSource dataSample = null)
-            : this(env, MakeArgs(columns, hasHeader,  separatorChar ?? Defaults.Separator, allowSparse, allowQuoting), dataSample)
+            : this(env, MakeArgs(columns, hasHeader,  separators ?? Defaults.Separators, allowSparse, allowQuoting), dataSample)
         {
         }
 
@@ -1441,7 +1442,7 @@ namespace Microsoft.ML.Data
            bool supportSparse = Defaults.AllowSparse,
            bool trimWhitespace = Defaults.TrimWhitespace)
         {
-            separator = separator ?? Defaults.Separator;
+            separator = separator ?? Defaults.Separators;
             var userType = typeof(TInput);
 
             var fieldInfos = userType.GetFields(BindingFlags.Public | BindingFlags.Instance);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -431,7 +431,7 @@ namespace Microsoft.ML.Data
             internal string Separator = Defaults.Separator;
 
             /// <summary>
-            /// The characters that should be used as separators column separator.
+            /// Array of characters used as separators between data points in a row. {'\t'} will be used if not specified.
             /// </summary>
             [Argument(ArgumentType.AtMostOnce, Name = nameof(Separator), Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly, HelpText = "Source column separator.", ShortName = "sep")]
             public char[] Separators = Defaults.Separators;
@@ -1065,7 +1065,7 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="columns">Defines a mapping between input columns in the file and IDataView columns.</param>
-        /// <param name="separators"> The character used as separator between data points in a row. {'\t'} will be used if not specified.</param>
+        /// <param name="separators"> The array of characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         /// <param name="allowQuoting">Whether the content of a column can be parsed from a string starting and ending with quote.</param>

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -16,19 +16,19 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="columns">Array of columns <see cref="TextLoader.Column"/> defining the schema.</param>
-        /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
+        /// <param name="separators">The characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         /// <param name="allowQuoting">Whether the file can contain column defined by a quoted string.</param>
         /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
         public static TextLoader CreateTextLoader(this DataOperationsCatalog catalog,
             TextLoader.Column[] columns,
-            char[] separatorChar = null,
+            char[] separators = null,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             IMultiStreamSource dataSample = null)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, separatorChar ?? TextLoader.Defaults.Separator, hasHeader, allowSparse, allowQuoting, dataSample);
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, separators ?? TextLoader.Defaults.Separators, hasHeader, allowSparse, allowQuoting, dataSample);
 
         /// <summary>
         /// Create a text loader <see cref="TextLoader"/>.
@@ -45,7 +45,7 @@ namespace Microsoft.ML
         /// Create a text loader <see cref="TextLoader"/> by inferencing the dataset schema from a data model type.
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
-        /// <param name="separatorChar">Column separator character. Default is '\t'</param>
+        /// <param name="separators">Column separator characters. {'\t'} will be used if not specified.</param>
         /// <param name="hasHeader">Does the file contains header?</param>
         /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
@@ -57,12 +57,12 @@ namespace Microsoft.ML
         /// except for 3rd and 5th columns which have values 6 and 3</param>
         /// <param name="trimWhitespace">Remove trailing whitespace from lines</param>
         public static TextLoader CreateTextLoader<TInput>(this DataOperationsCatalog catalog,
-            char[] separatorChar = null,
+            char[] separators = null,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)
-            => TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar ?? TextLoader.Defaults.Separator, allowQuoting, allowSparse, trimWhitespace);
+            => TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separators ?? TextLoader.Defaults.Separators, allowQuoting, allowSparse, trimWhitespace);
 
         /// <summary>
         /// Read a data view from a text file using <see cref="TextLoader"/>.
@@ -70,13 +70,13 @@ namespace Microsoft.ML
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separatorChar">The character used as separator between data points in a row. By default the tab character is used as separator.</param>
+        /// <param name="separators">The characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="path">The path to the file.</param>
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile(this DataOperationsCatalog catalog,
             string path,
             TextLoader.Column[] columns,
-            char[] separatorChar = null,
+            char[] separators = null,
             bool hasHeader = TextLoader.Defaults.HasHeader)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
@@ -85,7 +85,7 @@ namespace Microsoft.ML
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            var reader = new TextLoader(env, columns, separatorChar ?? TextLoader.Defaults.Separator, hasHeader, dataSample: null);
+            var reader = new TextLoader(env, columns, separators ?? TextLoader.Defaults.Separators, hasHeader, dataSample: null);
             return reader.Read(new MultiFileSource(path));
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="hasHeader">Does the file contains header?</param>
-        /// <param name="separatorChar">Column separator character. Default is '\t'</param>
+        /// <param name="separators">The characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
         /// and distinguish empty values from missing values. When true, consecutive separators
@@ -108,7 +108,7 @@ namespace Microsoft.ML
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile<TInput>(this DataOperationsCatalog catalog,
             string path,
-            char[] separatorChar = null,
+            char[] separators = null,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
@@ -119,7 +119,7 @@ namespace Microsoft.ML
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
             return TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader,
-                separatorChar ?? TextLoader.Defaults.Separator, allowQuoting, allowSparse, trimWhitespace).Read(new MultiFileSource(path));
+                separators ?? TextLoader.Defaults.Separators, allowQuoting, allowSparse, trimWhitespace).Read(new MultiFileSource(path));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="columns">Array of columns <see cref="TextLoader.Column"/> defining the schema.</param>
-        /// <param name="separators">The characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
+        /// <param name="separators">Array of characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
         /// <param name="allowSparse">Whether the file can contain numerical vectors in sparse format.</param>
         /// <param name="allowQuoting">Whether the file can contain column defined by a quoted string.</param>
@@ -45,7 +45,7 @@ namespace Microsoft.ML
         /// Create a text loader <see cref="TextLoader"/> by inferencing the dataset schema from a data model type.
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
-        /// <param name="separators">Column separator characters. {'\t'} will be used if not specified.</param>
+        /// <param name="separators">Array of characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="hasHeader">Does the file contains header?</param>
         /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
@@ -70,7 +70,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="columns">The columns of the schema.</param>
         /// <param name="hasHeader">Whether the file has a header.</param>
-        /// <param name="separators">The characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
+        /// <param name="separators">Array of characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="path">The path to the file.</param>
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile(this DataOperationsCatalog catalog,
@@ -94,7 +94,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="hasHeader">Does the file contains header?</param>
-        /// <param name="separators">The characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
+        /// <param name="separators">Array of characters used as separators between data points in a row. {'\t'} will be used if not specified.</param>
         /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
         /// and distinguish empty values from missing values. When true, consecutive separators

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -23,12 +23,12 @@ namespace Microsoft.ML
         /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
         public static TextLoader CreateTextLoader(this DataOperationsCatalog catalog,
             TextLoader.Column[] columns,
-            char separatorChar = TextLoader.Defaults.Separator,
+            char[] separatorChar = null,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             IMultiStreamSource dataSample = null)
-            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, separatorChar, hasHeader, allowSparse, allowQuoting, dataSample);
+            => new TextLoader(CatalogUtils.GetEnvironment(catalog), columns, separatorChar ?? TextLoader.Defaults.Separator, hasHeader, allowSparse, allowQuoting, dataSample);
 
         /// <summary>
         /// Create a text loader <see cref="TextLoader"/>.
@@ -57,12 +57,12 @@ namespace Microsoft.ML
         /// except for 3rd and 5th columns which have values 6 and 3</param>
         /// <param name="trimWhitespace">Remove trailing whitespace from lines</param>
         public static TextLoader CreateTextLoader<TInput>(this DataOperationsCatalog catalog,
-            char separatorChar = TextLoader.Defaults.Separator,
+            char[] separatorChar = null,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
             bool trimWhitespace = TextLoader.Defaults.TrimWhitespace)
-            => TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar, allowQuoting, allowSparse, trimWhitespace);
+            => TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar ?? TextLoader.Defaults.Separator, allowQuoting, allowSparse, trimWhitespace);
 
         /// <summary>
         /// Read a data view from a text file using <see cref="TextLoader"/>.
@@ -76,7 +76,7 @@ namespace Microsoft.ML
         public static IDataView ReadFromTextFile(this DataOperationsCatalog catalog,
             string path,
             TextLoader.Column[] columns,
-            char separatorChar = TextLoader.Defaults.Separator,
+            char[] separatorChar = null,
             bool hasHeader = TextLoader.Defaults.HasHeader)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
@@ -85,7 +85,7 @@ namespace Microsoft.ML
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            var reader = new TextLoader(env, columns, separatorChar, hasHeader, dataSample: null);
+            var reader = new TextLoader(env, columns, separatorChar ?? TextLoader.Defaults.Separator, hasHeader, dataSample: null);
             return reader.Read(new MultiFileSource(path));
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.ML
         /// <returns>The data view.</returns>
         public static IDataView ReadFromTextFile<TInput>(this DataOperationsCatalog catalog,
             string path,
-            char separatorChar = TextLoader.Defaults.Separator,
+            char[] separatorChar = null,
             bool hasHeader = TextLoader.Defaults.HasHeader,
             bool allowQuoting = TextLoader.Defaults.AllowQuoting,
             bool allowSparse = TextLoader.Defaults.AllowSparse,
@@ -118,8 +118,8 @@ namespace Microsoft.ML
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
-            return TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader, separatorChar, allowQuoting, allowSparse, trimWhitespace)
-                             .Read(new MultiFileSource(path));
+            return TextLoader.CreateTextReader<TInput>(CatalogUtils.GetEnvironment(catalog), hasHeader,
+                separatorChar ?? TextLoader.Defaults.Separator, allowQuoting, allowSparse, trimWhitespace).Read(new MultiFileSource(path));
         }
 
         /// <summary>

--- a/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
+++ b/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
@@ -120,7 +120,7 @@ namespace Microsoft.ML.SamplesUtils
                         new TextLoader.Column("native-country", DataKind.R4, 13),
                         new TextLoader.Column("IsOver50K", DataKind.BL, 14),
                     },
-                separatorChar: ',',
+                separatorChar: new[] { ',' },
                 hasHeader: true
             );
 

--- a/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
+++ b/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
@@ -120,7 +120,7 @@ namespace Microsoft.ML.SamplesUtils
                         new TextLoader.Column("native-country", DataKind.R4, 13),
                         new TextLoader.Column("IsOver50K", DataKind.BL, 14),
                     },
-                separatorChar: new[] { ',' },
+                separators: new[] { ',' },
                 hasHeader: true
             );
 

--- a/test/Microsoft.ML.Functional.Tests/DataIO.cs
+++ b/test/Microsoft.ML.Functional.Tests/DataIO.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Functional.Tests
             {
                 // Serialize a dataset with a known schema to a file.
                 var filePath = SerializeDatasetToFile(mlContext, dataBefore, separator);
-                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, separatorChar: separator, hasHeader: true, allowQuoting: true);
+                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, separatorChar: new[] { separator }, hasHeader: true, allowQuoting: true);
                 Common.AssertTestTypeDatasetsAreEqual(mlContext, dataBefore, dataAfter);
             }
         }

--- a/test/Microsoft.ML.Functional.Tests/DataIO.cs
+++ b/test/Microsoft.ML.Functional.Tests/DataIO.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Functional.Tests
             {
                 // Serialize a dataset with a known schema to a file.
                 var filePath = SerializeDatasetToFile(mlContext, dataBefore, separator);
-                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, separatorChar: new[] { separator }, hasHeader: true, allowQuoting: true);
+                var dataAfter = mlContext.Data.ReadFromTextFile<TypeTestData>(filePath, separators: new[] { separator }, hasHeader: true, allowQuoting: true);
                 Common.AssertTestTypeDatasetsAreEqual(mlContext, dataBefore, dataAfter);
             }
         }

--- a/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
+++ b/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Functional.Tests.Datasets
                         new TextLoader.Column("Ug", DataKind.UG, 15),
                         new TextLoader.Column("Features", DataKind.R4, 16, 16 + _numFeatures-1),
                     },
-                    separatorChar: new[] { separator },
+                    separators: new[] { separator },
                     hasHeader: true,
                     allowQuoting: true);
         }

--- a/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
+++ b/test/Microsoft.ML.Functional.Tests/Datasets/TypeTestData.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Functional.Tests.Datasets
                         new TextLoader.Column("Ug", DataKind.UG, 15),
                         new TextLoader.Column("Features", DataKind.R4, 16, 16 + _numFeatures-1),
                     },
-                    separatorChar: separator,
+                    separatorChar: new[] { separator },
                     hasHeader: true,
                     allowQuoting: true);
         }

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -51,8 +51,7 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                separatorChar: ';'
-,
+                separatorChar: new[] { ';' },
                 hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
@@ -129,7 +128,7 @@ namespace Microsoft.ML.Tests
             string dataPath = GetDataPath("breast-cancer.txt");
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var data = mlContext.Data.ReadFromTextFile<BreastCancerFeatureVector>(dataPath,
-                separatorChar: '\t',
+                separatorChar: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Normalize("Features").
@@ -207,7 +206,7 @@ namespace Microsoft.ML.Tests
             string dataPath = GetDataPath("breast-cancer.txt");
 
             var data = mlContext.Data.ReadFromTextFile<BreastCancerCatFeatureExample>(dataPath,
-                separatorChar: '\t',
+                separatorChar: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.Categorical.OneHotEncodingTransformer.OutputKind.Bag)
@@ -305,8 +304,7 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                separatorChar: ';'
-,
+                separatorChar: new[] { ';' },
                 hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
@@ -338,8 +336,7 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                separatorChar: ';'
-,
+                separatorChar: new[] { ';' },
                 hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
@@ -371,7 +368,7 @@ namespace Microsoft.ML.Tests
 
             string dataPath = GetDataPath("breast-cancer.txt");
             var data = mlContext.Data.ReadFromTextFile<BreastCancerMulticlassExample>(dataPath,
-                separatorChar: '\t',
+                separatorChar: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Normalize("Features").
@@ -401,7 +398,7 @@ namespace Microsoft.ML.Tests
 
             string dataPath = GetDataPath("breast-cancer.txt");
             var data = mlContext.Data.ReadFromTextFile<BreastCancerCatFeatureExample>(dataPath,
-                separatorChar: '\t',
+                separatorChar: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.Categorical.OneHotEncodingTransformer.OutputKind.Bag)
@@ -452,7 +449,7 @@ namespace Microsoft.ML.Tests
             var mlContext = new MLContext(seed: 1, conc: 1);
             var dataPath = GetDataPath(@"small-sentiment-test.tsv");
             var embedNetworkPath = GetDataPath(@"shortsentiment.emd");
-            var data = mlContext.Data.ReadFromTextFile<SmallSentimentExample>(dataPath, separatorChar: '\t', hasHeader: false);
+            var data = mlContext.Data.ReadFromTextFile<SmallSentimentExample>(dataPath, separatorChar: new[] { '\t' }, hasHeader: false);
 
             var pipeline = mlContext.Transforms.Text.ExtractWordEmbeddings("Embed", embedNetworkPath, "Tokens");
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                separatorChar: new[] { ';' },
+                separators: new[] { ';' },
                 hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
@@ -128,7 +128,7 @@ namespace Microsoft.ML.Tests
             string dataPath = GetDataPath("breast-cancer.txt");
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var data = mlContext.Data.ReadFromTextFile<BreastCancerFeatureVector>(dataPath,
-                separatorChar: new[] { '\t' },
+                separators: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Normalize("Features").
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Tests
             string dataPath = GetDataPath("breast-cancer.txt");
 
             var data = mlContext.Data.ReadFromTextFile<BreastCancerCatFeatureExample>(dataPath,
-                separatorChar: new[] { '\t' },
+                separators: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.Categorical.OneHotEncodingTransformer.OutputKind.Bag)
@@ -304,7 +304,7 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                separatorChar: new[] { ';' },
+                separators: new[] { ';' },
                 hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Tests
             var trainDataPath = GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename);
             var mlContext = new MLContext(seed: 1, conc: 1);
             var data = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
-                separatorChar: new[] { ';' },
+                separators: new[] { ';' },
                 hasHeader: true);
             var cachedTrainData = mlContext.Data.Cache(data);
             var dynamicPipeline =
@@ -368,7 +368,7 @@ namespace Microsoft.ML.Tests
 
             string dataPath = GetDataPath("breast-cancer.txt");
             var data = mlContext.Data.ReadFromTextFile<BreastCancerMulticlassExample>(dataPath,
-                separatorChar: new[] { '\t' },
+                separators: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Normalize("Features").
@@ -398,7 +398,7 @@ namespace Microsoft.ML.Tests
 
             string dataPath = GetDataPath("breast-cancer.txt");
             var data = mlContext.Data.ReadFromTextFile<BreastCancerCatFeatureExample>(dataPath,
-                separatorChar: new[] { '\t' },
+                separators: new[] { '\t' },
                 hasHeader: true);
 
             var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.Categorical.OneHotEncodingTransformer.OutputKind.Bag)
@@ -449,7 +449,7 @@ namespace Microsoft.ML.Tests
             var mlContext = new MLContext(seed: 1, conc: 1);
             var dataPath = GetDataPath(@"small-sentiment-test.tsv");
             var embedNetworkPath = GetDataPath(@"shortsentiment.emd");
-            var data = mlContext.Data.ReadFromTextFile<SmallSentimentExample>(dataPath, separatorChar: new[] { '\t' }, hasHeader: false);
+            var data = mlContext.Data.ReadFromTextFile<SmallSentimentExample>(dataPath, separators: new[] { '\t' }, hasHeader: false);
 
             var pipeline = mlContext.Transforms.Text.ExtractWordEmbeddings("Embed", embedNetworkPath, "Tokens");
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var trainData = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
                 // Default separator is tab, but we need a semicolon.
-                separatorChar: new[] { ';' },
+                separators: new[] { ';' },
                 // First line of the file is a header, not a data row.
                 hasHeader: true);
 
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Read the test dataset.
             var testData = mlContext.Data.ReadFromTextFile<AdultData>(testDataPath,
                 // Default separator is tab, but we need a semicolon.
-                separatorChar: new[] { ';' },
+                separators: new[] { ';' },
                 // First line of the file is a header, not a data row.
                 hasHeader: true);
 
@@ -150,7 +150,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             //  Retrieve the training data.
             var trainData = mlContext.Data.ReadFromTextFile<IrisInput>(irisDataPath,
                 // Default separator is tab, but the dataset has comma.
-                separatorChar: new[] { ',' }
+                separators: new[] { ',' }
             );
 
             //Preview the data
@@ -235,7 +235,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Read the training data.
             var trainData = mlContext.Data.ReadFromTextFile<IrisInputAllFeatures>(dataPath,
                 // Default separator is tab, but the dataset has comma.
-                separatorChar: new[] { ',' }
+                separators: new[] { ',' }
             );
 
             // Apply all kinds of standard ML.NET normalization to the raw features.
@@ -407,7 +407,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Step one: read the data as an IDataView.
             var data = mlContext.Data.ReadFromTextFile<IrisInput>(dataPath,
                 // Default separator is tab, but the dataset has comma.
-                separatorChar: new[] { ',' }
+                separators: new[] { ',' }
             );
 
             // Build the training pipeline.
@@ -456,7 +456,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var reader = mlContext.Data.ReadFromTextFile<AdultData>(dataPath,
                 // Default separator is tab, but we need a comma.
-                separatorChar: new[] { ',' });
+                separators: new[] { ',' });
         }
 
         // Define a class for all the input columns that we intend to consume.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -79,8 +79,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var trainData = mlContext.Data.ReadFromTextFile<AdultData>(trainDataPath,
                 // Default separator is tab, but we need a semicolon.
-                separatorChar: ';'
-,
+                separatorChar: new[] { ';' },
                 // First line of the file is a header, not a data row.
                 hasHeader: true);
 
@@ -115,8 +114,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Read the test dataset.
             var testData = mlContext.Data.ReadFromTextFile<AdultData>(testDataPath,
                 // Default separator is tab, but we need a semicolon.
-                separatorChar: ';'
-,
+                separatorChar: new[] { ';' },
                 // First line of the file is a header, not a data row.
                 hasHeader: true);
 
@@ -152,7 +150,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             //  Retrieve the training data.
             var trainData = mlContext.Data.ReadFromTextFile<IrisInput>(irisDataPath,
                 // Default separator is tab, but the dataset has comma.
-                separatorChar: ','
+                separatorChar: new[] { ',' }
             );
 
             //Preview the data
@@ -237,7 +235,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Read the training data.
             var trainData = mlContext.Data.ReadFromTextFile<IrisInputAllFeatures>(dataPath,
                 // Default separator is tab, but the dataset has comma.
-                separatorChar: ','
+                separatorChar: new[] { ',' }
             );
 
             // Apply all kinds of standard ML.NET normalization to the raw features.
@@ -409,7 +407,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Step one: read the data as an IDataView.
             var data = mlContext.Data.ReadFromTextFile<IrisInput>(dataPath,
                 // Default separator is tab, but the dataset has comma.
-                separatorChar: ','
+                separatorChar: new[] { ',' }
             );
 
             // Build the training pipeline.
@@ -458,7 +456,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // Now read the file (remember though, readers are lazy, so the actual reading will happen when the data is accessed).
             var reader = mlContext.Data.ReadFromTextFile<AdultData>(dataPath,
                 // Default separator is tab, but we need a comma.
-                separatorChar: ',');
+                separatorChar: new[] { ',' });
         }
 
         // Define a class for all the input columns that we intend to consume.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var ml = new MLContext();
 
-            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separatorChar: new[] { ',' });
+            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separators: new[] { ',' });
 
             var pipeline = new ColumnConcatenatingEstimator (ml, "Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(ml, "Label"), TransformerScope.TrainTest)
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' }, hasHeader: true);
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separators: new[] { ',' }, hasHeader: true);
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var ml = new MLContext();
 
-            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separatorChar: ',');
+            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separatorChar: new[] { ',' });
 
             var pipeline = new ColumnConcatenatingEstimator (ml, "Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(ml, "Label"), TransformerScope.TrainTest)
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',', hasHeader: true);
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' }, hasHeader: true);
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
 
             var ml = new MLContext();
-            var data = ml.Data.CreateTextLoader(TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',')
+            var data = ml.Data.CreateTextLoader(TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' })
                 .Read(dataPath);
 
             Action<IrisData, IrisData> action = (i, j) =>
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',');
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' });
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
 
             var ml = new MLContext();
-            var data = ml.Data.CreateTextLoader(TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' })
+            var data = ml.Data.CreateTextLoader(TestDatasets.irisData.GetLoaderColumns(), separators: new[] { ',' })
                 .Read(dataPath);
 
             Action<IrisData, IrisData> action = (i, j) =>
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPrediction>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' });
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separators: new[] { ',' });
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             foreach (var input in testData.Take(20))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void Metacomponents()
         {
             var ml = new MLContext();
-            var data = ml.Data.ReadFromTextFile<IrisData>(GetDataPath(TestDatasets.irisData.trainFilename), separatorChar: ',');
+            var data = ml.Data.ReadFromTextFile<IrisData>(GetDataPath(TestDatasets.irisData.trainFilename), separatorChar: new[] { ',' });
 
             var sdcaTrainer = ml.BinaryClassification.Trainers.StochasticDualCoordinateAscentNonCalibrated(
                 new SdcaNonCalibratedBinaryTrainer.Options { MaxIterations = 100, Shuffle = true, NumThreads = 1, });

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Metacomponents.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         public void Metacomponents()
         {
             var ml = new MLContext();
-            var data = ml.Data.ReadFromTextFile<IrisData>(GetDataPath(TestDatasets.irisData.trainFilename), separatorChar: new[] { ',' });
+            var data = ml.Data.ReadFromTextFile<IrisData>(GetDataPath(TestDatasets.irisData.trainFilename), separators: new[] { ',' });
 
             var sdcaTrainer = ml.BinaryClassification.Trainers.StochasticDualCoordinateAscentNonCalibrated(
                 new SdcaNonCalibratedBinaryTrainer.Options { MaxIterations = 100, Shuffle = true, NumThreads = 1, });

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var ml = new MLContext();
 
-            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separatorChar: new[] { ',' });
+            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separators: new[] { ',' });
 
             var pipeline = ml.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(ml.Transforms.Conversion.MapValueToKey("Label"), TransformerScope.TrainTest)
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPredictionNotCasted>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' }, hasHeader: true);
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separators: new[] { ',' }, hasHeader: true);
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             
             // During prediction we will get Score column with 3 float values.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var dataPath = GetDataPath(TestDatasets.irisData.trainFilename);
             var ml = new MLContext();
 
-            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separatorChar: ',');
+            var data = ml.Data.ReadFromTextFile<IrisData>(dataPath, separatorChar: new[] { ',' });
 
             var pipeline = ml.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(ml.Transforms.Conversion.MapValueToKey("Label"), TransformerScope.TrainTest)
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPredictionNotCasted>(ml);
 
-            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',', hasHeader: true);
+            var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' }, hasHeader: true);
             var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
             
             // During prediction we will get Score column with 3 float values.

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Scenarios
                     new TextLoader.Column("PetalWidth", DataKind.R4, 3),
                     new TextLoader.Column("IrisPlantType", DataKind.TX, 4),
                 },
-                separatorChar: ','
+                separatorChar: new[] { ',' }
             );
 
             // Read training and test data sets

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Scenarios
                     new TextLoader.Column("PetalWidth", DataKind.R4, 3),
                     new TextLoader.Column("IrisPlantType", DataKind.TX, 4),
                 },
-                separatorChar: new[] { ',' }
+                separators: new[] { ',' }
             );
 
             // Read training and test data sets

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -998,7 +998,7 @@ namespace Microsoft.ML.Scenarios
                         new TextLoader.Column("Words", DataKind.TX, 0),
                         new TextLoader.Column("Ids", DataKind.I4, 1),
                    },
-                separatorChar: ','
+                separatorChar: new[] { ',' }
                );
 
             // We cannot resize variable length vector to fixed length vector in ML.NET

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -998,7 +998,7 @@ namespace Microsoft.ML.Scenarios
                         new TextLoader.Column("Words", DataKind.TX, 0),
                         new TextLoader.Column("Ids", DataKind.I4, 1),
                    },
-                separatorChar: new[] { ',' }
+                separators: new[] { ',' }
                );
 
             // We cannot resize variable length vector to fixed length vector in ML.NET

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -722,7 +722,7 @@ namespace Microsoft.ML.EntryPoints.Tests
            var irisFirstRowValues = irisFirstRow.Values.GetEnumerator();
 
             // Simple load
-            var dataIris = mlContext.Data.CreateTextLoader<Iris>(separatorChar: ',').Read(dataPath);
+            var dataIris = mlContext.Data.CreateTextLoader<Iris>(separatorChar: new[] { ',' }).Read(dataPath);
             var previewIris = dataIris.Preview(1);
 
             Assert.Equal(5, previewIris.ColumnView.Length);
@@ -738,7 +738,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             Assert.Equal("Iris-setosa", previewIris.RowView[0].Values[index].Value.ToString());
 
             // Load with start and end indexes
-            var dataIrisStartEnd = mlContext.Data.CreateTextLoader<IrisStartEnd>(separatorChar: ',').Read(dataPath);
+            var dataIrisStartEnd = mlContext.Data.CreateTextLoader<IrisStartEnd>(separatorChar: new[] { ',' }).Read(dataPath);
             var previewIrisStartEnd = dataIrisStartEnd.Preview(1);
 
             Assert.Equal(2, previewIrisStartEnd.ColumnView.Length);
@@ -755,7 +755,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
 
             // load setting the distinct columns. Loading column 0 and 2
-            var dataIrisColumnIndices = mlContext.Data.CreateTextLoader<IrisColumnIndices>(separatorChar: ',').Read(dataPath);
+            var dataIrisColumnIndices = mlContext.Data.CreateTextLoader<IrisColumnIndices>(separatorChar: new[] { ',' }).Read(dataPath);
             var previewIrisColumnIndices = dataIrisColumnIndices.Preview(1);
 
             Assert.Equal(2, previewIrisColumnIndices.ColumnView.Length);

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -722,7 +722,7 @@ namespace Microsoft.ML.EntryPoints.Tests
            var irisFirstRowValues = irisFirstRow.Values.GetEnumerator();
 
             // Simple load
-            var dataIris = mlContext.Data.CreateTextLoader<Iris>(separatorChar: new[] { ',' }).Read(dataPath);
+            var dataIris = mlContext.Data.CreateTextLoader<Iris>(separators: new[] { ',' }).Read(dataPath);
             var previewIris = dataIris.Preview(1);
 
             Assert.Equal(5, previewIris.ColumnView.Length);
@@ -738,7 +738,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             Assert.Equal("Iris-setosa", previewIris.RowView[0].Values[index].Value.ToString());
 
             // Load with start and end indexes
-            var dataIrisStartEnd = mlContext.Data.CreateTextLoader<IrisStartEnd>(separatorChar: new[] { ',' }).Read(dataPath);
+            var dataIrisStartEnd = mlContext.Data.CreateTextLoader<IrisStartEnd>(separators: new[] { ',' }).Read(dataPath);
             var previewIrisStartEnd = dataIrisStartEnd.Preview(1);
 
             Assert.Equal(2, previewIrisStartEnd.ColumnView.Length);
@@ -755,7 +755,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
 
             // load setting the distinct columns. Loading column 0 and 2
-            var dataIrisColumnIndices = mlContext.Data.CreateTextLoader<IrisColumnIndices>(separatorChar: new[] { ',' }).Read(dataPath);
+            var dataIrisColumnIndices = mlContext.Data.CreateTextLoader<IrisColumnIndices>(separators: new[] { ',' }).Read(dataPath);
             var previewIrisColumnIndices = dataIrisColumnIndices.Preview(1);
 
             Assert.Equal(2, previewIrisColumnIndices.ColumnView.Length);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         [Fact]
         public void MetacomponentsFeaturesRenamed()
         {
-            var data = new TextLoader(Env, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' })
+            var data = new TextLoader(Env, TestDatasets.irisData.GetLoaderColumns(), separators: new[] { ',' })
                 .Read(GetDataPath(TestDatasets.irisData.trainFilename));
 
             var sdcaTrainer = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscentNonCalibrated(

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         [Fact]
         public void MetacomponentsFeaturesRenamed()
         {
-            var data = new TextLoader(Env, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',')
+            var data = new TextLoader(Env, TestDatasets.irisData.GetLoaderColumns(), separatorChar: new[] { ',' })
                 .Read(GetDataPath(TestDatasets.irisData.trainFilename));
 
             var sdcaTrainer = ML.BinaryClassification.Trainers.StochasticDualCoordinateAscentNonCalibrated(

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new TextLoader.Column("Float1", DataKind.R4, 0),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(0), new TextLoader.Range(2), new TextLoader.Range(4), new TextLoader.Range(10) }),
                     new TextLoader.Column("Text1", DataKind.Text, 0)
-            }, separatorChar: ',', hasHeader: true);
+            }, separatorChar: new[] { ',' }, hasHeader: true);
 
             var data = loader.Read(source);
 

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new TextLoader.Column("Float1", DataKind.R4, 0),
                     new TextLoader.Column("Float4", DataKind.R4, new[]{new TextLoader.Range(0), new TextLoader.Range(2), new TextLoader.Range(4), new TextLoader.Range(10) }),
                     new TextLoader.Column("Text1", DataKind.Text, 0)
-            }, separatorChar: new[] { ',' }, hasHeader: true);
+            }, separators: new[] { ',' }, hasHeader: true);
 
             var data = loader.Read(source);
 


### PR DESCRIPTION
Fix #2472. This PR makes all separators a `char[]` instead of `char` in the public area of `TextLoader`. Note that `TextLoader`'s advanced `options` is already using `char[]`.

