### PR TITLE
Move ReadFromEnum and CreateEnumerable and add sample

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
             {
                 var resample = mlContext.Data.BootstrapSample(data, seed: i);
 
-                var enumerable = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.BinaryLabelFloatFeatureVectorSample>(resample, reuseRowObject: false);
+                var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.BinaryLabelFloatFeatureVectorSample>(resample, reuseRowObject: false);
                 Console.WriteLine($"Label\tFeatures[0]");
                 foreach (var row in enumerable)
                 {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
         {
             int lines = 0;
             double columnAverage = 0.0;
-            var enumerable = mlContext.CreateEnumerable<DatasetUtils.HousingRegression>(data, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<DatasetUtils.HousingRegression>(data, reuseRowObject: true);
             var watch = System.Diagnostics.Stopwatch.StartNew();
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Data.DataView;
+using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
 
 namespace Microsoft.ML.Samples.Dynamic
@@ -23,12 +24,17 @@ namespace Microsoft.ML.Samples.Dynamic
             IDataView data = mlContext.Data.ReadFromEnumerable(enumerableOfData);
 
             // We can now examine the records in the IDataView. We first create an enumerable of rows in the IDataView.
-            var rowEnumerable = mlContext.Data.CreateEnumerable<DatasetUtils.SampleTemperatureData>(data, true);
+            var rowEnumerable = mlContext.Data.CreateEnumerable<DatasetUtils.SampleTemperatureData>(data, reuseRowObject: true);
+
+            // SampleTemperatureDataWithLatitude has the definition of a Latitude column of type float. 
+            // We can use the parameter ignoreMissingColumns to true to ignore any missing columns in the IDataView.
+            // The produced enumerable will have the Latitude field set to the default for the data type, in this case 0. 
+            var rowEnumerableIgnoreMissing = mlContext.Data.CreateEnumerable<DatasetUtils.SampleTemperatureDataWithLatitude>(data,
+                reuseRowObject: true, ignoreMissingColumns: true);
 
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in rowEnumerable)
                 Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
-            Console.ReadLine();
 
             // Expected output:
             //  Date    Temperature
@@ -37,6 +43,20 @@ namespace Microsoft.ML.Samples.Dynamic
             //  1/4/2012        34
             //  1/5/2012        35
             //  1/6/2012        35
+
+            Console.WriteLine($"Date\tTemperature\tLatitude");
+            foreach (var row in rowEnumerableIgnoreMissing)
+                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}\t{row.Latitude}");
+
+            // Expected output:
+            //  Date    Temperature     Latitude
+            //  1/2/2012        36      0
+            //  1/3/2012        36      0
+            //  1/4/2012        34      0
+            //  1/5/2012        35      0
+            //  1/6/2012        35      0
+
+            Console.ReadLine();
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.ML.Data;
+using Microsoft.Data.DataView;
 using Microsoft.ML.SamplesUtils;
 
 namespace Microsoft.ML.Samples.Dynamic
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Samples.Dynamic
             IDataView data = mlContext.Data.ReadFromEnumerable(enumerableOfData);
 
             // We can now examine the records in the IDataView. We first create an enumerable of rows in the IDataView.
-            var rowEnumerable = mlContext.CreateEnumerable<DatasetUtils.SampleTemperatureData>(data, true);
+            var rowEnumerable = mlContext.Data.CreateEnumerable<DatasetUtils.SampleTemperatureData>(data, true);
 
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in rowEnumerable)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.ML.Data;
+using Microsoft.ML.SamplesUtils;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    /// <summary>
+    /// Sample class showing how to use ShuffleRows.
+    /// </summary>
+    public static class DataViewEnumerable
+    {
+        public static void Example()
+        {
+            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // as a catalog of available operations and as the source of randomness.
+            var mlContext = new MLContext();
+
+            // Get a small dataset as an IEnumerable.
+            IEnumerable<DatasetUtils.SampleTemperatureData> enumerableOfData = DatasetUtils.GetSampleTemperatureData(5);
+
+            // Read in into an IDataView using ReadFromEnumerable. 
+            IDataView data = mlContext.Data.ReadFromEnumerable(enumerableOfData);
+
+            // We can now examine the records in the IDataView. We first create an enumerable of rows in the IDataView.
+            var rowEnumerable = mlContext.CreateEnumerable<DatasetUtils.SampleTemperatureData>(data, true);
+
+            Console.WriteLine($"Date\tTemperature");
+            foreach (var row in rowEnumerable)
+                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+            Console.ReadLine();
+
+            // Expected output:
+            //  Date    Temperature
+            //  1/2/2012        36
+            //  1/3/2012        36
+            //  1/4/2012        34
+            //  1/5/2012        35
+            //  1/6/2012        35
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.FilterRowsByColumn(data, columnName: "Temperature", lowerBound: 34, upperBound: 37);
 
             // Look at the filtered data and observe that values outside [34,37) have been dropped.
-            var enumerable = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByKeyColumnFraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByKeyColumnFraction.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // Before we apply a filter, examine all the records in the dataset.
-            var enumerable = mlContext.CreateEnumerable<MulticlassWithKeyLabel>(transformedData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<MulticlassWithKeyLabel>(transformedData, reuseRowObject: true);
             Console.WriteLine($"Label\tFeatures");
             foreach (var row in enumerable)
             {
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.FilterRowsByKeyColumnFraction(transformedData, columnName: "Label", lowerBound: 0, upperBound: 0.5);
 
             // Look at the data and observe that values above 2 have been filtered out
-            var filteredEnumerable = mlContext.CreateEnumerable<MulticlassWithKeyLabel>(filteredData, reuseRowObject: true);
+            var filteredEnumerable = mlContext.Data.CreateEnumerable<MulticlassWithKeyLabel>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Label\tFeatures");
             foreach (var row in filteredEnumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByMissingValues.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByMissingValues.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.FilterRowsByMissingValues(data, "Features");
 
             // Take a look at the resulting dataset and note that the Feature vectors with NaNs are missing.
-            var enumerable = mlContext.CreateEnumerable<DatasetUtils.FloatLabelFloatFeatureVectorSample>(filteredData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<DatasetUtils.FloatLabelFloatFeatureVectorSample>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Label\tFeatures");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var shuffledData = mlContext.Data.ShuffleRows(data, seed: 123);
 
             // Look at the shuffled data and observe that the rows are in a randomized order.
-            var enumerable = mlContext.CreateEnumerable<DatasetUtils.SampleTemperatureData>(shuffledData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<DatasetUtils.SampleTemperatureData>(shuffledData, reuseRowObject: true);
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.SkipRows(data, 5);
 
             // Look at the filtered data and observe that the first 5 rows have been dropped
-            var enumerable = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.TakeRows(data, 5);
 
             // Look at the filtered data and observe that only the first 5 rows are in the resulting dataset.
-            var enumerable = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Let's now walk through the first ten records and see which feature drove the values the most
             // Get prediction scores and contributions
-            var scoringEnumerator = mlContext.CreateEnumerable<HousingRegressionScoreAndContribution>(outputData, true).GetEnumerator();
+            var scoringEnumerator = mlContext.Data.CreateEnumerable<HousingRegressionScoreAndContribution>(outputData, true).GetEnumerator();
             int index = 0;
             Console.WriteLine("Label\tScore\tBiggestFeature\tValue\tWeight\tContribution");
             while (scoringEnumerator.MoveNext() && index < 10)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/IidChangePointDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/IidChangePointDetectorTransform.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = ml.Transforms.IidChangePointEstimator(outputColumnName, inputColumnName, 95, Size / 4).Fit(dataView).Transform(dataView);
 
             // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
-            var predictionColumn = ml.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
             Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/IidSpikeDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/IidSpikeDetectorTransform.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = ml.Transforms.IidSpikeEstimator(outputColumnName, inputColumnName, 95, Size / 4).Fit(dataView).Transform(dataView);
 
             // Getting the data of the newly created column as an IEnumerable of IidSpikePrediction.
-            var predictionColumn = ml.CreateEnumerable<IidSpikePrediction>(transformedData, reuseRowObject: false);
+            var predictionColumn = ml.Data.CreateEnumerable<IidSpikePrediction>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
             Console.WriteLine("Alert\tScore\tP-Value");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedValues = pipeline.Fit(idv).Transform(idv);
 
             // Retrieve model scores into Prediction class
-            var predictions = mlContext.CreateEnumerable<Prediction>(transformedValues, reuseRowObject: false);
+            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedValues, reuseRowObject: false);
 
             // Iterate rows
             foreach (var prediction in predictions)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SsaChangePointDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SsaChangePointDetectorTransform.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = ml.Transforms.SsaChangePointEstimator(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
 
             // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
-            var predictionColumn = ml.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
             Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/SsaSpikeDetectorTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/SsaSpikeDetectorTransform.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = ml.Transforms.SsaSpikeEstimator(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
 
             // Getting the data of the newly created column as an IEnumerable of SsaSpikePrediction.
-            var predictionColumn = ml.CreateEnumerable<SsaSpikePrediction>(transformedData, reuseRowObject: false);
+            var predictionColumn = ml.Data.CreateEnumerable<SsaSpikePrediction>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
             Console.WriteLine("Data\tAlert\tScore\tP-Value");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/ImageClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/ImageClassification.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedValues = estimator.Transform(idv);
 
             // Retrieve model scores.
-            var outScores = mlContext.CreateEnumerable<OutputScores>(transformedValues, reuseRowObject: false);
+            var outScores = mlContext.Data.CreateEnumerable<OutputScores>(transformedValues, reuseRowObject: false);
 
             // Display scores. (for the sake of brevity we display scores of the first 3 classes)
             foreach (var prediction in outScores)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SDCASupportVectorMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SDCASupportVectorMachine.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             // Step 4: Make prediction and evaluate its quality (on training set).
             var prediction = model.Transform(data);
 
-            var rawPrediction = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.NonCalibratedBinaryClassifierOutput>(prediction, false);
+            var rawPrediction = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.NonCalibratedBinaryClassifierOutput>(prediction, false);
 
             // Step 5: Inspect the prediction of the first example.
             // Note that positive/negative label may be associated with positive/negative score

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
             //   Macro accuracy: 0.8655, Micro accuracy: 0.8651.
 
             // IDataView with predictions, to an IEnumerable<DatasetUtils.MulticlassClassificationExample>.
-            var nativePredictions = mlContext.CreateEnumerable<DatasetUtils.MulticlassClassificationExample>(dataWithPredictions, false).ToList();
+            var nativePredictions = mlContext.Data.CreateEnumerable<DatasetUtils.MulticlassClassificationExample>(dataWithPredictions, false).ToList();
 
             // Get schema object out of the prediction. It contains annotations such as the mapping from predicted label index
             // (e.g., 1) to its actual label (e.g., "AA").

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
             //   Macro accuracy: 0.8619, Micro accuracy: 0.8611.
 
             // IDataView with predictions, to an IEnumerable<DatasetUtils.MulticlassClassificationExample>.
-            var nativePredictions = mlContext.CreateEnumerable<DatasetUtils.MulticlassClassificationExample>(dataWithPredictions, false).ToList();
+            var nativePredictions = mlContext.Data.CreateEnumerable<DatasetUtils.MulticlassClassificationExample>(dataWithPredictions, false).ToList();
 
             // Get schema object out of the prediction. It contains metadata such as the mapping from predicted label index
             // (e.g., 1) to its actual label (e.g., "AA").

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
             // Again, convert the test data to a format supported by ML.NET.
             var testDataView = mlContext.Data.ReadFromEnumerable(testMatrix);
             // Feed the test data into the model and then iterate through all predictions.
-            foreach (var pred in mlContext.CreateEnumerable<MatrixElementForScore>(model.Transform(testDataView), false))
+            foreach (var pred in mlContext.Data.CreateEnumerable<MatrixElementForScore>(model.Transform(testDataView), false))
                 Console.WriteLine($"Predicted value at row {pred.MatrixRowIndex - 1} and column {pred.MatrixColumnIndex - 1} is {pred.Score}");
             // Predicted value at row 7 and column 1 is 2.876928
             // Predicted value at row 6 and column 3 is 3.587935

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
             var testDataView = mlContext.Data.ReadFromEnumerable(testMatrix);
 
             // Feed the test data into the model and then iterate through all predictions.
-            foreach (var pred in mlContext.CreateEnumerable<MatrixElementForScore>(model.Transform(testDataView), false))
+            foreach (var pred in mlContext.Data.CreateEnumerable<MatrixElementForScore>(model.Transform(testDataView), false))
                 Console.WriteLine($"Predicted value at row {pred.MatrixRowIndex-1} and column {pred.MatrixColumnIndex-1} is {pred.Score}");
             // Predicted value at row 7 and column 1 is 2.828761
             // Predicted value at row 6 and column 3 is 3.642226

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Concatenate.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Concatenate.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Now let's take a look at what this concatenation did.
             // We can extract the newly created column as an IEnumerable of SampleInfertDataWithFeatures, the class we define above.
-            var featuresColumn = mlContext.CreateEnumerable<SampleInfertDataWithFeatures>(transformedData, reuseRowObject: false);
+            var featuresColumn = mlContext.Data.CreateEnumerable<SampleInfertDataWithFeatures>(transformedData, reuseRowObject: false);
 
             // And we can write out a few rows
             Console.WriteLine($"{outputColumnName} column obtained post-transformation.");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CopyColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CopyColumns.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = pipeline.Fit(trainData).Transform(trainData);
 
             // We can extract the newly created column as an IEnumerable of SampleInfertDataTransformed, the class we define below.
-            var rowEnumerable = mlContext.CreateEnumerable<SampleInfertDataTransformed>(transformedData, reuseRowObject: false);
+            var rowEnumerable = mlContext.Data.CreateEnumerable<SampleInfertDataTransformed>(transformedData, reuseRowObject: false);
 
             // And finally, we can write out the rows of the dataset, looking at the columns of interest.
             Console.WriteLine($"Label, Parity, and CustomValue columns obtained post-transformation.");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/DropColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/DropColumns.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // that it tries to access. 
             try
             {
-                var failingRowEnumerable = mlContext.CreateEnumerable<SampleInfertDataNonExistentColumns>(transformedData, reuseRowObject: false);
+                var failingRowEnumerable = mlContext.Data.CreateEnumerable<SampleInfertDataNonExistentColumns>(transformedData, reuseRowObject: false);
             } catch(ArgumentOutOfRangeException exception)
             {
                 Console.WriteLine($"Age and Education were not available, so an exception was thrown: {exception.Message}.");
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Samples.Dynamic
             //  Parameter name: Schema
 
             // And we can write a few columns out to see that the rest of the data is still available.
-            var rowEnumerable = mlContext.CreateEnumerable<SampleInfertDataTransformed>(transformedData, reuseRowObject: false);
+            var rowEnumerable = mlContext.Data.CreateEnumerable<SampleInfertDataTransformed>(transformedData, reuseRowObject: false);
             Console.WriteLine($"The columns we didn't drop are still available.");
             foreach (var row in rowEnumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Samples.Dynamic
             //  There are 2 columns in the dataset.
 
             // We can extract the newly created column as an IEnumerable of SampleInfertDataTransformed, the class we define below.
-            var rowEnumerable = mlContext.CreateEnumerable<SampleInfertDataTransformed>(transformedData, reuseRowObject: false);
+            var rowEnumerable = mlContext.Data.CreateEnumerable<SampleInfertDataTransformed>(transformedData, reuseRowObject: false);
 
             // And finally, we can write out the rows of the dataset, looking at the columns of interest.
             Console.WriteLine($"Age and Educations columns obtained post-transformation.");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMapping.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMapping.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Samples.Dynamic
             IDataView transformedData = pipeline.Fit(trainData).Transform(trainData);
 
             // Getting the resulting data as an IEnumerable of SampleInfertDataWithFeatures. This will contain the newly created column EducationCategory
-            IEnumerable<SampleInfertDataWithFeatures> featureRows = mlContext.CreateEnumerable<SampleInfertDataWithFeatures>(transformedData, reuseRowObject: false);
+            IEnumerable<SampleInfertDataWithFeatures> featureRows = mlContext.Data.CreateEnumerable<SampleInfertDataWithFeatures>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"Example of mapping string->string");
             Console.WriteLine($"Age\tEducation\tEducationCategory");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingFloatToString.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingFloatToString.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Samples.Dynamic
             IDataView transformedData = pipeline.Fit(trainData).Transform(trainData);
 
             // Getting the resulting data as an IEnumerable of SampleTemperatureDataWithCategory. This will contain the newly created column TemperatureCategory
-            IEnumerable<SampleTemperatureDataWithCategory> featureRows = mlContext.CreateEnumerable<SampleTemperatureDataWithCategory>(transformedData, reuseRowObject: false);
+            IEnumerable<SampleTemperatureDataWithCategory> featureRows = mlContext.Data.CreateEnumerable<SampleTemperatureDataWithCategory>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"Example of mapping float->string");
             Console.WriteLine($"Date\t\tTemperature\tTemperatureCategory");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Samples.Dynamic
             IDataView transformedData = pipeline.Fit(trainData).Transform(trainData);
 
             // Getting the resulting data as an IEnumerable of SampleInfertDataWithIntArray. This will contain the newly created column EducationCategory
-            IEnumerable<SampleInfertDataWithIntArray> featuresColumn = mlContext.CreateEnumerable<SampleInfertDataWithIntArray>(transformedData, reuseRowObject: false);
+            IEnumerable<SampleInfertDataWithIntArray> featuresColumn = mlContext.Data.CreateEnumerable<SampleInfertDataWithIntArray>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"Example of mapping string->array");
             Console.WriteLine($"Age\tEducation\tEducationFeature");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Samples.Dynamic
             IDataView transformedData = pipeline.Fit(trainData).Transform(trainData);
 
             // Getting the resulting data as an IEnumerable of SampleInfertDataWithFeatures.
-            IEnumerable<SampleInfertDataWithFeatures> featureRows = mlContext.CreateEnumerable<SampleInfertDataWithFeatures>(transformedData, reuseRowObject: false);
+            IEnumerable<SampleInfertDataWithFeatures> featureRows = mlContext.Data.CreateEnumerable<SampleInfertDataWithFeatures>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"Example of mapping string->keytype");
             Console.WriteLine($"Age\tEducation\tEducationCategory");

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Samples.Static
             Console.WriteLine ("Macro accuracy: {0}, Micro accuracy: {1}.", 0.863482146891263, 0.86309523809523814);
 
             // Convert prediction in ML.NET format to native C# class.
-            var nativePredictions = mlContext.CreateEnumerable<DatasetUtils.MulticlassClassificationExample>(prediction.AsDynamic, false).ToList();
+            var nativePredictions = mlContext.Data.CreateEnumerable<DatasetUtils.MulticlassClassificationExample>(prediction.AsDynamic, false).ToList();
 
             // Get schema object out of the prediction. It contains annotations such as the mapping from predicted label index
             // (e.g., 1) to its actual label (e.g., "AA"). The call to "AsDynamic" converts our statically-typed pipeline into

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -536,7 +536,8 @@ namespace Microsoft.ML.Data
     /// <summary>
     /// Utility methods that facilitate strongly-typed cursoring.
     /// </summary>
-    public static class CursoringUtils
+    [BestFriend]
+    internal static class CursoringUtils
     {
         /// <summary>
         /// Generate a strongly-typed cursorable wrapper of the <see cref="IDataView"/>.
@@ -547,8 +548,7 @@ namespace Microsoft.ML.Data
         /// <param name="ignoreMissingColumns">Whether to ignore the case when a requested column is not present in the data view.</param>
         /// <param name="schemaDefinition">Optional user-provided schema definition. If it is not present, the schema is inferred from the definition of T.</param>
         /// <returns>The cursorable wrapper of <paramref name="data"/>.</returns>
-        [BestFriend]
-        internal static ICursorable<TRow> AsCursorable<TRow>(this IHostEnvironment env, IDataView data, bool ignoreMissingColumns = false,
+        public static ICursorable<TRow> AsCursorable<TRow>(this IHostEnvironment env, IDataView data, bool ignoreMissingColumns = false,
             SchemaDefinition schemaDefinition = null)
             where TRow : class, new()
         {
@@ -556,28 +556,6 @@ namespace Microsoft.ML.Data
             env.CheckValueOrNull(schemaDefinition);
 
             return TypedCursorable<TRow>.Create(env, data, ignoreMissingColumns, schemaDefinition);
-        }
-
-        /// <summary>
-        /// Convert an <see cref="IDataView"/> into a strongly-typed <see cref="IEnumerable{TRow}"/>.
-        /// </summary>
-        /// <typeparam name="TRow">The user-defined row type.</typeparam>
-        /// <param name="mlContext">ML context.</param>
-        /// <param name="data">The underlying data view.</param>
-        /// <param name="reuseRowObject">Whether to return the same object on every row, or allocate a new one per row.</param>
-        /// <param name="ignoreMissingColumns">Whether to ignore the case when a requested column is not present in the data view.</param>
-        /// <param name="schemaDefinition">Optional user-provided schema definition. If it is not present, the schema is inferred from the definition of T.</param>
-        /// <returns>The <see cref="IEnumerable{TRow}"/> that holds the data in <paramref name="data"/>. It can be enumerated multiple times.</returns>
-        public static IEnumerable<TRow> CreateEnumerable<TRow>(this MLContext mlContext, IDataView data, bool reuseRowObject,
-            bool ignoreMissingColumns = false, SchemaDefinition schemaDefinition = null)
-            where TRow : class, new()
-        {
-            Contracts.AssertValue(mlContext);
-            mlContext.CheckValue(data, nameof(data));
-            mlContext.CheckValueOrNull(schemaDefinition);
-
-            var engine = new PipeEngine<TRow>(mlContext, data, ignoreMissingColumns, schemaDefinition);
-            return engine.RunPipe(reuseRowObject);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Utilities/ComponentCreation.cs
+++ b/src/Microsoft.ML.Data/Utilities/ComponentCreation.cs
@@ -15,7 +15,8 @@ namespace Microsoft.ML.Data
     /// This class defines extension methods for an <see cref="IHostEnvironment"/> to facilitate creating
     /// components (loaders, transforms, trainers, scorers, evaluators, savers).
     /// </summary>
-    public static class ComponentCreation
+    [BestFriend]
+    internal static class ComponentCreation
     {
         /// <summary>
         /// Create a new data view which is obtained by appending all columns of all the source data views.
@@ -25,7 +26,7 @@ namespace Microsoft.ML.Data
         /// <param name="env">The host environment to use.</param>
         /// <param name="sources">A non-empty collection of data views to zip together.</param>
         /// <returns>The resulting data view.</returns>
-        internal static IDataView Zip(this IHostEnvironment env, IEnumerable<IDataView> sources)
+        public static IDataView Zip(this IHostEnvironment env, IEnumerable<IDataView> sources)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(sources, nameof(sources));
@@ -43,8 +44,7 @@ namespace Microsoft.ML.Data
         /// <param name="weight">The name of the weight column. Can be null.</param>
         /// <param name="custom">Additional column mapping to be passed to the trainer or scorer (specific to the prediction type). Can be null or empty.</param>
         /// <returns>The constructed examples.</returns>
-        [BestFriend]
-        internal static RoleMappedData CreateExamples(this IHostEnvironment env, IDataView data, string features, string label = null,
+        public static RoleMappedData CreateExamples(this IHostEnvironment env, IDataView data, string features, string label = null,
             string group = null, string weight = null, IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> custom = null)
         {
             Contracts.CheckValue(env, nameof(env));
@@ -58,32 +58,6 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Create a new <see cref="IDataView"/> over an enumerable of the items of user-defined type.
-        /// The user maintains ownership of the <paramref name="data"/> and the resulting data view will
-        /// never alter the contents of the <paramref name="data"/>.
-        /// Since <see cref="IDataView"/> is assumed to be immutable, the user is expected to support
-        /// multiple enumeration of the <paramref name="data"/> that would return the same results, unless
-        /// the user knows that the data will only be cursored once.
-        ///
-        /// One typical usage for streaming data view could be: create the data view that lazily loads data
-        /// as needed, then apply pre-trained transformations to it and cursor through it for transformation
-        /// results.
-        /// </summary>
-        /// <typeparam name="TRow">The user-defined item type.</typeparam>
-        /// <param name="catalog">The context to use for data view creation.</param>
-        /// <param name="data">The data to wrap around.</param>
-        /// <param name="schemaDefinition">The optional schema definition of the data view to create. If <c>null</c>,
-        /// the schema definition is inferred from <typeparamref name="TRow"/>.</param>
-        /// <returns>The constructed <see cref="IDataView"/>.</returns>
-        public static IDataView ReadFromEnumerable<TRow>(this DataOperationsCatalog catalog, IEnumerable<TRow> data, SchemaDefinition schemaDefinition = null)
-            where TRow : class
-        {
-            catalog.Environment.CheckValue(data, nameof(data));
-            catalog.Environment.CheckValueOrNull(schemaDefinition);
-            return DataViewConstructionUtils.CreateFromEnumerable(catalog.Environment, data, schemaDefinition);
-        }
-
-        /// <summary>
         /// Create an on-demand prediction engine.
         /// </summary>
         /// <param name="env">The host environment to use.</param>
@@ -91,7 +65,7 @@ namespace Microsoft.ML.Data
         /// <param name="ignoreMissingColumns">Whether to ignore missing columns in the data view.</param>
         /// <param name="inputSchemaDefinition">The optional input schema. If <c>null</c>, the schema is inferred from the <typeparamref name="TSrc"/> type.</param>
         /// <param name="outputSchemaDefinition">The optional output schema. If <c>null</c>, the schema is inferred from the <typeparamref name="TDst"/> type.</param>
-        internal static PredictionEngine<TSrc, TDst> CreatePredictionEngine<TSrc, TDst>(this IHostEnvironment env, ITransformer transformer,
+        public static PredictionEngine<TSrc, TDst> CreatePredictionEngine<TSrc, TDst>(this IHostEnvironment env, ITransformer transformer,
             bool ignoreMissingColumns = false, SchemaDefinition inputSchemaDefinition = null, SchemaDefinition outputSchemaDefinition = null)
             where TSrc : class
             where TDst : class, new()
@@ -112,7 +86,7 @@ namespace Microsoft.ML.Data
         /// <param name="modelStream">The model stream to load from.</param>
         /// <param name="data">The data to apply transforms to.</param>
         /// <returns>The transformed data.</returns>
-        internal static IDataView LoadTransforms(this IHostEnvironment env, Stream modelStream, IDataView data)
+        public static IDataView LoadTransforms(this IHostEnvironment env, Stream modelStream, IDataView data)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(modelStream, nameof(modelStream));
@@ -125,8 +99,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Creates a data loader from the arguments object.
         /// </summary>
-        [BestFriend]
-        internal static IDataLoader CreateLoader<TArgs>(this IHostEnvironment env, TArgs arguments, IMultiStreamSource files)
+        public static IDataLoader CreateLoader<TArgs>(this IHostEnvironment env, TArgs arguments, IMultiStreamSource files)
             where TArgs : class, new()
         {
             Contracts.CheckValue(env, nameof(env));
@@ -137,8 +110,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Creates a data loader from the 'LoadName{settings}' string.
         /// </summary>
-        [BestFriend]
-        internal static IDataLoader CreateLoader(this IHostEnvironment env, string settings, IMultiStreamSource files)
+        public static IDataLoader CreateLoader(this IHostEnvironment env, string settings, IMultiStreamSource files)
         {
             Contracts.CheckValue(env, nameof(env));
             Contracts.CheckValue(files, nameof(files));
@@ -149,7 +121,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Creates a data saver from the arguments object.
         /// </summary>
-        internal static IDataSaver CreateSaver<TArgs>(this IHostEnvironment env, TArgs arguments)
+        public static IDataSaver CreateSaver<TArgs>(this IHostEnvironment env, TArgs arguments)
             where TArgs : class, new()
         {
             Contracts.CheckValue(env, nameof(env));
@@ -159,7 +131,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Creates a data saver from the 'LoadName{settings}' string.
         /// </summary>
-        internal static IDataSaver CreateSaver(this IHostEnvironment env, string settings)
+        public static IDataSaver CreateSaver(this IHostEnvironment env, string settings)
         {
             Contracts.CheckValue(env, nameof(env));
             return CreateCore<IDataSaver>(env, typeof(SignatureDataSaver), settings);
@@ -168,7 +140,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Creates a data transform from the arguments object.
         /// </summary>
-        internal static IDataTransform CreateTransform<TArgs>(this IHostEnvironment env, TArgs arguments, IDataView source)
+        public static IDataTransform CreateTransform<TArgs>(this IHostEnvironment env, TArgs arguments, IDataView source)
             where TArgs : class, new()
         {
             Contracts.CheckValue(env, nameof(env));
@@ -179,7 +151,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Creates a data transform from the 'LoadName{settings}' string.
         /// </summary>
-        internal static IDataTransform CreateTransform(this IHostEnvironment env, string settings, IDataView source)
+        public static IDataTransform CreateTransform(this IHostEnvironment env, string settings, IDataView source)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(source, nameof(source));
@@ -198,7 +170,7 @@ namespace Microsoft.ML.Data
         /// additional information, for example, label names. If this is <c>null</c>, no information will be
         /// extracted.</param>
         /// <returns>The scored data.</returns>
-        internal static IDataScorerTransform CreateScorer(this IHostEnvironment env, string settings,
+        public static IDataScorerTransform CreateScorer(this IHostEnvironment env, string settings,
             RoleMappedData data, IPredictor predictor, RoleMappedSchema trainSchema = null)
         {
             Contracts.CheckValue(env, nameof(env));
@@ -229,8 +201,7 @@ namespace Microsoft.ML.Data
         /// additional information, for example, label names. If this is <c>null</c>, no information will be
         /// extracted.</param>
         /// <returns>The scored data.</returns>
-        [BestFriend]
-        internal static IDataScorerTransform CreateDefaultScorer(this IHostEnvironment env, RoleMappedData data,
+        public static IDataScorerTransform CreateDefaultScorer(this IHostEnvironment env, RoleMappedData data,
             IPredictor predictor, RoleMappedSchema trainSchema = null)
         {
             Contracts.CheckValue(env, nameof(env));
@@ -241,8 +212,7 @@ namespace Microsoft.ML.Data
             return ScoreUtils.GetScorer(predictor, data, env, trainSchema);
         }
 
-        [BestFriend]
-        internal static IEvaluator CreateEvaluator(this IHostEnvironment env, string settings)
+        public static IEvaluator CreateEvaluator(this IHostEnvironment env, string settings)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckNonWhiteSpace(settings, nameof(settings));
@@ -254,20 +224,20 @@ namespace Microsoft.ML.Data
         /// </summary>
         /// <param name="env">The host environment to use.</param>
         /// <param name="modelStream">The model stream.</param>
-        internal static IPredictor LoadPredictorOrNull(this IHostEnvironment env, Stream modelStream)
+        public static IPredictor LoadPredictorOrNull(this IHostEnvironment env, Stream modelStream)
         {
             Contracts.CheckValue(modelStream, nameof(modelStream));
             return ModelFileUtils.LoadPredictorOrNull(env, modelStream);
         }
 
-        internal static ITrainer CreateTrainer<TArgs>(this IHostEnvironment env, TArgs arguments, out string loadName)
+        public static ITrainer CreateTrainer<TArgs>(this IHostEnvironment env, TArgs arguments, out string loadName)
             where TArgs : class, new()
         {
             Contracts.CheckValue(env, nameof(env));
             return CreateCore<ITrainer, TArgs, SignatureTrainer>(env, arguments, out loadName);
         }
 
-        internal static ITrainer CreateTrainer(this IHostEnvironment env, string settings, out string loadName)
+        public static ITrainer CreateTrainer(this IHostEnvironment env, string settings, out string loadName)
         {
             Contracts.CheckValue(env, nameof(env));
             return CreateCore<ITrainer>(env, typeof(SignatureTrainer), settings, out loadName);

--- a/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
+++ b/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
@@ -480,7 +480,7 @@ namespace Microsoft.ML.SamplesUtils
 
         /// <summary>
         /// Class used to capture prediction of <see cref="BinaryLabelFloatFeatureVectorSample"/> when
-        /// calling <see cref="CursoringUtils.CreateEnumerable"/> via on <see cref="MLContext"/>.
+        /// calling TODO via on <see cref="MLContext"/>.
         /// </summary>
         public class CalibratedBinaryClassifierOutput
         {
@@ -491,7 +491,7 @@ namespace Microsoft.ML.SamplesUtils
 
         /// <summary>
         /// Class used to capture prediction of <see cref="BinaryLabelFloatFeatureVectorSample"/> when
-        /// calling <see cref="CursoringUtils.CreateEnumerable"/> via on <see cref="MLContext"/>.
+        /// calling TODO via on <see cref="MLContext"/>.
         /// </summary>
         public class NonCalibratedBinaryClassifierOutput
         {

--- a/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
+++ b/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
@@ -326,6 +326,13 @@ namespace Microsoft.ML.SamplesUtils
             public float Temperature { get; set; }
         }
 
+        public class SampleTemperatureDataWithLatitude
+        {
+            public float Latitude { get; set; }
+            public DateTime Date { get; set; }
+            public float Temperature { get; set; }
+        }
+
         /// <summary>
         /// Get a fake temperature dataset.
         /// </summary>

--- a/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
+++ b/src/Microsoft.ML.SamplesUtils/SamplesDatasetUtils.cs
@@ -480,7 +480,7 @@ namespace Microsoft.ML.SamplesUtils
 
         /// <summary>
         /// Class used to capture prediction of <see cref="BinaryLabelFloatFeatureVectorSample"/> when
-        /// calling TODO via on <see cref="MLContext"/>.
+        /// calling <see cref="DataOperationsCatalog.CreateEnumerable{TRow}(IDataView, bool, bool, SchemaDefinition)"/> via on <see cref="MLContext"/>.
         /// </summary>
         public class CalibratedBinaryClassifierOutput
         {
@@ -491,7 +491,7 @@ namespace Microsoft.ML.SamplesUtils
 
         /// <summary>
         /// Class used to capture prediction of <see cref="BinaryLabelFloatFeatureVectorSample"/> when
-        /// calling TODO via on <see cref="MLContext"/>.
+        /// calling <see cref="DataOperationsCatalog.CreateEnumerable{TRow}(IDataView, bool, bool, SchemaDefinition)"/> via on <see cref="MLContext"/>.
         /// </summary>
         public class NonCalibratedBinaryClassifierOutput
         {

--- a/test/Microsoft.ML.Functional.Tests/Common.cs
+++ b/test/Microsoft.ML.Functional.Tests/Common.cs
@@ -72,8 +72,8 @@ namespace Microsoft.ML.Functional.Tests
             Common.AssertEqual(data1.Schema, data2.Schema);
 
             // Define how to serialize the IDataView to objects.
-            var enumerable1 = mlContext.CreateEnumerable<TypeTestData>(data1, true);
-            var enumerable2 = mlContext.CreateEnumerable<TypeTestData>(data2, true);
+            var enumerable1 = mlContext.Data.CreateEnumerable<TypeTestData>(data1, true);
+            var enumerable2 = mlContext.Data.CreateEnumerable<TypeTestData>(data2, true);
 
             AssertEqual(enumerable1, enumerable2);
         }

--- a/test/Microsoft.ML.Functional.Tests/DataIO.cs
+++ b/test/Microsoft.ML.Functional.Tests/DataIO.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Functional.Tests
             var data = mlContext.Data.ReadFromEnumerable(enumerableBefore);
 
             // Export back to an enumerable.
-            var enumerableAfter = mlContext.CreateEnumerable<TypeTestData>(data, true);
+            var enumerableAfter = mlContext.Data.CreateEnumerable<TypeTestData>(data, true);
 
             Common.AssertEqual(enumerableBefore, enumerableAfter);
         }

--- a/test/Microsoft.ML.Functional.Tests/Explainability.cs
+++ b/test/Microsoft.ML.Functional.Tests/Explainability.cs
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Functional.Tests
 
             // Validate that the contributions are there
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
-            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+            var scoringEnumerator = mlContext.Data.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
             // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)
@@ -198,7 +198,7 @@ namespace Microsoft.ML.Functional.Tests
 
             // Validate that the contributions are there
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
-            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+            var scoringEnumerator = mlContext.Data.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
             // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)
@@ -235,7 +235,7 @@ namespace Microsoft.ML.Functional.Tests
 
             // Validate that the contributions are there
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
-            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+            var scoringEnumerator = mlContext.Data.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
             // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)
@@ -273,7 +273,7 @@ namespace Microsoft.ML.Functional.Tests
 
             // Validate that the contributions are there
             var shuffledSubset = mlContext.Data.TakeRows(mlContext.Data.ShuffleRows(outputData), 10);
-            var scoringEnumerator = mlContext.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
+            var scoringEnumerator = mlContext.Data.CreateEnumerable<FeatureContributionOutput>(shuffledSubset, true);
 
             // Make sure the number of feature contributions returned matches the length of the input feature vector.
             foreach (var row in scoringEnumerator)

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.ML.Tests
             var idv = mlContext.Data.ReadFromEnumerable(data);
             var pipeline = ML.Transforms.ApplyOnnxModel(modelFile);
             var transformedValues = pipeline.Fit(idv).Transform(idv);
-            var predictions = mlContext.CreateEnumerable<PredictionUnknownDimensions>(transformedValues, reuseRowObject: false).ToArray();
+            var predictions = mlContext.Data.CreateEnumerable<PredictionUnknownDimensions>(transformedValues, reuseRowObject: false).ToArray();
 
             Assert.Equal(1, predictions[0].argmax[0]);
             Assert.Equal(0, predictions[1].argmax[0]);

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -1256,7 +1256,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             Assert.Equal(0.86507936507936511, metrics.AccuracyMicro, 6);
 
             // Convert prediction in ML.NET format to native C# class.
-            var nativePredictions = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.MulticlassClassificationExample>(prediction.AsDynamic, false).ToList();
+            var nativePredictions = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.MulticlassClassificationExample>(prediction.AsDynamic, false).ToList();
 
             // Get schema object of the prediction. It contains metadata such as the mapping from predicted label index
             // (e.g., 1) to its actual label (e.g., "AA").

--- a/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
+++ b/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.RunTests
                 }
             }
             Assert.True(n == 2);
-            var iter = env.CreateEnumerable<SparseExample<T>>(data, false).GetEnumerator();
+            var iter = env.Data.CreateEnumerable<SparseExample<T>>(data, false).GetEnumerator();
             n = 0;
             while (iter.MoveNext())
                 ++n;
@@ -102,7 +102,7 @@ namespace Microsoft.ML.RunTests
                 }
             }
             Assert.True(n == 2);
-            var iter = env.CreateEnumerable<DenseExample<T>>(data, false).GetEnumerator();
+            var iter = env.Data.CreateEnumerable<DenseExample<T>>(data, false).GetEnumerator();
             n = 0;
             while (iter.MoveNext())
                 ++n;

--- a/test/Microsoft.ML.Tests/CollectionsDataViewTest.cs
+++ b/test/Microsoft.ML.Tests/CollectionsDataViewTest.cs
@@ -159,7 +159,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ConversionSimpleClass>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ConversionSimpleClass>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
             {
@@ -190,7 +190,7 @@ namespace Microsoft.ML.EntryPoints.Tests
                     field.SetValue(data[0], fi.GetValue(null));
                 }
                 var dataView = env.Data.ReadFromEnumerable(data);
-                var enumerator = env.CreateEnumerable<ConversionNotSupportedMinValueClass>(dataView, false).GetEnumerator();
+                var enumerator = env.Data.CreateEnumerable<ConversionNotSupportedMinValueClass>(dataView, false).GetEnumerator();
                 try
                 {
                     enumerator.MoveNext();
@@ -233,7 +233,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ClassWithConstField>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ClassWithConstField>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
                 Assert.True(CompareThroughReflection(enumeratorSimple.Current, originalEnumerator.Current));
@@ -259,7 +259,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ClassWithMixOfFieldsAndProperties>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ClassWithMixOfFieldsAndProperties>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
                 Assert.True(CompareThroughReflection(enumeratorSimple.Current, originalEnumerator.Current));
@@ -313,7 +313,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ClassWithPrivateFieldsAndProperties>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ClassWithPrivateFieldsAndProperties>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
             {
@@ -343,7 +343,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ClassWithInheritedProperties>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ClassWithInheritedProperties>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
                 Assert.True(CompareThroughReflection(enumeratorSimple.Current, originalEnumerator.Current));
@@ -394,7 +394,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ClassWithArrays>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ClassWithArrays>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
             {
@@ -445,7 +445,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ClassWithArrayProperties>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ClassWithArrayProperties>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
                 Assert.True(CompareThroughReflection(enumeratorSimple.Current, originalEnumerator.Current));
@@ -482,7 +482,7 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             var env = new MLContext();
             var dataView = env.Data.ReadFromEnumerable(data);
-            var enumeratorSimple = env.CreateEnumerable<ClassWithSetter>(dataView, false).GetEnumerator();
+            var enumeratorSimple = env.Data.CreateEnumerable<ClassWithSetter>(dataView, false).GetEnumerator();
             var originalEnumerator = data.GetEnumerator();
             while (enumeratorSimple.MoveNext() && originalEnumerator.MoveNext())
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // 'transformedData' is a 'promise' of data. Let's actually read it.
             var someRows = mlContext
                 // Convert to an enumerable of user-defined type. 
-                .CreateEnumerable<InspectedRow>(transformedData.AsDynamic, reuseRowObject: false)
+                .Data.CreateEnumerable<InspectedRow>(transformedData.AsDynamic, reuseRowObject: false)
                 // Take a couple values as an array.
                 .Take(4).ToArray();
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // 'transformedData' is a 'promise' of data. Let's actually read it.
             var someRows = mlContext
                 // Convert to an enumerable of user-defined type. 
-                .CreateEnumerable<InspectedRowWithAllFeatures>(transformedData, reuseRowObject: false)
+                .Data.CreateEnumerable<InspectedRowWithAllFeatures>(transformedData, reuseRowObject: false)
                 // Take a couple values as an array.
                 .Take(4).ToArray();
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPrediction>(ml);
 
             var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',', hasHeader: true);
-            var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
+            var testData = ml.Data.CreateEnumerable<IrisData>(testLoader, false);
             foreach (var input in testData.Take(20))
             {
                 var prediction = engine.Predict(input);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPrediction>(ml);
 
             var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',');
-            var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
+            var testData = ml.Data.CreateEnumerable<IrisData>(testLoader, false);
             foreach (var input in testData.Take(20))
             {
                 var prediction = engine.Predict(input);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var engine = model.CreatePredictionEngine<SentimentData, SentimentPrediction>(ml);
 
             // Take a couple examples out of the test data and run predictions on top.
-            var testData = ml.CreateEnumerable<SentimentData>(
+            var testData = ml.Data.CreateEnumerable<SentimentData>(
                 ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.testFilename), hasHeader: true), false);
 
             Parallel.ForEach(testData, (input) =>

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var engine = model.CreatePredictionEngine<IrisDataNoLabel, IrisPredictionNotCasted>(ml);
 
             var testLoader = ml.Data.ReadFromTextFile(dataPath, TestDatasets.irisData.GetLoaderColumns(), separatorChar: ',', hasHeader: true);
-            var testData = ml.CreateEnumerable<IrisData>(testLoader, false);
+            var testData = ml.Data.CreateEnumerable<IrisData>(testLoader, false);
             
             // During prediction we will get Score column with 3 float values.
             // We need to find way to map each score to original label.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var engine = model.CreatePredictionEngine<SentimentData, SentimentPrediction>(ml);
 
             // Take a couple examples out of the test data and run predictions on top.
-            var testData = ml.CreateEnumerable<SentimentData>(
+            var testData = ml.Data.CreateEnumerable<SentimentData>(
                 ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.testFilename), hasHeader: true), false);
             foreach (var input in testData.Take(5))
             {
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var engine = model.CreatePredictionEngine<SentimentData, SentimentPrediction>(ml);
 
             // Take a couple examples out of the test data and run predictions on top.
-            var testData = ml.CreateEnumerable<SentimentData>(
+            var testData = ml.Data.CreateEnumerable<SentimentData>(
                 ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.testFilename), hasHeader: true), false);
             foreach (var input in testData.Take(5))
             {

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainSaveModelAndPredict.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var engine = loadedModel.CreatePredictionEngine<SentimentData, SentimentPrediction>(ml);
 
             // Take a couple examples out of the test data and run predictions on top.
-            var testData = ml.CreateEnumerable<SentimentData>(
+            var testData = ml.Data.CreateEnumerable<SentimentData>(
                 ml.Data.ReadFromTextFile<SentimentData>(GetDataPath(TestDatasets.Sentiment.testFilename), hasHeader: true), false);
             foreach (var input in testData.Take(5))
             {

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var testDataView = mlContext.Data.ReadFromEnumerable(testMatrix);
 
             // Feed the test data into the model and then iterate through all predictions.
-            foreach (var pred in mlContext.CreateEnumerable<MatrixElementForScore>(model.Transform(testDataView), false))
+            foreach (var pred in mlContext.Data.CreateEnumerable<MatrixElementForScore>(model.Transform(testDataView), false))
                 Assert.True(pred.Score != 0);
         }
 
@@ -330,7 +330,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Make sure the prediction error is not too large.
             Assert.InRange(metrics.L2, 0, 0.1);
 
-            foreach (var pred in mlContext.CreateEnumerable<MatrixElementZeroBasedForScore>(prediction, false))
+            foreach (var pred in mlContext.Data.CreateEnumerable<MatrixElementZeroBasedForScore>(prediction, false))
                 // Test data contains no out-of-range indexes (i.e., all indexes can be found in the training matrix),
                 // so NaN should never happen.
                 Assert.True(!float.IsNaN(pred.Score));
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Apply the trained model to the examples with out-of-range indexes. 
             var invalidPrediction = model.Transform(invalidTestDataView);
 
-            foreach (var pred in mlContext.CreateEnumerable<MatrixElementZeroBasedForScore>(invalidPrediction, false))
+            foreach (var pred in mlContext.Data.CreateEnumerable<MatrixElementZeroBasedForScore>(invalidPrediction, false))
                 // The presence of out-of-range indexes may lead to NaN
                 Assert.True(float.IsNaN(pred.Score));
         }
@@ -457,7 +457,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Apply the trained model to the test data.
             var testPrediction = model.Transform(testDataView);
 
-            var testResults = mlContext.CreateEnumerable<OneClassMatrixElementZeroBasedForScore>(testPrediction, false).ToList();
+            var testResults = mlContext.Data.CreateEnumerable<OneClassMatrixElementZeroBasedForScore>(testPrediction, false).ToList();
             // Positive example (i.e., examples can be found in dataMatrix) is close to 1.
             CompareNumbersWithTolerance(0.982391, testResults[0].Score, digitsOfPrecision: 5);
             // Negative example (i.e., examples can not be found in dataMatrix) is close to 0.15 (specified by s.C = 0.15 in the trainer).
@@ -521,7 +521,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Apply the trained model to the test data.
             var testPrediction = model.Transform(testDataView);
 
-            var testResults = mlContext.CreateEnumerable<OneClassMatrixElementZeroBasedForScore>(testPrediction, false).ToList();
+            var testResults = mlContext.Data.CreateEnumerable<OneClassMatrixElementZeroBasedForScore>(testPrediction, false).ToList();
             // Positive example (i.e., examples can be found in dataMatrix) is close to 1.
             CompareNumbersWithTolerance(0.982391, testResults[0].Score, digitsOfPrecision: 5);
             // Negative example (i.e., examples can not be found in dataMatrix) is close to 0.15 (specified by s.C = 0.15 in the trainer).
@@ -591,7 +591,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Apply the trained model to the test data.
             var testPrediction = model.Transform(testDataView);
 
-            var testResults = mlContext.CreateEnumerable<OneClassMatrixElementZeroBasedForScore>(testPrediction, false).ToList();
+            var testResults = mlContext.Data.CreateEnumerable<OneClassMatrixElementZeroBasedForScore>(testPrediction, false).ToList();
             // Positive example (i.e., examples can be found in dataMatrix) is close to 1.
             CompareNumbersWithTolerance(0.9823623, testResults[0].Score, digitsOfPrecision: 5);
             // Negative examples' scores (i.e., examples can not be found in dataMatrix) are closer

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             Assert.InRange(metrics.Auc, 0.9, 1);
             Assert.InRange(metrics.LogLoss, 0, 0.5);
 
-            var rawPrediction = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.CalibratedBinaryClassifierOutput>(prediction, false);
+            var rawPrediction = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.CalibratedBinaryClassifierOutput>(prediction, false);
 
             // Step 5: Inspect the prediction of the first example.
             var first = rawPrediction.First();
@@ -115,7 +115,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // Check a few metrics to make sure the trained model is ok.
             Assert.InRange(metrics.Auc, 0.9, 1);
 
-            var rawPrediction = mlContext.CreateEnumerable<SamplesUtils.DatasetUtils.NonCalibratedBinaryClassifierOutput>(prediction, false);
+            var rawPrediction = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.NonCalibratedBinaryClassifierOutput>(prediction, false);
 
             // Step 5: Inspect the prediction of the first example.
             var first = rawPrediction.First();

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
@@ -303,7 +303,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var gbm = gbmTrainer.Fit(dataView);
             var predicted = gbm.Transform(dataView);
-            mlnetPredictions = mlContext.CreateEnumerable<GbmExample>(predicted, false).ToList();
+            mlnetPredictions = mlContext.Data.CreateEnumerable<GbmExample>(predicted, false).ToList();
 
             // Convert training to LightGBM's native format and train LightGBM model via its APIs
             // Convert the whole training matrix to CSC format required by LightGBM interface. Notice that the training matrix

--- a/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CustomMappingTests.cs
@@ -76,8 +76,8 @@ namespace Microsoft.ML.Tests.Transformers
             TestEstimatorCore(customEst, data);
             transformedData = customEst.Fit(data).Transform(data);
 
-            var inputs = ML.CreateEnumerable<MyInput>(transformedData, true);
-            var outputs = ML.CreateEnumerable<MyOutput>(transformedData, true);
+            var inputs = ML.Data.CreateEnumerable<MyInput>(transformedData, true);
+            var outputs = ML.Data.CreateEnumerable<MyOutput>(transformedData, true);
 
             Assert.True(inputs.Zip(outputs, (x, y) => y.Together == $"{x.Float1} + {string.Join(", ", x.Float4)}").All(x => x));
 

--- a/test/Microsoft.ML.Tests/Transformers/GroupUngroup.cs
+++ b/test/Microsoft.ML.Tests/Transformers/GroupUngroup.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Tests.Transformers
             var dataView = ML.Data.ReadFromEnumerable(data);
 
             var groupTransform = new GroupTransform(Env, dataView, "Age", "UserName", "Gender");
-            var grouped = ML.CreateEnumerable<UngroupExample>(groupTransform, false).ToList();
+            var grouped = ML.Data.CreateEnumerable<UngroupExample>(groupTransform, false).ToList();
 
             // Expected content of grouped should contains two rows.
             // Age, UserName, Gender
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Tests.Transformers
             var dataView = ML.Data.ReadFromEnumerable(data);
 
             var ungroupTransform = new UngroupTransform(Env, dataView, UngroupTransform.UngroupMode.Inner, "UserName", "Gender");
-            var ungrouped = ML.CreateEnumerable<GroupExample>(ungroupTransform, false).ToList();
+            var ungrouped = ML.Data.CreateEnumerable<GroupExample>(ungroupTransform, false).ToList();
 
             Assert.Equal(4, ungrouped.Count);
 

--- a/test/Microsoft.ML.Tests/Transformers/WordTokenizeTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/WordTokenizeTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Tests.Transformers
             var result = pipe.Fit(dataView).Transform(dataView);
 
             // Extract the transformed result of the first row (the only row we have because data contains only one TestClass) as a native class.
-            var nativeResult = ML.CreateEnumerable<NativeResult>(result, false).First();
+            var nativeResult = ML.Data.CreateEnumerable<NativeResult>(result, false).First();
 
             // Check the tokenization of A. Expected result is { "This", "is", "a", "good", "sentence." }.
             var tokenizeA = new[] { "This", "is", "a", "good", "sentence." };

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Tests
             // Transform
             var output = detector.Transform(dataView);
             // Get predictions
-            var enumerator = env.CreateEnumerable<Prediction>(output, true).GetEnumerator();
+            var enumerator = env.Data.CreateEnumerable<Prediction>(output, true).GetEnumerator();
             Prediction row = null;
             List<double> expectedValues = new List<double>() { 0, 5, 0.5, 5.1200000000000114E-08, 0, 5, 0.4999999995, 5.1200000046080209E-08, 0, 5, 0.4999999995, 5.1200000092160303E-08,
                 0, 5, 0.4999999995, 5.12000001382404E-08};
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Tests
             // Transform
             var output = detector.Transform(dataView);
             // Get predictions
-            var enumerator = env.CreateEnumerable<Prediction>(output, true).GetEnumerator();
+            var enumerator = env.Data.CreateEnumerable<Prediction>(output, true).GetEnumerator();
             Prediction row = null;
             List<double> expectedValues = new List<double>() { 0, -3.31410598754883, 0.5, 5.12000000000001E-08, 0, 1.5700820684432983, 5.2001145245395008E-07,
                     0.012414560443710681, 0, 1.2854313254356384, 0.28810801662678009, 0.02038940454467935, 0, -1.0950627326965332, 0.36663890634019225, 0.026956459625565483};

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesStaticTests.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesStaticTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Tests
             var output = detector.Transform(staticData);
 
             // Get predictions
-            var enumerator = env.CreateEnumerable<ChangePointPrediction>(output.AsDynamic, true).GetEnumerator();
+            var enumerator = env.Data.CreateEnumerable<ChangePointPrediction>(output.AsDynamic, true).GetEnumerator();
             ChangePointPrediction row = null;
             List<double> expectedValues = new List<double>() { 0, 5, 0.5, 5.1200000000000114E-08, 0, 5, 0.4999999995, 5.1200000046080209E-08, 0, 5, 0.4999999995, 5.1200000092160303E-08,
                 0, 5, 0.4999999995, 5.12000001382404E-08};
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Tests
             var output = detector.Transform(staticData);
 
             // Get predictions
-            var enumerator = env.CreateEnumerable<ChangePointPrediction>(output.AsDynamic, true).GetEnumerator();
+            var enumerator = env.Data.CreateEnumerable<ChangePointPrediction>(output.AsDynamic, true).GetEnumerator();
             ChangePointPrediction row = null;
             List<double> expectedValues = new List<double>() { 0, -3.31410598754883, 0.5, 5.12000000000001E-08, 0, 1.5700820684432983, 5.2001145245395008E-07,
                     0.012414560443710681, 0, 1.2854313254356384, 0.28810801662678009, 0.02038940454467935, 0, -1.0950627326965332, 0.36663890634019225, 0.026956459625565483};
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Tests
             var output = detector.Transform(staticData);
 
             // Get predictions
-            var enumerator = env.CreateEnumerable<SpikePrediction>(output.AsDynamic, true).GetEnumerator();
+            var enumerator = env.Data.CreateEnumerable<SpikePrediction>(output.AsDynamic, true).GetEnumerator();
             var expectedValues = new List<double[]>() {
                 //            Alert   Score   P-Value
                 new double[] {0,      5,      0.5},
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Tests
             var output = detector.Transform(staticData);
 
             // Get predictions
-            var enumerator = env.CreateEnumerable<SpikePrediction>(output.AsDynamic, true).GetEnumerator();
+            var enumerator = env.Data.CreateEnumerable<SpikePrediction>(output.AsDynamic, true).GetEnumerator();
             var expectedValues = new List<double[]>() {
                 //            Alert   Score   P-Value
                 new double[] {0,      0.0,    0.5},


### PR DESCRIPTION
Fixes #2609.

1. I moved `ReadFromEnumerable` method outside of `ComponentCreation`. I could therefore make the class `ComponentCreation` BestFriend internal, while making the internal methods public. 
2. I moved the extension method for `CreateEnumerable` which used to be under `MLContext` to the `Data` extensions where `ReadFromEnumerable` lives. I could therefore make the `CursoringUtils` class internal.
3. I added a sample for `CreateEnumerable` and `ReadFromEnumerable`.

Only non trivial changes are in DataViewEnumerable.cs, DataOperationsCatalog.cs, MLContext.cs, TypedCursor.cs, ComponentCreation.cs. The rest are simply adjusting the code to use `mlContext.Data.CreateEnumerable`.