### PR TITLE
Added performance tests for small array input for cpumath functions

### DIFF
--- a/test/Microsoft.ML.CpuMath.PerformanceTests/SmallInputCpuMathPerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/SmallInputCpuMathPerformanceTests.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.ML.Internal.CpuMath;
+
+namespace Microsoft.ML.CpuMath.PerformanceTests
+{
+    public class SmallInputCpuMathPerformanceTests: PerformanceTests
+    {
+        private int _smallInputLength = 10;
+
+        [Benchmark]
+        public void AddScalarU()
+            => CpuMathUtils.Add(DefaultScale, new Span<float>(dst, 0, _smallInputLength));
+
+        [Benchmark]
+        public void Scale()
+            => CpuMathUtils.Scale(DefaultScale, new Span<float>(dst, 0, _smallInputLength));
+
+        [Benchmark]
+        public void ScaleSrcU()
+            => CpuMathUtils.Scale(DefaultScale, src, dst, _smallInputLength);
+
+        [Benchmark]
+        public void ScaleAddU()
+            => CpuMathUtils.ScaleAdd(DefaultScale, DefaultScale, new Span<float>(dst, 0, _smallInputLength));
+
+        [Benchmark]
+        public void AddScaleU()
+            => CpuMathUtils.AddScale(DefaultScale, src, dst, _smallInputLength);
+
+        [Benchmark]
+        public void AddScaleSU()
+            => CpuMathUtils.AddScale(DefaultScale, src, idx, dst, _smallInputLength);
+
+        [Benchmark]
+        public void AddScaleCopyU()
+            => CpuMathUtils.AddScaleCopy(DefaultScale, src, dst, result, _smallInputLength);
+
+        [Benchmark]
+        public void AddU()
+            => CpuMathUtils.Add(src, dst, _smallInputLength);
+
+        [Benchmark]
+        public void AddSU()
+            => CpuMathUtils.Add(src, idx, dst, _smallInputLength);
+
+        [Benchmark]
+        public void MulElementWiseU()
+            => CpuMathUtils.MulElementWise(src1, src2, dst, _smallInputLength);
+
+        [Benchmark]
+        public float Sum()
+            => CpuMathUtils.Sum(new Span<float>(src, 0, _smallInputLength));
+
+        [Benchmark]
+        public float SumSqU()
+            => CpuMathUtils.SumSq(new Span<float>(src, 0, _smallInputLength));
+
+        [Benchmark]
+        public float SumSqDiffU()
+            => CpuMathUtils.SumSq(DefaultScale, new Span<float>(src, 0, Length));
+
+        [Benchmark]
+        public float SumAbsU()
+             => CpuMathUtils.SumAbs(new Span<float>(src, 0, _smallInputLength));
+
+        [Benchmark]
+        public float SumAbsDiffU()
+            => CpuMathUtils.SumAbs(DefaultScale, new Span<float>(src, 0, Length));
+
+        [Benchmark]
+        public float MaxAbsU()
+            => CpuMathUtils.MaxAbs(new Span<float>(src, 0, Length));
+
+        [Benchmark]
+        public float MaxAbsDiffU()
+            => CpuMathUtils.MaxAbsDiff(DefaultScale, new Span<float>(src, 0, _smallInputLength));
+
+        [Benchmark]
+        public float DotU()
+            => CpuMathUtils.DotProductDense(src, dst, _smallInputLength);
+
+        [Benchmark]
+        public float DotSU()
+            => CpuMathUtils.DotProductSparse(src, dst, idx, _smallInputLength);
+
+        [Benchmark]
+        public float Dist2()
+            => CpuMathUtils.L2DistSquared(src, dst, _smallInputLength);
+
+        [Benchmark]
+        public void SdcaL1UpdateU()
+            => CpuMathUtils.SdcaL1UpdateDense(DefaultScale, _smallInputLength, src, DefaultScale, dst, result);
+
+        [Benchmark]
+        public void SdcaL1UpdateSU()
+            => CpuMathUtils.SdcaL1UpdateSparse(DefaultScale, _smallInputLength, src, idx, DefaultScale, dst, result);
+    }
+}

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/SmallInputCpuMathPerformanceTests.cs
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/SmallInputCpuMathPerformanceTests.cs
@@ -14,11 +14,11 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
 
         [Benchmark]
         public void AddScalarU()
-            => CpuMathUtils.Add(DefaultScale, new Span<float>(dst, 0, _smallInputLength));
+            => CpuMathUtils.Add(DefaultScale, dst.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public void Scale()
-            => CpuMathUtils.Scale(DefaultScale, new Span<float>(dst, 0, _smallInputLength));
+            => CpuMathUtils.Scale(DefaultScale, dst.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public void ScaleSrcU()
@@ -26,7 +26,7 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
 
         [Benchmark]
         public void ScaleAddU()
-            => CpuMathUtils.ScaleAdd(DefaultScale, DefaultScale, new Span<float>(dst, 0, _smallInputLength));
+            => CpuMathUtils.ScaleAdd(DefaultScale, DefaultScale, dst.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public void AddScaleU()
@@ -62,23 +62,23 @@ namespace Microsoft.ML.CpuMath.PerformanceTests
 
         [Benchmark]
         public float SumSqDiffU()
-            => CpuMathUtils.SumSq(DefaultScale, new Span<float>(src, 0, Length));
+            => CpuMathUtils.SumSq(DefaultScale, src.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public float SumAbsU()
-             => CpuMathUtils.SumAbs(new Span<float>(src, 0, _smallInputLength));
+             => CpuMathUtils.SumAbs(src.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public float SumAbsDiffU()
-            => CpuMathUtils.SumAbs(DefaultScale, new Span<float>(src, 0, Length));
+            => CpuMathUtils.SumAbs(DefaultScale, src.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public float MaxAbsU()
-            => CpuMathUtils.MaxAbs(new Span<float>(src, 0, Length));
+            => CpuMathUtils.MaxAbs(src.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public float MaxAbsDiffU()
-            => CpuMathUtils.MaxAbsDiff(DefaultScale, new Span<float>(src, 0, _smallInputLength));
+            => CpuMathUtils.MaxAbsDiff(DefaultScale, src.AsSpan(0, _smallInputLength));
 
         [Benchmark]
         public float DotU()


### PR DESCRIPTION
I also tried Unrolling the loop for small input. 
For small functions like add, scale unrolling the loop only shows improvement for length 13-15
For little complex functions like dotproduct , loop is always better than the unrolling scenario.

The pr adds the performance tests for small inputs software implementation
