### PR TITLE
Add an example of random PCA using in-memory data structure

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
@@ -11,18 +11,16 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
         private class DataPoint
         {
             [VectorType(3)]
-            public float[] Features;
+            public float[] Features { get; set; }
         }
 
         // Class used to capture prediction of DataPoint.
-        // Please disable warning 649 if complier says those fields are never assigned. They will
-        // be assigned in runtime.
         private class Result
         {
             // Outlier gets false while inlier has true.
-            public bool PredictedLabel;
+            public bool PredictedLabel { get; set; }
             // Outlier gets smaller score.
-            public float Score;
+            public float Score { get; set; }
         }
 
         public static void Example()

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
@@ -7,22 +7,6 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
 {
     public static class RandomizedPcaSample
     {
-        // Example with 3 feature values. A training data set is a collection of such examples.
-        private class DataPoint
-        {
-            [VectorType(3)]
-            public float[] Features { get; set; }
-        }
-
-        // Class used to capture prediction of DataPoint.
-        private class Result
-        {
-            // Outlier gets false while inlier has true.
-            public bool PredictedLabel { get; set; }
-            // Outlier gets smaller score.
-            public float Score { get; set; }
-        }
-
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
@@ -30,14 +14,15 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
             // Setting the seed to a fixed number in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
+            // Training data.
             var samples = new List<DataPoint>()
             {
-                new DataPoint(){ Features= new float[3] {1, 0, 0} },
-                new DataPoint(){ Features= new float[3] {0, 2, 1} },
-                new DataPoint(){ Features= new float[3] {1, 2, 3} },
-                new DataPoint(){ Features= new float[3] {0, 1, 0} },
-                new DataPoint(){ Features= new float[3] {0, 2, 1} },
-                new DataPoint(){ Features= new float[3] {-100, 50, -100} }
+                new DataPoint(){ Features = new float[3] {1, 0, 0} },
+                new DataPoint(){ Features = new float[3] {0, 2, 1} },
+                new DataPoint(){ Features = new float[3] {1, 2, 3} },
+                new DataPoint(){ Features = new float[3] {0, 1, 0} },
+                new DataPoint(){ Features = new float[3] {0, 2, 1} },
+                new DataPoint(){ Features = new float[3] {-100, 50, -100} }
             };
 
             // Convert the List<DataPoint> to IDataView, a consumble format to ML.NET functions.
@@ -56,13 +41,6 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
             var results = mlContext.Data.CreateEnumerable<Result>(transformed, reuseRowObject: false).ToList();
 
             // Let's go through all predictions.
-            // Lines printed out should be
-            //   The 0 - th example with features[1, 0, 0] is an inlier with a score of being inlier 0.7453707
-            //   The 1 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 2 - th example with features[1, 2, 3] is an inlier with a score of being inlier 0.8450122
-            //   The 3 - th example with features[0, 1, 0] is an inlier with a score of being inlier 0.9428905
-            //   The 4 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 5 - th example with features[-100, 50, -100] is an outlier with a score of being inlier 0
             for (int i = 0; i < samples.Count; ++i)
             {
                 // The i-th example's prediction result.
@@ -80,6 +58,29 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
                     Console.WriteLine("The {0}-th example with features [{1}] is an outlier with a score of being inlier {2}",
                         i, featuresInText, result.Score);
             }
+            // Lines printed out should be
+            //   The 0 - th example with features[1, 0, 0] is an inlier with a score of being inlier 0.7453707
+            //   The 1 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
+            //   The 2 - th example with features[1, 2, 3] is an inlier with a score of being inlier 0.8450122
+            //   The 3 - th example with features[0, 1, 0] is an inlier with a score of being inlier 0.9428905
+            //   The 4 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
+            //   The 5 - th example with features[-100, 50, -100] is an outlier with a score of being inlier 0
+        }
+
+        // Example with 3 feature values. A training data set is a collection of such examples.
+        private class DataPoint
+        {
+            [VectorType(3)]
+            public float[] Features { get; set; }
+        }
+
+        // Class used to capture prediction of DataPoint.
+        private class Result
+        {
+            // Outlier gets false while inlier has true.
+            public bool PredictedLabel { get; set; }
+            // Outlier gets smaller score.
+            public float Score { get; set; }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
                 new DataPoint(){ Features= new float[3] {1, 2, 3} },
                 new DataPoint(){ Features= new float[3] {0, 1, 0} },
                 new DataPoint(){ Features= new float[3] {0, 2, 1} },
-                new DataPoint(){ Features= new float[3] {-100, -50, -100} }
+                new DataPoint(){ Features= new float[3] {-100, 50, -100} }
             };
 
             // Convert native C# class to IDataView, a consumble format to ML.NET functions.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
+{
+    public static class RandomizedPcaSample
+    {
+        /// <summary>
+        /// Example with 3 feature values.
+        /// </summary>
+        private class DataPoint
+        {
+            [VectorType(3)]
+            public float[] Features;
+        }
+
+        /// <summary>
+        /// Class used to capture prediction of <see cref="DataPoint"/> in <see cref="Example"/>.
+        /// </summary>
+        // We disable this warning because complier doesn't realize those fields below are assigned somewhere.
+#pragma warning disable 649
+        private class Result
+        {
+            // Outlier gets false while inlier has true.
+            public bool PredictedLabel;
+            // Outlier gets smaller score.
+            public float Score;
+        }
+#pragma warning restore 649
+
+        public static void Example()
+        {
+            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // as a catalog of available operations and as the source of randomness.
+            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            var mlContext = new MLContext(seed: 0);
+
+            var samples = new List<DataPoint>()
+            {
+                new DataPoint(){ Features= new float[3] {1, 0, 0} },
+                new DataPoint(){ Features= new float[3] {0, 2, 1} },
+                new DataPoint(){ Features= new float[3] {1, 2, 3} },
+                new DataPoint(){ Features= new float[3] {0, 1, 0} },
+                new DataPoint(){ Features= new float[3] {0, 2, 1} },
+                new DataPoint(){ Features= new float[3] {-100, -50, -100} }
+            };
+
+            // Convert native C# class to IDataView, a consumble format to ML.NET functions.
+            var data = mlContext.Data.LoadFromEnumerable(samples);
+
+            // Create an anomaly detector. Its underlying algorithm is randomized PCA.
+            var pipeline = mlContext.AnomalyDetection.Trainers.RandomizedPca(featureColumnName: nameof(DataPoint.Features), rank: 1, center: false);
+
+            // Train the anomaly detector.
+            var model = pipeline.Fit(data);
+
+            // Apply the trained model on the training data.
+            var transformed = model.Transform(data);
+
+            // Read ML.NET predictions into C# class.
+            var results = mlContext.Data.CreateEnumerable<Result>(transformed, reuseRowObject: false).ToList();
+
+            // Let's go through all predictions.
+            for (int i = 0; i < samples.Count; ++i)
+            {
+                // The i-th example's prediction result.
+                var result = results[i];
+
+                // The i-th example's feature vector in text format.
+                var featuresInText = string.Join(',', samples[i].Features);
+
+                if (result.PredictedLabel)
+                    // The i-th sample is predicted as an inlier.
+                    Console.WriteLine("The {0}-th example with features [{1}] is an inlier with a score of being inlier {2}",
+                        i, featuresInText, result.Score);
+                else
+                    // The i-th sample is predicted as an outlier.
+                    Console.WriteLine("The {0}-th example with features [{1}] is an outlier with a score of being inlier {2}",
+                        i, featuresInText, result.Score);
+            }
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
@@ -7,22 +7,6 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
 {
     public static class RandomizedPcaSampleWithOptions
     {
-        // Example with 3 feature values. A training data set is a collection of such examples.
-        private class DataPoint
-        {
-            [VectorType(3)]
-            public float[] Features { get; set; }
-        }
-
-        // Class used to capture prediction of DataPoint.
-        private class Result
-        {
-            // Outlier gets false while inlier has true.
-            public bool PredictedLabel { get; set; }
-            // Outlier gets smaller score.
-            public float Score { get; set; }
-        }
-
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
@@ -30,14 +14,15 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
             // Setting the seed to a fixed number in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
+            // Training data.
             var samples = new List<DataPoint>()
             {
-                new DataPoint(){ Features= new float[3] {1, 0, 0} },
-                new DataPoint(){ Features= new float[3] {0, 2, 1} },
-                new DataPoint(){ Features= new float[3] {1, 2, 3} },
-                new DataPoint(){ Features= new float[3] {0, 1, 0} },
-                new DataPoint(){ Features= new float[3] {0, 2, 1} },
-                new DataPoint(){ Features= new float[3] {-100, 50, -100} }
+                new DataPoint(){ Features = new float[3] {1, 0, 0} },
+                new DataPoint(){ Features = new float[3] {0, 2, 1} },
+                new DataPoint(){ Features = new float[3] {1, 2, 3} },
+                new DataPoint(){ Features = new float[3] {0, 1, 0} },
+                new DataPoint(){ Features = new float[3] {0, 2, 1} },
+                new DataPoint(){ Features = new float[3] {-100, 50, -100} }
             };
 
             // Convert the List<DataPoint> to IDataView, a consumble format to ML.NET functions.
@@ -63,13 +48,6 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
             var results = mlContext.Data.CreateEnumerable<Result>(transformed, reuseRowObject: false).ToList();
 
             // Let's go through all predictions.
-            // Lines printed out should be
-            //   The 0 - th example with features[1, 0, 0] is an inlier with a score of being inlier 0.7453707
-            //   The 1 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 2 - th example with features[1, 2, 3] is an inlier with a score of being inlier 0.8450122
-            //   The 3 - th example with features[0, 1, 0] is an inlier with a score of being inlier 0.9428905
-            //   The 4 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 5 - th example with features[-100, 50, -100] is an outlier with a score of being inlier 0
             for (int i = 0; i < samples.Count; ++i)
             {
                 // The i-th example's prediction result.
@@ -87,6 +65,29 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
                     Console.WriteLine("The {0}-th example with features [{1}] is an outlier with a score of being inlier {2}",
                         i, featuresInText, result.Score);
             }
+            // Lines printed out should be
+            //   The 0 - th example with features[1, 0, 0] is an inlier with a score of being inlier 0.7453707
+            //   The 1 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
+            //   The 2 - th example with features[1, 2, 3] is an inlier with a score of being inlier 0.8450122
+            //   The 3 - th example with features[0, 1, 0] is an inlier with a score of being inlier 0.9428905
+            //   The 4 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
+            //   The 5 - th example with features[-100, 50, -100] is an outlier with a score of being inlier 0
+        }
+
+        // Example with 3 feature values. A training data set is a collection of such examples.
+        private class DataPoint
+        {
+            [VectorType(3)]
+            public float[] Features { get; set; }
+        }
+
+        // Class used to capture prediction of DataPoint.
+        private class Result
+        {
+            // Outlier gets false while inlier has true.
+            public bool PredictedLabel { get; set; }
+            // Outlier gets smaller score.
+            public float Score { get; set; }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
@@ -11,18 +11,16 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
         private class DataPoint
         {
             [VectorType(3)]
-            public float[] Features;
+            public float[] Features { get; set; }
         }
 
         // Class used to capture prediction of DataPoint.
-        // Please disable warning 649 if complier says those fields are never assigned. They will
-        // be assigned in runtime.
         private class Result
         {
             // Outlier gets false while inlier has true.
-            public bool PredictedLabel;
+            public bool PredictedLabel { get; set; }
             // Outlier gets smaller score.
-            public float Score;
+            public float Score { get; set; }
         }
 
         public static void Example()

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
 {
-    class RandomizedPcaSampleWithOptions
+    public static class RandomizedPcaSampleWithOptions
     {
         // Example with 3 feature values. A training data set is a collection of such examples.
         private class DataPoint

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
 {
-    public static class RandomizedPcaSample
+    class RandomizedPcaSampleWithOptions
     {
         // Example with 3 feature values. A training data set is a collection of such examples.
         private class DataPoint
@@ -45,8 +45,15 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
             // Convert the List<DataPoint> to IDataView, a consumble format to ML.NET functions.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
+            var options = new ML.Trainers.RandomizedPcaTrainer.Options()
+            {
+                FeatureColumnName = nameof(DataPoint.Features),
+                Rank = 1,
+                Seed = 10,
+            };
+
             // Create an anomaly detector. Its underlying algorithm is randomized PCA.
-            var pipeline = mlContext.AnomalyDetection.Trainers.RandomizedPca(featureColumnName: nameof(DataPoint.Features), rank: 1, center: false);
+            var pipeline = mlContext.AnomalyDetection.Trainers.RandomizedPca(options);
 
             // Train the anomaly detector.
             var model = pipeline.Fit(data);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.ML.Data;
 using static Microsoft.ML.SamplesUtils.DatasetUtils;
 
 namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 using static Microsoft.ML.SamplesUtils.DatasetUtils;
 

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
+    <NoWarn>1701;1702;0649</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <NoWarn>1701;1702;0649</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.PCA/PCACatalog.cs
+++ b/src/Microsoft.ML.PCA/PCACatalog.cs
@@ -47,6 +47,12 @@ namespace Microsoft.ML
         /// <param name="oversampling">Oversampling parameter for randomized PCA training.</param>
         /// <param name="center">If enabled, data is centered to be zero mean.</param>
         /// <param name="seed">The seed for random number generation.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[RPCA](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs)]
+        /// ]]></format>
+        /// </example>
         public static RandomizedPcaTrainer RandomizedPca(this AnomalyDetectionCatalog.AnomalyDetectionTrainers catalog,
             string featureColumnName = DefaultColumnNames.Features,
             string exampleWeightColumnName = null,
@@ -65,6 +71,12 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The anomaly detection catalog trainer object.</param>
         /// <param name="options">Advanced options to the algorithm.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[RPCA](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs)]
+        /// ]]></format>
+        /// </example>
         public static RandomizedPcaTrainer RandomizedPca(this AnomalyDetectionCatalog.AnomalyDetectionTrainers catalog, Options options)
         {
             Contracts.CheckValue(catalog, nameof(catalog));

--- a/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
+++ b/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
@@ -85,21 +85,19 @@ namespace Microsoft.ML.Tests
         private class DataPoint
         {
             [VectorType(3)]
-            public float[] Features;
+            public float[] Features { get; set; }
         }
 
         /// <summary>
         /// Class used to capture prediction of <see cref="DataPoint"/> in <see cref="ExecutePipelineWithGivenRandomizedPcaTrainer"/>.
         /// </summary>
-#pragma warning disable 649
         private class Result
         {
             // Outlier gets false while inlier has true.
-            public bool PredictedLabel;
+            public bool PredictedLabel { get; set; }
             // Outlier gets smaller score.
-            public float Score;
+            public float Score { get; set; }
         }
-#pragma warning restore 649
 
         /// <summary>
         /// Help function used to execute trainers defined in <see cref="RandomizedPcaInMemory"/>.

--- a/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
+++ b/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML.Data;
 using Microsoft.ML.RunTests;
@@ -46,6 +48,75 @@ namespace Microsoft.ML.Tests
             var transformedData = DetectAnomalyInMnistOneClass(trainPath, trainPath);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => ML.AnomalyDetection.Evaluate(transformedData));
+        }
+
+        /// <summary>
+        /// Example with 3 feature values.
+        /// </summary>
+        private class DataPoint
+        {
+            [VectorType(3)]
+            public float[] Features;
+        }
+
+        /// <summary>
+        /// Class used to capture prediction of <see cref="DataPoint"/> in <see cref="RandomizedPcaInMemory"/>.
+        /// </summary>
+#pragma warning disable 649
+        private class Result
+        {
+            // Outlier gets false while inlier has true.
+            public bool PredictedLabel;
+            // Outlier gets smaller score.
+            public float Score;
+        }
+#pragma warning restore 649
+
+        [Fact]
+        public void RandomizedPcaInMemory()
+        {
+            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // as a catalog of available operations and as the source of randomness.
+            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            var mlContext = new MLContext(seed: 0);
+
+            var samples = new List<DataPoint>()
+            {
+                new DataPoint(){ Features= new float[3] {1, 0, 0} },
+                new DataPoint(){ Features= new float[3] {0, 2, 1} },
+                new DataPoint(){ Features= new float[3] {1, 2, 3} },
+                new DataPoint(){ Features= new float[3] {0, 1, 0} },
+                new DataPoint(){ Features= new float[3] {0, 2, 1} },
+                new DataPoint(){ Features= new float[3] {-100, -50, -100} }
+            };
+
+            // Convert native C# class to IDataView, a consumble format to ML.NET functions.
+            var data = mlContext.Data.LoadFromEnumerable(samples);
+
+            // Create an anomaly detector. Its underlying algorithm is randomized PCA.
+            var pipeline = mlContext.AnomalyDetection.Trainers.RandomizedPca(featureColumnName: nameof(DataPoint.Features), rank: 1, center: false);
+
+            // Train the anomaly detector.
+            var model = pipeline.Fit(data);
+
+            // Apply the trained model on the training data.
+            var transformed = model.Transform(data);
+
+            // Read ML.NET predictions into C# class.
+            var results = mlContext.Data.CreateEnumerable<Result>(transformed, reuseRowObject: false).ToList();
+
+            // First 5 examples are inliers.
+            for (int i = 0; i < 5; ++i)
+            {
+                // Inlier should be predicted as true.
+                Assert.True(results[i].PredictedLabel);
+                // Higher score means closer to inlier.
+                Assert.InRange(results[i].Score, 0.3, 1);
+            }
+
+            // Last example is outlier. Note that outlier should be predicted as false.
+            Assert.False(results[5].PredictedLabel);
+            Assert.InRange(results[5].Score, 0, 0.3);
         }
 
         private IDataView DetectAnomalyInMnistOneClass(string trainPath, string testPath)

--- a/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
+++ b/test/Microsoft.ML.Tests/AnomalyDetectionTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Tests
                 new DataPoint(){ Features= new float[3] {-100, 50, -100} }
             };
 
-            // Convert native C# class to IDataView, a consumble format to ML.NET functions.
+            // Convert the List<DataPoint> to IDataView, a consumble format to ML.NET functions.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
             // Train the anomaly detector.
@@ -125,7 +125,7 @@ namespace Microsoft.ML.Tests
             // Apply the trained model on the training data.
             var transformed = model.Transform(data);
 
-            // Read ML.NET predictions into C# class.
+            // Read ML.NET predictions into IEnumerable<Result>.
             var results = mlContext.Data.CreateEnumerable<Result>(transformed, reuseRowObject: false).ToList();
 
             // First 5 examples are inliers.


### PR DESCRIPTION
As title. It also shows some benefits of using in-memory data described in #2726.

