### PR TITLE
Remove unused fileHandle

### DIFF
--- a/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/InputBase.cs
@@ -187,11 +187,8 @@ namespace Microsoft.ML.EntryPoints
                 var roleMappedData = new RoleMappedData(view, label, feature, group, weight, name, custom);
 
                 RoleMappedData cachedRoleMappedData = roleMappedData;
-                IFileHandle fileHandle = null;
-
                 const string registrationName = "CreateCache";
                 var createCacheHost = host.Register(registrationName);
-
                 IDataView outputData = null;
 
                 switch (input.Caching)
@@ -221,7 +218,6 @@ namespace Microsoft.ML.EntryPoints
                 }
 
                 var predictor = TrainUtils.Train(host, ch, cachedRoleMappedData, trainer, calibrator, maxCalibrationExamples);
-                fileHandle?.Dispose();
                 return new TOut() { PredictorModel = new PredictorModelImpl(host, roleMappedData, input.TrainingData, predictor) };
             }
         }


### PR DESCRIPTION
fileHandle variable is not used in the code block. The logic for which it was used is deleted and therefore no need for fileHandle variable.

Code cleanup from PR: https://github.com/dotnet/machinelearning/pull/2568

We are excited to review your PR.

So we can do the best job, please check:

- [ ] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [ ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

