### PR TITLE
Polish GetColumn on IDataView

### DIFF
--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -303,8 +303,8 @@ var someRows = mlContext
 // This will give the entire dataset: make sure to only take several row
 // in case the dataset is huge. The is similar to the static API, except
 // you have to specify the column name and type.
-var featureColumns = transformedData.GetColumn<string[]>(mlContext, "AllFeatures")
-    .Take(20).ToArray();
+var featureColumns = transformedData.GetColumn<string[]>(transformedData.Schema["AllFeatures"])
+
 ```
 ## How do I train a regression model?
 
@@ -637,7 +637,7 @@ var pipeline =
 var normalizedData = pipeline.Fit(trainData).Transform(trainData);
 
 // Inspect one column of the resulting dataset.
-var meanVarValues = normalizedData.GetColumn<float[]>(mlContext, "MeanVarNormalized").ToArray();
+var meanVarValues = normalizedData.GetColumn<float[]>(normalizedData.Schema["MeanVarNormalized"]).ToArray();
 ```
 
 ## How do I train my model on categorical data?
@@ -682,8 +682,8 @@ var loader = mlContext.Data.CreateTextLoader(new[]
 // Load the data.
 var data = loader.Load(dataPath);
 
-// Inspect the first 10 records of the categorical columns to check that they are correctly load.
-var catColumns = data.GetColumn<string[]>(mlContext, "CategoricalFeatures").Take(10).ToArray();
+// Inspect the first 10 records of the categorical columns to check that they are correctly read.
+var catColumns = data.GetColumn<string[]>(data.Schema["CategoricalFeatures"]).Take(10).ToArray();
 
 // Build several alternative featurization pipelines.
 var pipeline =
@@ -699,8 +699,8 @@ var pipeline =
 var transformedData = pipeline.Fit(data).Transform(data);
 
 // Inspect some columns of the resulting dataset.
-var categoricalBags = transformedData.GetColumn<float[]>(mlContext, "CategoricalBag").Take(10).ToArray();
-var workclasses = transformedData.GetColumn<float[]>(mlContext, "WorkclassOneHotTrimmed").Take(10).ToArray();
+var categoricalBags = transformedData.GetColumn<float[]>(transformedData.Schema["CategoricalBag"]).Take(10).ToArray();
+var workclasses = transformedData.GetColumn<float[]>(transformedData.Schema["WorkclassOneHotTrimmed"]).Take(10).ToArray();
 
 // Of course, if we want to train the model, we will need to compose a single float vector of all the features.
 // Here's how we could do this:
@@ -756,8 +756,8 @@ var loader = mlContext.Data.CreateTextLoader(new[]
 // Load the data.
 var data = loader.Load(dataPath);
 
-// Inspect the message texts that are load from the file.
-var messageTexts = data.GetColumn<string>(mlContext, "Message").Take(20).ToArray();
+// Inspect the message texts that are read from the file.
+var messageTexts = data.GetColumn<string>(data.Schema["Message"]).Take(20).ToArray();
 
 // Apply various kinds of text operations supported by ML.NET.
 var pipeline =

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
@@ -82,8 +82,8 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Print the data that results from the transformations.
-            var countSelectColumn = transformedData.GetColumn<VBuffer<float>>(ml, "FeaturesCountSelect");
-            var MISelectColumn = transformedData.GetColumn<VBuffer<float>>(ml, "FeaturesMISelect");
+            var countSelectColumn = transformedData.GetColumn<VBuffer<float>>("FeaturesCountSelect");
+            var MISelectColumn = transformedData.GetColumn<VBuffer<float>>("FeaturesMISelect");
             printHelper("FeaturesCountSelect", countSelectColumn);
             printHelper("FeaturesMISelect", MISelectColumn);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs
@@ -82,8 +82,8 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Print the data that results from the transformations.
-            var countSelectColumn = transformedData.GetColumn<VBuffer<float>>("FeaturesCountSelect");
-            var MISelectColumn = transformedData.GetColumn<VBuffer<float>>("FeaturesMISelect");
+            var countSelectColumn = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema["FeaturesCountSelect"]);
+            var MISelectColumn = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema["FeaturesMISelect"]);
             printHelper("FeaturesCountSelect", countSelectColumn);
             printHelper("FeaturesMISelect", MISelectColumn);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Preview of the DefaultKeys column obtained after processing the input.
-            var defaultColumn = transformedData_default.GetColumn<VBuffer<uint>>(defaultColumnName);
+            var defaultColumn = transformedData_default.GetColumn<VBuffer<uint>>(transformedData_default.Schema[defaultColumnName]);
             printHelper(defaultColumnName, defaultColumn);
 
             // DefaultKeys column obtained post-transformation.
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // 9 10 11 12 13 6
 
             // Previewing the CustomizedKeys column obtained after processing the input.
-            var customizedColumn = transformedData_customized.GetColumn<VBuffer<uint>>(customizedColumnName);
+            var customizedColumn = transformedData_customized.GetColumn<VBuffer<uint>>(transformedData_customized.Schema[customizedColumnName]);
             printHelper(customizedColumnName, customizedColumn);
 
             // CustomizedKeys column obtained post-transformation.
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Samples.Dynamic
             transformedData_default = pipeline.Fit(trainData).Transform(trainData);
 
             // Preview of the DefaultColumnName column obtained.
-            var originalColumnBack = transformedData_default.GetColumn<VBuffer<ReadOnlyMemory<char>>>(defaultColumnName);
+            var originalColumnBack = transformedData_default.GetColumn<VBuffer<ReadOnlyMemory<char>>>(transformedData_default.Schema[defaultColumnName]);
 
             foreach (var row in originalColumnBack)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Preview of the DefaultKeys column obtained after processing the input.
-            var defaultColumn = transformedData_default.GetColumn<VBuffer<uint>>(ml, defaultColumnName);
+            var defaultColumn = transformedData_default.GetColumn<VBuffer<uint>>(defaultColumnName);
             printHelper(defaultColumnName, defaultColumn);
 
             // DefaultKeys column obtained post-transformation.
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // 9 10 11 12 13 6
 
             // Previewing the CustomizedKeys column obtained after processing the input.
-            var customizedColumn = transformedData_customized.GetColumn<VBuffer<uint>>(ml, customizedColumnName);
+            var customizedColumn = transformedData_customized.GetColumn<VBuffer<uint>>(customizedColumnName);
             printHelper(customizedColumnName, customizedColumn);
 
             // CustomizedKeys column obtained post-transformation.
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Samples.Dynamic
             transformedData_default = pipeline.Fit(trainData).Transform(trainData);
 
             // Preview of the DefaultColumnName column obtained.
-            var originalColumnBack = transformedData_default.GetColumn<VBuffer<ReadOnlyMemory<char>>>(ml, defaultColumnName);
+            var originalColumnBack = transformedData_default.GetColumn<VBuffer<ReadOnlyMemory<char>>>(defaultColumnName);
 
             foreach (var row in originalColumnBack)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformed_data = transformer.Transform(trainData);
 
             // Column obtained after processing the input.
-            var ldaFeaturesColumn = transformed_data.GetColumn<VBuffer<float>>(ml, ldaFeatures);
+            var ldaFeaturesColumn = transformed_data.GetColumn<VBuffer<float>>(ldaFeatures);
 
             Console.WriteLine($"{ldaFeatures} column obtained post-transformation.");
             foreach (var featureRow in ldaFeaturesColumn)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformed_data = transformer.Transform(trainData);
 
             // Column obtained after processing the input.
-            var ldaFeaturesColumn = transformed_data.GetColumn<VBuffer<float>>(ldaFeatures);
+            var ldaFeaturesColumn = transformed_data.GetColumn<VBuffer<float>>(transformed_data.Schema[ldaFeatures]);
 
             Console.WriteLine($"{ldaFeatures} column obtained post-transformation.");
             foreach (var featureRow in ldaFeaturesColumn)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Preview of the CharsUnigrams column obtained after processing the input.
             VBuffer<ReadOnlyMemory<char>> slotNames = default;
             transformedData_onechars.Schema["CharsUnigrams"].GetSlotNames(ref slotNames);
-            var charsOneGramColumn = transformedData_onechars.GetColumn<VBuffer<float>>(ml, "CharsUnigrams");
+            var charsOneGramColumn = transformedData_onechars.GetColumn<VBuffer<float>>("CharsUnigrams");
             printHelper("CharsUnigrams", charsOneGramColumn, slotNames);
 
             // CharsUnigrams column obtained post-transformation.
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // 'e' - 1 '<?>' - 2 'd' - 1 '=' - 4 'R' - 1 'U' - 1 'D' - 2 'E' - 1 'u' - 1 ',' - 1 '2' - 1
             // 'B' - 0 'e' - 6 's' - 3 't' - 6 '<?>' - 9 'g' - 2 'a' - 2 'm' - 2 'I' - 0 ''' - 0 'v' - 0 ...
             // Preview of the CharsTwoGrams column obtained after processing the input.
-            var charsTwoGramColumn = transformedData_twochars.GetColumn<VBuffer<float>>(ml, "CharsTwograms");
+            var charsTwoGramColumn = transformedData_twochars.GetColumn<VBuffer<float>>("CharsTwograms");
             transformedData_twochars.Schema["CharsTwograms"].GetSlotNames(ref slotNames);
             printHelper("CharsTwograms", charsTwoGramColumn, slotNames);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
@@ -26,8 +26,8 @@ namespace Microsoft.ML.Samples.Dynamic
             // A pipeline to tokenize text as characters and then combine them together into ngrams
             // The pipeline uses the default settings to featurize.
 
-            var charsPipeline = ml.Transforms.Text.TokenizeCharacters("Chars", "SentimentText", useMarkerCharacters:false);
-            var ngramOnePipeline = ml.Transforms.Text.ProduceNgrams("CharsUnigrams", "Chars", ngramLength:1);
+            var charsPipeline = ml.Transforms.Text.TokenizeCharacters("Chars", "SentimentText", useMarkerCharacters: false);
+            var ngramOnePipeline = ml.Transforms.Text.ProduceNgrams("CharsUnigrams", "Chars", ngramLength: 1);
             var ngramTwpPipeline = ml.Transforms.Text.ProduceNgrams("CharsTwograms", "Chars");
             var oneCharsPipeline = charsPipeline.Append(ngramOnePipeline);
             var twoCharsPipeline = charsPipeline.Append(ngramTwpPipeline);
@@ -38,22 +38,22 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Small helper to print the text inside the columns, in the console. 
             Action<string, IEnumerable<VBuffer<float>>, VBuffer<ReadOnlyMemory<char>>> printHelper = (columnName, column, names) =>
-           {
-               Console.WriteLine($"{columnName} column obtained post-transformation.");
-               var slots = names.GetValues();
-               foreach (var featureRow in column)
-               {
-                   foreach (var item in featureRow.Items())
-                       Console.Write($"'{slots[item.Key]}' - {item.Value} ");
-                   Console.WriteLine("");
-               }
+            {
+                Console.WriteLine($"{columnName} column obtained post-transformation.");
+                var slots = names.GetValues();
+                foreach (var featureRow in column)
+                {
+                    foreach (var item in featureRow.Items())
+                        Console.Write($"'{slots[item.Key]}' - {item.Value} ");
+                    Console.WriteLine("");
+                }
 
-               Console.WriteLine("===================================================");
-           };
+                Console.WriteLine("===================================================");
+            };
             // Preview of the CharsUnigrams column obtained after processing the input.
             VBuffer<ReadOnlyMemory<char>> slotNames = default;
             transformedData_onechars.Schema["CharsUnigrams"].GetSlotNames(ref slotNames);
-            var charsOneGramColumn = transformedData_onechars.GetColumn<VBuffer<float>>("CharsUnigrams");
+            var charsOneGramColumn = transformedData_onechars.GetColumn<VBuffer<float>>(transformedData_onechars.Schema["CharsUnigrams"]);
             printHelper("CharsUnigrams", charsOneGramColumn, slotNames);
 
             // CharsUnigrams column obtained post-transformation.
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // 'e' - 1 '<?>' - 2 'd' - 1 '=' - 4 'R' - 1 'U' - 1 'D' - 2 'E' - 1 'u' - 1 ',' - 1 '2' - 1
             // 'B' - 0 'e' - 6 's' - 3 't' - 6 '<?>' - 9 'g' - 2 'a' - 2 'm' - 2 'I' - 0 ''' - 0 'v' - 0 ...
             // Preview of the CharsTwoGrams column obtained after processing the input.
-            var charsTwoGramColumn = transformedData_twochars.GetColumn<VBuffer<float>>("CharsTwograms");
+            var charsTwoGramColumn = transformedData_twochars.GetColumn<VBuffer<float>>(transformedData_onechars.Schema["CharsUnigrams"]);
             transformedData_twochars.Schema["CharsTwograms"].GetSlotNames(ref slotNames);
             printHelper("CharsTwograms", charsTwoGramColumn, slotNames);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = transformer.Transform(trainData);
 
             // Getting the data of the newly created column, so we can preview it.
-            var normalizedColumn = transformedData.GetColumn<float>(ml, "Induced");
+            var normalizedColumn = transformedData.GetColumn<float>("Induced");
 
             // A small printing utility.
             Action<string, IEnumerable<float>> printHelper = (colName, column) =>
@@ -72,8 +72,8 @@ namespace Microsoft.ML.Samples.Dynamic
             var multiColtransformedData = multiColtransformer.Transform(trainData);
 
             // Getting the newly created columns. 
-            var normalizedInduced = multiColtransformedData.GetColumn<float>(ml, "LogInduced");
-            var normalizedSpont = multiColtransformedData.GetColumn<float>(ml, "LogSpontaneous");
+            var normalizedInduced = multiColtransformedData.GetColumn<float>("LogInduced");
+            var normalizedSpont = multiColtransformedData.GetColumn<float>("LogSpontaneous");
 
             printHelper("LogInduced", normalizedInduced);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = transformer.Transform(trainData);
 
             // Getting the data of the newly created column, so we can preview it.
-            var normalizedColumn = transformedData.GetColumn<float>("Induced");
+            var normalizedColumn = transformedData.GetColumn<float>(transformedData.Schema["Induced"]);
 
             // A small printing utility.
             Action<string, IEnumerable<float>> printHelper = (colName, column) =>
@@ -72,8 +72,8 @@ namespace Microsoft.ML.Samples.Dynamic
             var multiColtransformedData = multiColtransformer.Transform(trainData);
 
             // Getting the newly created columns. 
-            var normalizedInduced = multiColtransformedData.GetColumn<float>("LogInduced");
-            var normalizedSpont = multiColtransformedData.GetColumn<float>("LogSpontaneous");
+            var normalizedInduced = multiColtransformedData.GetColumn<float>(multiColtransformedData.Schema["LogInduced"]);
+            var normalizedSpont = multiColtransformedData.GetColumn<float>(multiColtransformedData.Schema["LogSpontaneous"]);
 
             printHelper("LogInduced", normalizedInduced);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             var transformedData = rffPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var randomFourier = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var randomFourier = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), randomFourier);
 
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             transformedData = lpNormalizePipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var lpNormalize= transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var lpNormalize= transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), lpNormalize);
 
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             transformedData = gcNormalizePipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var gcNormalize = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var gcNormalize = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), gcNormalize);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             var transformedData = rffPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var randomFourier = transformedData.GetColumn<VBuffer<float>>(ml, nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var randomFourier = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), randomFourier);
 
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             transformedData = lpNormalizePipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var lpNormalize= transformedData.GetColumn<VBuffer<float>>(ml, nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var lpNormalize= transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), lpNormalize);
 
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             transformedData = gcNormalizePipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var gcNormalize = transformedData.GetColumn<VBuffer<float>>(ml, nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var gcNormalize = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), gcNormalize);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/StopWordRemoverTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/StopWordRemoverTransform.cs
@@ -54,14 +54,14 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Preview the result of breaking string into array of words.
-            var originalText = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>(originalTextColumnName);
+            var originalText = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>(transformedDataDefault.Schema[originalTextColumnName]);
             printHelper(originalTextColumnName, originalText);
             // Best|game|I've|ever|played.|
             // == RUDE ==| Dude,| 2 |
             // Until | the | next | game,| this |is| the | best | Xbox | game!|
 
             // Preview the result of cleaning with default stop word remover.
-            var defaultRemoverData = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>("DefaultRemover");
+            var defaultRemoverData = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>(transformedDataDefault.Schema["DefaultRemover"]);
             printHelper("DefaultRemover", defaultRemoverData);
             // Best|game|I've|played.|
             // == RUDE ==| Dude,| 2 |
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
 
             // Preview the result of cleaning with default customized stop word remover.
-            var customizeRemoverData = transformedDataCustomized.GetColumn<VBuffer<ReadOnlyMemory<char>>>("RemovedWords");
+            var customizeRemoverData = transformedDataCustomized.GetColumn<VBuffer<ReadOnlyMemory<char>>>(transformedDataCustomized.Schema["RemovedWords"]);
             printHelper("RemovedWords", customizeRemoverData);
 
             // Best|game|I've|ever|played.|

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/StopWordRemoverTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/StopWordRemoverTransform.cs
@@ -54,14 +54,14 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Preview the result of breaking string into array of words.
-            var originalText = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>(ml, originalTextColumnName);
+            var originalText = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>(originalTextColumnName);
             printHelper(originalTextColumnName, originalText);
             // Best|game|I've|ever|played.|
             // == RUDE ==| Dude,| 2 |
             // Until | the | next | game,| this |is| the | best | Xbox | game!|
 
             // Preview the result of cleaning with default stop word remover.
-            var defaultRemoverData = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>(ml, "DefaultRemover");
+            var defaultRemoverData = transformedDataDefault.GetColumn<VBuffer<ReadOnlyMemory<char>>>("DefaultRemover");
             printHelper("DefaultRemover", defaultRemoverData);
             // Best|game|I've|played.|
             // == RUDE ==| Dude,| 2 |
@@ -70,7 +70,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
 
             // Preview the result of cleaning with default customized stop word remover.
-            var customizeRemoverData = transformedDataCustomized.GetColumn<VBuffer<ReadOnlyMemory<char>>>(ml, "RemovedWords");
+            var customizeRemoverData = transformedDataCustomized.GetColumn<VBuffer<ReadOnlyMemory<char>>>("RemovedWords");
             printHelper("RemovedWords", customizeRemoverData);
 
             // Best|game|I've|ever|played.|

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Preview of the DefaultTextFeatures column obtained after processing the input.
-            var defaultColumn = transformedData_default.GetColumn<VBuffer<float>>(ml, defaultColumnName);
+            var defaultColumn = transformedData_default.GetColumn<VBuffer<float>>(defaultColumnName);
             printHelper(defaultColumnName, defaultColumn);
 
             // DefaultTextFeatures column obtained post-transformation.
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // 0 0.1230915 0.1230915 0.1230915 0.1230915 0.246183 0.246183 0.246183 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1230915 0 0 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.3692745 0.246183 0.246183 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.246183 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.2886751 0 0 0 0 0 0 0 0.2886751 0.5773503 0.2886751 0.2886751 0.2886751 0.2886751 0.2886751 0.2886751
 
             // Preview of the CustomizedTextFeatures column obtained after processing the input.
-            var customizedColumn = transformedData_customized.GetColumn<VBuffer<float>>(ml, customizedColumnName);
+            var customizedColumn = transformedData_customized.GetColumn<VBuffer<float>>(customizedColumnName);
             printHelper(customizedColumnName, customizedColumn);
 
             // CustomizedTextFeatures column obtained post-transformation.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Preview of the DefaultTextFeatures column obtained after processing the input.
-            var defaultColumn = transformedData_default.GetColumn<VBuffer<float>>(defaultColumnName);
+            var defaultColumn = transformedData_default.GetColumn<VBuffer<float>>(transformedData_default.Schema[defaultColumnName]);
             printHelper(defaultColumnName, defaultColumn);
 
             // DefaultTextFeatures column obtained post-transformation.
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // 0 0.1230915 0.1230915 0.1230915 0.1230915 0.246183 0.246183 0.246183 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1230915 0 0 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.3692745 0.246183 0.246183 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.246183 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.1230915 0.2886751 0 0 0 0 0 0 0 0.2886751 0.5773503 0.2886751 0.2886751 0.2886751 0.2886751 0.2886751 0.2886751
 
             // Preview of the CustomizedTextFeatures column obtained after processing the input.
-            var customizedColumn = transformedData_customized.GetColumn<VBuffer<float>>(customizedColumnName);
+            var customizedColumn = transformedData_customized.GetColumn<VBuffer<float>>(transformedData_customized.Schema[customizedColumnName]);
             printHelper(customizedColumnName, customizedColumn);
 
             // CustomizedTextFeatures column obtained post-transformation.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhiten.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhiten.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             var transformedData = whiteningPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var whitening = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var whitening = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhiten.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhiten.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             var transformedData = whiteningPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var whitening = transformedData.GetColumn<VBuffer<float>>(ml, nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var whitening = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhitenWithColumnOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhitenWithColumnOptions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             var transformedData = whiteningPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var whitening = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var whitening = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhitenWithColumnOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhitenWithColumnOptions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // The transformed (projected) data.
             var transformedData = whiteningPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var whitening = transformedData.GetColumn<VBuffer<float>>(ml, nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
+            var whitening = transformedData.GetColumn<VBuffer<float>>(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features));
 
             printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/WordEmbeddingTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/WordEmbeddingTransform.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var wordsDataview = wordsPipeline.Fit(trainData).Transform(trainData);
             // Preview of the CleanWords column obtained after processing SentimentText.
-            var cleanWords = wordsDataview.GetColumn<ReadOnlyMemory<char>[]>("CleanWords");
+            var cleanWords = wordsDataview.GetColumn<ReadOnlyMemory<char>[]>(wordsDataview.Schema["CleanWords"]);
             Console.WriteLine($" CleanWords column obtained post-transformation.");
             foreach (var featureRow in cleanWords)
             {
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // And do all required transformations.
             var embeddingDataview = pipeline.Fit(wordsDataview).Transform(wordsDataview);
 
-            var customEmbeddings = embeddingDataview.GetColumn<float[]>("CustomEmbeddings");
+            var customEmbeddings = embeddingDataview.GetColumn<float[]>(embeddingDataview.Schema["CustomEmbeddings"]);
             printEmbeddings("GloveEmbeddings", customEmbeddings);
 
             // -1  -2   -3  -0.5   -1  8.5  0   0   20
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Second set of 3 floats in output represent average (for each dimension) for extracted values.
             // Third set of 3 floats in output represent maximum values (for each dimension) for extracted values.
             // Preview of GloveEmbeddings.
-            var gloveEmbeddings = embeddingDataview.GetColumn<float[]>("GloveEmbeddings");
+            var gloveEmbeddings = embeddingDataview.GetColumn<float[]>(embeddingDataview.Schema["GloveEmbeddings"]);
             printEmbeddings("GloveEmbeddings", gloveEmbeddings);
             // 0.23166 0.048825 0.26878 -1.3945 -0.86072 -0.026778 0.84075 -0.81987 -1.6681 -1.0658 -0.30596 0.50974 ...
             //-0.094905 0.61109 0.52546 - 0.2516 0.054786 0.022661 1.1801 0.33329 - 0.85388 0.15471 - 0.5984 0.4364  ...

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/WordEmbeddingTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/WordEmbeddingTransform.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var wordsDataview = wordsPipeline.Fit(trainData).Transform(trainData);
             // Preview of the CleanWords column obtained after processing SentimentText.
-            var cleanWords = wordsDataview.GetColumn<ReadOnlyMemory<char>[]>(ml, "CleanWords");
+            var cleanWords = wordsDataview.GetColumn<ReadOnlyMemory<char>[]>("CleanWords");
             Console.WriteLine($" CleanWords column obtained post-transformation.");
             foreach (var featureRow in cleanWords)
             {
@@ -86,7 +86,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // And do all required transformations.
             var embeddingDataview = pipeline.Fit(wordsDataview).Transform(wordsDataview);
 
-            var customEmbeddings = embeddingDataview.GetColumn<float[]>(ml, "CustomEmbeddings");
+            var customEmbeddings = embeddingDataview.GetColumn<float[]>("CustomEmbeddings");
             printEmbeddings("GloveEmbeddings", customEmbeddings);
 
             // -1  -2   -3  -0.5   -1  8.5  0   0   20
@@ -98,7 +98,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Second set of 3 floats in output represent average (for each dimension) for extracted values.
             // Third set of 3 floats in output represent maximum values (for each dimension) for extracted values.
             // Preview of GloveEmbeddings.
-            var gloveEmbeddings = embeddingDataview.GetColumn<float[]>(ml, "GloveEmbeddings");
+            var gloveEmbeddings = embeddingDataview.GetColumn<float[]>("GloveEmbeddings");
             printEmbeddings("GloveEmbeddings", gloveEmbeddings);
             // 0.23166 0.048825 0.26878 -1.3945 -0.86072 -0.026778 0.84075 -0.81987 -1.6681 -1.0658 -0.30596 0.50974 ...
             //-0.094905 0.61109 0.52546 - 0.2516 0.054786 0.022661 1.1801 0.33329 - 0.85388 0.15471 - 0.5984 0.4364  ...

--- a/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
@@ -83,8 +83,8 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Print the data that results from the transformations.
-            var countSelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>(ml, "FeaturesCountSelect");
-            var MISelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>(ml, "FeaturesMISelect");
+            var countSelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>("FeaturesCountSelect");
+            var MISelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>("FeaturesMISelect");
             printHelper("FeaturesCountSelect", countSelectColumn);
             printHelper("FeaturesMISelect", MISelectColumn);
 

--- a/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
@@ -83,8 +83,8 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Print the data that results from the transformations.
-            var countSelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>("FeaturesCountSelect");
-            var MISelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>("FeaturesMISelect");
+            var countSelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>(transformedData.AsDynamic.Schema["FeaturesCountSelect"]);
+            var MISelectColumn = transformedData.AsDynamic.GetColumn<VBuffer<float>>(transformedData.AsDynamic.Schema["FeaturesMISelect"]);
             printHelper("FeaturesCountSelect", countSelectColumn);
             printHelper("FeaturesMISelect", MISelectColumn);
 

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -26,12 +26,15 @@ namespace Microsoft.ML.Data
             Contracts.CheckValue(data, nameof(data));
             Contracts.CheckNonEmpty(column.Name, nameof(column));
 
-            if (!data.Schema.TryGetColumnIndex(column.Name, out int colIndex))
-                throw Contracts.ExceptParam(nameof(column), string.Format("column name {0} cannot be found in {1}", column.Name, nameof(data)));
+            var colIndex = column.Index;
+            var colType = column.Type;
+            var colName = column.Name;
 
-            if (data.Schema[colIndex].Type != column.Type)
-                throw Contracts.ExceptParam(nameof(column), string.Format("column {0}'s type {1} doesn't match the expected type {2} in {3}",
-                    column.Name, column.Type, data.Schema[colIndex].Type, nameof(data)));
+            // Use column index as the principle address of the specified input column and check if that address in data contains
+            // the column indicated.
+            if (data.Schema[colIndex].Name != colName || data.Schema[colIndex].Type != colType)
+                throw Contracts.ExceptParam(nameof(column), string.Format("column with name {0}, type {1}, and index {2} cannot be found in {3}",
+                    colName, colType, colIndex, nameof(data)));
 
             // There are two decisions that we make here:
             // - Is the T an array type?
@@ -41,7 +44,6 @@ namespace Microsoft.ML.Data
             //     - If this is the same type, we can map directly.
             //     - Otherwise, we need a conversion delegate.
 
-            var colType = column.Type;
             if (colType.RawType == typeof(T))
             {
                 // Direct mapping is possible.

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -15,6 +15,17 @@ namespace Microsoft.ML.Data
     /// </summary>
     public static class ColumnCursorExtensions
     {
+
+        /// <summary>
+        /// Extract all values of one column of the data view in a form of an <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the values. This must match the actual column type.</typeparam>
+        /// <param name="data">The data view to get the column from.</param>
+        /// <param name="columnName">The name of the column to be extracted.</param>
+
+        public static IEnumerable<T> GetColumn<T>(this IDataView data, string columnName)
+            => GetColumn<T>(data, data.Schema[columnName]);
+
         /// <summary>
         /// Extract all values of one column of the data view in a form of an <see cref="IEnumerable{T}"/>.
         /// </summary>

--- a/src/Microsoft.ML.StaticPipe/DataView.cs
+++ b/src/Microsoft.ML.StaticPipe/DataView.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.StaticPipe
             var indexer = StaticPipeUtils.GetIndexer(data);
             string columnName = indexer.Get(column(indexer.Indices));
 
-            return data.AsDynamic.GetColumn<TOut>(env, columnName);
+            return data.AsDynamic.GetColumn<TOut>(columnName);
         }
 
         public static IEnumerable<TItem> GetColumn<TItem, TShape>(this DataView<TShape> data, Func<TShape, Scalar<TItem>> column)

--- a/src/Microsoft.ML.StaticPipe/DataView.cs
+++ b/src/Microsoft.ML.StaticPipe/DataView.cs
@@ -49,7 +49,8 @@ namespace Microsoft.ML.StaticPipe
             var indexer = StaticPipeUtils.GetIndexer(data);
             string columnName = indexer.Get(column(indexer.Indices));
 
-            return data.AsDynamic.GetColumn<TOut>(columnName);
+            var dynamicData = data.AsDynamic;
+            return dynamicData.GetColumn<TOut>(dynamicData.Schema[columnName]);
         }
 
         public static IEnumerable<TItem> GetColumn<TItem, TShape>(this DataView<TShape> data, Func<TShape, Scalar<TItem>> column)

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -793,10 +793,10 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             IDataView newData = ml.Data.TakeRows(est.Fit(data).Transform(data).AsDynamic, 4);
             Assert.NotNull(newData);
-            bool[] ScalarFloat = newData.GetColumn<bool>("A").ToArray();
-            bool[] ScalarDouble = newData.GetColumn<bool>("B").ToArray();
-            bool[][] VectorFloat = newData.GetColumn<bool[]>("C").ToArray();
-            bool[][] VectorDoulbe = newData.GetColumn<bool[]>("D").ToArray();
+            bool[] ScalarFloat = newData.GetColumn<bool>(newData.Schema["A"]).ToArray();
+            bool[] ScalarDouble = newData.GetColumn<bool>(newData.Schema["B"]).ToArray();
+            bool[][] VectorFloat = newData.GetColumn<bool[]>(newData.Schema["C"]).ToArray();
+            bool[][] VectorDoulbe = newData.GetColumn<bool[]>(newData.Schema["D"]).ToArray();
 
             Assert.NotNull(ScalarFloat);
             Assert.NotNull(ScalarDouble);

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -793,10 +793,10 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             IDataView newData = ml.Data.TakeRows(est.Fit(data).Transform(data).AsDynamic, 4);
             Assert.NotNull(newData);
-            bool[] ScalarFloat = newData.GetColumn<bool>(ml, "A").ToArray();
-            bool[] ScalarDouble = newData.GetColumn<bool>(ml, "B").ToArray();
-            bool[][] VectorFloat = newData.GetColumn<bool[]>(ml, "C").ToArray();
-            bool[][] VectorDoulbe = newData.GetColumn<bool[]>(ml, "D").ToArray();
+            bool[] ScalarFloat = newData.GetColumn<bool>("A").ToArray();
+            bool[] ScalarDouble = newData.GetColumn<bool>("B").ToArray();
+            bool[][] VectorFloat = newData.GetColumn<bool[]>("C").ToArray();
+            bool[][] VectorDoulbe = newData.GetColumn<bool[]>("D").ToArray();
 
             Assert.NotNull(ScalarFloat);
             Assert.NotNull(ScalarDouble);

--- a/test/Microsoft.ML.Tests/CachingTests.cs
+++ b/test/Microsoft.ML.Tests/CachingTests.cs
@@ -66,15 +66,15 @@ namespace Microsoft.ML.Tests
         {
             var src = Enumerable.Range(0, 100).Select(c => new MyData()).ToArray();
             var data = ML.Data.LoadFromEnumerable(src);
-            data.GetColumn<float[]>("Features").ToArray();
-            data.GetColumn<float[]>("Features").ToArray();
+            data.GetColumn<float[]>(data.Schema["Features"]).ToArray();
+            data.GetColumn<float[]>(data.Schema["Features"]).ToArray();
             Assert.True(src.All(x => x.AccessCount == 2));
 
             src = Enumerable.Range(0, 100).Select(c => new MyData()).ToArray();
             data = ML.Data.LoadFromEnumerable(src);
             data = ML.Data.Cache(data);
-            data.GetColumn<float[]>("Features").ToArray();
-            data.GetColumn<float[]>("Features").ToArray();
+            data.GetColumn<float[]>(data.Schema["Features"]).ToArray();
+            data.GetColumn<float[]>(data.Schema["Features"]).ToArray();
             Assert.True(src.All(x => x.AccessCount == 1));
         }
 

--- a/test/Microsoft.ML.Tests/CachingTests.cs
+++ b/test/Microsoft.ML.Tests/CachingTests.cs
@@ -66,15 +66,15 @@ namespace Microsoft.ML.Tests
         {
             var src = Enumerable.Range(0, 100).Select(c => new MyData()).ToArray();
             var data = ML.Data.LoadFromEnumerable(src);
-            data.GetColumn<float[]>(ML, "Features").ToArray();
-            data.GetColumn<float[]>(ML, "Features").ToArray();
+            data.GetColumn<float[]>("Features").ToArray();
+            data.GetColumn<float[]>("Features").ToArray();
             Assert.True(src.All(x => x.AccessCount == 2));
 
             src = Enumerable.Range(0, 100).Select(c => new MyData()).ToArray();
             data = ML.Data.LoadFromEnumerable(src);
             data = ML.Data.Cache(data);
-            data.GetColumn<float[]>(ML, "Features").ToArray();
-            data.GetColumn<float[]>(ML, "Features").ToArray();
+            data.GetColumn<float[]>("Features").ToArray();
+            data.GetColumn<float[]>("Features").ToArray();
             Assert.True(src.All(x => x.AccessCount == 1));
         }
 

--- a/test/Microsoft.ML.Tests/RangeFilterTests.cs
+++ b/test/Microsoft.ML.Tests/RangeFilterTests.cs
@@ -26,12 +26,12 @@ namespace Microsoft.ML.Tests
             var data = builder.GetDataView();
 
             var data1 = ML.Data.FilterRowsByColumn(data, "Floats", upperBound: 2.8);
-            var cnt = data1.GetColumn<float>("Floats").Count();
+            var cnt = data1.GetColumn<float>(data1.Schema["Floats"]).Count();
             Assert.Equal(2L, cnt);
 
             data = ML.Transforms.Conversion.Hash("Key", "Strings", hashBits: 20).Fit(data).Transform(data);
             var data2 = ML.Data.FilterRowsByKeyColumnFraction(data, "Key", upperBound: 0.5);
-            cnt = data2.GetColumn<float>("Floats").Count();
+            cnt = data2.GetColumn<float>(data.Schema["Floats"]).Count();
             Assert.Equal(1L, cnt);
         }
     }

--- a/test/Microsoft.ML.Tests/RangeFilterTests.cs
+++ b/test/Microsoft.ML.Tests/RangeFilterTests.cs
@@ -26,12 +26,12 @@ namespace Microsoft.ML.Tests
             var data = builder.GetDataView();
 
             var data1 = ML.Data.FilterRowsByColumn(data, "Floats", upperBound: 2.8);
-            var cnt = data1.GetColumn<float>(ML, "Floats").Count();
+            var cnt = data1.GetColumn<float>("Floats").Count();
             Assert.Equal(2L, cnt);
 
             data = ML.Transforms.Conversion.Hash("Key", "Strings", hashBits: 20).Fit(data).Transform(data);
             var data2 = ML.Data.FilterRowsByKeyColumnFraction(data, "Key", upperBound: 0.5);
-            cnt = data2.GetColumn<float>(ML, "Floats").Count();
+            cnt = data2.GetColumn<float>("Floats").Count();
             Assert.Equal(1L, cnt);
         }
     }

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // The same extension method also applies to the dynamic-typed data, except you have to
             // specify the column name and type:
             var dynamicData = transformedData.AsDynamic;
-            var sameFeatureColumns = dynamicData.GetColumn<string[]>("AllFeatures")
+            var sameFeatureColumns = dynamicData.GetColumn<string[]>(dynamicData.Schema["AllFeatures"])
                 .Take(20).ToArray();
         }
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamples.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // The same extension method also applies to the dynamic-typed data, except you have to
             // specify the column name and type:
             var dynamicData = transformedData.AsDynamic;
-            var sameFeatureColumns = dynamicData.GetColumn<string[]>(mlContext, "AllFeatures")
+            var sameFeatureColumns = dynamicData.GetColumn<string[]>("AllFeatures")
                 .Take(20).ToArray();
         }
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // This will give the entire dataset: make sure to only take several row
             // in case the dataset is huge. The is similar to the static API, except
             // you have to specify the column name and type.
-            var featureColumns = transformedData.GetColumn<string[]>("AllFeatures")
+            var featureColumns = transformedData.GetColumn<string[]>(transformedData.Schema["AllFeatures"])
                 .Take(20).ToArray();
         }
 
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var normalizedData = pipeline.Fit(trainData).Transform(trainData);
 
             // Inspect one column of the resulting dataset.
-            var meanVarValues = normalizedData.GetColumn<float[]>("MeanVarNormalized").ToArray();
+            var meanVarValues = normalizedData.GetColumn<float[]>(normalizedData.Schema["MeanVarNormalized"]).ToArray();
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var data = loader.Load(dataPath);
 
             // Inspect the message texts that are read from the file.
-            var messageTexts = data.GetColumn<string>("Message").Take(20).ToArray();
+            var messageTexts = data.GetColumn<string>(data.Schema["Message"]).Take(20).ToArray();
 
             // Apply various kinds of text operations supported by ML.NET.
             var pipeline =
@@ -321,8 +321,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // Inspect some columns of the resulting dataset.
-            var embeddings = transformedData.GetColumn<float[]>("Embeddings").Take(10).ToArray();
-            var unigrams = transformedData.GetColumn<float[]>("BagOfWords").Take(10).ToArray();
+            var embeddings = transformedData.GetColumn<float[]>(transformedData.Schema["Embeddings"]).Take(10).ToArray();
+            var unigrams = transformedData.GetColumn<float[]>(transformedData.Schema["BagOfWords"]).Take(10).ToArray();
         }
 
         [Fact(Skip = "This test is running for one minute")]
@@ -361,7 +361,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var data = loader.Load(dataPath);
 
             // Inspect the first 10 records of the categorical columns to check that they are correctly read.
-            var catColumns = data.GetColumn<string[]>("CategoricalFeatures").Take(10).ToArray();
+            var catColumns = data.GetColumn<string[]>(data.Schema["CategoricalFeatures"]).Take(10).ToArray();
 
             // Build several alternative featurization pipelines.
             var pipeline =
@@ -377,8 +377,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // Inspect some columns of the resulting dataset.
-            var categoricalBags = transformedData.GetColumn<float[]>("CategoricalBag").Take(10).ToArray();
-            var workclasses = transformedData.GetColumn<float[]>("WorkclassOneHotTrimmed").Take(10).ToArray();
+            var categoricalBags = transformedData.GetColumn<float[]>(transformedData.Schema["CategoricalBag"]).Take(10).ToArray();
+            var workclasses = transformedData.GetColumn<float[]>(transformedData.Schema["WorkclassOneHotTrimmed"]).Take(10).ToArray();
 
             // Of course, if we want to train the model, we will need to compose a single float vector of all the features.
             // Here's how we could do this:

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // This will give the entire dataset: make sure to only take several row
             // in case the dataset is huge. The is similar to the static API, except
             // you have to specify the column name and type.
-            var featureColumns = transformedData.GetColumn<string[]>(mlContext, "AllFeatures")
+            var featureColumns = transformedData.GetColumn<string[]>("AllFeatures")
                 .Take(20).ToArray();
         }
 
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var normalizedData = pipeline.Fit(trainData).Transform(trainData);
 
             // Inspect one column of the resulting dataset.
-            var meanVarValues = normalizedData.GetColumn<float[]>(mlContext, "MeanVarNormalized").ToArray();
+            var meanVarValues = normalizedData.GetColumn<float[]>("MeanVarNormalized").ToArray();
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var data = loader.Load(dataPath);
 
             // Inspect the message texts that are read from the file.
-            var messageTexts = data.GetColumn<string>(mlContext, "Message").Take(20).ToArray();
+            var messageTexts = data.GetColumn<string>("Message").Take(20).ToArray();
 
             // Apply various kinds of text operations supported by ML.NET.
             var pipeline =
@@ -321,8 +321,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // Inspect some columns of the resulting dataset.
-            var embeddings = transformedData.GetColumn<float[]>(mlContext, "Embeddings").Take(10).ToArray();
-            var unigrams = transformedData.GetColumn<float[]>(mlContext, "BagOfWords").Take(10).ToArray();
+            var embeddings = transformedData.GetColumn<float[]>("Embeddings").Take(10).ToArray();
+            var unigrams = transformedData.GetColumn<float[]>("BagOfWords").Take(10).ToArray();
         }
 
         [Fact(Skip = "This test is running for one minute")]
@@ -361,7 +361,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var data = loader.Load(dataPath);
 
             // Inspect the first 10 records of the categorical columns to check that they are correctly read.
-            var catColumns = data.GetColumn<string[]>(mlContext, "CategoricalFeatures").Take(10).ToArray();
+            var catColumns = data.GetColumn<string[]>("CategoricalFeatures").Take(10).ToArray();
 
             // Build several alternative featurization pipelines.
             var pipeline =
@@ -377,8 +377,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // Inspect some columns of the resulting dataset.
-            var categoricalBags = transformedData.GetColumn<float[]>(mlContext, "CategoricalBag").Take(10).ToArray();
-            var workclasses = transformedData.GetColumn<float[]>(mlContext, "WorkclassOneHotTrimmed").Take(10).ToArray();
+            var categoricalBags = transformedData.GetColumn<float[]>("CategoricalBag").Take(10).ToArray();
+            var workclasses = transformedData.GetColumn<float[]>("WorkclassOneHotTrimmed").Take(10).ToArray();
 
             // Of course, if we want to train the model, we will need to compose a single float vector of all the features.
             // Here's how we could do this:

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
@@ -31,9 +31,9 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));
             var data = pipeline.Fit(src).Load(src);
 
-            var textColumn = data.GetColumn<string>("SentimentText").Take(20);
-            var transformedTextColumn = data.GetColumn<string[]>("Features_TransformedText").Take(20);
-            var features = data.GetColumn<float[]>("Features").Take(20);
+            var textColumn = data.GetColumn<string>(data.Schema["SentimentText"]).Take(20);
+            var transformedTextColumn = data.GetColumn<string[]>(data.Schema["Features_TransformedText"]).Take(20);
+            var features = data.GetColumn<float[]>(data.Schema["Features"]).Take(20);
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
@@ -31,9 +31,9 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));
             var data = pipeline.Fit(src).Load(src);
 
-            var textColumn = data.GetColumn<string>(ml, "SentimentText").Take(20);
-            var transformedTextColumn = data.GetColumn<string[]>(ml, "Features_TransformedText").Take(20);
-            var features = data.GetColumn<float[]>(ml, "Features").Take(20);
+            var textColumn = data.GetColumn<string>("SentimentText").Take(20);
+            var transformedTextColumn = data.GetColumn<string[]>("Features_TransformedText").Take(20);
+            var features = data.GetColumn<float[]>("Features").Take(20);
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             // this function will accept dataview and return content of "Workclass" column as List of strings.
             Func<IDataView, List<string>> getWorkclass = (IDataView view) =>
             {
-                return view.GetColumn<ReadOnlyMemory<char>>("Workclass").Select(x => x.ToString()).ToList();
+                return view.GetColumn<ReadOnlyMemory<char>>(view.Schema["Workclass"]).Select(x => x.ToString()).ToList();
             };
 
             // Let's test what train test properly works with seed.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             // this function will accept dataview and return content of "Workclass" column as List of strings.
             Func<IDataView, List<string>> getWorkclass = (IDataView view) =>
             {
-                return view.GetColumn<ReadOnlyMemory<char>>(mlContext, "Workclass").Select(x => x.ToString()).ToList();
+                return view.GetColumn<ReadOnlyMemory<char>>("Workclass").Select(x => x.ToString()).ToList();
             };
 
             // Let's test what train test properly works with seed.

--- a/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
@@ -66,11 +66,25 @@ namespace Microsoft.ML.Tests.Scenarios
             mustFail(() => data.AsDynamic.GetColumn<int?>(data.AsDynamic.Schema["floatScalar"]));
             mustFail(() => data.AsDynamic.GetColumn<string>(data.AsDynamic.Schema["floatScalar"]));
 
+
             // Static types.
             var enum8 = data.GetColumn(r => r.floatScalar);
             var enum9 = data.GetColumn(r => r.floatVector);
             var enum10 = data.GetColumn(r => r.stringScalar);
             var enum11 = data.GetColumn(r => r.stringVector);
+
+            var data1 = TextLoaderStatic.CreateLoader(env, ctx => (
+                floatScalar: ctx.LoadText(1),
+                anotherFloatVector: ctx.LoadFloat(2, 6),
+                stringVector: ctx.LoadText(5, 7)
+            )).Load(path);
+
+            // Type wrong. Load float as string.
+            mustFail(() => data.AsDynamic.GetColumn<float>(data1.AsDynamic.Schema["floatScalar"]));
+            // Name wrong. Load anotherFloatVector from floatVector column.
+            mustFail(() => data.AsDynamic.GetColumn<float>(data1.AsDynamic.Schema["anotherFloatVector"]));
+            // Index wrong. stringVector is indexed by 3 in data but 2 in data1.
+            mustFail(() => data.AsDynamic.GetColumn<string[]>(data1.AsDynamic.Schema["stringVector"]).ToArray());
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.ML.Tests.Scenarios
         [Fact]
         public void TestGetColumn()
         {
-            
             var path = GetDataPath(TestDatasets.breastCancer.trainFilename);
             var env = new MLContext();
             var data = TextLoaderStatic.CreateLoader(env, ctx => (
@@ -33,26 +32,6 @@ namespace Microsoft.ML.Tests.Scenarios
                 stringVector: ctx.LoadText(5, 7)
             )).Load(path);
 
-            Action<Action> mustFail = (Action action) =>
-            {
-                try
-                {
-                    action();
-                    Assert.False(true);
-                }
-                catch (ArgumentOutOfRangeException) { }
-                catch (InvalidOperationException) { }
-                catch (TargetInvocationException ex)
-                {
-                    Exception e;
-                    for (e = ex; e.InnerException != null; e = e.InnerException)
-                    {
-                    }
-                    Assert.True(e is ArgumentOutOfRangeException || e is InvalidOperationException);
-                    Assert.True(e.IsMarked());
-                }
-            };
-
             var enum1 = data.AsDynamic.GetColumn<float>(data.AsDynamic.Schema["floatScalar"]).ToArray();
             var enum2 = data.AsDynamic.GetColumn<float[]>(data.AsDynamic.Schema["floatVector"]).ToArray();
             var enum3 = data.AsDynamic.GetColumn<VBuffer<float>>(data.AsDynamic.Schema["floatVector"]).ToArray();
@@ -60,6 +39,7 @@ namespace Microsoft.ML.Tests.Scenarios
             var enum4 = data.AsDynamic.GetColumn<string>(data.AsDynamic.Schema["stringScalar"]).ToArray();
             var enum5 = data.AsDynamic.GetColumn<string[]>(data.AsDynamic.Schema["stringVector"]).ToArray();
 
+            var mustFail = GetMustFail();
             mustFail(() => data.AsDynamic.GetColumn<float[]>(data.AsDynamic.Schema["floatScalar"]));
             mustFail(() => data.AsDynamic.GetColumn<int[]>(data.AsDynamic.Schema["floatVector"]));
             mustFail(() => data.AsDynamic.GetColumn<int>(data.AsDynamic.Schema["floatScalar"]));
@@ -85,6 +65,63 @@ namespace Microsoft.ML.Tests.Scenarios
             mustFail(() => data.AsDynamic.GetColumn<float>(data1.AsDynamic.Schema["anotherFloatVector"]));
             // Index wrong. stringVector is indexed by 3 in data but 2 in data1.
             mustFail(() => data.AsDynamic.GetColumn<string[]>(data1.AsDynamic.Schema["stringVector"]).ToArray());
+        }
+
+        [Fact]
+        public void TestGetColumnSelectedByString()
+        {
+            var path = GetDataPath(TestDatasets.breastCancer.trainFilename);
+            var env = new MLContext();
+            var data = TextLoaderStatic.CreateLoader(env, ctx => (
+                floatScalar: ctx.LoadFloat(1),
+                floatVector: ctx.LoadFloat(2, 6),
+                stringScalar: ctx.LoadText(4),
+                stringVector: ctx.LoadText(5, 7)
+            )).Load(path);
+
+            var enum1 = data.AsDynamic.GetColumn<float>("floatScalar").ToArray();
+            var enum2 = data.AsDynamic.GetColumn<float[]>("floatVector").ToArray();
+            var enum3 = data.AsDynamic.GetColumn<VBuffer<float>>("floatVector").ToArray();
+
+            var enum4 = data.AsDynamic.GetColumn<string>("stringScalar").ToArray();
+            var enum5 = data.AsDynamic.GetColumn<string[]>("stringVector").ToArray();
+
+            var mustFail = GetMustFail();
+            mustFail(() => data.AsDynamic.GetColumn<float[]>("floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<int[]>("floatVector"));
+            mustFail(() => data.AsDynamic.GetColumn<int>("floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<int?>("floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<string>("floatScalar"));
+
+
+            // Static types.
+            var enum8 = data.GetColumn(r => r.floatScalar);
+            var enum9 = data.GetColumn(r => r.floatVector);
+            var enum10 = data.GetColumn(r => r.stringScalar);
+            var enum11 = data.GetColumn(r => r.stringVector);
+        }
+
+        private static Action<Action> GetMustFail()
+        {
+            return (Action action) =>
+            {
+                try
+                {
+                    action();
+                    Assert.False(true);
+                }
+                catch (ArgumentOutOfRangeException) { }
+                catch (InvalidOperationException) { }
+                catch (TargetInvocationException ex)
+                {
+                    Exception e;
+                    for (e = ex; e.InnerException != null; e = e.InnerException)
+                    {
+                    }
+                    Assert.True(e is ArgumentOutOfRangeException || e is InvalidOperationException);
+                    Assert.True(e.IsMarked());
+                }
+            };
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
@@ -53,18 +53,18 @@ namespace Microsoft.ML.Tests.Scenarios
                 }
             };
 
-            var enum1 = data.AsDynamic.GetColumn<float>("floatScalar").ToArray();
-            var enum2 = data.AsDynamic.GetColumn<float[]>("floatVector").ToArray();
-            var enum3 = data.AsDynamic.GetColumn<VBuffer<float>>("floatVector").ToArray();
+            var enum1 = data.AsDynamic.GetColumn<float>(data.AsDynamic.Schema["floatScalar"]).ToArray();
+            var enum2 = data.AsDynamic.GetColumn<float[]>(data.AsDynamic.Schema["floatVector"]).ToArray();
+            var enum3 = data.AsDynamic.GetColumn<VBuffer<float>>(data.AsDynamic.Schema["floatVector"]).ToArray();
 
-            var enum4 = data.AsDynamic.GetColumn<string>("stringScalar").ToArray();
-            var enum5 = data.AsDynamic.GetColumn<string[]>("stringVector").ToArray();
+            var enum4 = data.AsDynamic.GetColumn<string>(data.AsDynamic.Schema["stringScalar"]).ToArray();
+            var enum5 = data.AsDynamic.GetColumn<string[]>(data.AsDynamic.Schema["stringVector"]).ToArray();
 
-            mustFail(() => data.AsDynamic.GetColumn<float[]>("floatScalar"));
-            mustFail(() => data.AsDynamic.GetColumn<int[]>("floatVector"));
-            mustFail(() => data.AsDynamic.GetColumn<int>("floatScalar"));
-            mustFail(() => data.AsDynamic.GetColumn<int?>("floatScalar"));
-            mustFail(() => data.AsDynamic.GetColumn<string>("floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<float[]>(data.AsDynamic.Schema["floatScalar"]));
+            mustFail(() => data.AsDynamic.GetColumn<int[]>(data.AsDynamic.Schema["floatVector"]));
+            mustFail(() => data.AsDynamic.GetColumn<int>(data.AsDynamic.Schema["floatScalar"]));
+            mustFail(() => data.AsDynamic.GetColumn<int?>(data.AsDynamic.Schema["floatScalar"]));
+            mustFail(() => data.AsDynamic.GetColumn<string>(data.AsDynamic.Schema["floatScalar"]));
 
             // Static types.
             var enum8 = data.GetColumn(r => r.floatScalar);

--- a/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
@@ -92,13 +92,6 @@ namespace Microsoft.ML.Tests.Scenarios
             mustFail(() => data.AsDynamic.GetColumn<int>("floatScalar"));
             mustFail(() => data.AsDynamic.GetColumn<int?>("floatScalar"));
             mustFail(() => data.AsDynamic.GetColumn<string>("floatScalar"));
-
-
-            // Static types.
-            var enum8 = data.GetColumn(r => r.floatScalar);
-            var enum9 = data.GetColumn(r => r.floatVector);
-            var enum10 = data.GetColumn(r => r.stringScalar);
-            var enum11 = data.GetColumn(r => r.stringVector);
         }
 
         private static Action<Action> GetMustFail()

--- a/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/GetColumnTests.cs
@@ -53,18 +53,18 @@ namespace Microsoft.ML.Tests.Scenarios
                 }
             };
 
-            var enum1 = data.AsDynamic.GetColumn<float>(env, "floatScalar").ToArray();
-            var enum2 = data.AsDynamic.GetColumn<float[]>(env, "floatVector").ToArray();
-            var enum3 = data.AsDynamic.GetColumn<VBuffer<float>>(env, "floatVector").ToArray();
+            var enum1 = data.AsDynamic.GetColumn<float>("floatScalar").ToArray();
+            var enum2 = data.AsDynamic.GetColumn<float[]>("floatVector").ToArray();
+            var enum3 = data.AsDynamic.GetColumn<VBuffer<float>>("floatVector").ToArray();
 
-            var enum4 = data.AsDynamic.GetColumn<string>(env, "stringScalar").ToArray();
-            var enum5 = data.AsDynamic.GetColumn<string[]>(env, "stringVector").ToArray();
+            var enum4 = data.AsDynamic.GetColumn<string>("stringScalar").ToArray();
+            var enum5 = data.AsDynamic.GetColumn<string[]>("stringVector").ToArray();
 
-            mustFail(() => data.AsDynamic.GetColumn<float[]>(env, "floatScalar"));
-            mustFail(() => data.AsDynamic.GetColumn<int[]>(env, "floatVector"));
-            mustFail(() => data.AsDynamic.GetColumn<int>(env, "floatScalar"));
-            mustFail(() => data.AsDynamic.GetColumn<int?>(env, "floatScalar"));
-            mustFail(() => data.AsDynamic.GetColumn<string>(env, "floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<float[]>("floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<int[]>("floatVector"));
+            mustFail(() => data.AsDynamic.GetColumn<int>("floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<int?>("floatScalar"));
+            mustFail(() => data.AsDynamic.GetColumn<string>("floatScalar"));
 
             // Static types.
             var enum8 = data.GetColumn(r => r.floatScalar);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -42,9 +42,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var outNoInitData = notInitPredictor.Transform(transformedData);
 
             int numExamples = 10;
-            var col1 = data.GetColumn<float>("Score").Take(numExamples).ToArray();
-            var col2 = outInitData.GetColumn<float>("Score").Take(numExamples).ToArray();
-            var col3 = outNoInitData.GetColumn<float>("Score").Take(numExamples).ToArray();
+            var col1 = data.GetColumn<float>(data.Schema["Score"]).Take(numExamples).ToArray();
+            var col2 = outInitData.GetColumn<float>(outInitData.Schema["Score"]).Take(numExamples).ToArray();
+            var col3 = outNoInitData.GetColumn<float>(outNoInitData.Schema["Score"]).Take(numExamples).ToArray();
 
             bool col12Diff = default;
             bool col23Diff = default;

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SymSgdClassificationTests.cs
@@ -42,9 +42,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var outNoInitData = notInitPredictor.Transform(transformedData);
 
             int numExamples = 10;
-            var col1 = data.GetColumn<float>(Env, "Score").Take(numExamples).ToArray();
-            var col2 = outInitData.GetColumn<float>(Env, "Score").Take(numExamples).ToArray();
-            var col3 = outNoInitData.GetColumn<float>(Env, "Score").Take(numExamples).ToArray();
+            var col1 = data.GetColumn<float>("Score").Take(numExamples).ToArray();
+            var col2 = outInitData.GetColumn<float>("Score").Take(numExamples).ToArray();
+            var col3 = outNoInitData.GetColumn<float>("Score").Take(numExamples).ToArray();
 
             bool col12Diff = default;
             bool col23Diff = default;

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -647,7 +647,7 @@ namespace Microsoft.ML.Tests.Transformers
                 Assert.True(result.Schema[labelIdx].Type is KeyType);
                 Assert.Equal((ulong)5, result.Schema[labelIdx].Type.GetItemType().GetKeyCount());
 
-                var t = result.GetColumn<uint>(Env, "Label");
+                var t = result.GetColumn<uint>("Label");
                 uint s = t.First();
                 Assert.Equal((uint)3, s);
             }

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -647,7 +647,7 @@ namespace Microsoft.ML.Tests.Transformers
                 Assert.True(result.Schema[labelIdx].Type is KeyType);
                 Assert.Equal((ulong)5, result.Schema[labelIdx].Type.GetItemType().GetKeyCount());
 
-                var t = result.GetColumn<uint>("Label");
+                var t = result.GetColumn<uint>(result.Schema["Label"]);
                 uint s = t.First();
                 Assert.Equal((uint)3, s);
             }


### PR DESCRIPTION
To fix #2473, we need to

- [x] Remove IHostEnviroment from GetColumn's argument list. Note that our strategy is using `Constracts`.
- [x] Replace column name with `DataViewSchema.Column` in GetColumn's argument list.

Review steps:
1. Start with the 2nd iteration because some changes in the 1st iteration got discarded.
2. Removal of IHostEnviroment happens in the 2nd iteration.
3. Uses of `DataViewSchema.Column` are done in the 3rd iteration.
