### PR TITLE
Replace predicate with an IEnumerable<DataViewSchema.Column> for IRowToRowMapper.GetRow and  ISchemaBoundRowMapper.GetRow

### DIFF
--- a/src/Microsoft.Data.DataView/DataViewSchema.cs
+++ b/src/Microsoft.Data.DataView/DataViewSchema.cs
@@ -217,14 +217,14 @@ namespace Microsoft.Data.DataView
             /// <summary>
             /// Get a getter delegate for one value of the annotations row.
             /// </summary>
-            public ValueGetter<TValue> GetGetter<TValue>(int col)
+            public ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                if (!(0 <= col && col < Schema.Count))
-                    throw new ArgumentOutOfRangeException(nameof(col));
-                var typedGetter = _getters[col] as ValueGetter<TValue>;
+                if (!(0 <= columnIndex && columnIndex < Schema.Count))
+                    throw new ArgumentOutOfRangeException(nameof(columnIndex));
+                var typedGetter = _getters[columnIndex] as ValueGetter<TValue>;
                 if (typedGetter == null)
                 {
-                    Debug.Assert(_getters[col] != null);
+                    Debug.Assert(_getters[columnIndex] != null);
                     throw new InvalidOperationException($"Invalid call to '{nameof(GetGetter)}'");
                 }
                 return typedGetter;

--- a/src/Microsoft.Data.DataView/DataViewSchema.cs
+++ b/src/Microsoft.Data.DataView/DataViewSchema.cs
@@ -217,14 +217,14 @@ namespace Microsoft.Data.DataView
             /// <summary>
             /// Get a getter delegate for one value of the annotations row.
             /// </summary>
-            public ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            public ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                if (!(0 <= columnIndex && columnIndex < Schema.Count))
-                    throw new ArgumentOutOfRangeException(nameof(columnIndex));
-                var typedGetter = _getters[columnIndex] as ValueGetter<TValue>;
+                if (column.Index >= _getters.Length)
+                    throw new ArgumentException(nameof(column));
+                var typedGetter = _getters[column.Index] as ValueGetter<TValue>;
                 if (typedGetter == null)
                 {
-                    Debug.Assert(_getters[columnIndex] != null);
+                    Debug.Assert(_getters[column.Index] != null);
                     throw new InvalidOperationException($"Invalid call to '{nameof(GetGetter)}'");
                 }
                 return typedGetter;
@@ -238,7 +238,7 @@ namespace Microsoft.Data.DataView
                 var column = Schema.GetColumnOrNull(kind);
                 if (column == null)
                     throw new InvalidOperationException($"Invalid call to '{nameof(GetValue)}'");
-                GetGetter<TValue>(column.Value.Index)(ref value);
+                GetGetter<TValue>(column.Value)(ref value);
             }
 
             public override string ToString() => string.Join(", ", Schema.Select(x => x.Name));

--- a/src/Microsoft.Data.DataView/IDataView.cs
+++ b/src/Microsoft.Data.DataView/IDataView.cs
@@ -132,9 +132,9 @@ namespace Microsoft.Data.DataView
         public abstract ValueGetter<DataViewRowId> GetIdGetter();
 
         /// <summary>
-        /// Returns whether the column with the given index, is active in this row.
+        /// Returns whether the give column is active in this row.
         /// </summary>
-        public abstract bool IsColumnActive(int columnIndex);
+        public abstract bool IsColumnActive(DataViewSchema.Column column);
 
         /// <summary>
         /// Returns a value getter delegate to fetch the value of the given <paramref name="column"/>, from the row.

--- a/src/Microsoft.Data.DataView/IDataView.cs
+++ b/src/Microsoft.Data.DataView/IDataView.cs
@@ -141,6 +141,8 @@ namespace Microsoft.Data.DataView
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
+        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
         public abstract ValueGetter<TValue> GetGetter<TValue>(int columnIndex);
 
         /// <summary>

--- a/src/Microsoft.Data.DataView/IDataView.cs
+++ b/src/Microsoft.Data.DataView/IDataView.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Data.DataView
         public abstract ValueGetter<DataViewRowId> GetIdGetter();
 
         /// <summary>
-        /// Returns whether the give column is active in this row.
+        /// Returns whether the given column is active in this row.
         /// </summary>
         public abstract bool IsColumnActive(DataViewSchema.Column column);
 
@@ -141,7 +141,7 @@ namespace Microsoft.Data.DataView
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
-        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+        /// <typeparam name="TValue"> is the column's content type.</typeparam>
         /// <param name="column"> is the output column whose getter should be returned.</param>
         public abstract ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column);
 

--- a/src/Microsoft.Data.DataView/IDataView.cs
+++ b/src/Microsoft.Data.DataView/IDataView.cs
@@ -132,16 +132,16 @@ namespace Microsoft.Data.DataView
         public abstract ValueGetter<DataViewRowId> GetIdGetter();
 
         /// <summary>
-        /// Returns whether the given column is active in this row.
+        /// Returns whether the column with the given index, is active in this row.
         /// </summary>
-        public abstract bool IsColumnActive(int col);
+        public abstract bool IsColumnActive(int columnIndex);
 
         /// <summary>
-        /// Returns a value getter delegate to fetch the given column value from the row.
+        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
-        public abstract ValueGetter<TValue> GetGetter<TValue>(int col);
+        public abstract ValueGetter<TValue> GetGetter<TValue>(int columnIndex);
 
         /// <summary>
         /// Gets a <see cref="Schema"/>, which provides name and type information for variables

--- a/src/Microsoft.Data.DataView/IDataView.cs
+++ b/src/Microsoft.Data.DataView/IDataView.cs
@@ -137,13 +137,13 @@ namespace Microsoft.Data.DataView
         public abstract bool IsColumnActive(int columnIndex);
 
         /// <summary>
-        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+        /// Returns a value getter delegate to fetch the value of the given <paramref name="column"/>, from the row.
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
         /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-        public abstract ValueGetter<TValue> GetGetter<TValue>(int columnIndex);
+        /// <param name="column"> is the output column whose getter should be returned.</param>
+        public abstract ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column);
 
         /// <summary>
         /// Gets a <see cref="Schema"/>, which provides name and type information for variables

--- a/src/Microsoft.Data.DataView/SchemaDebuggerProxy.cs
+++ b/src/Microsoft.Data.DataView/SchemaDebuggerProxy.cs
@@ -41,16 +41,16 @@ namespace Microsoft.Data.DataView
             foreach (var column in annotations.Schema)
             {
                 var name = column.Name;
-                var value = Utils.MarshalInvoke(GetValue<int>, column.Type.RawType, annotations, column.Index);
+                var value = Utils.MarshalInvoke(GetValue<DataViewSchema.Column>, column.Type.RawType, annotations, column);
                 result.Add(new KeyValuePair<string, object>(name, value));
             }
             return result;
         }
 
-        private static object GetValue<T>(DataViewSchema.Annotations annotations, int columnIndex)
+        private static object GetValue<T>(DataViewSchema.Annotations annotations, DataViewSchema.Column column)
         {
             T value = default;
-            annotations.GetGetter<T>(annotations.Schema[columnIndex])(ref value);
+            annotations.GetGetter<T>(column)(ref value);
             return value;
         }
     }

--- a/src/Microsoft.Data.DataView/SchemaDebuggerProxy.cs
+++ b/src/Microsoft.Data.DataView/SchemaDebuggerProxy.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.DataView
         private static object GetValue<T>(DataViewSchema.Annotations annotations, int columnIndex)
         {
             T value = default;
-            annotations.GetGetter<T>(columnIndex)(ref value);
+            annotations.GetGetter<T>(annotations.Schema[columnIndex])(ref value);
             return value;
         }
     }

--- a/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
+++ b/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
@@ -460,9 +460,22 @@ namespace Microsoft.ML.Data
             public override DataViewSchema Schema => _annotations.Schema;
             public override long Position => 0;
             public override long Batch => 0;
-            public override ValueGetter<TValue> GetGetter<TValue>(int col) => _annotations.GetGetter<TValue>(col);
+
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _annotations.GetGetter<TValue>(columnIndex);
+
             public override ValueGetter<DataViewRowId> GetIdGetter() => (ref DataViewRowId dst) => dst = default;
-            public override bool IsColumnActive(int col) => true;
+
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex) => true;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
+++ b/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
@@ -475,7 +475,7 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex) => true;
+            public override bool IsColumnActive(DataViewSchema.Column column) => true;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
+++ b/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
@@ -466,7 +466,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column) => _annotations.GetGetter<TValue>(column);
 

--- a/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
+++ b/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
@@ -462,13 +462,13 @@ namespace Microsoft.ML.Data
             public override long Batch => 0;
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _annotations.GetGetter<TValue>(columnIndex);
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column) => _annotations.GetGetter<TValue>(column);
 
             public override ValueGetter<DataViewRowId> GetIdGetter() => (ref DataViewRowId dst) => dst = default;
 

--- a/src/Microsoft.ML.Core/Data/IRowToRowMapper.cs
+++ b/src/Microsoft.ML.Core/Data/IRowToRowMapper.cs
@@ -35,8 +35,7 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// Get an <see cref="DataViewRow"/> with the indicated active columns, based on the input <paramref name="input"/>.
-        /// The active columns are those for which <paramref name="active"/> returns true. Getting values on inactive
-        /// columns of the returned row will throw. Null predicates are disallowed.
+        /// Getting values on inactive columns of the returned row will throw.
         ///
         /// The <see cref="DataViewRow.Schema"/> of <paramref name="input"/> should be the same object as
         /// <see cref="InputSchema"/>. Implementors of this method should throw if that is not the case. Conversely,
@@ -48,6 +47,6 @@ namespace Microsoft.ML.Data
         /// The output <see cref="DataViewRow"/> values are re-computed when requested through the getters. Also, the returned
         /// <see cref="DataViewRow"/> will dispose <paramref name="input"/> when it is disposed.
         /// </summary>
-        DataViewRow GetRow(DataViewRow input, Func<int, bool> active);
+        DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns);
     }
 }

--- a/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
+++ b/src/Microsoft.ML.Core/Data/ISchemaBindableMapper.cs
@@ -73,8 +73,7 @@ namespace Microsoft.ML.Data
 
         /// <summary>
         /// Get an <see cref="DataViewRow"/> with the indicated active columns, based on the input <paramref name="input"/>.
-        /// The active columns are those for which <paramref name="active"/> returns true. Getting values on inactive
-        /// columns of the returned row will throw. Null predicates are disallowed.
+        /// Getting values on inactive columns of the returned row will throw.
         ///
         /// The <see cref="DataViewRow.Schema"/> of <paramref name="input"/> should be the same object as
         /// <see cref="InputSchema"/>. Implementors of this method should throw if that is not the case. Conversely,
@@ -86,6 +85,6 @@ namespace Microsoft.ML.Data
         /// The output <see cref="DataViewRow"/> values are re-computed when requested through the getters. Also, the returned
         /// <see cref="DataViewRow"/> will dispose <paramref name="input"/> when it is disposed.
         /// </summary>
-        DataViewRow GetRow(DataViewRow input, Func<int, bool> active);
+        DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns);
     }
 }

--- a/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Data
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
-        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+        /// <typeparam name="TValue"> is the column's content type.</typeparam>
         /// <param name="column"> is the output column whose getter should be returned.</param>
         public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
         {

--- a/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
@@ -29,15 +29,25 @@ namespace Microsoft.ML.Data
             Schema = schema;
         }
 
-        public sealed override bool IsColumnActive(int col)
+        /// <summary>
+        /// Returns whether the given column is active in this row.
+        /// </summary>
+        public sealed override bool IsColumnActive(int columnIndex)
         {
-            Ch.Check(0 <= col && col < Schema.Count);
-            return _active == null || _active[col];
+            Ch.Check(0 <= columnIndex && columnIndex < Schema.Count);
+            return _active == null || _active[columnIndex];
         }
 
-        public override ValueGetter<TValue> GetGetter<TValue>(int col)
+        /// <summary>
+        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+        /// This throws if the column is not active in this row, or if the type
+        /// <typeparamref name="TValue"/> differs from this column's type.
+        /// </summary>
+        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+        public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
         {
-            return Input.GetGetter<TValue>(col);
+            return Input.GetGetter<TValue>(columnIndex);
         }
     }
 }

--- a/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
@@ -32,10 +32,10 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Returns whether the given column is active in this row.
         /// </summary>
-        public sealed override bool IsColumnActive(int columnIndex)
+        public sealed override bool IsColumnActive(DataViewSchema.Column column)
         {
-            Ch.Check(0 <= columnIndex && columnIndex < Schema.Count);
-            return _active == null || _active[columnIndex];
+            Ch.Check(column.Index < Schema.Count);
+            return _active == null || _active[column.Index];
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
+++ b/src/Microsoft.ML.Core/Data/LinkedRowRootCursorBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Data
     /// <summary>
     /// A base class for a <see cref="DataViewRowCursor"/> that has an input cursor, but still needs to do work on
     /// <see cref="DataViewRowCursor.MoveNext"/>. Note that the default
-    /// <see cref="LinkedRowRootCursorBase.GetGetter{TValue}(int)"/> assumes that each input column is exposed as an
+    /// <see cref="LinkedRowRootCursorBase.GetGetter{TValue}(DataViewSchema.Column)"/> assumes that each input column is exposed as an
     /// output column with the same column index.
     /// </summary>
     [BestFriend]
@@ -39,15 +39,15 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+        /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
         /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-        public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+        /// <param name="column"> is the output column whose getter should be returned.</param>
+        public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
         {
-            return Input.GetGetter<TValue>(columnIndex);
+            return Input.GetGetter<TValue>(column);
         }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -782,6 +782,42 @@ namespace Microsoft.ML.Internal.Utilities
         /// map.
         /// </summary>
         /// <param name="lim">Indicates the exclusive upper bound on the tested values</param>
+        /// <param name="schema">The input schema where the predicate can checkif columns are active.</param>
+        /// <param name="pred">The predicate to test for various value</param>
+        /// <param name="map">An ascending array of values from 0 inclusive
+        /// to <paramref name="lim"/> exclusive, holding all values for which
+        /// <paramref name="pred"/> is true</param>
+        /// <param name="invMap">Forms an inverse mapping of <paramref name="map"/>,
+        /// so that <c><paramref name="invMap"/>[<paramref name="map"/>[i]] == i</c>,
+        /// and for other entries not appearing in <paramref name="map"/>,
+        /// <c><paramref name="invMap"/>[i] == -1</c></param>
+        public static void BuildSubsetMaps(int lim, DataViewSchema schema, Func<DataViewSchema.Column, bool> pred, out int[] map, out int[] invMap)
+        {
+            Contracts.CheckParam(lim >= 0, nameof(lim));
+            Contracts.CheckValue(pred, nameof(pred));
+            // REVIEW: Better names?
+            List<int> mapList = new List<int>();
+            invMap = new int[lim];
+            for (int c = 0; c < lim; ++c)
+            {
+                if (!pred(schema[c]))
+                {
+                    invMap[c] = -1;
+                    continue;
+                }
+                invMap[c] = mapList.Count;
+                mapList.Add(c);
+            }
+            map = mapList.ToArray();
+        }
+
+        //SENJA: REMOVE BEFORE COMMIT
+        /// <summary>
+        /// Given a predicate, over a range of values defined by a limit calculate
+        /// first the values for which that predicate was true, and second an inverse
+        /// map.
+        /// </summary>
+        /// <param name="lim">Indicates the exclusive upper bound on the tested values</param>
         /// <param name="pred">The predicate to test for various value</param>
         /// <param name="map">An ascending array of values from 0 inclusive
         /// to <paramref name="lim"/> exclusive, holding all values for which

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -781,24 +781,24 @@ namespace Microsoft.ML.Internal.Utilities
         /// first the values for which that predicate was true, and second an inverse
         /// map.
         /// </summary>
-        /// <param name="lim">Indicates the exclusive upper bound on the tested values</param>
-        /// <param name="schema">The input schema where the predicate can checkif columns are active.</param>
+        /// <param name="schema">The input schema where the predicate can check if columns are active.</param>
         /// <param name="pred">The predicate to test for various value</param>
         /// <param name="map">An ascending array of values from 0 inclusive
-        /// to <paramref name="lim"/> exclusive, holding all values for which
+        /// to <paramref name="schema.Count"/> exclusive, holding all values for which
         /// <paramref name="pred"/> is true</param>
         /// <param name="invMap">Forms an inverse mapping of <paramref name="map"/>,
         /// so that <c><paramref name="invMap"/>[<paramref name="map"/>[i]] == i</c>,
         /// and for other entries not appearing in <paramref name="map"/>,
         /// <c><paramref name="invMap"/>[i] == -1</c></param>
-        public static void BuildSubsetMaps(int lim, DataViewSchema schema, Func<DataViewSchema.Column, bool> pred, out int[] map, out int[] invMap)
+        public static void BuildSubsetMaps(DataViewSchema schema, Func<DataViewSchema.Column, bool> pred, out int[] map, out int[] invMap)
         {
-            Contracts.CheckParam(lim >= 0, nameof(lim));
+            Contracts.CheckValue(schema, nameof(schema));
+            Contracts.Check(schema.Count > 0, nameof(schema));
             Contracts.CheckValue(pred, nameof(pred));
             // REVIEW: Better names?
             List<int> mapList = new List<int>();
-            invMap = new int[lim];
-            for (int c = 0; c < lim; ++c)
+            invMap = new int[schema.Count];
+            for (int c = 0; c < schema.Count; ++c)
             {
                 if (!pred(schema[c]))
                 {
@@ -811,7 +811,6 @@ namespace Microsoft.ML.Internal.Utilities
             map = mapList.ToArray();
         }
 
-        //SENJA: REMOVE BEFORE COMMIT
         /// <summary>
         /// Given a predicate, over a range of values defined by a limit calculate
         /// first the values for which that predicate was true, and second an inverse

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -173,14 +173,14 @@ namespace Microsoft.ML.Data
         /// Return whether all the active columns, as determined by the predicate, are
         /// cachable - either primitive types or vector types.
         /// </summary>
-        public static bool AllCacheable(DataViewSchema schema, Func<int, bool> predicate)
+        public static bool AllCacheable(DataViewSchema schema, Func<DataViewSchema.Column, bool> predicate)
         {
             Contracts.CheckValue(schema, nameof(schema));
             Contracts.CheckValue(predicate, nameof(predicate));
 
             for (int col = 0; col < schema.Count; col++)
             {
-                if (!predicate(col))
+                if (!predicate(schema[col]))
                     continue;
                 var type = schema[col].Type;
                 if (!IsCacheable(type))
@@ -239,10 +239,10 @@ namespace Microsoft.ML.Data
             // All cursors must have the same columns active.
             for (int c = 0; c < schema.Count; ++c)
             {
-                bool active = firstCursor.IsColumnActive(c);
+                bool active = firstCursor.IsColumnActive(schema[c]);
                 for (int i = 1; i < cursors.Length; ++i)
                 {
-                    if (cursors[i].IsColumnActive(c) != active)
+                    if (cursors[i].IsColumnActive(schema[c]) != active)
                         return false;
                 }
             }
@@ -334,7 +334,7 @@ namespace Microsoft.ML.Data
 
                 int[] activeToCol;
                 int[] colToActive;
-                Utils.BuildSubsetMaps(schema.Count, cursor.IsColumnActive, out activeToCol, out colToActive);
+                Utils.BuildSubsetMaps(schema.Count, schema, cursor.IsColumnActive, out activeToCol, out colToActive);
 
                 // Because the schema of the consolidator is not necessary fixed, we are merely
                 // opportunistic about buffer sharing, from cursoring to cursoring. If we can do
@@ -517,7 +517,7 @@ namespace Microsoft.ML.Data
                 // Create the mappings between active column index, and column index.
                 int[] activeToCol;
                 int[] colToActive;
-                Utils.BuildSubsetMaps(_schema.Count, input.IsColumnActive, out activeToCol, out colToActive);
+                Utils.BuildSubsetMaps(_schema.Count, _schema, input.IsColumnActive, out activeToCol, out colToActive);
 
                 Func<DataViewRowCursor, int, InPipe> createFunc = CreateInPipe<int>;
                 var inGenMethod = createFunc.GetMethodInfo().GetGenericMethodDefinition();
@@ -534,14 +534,14 @@ namespace Microsoft.ML.Data
                 {
                     ch.Assert(0 <= activeToCol[c] && activeToCol[c] < _schema.Count);
                     ch.Assert(c == 0 || activeToCol[c - 1] < activeToCol[c]);
-                    ch.Assert(input.IsColumnActive(activeToCol[c]));
-                    var type = input.Schema[activeToCol[c]].Type;
-                    ch.Assert(type.IsCacheable());
+                    var column = input.Schema[activeToCol[c]];
+                    ch.Assert(input.IsColumnActive(column));
+                    ch.Assert(column.Type.IsCacheable());
                     arguments[1] = activeToCol[c];
                     var inPipe = inPipes[c] =
-                        (InPipe)inGenMethod.MakeGenericMethod(type.RawType).Invoke(this, arguments);
+                        (InPipe)inGenMethod.MakeGenericMethod(column.Type.RawType).Invoke(this, arguments);
                     for (int i = 0; i < cthd; ++i)
-                        outPipes[i][c] = inPipe.CreateOutPipe(type);
+                        outPipes[i][c] = inPipe.CreateOutPipe(column.Type);
                 }
                 // Beyond the InPipes corresponding to column values, we have extra side info pipes.
                 int idIdx = activeToCol.Length + (int)ExtraIndex.Id;
@@ -1105,10 +1105,10 @@ namespace Microsoft.ML.Data
                 /// <summary>
                 /// Returns whether the given column is active in this row.
                 /// </summary>
-                public override bool IsColumnActive(int columnIndex)
+                public override bool IsColumnActive(DataViewSchema.Column column)
                 {
-                    Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActive.Length, nameof(columnIndex));
-                    return _colToActive[columnIndex] >= 0;
+                    Ch.CheckParam(column.Index < _colToActive.Length, nameof(column));
+                    return _colToActive[column.Index] >= 0;
                 }
 
                 /// <summary>
@@ -1120,7 +1120,7 @@ namespace Microsoft.ML.Data
                 /// <param name="column"> is the output column whose getter should be returned.</param>
                 public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 {
-                    Ch.CheckParam(IsColumnActive(column.Index), nameof(column), "requested column not active.");
+                    Ch.CheckParam(IsColumnActive(column), nameof(column), "requested column not active.");
                     Ch.CheckParam(column.Index < _colToActive.Length, nameof(column), "requested column is not active or valid for the Schema.");
 
                     var getter = _getters[_colToActive[column.Index]] as ValueGetter<TValue>;
@@ -1180,7 +1180,7 @@ namespace Microsoft.ML.Data
                 _cursors = cursors;
                 _schema = _cursors[0].Schema;
 
-                Utils.BuildSubsetMaps(_schema.Count, _cursors[0].IsColumnActive, out _activeToCol, out _colToActive);
+                Utils.BuildSubsetMaps(_schema.Count, _schema, _cursors[0].IsColumnActive, out _activeToCol, out _colToActive);
 
                 Func<int, Delegate> func = CreateGetter<int>;
                 _methInfo = func.GetMethodInfo().GetGenericMethodDefinition();
@@ -1251,7 +1251,7 @@ namespace Microsoft.ML.Data
                     var cursor = _cursors[i];
                     Ch.AssertValue(cursor);
                     Ch.Assert(col < cursor.Schema.Count);
-                    Ch.Assert(cursor.IsColumnActive(col));
+                    Ch.Assert(cursor.IsColumnActive(Schema[col]));
                     Ch.Assert(type.Equals(cursor.Schema[col].Type));
                     getters[i] = _cursors[i].GetGetter<T>(cursor.Schema[col]);
                 }
@@ -1296,10 +1296,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActive.Length, nameof(columnIndex));
-                return _colToActive[columnIndex] >= 0;
+                Ch.CheckParam(column.Index < _colToActive.Length, nameof(column));
+                return _colToActive[column.Index] >= 0;
             }
 
             /// <summary>
@@ -1311,7 +1311,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(IsColumnActive(column.Index), nameof(column), "requested column not active");
+                Ch.CheckParam(IsColumnActive(column), nameof(column), "requested column not active");
                 Ch.CheckParam(column.Index < _colToActive.Length, nameof(column), "requested column not active or is invalid for the schema. ");
 
                 var getter = _getters[_colToActive[column.Index]] as ValueGetter<TValue>;

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -334,7 +334,7 @@ namespace Microsoft.ML.Data
 
                 int[] activeToCol;
                 int[] colToActive;
-                Utils.BuildSubsetMaps(schema.Count, schema, cursor.IsColumnActive, out activeToCol, out colToActive);
+                Utils.BuildSubsetMaps(schema, cursor.IsColumnActive, out activeToCol, out colToActive);
 
                 // Because the schema of the consolidator is not necessary fixed, we are merely
                 // opportunistic about buffer sharing, from cursoring to cursoring. If we can do
@@ -517,7 +517,7 @@ namespace Microsoft.ML.Data
                 // Create the mappings between active column index, and column index.
                 int[] activeToCol;
                 int[] colToActive;
-                Utils.BuildSubsetMaps(_schema.Count, _schema, input.IsColumnActive, out activeToCol, out colToActive);
+                Utils.BuildSubsetMaps(_schema, input.IsColumnActive, out activeToCol, out colToActive);
 
                 Func<DataViewRowCursor, int, InPipe> createFunc = CreateInPipe<int>;
                 var inGenMethod = createFunc.GetMethodInfo().GetGenericMethodDefinition();
@@ -1116,7 +1116,7 @@ namespace Microsoft.ML.Data
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
-                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <typeparam name="TValue"> is the column's content type.</typeparam>
                 /// <param name="column"> is the output column whose getter should be returned.</param>
                 public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 {
@@ -1180,7 +1180,7 @@ namespace Microsoft.ML.Data
                 _cursors = cursors;
                 _schema = _cursors[0].Schema;
 
-                Utils.BuildSubsetMaps(_schema.Count, _schema, _cursors[0].IsColumnActive, out _activeToCol, out _colToActive);
+                Utils.BuildSubsetMaps(_schema, _cursors[0].IsColumnActive, out _activeToCol, out _colToActive);
 
                 Func<int, Delegate> func = CreateGetter<int>;
                 _methInfo = func.GetMethodInfo().GetGenericMethodDefinition();
@@ -1307,7 +1307,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -1102,16 +1102,26 @@ namespace Microsoft.ML.Data
                     return true;
                 }
 
-                public override bool IsColumnActive(int col)
+                /// <summary>
+                /// Returns whether the given column is active in this row.
+                /// </summary>
+                public override bool IsColumnActive(int columnIndex)
                 {
-                    Ch.CheckParam(0 <= col && col < _colToActive.Length, nameof(col));
-                    return _colToActive[col] >= 0;
+                    Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActive.Length, nameof(columnIndex));
+                    return _colToActive[columnIndex] >= 0;
                 }
 
-                public override ValueGetter<TValue> GetGetter<TValue>(int col)
+                /// <summary>
+                /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                /// This throws if the column is not active in this row, or if the type
+                /// <typeparamref name="TValue"/> differs from this column's type.
+                /// </summary>
+                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
                 {
-                    Ch.CheckParam(IsColumnActive(col), nameof(col), "requested column not active");
-                    var getter = _getters[_colToActive[col]] as ValueGetter<TValue>;
+                    Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column not active");
+                    var getter = _getters[_colToActive[columnIndex]] as ValueGetter<TValue>;
                     if (getter == null)
                         throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                     return getter;
@@ -1281,16 +1291,26 @@ namespace Microsoft.ML.Data
                 return true;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _colToActive.Length, nameof(col));
-                return _colToActive[col] >= 0;
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActive.Length, nameof(columnIndex));
+                return _colToActive[columnIndex] >= 0;
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.CheckParam(IsColumnActive(col), nameof(col), "requested column not active");
-                var getter = _getters[_colToActive[col]] as ValueGetter<TValue>;
+                Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column not active");
+                var getter = _getters[_colToActive[columnIndex]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -555,11 +555,18 @@ namespace Microsoft.ML.Data
 
                 protected override bool MoveNextCore() => Position < 0;
 
-                public override ValueGetter<TValue> GetGetter<TValue>(int col)
+                /// <summary>
+                /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                /// This throws if the column is not active in this row, or if the type
+                /// <typeparamref name="TValue"/> differs from this column's type.
+                /// </summary>
+                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
                 {
-                    Ch.CheckParam(0 <= col && col < Schema.Count, nameof(col));
-                    Ch.CheckParam(IsColumnActive(col), nameof(col), "Requested column is not active");
-                    var getter = _parent._row.GetGetter<TValue>(col);
+                    Ch.CheckParam(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
+                    Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "Requested column is not active");
+                    var getter = _parent._row.GetGetter<TValue>(columnIndex);
                     return
                         (ref TValue val) =>
                         {
@@ -568,13 +575,16 @@ namespace Microsoft.ML.Data
                         };
                 }
 
-                public override bool IsColumnActive(int col)
+                /// <summary>
+                /// Returns whether the given column is active in this row.
+                /// </summary>
+                public override bool IsColumnActive(int columnIndex)
                 {
-                    Ch.CheckParam(0 <= col && col < Schema.Count, nameof(col));
+                    Ch.CheckParam(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
                     // We present the "illusion" that this column is not active, even though it must be
                     // in the input row.
-                    Ch.Assert(_parent._row.IsColumnActive(col));
-                    return _active[col];
+                    Ch.Assert(_parent._row.IsColumnActive(columnIndex));
+                    return _active[columnIndex];
                 }
 
                 public override ValueGetter<DataViewRowId> GetIdGetter()

--- a/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
+++ b/src/Microsoft.ML.Data/Data/RowCursorUtils.cs
@@ -560,7 +560,7 @@ namespace Microsoft.ML.Data
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
-                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <typeparam name="TValue"> is the column's content type.</typeparam>
                 /// <param name="column"> is the output column whose getter should be returned.</param>
                 public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 {

--- a/src/Microsoft.ML.Data/DataDebuggerPreview.cs
+++ b/src/Microsoft.ML.Data/DataDebuggerPreview.cs
@@ -64,13 +64,13 @@ namespace Microsoft.ML.Data
 
         private Action<RowInfo, List<object>> MakeSetter<T>(DataViewRow row, int col)
         {
-            var getter = row.GetGetter<T>(col);
-            string name = row.Schema[col].Name;
+            var column = row.Schema[col];
+            var getter = row.GetGetter<T>(column);
             Action<RowInfo, List<object>> result = (rowInfo, list) =>
             {
                 T value = default;
                 getter(ref value);
-                rowInfo.Values[col] = new KeyValuePair<string, object>(name, value);
+                rowInfo.Values[col] = new KeyValuePair<string, object>(column.Name, value);
 
                 // Call getter again on another buffer, since we store it in two places.
                 value = default;

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -2055,7 +2055,7 @@ namespace Microsoft.ML.Data.IO
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -1989,10 +1989,10 @@ namespace Microsoft.ML.Data.IO
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
-                return _colToActivesIndex[columnIndex] >= 0;
+                Ch.CheckParam(column.Index < _colToActivesIndex.Length, nameof(column));
+                return _colToActivesIndex[column.Index] >= 0;
             }
 
             protected override bool MoveNextCore()

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -1986,10 +1986,13 @@ namespace Microsoft.ML.Data.IO
                 }
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _colToActivesIndex.Length, nameof(col));
-                return _colToActivesIndex[col] >= 0;
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
+                return _colToActivesIndex[columnIndex] >= 0;
             }
 
             protected override bool MoveNextCore()
@@ -2047,11 +2050,18 @@ namespace Microsoft.ML.Data.IO
                 return more;
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _colToActivesIndex.Length, nameof(col));
-                Ch.CheckParam(_colToActivesIndex[col] >= 0, nameof(col), "requested column not active");
-                var getter = _pipeGetters[_colToActivesIndex[col]] as ValueGetter<TValue>;
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
+                Ch.CheckParam(_colToActivesIndex[columnIndex] >= 0, nameof(columnIndex), "requested column not active");
+                var getter = _pipeGetters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -2051,17 +2051,17 @@ namespace Microsoft.ML.Data.IO
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
-                Ch.CheckParam(_colToActivesIndex[columnIndex] >= 0, nameof(columnIndex), "requested column not active");
-                var getter = _pipeGetters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
+                Ch.CheckParam(column.Index < _colToActivesIndex.Length, nameof(column), "requested column not active.");
+
+                var getter = _pipeGetters[_colToActivesIndex[column.Index]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;
@@ -2072,9 +2072,7 @@ namespace Microsoft.ML.Data.IO
             /// a delegate that simply always throws.
             /// </summary>
             private Delegate GetNoRowGetter(DataViewType type)
-            {
-                return Utils.MarshalInvoke(NoRowGetter<int>, type.RawType);
-            }
+                => Utils.MarshalInvoke(NoRowGetter<int>, type.RawType);
 
             private Delegate NoRowGetter<T>()
             {

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinarySaver.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Data.IO
                 var codec = col.Codec as IValueCodec<T>;
                 Contracts.AssertValue(codec);
                 _codec = codec;
-                _getter = cursor.GetGetter<T>(col.SourceIndex);
+                _getter = cursor.GetGetter<T>(cursor.Schema[col.SourceIndex]);
             }
 
             public override void BeginBlock()
@@ -776,7 +776,7 @@ namespace Microsoft.ML.Data.IO
         private void EstimatorCore<T>(DataViewRowCursor cursor, ColumnCodec col,
             out Func<long> fetchWriteEstimator, out IValueWriter writer)
         {
-            ValueGetter<T> getter = cursor.GetGetter<T>(col.SourceIndex);
+            ValueGetter<T> getter = cursor.GetGetter<T>(cursor.Schema[col.SourceIndex]);
             IValueCodec<T> codec = col.Codec as IValueCodec<T>;
             _host.AssertValue(codec);
             IValueWriter<T> specificWriter = codec.OpenWriter(Stream.Null);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
@@ -300,10 +300,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _bindings.Infos.Length);
-                return _active == null || _active[columnIndex];
+                Ch.Check(column.Index < _bindings.Infos.Length);
+                return _active == null || _active[column.Index];
             }
 
             /// <summary>
@@ -316,7 +316,7 @@ namespace Microsoft.ML.Data
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
                 Ch.CheckParam(column.Index < _getters.Length, nameof(column), "requested column not valid.");
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 var fn = _getters[column.Index] as ValueGetter<TValue>;
                 if (fn == null)

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
@@ -307,16 +307,18 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex));
-                var fn = _getters[columnIndex] as ValueGetter<TValue>;
+                Ch.CheckParam(column.Index < _getters.Length, nameof(column), "requested column not valid.");
+                Ch.Check(IsColumnActive(column.Index));
+
+                var fn = _getters[column.Index] as ValueGetter<TValue>;
                 if (fn == null)
                     throw Ch.Except("Invalid TValue in GetGetter: '{0}'", typeof(TValue));
                 return fn;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
@@ -311,7 +311,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderCursor.cs
@@ -297,16 +297,26 @@ namespace Microsoft.ML.Data
                 return false;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.Infos.Length);
-                return _active == null || _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.Infos.Length);
+                return _active == null || _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
-                var fn = _getters[col] as ValueGetter<TValue>;
+                Ch.Check(IsColumnActive(columnIndex));
+                var fn = _getters[columnIndex] as ValueGetter<TValue>;
                 if (fn == null)
                     throw Ch.Except("Invalid TValue in GetGetter: '{0}'", typeof(TValue));
                 return fn;

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextSaver.cs
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Data.IO
             public VecValueWriter(DataViewRowCursor cursor, VectorType type, int source, char sep)
                 : base(type.ItemType, source, sep)
             {
-                _getSrc = cursor.GetGetter<VBuffer<T>>(source);
+                _getSrc = cursor.GetGetter<VBuffer<T>>(cursor.Schema[source]);
                 VectorType typeNames;
                 if (type.IsKnownSize
                     && (typeNames = cursor.Schema[source].Annotations.Schema.GetColumnOrNull(AnnotationUtils.Kinds.SlotNames)?.Type as VectorType) != null
@@ -226,8 +226,9 @@ namespace Microsoft.ML.Data.IO
             public ValueWriter(DataViewRowCursor cursor, PrimitiveDataViewType type, int source, char sep)
                 : base(type, source, sep)
             {
-                _getSrc = cursor.GetGetter<T>(source);
-                _columnName = cursor.Schema[source].Name;
+                var column = cursor.Schema[source];
+                _getSrc = cursor.GetGetter<T>(column);
+                _columnName = column.Name;
             }
 
             public override void WriteData(Action<StringBuilder, int> appendItem, out int length)

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -862,19 +862,29 @@ namespace Microsoft.ML.Data.IO
                 return more;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col <= _colToActivesIndex.Length, nameof(col));
-                return _colToActivesIndex[col] >= 0;
+                Ch.CheckParam(0 <= columnIndex && columnIndex <= _colToActivesIndex.Length, nameof(columnIndex));
+                return _colToActivesIndex[columnIndex] >= 0;
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col <= _colToActivesIndex.Length, nameof(col));
-                Ch.CheckParam(IsColumnActive(col), nameof(col), "requested column not active");
+                Ch.CheckParam(0 <= columnIndex && columnIndex <= _colToActivesIndex.Length, nameof(columnIndex));
+                Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column not active");
 
-                Ch.AssertValue(_getters[_colToActivesIndex[col]]);
-                var getter = _getters[_colToActivesIndex[col]] as ValueGetter<TValue>;
+                Ch.AssertValue(_getters[_colToActivesIndex[columnIndex]]);
+                var getter = _getters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -683,7 +683,7 @@ namespace Microsoft.ML.Data.IO
                 Ch.Assert(cursor.Schema[0].Type is VectorType);
                 _rowCursor = cursor;
 
-                _getter = _rowCursor.GetGetter<VBuffer<T>>(0);
+                _getter = _rowCursor.GetGetter<VBuffer<T>>(cursor.Schema[0]);
             }
 
             public override VectorType GetSlotType()
@@ -872,19 +872,18 @@ namespace Microsoft.ML.Data.IO
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex <= _colToActivesIndex.Length, nameof(columnIndex));
-                Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column not active");
+                Ch.CheckParam(column.Index <= _colToActivesIndex.Length && IsColumnActive(column.Index), nameof(column), "requested column not active");
+                Ch.AssertValue(_getters[_colToActivesIndex[column.Index]]);
 
-                Ch.AssertValue(_getters[_colToActivesIndex[columnIndex]]);
-                var getter = _getters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
+                var getter = _getters[_colToActivesIndex[column.Index]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;

--- a/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Transpose/TransposeLoader.cs
@@ -874,7 +874,7 @@ namespace Microsoft.ML.Data.IO
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -34,13 +34,11 @@ namespace Microsoft.ML.Data
 
         private readonly IDataView[] _sources;
         private readonly int[] _counts;
-        private readonly DataViewSchema _schema;
         private readonly IHost _host;
-        private readonly bool _canShuffle;
 
-        public bool CanShuffle { get { return _canShuffle; } }
+        public bool CanShuffle { get; }
 
-        public DataViewSchema Schema { get { return _schema; } }
+        public DataViewSchema Schema { get; }
 
         // REVIEW: AppendRowsDataView now only checks schema consistency up to column names and types.
         // A future task will be to ensure that the sources are consistent on the metadata level.
@@ -77,25 +75,25 @@ namespace Microsoft.ML.Data
             _host.Assert(sources.Length >= 2);
 
             _sources = sources;
-            _schema = schema ?? _sources[0].Schema;
+            Schema = schema ?? _sources[0].Schema;
 
             CheckSchemaConsistency();
 
-            _canShuffle = true;
+            CanShuffle = true;
             _counts = new int[_sources.Length];
             for (int i = 0; i < _sources.Length; i++)
             {
                 IDataView dv = _sources[i];
                 if (!dv.CanShuffle)
                 {
-                    _canShuffle = false;
+                    CanShuffle = false;
                     _counts = null;
                     break;
                 }
                 long? count = dv.GetRowCount();
                 if (count == null || count < 0 || count > int.MaxValue)
                 {
-                    _canShuffle = false;
+                    CanShuffle = false;
                     _counts = null;
                     break;
                 }
@@ -108,16 +106,16 @@ namespace Microsoft.ML.Data
             // REVIEW: Allow schema isomorphism.
             const string errMsg = "Inconsistent schema: all source dataviews must have identical column names, sizes, and item types.";
 
-            int startingSchemaIndex = _schema == _sources[0].Schema ? 1 : 0;
-            int colCount = _schema.Count;
+            int startingSchemaIndex = Schema == _sources[0].Schema ? 1 : 0;
+            int colCount = Schema.Count;
 
             // Check if the column counts are identical.
             _host.Check(_sources.All(source => source.Schema.Count == colCount), errMsg);
 
             for (int c = 0; c < colCount; c++)
             {
-                string name = _schema[c].Name;
-                DataViewType type = _schema[c].Type;
+                string name = Schema[c].Name;
+                DataViewType type = Schema[c].Type;
 
                 for (int i = startingSchemaIndex; i < _sources.Length; i++)
                 {
@@ -148,7 +146,7 @@ namespace Microsoft.ML.Data
 
         public DataViewRowCursor GetRowCursor(IEnumerable<DataViewSchema.Column> columnsNeeded, Random rand = null)
         {
-            if (rand == null || !_canShuffle)
+            if (rand == null || !CanShuffle)
                 return new Cursor(this, columnsNeeded);
             return new RandCursor(this, columnsNeeded, rand, _counts);
         }
@@ -172,7 +170,7 @@ namespace Microsoft.ML.Data
             {
                 Sources = parent._sources;
                 Ch.AssertNonEmpty(Sources);
-                Schema = parent._schema;
+                Schema = parent.Schema;
                 Getters = new Delegate[Schema.Count];
             }
 
@@ -187,12 +185,13 @@ namespace Microsoft.ML.Data
 
             protected abstract ValueGetter<TValue> CreateTypedGetter<TValue>(int col);
 
-            public sealed override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            public sealed override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex), "The column must be active against the defined predicate.");
-                if (!(Getters[columnIndex] is ValueGetter<TValue>))
+                Ch.CheckParam(column.Index <= Getters.Length && IsColumnActive(column.Index), nameof(column), "requested column not active");
+
+                if (!(Getters[column.Index] is ValueGetter<TValue>))
                     throw Ch.Except($"Invalid TValue in GetGetter: '{typeof(TValue)}'");
-                return Getters[columnIndex] as ValueGetter<TValue>;
+                return Getters[column.Index] as ValueGetter<TValue>;
             }
 
             /// <summary>
@@ -254,7 +253,7 @@ namespace Microsoft.ML.Data
                         {
                             Ch.Assert(0 <= _currentSourceIndex && _currentSourceIndex < Sources.Length);
                             Ch.Assert(_currentCursor != null);
-                            getSrc = _currentCursor.GetGetter<TValue>(col);
+                            getSrc = _currentCursor.GetGetter<TValue>(_currentCursor.Schema[col]);
                             capturedSourceIndex = _currentSourceIndex;
                         }
                         getSrc(ref val);
@@ -350,8 +349,11 @@ namespace Microsoft.ML.Data
                     {
                         Ch.Check(Position >= 0, RowCursorUtils.FetchValueStateError);
                         Ch.Assert(0 <= _currentSourceIndex && _currentSourceIndex < Sources.Length);
+
+                        var rowCursor = _cursorSet[_currentSourceIndex];
+
                         if (getSrc[_currentSourceIndex] == null)
-                            getSrc[_currentSourceIndex] = _cursorSet[_currentSourceIndex].GetGetter<TValue>(col);
+                            getSrc[_currentSourceIndex] = rowCursor.GetGetter<TValue>(rowCursor.Schema[col]);
                         getSrc[_currentSourceIndex](ref val);
                     };
             }

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -187,18 +187,21 @@ namespace Microsoft.ML.Data
 
             protected abstract ValueGetter<TValue> CreateTypedGetter<TValue>(int col);
 
-            public sealed override ValueGetter<TValue> GetGetter<TValue>(int col)
+            public sealed override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col), "The column must be active against the defined predicate.");
-                if (!(Getters[col] is ValueGetter<TValue>))
+                Ch.Check(IsColumnActive(columnIndex), "The column must be active against the defined predicate.");
+                if (!(Getters[columnIndex] is ValueGetter<TValue>))
                     throw Ch.Except($"Invalid TValue in GetGetter: '{typeof(TValue)}'");
-                return Getters[col] as ValueGetter<TValue>;
+                return Getters[columnIndex] as ValueGetter<TValue>;
             }
 
-            public sealed override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public sealed override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < Schema.Count, "Column index is out of range");
-                return Getters[col] != null;
+                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count, "Column index is out of range");
+                return Getters[columnIndex] != null;
             }
         }
 

--- a/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/AppendRowsDataView.cs
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Data
 
             public sealed override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(column.Index <= Getters.Length && IsColumnActive(column.Index), nameof(column), "requested column not active");
+                Ch.CheckParam(column.Index <= Getters.Length && IsColumnActive(column), nameof(column), "requested column not active");
 
                 if (!(Getters[column.Index] is ValueGetter<TValue>))
                     throw Ch.Except($"Invalid TValue in GetGetter: '{typeof(TValue)}'");
@@ -197,10 +197,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public sealed override bool IsColumnActive(int columnIndex)
+            public sealed override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count, "Column index is out of range");
-                return Getters[columnIndex] != null;
+                Ch.Check(column.Index < Schema.Count, "Column index is out of range");
+                return Getters[column.Index] != null;
             }
         }
 
@@ -271,7 +271,7 @@ namespace Microsoft.ML.Data
                     if (++_currentSourceIndex >= Sources.Length)
                         return false;
 
-                    var columnsNeeded = Schema.Where(col => IsColumnActive(col.Index));
+                    var columnsNeeded = Schema.Where(col => IsColumnActive(col));
                     _currentCursor = Sources[_currentSourceIndex].GetRowCursor(columnsNeeded);
                     _currentIdGetter = _currentCursor.GetIdGetter();
                 }

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -304,17 +304,27 @@ namespace Microsoft.ML.Data
                     }
                 }
 
-                public override bool IsColumnActive(int col)
+                /// <summary>
+                /// Returns whether the given column is active in this row.
+                /// </summary>
+                public override bool IsColumnActive(int columnIndex)
                 {
-                    Ch.Check(0 <= col & col < Schema.Count);
-                    return _active[col];
+                    Ch.Check(0 <= columnIndex & columnIndex < Schema.Count);
+                    return _active[columnIndex];
                 }
 
-                public override ValueGetter<TValue> GetGetter<TValue>(int col)
+                /// <summary>
+                /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                /// This throws if the column is not active in this row, or if the type
+                /// <typeparamref name="TValue"/> differs from this column's type.
+                /// </summary>
+                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
                 {
-                    Ch.Check(0 <= col & col < Schema.Count);
-                    Ch.Check(_active[col], "column is not active");
-                    var column = _view._columns[col] as Column<TValue>;
+                    Ch.Check(0 <= columnIndex & columnIndex < Schema.Count);
+                    Ch.Check(_active[columnIndex], "column is not active");
+                    var column = _view._columns[columnIndex] as Column<TValue>;
                     if (column == null)
                         throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
 

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Data
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
-                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <typeparam name="TValue"> is the column's content type.</typeparam>
                 /// <param name="column"> is the output column whose getter should be returned.</param>
                 public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 {

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -307,10 +307,10 @@ namespace Microsoft.ML.Data
                 /// <summary>
                 /// Returns whether the given column is active in this row.
                 /// </summary>
-                public override bool IsColumnActive(int columnIndex)
+                public override bool IsColumnActive(DataViewSchema.Column column)
                 {
-                    Ch.Check(0 <= columnIndex & columnIndex < Schema.Count);
-                    return _active[columnIndex];
+                    Ch.Check(column.Index < Schema.Count);
+                    return _active[column.Index];
                 }
 
                 /// <summary>

--- a/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
+++ b/src/Microsoft.ML.Data/DataView/ArrayDataViewBuilder.cs
@@ -314,25 +314,26 @@ namespace Microsoft.ML.Data
                 }
 
                 /// <summary>
-                /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
                 /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-                /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-                public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+                /// <param name="column"> is the output column whose getter should be returned.</param>
+                public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 {
-                    Ch.Check(0 <= columnIndex & columnIndex < Schema.Count);
-                    Ch.Check(_active[columnIndex], "column is not active");
-                    var column = _view._columns[columnIndex] as Column<TValue>;
-                    if (column == null)
+                    Ch.Check(column.Index < Schema.Count);
+                    Ch.Check(column.Index < _active.Length && _active[column.Index], "the requested column is not active");
+
+                    var columnValue = _view._columns[column.Index] as Column<TValue>;
+                    if (columnValue == null)
                         throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
 
                     return
                         (ref TValue value) =>
                         {
                             Ch.Check(IsGood, RowCursorUtils.FetchValueStateError);
-                            column.CopyOut(MappedIndex(), ref value);
+                            columnValue.CopyOut(MappedIndex(), ref value);
                         };
                 }
 

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -514,7 +514,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column) => _internal.GetGetter<TValue>(column);
             public override ValueGetter<DataViewRowId> GetIdGetter() => _internal.GetIdGetter();

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -522,7 +522,7 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex) => _internal.IsColumnActive(columnIndex);
+            public override bool IsColumnActive(DataViewSchema.Column column) => _internal.IsColumnActive(column);
             public override bool MoveTo(long rowIndex) => _internal.MoveTo(rowIndex);
         }
 
@@ -1171,10 +1171,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public sealed override bool IsColumnActive(int columnIndex)
+            public sealed override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
-                return _colToActivesIndex[columnIndex] >= 0;
+                Ch.CheckParam(column.Index < _colToActivesIndex.Length, nameof(column));
+                return _colToActivesIndex[column.Index] >= 0;
             }
 
             protected sealed override void Dispose(bool disposing)
@@ -1193,7 +1193,7 @@ namespace Microsoft.ML.Data
 
             public sealed override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(column.Index <= _colToActivesIndex.Length && IsColumnActive(column.Index), nameof(column), "requested column not active");
+                Ch.CheckParam(column.Index <= _colToActivesIndex.Length && IsColumnActive(column), nameof(column), "requested column not active");
                 Ch.Check(_colToActivesIndex[column.Index] < _getters.Length);
 
                 var getter = _getters[_colToActivesIndex[column.Index]] as ValueGetter<TValue>;
@@ -1270,7 +1270,7 @@ namespace Microsoft.ML.Data
                 var host = parent._host;
                 host.AssertValue(input);
                 host.Assert(0 <= srcCol & srcCol < input.Schema.Count);
-                host.Assert(input.IsColumnActive(srcCol));
+                host.Assert(input.IsColumnActive(input.Schema[srcCol]));
 
                 var type = input.Schema[srcCol].Type;
                 Type pipeType;

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -509,9 +509,20 @@ namespace Microsoft.ML.Data
             public override long Batch => _internal.Batch;
             public override DataViewSchema Schema => _internal.Schema;
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col) => _internal.GetGetter<TValue>(col);
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _internal.GetGetter<TValue>(columnIndex);
             public override ValueGetter<DataViewRowId> GetIdGetter() => _internal.GetIdGetter();
-            public override bool IsColumnActive(int col) => _internal.IsColumnActive(col);
+
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex) => _internal.IsColumnActive(columnIndex);
             public override bool MoveTo(long rowIndex) => _internal.MoveTo(rowIndex);
         }
 
@@ -1157,10 +1168,13 @@ namespace Microsoft.ML.Data
                 }
             }
 
-            public sealed override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public sealed override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _colToActivesIndex.Length, nameof(col));
-                return _colToActivesIndex[col] >= 0;
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
+                return _colToActivesIndex[columnIndex] >= 0;
             }
 
             protected sealed override void Dispose(bool disposing)
@@ -1177,11 +1191,11 @@ namespace Microsoft.ML.Data
                 _disposed = true;
             }
 
-            public sealed override ValueGetter<TValue> GetGetter<TValue>(int col)
+            public sealed override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                if (!IsColumnActive(col))
-                    throw Ch.Except("Column #{0} is requested but not active in the cursor", col);
-                var getter = _getters[_colToActivesIndex[col]] as ValueGetter<TValue>;
+                if (!IsColumnActive(columnIndex))
+                    throw Ch.Except("Column #{0} is requested but not active in the cursor", columnIndex);
+                var getter = _getters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -108,7 +108,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column) => _row.GetGetter<TValue>(column);
             public override ValueGetter<DataViewRowId> GetIdGetter() => _row.GetIdGetter();

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -102,9 +102,21 @@ namespace Microsoft.ML.Data
             public override DataViewSchema Schema => _row.Schema;
             public override long Position => _row.Position;
             public override long Batch => _row.Batch;
-            public override ValueGetter<TValue> GetGetter<TValue>(int col) => _row.GetGetter<TValue>(col);
+
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _row.GetGetter<TValue>(columnIndex);
             public override ValueGetter<DataViewRowId> GetIdGetter() => _row.GetIdGetter();
-            public override bool IsColumnActive(int col) => _pred(col);
+
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex) => _pred(columnIndex);
         }
     }
 }

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Data
             return columnsNeeded;
         }
 
-        public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+        DataViewRow IRowToRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
         {
             Contracts.CheckValue(input, nameof(input));
             Contracts.CheckValue(activeColumns, nameof(activeColumns));

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Data
                 for (int c = 0; c < input.Schema.Count; ++c)
                 {
                     bool wantsActive = activeIndices.Contains(c);
-                    bool isActive = input.IsColumnActive(c);
+                    bool isActive = input.IsColumnActive(input.Schema[c]);
                     differentActive |= wantsActive != isActive;
 
                     if (wantsActive && !isActive)
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex) => _pred(columnIndex);
+            public override bool IsColumnActive(DataViewSchema.Column column) => _pred(column.Index);
         }
     }
 }

--- a/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
+++ b/src/Microsoft.ML.Data/DataView/CompositeRowToRowMapper.cs
@@ -104,13 +104,13 @@ namespace Microsoft.ML.Data
             public override long Batch => _row.Batch;
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _row.GetGetter<TValue>(columnIndex);
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column) => _row.GetGetter<TValue>(column);
             public override ValueGetter<DataViewRowId> GetIdGetter() => _row.GetIdGetter();
 
             /// <summary>

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -331,10 +331,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                CheckColumnInRange(columnIndex);
-                return _getters[columnIndex] != null;
+                CheckColumnInRange(column.Index);
+                return _getters[column.Index] != null;
             }
 
             private void CheckColumnInRange(int columnIndex)
@@ -352,7 +352,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Host.CheckParam(column.Index <= _getters.Length && IsColumnActive(column.Index), nameof(column), "requested column not active");
+                Host.CheckParam(column.Index <= _getters.Length && IsColumnActive(column), nameof(column), "requested column not active");
 
                 var getter = _getters[column.Index];
                 Contracts.AssertValue(getter);
@@ -442,7 +442,7 @@ namespace Microsoft.ML.Data
                 /// <summary>
                 /// Returns whether the given column is active in this row.
                 /// </summary>
-                public override bool IsColumnActive(int columnIndex) => _toWrap.IsColumnActive(columnIndex);
+                public override bool IsColumnActive(DataViewSchema.Column column) => _toWrap.IsColumnActive(column);
                 public override bool MoveNext() => _toWrap.MoveNext();
             }
 

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -344,21 +344,21 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                if (!IsColumnActive(columnIndex))
-                    throw Host.Except("Column {0} is not active in the cursor", columnIndex);
-                var getter = _getters[columnIndex];
+                Host.CheckParam(column.Index <= _getters.Length && IsColumnActive(column.Index), nameof(column), "requested column not active");
+
+                var getter = _getters[column.Index];
                 Contracts.AssertValue(getter);
                 var fn = getter as ValueGetter<TValue>;
                 if (fn == null)
-                    throw Host.Except("Invalid TValue in GetGetter for column #{0}: '{1}'", columnIndex, typeof(TValue));
+                    throw Host.Except("Invalid TValue in GetGetter for column #{0}: '{1}'", column, typeof(TValue));
                 return fn;
             }
         }
@@ -428,14 +428,14 @@ namespace Microsoft.ML.Data
                 }
 
                 /// <summary>
-                /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
                 /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-                /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-                public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
-                    => _toWrap.GetGetter<TValue>(columnIndex);
+                /// <param name="column"> is the output column whose getter should be returned.</param>
+                public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
+                    => _toWrap.GetGetter<TValue>(column);
 
                 public override ValueGetter<DataViewRowId> GetIdGetter() => _toWrap.GetIdGetter();
 

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -348,7 +348,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
@@ -432,7 +432,7 @@ namespace Microsoft.ML.Data
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
-                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <typeparam name="TValue"> is the column's content type.</typeparam>
                 /// <param name="column"> is the output column whose getter should be returned.</param>
                 public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                     => _toWrap.GetGetter<TValue>(column);

--- a/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewExtensions.cs
@@ -50,8 +50,18 @@ namespace Microsoft.ML.Data
         public static DataViewRowCursor GetRowCursor(this IDataView dv) =>  dv.GetRowCursor(Enumerable.Empty<DataViewSchema.Column>());
 
         /// <summary>
-        /// Get a row cursor including all the columns of the <see cref="IDataView"/> it is called upon..
+        /// Get a row cursor including all the columns of the <see cref="IDataView"/>.
         /// </summary>
         public static DataViewRowCursor GetRowCursorForAllColumns(this IDataView dv) => dv.GetRowCursor(dv.Schema);
+
+        /// <summary>
+        /// Extension method.
+        /// </summary>
+        /// <param name="rowMapper"></param>
+        /// <param name="input"></param>
+        /// <param name="activeColumns"></param>
+        /// <returns></returns>
+        public static DataViewRow GetRow(this IRowToRowMapper rowMapper, DataViewRow input, params DataViewSchema.Column[] activeColumns)
+            => rowMapper.GetRow(input, activeColumns);
     }
 }

--- a/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex) => 0 <= columnIndex && columnIndex < _active.Length && _active[columnIndex];
+            public override bool IsColumnActive(DataViewSchema.Column column) => column.Index < _active.Length && _active[column.Index];
 
             /// <summary>
             /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index), "Cannot get getter for inactive column");
+                Ch.CheckParam(IsColumnActive(column), nameof(column), "requested column not active");
                 return (ref TValue value) => throw Ch.Except(RowCursorUtils.FetchValueStateError);
             }
         }

--- a/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
@@ -64,11 +64,21 @@ namespace Microsoft.ML.Data
 
             protected override bool MoveNextCore() => false;
 
-            public override bool IsColumnActive(int col) => 0 <= col && col < _active.Length && _active[col];
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex) => 0 <= columnIndex && columnIndex < _active.Length && _active[columnIndex];
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col), "Cannot get getter for inactive column");
+                Ch.Check(IsColumnActive(columnIndex), "Cannot get getter for inactive column");
                 return (ref TValue value) => throw Ch.Except(RowCursorUtils.FetchValueStateError);
             }
         }

--- a/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/EmptyDataView.cs
@@ -70,15 +70,15 @@ namespace Microsoft.ML.Data
             public override bool IsColumnActive(int columnIndex) => 0 <= columnIndex && columnIndex < _active.Length && _active[columnIndex];
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex), "Cannot get getter for inactive column");
+                Ch.Check(IsColumnActive(column.Index), "Cannot get getter for inactive column");
                 return (ref TValue value) => throw Ch.Except(RowCursorUtils.FetchValueStateError);
             }
         }

--- a/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
+++ b/src/Microsoft.ML.Data/DataView/LambdaFilter.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Data
                 public Cursor(Impl<T1, T2> parent, DataViewRowCursor input, bool[] active)
                     : base(parent.Host, input, parent.OutputSchema, active)
                 {
-                    _getSrc = Input.GetGetter<T1>(parent._colSrc);
+                    _getSrc = Input.GetGetter<T1>(Input.Schema[parent._colSrc]);
                     if (parent._conv == null)
                     {
                         Ch.Assert(typeof(T1) == typeof(T2));

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -246,7 +246,7 @@ namespace Microsoft.ML.Data
 
         public DataViewSchema InputSchema => Source.Schema;
 
-        public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+        DataViewRow IRowToRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
         {
             Host.CheckValue(input, nameof(input));
             Host.CheckValue(activeColumns, nameof(activeColumns));

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -324,7 +324,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
@@ -386,7 +386,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -320,18 +320,18 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return Input.GetGetter<TValue>(index);
+                    return Input.GetGetter<TValue>(Input.Schema[index]);
 
                 Contracts.Assert(_getters[index] != null);
                 var fn = _getters[index] as ValueGetter<TValue>;
@@ -382,20 +382,20 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex));
+                Ch.Check(IsColumnActive(column.Index));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return Input.GetGetter<TValue>(index);
+                    return Input.GetGetter<TValue>(Input.Schema[index]);
 
                 Ch.AssertValue(_getters);
                 var getter = _getters[index];

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -343,12 +343,12 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return Input.IsColumnActive((index));
+                    return Input.IsColumnActive(Schema[index]);
                 return _getters[index] != null;
             }
         }
@@ -375,10 +375,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _bindings.Schema.Count);
-                return _active[columnIndex];
+                Ch.Check(column.Index < _bindings.Schema.Count);
+                return _active[column.Index];
             }
 
             /// <summary>
@@ -390,7 +390,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 bool isSrc;
                 int index = _bindings.MapColumnIndex(out isSrc, column.Index);

--- a/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
+++ b/src/Microsoft.ML.Data/DataView/RowToRowMapperTransform.cs
@@ -319,10 +319,17 @@ namespace Microsoft.ML.Data
                     _disposer?.Invoke();
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, col);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 
@@ -333,10 +340,13 @@ namespace Microsoft.ML.Data
                 return fn;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, col);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.IsColumnActive((index));
                 return _getters[index] != null;
@@ -362,18 +372,28 @@ namespace Microsoft.ML.Data
                 _bindings = parent._bindings;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.Schema.Count);
-                return _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.Schema.Count);
+                return _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 

--- a/src/Microsoft.ML.Data/DataView/SimpleRow.cs
+++ b/src/Microsoft.ML.Data/DataView/SimpleRow.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Data
         public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
         {
             Contracts.CheckParam(column.Index < _getters.Length, nameof(column), "Invalid col value in GetGetter");
-            Contracts.Check(IsColumnActive(column.Index));
+            Contracts.Check(IsColumnActive(column));
             if (_getters[column.Index] is ValueGetter<TValue> fn)
                 return fn;
             throw Contracts.Except("Unexpected TValue in GetGetter");
@@ -66,10 +66,10 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Returns whether the given column is active in this row.
         /// </summary>
-        public override bool IsColumnActive(int columnIndex)
+        public override bool IsColumnActive(DataViewSchema.Column column)
         {
-            Contracts.Check(0 <= columnIndex && columnIndex < _getters.Length);
-            return _getters[columnIndex] != null;
+            Contracts.Check(column.Index < _getters.Length);
+            return _getters[column.Index] != null;
         }
     }
 }

--- a/src/Microsoft.ML.Data/DataView/SimpleRow.cs
+++ b/src/Microsoft.ML.Data/DataView/SimpleRow.cs
@@ -54,11 +54,11 @@ namespace Microsoft.ML.Data
                 _disposer?.Invoke();
         }
 
-        public override ValueGetter<T> GetGetter<T>(int col)
+        public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
         {
-            Contracts.CheckParam(0 <= col && col < _getters.Length, nameof(col), "Invalid col value in GetGetter");
-            Contracts.Check(IsColumnActive(col));
-            if (_getters[col] is ValueGetter<T> fn)
+            Contracts.CheckParam(column.Index < _getters.Length, nameof(column), "Invalid col value in GetGetter");
+            Contracts.Check(IsColumnActive(column.Index));
+            if (_getters[column.Index] is ValueGetter<TValue> fn)
                 return fn;
             throw Contracts.Except("Unexpected TValue in GetGetter");
         }

--- a/src/Microsoft.ML.Data/DataView/SimpleRow.cs
+++ b/src/Microsoft.ML.Data/DataView/SimpleRow.cs
@@ -63,10 +63,13 @@ namespace Microsoft.ML.Data
             throw Contracts.Except("Unexpected TValue in GetGetter");
         }
 
-        public override bool IsColumnActive(int col)
+        /// <summary>
+        /// Returns whether the given column is active in this row.
+        /// </summary>
+        public override bool IsColumnActive(int columnIndex)
         {
-            Contracts.Check(0 <= col && col < _getters.Length);
-            return _getters[col] != null;
+            Contracts.Check(0 <= columnIndex && columnIndex < _getters.Length);
+            return _getters[columnIndex] != null;
         }
     }
 }

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1046,7 +1046,7 @@ namespace Microsoft.ML.Data
                         /// This throws if the column is not active in this row, or if the type
                         /// <typeparamref name="TValue"/> differs from this column's type.
                         /// </summary>
-                        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                        /// <typeparam name="TValue"> is the column's content type.</typeparam>
                         /// <param name="column"> is the output column whose getter should be returned.</param>
                         public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                         {
@@ -1155,7 +1155,7 @@ namespace Microsoft.ML.Data
                         /// This throws if the column is not active in this row, or if the type
                         /// <typeparamref name="TValue"/> differs from this column's type.
                         /// </summary>
-                        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                        /// <typeparam name="TValue"> is the column's content type.</typeparam>
                         /// <param name="column"> is the output column whose getter should be returned.</param>
                         public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                         {
@@ -1301,7 +1301,7 @@ namespace Microsoft.ML.Data
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
-                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <typeparam name="TValue"> is the column's content type.</typeparam>
                 /// <param name="column"> is the output column whose getter should be returned.</param>
                 public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 {
@@ -1479,7 +1479,7 @@ namespace Microsoft.ML.Data
                 /// This throws if the column is not active in this row, or if the type
                 /// <typeparamref name="TValue"/> differs from this column's type.
                 /// </summary>
-                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <typeparam name="TValue"> is the column's content type.</typeparam>
                 /// <param name="column"> is the output column whose getter should be returned.</param>
                 public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 {
@@ -1539,7 +1539,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1030,15 +1030,25 @@ namespace Microsoft.ML.Data
                             _isActive = isActive;
                         }
 
-                        public override bool IsColumnActive(int col)
+                        /// <summary>
+                        /// Returns whether the given column is active in this row.
+                        /// </summary>
+                        public override bool IsColumnActive(int columnIndex)
                         {
-                            Contracts.CheckParam(0 <= col && col < Parent.ColumnCount, nameof(col));
+                            Contracts.CheckParam(0 <= columnIndex && columnIndex < Parent.ColumnCount, nameof(columnIndex));
                             return _isActive;
                         }
 
-                        public override ValueGetter<TValue> GetGetter<TValue>(int col)
+                        /// <summary>
+                        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                        /// This throws if the column is not active in this row, or if the type
+                        /// <typeparamref name="TValue"/> differs from this column's type.
+                        /// </summary>
+                        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                        public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
                         {
-                            Contracts.Check(IsColumnActive(col));
+                            Contracts.Check(IsColumnActive(columnIndex));
                             return Input.GetGetter<TValue>(Parent.SrcCol);
                         }
                     }
@@ -1129,17 +1139,27 @@ namespace Microsoft.ML.Data
                                 _getters[c] = pred(c) ? CreateGetter(c) : null;
                         }
 
-                        public override bool IsColumnActive(int col)
+                        /// <summary>
+                        /// Returns whether the given column is active in this row.
+                        /// </summary>
+                        public override bool IsColumnActive(int columnIndex)
                         {
-                            Contracts.CheckParam(0 <= col && col < Parent.ColumnCount, nameof(col));
-                            return _getters[col] != null;
+                            Contracts.CheckParam(0 <= columnIndex && columnIndex < Parent.ColumnCount, nameof(columnIndex));
+                            return _getters[columnIndex] != null;
                         }
 
-                        public override ValueGetter<TValue> GetGetter<TValue>(int col)
+                        /// <summary>
+                        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                        /// This throws if the column is not active in this row, or if the type
+                        /// <typeparamref name="TValue"/> differs from this column's type.
+                        /// </summary>
+                        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                        public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
                         {
-                            Contracts.Check(IsColumnActive(col));
-                            Contracts.AssertValue(_getters[col]);
-                            var fn = _getters[col] as ValueGetter<TValue>;
+                            Contracts.Check(IsColumnActive(columnIndex));
+                            Contracts.AssertValue(_getters[columnIndex]);
+                            var fn = _getters[columnIndex] as ValueGetter<TValue>;
                             if (fn == null)
                                 throw Contracts.Except("Invalid TValue in GetGetter: '{0}'", typeof(TValue));
                             return fn;
@@ -1261,21 +1281,31 @@ namespace Microsoft.ML.Data
                     }
                 }
 
-                public override bool IsColumnActive(int col)
+                /// <summary>
+                /// Returns whether the given column is active in this row.
+                /// </summary>
+                public override bool IsColumnActive(int columnIndex)
                 {
-                    Ch.Check(0 <= col && col < Schema.Count, "col");
+                    Ch.Check(0 <= columnIndex && columnIndex < Schema.Count, "col");
                     int splitInd;
                     int splitCol;
-                    _slicer.OutputColumnToSplitterIndices(col, out splitInd, out splitCol);
+                    _slicer.OutputColumnToSplitterIndices(columnIndex, out splitInd, out splitCol);
                     return _sliceRows[splitInd] != null && _sliceRows[splitInd].IsColumnActive(splitCol);
                 }
 
-                public override ValueGetter<TValue> GetGetter<TValue>(int col)
+                /// <summary>
+                /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                /// This throws if the column is not active in this row, or if the type
+                /// <typeparamref name="TValue"/> differs from this column's type.
+                /// </summary>
+                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
                 {
-                    Ch.Check(IsColumnActive(col));
+                    Ch.Check(IsColumnActive(columnIndex));
                     int splitInd;
                     int splitCol;
-                    _slicer.OutputColumnToSplitterIndices(col, out splitInd, out splitCol);
+                    _slicer.OutputColumnToSplitterIndices(columnIndex, out splitInd, out splitCol);
                     return _sliceRows[splitInd].GetGetter<TValue>(splitCol);
                 }
             }
@@ -1431,16 +1461,26 @@ namespace Microsoft.ML.Data
                         _getter = _slotCursor.GetGetter<T>();
                 }
 
-                public override bool IsColumnActive(int col)
+                /// <summary>
+                /// Returns whether the given column is active in this row.
+                /// </summary>
+                public override bool IsColumnActive(int columnIndex)
                 {
-                    Ch.CheckParam(col == 0, nameof(col));
+                    Ch.CheckParam(columnIndex == 0, nameof(columnIndex));
                     return _getter != null;
                 }
 
-                public override ValueGetter<TValue> GetGetter<TValue>(int col)
+                /// <summary>
+                /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                /// This throws if the column is not active in this row, or if the type
+                /// <typeparamref name="TValue"/> differs from this column's type.
+                /// </summary>
+                /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
                 {
-                    Ch.CheckParam(col == 0, nameof(col));
-                    Ch.CheckParam(_getter != null, nameof(col), "requested column not active");
+                    Ch.CheckParam(columnIndex == 0, nameof(columnIndex));
+                    Ch.CheckParam(_getter != null, nameof(columnIndex), "requested column not active");
 
                     var getter = _getter as ValueGetter<TValue>;
                     if (getter == null)
@@ -1481,15 +1521,25 @@ namespace Microsoft.ML.Data
                 Schema = builder.ToSchema();
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(col == 0, nameof(col));
+                Ch.CheckParam(columnIndex == 0, nameof(columnIndex));
                 return true;
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.CheckParam(col == 0, nameof(col));
+                Ch.CheckParam(columnIndex == 0, nameof(columnIndex));
                 return _slotCursor.GetGetterWithVectorType<TValue>(Ch);
             }
 

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -442,14 +442,24 @@ namespace Microsoft.ML.Data
                     setter(row);
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                return Input.IsColumnActive(col);
+                return Input.IsColumnActive(columnIndex);
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                return Input.GetGetter<TValue>(col);
+                return Input.GetGetter<TValue>(columnIndex);
             }
         }
 
@@ -480,7 +490,7 @@ namespace Microsoft.ML.Data
             public long Batch => _row.Batch;
             public DataViewSchema Schema => _row.Schema;
             public void FillValues(TRow row) => _row.FillValues(row);
-            public ValueGetter<TValue> GetGetter<TValue>(int col) => _row.GetGetter<TValue>(col);
+            public ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _row.GetGetter<TValue>(columnIndex);
             public ValueGetter<DataViewRowId> GetIdGetter() => _row.GetIdGetter();
             public bool IsColumnActive(int col) => _row.IsColumnActive(col);
         }
@@ -507,9 +517,21 @@ namespace Microsoft.ML.Data
             }
 
             public override void FillValues(TRow row) => _cursor.FillValues(row);
-            public override ValueGetter<TValue> GetGetter<TValue>(int col) => _cursor.GetGetter<TValue>(col);
+           
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _cursor.GetGetter<TValue>(columnIndex);
             public override ValueGetter<DataViewRowId> GetIdGetter() => _cursor.GetIdGetter();
-            public override bool IsColumnActive(int col) => _cursor.IsColumnActive(col);
+
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex) => _cursor.IsColumnActive(columnIndex);
             public override bool MoveNext() => _cursor.MoveNext();
         }
 

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -445,10 +445,8 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
-            {
-                return Input.IsColumnActive(columnIndex);
-            }
+            public override bool IsColumnActive(DataViewSchema.Column column)
+                => Input.IsColumnActive(column);
 
             /// <summary>
             /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
@@ -458,9 +456,7 @@ namespace Microsoft.ML.Data
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
-            {
-                return Input.GetGetter<TValue>(column);
-            }
+                => Input.GetGetter<TValue>(column);
         }
 
         private sealed class TypedRow : TypedRowBase
@@ -494,7 +490,7 @@ namespace Microsoft.ML.Data
                 => _row.GetGetter<TValue>(column);
 
             public ValueGetter<DataViewRowId> GetIdGetter() => _row.GetIdGetter();
-            public bool IsColumnActive(int col) => _row.IsColumnActive(col);
+            public bool IsColumnActive(int col) => _row.IsColumnActive(_row.Schema[col]);
         }
 
         private sealed class RowCursorImplementation : RowCursor<TRow>
@@ -535,7 +531,7 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex) => _cursor.IsColumnActive(columnIndex);
+            public override bool IsColumnActive(DataViewSchema.Column column) => _cursor.IsColumnActive(column);
             public override bool MoveNext() => _cursor.MoveNext();
         }
 

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -333,7 +333,7 @@ namespace Microsoft.ML.Data
             // of affected types is pretty arbitrary (signed integers and bools, but not uints and floats).
             private Action<TRow> CreateConvertingVBufferSetter<TSrc, TDst>(DataViewRow input, int col, Delegate poke, Delegate peek, Func<TSrc, TDst> convert)
             {
-                var getter = input.GetGetter<VBuffer<TSrc>>(col);
+                var getter = input.GetGetter<VBuffer<TSrc>>(input.Schema[col]);
                 var typedPoke = poke as Poke<TRow, TDst[]>;
                 var typedPeek = peek as Peek<TRow, TDst[]>;
                 Contracts.AssertValue(typedPoke);
@@ -355,7 +355,7 @@ namespace Microsoft.ML.Data
 
             private Action<TRow> CreateDirectVBufferSetter<TDst>(DataViewRow input, int col, Delegate poke, Delegate peek)
             {
-                var getter = input.GetGetter<VBuffer<TDst>>(col);
+                var getter = input.GetGetter<VBuffer<TDst>>(input.Schema[col]);
                 var typedPoke = poke as Poke<TRow, TDst[]>;
                 var typedPeek = peek as Peek<TRow, TDst[]>;
                 Contracts.AssertValue(typedPoke);
@@ -393,7 +393,7 @@ namespace Microsoft.ML.Data
 
             private static Action<TRow> CreateConvertingActionSetter<TSrc, TDst>(DataViewRow input, int col, Delegate poke, Func<TSrc, TDst> convert)
             {
-                var getter = input.GetGetter<TSrc>(col);
+                var getter = input.GetGetter<TSrc>(input.Schema[col]);
                 var typedPoke = poke as Poke<TRow, TDst>;
                 Contracts.AssertValue(typedPoke);
                 TSrc value = default;
@@ -409,7 +409,7 @@ namespace Microsoft.ML.Data
             {
                 // Awkward to have a parameter that's always null, but slightly more convenient for generalizing the setter.
                 Contracts.Assert(peek == null);
-                var getter = input.GetGetter<TDst>(col);
+                var getter = input.GetGetter<TDst>(input.Schema[col]);
                 var typedPoke = poke as Poke<TRow, TDst>;
                 Contracts.AssertValue(typedPoke);
                 TDst value = default(TDst);
@@ -422,7 +422,7 @@ namespace Microsoft.ML.Data
 
             private Action<TRow> CreateVBufferToVBufferSetter<TDst>(DataViewRow input, int col, Delegate poke, Delegate peek)
             {
-                var getter = input.GetGetter<VBuffer<TDst>>(col);
+                var getter = input.GetGetter<VBuffer<TDst>>(input.Schema[col]);
                 var typedPoke = poke as Poke<TRow, VBuffer<TDst>>;
                 var typedPeek = peek as Peek<TRow, VBuffer<TDst>>;
                 Contracts.AssertValue(typedPoke);
@@ -451,15 +451,15 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                return Input.GetGetter<TValue>(columnIndex);
+                return Input.GetGetter<TValue>(column);
             }
         }
 
@@ -490,7 +490,9 @@ namespace Microsoft.ML.Data
             public long Batch => _row.Batch;
             public DataViewSchema Schema => _row.Schema;
             public void FillValues(TRow row) => _row.FillValues(row);
-            public ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _row.GetGetter<TValue>(columnIndex);
+            public ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
+                => _row.GetGetter<TValue>(column);
+
             public ValueGetter<DataViewRowId> GetIdGetter() => _row.GetIdGetter();
             public bool IsColumnActive(int col) => _row.IsColumnActive(col);
         }
@@ -517,15 +519,17 @@ namespace Microsoft.ML.Data
             }
 
             public override void FillValues(TRow row) => _cursor.FillValues(row);
-           
+
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => _cursor.GetGetter<TValue>(columnIndex);
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
+                => _cursor.GetGetter<TValue>(column);
+
             public override ValueGetter<DataViewRowId> GetIdGetter() => _cursor.GetIdGetter();
 
             /// <summary>

--- a/src/Microsoft.ML.Data/DataView/TypedCursor.cs
+++ b/src/Microsoft.ML.Data/DataView/TypedCursor.cs
@@ -453,7 +453,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 => Input.GetGetter<TValue>(column);
@@ -521,7 +521,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
                 => _cursor.GetGetter<TValue>(column);

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -164,10 +164,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                _zipBinding.CheckColumnInRange(columnIndex);
-                return _isColumnActive[columnIndex];
+                _zipBinding.CheckColumnInRange(column.Index);
+                return _isColumnActive[column.Index];
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -175,7 +175,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -171,18 +171,19 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
                 int dv;
                 int srcCol;
-                _zipBinding.GetColumnSource(columnIndex, out dv, out srcCol);
-                return _cursors[dv].GetGetter<TValue>(srcCol);
+                _zipBinding.GetColumnSource(column.Index, out dv, out srcCol);
+                var rowCursor = _cursors[dv];
+                return rowCursor.GetGetter<TValue>(rowCursor.Schema[srcCol]);
             }
         }
     }

--- a/src/Microsoft.ML.Data/DataView/ZipDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/ZipDataView.cs
@@ -161,17 +161,27 @@ namespace Microsoft.ML.Data
 
             public override DataViewSchema Schema => _zipBinding.OutputSchema;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                _zipBinding.CheckColumnInRange(col);
-                return _isColumnActive[col];
+                _zipBinding.CheckColumnInRange(columnIndex);
+                return _isColumnActive[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
                 int dv;
                 int srcCol;
-                _zipBinding.GetColumnSource(col, out dv, out srcCol);
+                _zipBinding.GetColumnSource(columnIndex, out dv, out srcCol);
                 return _cursors[dv].GetGetter<TValue>(srcCol);
             }
         }

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -296,10 +296,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _bindings.OutputSchema.Count);
-                return _active == null || _active[columnIndex];
+                Ch.Check(column.Index < _bindings.OutputSchema.Count);
+                return _active == null || _active[column.Index];
             }
 
             /// <summary>
@@ -311,7 +311,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 var src = _bindings.GetSourceColumnIndex(column.Index);
                 return Input.GetGetter<TValue>(Input.Schema[src]);

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -307,7 +307,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -303,18 +303,18 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex));
+                Ch.Check(IsColumnActive(column.Index));
 
-                var src = _bindings.GetSourceColumnIndex(columnIndex);
-                return Input.GetGetter<TValue>(src);
+                var src = _bindings.GetSourceColumnIndex(column.Index);
+                return Input.GetGetter<TValue>(Input.Schema[src]);
             }
         }
     }

--- a/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
+++ b/src/Microsoft.ML.Data/Dirty/ChooseColumnsByIndexTransform.cs
@@ -293,17 +293,27 @@ namespace Microsoft.ML.Data
 
             public override DataViewSchema Schema => _bindings.OutputSchema;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.OutputSchema.Count);
-                return _active == null || _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.OutputSchema.Count);
+                return _active == null || _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
-                var src = _bindings.GetSourceColumnIndex(col);
+                var src = _bindings.GetSourceColumnIndex(columnIndex);
                 return Input.GetGetter<TValue>(src);
             }
         }

--- a/src/Microsoft.ML.Data/EntryPoints/TransformModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/TransformModelImpl.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ML.EntryPoints
 
             public DataViewSchema InputSchema => _rootSchema;
 
-            public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+            DataViewRow IRowToRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 _ectx.Assert(IsCompositeRowToRowMapper(_chain));
                 _ectx.AssertValue(input);

--- a/src/Microsoft.ML.Data/EntryPoints/TransformModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/TransformModelImpl.cs
@@ -244,28 +244,28 @@ namespace Microsoft.ML.EntryPoints
 
             public DataViewSchema InputSchema => _rootSchema;
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> active)
+            public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 _ectx.Assert(IsCompositeRowToRowMapper(_chain));
                 _ectx.AssertValue(input);
-                _ectx.AssertValue(active);
+                _ectx.AssertValue(activeColumns);
 
                 _ectx.Check(input.Schema == InputSchema, "Schema of input row must be the same as the schema the mapper is bound to");
 
                 var mappers = new List<IRowToRowMapper>();
-                var actives = new List<Func<int, bool>>();
+                var actives = new List<IEnumerable<DataViewSchema.Column>>();
                 var transform = _chain as IDataTransform;
-                var activeCur = active;
+                var activeCur = activeColumns;
                 while (transform != null)
                 {
                     var mapper = transform as IRowToRowMapper;
                     _ectx.AssertValue(mapper);
                     mappers.Add(mapper);
                     actives.Add(activeCur);
-                    var activeCurCol = mapper.GetDependencies(mapper.OutputSchema.Where(col => activeCur(col.Index)));
-                    activeCur = RowCursorUtils.FromColumnsToPredicate(activeCurCol, mapper.InputSchema);
+                    activeCur = mapper.GetDependencies(activeCur);
                     transform = transform.Source as IDataTransform;
                 }
+
                 mappers.Reverse();
                 actives.Reverse();
                 var row = input;

--- a/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/BinaryClassifierEvaluator.cs
@@ -617,7 +617,7 @@ namespace Microsoft.ML.Data
                 var score = schema.GetUniqueColumn(AnnotationUtils.Const.ScoreValueKind.Score);
 
                 _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
-                _scoreGetter = row.GetGetter<Single>(score.Index);
+                _scoreGetter = row.GetGetter<Single>(score);
                 Host.AssertValue(_labelGetter);
                 Host.AssertValue(_scoreGetter);
 
@@ -625,13 +625,13 @@ namespace Microsoft.ML.Data
                 Host.Assert(prob == null || prob.Count == 1);
 
                 if (prob != null)
-                    _probGetter = row.GetGetter<Single>(prob[0].Index);
+                    _probGetter = row.GetGetter<Single>(prob[0]);
                 else
                     _probGetter = (ref Single value) => value = Single.NaN;
 
                 Host.Assert((schema.Weight != null) == Weighted);
                 if (Weighted)
-                    _weightGetter = row.GetGetter<Single>(schema.Weight.Value.Index);
+                    _weightGetter = row.GetGetter<Single>(schema.Weight.Value);
             }
 
             public override void ProcessRow()
@@ -999,12 +999,12 @@ namespace Microsoft.ML.Data
                 RowCursorUtils.GetLabelGetter(input, LabelIndex) : nanGetter;
             ValueGetter<Single> probGetter;
             if (_probIndex >= 0 && activeCols(LogLossCol))
-                probGetter = input.GetGetter<Single>(_probIndex);
+                probGetter = input.GetGetter<Single>(input.Schema[_probIndex]);
             else
                 probGetter = nanGetter;
             ValueGetter<Single> scoreGetter;
             if (activeCols(AssignedCol) && ScoreIndex >= 0)
-                scoreGetter = input.GetGetter<Single>(ScoreIndex);
+                scoreGetter = input.GetGetter<Single>(input.Schema[ScoreIndex]);
             else
                 scoreGetter = nanGetter;
 

--- a/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/ClusteringEvaluator.cs
@@ -494,11 +494,11 @@ namespace Microsoft.ML.Data
                 if (_calculateDbi)
                 {
                     Host.Assert(schema.Feature.HasValue);
-                    _featGetter = row.GetGetter<VBuffer<Single>>(schema.Feature.Value.Index);
+                    _featGetter = row.GetGetter<VBuffer<Single>>(schema.Feature.Value);
                 }
                 var score = schema.GetUniqueColumn(AnnotationUtils.Const.ScoreValueKind.Score);
                 Host.Assert(score.Type.GetVectorSize() == _scoresArr.Length);
-                _scoreGetter = row.GetGetter<VBuffer<Single>>(score.Index);
+                _scoreGetter = row.GetGetter<VBuffer<Single>>(score);
 
                 if (PassNum == 0)
                 {
@@ -507,7 +507,7 @@ namespace Microsoft.ML.Data
                     else
                         _labelGetter = (ref Single value) => value = Single.NaN;
                     if (schema.Weight.HasValue)
-                        _weightGetter = row.GetGetter<Single>(schema.Weight.Value.Index);
+                        _weightGetter = row.GetGetter<Single>(schema.Weight.Value);
                 }
                 else
                 {
@@ -660,7 +660,7 @@ namespace Microsoft.ML.Data
             var scoresArr = new Single[_numClusters];
             int[] sortedIndices = new int[_numClusters];
 
-            var scoreGetter = input.GetGetter<VBuffer<Single>>(ScoreIndex);
+            var scoreGetter = input.GetGetter<VBuffer<Single>>(input.Schema[ScoreIndex]);
             Action updateCacheIfNeeded =
                 () =>
                 {

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorBase.cs
@@ -402,7 +402,7 @@ namespace Microsoft.ML.Data
                 // This is used to get the current stratification value in the Get() method.
                 private TStrat _value;
 
-                public override int Count { get { return _dict.Count; } }
+                public override int Count => _dict.Count;
 
                 public GenericAggregatorDictionary(RoleMappedSchema schema, string stratCol, DataViewType stratType, Func<string, TAgg> createAgg)
                     : base(schema, stratCol, createAgg)
@@ -414,10 +414,9 @@ namespace Microsoft.ML.Data
                 public override void Reset(DataViewRow row)
                 {
                     Row = row;
-                    int col;
-                    var found = row.Schema.TryGetColumnIndex(ColName, out col);
-                    Contracts.Assert(found);
-                    _stratGetter = row.GetGetter<TStrat>(col);
+                    var col = row.Schema.GetColumnOrNull(ColName);
+                    Contracts.Assert(col.HasValue);
+                    _stratGetter = row.GetGetter<TStrat>(col.Value);
                     Contracts.AssertValue(_stratGetter);
                 }
 

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -278,7 +278,7 @@ namespace Microsoft.ML.Data
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;
                 if (hasWeighted)
-                    isWeightedGetter = cursor.GetGetter<bool>(isWeightedCol);
+                    isWeightedGetter = cursor.GetGetter<bool>(schema[isWeightedCol]);
                 else
                     isWeightedGetter = (ref bool dst) => dst = false;
 
@@ -298,7 +298,8 @@ namespace Microsoft.ML.Data
 
                 for (int i = 0; i < schema.Count; i++)
                 {
-                    if (schema[i].IsHidden || hasWeighted && i == isWeightedCol ||
+                    var column = schema[i];
+                    if (column.IsHidden || hasWeighted && i == isWeightedCol ||
                         hasStrats && (i == stratCol || i == stratVal))
                         continue;
 
@@ -309,7 +310,7 @@ namespace Microsoft.ML.Data
                         && vectorType.IsKnownSize
                         && vectorType.ItemType == NumberDataViewType.Double
                         && getVectorMetrics)
-                        vBufferGetters[i] = cursor.GetGetter<VBuffer<double>>(i);
+                        vBufferGetters[i] = cursor.GetGetter<VBuffer<double>>(column);
                 }
 
                 Double metricVal = 0;
@@ -1021,7 +1022,7 @@ namespace Microsoft.ML.Data
                         continue;
                     }
 
-                    vBufferGetters[i] = row.GetGetter<VBuffer<double>>(i);
+                    vBufferGetters[i] = row.GetGetter<VBuffer<double>>(schema[i]);
                     metricCount += vectorType.Size;
                     var slotNamesType = schema[i].Annotations.Schema.GetColumnOrNull(AnnotationUtils.Kinds.SlotNames)?.Type as VectorType;
                     if (slotNamesType != null && slotNamesType.Size == vectorType.Size && slotNamesType.ItemType is TextDataViewType)
@@ -1074,13 +1075,14 @@ namespace Microsoft.ML.Data
         internal static AggregatedMetric[] ComputeMetricsSum(IHostEnvironment env, IDataView data, int numFolds, out int isWeightedCol,
             out int stratCol, out int stratVal, out int foldCol, out AggregatedMetric[] weightedAgg)
         {
-            var hasWeighted = data.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.IsWeighted, out int wcol);
+            var isWeightedColumn = data.Schema.GetColumnOrNull(MetricKinds.ColumnNames.IsWeighted);
+            var hasWeighted = isWeightedColumn != null && isWeightedColumn.HasValue;
             var hasStrats = data.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratCol, out int scol);
             var hasStratVals = data.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratVal, out int svalcol);
             env.Assert(hasStrats == hasStratVals);
             var hasFoldCol = data.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.FoldIndex, out int fcol);
 
-            isWeightedCol = hasWeighted ? wcol : -1;
+            isWeightedCol = hasWeighted ? isWeightedColumn.Value.Index : -1;
             stratCol = hasStrats ? scol : -1;
             stratVal = hasStratVals ? svalcol : -1;
             foldCol = hasFoldCol ? fcol : -1;
@@ -1097,7 +1099,7 @@ namespace Microsoft.ML.Data
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;
                 if (hasWeighted)
-                    isWeightedGetter = cursor.GetGetter<bool>(isWeightedCol);
+                    isWeightedGetter = cursor.GetGetter<bool>(isWeightedColumn.Value);
                 else
                     isWeightedGetter = (ref bool dst) => dst = false;
 
@@ -1116,7 +1118,7 @@ namespace Microsoft.ML.Data
                 using (var ch = env.Register("GetMetricsAsString").Start("Get Metric Names"))
                 {
                     metricNames = GetMetricNames(ch, data.Schema, cursor,
-                        i => hasWeighted && i == wcol || hasStrats && (i == scol || i == svalcol) ||
+                        i => hasWeighted && i == isWeightedColumn.Value.Index || hasStrats && (i == scol || i == svalcol) ||
                             hasFoldCol && i == fcol, getters, vBufferGetters);
                 }
                 agg = new AggregatedMetric[metricNames.Count];
@@ -1153,7 +1155,7 @@ namespace Microsoft.ML.Data
                             throw Contracts.Except("Multiple unweighted rows found in metrics data view.");
 
                         numResults++;
-                        UpdateSums(isWeightedCol, stratCol, stratVal, agg, numFolds > 1, metricNames, hasWeighted, hasStrats,
+                        UpdateSums(isWeightedColumn.Value.Index, stratCol, stratVal, agg, numFolds > 1, metricNames, hasWeighted, hasStrats,
                             colCount, getters, vBufferGetters, ref metricVal, ref metricVals);
                     }
 
@@ -1440,7 +1442,7 @@ namespace Microsoft.ML.Data
             {
                 var type = cursor.Schema[countIndex].Type as VectorType;
                 Contracts.Check(type != null && type.IsKnownSize && type.ItemType == NumberDataViewType.Double);
-                var countGetter = cursor.GetGetter<VBuffer<double>>(countIndex);
+                var countGetter = cursor.GetGetter<VBuffer<double>>(cursor.Schema[countIndex]);
                 ValueGetter<uint> stratGetter = null;
                 if (hasStrat)
                 {
@@ -1698,13 +1700,13 @@ namespace Microsoft.ML.Data
             IDataView warnings;
             if (metrics.TryGetValue(MetricKinds.Warnings, out warnings))
             {
-                int col;
-                if (warnings.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.WarningText, out col) && warnings.Schema[col].Type is TextDataViewType)
+                var warningTextColumn = warnings.Schema.GetColumnOrNull(MetricKinds.ColumnNames.WarningText);
+                if (warningTextColumn !=null && warningTextColumn.HasValue && warningTextColumn.Value.Type is TextDataViewType)
                 {
                     using (var cursor = warnings.GetRowCursor(warnings.Schema[MetricKinds.ColumnNames.WarningText]))
                     {
                         var warning = default(ReadOnlyMemory<char>);
-                        var getter = cursor.GetGetter<ReadOnlyMemory<char>>(col);
+                        var getter = cursor.GetGetter<ReadOnlyMemory<char>>(warningTextColumn.Value);
                         while (cursor.MoveNext())
                         {
                             getter(ref warning);

--- a/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
+++ b/src/Microsoft.ML.Data/Evaluators/EvaluatorUtils.cs
@@ -1076,7 +1076,7 @@ namespace Microsoft.ML.Data
             out int stratCol, out int stratVal, out int foldCol, out AggregatedMetric[] weightedAgg)
         {
             var isWeightedColumn = data.Schema.GetColumnOrNull(MetricKinds.ColumnNames.IsWeighted);
-            var hasWeighted = isWeightedColumn != null && isWeightedColumn.HasValue;
+            var hasWeighted = isWeightedColumn.HasValue;
             var hasStrats = data.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratCol, out int scol);
             var hasStratVals = data.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratVal, out int svalcol);
             env.Assert(hasStrats == hasStratVals);
@@ -1155,7 +1155,7 @@ namespace Microsoft.ML.Data
                             throw Contracts.Except("Multiple unweighted rows found in metrics data view.");
 
                         numResults++;
-                        UpdateSums(isWeightedColumn.Value.Index, stratCol, stratVal, agg, numFolds > 1, metricNames, hasWeighted, hasStrats,
+                        UpdateSums(isWeightedCol, stratCol, stratVal, agg, numFolds > 1, metricNames, hasWeighted, hasStrats,
                             colCount, getters, vBufferGetters, ref metricVal, ref metricVals);
                     }
 

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/BinaryClassificationMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/BinaryClassificationMetrics.cs
@@ -76,10 +76,11 @@ namespace Microsoft.ML.Data
 
         private protected static T Fetch<T>(IExceptionContext ectx, DataViewRow row, string name)
         {
-            if (!row.Schema.TryGetColumnIndex(name, out int col))
+            var column = row.Schema.GetColumnOrNull(name);
+            if (!column.HasValue)
                 throw ectx.Except($"Could not find column '{name}'");
             T val = default;
-            row.GetGetter<T>(col)(ref val);
+            row.GetGetter<T>(column.Value)(ref val);
             return val;
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/RankingMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/RankingMetrics.cs
@@ -31,10 +31,11 @@ namespace Microsoft.ML.Data
 
         private static T Fetch<T>(IExceptionContext ectx, DataViewRow row, string name)
         {
-            if (!row.Schema.TryGetColumnIndex(name, out int col))
+            var column = row.Schema.GetColumnOrNull(name);
+            if (!column.HasValue)
                 throw ectx.Except($"Could not find column '{name}'");
             T val = default;
-            row.GetGetter<T>(col)(ref val);
+            row.GetGetter<T>(column.Value)(ref val);
             return val;
         }
 

--- a/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiClassClassifierEvaluator.cs
@@ -394,12 +394,12 @@ namespace Microsoft.ML.Data
                 var score = schema.GetUniqueColumn(AnnotationUtils.Const.ScoreValueKind.Score);
                 Host.Assert(score.Type.GetVectorSize() == _scoresArr.Length);
                 _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
-                _scoreGetter = row.GetGetter<VBuffer<float>>(score.Index);
+                _scoreGetter = row.GetGetter<VBuffer<float>>(score);
                 Host.AssertValue(_labelGetter);
                 Host.AssertValue(_scoreGetter);
 
                 if (schema.Weight.HasValue)
-                    _weightGetter = row.GetGetter<float>(schema.Weight.Value.Index);
+                    _weightGetter = row.GetGetter<float>(schema.Weight.Value);
             }
 
             public override void ProcessRow()
@@ -678,7 +678,7 @@ namespace Microsoft.ML.Data
 
             var labelGetter = activeCols(LogLossCol) ? RowCursorUtils.GetLabelGetter(input, LabelIndex) :
                 (ref float dst) => dst = float.NaN;
-            var scoreGetter = input.GetGetter<VBuffer<float>>(ScoreIndex);
+            var scoreGetter = input.GetGetter<VBuffer<float>>(input.Schema[ScoreIndex]);
             Action updateCacheIfNeeded =
                 () =>
                 {

--- a/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/MultiOutputRegressionEvaluator.cs
@@ -306,12 +306,12 @@ namespace Microsoft.ML.Data
                 var score = schema.GetUniqueColumn(AnnotationUtils.Const.ScoreValueKind.Score);
 
                 _labelGetter = RowCursorUtils.GetVecGetterAs<float>(NumberDataViewType.Single, row, schema.Label.Value.Index);
-                _scoreGetter = row.GetGetter<VBuffer<float>>(score.Index);
+                _scoreGetter = row.GetGetter<VBuffer<float>>(score);
                 Contracts.AssertValue(_labelGetter);
                 Contracts.AssertValue(_scoreGetter);
 
                 if (schema.Weight.HasValue)
-                    _weightGetter = row.GetGetter<float>(schema.Weight.Value.Index);
+                    _weightGetter = row.GetGetter<float>(schema.Weight.Value);
             }
 
             public override void ProcessRow()
@@ -472,7 +472,7 @@ namespace Microsoft.ML.Data
                 ? RowCursorUtils.GetVecGetterAs<float>(NumberDataViewType.Single, input, LabelIndex)
                 : nullGetter;
             var scoreGetter = activeCols(ScoreOutput) || activeCols(L1Output) || activeCols(L2Output) || activeCols(DistCol)
-                ? input.GetGetter<VBuffer<float>>(ScoreIndex)
+                ? input.GetGetter<VBuffer<float>>(input.Schema[ScoreIndex])
                 : nullGetter;
             Action updateCacheIfNeeded =
                 () =>
@@ -664,8 +664,7 @@ namespace Microsoft.ML.Data
             if (!metrics.TryGetValue(MetricKinds.OverallMetrics, out fold))
                 throw ch.Except("No overall metrics found");
 
-            int isWeightedCol;
-            bool needWeighted = fold.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.IsWeighted, out isWeightedCol);
+            var isWeightedCol = fold.Schema.GetColumnOrNull(MetricKinds.ColumnNames.IsWeighted);
 
             int stratCol;
             bool hasStrats = fold.Schema.TryGetColumnIndex(MetricKinds.ColumnNames.StratCol, out stratCol);
@@ -680,8 +679,8 @@ namespace Microsoft.ML.Data
             {
                 bool isWeighted = false;
                 ValueGetter<bool> isWeightedGetter;
-                if (needWeighted)
-                    isWeightedGetter = cursor.GetGetter<bool>(isWeightedCol);
+                if (isWeightedCol.HasValue)
+                    isWeightedGetter = cursor.GetGetter<bool>(isWeightedCol.Value);
                 else
                     isWeightedGetter = (ref bool dst) => dst = false;
 
@@ -697,7 +696,8 @@ namespace Microsoft.ML.Data
                 int labelCount = 0;
                 for (int i = 0; i < fold.Schema.Count; i++)
                 {
-                    if (fold.Schema[i].IsHidden || (needWeighted && i == isWeightedCol) ||
+                    var currentColumn = fold.Schema[i];
+                    if (currentColumn.IsHidden || (isWeightedCol.HasValue && i == isWeightedCol.Value.Index) ||
                         (hasStrats && (i == stratCol || i == stratVal)))
                     {
                         continue;
@@ -706,7 +706,7 @@ namespace Microsoft.ML.Data
                     var type = fold.Schema[i].Type as VectorType;
                     if (type != null && type.IsKnownSize && type.ItemType == NumberDataViewType.Double)
                     {
-                        vBufferGetters[i] = cursor.GetGetter<VBuffer<double>>(i);
+                        vBufferGetters[i] = cursor.GetGetter<VBuffer<double>>(currentColumn);
                         if (labelCount == 0)
                             labelCount = type.Size;
                         else
@@ -725,7 +725,7 @@ namespace Microsoft.ML.Data
                 sb.AppendLine();
 
                 VBuffer<Double> metricVals = default(VBuffer<Double>);
-                bool foundWeighted = !needWeighted;
+                bool foundWeighted = !isWeightedCol.HasValue;
                 bool foundUnweighted = false;
                 uint strat = 0;
                 while (cursor.MoveNext())

--- a/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/QuantileRegressionEvaluator.cs
@@ -393,7 +393,7 @@ namespace Microsoft.ML.Data
             var labelGetter = activeCols(L1Col) || activeCols(L2Col) ? RowCursorUtils.GetLabelGetter(input, LabelIndex) : nanGetter;
             ValueGetter<VBuffer<float>> scoreGetter;
             if (activeCols(L1Col) || activeCols(L2Col))
-                scoreGetter = input.GetGetter<VBuffer<float>>(ScoreIndex);
+                scoreGetter = input.GetGetter<VBuffer<float>>(input.Schema[ScoreIndex]);
             else
                 scoreGetter = (ref VBuffer<float> dst) => dst = default(VBuffer<float>);
             Action updateCacheIfNeeded =

--- a/src/Microsoft.ML.Data/Evaluators/RankingEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RankingEvaluator.cs
@@ -448,10 +448,10 @@ namespace Microsoft.ML.Data
                 var score = schema.GetUniqueColumn(AnnotationUtils.Const.ScoreValueKind.Score);
 
                 _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
-                _scoreGetter = row.GetGetter<Single>(score.Index);
+                _scoreGetter = row.GetGetter<Single>(score);
                 _newGroupDel = RowCursorUtils.GetIsNewGroupDelegate(row, schema.Group.Value.Index);
                 if (schema.Weight.HasValue)
-                    _weightGetter = row.GetGetter<Single>(schema.Weight.Value.Index);
+                    _weightGetter = row.GetGetter<Single>(schema.Weight.Value);
 
                 if (UnweightedCounters.GroupSummary)
                 {
@@ -784,7 +784,7 @@ namespace Microsoft.ML.Data
 
             protected override ValueGetter<Single> GetScoreGetter(DataViewRow row)
             {
-                return row.GetGetter<Single>(_bindings.ScoreIndex);
+                return row.GetGetter<Single>(row.Schema[_bindings.ScoreIndex]);
             }
 
             protected override RowCursorState InitializeState(DataViewRow input)

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluator.cs
@@ -273,7 +273,7 @@ namespace Microsoft.ML.Data
             var labelGetter = activeCols(L1Col) || activeCols(L2Col) ? RowCursorUtils.GetLabelGetter(input, LabelIndex) : nan;
             ValueGetter<float> scoreGetter;
             if (activeCols(L1Col) || activeCols(L2Col))
-                scoreGetter = input.GetGetter<float>(ScoreIndex);
+                scoreGetter = input.GetGetter<float>(input.Schema[ScoreIndex]);
             else
                 scoreGetter = nan;
             Action updateCacheIfNeeded =

--- a/src/Microsoft.ML.Data/Evaluators/RegressionEvaluatorBase.cs
+++ b/src/Microsoft.ML.Data/Evaluators/RegressionEvaluatorBase.cs
@@ -204,12 +204,12 @@ namespace Microsoft.ML.Data
                 var score = schema.GetUniqueColumn(AnnotationUtils.Const.ScoreValueKind.Score);
 
                 _labelGetter = RowCursorUtils.GetLabelGetter(row, schema.Label.Value.Index);
-                _scoreGetter = row.GetGetter<TScore>(score.Index);
+                _scoreGetter = row.GetGetter<TScore>(score);
                 Contracts.AssertValue(_labelGetter);
                 Contracts.AssertValue(_scoreGetter);
 
                 if (schema.Weight.HasValue)
-                    _weightGetter = row.GetGetter<float>(schema.Weight.Value.Index);
+                    _weightGetter = row.GetGetter<float>(schema.Weight.Value);
             }
 
             public override void ProcessRow()

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -630,27 +630,20 @@ namespace Microsoft.ML.Calibrators
                 return _predictor.GetInputColumnRoles();
             }
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> predicate)
+            DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
-                Func<int, bool> predictorPredicate = col => false;
-                for (int i = 0; i < OutputSchema.Count; i++)
-                {
-                    if (predicate(i))
-                    {
-                        predictorPredicate = col => true;
-                        break;
-                    }
-                }
-                var predictorRow = _predictor.GetRow(input, predictorPredicate);
+                var predictorRow = _predictor.GetRow(input, activeColumns.Count() > 0 ? OutputSchema : Enumerable.Empty<DataViewSchema.Column>());
                 var getters = new Delegate[OutputSchema.Count];
-                for (int i = 0; i < OutputSchema.Count - 1; i++)
+
+                foreach (var column in activeColumns)
                 {
-                    var type = predictorRow.Schema[i].Type;
-                    if (!predicate(i))
+                    if (column.Index == OutputSchema.Count - 1)
                         continue;
-                    getters[i] = Utils.MarshalInvoke(GetPredictorGetter<int>, type.RawType, predictorRow, i);
+                    var type = predictorRow.Schema[column.Index].Type;
+                    getters[column.Index] = Utils.MarshalInvoke(GetPredictorGetter<int>, type.RawType, predictorRow, column.Index);
                 }
-                if (predicate(OutputSchema.Count - 1))
+
+                if (activeColumns.Select(c => c.Name).Contains(DefaultColumnNames.Probability))
                     getters[OutputSchema.Count - 1] = GetProbGetter(predictorRow);
                 return new SimpleRow(OutputSchema, predictorRow, getters);
             }

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Calibrators
                 Host.AssertValue(input);
                 disposer = null;
 
-                Host.Assert(input.IsColumnActive(_scoreColIndex));
+                Host.Assert(input.IsColumnActive(input.Schema[_scoreColIndex]));
                 var getScore = input.GetGetter<float>(input.Schema[_scoreColIndex]);
 
                 float score = default;

--- a/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
+++ b/src/Microsoft.ML.Data/Prediction/CalibratorCatalog.cs
@@ -235,7 +235,7 @@ namespace Microsoft.ML.Calibrators
                 disposer = null;
 
                 Host.Assert(input.IsColumnActive(_scoreColIndex));
-                var getScore = input.GetGetter<float>(_scoreColIndex);
+                var getScore = input.GetGetter<float>(input.Schema[_scoreColIndex]);
 
                 float score = default;
 

--- a/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
+++ b/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
@@ -140,7 +140,7 @@ namespace Microsoft.ML
                  SchemaDefinition inputSchemaDefinition, SchemaDefinition outputSchemaDefinition, out Action disposer, out IRowReadableAs<TDst> outputRow)
         {
             var cursorable = TypedCursorable<TDst>.Create(env, new EmptyDataView(env, mapper.OutputSchema), ignoreMissingColumns, outputSchemaDefinition);
-            var outputRowLocal = mapper.GetRow(inputRow, col => true);
+            var outputRowLocal = mapper.GetRow(inputRow, mapper.OutputSchema);
             outputRow = cursorable.GetRow(outputRowLocal);
             disposer = inputRow.Dispose;
         }

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Data
         {
             Host.AssertValue(output);
             Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
-            Host.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
+            Host.Assert(output.IsColumnActive(output.Schema[Bindings.ScoreColumnIndex]));
 
             var scoreColumn = output.Schema[Bindings.ScoreColumnIndex];
             ValueGetter<float> mapperScoreGetter = output.GetGetter<float>(scoreColumn);

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -222,7 +222,8 @@ namespace Microsoft.ML.Data
             Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
             Host.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
 
-            ValueGetter<float> mapperScoreGetter = output.GetGetter<float>(Bindings.ScoreColumnIndex);
+            var scoreColumn = output.Schema[Bindings.ScoreColumnIndex];
+            ValueGetter<float> mapperScoreGetter = output.GetGetter<float>(scoreColumn);
 
             long cachedPosition = -1;
             float score = 0;

--- a/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Data
             Contracts.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
             Contracts.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
 
-            ValueGetter<VBuffer<float>> mapperScoreGetter = output.GetGetter<VBuffer<float>>(Bindings.ScoreColumnIndex);
+            ValueGetter<VBuffer<float>> mapperScoreGetter = output.GetGetter<VBuffer<float>>(output.Schema[Bindings.ScoreColumnIndex]);
 
             long cachedPosition = -1;
             VBuffer<float> score = default(VBuffer<float>);

--- a/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/ClusteringScorer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Data
         {
             Contracts.AssertValue(output);
             Contracts.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
-            Contracts.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
+            Contracts.Assert(output.IsColumnActive(output.Schema[Bindings.ScoreColumnIndex]));
 
             ValueGetter<VBuffer<float>> mapperScoreGetter = output.GetGetter<VBuffer<float>>(output.Schema[Bindings.ScoreColumnIndex]);
 

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculation.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculation.cs
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Data
                 Contracts.AssertValue(input);
                 Contracts.AssertValue(Predictor);
 
-                var featureGetter = input.GetGetter<TSrc>(colSrc);
+                var featureGetter = input.GetGetter<TSrc>(input.Schema[colSrc]);
                 var map = Predictor.GetFeatureContributionMapper<TSrc, VBuffer<float>>(_topContributionsCount, _bottomContributionsCount, _normalize);
 
                 var features = default(TSrc);
@@ -263,7 +263,7 @@ namespace Microsoft.ML.Data
                 Contracts.AssertValue(input);
                 Contracts.AssertValue(Predictor);
 
-                var featureGetter = input.GetGetter<TSrc>(colSrc);
+                var featureGetter = input.GetGetter<TSrc>(input.Schema[colSrc]);
 
                 // REVIEW: Scorer can call Sparsification\Norm routine.
 
@@ -367,7 +367,7 @@ namespace Microsoft.ML.Data
                 var totalColumnsCount = 1 + _outputGenericSchema.Count;
                 var getters = new Delegate[totalColumnsCount];
 
-                if (activeColumns.Select(c => c.Index).Contains(totalColumnsCount - 1))
+                if (activeColumns.Select(c => c.Index).Contains(_outputGenericSchema.Count))
                 {
                     getters[totalColumnsCount - 1] = _parent.Stringify
                         ? _parent.GetTextContributionGetter(input, FeatureColumn.Index, _slotNames)
@@ -383,9 +383,6 @@ namespace Microsoft.ML.Data
 
                 return new SimpleRow(OutputSchema, genericRow, getters);
             }
-
-            public Func<int, bool> GetGenericPredicate(Func<int, bool> predicate)
-                => col => predicate(col);
 
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculation.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculation.cs
@@ -360,7 +360,7 @@ namespace Microsoft.ML.Data
                 return Enumerable.Repeat(FeatureColumn, 1);
             }
 
-            public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+            DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 Contracts.AssertValue(input);
                 Contracts.AssertValue(activeColumns);

--- a/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculation.cs
+++ b/src/Microsoft.ML.Data/Scorers/FeatureContributionCalculation.cs
@@ -377,7 +377,7 @@ namespace Microsoft.ML.Data
                 var genericRow = _genericRowMapper.GetRow(input, activeColumns);
                 for (var i = 0; i < _outputGenericSchema.Count; i++)
                 {
-                    if (genericRow.IsColumnActive(i))
+                    if (genericRow.IsColumnActive(genericRow.Schema[i]))
                         getters[i] = RowCursorUtils.GetGetterAsDelegate(genericRow, i);
                 }
 

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -359,7 +359,7 @@ namespace Microsoft.ML.Data
                     /// <summary>
                     /// Returns whether the given column is active in this row.
                     /// </summary>
-                    public override bool IsColumnActive(int columnIndex) => Input.IsColumnActive(columnIndex);
+                    public override bool IsColumnActive(DataViewSchema.Column column) => Input.IsColumnActive(column);
 
                     /// <summary>
                     /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
@@ -509,7 +509,7 @@ namespace Microsoft.ML.Data
         {
             Host.AssertValue(output);
             Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
-            Host.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
+            Host.Assert(output.IsColumnActive(output.Schema[Bindings.ScoreColumnIndex]));
 
             ValueGetter<VBuffer<float>> mapperScoreGetter = output.GetGetter<VBuffer<float>>(Bindings.RowMapper.OutputSchema[Bindings.ScoreColumnIndex]);
 

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -356,9 +356,19 @@ namespace Microsoft.ML.Data
                         _schema = schema;
                     }
 
-                    public override bool IsColumnActive(int col) => Input.IsColumnActive(col);
+                    /// <summary>
+                    /// Returns whether the given column is active in this row.
+                    /// </summary>
+                    public override bool IsColumnActive(int columnIndex) => Input.IsColumnActive(columnIndex);
 
-                    public override ValueGetter<TValue> GetGetter<TValue>(int col) => Input.GetGetter<TValue>(col);
+                    /// <summary>
+                    /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                    /// This throws if the column is not active in this row, or if the type
+                    /// <typeparamref name="TValue"/> differs from this column's type.
+                    /// </summary>
+                    /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                    /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+                    public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => Input.GetGetter<TValue>(columnIndex);
                 }
             }
         }

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -362,13 +362,13 @@ namespace Microsoft.ML.Data
                     public override bool IsColumnActive(int columnIndex) => Input.IsColumnActive(columnIndex);
 
                     /// <summary>
-                    /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+                    /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
                     /// This throws if the column is not active in this row, or if the type
                     /// <typeparamref name="TValue"/> differs from this column's type.
                     /// </summary>
                     /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-                    /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-                    public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex) => Input.GetGetter<TValue>(columnIndex);
+                    /// <param name="column"> is the output column whose getter should be returned.</param>
+                    public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column) => Input.GetGetter<TValue>(column);
                 }
             }
         }
@@ -511,7 +511,7 @@ namespace Microsoft.ML.Data
             Host.Assert(output.Schema == Bindings.RowMapper.OutputSchema);
             Host.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
 
-            ValueGetter<VBuffer<float>> mapperScoreGetter = output.GetGetter<VBuffer<float>>(Bindings.ScoreColumnIndex);
+            ValueGetter<VBuffer<float>> mapperScoreGetter = output.GetGetter<VBuffer<float>>(Bindings.RowMapper.OutputSchema[Bindings.ScoreColumnIndex]);
 
             long cachedPosition = -1;
             VBuffer<float> score = default;

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -366,7 +366,7 @@ namespace Microsoft.ML.Data
                     /// This throws if the column is not active in this row, or if the type
                     /// <typeparamref name="TValue"/> differs from this column's type.
                     /// </summary>
-                    /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+                    /// <typeparam name="TValue"> is the column's content type.</typeparam>
                     /// <param name="column"> is the output column whose getter should be returned.</param>
                     public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column) => Input.GetGetter<TValue>(column);
                 }

--- a/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/MultiClassClassifierScorer.cs
@@ -334,9 +334,9 @@ namespace Microsoft.ML.Data
 
                 public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles() => _mapper.GetInputColumnRoles();
 
-                public DataViewRow GetRow(DataViewRow input, Func<int, bool> predicate)
+                DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
                 {
-                    var innerRow = _mapper.GetRow(input, predicate);
+                    var innerRow = _mapper.GetRow(input, activeColumns);
                     return new RowImpl(innerRow, OutputSchema);
                 }
 

--- a/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
@@ -85,11 +85,9 @@ namespace Microsoft.ML.Data
             private static DataViewSchema.Annotations KeyValueMetadataFromMetadata<T>(DataViewSchema.Annotations meta, DataViewSchema.Column metaCol)
             {
                 Contracts.AssertValue(meta);
-                Contracts.Assert(0 <= metaCol.Index && metaCol.Index < meta.Schema.Count);
                 Contracts.Assert(metaCol.Type.RawType == typeof(T));
-                var getter = meta.GetGetter<T>(metaCol.Index);
                 var builder = new DataViewSchema.Annotations.Builder();
-                builder.Add(AnnotationUtils.Kinds.KeyValues, metaCol.Type, meta.GetGetter<T>(metaCol.Index));
+                builder.Add(AnnotationUtils.Kinds.KeyValues, metaCol.Type, meta.GetGetter<T>(metaCol));
                 return builder.ToAnnotations();
             }
 
@@ -233,13 +231,13 @@ namespace Microsoft.ML.Data
                 }
                 if (iinfo < DerivedColumnCount && _predColMetadata != null)
                 {
-                    int mcol;
-                    if (_predColMetadata.Schema.TryGetColumnIndex(kind, out mcol))
+                    var mcol = _predColMetadata.Schema.GetColumnOrNull(kind);
+                    if (mcol.HasValue)
                     {
                         // REVIEW: In the event that TValue is not the right type, it won't really be
                         // the "right" type of exception. However considering that I consider the metadata
                         // schema as it stands right now to be temporary, let's suppose we don't really care.
-                        _predColMetadata.GetGetter<TValue>(mcol)(ref value);
+                        _predColMetadata.GetGetter<TValue>(mcol.Value)(ref value);
                         return;
                     }
                 }

--- a/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictedLabelScorerBase.cs
@@ -417,7 +417,7 @@ namespace Microsoft.ML.Data
             Delegate delScore = null;
             if (predicate(0))
             {
-                Host.Assert(output.IsColumnActive(Bindings.ScoreColumnIndex));
+                Host.Assert(output.IsColumnActive(output.Schema[Bindings.ScoreColumnIndex]));
                 getters[0] = GetPredictedLabelGetter(output, out delScore);
             }
 

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -268,18 +268,28 @@ namespace Microsoft.ML.Data
                 base.Dispose(disposing);
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.ColumnCount);
-                return _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.ColumnCount);
+                return _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Data.DataView;
 using Microsoft.ML.CommandLine;
-using Microsoft.ML.Model;
 
 namespace Microsoft.ML.Data
 {
@@ -202,7 +201,7 @@ namespace Microsoft.ML.Data
         {
             Contracts.AssertValue(row);
             Contracts.Assert(0 <= col && col < row.Schema.Count);
-            Contracts.Assert(row.IsColumnActive(col));
+            Contracts.Assert(row.IsColumnActive(row.Schema[col]));
 
             var type = row.Schema[col].Type;
             Func<DataViewRow, int, ValueGetter<int>> del = GetGetterFromRow<int>;
@@ -214,7 +213,7 @@ namespace Microsoft.ML.Data
         {
             Contracts.AssertValue(output);
             Contracts.Assert(0 <= col && col < output.Schema.Count);
-            Contracts.Assert(output.IsColumnActive(col));
+            Contracts.Assert(output.IsColumnActive(output.Schema[col]));
             return output.GetGetter<T>(output.Schema[col]);
         }
 
@@ -272,10 +271,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _bindings.ColumnCount);
-                return _active[columnIndex];
+                Ch.Check(column.Index < _bindings.ColumnCount);
+                return _active[column.Index];
             }
 
             /// <summary>
@@ -287,7 +286,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 bool isSrc;
                 int index = _bindings.MapColumnIndex(out isSrc, column.Index);

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -282,7 +282,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -168,7 +168,7 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(input);
             Contracts.Assert(ValueMapper != null);
 
-            var featureGetter = input.GetGetter<TSrc>(colSrc);
+            var featureGetter = input.GetGetter<TSrc>(input.Schema[colSrc]);
             var map = ValueMapper.GetMapper<TSrc, TDst>();
             var features = default(TSrc);
             return
@@ -524,7 +524,7 @@ namespace Microsoft.ML.Data
                 if (active[0] || active[1])
                 {
                     // Put all captured locals at this scope.
-                    var featureGetter = InputRoleMappedSchema.Feature?.Index is int idx ? input.GetGetter<VBuffer<float>>(idx) : null;
+                    var featureGetter = InputRoleMappedSchema.Feature.HasValue ? input.GetGetter<VBuffer<float>>(InputRoleMappedSchema.Feature.Value) : null;
                     float prob = 0;
                     float score = 0;
                     long cachedPosition = -1;
@@ -665,13 +665,14 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(input);
             Contracts.Assert(0 <= colSrc && colSrc < input.Schema.Count);
 
-            var typeSrc = input.Schema[colSrc].Type as VectorType;
+            var column = input.Schema[colSrc];
+            var typeSrc = column.Type as VectorType;
             Contracts.Assert(typeSrc != null && typeSrc.ItemType == NumberDataViewType.Single);
             Contracts.Assert(ValueMapper == null ||
                 typeSrc.Size == ValueMapper.InputType.GetVectorSize() || ValueMapper.InputType.GetVectorSize() == 0);
             Contracts.Assert(Utils.Size(_quantiles) > 0);
 
-            var featureGetter = input.GetGetter<VBuffer<float>>(colSrc);
+            var featureGetter = input.GetGetter<VBuffer<float>>(column);
             var featureCount = ValueMapper != null ? ValueMapper.InputType.GetVectorSize() : 0;
 
             var quantiles = new float[_quantiles.Length];

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -232,13 +232,13 @@ namespace Microsoft.ML.Data
 
             public DataViewSchema InputSchema => InputRoleMappedSchema.Schema;
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> predicate)
+            DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 Contracts.AssertValue(input);
-                Contracts.AssertValue(predicate);
+                Contracts.AssertValue(activeColumns);
 
                 var getters = new Delegate[1];
-                if (predicate(0))
+                if (activeColumns.Select(c => c.Index).Contains(0))
                     getters[0] = _parent.GetPredictionGetter(input, InputRoleMappedSchema.Feature.Value.Index);
                 return new SimpleRow(OutputSchema, input, getters);
             }
@@ -571,10 +571,10 @@ namespace Microsoft.ML.Data
                 }
             }
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> predicate)
+            DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 Contracts.AssertValue(input);
-                var active = Utils.BuildArray(OutputSchema.Count, predicate);
+                var active = Utils.BuildArray(OutputSchema.Count, activeColumns);
                 var getters = CreateGetters(input, active);
                 return new SimpleRow(OutputSchema, input, getters);
             }

--- a/src/Microsoft.ML.Data/Training/TrainerUtils.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerUtils.cs
@@ -267,7 +267,7 @@ namespace Microsoft.ML.Trainers
             Contracts.CheckParam(schema.Schema == row.Schema, nameof(schema), "schemas don't match!");
             Contracts.CheckParam(schema.Feature.HasValue, nameof(schema), "Missing feature column");
 
-            return row.GetGetter<VBuffer<float>>(schema.Feature.Value.Index);
+            return row.GetGetter<VBuffer<float>>(schema.Feature.Value);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
+++ b/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML.Data
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
-        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+        /// <typeparam name="TValue"> is the column's content type.</typeparam>
         /// <param name="column"> is the output column whose getter should be returned.</param>
         public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
         {

--- a/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
+++ b/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
@@ -34,21 +34,31 @@ namespace Microsoft.ML.Data
             _bindings = bindings;
         }
 
-        public override bool IsColumnActive(int col)
+        /// <summary>
+        /// Returns whether the given column is active in this row.
+        /// </summary>
+        public override bool IsColumnActive(int columnIndex)
         {
-            Ch.Check(0 <= col & col < _bindings.ColumnCount, "col");
+            Ch.Check(0 <= columnIndex & columnIndex < _bindings.ColumnCount, "col");
             bool isSrc;
-            col = _bindings.MapColumnIndex(out isSrc, col);
-            return isSrc && Input.IsColumnActive(col);
+            columnIndex = _bindings.MapColumnIndex(out isSrc, columnIndex);
+            return isSrc && Input.IsColumnActive(columnIndex);
         }
 
-        public override ValueGetter<TValue> GetGetter<TValue>(int col)
+        /// <summary>
+        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+        /// This throws if the column is not active in this row, or if the type
+        /// <typeparamref name="TValue"/> differs from this column's type.
+        /// </summary>
+        /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+        public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
         {
-            Ch.Check(IsColumnActive(col), "col");
+            Ch.Check(IsColumnActive(columnIndex), nameof(columnIndex));
             bool isSrc;
-            col = _bindings.MapColumnIndex(out isSrc, col);
+            columnIndex = _bindings.MapColumnIndex(out isSrc, columnIndex);
             Ch.Assert(isSrc);
-            return Input.GetGetter<TValue>(col);
+            return Input.GetGetter<TValue>(columnIndex);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
+++ b/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
@@ -37,12 +37,12 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Returns whether the given column is active in this row.
         /// </summary>
-        public override bool IsColumnActive(int columnIndex)
+        public override bool IsColumnActive(DataViewSchema.Column column)
         {
-            Ch.Check(0 <= columnIndex & columnIndex < _bindings.ColumnCount, nameof(columnIndex));
+            Ch.Check(column.Index < _bindings.ColumnCount, nameof(column));
             bool isSrc;
-            columnIndex = _bindings.MapColumnIndex(out isSrc, columnIndex);
-            return isSrc && Input.IsColumnActive(columnIndex);
+            int srcColumnIndex = _bindings.MapColumnIndex(out isSrc, column.Index);
+            return isSrc && Input.IsColumnActive(Schema[srcColumnIndex]);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Data
         /// <param name="column"> is the output column whose getter should be returned.</param>
         public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
         {
-            Ch.Check(IsColumnActive(column.Index), nameof(column));
+            Ch.Check(IsColumnActive(column), nameof(column));
             bool isSrc;
             var index = _bindings.MapColumnIndex(out isSrc, column.Index);
             Ch.Assert(isSrc);

--- a/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
+++ b/src/Microsoft.ML.Data/Transforms/BindingsWrappedRowCursor.cs
@@ -39,26 +39,26 @@ namespace Microsoft.ML.Data
         /// </summary>
         public override bool IsColumnActive(int columnIndex)
         {
-            Ch.Check(0 <= columnIndex & columnIndex < _bindings.ColumnCount, "col");
+            Ch.Check(0 <= columnIndex & columnIndex < _bindings.ColumnCount, nameof(columnIndex));
             bool isSrc;
             columnIndex = _bindings.MapColumnIndex(out isSrc, columnIndex);
             return isSrc && Input.IsColumnActive(columnIndex);
         }
 
         /// <summary>
-        /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+        /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
         /// This throws if the column is not active in this row, or if the type
         /// <typeparamref name="TValue"/> differs from this column's type.
         /// </summary>
         /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-        /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-        public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+        /// <param name="column"> is the output column whose getter should be returned.</param>
+        public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
         {
-            Ch.Check(IsColumnActive(columnIndex), nameof(columnIndex));
+            Ch.Check(IsColumnActive(column.Index), nameof(column));
             bool isSrc;
-            columnIndex = _bindings.MapColumnIndex(out isSrc, columnIndex);
+            var index = _bindings.MapColumnIndex(out isSrc, column.Index);
             Ch.Assert(isSrc);
-            return Input.GetGetter<TValue>(columnIndex);
+            return Input.GetGetter<TValue>(Input.Schema[index]);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
@@ -227,9 +227,9 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                return Input.IsColumnActive(columnIndex);
+                return Input.IsColumnActive(column);
             }
 
             protected override bool MoveNextCore()

--- a/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
@@ -213,15 +213,15 @@ namespace Microsoft.ML.Transforms
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                return Input.GetGetter<TValue>(columnIndex);
+                return Input.GetGetter<TValue>(column);
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
@@ -217,7 +217,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/BootstrapSamplingTransformer.cs
@@ -212,14 +212,24 @@ namespace Microsoft.ML.Transforms
                     };
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                return Input.GetGetter<TValue>(col);
+                return Input.GetGetter<TValue>(columnIndex);
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                return Input.IsColumnActive(col);
+                return Input.IsColumnActive(columnIndex);
             }
 
             protected override bool MoveNextCore()

--- a/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnConcatenatingTransformer.cs
@@ -678,19 +678,22 @@ namespace Microsoft.ML.Data
                 private Delegate MakeIdentityGetter<T>(DataViewRow input)
                 {
                     Contracts.Assert(SrcIndices.Length == 1);
-                    return input.GetGetter<T>(SrcIndices[0]);
+                    return input.GetGetter<T>(input.Schema[SrcIndices[0]]);
                 }
 
                 private Delegate MakeGetter<T>(DataViewRow input)
                 {
                     var srcGetterOnes = new ValueGetter<T>[SrcIndices.Length];
                     var srcGetterVecs = new ValueGetter<VBuffer<T>>[SrcIndices.Length];
+
                     for (int j = 0; j < SrcIndices.Length; j++)
                     {
+                        var column = input.Schema[SrcIndices[j]];
+
                         if (_srcTypes[j] is VectorType)
-                            srcGetterVecs[j] = input.GetGetter<VBuffer<T>>(SrcIndices[j]);
+                            srcGetterVecs[j] = input.GetGetter<VBuffer<T>>(column);
                         else
-                            srcGetterOnes[j] = input.GetGetter<T>(SrcIndices[j]);
+                            srcGetterOnes[j] = input.GetGetter<T>(column);
                     }
 
                     T tmp = default(T);

--- a/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnCopying.cs
@@ -195,7 +195,7 @@ namespace Microsoft.ML.Transforms
                 disposer = null;
 
                 Delegate MakeGetter<T>(DataViewRow row, int index)
-                    => input.GetGetter<T>(index);
+                    => input.GetGetter<T>(input.Schema[index]);
 
                 input.Schema.TryGetColumnIndex(_columns[iinfo].inputColumnName, out int colIndex);
                 var type = input.Schema[colIndex].Type;

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -606,16 +606,16 @@ namespace Microsoft.ML.Transforms
             public override DataViewSchema Schema => _mapper.OutputSchema;
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                int index = _mapper.GetInputIndex(columnIndex);
-                return Input.GetGetter<TValue>(index);
+                int index = _mapper.GetInputIndex(column.Index);
+                return Input.GetGetter<TValue>(Input.Schema[index]);
             }
 
             /// <summary>
@@ -719,16 +719,16 @@ namespace Microsoft.ML.Transforms
             public override DataViewSchema Schema => _mapper.OutputSchema;
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                int index = _mapper.GetInputIndex(columnIndex);
-                return _inputCursor.GetGetter<TValue>(index);
+                int index = _mapper.GetInputIndex(column.Index);
+                return _inputCursor.GetGetter<TValue>(_inputCursor.Schema[index]);
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -605,13 +605,23 @@ namespace Microsoft.ML.Transforms
 
             public override DataViewSchema Schema => _mapper.OutputSchema;
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                int index = _mapper.GetInputIndex(col);
+                int index = _mapper.GetInputIndex(columnIndex);
                 return Input.GetGetter<TValue>(index);
             }
 
-            public override bool IsColumnActive(int col) => true;
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex) => true;
         }
 
         private sealed class SelectColumnsDataTransform : IDataTransform, IRowToRowMapper, ITransformTemplate
@@ -708,13 +718,23 @@ namespace Microsoft.ML.Transforms
 
             public override DataViewSchema Schema => _mapper.OutputSchema;
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                int index = _mapper.GetInputIndex(col);
+                int index = _mapper.GetInputIndex(columnIndex);
                 return _inputCursor.GetGetter<TValue>(index);
             }
 
-            public override bool IsColumnActive(int col) => _active[col];
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex) => _active[columnIndex];
         }
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -621,7 +621,7 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex) => true;
+            public override bool IsColumnActive(DataViewSchema.Column column) => true;
         }
 
         private sealed class SelectColumnsDataTransform : IDataTransform, IRowToRowMapper, ITransformTemplate
@@ -734,7 +734,7 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex) => _active[columnIndex];
+            public override bool IsColumnActive(DataViewSchema.Column column) => _active[column.Index];
         }
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -686,10 +686,8 @@ namespace Microsoft.ML.Transforms
                 return _mapper.InputSchema.Where(col => col.Index < active.Length && active[col.Index]);
             }
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> active)
-            {
-                return new RowImpl(input, _mapper);
-            }
+            DataViewRow IRowToRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+                => new RowImpl(input, _mapper);
 
             IDataTransform ITransformTemplate.ApplyToData(IHostEnvironment env, IDataView newSource)
                 => new SelectColumnsDataTransform(env, _transform, new Mapper(_transform, newSource.Schema), newSource);

--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -610,7 +610,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
@@ -723,7 +723,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/FeatureContributionCalculationTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/FeatureContributionCalculationTransformer.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Transforms
                 Contracts.AssertValue(input);
                 Contracts.AssertValue(_parent._predictor);
 
-                var featureGetter = input.GetGetter<TSrc>(colSrc);
+                var featureGetter = input.GetGetter<TSrc>(input.Schema[colSrc]);
 
                 var map = _parent._predictor.GetFeatureContributionMapper<TSrc, VBuffer<float>>(_parent.Top, _parent.Bottom, _parent.Normalize);
                 var features = default(TSrc);

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -429,7 +429,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -415,18 +415,28 @@ namespace Microsoft.ML.Transforms
 
             public override DataViewSchema Schema => _bindings.AsSchema;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.ColumnCount);
-                return _active == null || _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.ColumnCount);
+                return _active == null || _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -425,20 +425,20 @@ namespace Microsoft.ML.Transforms
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex));
+                Ch.Check(IsColumnActive(column.Index));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return Input.GetGetter<TValue>(index);
+                    return Input.GetGetter<TValue>(Input.Schema[index]);
 
                 Ch.Assert(_getters[index] != null);
                 var fn = _getters[index] as ValueGetter<TValue>;

--- a/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/GenerateNumberTransform.cs
@@ -405,7 +405,7 @@ namespace Microsoft.ML.Transforms
                 for (int iinfo = 0; iinfo < length; iinfo++)
                 {
                     _getters[iinfo] = _bindings.UseCounter[iinfo] ? MakeGetter() : (Delegate)MakeGetter(iinfo);
-                    if (!_bindings.UseCounter[iinfo] && IsColumnActive(_bindings.MapIinfoToCol(iinfo)))
+                    if (!_bindings.UseCounter[iinfo] && IsColumnActive(Schema[_bindings.MapIinfoToCol(iinfo)]))
                     {
                         _rngs[iinfo] = new TauswortheHybrid(_bindings.States[iinfo]);
                         _lastCounters[iinfo] = -1;
@@ -418,10 +418,10 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _bindings.ColumnCount);
-                return _active == null || _active[columnIndex];
+                Ch.Check(column.Index < _bindings.ColumnCount);
+                return _active == null || _active[column.Index];
             }
 
             /// <summary>
@@ -433,7 +433,7 @@ namespace Microsoft.ML.Transforms
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 bool isSrc;
                 int index = _bindings.MapColumnIndex(out isSrc, column.Index);

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -432,7 +432,7 @@ namespace Microsoft.ML.Transforms
         {
             Host.Assert(srcType.ItemType.RawType == typeof(T));
 
-            var getSrc = input.GetGetter<VBuffer<T>>(srcCol);
+            var getSrc = input.GetGetter<VBuffer<T>>(input.Schema[srcCol]);
             var ex = _columns[iinfo];
             var mask = (1U << ex.HashBits) - 1;
             var seed = ex.Seed;
@@ -638,7 +638,7 @@ namespace Microsoft.ML.Transforms
             Contracts.Assert(0 <= srcCol && srcCol < input.Schema.Count);
             Contracts.Assert(input.Schema[srcCol].Type.RawType == typeof(T));
 
-            var srcGetter = input.GetGetter<T>(srcCol);
+            var srcGetter = input.GetGetter<T>(input.Schema[srcCol]);
             T src = default;
             THash hasher = default;
             return (ref uint dst) =>
@@ -991,7 +991,7 @@ namespace Microsoft.ML.Transforms
                 public ImplOne(DataViewRow row, HashingEstimator.ColumnOptions ex, int invertHashMaxCount, Delegate dstGetter)
                     : base(row, ex, invertHashMaxCount)
                 {
-                    _srcGetter = Row.GetGetter<T>(_srcCol);
+                    _srcGetter = Row.GetGetter<T>(Row.Schema[_srcCol]);
                     _dstGetter = dstGetter as ValueGetter<uint>;
                     Contracts.AssertValue(_dstGetter);
                 }
@@ -1025,7 +1025,7 @@ namespace Microsoft.ML.Transforms
                 public ImplVec(DataViewRow row, HashingEstimator.ColumnOptions ex, int invertHashMaxCount, Delegate dstGetter)
                     : base(row, ex, invertHashMaxCount)
                 {
-                    _srcGetter = Row.GetGetter<VBuffer<T>>(_srcCol);
+                    _srcGetter = Row.GetGetter<VBuffer<T>>(Row.Schema[_srcCol]);
                     _dstGetter = dstGetter as ValueGetter<VBuffer<uint>>;
                     Contracts.AssertValue(_dstGetter);
                 }
@@ -1059,7 +1059,7 @@ namespace Microsoft.ML.Transforms
                 public ImplVecOrdered(DataViewRow row, HashingEstimator.ColumnOptions ex, int invertHashMaxCount, Delegate dstGetter)
                     : base(row, ex, invertHashMaxCount)
                 {
-                    _srcGetter = Row.GetGetter<VBuffer<T>>(_srcCol);
+                    _srcGetter = Row.GetGetter<VBuffer<T>>(Row.Schema[_srcCol]);
                     _dstGetter = dstGetter as ValueGetter<VBuffer<uint>>;
                     Contracts.AssertValue(_dstGetter);
                 }

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -364,11 +364,11 @@ namespace Microsoft.ML.Transforms
                     // NA value.
 
                     Parent.Host.AssertValue(input);
-
+                    var column = input.Schema[Parent.ColMapNewToOld[InfoIndex]];
                     if (!(Parent._types[InfoIndex] is VectorType))
                     {
                         var src = default(TKey);
-                        ValueGetter<TKey> getSrc = input.GetGetter<TKey>(Parent.ColMapNewToOld[InfoIndex]);
+                        ValueGetter<TKey> getSrc = input.GetGetter<TKey>(column);
                         ValueGetter<TValue> retVal =
                             (ref TValue dst) =>
                             {
@@ -381,7 +381,7 @@ namespace Microsoft.ML.Transforms
                     {
                         var src = default(VBuffer<TKey>);
                         var dstItem = default(TValue);
-                        ValueGetter<VBuffer<TKey>> getSrc = input.GetGetter<VBuffer<TKey>>(Parent.ColMapNewToOld[InfoIndex]);
+                        ValueGetter<VBuffer<TKey>> getSrc = input.GetGetter<VBuffer<TKey>>(column);
                         ValueGetter<VBuffer<TValue>> retVal =
                             (ref VBuffer<TValue> dst) =>
                             {

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -295,9 +295,10 @@ namespace Microsoft.ML.Transforms
                 int srcValueCount = srcType.GetValueCount();
 
                 VectorType typeNames = null;
-                int metaKeyValuesCol = 0;
-                if (inputMetadata.Schema.TryGetColumnIndex(AnnotationUtils.Kinds.KeyValues, out metaKeyValuesCol))
-                    typeNames = inputMetadata.Schema[metaKeyValuesCol].Type as VectorType;
+
+                var keyValuesColumn = inputMetadata.Schema.GetColumnOrNull(AnnotationUtils.Kinds.KeyValues);
+                if (keyValuesColumn.HasValue)
+                    typeNames = keyValuesColumn.Value.Type as VectorType;
                 if (typeNames == null || !typeNames.IsKnownSize || !(typeNames.ItemType is TextDataViewType) ||
                     typeNames.Size != srcType.GetItemType().GetKeyCountAsInt32(Host))
                 {
@@ -308,7 +309,7 @@ namespace Microsoft.ML.Transforms
                 {
                     if (typeNames != null)
                     {
-                        var getter = inputMetadata.GetGetter<VBuffer<ReadOnlyMemory<char>>>(metaKeyValuesCol);
+                        var getter = inputMetadata.GetGetter<VBuffer<ReadOnlyMemory<char>>>(keyValuesColumn.Value);
                         var slotNamesType = new VectorType(TextDataViewType.Instance, _types[iinfo]);
                         builder.AddSlotNames(slotNamesType.Size, getter);
                     }

--- a/src/Microsoft.ML.Data/Transforms/LabelIndicatorTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/LabelIndicatorTransform.cs
@@ -184,11 +184,12 @@ namespace Microsoft.ML.Transforms
             ch.Assert(0 <= iinfo && iinfo < Infos.Length);
 
             var info = Infos[iinfo];
+            var column = input.Schema[info.Source];
             ch.Assert(TestIsMulticlassLabel(info.TypeSrc) == null);
 
             if (info.TypeSrc.GetKeyCount() > 0)
             {
-                var srcGetter = input.GetGetter<uint>(info.Source);
+                var srcGetter = input.GetGetter<uint>(column);
                 var src = default(uint);
                 uint cls = (uint)(_classIndex[iinfo] + 1);
 
@@ -201,7 +202,7 @@ namespace Microsoft.ML.Transforms
             }
             if (info.TypeSrc == NumberDataViewType.Single)
             {
-                var srcGetter = input.GetGetter<float>(info.Source);
+                var srcGetter = input.GetGetter<float>(column);
                 var src = default(float);
 
                 return
@@ -213,7 +214,7 @@ namespace Microsoft.ML.Transforms
             }
             if (info.TypeSrc == NumberDataViewType.Double)
             {
-                var srcGetter = input.GetGetter<double>(info.Source);
+                var srcGetter = input.GetGetter<double>(column);
                 var src = default(double);
 
                 return

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -394,7 +394,7 @@ namespace Microsoft.ML.Transforms
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 ValueGetter<TValue> fn;
                 if (TryGetColumnValueGetter(column.Index, out fn))
@@ -410,7 +410,7 @@ namespace Microsoft.ML.Transforms
             /// </summary>
             private bool TryGetColumnValueGetter<TValue>(int col, out ValueGetter<TValue> fn)
             {
-                Ch.Assert(IsColumnActive(col));
+                Ch.Assert(IsColumnActive(Schema[col]));
 
                 int index;
                 if (!_parent._srcIndexToInfoIndex.TryGetValue(col, out index))

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -385,14 +385,21 @@ namespace Microsoft.ML.Transforms
                     _values[i] = Value.Create(this, _parent._infos[i]);
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
                 ValueGetter<TValue> fn;
-                if (TryGetColumnValueGetter(col, out fn))
+                if (TryGetColumnValueGetter(columnIndex, out fn))
                     return fn;
-                return Input.GetGetter<TValue>(col);
+                return Input.GetGetter<TValue>(columnIndex);
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -289,7 +289,7 @@ namespace Microsoft.ML.Transforms
                     Contracts.Assert(!(info.Type is VectorType));
                     Contracts.Assert(info.Type.RawType == typeof(T));
 
-                    var getSrc = cursor.Input.GetGetter<T>(info.Index);
+                    var getSrc = cursor.Input.GetGetter<T>(cursor.Input.Schema[info.Index]);
                     var hasBad = Data.Conversion.Conversions.Instance.GetIsNAPredicate<T>(info.Type);
                     return new ValueOne<T>(cursor, getSrc, hasBad);
                 }
@@ -301,7 +301,7 @@ namespace Microsoft.ML.Transforms
                     Contracts.Assert(info.Type is VectorType);
                     Contracts.Assert(info.Type.RawType == typeof(VBuffer<T>));
 
-                    var getSrc = cursor.Input.GetGetter<VBuffer<T>>(info.Index);
+                    var getSrc = cursor.Input.GetGetter<VBuffer<T>>(cursor.Input.Schema[info.Index]);
                     var hasBad = Data.Conversion.Conversions.Instance.GetHasMissingPredicate<T>((VectorType)info.Type);
                     return new ValueVec<T>(cursor, getSrc, hasBad);
                 }
@@ -386,20 +386,20 @@ namespace Microsoft.ML.Transforms
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex));
+                Ch.Check(IsColumnActive(column.Index));
 
                 ValueGetter<TValue> fn;
-                if (TryGetColumnValueGetter(columnIndex, out fn))
+                if (TryGetColumnValueGetter(column.Index, out fn))
                     return fn;
-                return Input.GetGetter<TValue>(columnIndex);
+                return Input.GetGetter<TValue>(column);
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Data/Transforms/NAFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/NAFilter.cs
@@ -390,7 +390,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/NopTransform.cs
+++ b/src/Microsoft.ML.Data/Transforms/NopTransform.cs
@@ -130,10 +130,10 @@ namespace Microsoft.ML.Data
         IEnumerable<DataViewSchema.Column> IRowToRowMapper.GetDependencies(IEnumerable<DataViewSchema.Column> dependingColumns)
             => dependingColumns;
 
-        public DataViewRow GetRow(DataViewRow input, Func<int, bool> active)
+        DataViewRow IRowToRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
         {
             Contracts.CheckValue(input, nameof(input));
-            Contracts.CheckValue(active, nameof(active));
+            Contracts.CheckValue(activeColumns, nameof(activeColumns));
             Contracts.CheckParam(input.Schema == Source.Schema, nameof(input), "Schema of input row must be the same as the schema the mapper is bound to");
             return input;
         }

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumn.cs
@@ -838,7 +838,7 @@ namespace Microsoft.ML.Transforms
                 DataViewRow dataRow)
                 : base(host, lim, labelColId, dataRow)
             {
-                _colGetterSrc = dataRow.GetGetter<TFloat>(valueColId);
+                _colGetterSrc = dataRow.GetGetter<TFloat>(dataRow.Schema[valueColId]);
                 ColValues = new List<TFloat>();
             }
 
@@ -866,10 +866,11 @@ namespace Microsoft.ML.Transforms
             protected VecColumnSupervisedBinFunctionBuilderBase(IHost host, long lim, int valueColId, int labelColId, DataViewRow dataRow)
                 : base(host, lim, labelColId, dataRow)
             {
-                _colValueGetter = dataRow.GetGetter<VBuffer<TFloat>>(valueColId);
-                var valueColType = dataRow.Schema[valueColId].Type;
-                Host.Assert(valueColType.IsKnownSizeVector());
-                ColumnSlotCount = valueColType.GetValueCount();
+                var valueCol = dataRow.Schema[valueColId];
+                _colValueGetter = dataRow.GetGetter<VBuffer<TFloat>>(valueCol);
+
+                Host.Assert(valueCol.Type.IsKnownSizeVector());
+                ColumnSlotCount = valueCol.Type.GetValueCount();
 
                 ColValues = new List<TFloat>[ColumnSlotCount];
                 for (int i = 0; i < ColumnSlotCount; i++)
@@ -933,21 +934,22 @@ namespace Microsoft.ML.Transforms
             public static IColumnFunctionBuilder CreateBuilder(NormalizingEstimator.MinMaxColumnOptions column, IHost host,
                 int srcIndex, DataViewType srcType, DataViewRowCursor cursor)
             {
+                var srcColumn = cursor.Schema[srcIndex];
                 if (srcType is NumberDataViewType)
                 {
                     if (srcType == NumberDataViewType.Single)
-                        return Sng.MinMaxOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
+                        return Sng.MinMaxOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcColumn));
                     if (srcType == NumberDataViewType.Double)
-                        return Dbl.MinMaxOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
+                        return Dbl.MinMaxOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcColumn));
                 }
                 if (srcType is VectorType vectorType && vectorType.IsKnownSize && vectorType.ItemType is NumberDataViewType)
                 {
                     if (vectorType.ItemType == NumberDataViewType.Single)
-                        return Sng.MinMaxVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
+                        return Sng.MinMaxVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcColumn));
                     if (vectorType.ItemType == NumberDataViewType.Double)
-                        return Dbl.MinMaxVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcIndex));
+                        return Dbl.MinMaxVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcColumn));
                 }
-                throw host.ExceptParam(nameof(srcType), "Wrong column type for input column. Expected: R4, R8, Vec<R4, n> or Vec<R8, n>. Got: {0}.", srcType.ToString());
+                throw host.ExceptParam(nameof(srcType), "Wrong column type for input column. Expected: float, double, Vec<float, n> or Vec<double, n>. Got: {0}.", srcType.ToString());
             }
         }
 
@@ -971,22 +973,22 @@ namespace Microsoft.ML.Transforms
                 int srcIndex, DataViewType srcType, DataViewRowCursor cursor)
             {
                 Contracts.AssertValue(host);
-
+                var srcColumn = cursor.Schema[srcIndex];
                 if (srcType is NumberDataViewType)
                 {
                     if (srcType == NumberDataViewType.Single)
-                        return Sng.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
+                        return Sng.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcColumn));
                     if (srcType == NumberDataViewType.Double)
-                        return Dbl.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
+                        return Dbl.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcColumn));
                 }
                 if (srcType is VectorType vectorType && vectorType.IsKnownSize && vectorType.ItemType is NumberDataViewType)
                 {
                     if (vectorType.ItemType == NumberDataViewType.Single)
-                        return Sng.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
+                        return Sng.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcColumn));
                     if (vectorType.ItemType == NumberDataViewType.Double)
-                        return Dbl.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcIndex));
+                        return Dbl.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcColumn));
                 }
-                throw host.ExceptParam(nameof(srcType), "Wrong column type for input column. Expected: R4, R8, Vec<R4, n> or Vec<R8, n>. Got: {0}.", srcType.ToString());
+                throw host.ExceptParam(nameof(srcType), "Wrong column type for input column. Expected: float, double, Vec<float, n> or Vec<double, n>. Got: {0}.", srcType.ToString());
             }
 
         }
@@ -1012,21 +1014,22 @@ namespace Microsoft.ML.Transforms
                 Contracts.AssertValue(host);
                 host.AssertValue(column);
 
+                var srcColumn = cursor.Schema[srcIndex];
                 if (srcType is NumberDataViewType)
                 {
                     if (srcType == NumberDataViewType.Single)
-                        return Sng.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
+                        return Sng.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcColumn));
                     if (srcType == NumberDataViewType.Double)
-                        return Dbl.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
+                        return Dbl.MeanVarOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcColumn));
                 }
                 if (srcType is VectorType vectorType && vectorType.IsKnownSize && vectorType.ItemType is NumberDataViewType)
                 {
                     if (vectorType.ItemType == NumberDataViewType.Single)
-                        return Sng.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
+                        return Sng.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcColumn));
                     if (vectorType.ItemType == NumberDataViewType.Double)
-                        return Dbl.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcIndex));
+                        return Dbl.MeanVarVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcColumn));
                 }
-                throw host.ExceptUserArg(nameof(column), "Wrong column type for column {0}. Expected: R4, R8, Vec<R4, n> or Vec<R8, n>. Got: {1}.", column.InputColumnName, srcType.ToString());
+                throw host.ExceptUserArg(nameof(column), "Wrong column type for column {0}. Expected: float, double, Vec<float, n> or Vec<double, n>. Got: {1}.", column.InputColumnName, srcType.ToString());
             }
         }
 
@@ -1051,21 +1054,22 @@ namespace Microsoft.ML.Transforms
             {
                 Contracts.AssertValue(host);
 
+                var srcColumn = cursor.Schema[srcIndex];
                 if (srcType is NumberDataViewType)
                 {
                     if (srcType == NumberDataViewType.Single)
-                        return Sng.BinOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcIndex));
+                        return Sng.BinOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Single>(srcColumn));
                     if (srcType == NumberDataViewType.Double)
-                        return Dbl.BinOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcIndex));
+                        return Dbl.BinOneColumnFunctionBuilder.Create(column, host, srcType, cursor.GetGetter<Double>(srcColumn));
                 }
                 if (srcType is VectorType vectorType && vectorType.IsKnownSize && vectorType.ItemType is NumberDataViewType)
                 {
                     if (vectorType.ItemType == NumberDataViewType.Single)
-                        return Sng.BinVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcIndex));
+                        return Sng.BinVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Single>>(srcColumn));
                     if (vectorType.ItemType == NumberDataViewType.Double)
-                        return Dbl.BinVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcIndex));
+                        return Dbl.BinVecColumnFunctionBuilder.Create(column, host, vectorType, cursor.GetGetter<VBuffer<Double>>(srcColumn));
                 }
-                throw host.ExceptParam(nameof(column), "Wrong column type for column {0}. Expected: R4, R8, Vec<R4, n> or Vec<R8, n>. Got: {1}.", column.InputColumnName, srcType.ToString());
+                throw host.ExceptParam(nameof(column), "Wrong column type for column {0}. Expected: float, double, Vec<float, n> or Vec<double, n>. Got: {1}.", column.InputColumnName, srcType.ToString());
             }
         }
 

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnDbl.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnDbl.cs
@@ -584,7 +584,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<TFloat>(icol);
+                        var getSrc = input.GetGetter<TFloat>(input.Schema[icol]);
                         ValueGetter<TFloat> del =
                             (ref TFloat dst) =>
                             {
@@ -660,7 +660,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<VBuffer<TFloat>>(icol);
+                        var getSrc = input.GetGetter<VBuffer<TFloat>>(input.Schema[icol]);
                         var bldr = new BufferBuilder<TFloat>(R8Adder.Instance);
                         ValueGetter<VBuffer<TFloat>> del;
                         if (Offset == null)
@@ -912,7 +912,7 @@ namespace Microsoft.ML.Transforms
                             return trivial;
                         }
 
-                        var getSrc = input.GetGetter<TFloat>(icol);
+                        var getSrc = input.GetGetter<TFloat>(input.Schema[icol]);
                         ValueGetter<TFloat> del =
                             (ref TFloat dst) =>
                             {
@@ -957,7 +957,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<VBuffer<TFloat>>(icol);
+                        var getSrc = input.GetGetter<VBuffer<TFloat>>(input.Schema[icol]);
                         var bldr = new BufferBuilder<TFloat>(R8Adder.Instance);
                         ValueGetter<VBuffer<TFloat>> del;
                         del = (ref VBuffer<TFloat> dst) =>
@@ -1086,7 +1086,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<TFloat>(icol);
+                        var getSrc = input.GetGetter<TFloat>(input.Schema[icol]);
                         ValueGetter<TFloat> del =
                             (ref TFloat dst) =>
                             {
@@ -1171,7 +1171,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<VBuffer<TFloat>>(icol);
+                        var getSrc = input.GetGetter<VBuffer<TFloat>>(input.Schema[icol]);
                         var bldr = new BufferBuilder<TFloat>(R8Adder.Instance);
                         ValueGetter<VBuffer<TFloat>> del =
                             (ref VBuffer<TFloat> dst) =>

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
@@ -586,7 +586,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<TFloat>(icol);
+                        var getSrc = input.GetGetter<TFloat>(input.Schema[icol]);
                         ValueGetter<TFloat> del =
                             (ref TFloat dst) =>
                             {
@@ -661,7 +661,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<VBuffer<TFloat>>(icol);
+                        var getSrc = input.GetGetter<VBuffer<TFloat>>(input.Schema[icol]);
                         var bldr = new BufferBuilder<TFloat>(R4Adder.Instance);
                         ValueGetter<VBuffer<TFloat>> del;
                         if (Offset == null)
@@ -916,7 +916,7 @@ namespace Microsoft.ML.Transforms
                             return trivial;
                         }
 
-                        var getSrc = input.GetGetter<TFloat>(icol);
+                        var getSrc = input.GetGetter<TFloat>(input.Schema[icol]);
                         ValueGetter<TFloat> del =
                             (ref TFloat dst) =>
                             {
@@ -961,7 +961,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<VBuffer<TFloat>>(icol);
+                        var getSrc = input.GetGetter<VBuffer<TFloat>>(input.Schema[icol]);
                         var bldr = new BufferBuilder<TFloat>(R4Adder.Instance);
                         ValueGetter<VBuffer<TFloat>> del;
                         del = (ref VBuffer<TFloat> dst) =>
@@ -1091,7 +1091,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<TFloat>(icol);
+                        var getSrc = input.GetGetter<TFloat>(input.Schema[icol]);
                         ValueGetter<TFloat> del =
                             (ref TFloat dst) =>
                             {
@@ -1176,7 +1176,7 @@ namespace Microsoft.ML.Transforms
 
                     public override Delegate GetGetter(DataViewRow input, int icol)
                     {
-                        var getSrc = input.GetGetter<VBuffer<TFloat>>(icol);
+                        var getSrc = input.GetGetter<VBuffer<TFloat>>(input.Schema[icol]);
                         var bldr = new BufferBuilder<TFloat>(R4Adder.Instance);
                         ValueGetter<VBuffer<TFloat>> del =
                             (ref VBuffer<TFloat> dst) =>

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -283,26 +283,26 @@ namespace Microsoft.ML.Data
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Contracts.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column is not active");
+                Contracts.CheckParam(IsColumnActive(column.Index), nameof(column), "requested column is not active");
 
                 bool isSrc;
-                columnIndex = _parent.GetBindings().MapColumnIndex(out isSrc, columnIndex);
+                var index = _parent.GetBindings().MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
                 {
                     Contracts.AssertValue(_input);
-                    return _input.GetGetter<TValue>(columnIndex);
+                    return _input.GetGetter<TValue>(_input.Schema[index]);
                 }
 
                 Ch.AssertValue(_getters);
-                var getter = _getters[columnIndex];
+                var getter = _getters[index];
                 Ch.Assert(getter != null);
                 var fn = getter as ValueGetter<TValue>;
                 if (fn == null)

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -276,10 +276,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _parent.GetBindings().ColumnCount);
-                return _active[columnIndex];
+                Ch.Check(column.Index < _parent.GetBindings().ColumnCount);
+                return _active[column.Index];
             }
 
             /// <summary>
@@ -291,7 +291,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Contracts.CheckParam(IsColumnActive(column.Index), nameof(column), "requested column is not active");
+                Contracts.CheckParam(IsColumnActive(column), nameof(column), "requested column is not active");
 
                 bool isSrc;
                 var index = _parent.GetBindings().MapColumnIndex(out isSrc, column.Index);

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -287,7 +287,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/PerGroupTransformBase.cs
@@ -273,26 +273,36 @@ namespace Microsoft.ML.Data
                 _scoreGetter = _parent.GetScoreGetter(_groupCursor);
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _parent.GetBindings().ColumnCount);
-                return _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _parent.GetBindings().ColumnCount);
+                return _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Contracts.CheckParam(IsColumnActive(col), nameof(col), "requested column is not active");
+                Contracts.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column is not active");
 
                 bool isSrc;
-                col = _parent.GetBindings().MapColumnIndex(out isSrc, col);
+                columnIndex = _parent.GetBindings().MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                 {
                     Contracts.AssertValue(_input);
-                    return _input.GetGetter<TValue>(col);
+                    return _input.GetGetter<TValue>(columnIndex);
                 }
 
                 Ch.AssertValue(_getters);
-                var getter = _getters[col];
+                var getter = _getters[columnIndex];
                 Ch.Assert(getter != null);
                 var fn = getter as ValueGetter<TValue>;
                 if (fn == null)

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Transforms
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
                 Ch.Check(0 <= column.Index && column.Index < Schema.Count);
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 if (column.Index != Parent._index)
                     return Input.GetGetter<TValue>(column);

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -309,19 +309,19 @@ namespace Microsoft.ML.Transforms
 
             protected abstract Delegate GetGetter();
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count);
-                Ch.Check(IsColumnActive(columnIndex));
+                Ch.Check(0 <= column.Index && column.Index < Schema.Count);
+                Ch.Check(IsColumnActive(column.Index));
 
-                if (columnIndex != Parent._index)
-                    return Input.GetGetter<TValue>(columnIndex);
+                if (column.Index != Parent._index)
+                    return Input.GetGetter<TValue>(column);
                 var fn = GetGetter() as ValueGetter<TValue>;
                 if (fn == null)
                     throw Ch.Except("Invalid TValue in GetGetter: '{0}'", typeof(TValue));
@@ -354,7 +354,7 @@ namespace Microsoft.ML.Transforms
                 : base(parent, input, active)
             {
                 Ch.Assert(Parent._type == NumberDataViewType.Single);
-                _srcGetter = Input.GetGetter<Single>(Parent._index);
+                _srcGetter = Input.GetGetter<Single>(Input.Schema[Parent._index]);
                 _getter =
                     (ref Single value) =>
                     {
@@ -387,7 +387,7 @@ namespace Microsoft.ML.Transforms
                 : base(parent, input, active)
             {
                 Ch.Assert(Parent._type == NumberDataViewType.Double);
-                _srcGetter = Input.GetGetter<Double>(Parent._index);
+                _srcGetter = Input.GetGetter<Double>(Input.Schema[Parent._index]);
                 _getter =
                     (ref Double value) =>
                     {
@@ -423,7 +423,7 @@ namespace Microsoft.ML.Transforms
             {
                 Ch.Assert(Parent._type.GetKeyCount() > 0);
                 _count = Parent._type.GetKeyCount();
-                _srcGetter = Input.GetGetter<T>(Parent._index);
+                _srcGetter = Input.GetGetter<T>(Input.Schema[Parent._index]);
                 _getter =
                     (ref T dst) =>
                     {

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -308,14 +308,20 @@ namespace Microsoft.ML.Transforms
             private bool TestNotCC(Double value) => _min > value || value > _max;
 
             protected abstract Delegate GetGetter();
-
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(0 <= col && col < Schema.Count);
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count);
+                Ch.Check(IsColumnActive(columnIndex));
 
-                if (col != Parent._index)
-                    return Input.GetGetter<TValue>(col);
+                if (columnIndex != Parent._index)
+                    return Input.GetGetter<TValue>(columnIndex);
                 var fn = GetGetter() as ValueGetter<TValue>;
                 if (fn == null)
                     throw Ch.Except("Invalid TValue in GetGetter: '{0}'", typeof(TValue));

--- a/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
+++ b/src/Microsoft.ML.Data/Transforms/RangeFilter.cs
@@ -313,7 +313,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -706,17 +706,17 @@ namespace Microsoft.ML.Transforms
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
-                Ch.CheckParam(_colToActivesIndex[columnIndex] >= 0, nameof(columnIndex), "requested column not active");
-                ValueGetter<TValue> getter = _getters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
+                Ch.CheckParam(column.Index < _colToActivesIndex.Length, nameof(column));
+                Ch.CheckParam(_colToActivesIndex[column.Index] >= 0, nameof(column), "requested column not active");
+                ValueGetter<TValue> getter = _getters[_colToActivesIndex[column.Index]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -665,11 +665,14 @@ namespace Microsoft.ML.Transforms
                 return true;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _colToActivesIndex.Length, nameof(col));
-                Ch.Assert((_colToActivesIndex[col] >= 0) == _input.IsColumnActive(col));
-                return _input.IsColumnActive(col);
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
+                Ch.Assert((_colToActivesIndex[columnIndex] >= 0) == _input.IsColumnActive(columnIndex));
+                return _input.IsColumnActive(columnIndex);
             }
 
             private Delegate CreateGetterDelegate(int col)
@@ -702,11 +705,18 @@ namespace Microsoft.ML.Transforms
                 return getter;
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _colToActivesIndex.Length, nameof(col));
-                Ch.CheckParam(_colToActivesIndex[col] >= 0, nameof(col), "requested column not active");
-                ValueGetter<TValue> getter = _getters[_colToActivesIndex[col]] as ValueGetter<TValue>;
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
+                Ch.CheckParam(_colToActivesIndex[columnIndex] >= 0, nameof(columnIndex), "requested column not active");
+                ValueGetter<TValue> getter = _getters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
                 return getter;

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -517,7 +517,7 @@ namespace Microsoft.ML.Transforms
                 int numActive = 0;
                 _colToActivesIndex = new int[colLim];
                 for (int c = 0; c < colLim; ++c)
-                    _colToActivesIndex[c] = _input.IsColumnActive(c) ? numActive++ : -1;
+                    _colToActivesIndex[c] = _input.IsColumnActive(Schema[c]) ? numActive++ : -1;
                 _pipes = new ShufflePipe[numActive + (int)ExtraIndex.Lim];
                 _getters = new Delegate[numActive];
                 for (int c = 0; c < colLim; ++c)
@@ -668,11 +668,11 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
-                Ch.Assert((_colToActivesIndex[columnIndex] >= 0) == _input.IsColumnActive(columnIndex));
-                return _input.IsColumnActive(columnIndex);
+                Ch.CheckParam(column.Index < _colToActivesIndex.Length, nameof(column));
+                Ch.Assert((_colToActivesIndex[column.Index] >= 0) == _input.IsColumnActive(column));
+                return _input.IsColumnActive(column);
             }
 
             private Delegate CreateGetterDelegate(int col)

--- a/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowShufflingTransformer.cs
@@ -710,7 +710,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
@@ -800,8 +800,8 @@ namespace Microsoft.ML.Transforms
             {
                 Host.AssertValue(input);
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
-                int src = _cols[iinfo];
-                Host.Assert(input.IsColumnActive(src));
+                var src = input.Schema[_cols[iinfo]];
+                Host.Assert(input.IsColumnActive(src.Index));
                 return input.GetGetter<T>(src);
             }
 

--- a/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
@@ -801,7 +801,7 @@ namespace Microsoft.ML.Transforms
                 Host.AssertValue(input);
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
                 var src = input.Schema[_cols[iinfo]];
-                Host.Assert(input.IsColumnActive(src.Index));
+                Host.Assert(input.IsColumnActive(src));
                 return input.GetGetter<T>(src);
             }
 

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -215,10 +215,17 @@ namespace Microsoft.ML.Data
                     _disposer?.Invoke();
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
                 bool isSrc;
-                int index = _parent.MapColumnIndex(out isSrc, col);
+                int index = _parent.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 
@@ -229,10 +236,13 @@ namespace Microsoft.ML.Data
                 return fn;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
                 bool isSrc;
-                int index = _parent.MapColumnIndex(out isSrc, col);
+                int index = _parent.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.IsColumnActive((index));
                 return _getters[index] != null;
@@ -869,12 +879,19 @@ namespace Microsoft.ML.Data
 
             public override DataViewSchema Schema => _bindings.AsSchema;
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 
@@ -885,10 +902,13 @@ namespace Microsoft.ML.Data
                 return fn;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.ColumnCount);
-                return _active == null || _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.ColumnCount);
+                return _active == null || _active[columnIndex];
             }
         }
 

--- a/src/Microsoft.ML.Data/Transforms/TransformBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformBase.cs
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
@@ -885,7 +885,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Transforms
                 if (autoConvert)
                     inputGetter = RowCursorUtils.GetGetterAs<T>(bldr.ItemType, row, col);
                 else
-                    inputGetter = row.GetGetter<T>(col);
+                    inputGetter = row.GetGetter<T>(row.Schema[col]);
 
                 return new ImplOne<T>(inputGetter, count, bldrT);
             }
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Transforms
                 Contracts.Assert(bldr is Builder<T>);
                 var bldrT = (Builder<T>)bldr;
 
-                var inputGetter = row.GetGetter<VBuffer<T>>(col);
+                var inputGetter = row.GetGetter<VBuffer<T>>(row.Schema[col]);
                 return new ImplVec<T>(inputGetter, count, bldrT);
             }
 
@@ -905,9 +905,9 @@ namespace Microsoft.ML.Transforms
                         var info = _infos[_iinfo];
                         T src = default(T);
                         Contracts.Assert(!(info.TypeSrc is VectorType));
-                        input.Schema.TryGetColumnIndex(info.InputColumnName, out int colIndex);
-                        _host.Assert(input.IsColumnActive(colIndex));
-                        var getSrc = input.GetGetter<T>(colIndex);
+                        var inputColumn = input.Schema[info.InputColumnName];
+                        _host.Assert(input.IsColumnActive(inputColumn.Index));
+                        var getSrc = input.GetGetter<T>(inputColumn);
                         ValueGetter<uint> retVal =
                             (ref uint dst) =>
                             {
@@ -926,9 +926,9 @@ namespace Microsoft.ML.Transforms
                         ValueMapper<T, uint> map = TypedMap.GetKeyMapper();
                         var info = _infos[_iinfo];
                         // First test whether default maps to default. If so this is sparsity preserving.
-                        input.Schema.TryGetColumnIndex(info.InputColumnName, out int colIndex);
-                        _host.Assert(input.IsColumnActive(colIndex));
-                        var getSrc = input.GetGetter<VBuffer<T>>(colIndex);
+                        var inputColumn = input.Schema[info.InputColumnName];
+                        _host.Assert(input.IsColumnActive(inputColumn.Index));
+                        var getSrc = input.GetGetter<VBuffer<T>>(inputColumn);
                         VBuffer<T> src = default(VBuffer<T>);
                         ValueGetter<VBuffer<uint>> retVal;
                         // REVIEW: Consider whether possible or reasonable to not use a builder here.

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -906,7 +906,7 @@ namespace Microsoft.ML.Transforms
                         T src = default(T);
                         Contracts.Assert(!(info.TypeSrc is VectorType));
                         var inputColumn = input.Schema[info.InputColumnName];
-                        _host.Assert(input.IsColumnActive(inputColumn.Index));
+                        _host.Assert(input.IsColumnActive(inputColumn));
                         var getSrc = input.GetGetter<T>(inputColumn);
                         ValueGetter<uint> retVal =
                             (ref uint dst) =>
@@ -927,7 +927,7 @@ namespace Microsoft.ML.Transforms
                         var info = _infos[_iinfo];
                         // First test whether default maps to default. If so this is sparsity preserving.
                         var inputColumn = input.Schema[info.InputColumnName];
-                        _host.Assert(input.IsColumnActive(inputColumn.Index));
+                        _host.Assert(input.IsColumnActive(inputColumn));
                         var getSrc = input.GetGetter<VBuffer<T>>(inputColumn);
                         VBuffer<T> src = default(VBuffer<T>);
                         ValueGetter<VBuffer<uint>> retVal;

--- a/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
+++ b/src/Microsoft.ML.Data/Utilities/ColumnCursor.cs
@@ -101,9 +101,10 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema[col]))
+            var column = data.Schema[col];
+            using (var cursor = data.GetRowCursor(column))
             {
-                var getter = cursor.GetGetter<T>(col);
+                var getter = cursor.GetGetter<T>(column);
                 T curValue = default;
                 while (cursor.MoveNext())
                 {
@@ -118,9 +119,10 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema[col]))
+            var column = data.Schema[col];
+            using (var cursor = data.GetRowCursor(column))
             {
-                var getter = cursor.GetGetter<TData>(col);
+                var getter = cursor.GetGetter<TData>(column);
                 TData curValue = default;
                 while (cursor.MoveNext())
                 {
@@ -135,9 +137,10 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema[col]))
+            var column = data.Schema[col];
+            using (var cursor = data.GetRowCursor(column))
             {
-                var getter = cursor.GetGetter<VBuffer<T>>(col);
+                var getter = cursor.GetGetter<VBuffer<T>>(column);
                 VBuffer<T> curValue = default;
                 while (cursor.MoveNext())
                 {
@@ -156,9 +159,10 @@ namespace Microsoft.ML.Data
             Contracts.AssertValue(data);
             Contracts.Assert(0 <= col && col < data.Schema.Count);
 
-            using (var cursor = data.GetRowCursor(data.Schema[col]))
+            var column = data.Schema[col];
+            using (var cursor = data.GetRowCursor(column))
             {
-                var getter = cursor.GetGetter<VBuffer<TData>>(col);
+                var getter = cursor.GetGetter<VBuffer<TData>>(column);
                 VBuffer<TData> curValue = default;
                 while (cursor.MoveNext())
                 {

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -289,8 +289,8 @@ namespace Microsoft.ML.Model
 
                 using (var cursor = loader.GetRowCursorForAllColumns())
                 {
-                    var roleGetter = cursor.GetGetter<ReadOnlyMemory<char>>(0);
-                    var colGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);
+                    var roleGetter = cursor.GetGetter<ReadOnlyMemory<char>>(cursor.Schema[0]);
+                    var colGetter = cursor.GetGetter<ReadOnlyMemory<char>>(cursor.Schema[1]);
                     var role = default(ReadOnlyMemory<char>);
                     var col = default(ReadOnlyMemory<char>);
                     while (cursor.MoveNext())

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ML.Trainers.Ensemble
 
                         // Next we get the output row from the predictors. We activate the score column as output predicate.
                         var predictorRow = Mappers[i].GetRow(pipelineRow, Enumerable.Repeat(Mappers[i].InputSchema[ScoreCols[i]], 1));
-                        getters[i] = predictorRow.GetGetter<T>(ScoreCols[i]);
+                        getters[i] = predictorRow.GetGetter<T>(predictorRow.Schema[ScoreCols[i]]);
                         disposer += predictorRow.Dispose;
                     }
 
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Trainers.Ensemble
 
                     var pipelineRow = BoundPipelines[i].GetRow(input, inputColumns);
                     disposer = pipelineRow.Dispose;
-                    return pipelineRow.GetGetter<float>(weightCol.Index);
+                    return pipelineRow.GetGetter<float>(weightCol);
 
                 }
             }

--- a/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/PipelineEnsemble.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Trainers.Ensemble
                 yield break;
             }
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> predicate)
+            DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 var scoreGetter = CreateScoreGetter(input, out Action disposer);
                 return new SimpleRow(OutputSchema, input, new[] { scoreGetter }, disposer);
@@ -140,11 +140,10 @@ namespace Microsoft.ML.Trainers.Ensemble
                         var mapperColumns = Mappers[i].OutputSchema.Where(col => col.Name == DefaultColumnNames.Score);
                         var inputColumns = Mappers[i].GetDependenciesForNewColumns(mapperColumns);
 
-                        Func<int, bool> inputPredicate = c => inputColumns.Any(col => col.Index == c);
-                        var pipelineRow = BoundPipelines[i].GetRow(input, inputPredicate);
+                        var pipelineRow = BoundPipelines[i].GetRow(input, inputColumns);
 
                         // Next we get the output row from the predictors. We activate the score column as output predicate.
-                        var predictorRow = Mappers[i].GetRow(pipelineRow, col => col == ScoreCols[i]);
+                        var predictorRow = Mappers[i].GetRow(pipelineRow, Enumerable.Repeat(Mappers[i].InputSchema[ScoreCols[i]], 1));
                         getters[i] = predictorRow.GetGetter<T>(ScoreCols[i]);
                         disposer += predictorRow.Dispose;
                     }
@@ -168,7 +167,7 @@ namespace Microsoft.ML.Trainers.Ensemble
                     var labelCol = Mappers[i].InputRoleMappedSchema.Label.Value;
 
                     // The label should be in the output row of the i'th pipeline
-                    var pipelineRow = BoundPipelines[i].GetRow(input, col => col == labelCol.Index);
+                    var pipelineRow = BoundPipelines[i].GetRow(input, labelCol);
                     disposer = pipelineRow.Dispose;
                     return RowCursorUtils.GetLabelGetter(pipelineRow, labelCol.Index);
                 }
@@ -187,8 +186,7 @@ namespace Microsoft.ML.Trainers.Ensemble
                     // The weight should be in the output row of the i'th pipeline if it exists.
                     var inputColumns = Mappers[i].GetDependenciesForNewColumns(Enumerable.Repeat(weightCol, 1));
 
-                    Func<int, bool> inputPredicate = c => inputColumns.Any(col => col.Index == c);
-                    var pipelineRow = BoundPipelines[i].GetRow(input, inputPredicate);
+                    var pipelineRow = BoundPipelines[i].GetRow(input, inputColumns);
                     disposer = pipelineRow.Dispose;
                     return pipelineRow.GetGetter<float>(weightCol.Index);
 

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -144,23 +144,24 @@ namespace Microsoft.ML.Data
                 Contracts.Assert(OutputSchema[OutputColumnNames.Paths].Index == PathIdsColumnId);
             }
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> predicate)
+            DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 _ectx.CheckValue(input, nameof(input));
-                _ectx.CheckValue(predicate, nameof(predicate));
-                return new SimpleRow(OutputSchema, input, CreateGetters(input, predicate));
+                _ectx.CheckValue(activeColumns, nameof(activeColumns));
+                return new SimpleRow(OutputSchema, input, CreateGetters(input, activeColumns));
             }
 
-            private Delegate[] CreateGetters(DataViewRow input, Func<int, bool> predicate)
+            private Delegate[] CreateGetters(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 _ectx.AssertValue(input);
-                _ectx.AssertValue(predicate);
+                _ectx.AssertValue(activeColumns);
 
                 var delegates = new Delegate[3];
 
-                var treeValueActive = predicate(TreeValuesColumnId);
-                var leafIdActive = predicate(LeafIdsColumnId);
-                var pathIdActive = predicate(PathIdsColumnId);
+                var activeIndices = activeColumns.Select(c => c.Index);
+                var treeValueActive = activeIndices.Contains(TreeValuesColumnId);
+                var leafIdActive = activeIndices.Contains(LeafIdsColumnId);
+                var pathIdActive = activeIndices.Contains(PathIdsColumnId);
 
                 if (!treeValueActive && !leafIdActive && !pathIdActive)
                     return delegates;

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -225,7 +225,7 @@ namespace Microsoft.ML.Data
                     _numLeaves = numLeaves;
 
                     _src = default(VBuffer<float>);
-                    _featureGetter = input.GetGetter<VBuffer<float>>(featureIndex);
+                    _featureGetter = input.GetGetter<VBuffer<float>>(input.Schema[featureIndex]);
 
                     _cachedPosition = -1;
                     _leafIds = new int[_numTrees];

--- a/src/Microsoft.ML.ImageAnalytics/ImageGrayscale.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageGrayscale.cs
@@ -189,7 +189,7 @@ namespace Microsoft.ML.ImageAnalytics
                 Contracts.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
 
                 var src = default(Bitmap);
-                var getSrc = input.GetGetter<Bitmap>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<Bitmap>(input.Schema[ColMapNewToOld[iinfo]]);
 
                 disposer =
                     () =>

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -184,7 +184,7 @@ namespace Microsoft.ML.ImageAnalytics
                 Contracts.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
 
                 disposer = null;
-                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(input.Schema[ColMapNewToOld[iinfo]]);
                 ReadOnlyMemory<char> src = default;
                 ValueGetter<Bitmap> del =
                     (ref Bitmap dst) =>

--- a/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractor.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImagePixelExtractor.cs
@@ -331,7 +331,7 @@ namespace Microsoft.ML.ImageAnalytics
                 Contracts.Assert(size == planes * height * width);
                 int cpix = height * width;
 
-                var getSrc = input.GetGetter<Bitmap>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<Bitmap>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(Bitmap);
 
                 disposer =

--- a/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageResizer.cs
@@ -286,7 +286,7 @@ namespace Microsoft.ML.ImageAnalytics
                 Contracts.Assert(0 <= iinfo && iinfo < _parent._columns.Length);
 
                 var src = default(Bitmap);
-                var getSrc = input.GetGetter<Bitmap>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<Bitmap>(input.Schema[ColMapNewToOld[iinfo]]);
                 var info = _parent._columns[iinfo];
 
                 disposer =

--- a/src/Microsoft.ML.Mkl.Components/VectorWhitening.cs
+++ b/src/Microsoft.ML.Mkl.Components/VectorWhitening.cs
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Transforms
             {
                 var getters = new ValueGetter<VBuffer<float>>[columns.Length];
                 for (int i = 0; i < columns.Length; i++)
-                    getters[i] = cursor.GetGetter<VBuffer<float>>(cols[i]);
+                    getters[i] = cursor.GetGetter<VBuffer<float>>(cursor.Schema[cols[i]]);
                 var val = default(VBuffer<float>);
                 int irow = 0;
                 while (irow < maxActualRowCount && cursor.MoveNext())
@@ -625,7 +625,7 @@ namespace Microsoft.ML.Transforms
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
                 int src = _cols[iinfo];
                 Host.Assert(input.IsColumnActive(src));
-                return input.GetGetter<T>(src);
+                return input.GetGetter<T>(input.Schema[src]);
             }
 
             private static void FillValues(float[] model, ref VBuffer<float> src, ref VBuffer<float> dst, int cdst)

--- a/src/Microsoft.ML.Mkl.Components/VectorWhitening.cs
+++ b/src/Microsoft.ML.Mkl.Components/VectorWhitening.cs
@@ -623,9 +623,9 @@ namespace Microsoft.ML.Transforms
             {
                 Host.AssertValue(input);
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
-                int src = _cols[iinfo];
-                Host.Assert(input.IsColumnActive(src));
-                return input.GetGetter<T>(input.Schema[src]);
+                var srcCol = input.Schema[_cols[iinfo]];
+                Host.Assert(input.IsColumnActive(srcCol));
+                return input.GetGetter<T>(srcCol);
             }
 
             private static void FillValues(float[] model, ref VBuffer<float> src, ref VBuffer<float> dst, int cdst)

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -475,7 +475,7 @@ namespace Microsoft.ML.Transforms
                 public NameOnnxValueGetter(DataViewRow input, string colName, int colIndex)
                 {
                     _colName = colName;
-                    _srcgetter = input.GetGetter<T>(colIndex);
+                    _srcgetter = input.GetGetter<T>(input.Schema[colIndex]);
                 }
                 public NamedOnnxValue GetNamedOnnxValue()
                 {
@@ -494,7 +494,7 @@ namespace Microsoft.ML.Transforms
                 private VBuffer<T> _vBufferDense;
                 public NamedOnnxValueGetterVec(DataViewRow input, string colName, int colIndex, OnnxShape tensorShape)
                 {
-                    _srcgetter = input.GetGetter<VBuffer<T>>(colIndex);
+                    _srcgetter = input.GetGetter<VBuffer<T>>(input.Schema[colIndex]);
                     _tensorShape = tensorShape;
                     _colName = colName;
                     _vBuffer = default;

--- a/src/Microsoft.ML.PCA/PcaTransformer.cs
+++ b/src/Microsoft.ML.PCA/PcaTransformer.cs
@@ -422,8 +422,8 @@ namespace Microsoft.ML.Transforms
                 {
                     var sInfo = _schemaInfos[iinfo];
                     if (sInfo.WeightColumnIndex >= 0)
-                        weightGetters[iinfo] = cursor.GetGetter<float>(sInfo.WeightColumnIndex);
-                    columnGetters[iinfo] = cursor.GetGetter<VBuffer<float>>(sInfo.InputIndex);
+                        weightGetters[iinfo] = cursor.GetGetter<float>(cursor.Schema[sInfo.WeightColumnIndex]);
+                    columnGetters[iinfo] = cursor.GetGetter<VBuffer<float>>(cursor.Schema[sInfo.InputIndex]);
                 }
 
                 var features = default(VBuffer<float>);
@@ -572,7 +572,7 @@ namespace Microsoft.ML.Transforms
                 Contracts.Assert(0 <= iinfo && iinfo < _numColumns);
                 disposer = null;
 
-                var srcGetter = input.GetGetter<VBuffer<float>>(ColMapNewToOld[iinfo]);
+                var srcGetter = input.GetGetter<VBuffer<float>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(VBuffer<float>);
 
                 ValueGetter<VBuffer<float>> dstGetter = (ref VBuffer<float> dst) =>

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -591,11 +591,18 @@ namespace Microsoft.ML.Data
 
             public override long Batch => 0;
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.CheckParam(IsColumnActive(col), nameof(col), "requested column not active");
+                Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column not active");
 
-                var getter = _getters[_colToActivesIndex[col]] as ValueGetter<TValue>;
+                var getter = _getters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
 
@@ -613,10 +620,13 @@ namespace Microsoft.ML.Data
                    };
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _colToActivesIndex.Length, nameof(col));
-                return _colToActivesIndex[col] >= 0;
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
+                return _colToActivesIndex[columnIndex] >= 0;
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -595,7 +595,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -396,8 +396,7 @@ namespace Microsoft.ML.Data
         public DataViewRowCursor GetRowCursor(IEnumerable<DataViewSchema.Column> columnsNeeded, Random rand = null)
         {
             _host.CheckValueOrNull(rand);
-            var predicate = RowCursorUtils.FromColumnsToPredicate(columnsNeeded, Schema);
-            return new Cursor(this, predicate, rand);
+            return new Cursor(this, columnsNeeded, rand);
         }
 
         public DataViewRowCursor[] GetRowCursorSet(IEnumerable<DataViewSchema.Column> columnsNeeded, int n, Random rand = null)
@@ -448,10 +447,10 @@ namespace Microsoft.ML.Data
             private IList[] _columnValues;
             private Random _rand;
 
-            public Cursor(ParquetLoader parent, Func<int, bool> predicate, Random rand)
+            public Cursor(ParquetLoader parent, IEnumerable<DataViewSchema.Column> columnsNeeded, Random rand)
                : base(parent._host)
             {
-                Ch.AssertValue(predicate);
+                Ch.AssertValue(columnsNeeded);
                 Ch.AssertValue(parent._parquetStream);
 
                 _loader = parent;
@@ -460,7 +459,7 @@ namespace Microsoft.ML.Data
                 _rand = rand;
 
                 // Create Getter delegates
-                Utils.BuildSubsetMaps(Schema.Count, predicate, out _actives, out _colToActivesIndex);
+                Utils.BuildSubsetMaps(Schema.Count, columnsNeeded, out _actives, out _colToActivesIndex);
                 _readerOptions = new ReaderOptions
                 {
                     Count = _loader._columnChunkReadSize,
@@ -491,7 +490,7 @@ namespace Microsoft.ML.Data
             #region CreateGetterDelegates
             private Delegate CreateGetterDelegate(int col)
             {
-                Ch.CheckParam(IsColumnActive(col), nameof(col));
+                Ch.CheckParam(IsColumnActive(Schema[col]), nameof(col));
 
                 var parquetType = _loader._columnsLoaded[col].DataType;
                 switch (parquetType)
@@ -539,7 +538,7 @@ namespace Microsoft.ML.Data
 
             private ValueGetter<TValue> CreateGetterDelegateCore<TSource, TValue>(int col, ValueMapper<TSource, TValue> valueConverter)
             {
-                Ch.CheckParam(IsColumnActive(col), nameof(col));
+                Ch.CheckParam(IsColumnActive(Schema[col]), nameof(col));
                 Ch.CheckValue(valueConverter, nameof(valueConverter));
 
                 int activeIdx = _colToActivesIndex[col];
@@ -600,7 +599,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(IsColumnActive(column.Index), nameof(column), "requested column not active");
+                Ch.CheckParam(IsColumnActive(column), nameof(column), "requested column not active");
 
                 var getter = _getters[_colToActivesIndex[column.Index]] as ValueGetter<TValue>;
                 if (getter == null)
@@ -623,10 +622,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _colToActivesIndex.Length, nameof(columnIndex));
-                return _colToActivesIndex[columnIndex] >= 0;
+                Ch.CheckParam(column.Index < _colToActivesIndex.Length, nameof(column));
+                return _colToActivesIndex[column.Index] >= 0;
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Parquet/ParquetLoader.cs
+++ b/src/Microsoft.ML.Parquet/ParquetLoader.cs
@@ -592,17 +592,17 @@ namespace Microsoft.ML.Data
             public override long Batch => 0;
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex), "requested column not active");
+                Ch.CheckParam(IsColumnActive(column.Index), nameof(column), "requested column not active");
 
-                var getter = _getters[_colToActivesIndex[columnIndex]] as ValueGetter<TValue>;
+                var getter = _getters[_colToActivesIndex[column.Index]] as ValueGetter<TValue>;
                 if (getter == null)
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
 

--- a/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
@@ -413,7 +413,7 @@ namespace Microsoft.ML.Data
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 var getter = _getters[column.Index] as ValueGetter<TValue>;
                 if (getter == null)
@@ -438,10 +438,10 @@ namespace Microsoft.ML.Data
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count);
-                return _active[columnIndex];
+                Ch.Check(column.Index < Schema.Count);
+                return _active[column.Index];
             }
 
             protected override bool MoveNextCore()

--- a/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
@@ -409,7 +409,7 @@ namespace Microsoft.ML.Data
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
@@ -404,11 +404,18 @@ namespace Microsoft.ML.Data
 
             public override DataViewSchema Schema => _parent.Schema;
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
-                var getter = _getters[col] as ValueGetter<TValue>;
+                var getter = _getters[columnIndex] as ValueGetter<TValue>;
                 if (getter == null)
                 {
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
@@ -428,10 +435,13 @@ namespace Microsoft.ML.Data
                     };
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < Schema.Count);
-                return _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count);
+                return _active[columnIndex];
             }
 
             protected override bool MoveNextCore()

--- a/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
+++ b/src/Microsoft.ML.Parquet/PartitionedFileLoader.cs
@@ -405,17 +405,17 @@ namespace Microsoft.ML.Data
             public override DataViewSchema Schema => _parent.Schema;
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex));
+                Ch.Check(IsColumnActive(column.Index));
 
-                var getter = _getters[columnIndex] as ValueGetter<TValue>;
+                var getter = _getters[column.Index] as ValueGetter<TValue>;
                 if (getter == null)
                 {
                     throw Ch.Except("Invalid TValue: '{0}'", typeof(TValue));
@@ -542,7 +542,7 @@ namespace Microsoft.ML.Data
                     if (_subActive[i])
                     {
                         var type = _subCursor.Schema[i].Type;
-                        _subGetters[i] = MarshalGetter(_subCursor.GetGetter<int>, type.RawType, i);
+                        _subGetters[i] = MarshalGetter(_subCursor.GetGetter<DataViewSchema.Column>, type.RawType, _subCursor.Schema[i]);
                     }
                 }
             }
@@ -672,13 +672,13 @@ namespace Microsoft.ML.Data
                 return true;
             }
 
-            private Delegate MarshalGetter(Func<int, ValueGetter<int>> func, Type type, int col)
+            private Delegate MarshalGetter(Func<DataViewSchema.Column, ValueGetter<DataViewSchema.Column>> func, Type type, DataViewSchema.Column column)
             {
                 var returnType = typeof(ValueGetter<>).MakeGenericType(type);
                 var meth = func.Method;
 
                 var typedMeth = meth.GetGenericMethodDefinition().MakeGenericMethod(type);
-                return (Delegate)typedMeth.Invoke(func.Target, new object[] { col });
+                return (Delegate)typedMeth.Invoke(func.Target, new object[] { column });
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -387,7 +387,7 @@ namespace Microsoft.ML.Trainers.Recommender
                 return getters;
             }
 
-            public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+            DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 var activeArray = Utils.BuildArray(OutputSchema.Count, activeColumns);
                 var getters = CreateGetter(input, activeArray);

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -387,9 +387,9 @@ namespace Microsoft.ML.Trainers.Recommender
                 return getters;
             }
 
-            public DataViewRow GetRow(DataViewRow input, Func<int, bool> active)
+            public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
-                var activeArray = Utils.BuildArray(OutputSchema.Count, active);
+                var activeArray = Utils.BuildArray(OutputSchema.Count, activeColumns);
                 var getters = CreateGetter(input, activeArray);
                 return new SimpleRow(OutputSchema, input, getters);
             }

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -313,9 +313,9 @@ namespace Microsoft.ML.Trainers
             using (var cursor = data.Data.GetRowCursor(columns))
             {
                 var labelGetter = RowCursorUtils.GetLabelGetter(cursor, data.Schema.Label.Value.Index);
-                var weightGetter = data.Schema.Weight?.Index is int weightIdx ? cursor.GetGetter<float>(weightIdx) : null;
+                var weightGetter = data.Schema.Weight.HasValue ? cursor.GetGetter<float>(data.Schema.Weight.Value) : null;
                 for (int f = 0; f < featureColumns.Count; f++)
-                    getters[f] = cursor.GetGetter<VBuffer<float>>(featureColumns[f].Index);
+                    getters[f] = cursor.GetGetter<VBuffer<float>>(featureColumns[f]);
                 while (cursor.MoveNext())
                 {
                     labelGetter(ref label);
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Trainers
                     var labelGetter = RowCursorUtils.GetLabelGetter(cursor, data.Schema.Label.Value.Index);
                     var weightGetter = data.Schema.Weight?.Index is int weightIdx ? RowCursorUtils.GetGetterAs<float>(NumberDataViewType.Single, cursor, weightIdx) : null;
                     for (int i = 0; i < fieldCount; i++)
-                        featureGetters[i] = cursor.GetGetter<VBuffer<float>>(fieldColumnIndexes[i]);
+                        featureGetters[i] = cursor.GetGetter<VBuffer<float>>(cursor.Schema[fieldColumnIndexes[i]]);
                     loss = 0;
                     exampleCount = 0;
                     badExampleCount = 0;

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+        DataViewRow ISchemaBoundRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
         {
             var latentSum = new AlignedArray(_pred.FieldCount * _pred.FieldCount * _pred.LatentDimAligned, 16);
             var featureBuffer = new VBuffer<float>();

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Trainers
             if (active0 || active1)
             {
                 for (int f = 0; f < _pred.FieldCount; f++)
-                    inputGetters[f] = input.GetGetter<VBuffer<float>>(_inputColumnIndexes[f]);
+                    inputGetters[f] = input.GetGetter<VBuffer<float>>(input.Schema[_inputColumnIndexes[f]]);
             }
 
             var getters = new Delegate[2];

--- a/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
+++ b/src/Microsoft.ML.StandardLearners/FactorizationMachine/FieldAwareFactorizationMachineUtils.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        public DataViewRow GetRow(DataViewRow input, Func<int, bool> predicate)
+        public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
         {
             var latentSum = new AlignedArray(_pred.FieldCount * _pred.FieldCount * _pred.LatentDimAligned, 16);
             var featureBuffer = new VBuffer<float>();
@@ -105,14 +105,18 @@ namespace Microsoft.ML.Trainers
             var featureValueBuffer = new float[_pred.FeatureCount];
             var inputGetters = new ValueGetter<VBuffer<float>>[_pred.FieldCount];
 
-            if (predicate(0) || predicate(1))
+            var activeIndices = activeColumns.Select(c => c.Index).ToArray();
+            var active0 = activeIndices.Contains(0);
+            var active1 = activeIndices.Contains(1);
+
+            if (active0 || active1)
             {
                 for (int f = 0; f < _pred.FieldCount; f++)
                     inputGetters[f] = input.GetGetter<VBuffer<float>>(_inputColumnIndexes[f]);
             }
 
             var getters = new Delegate[2];
-            if (predicate(0))
+            if (active0)
             {
                 ValueGetter<float> responseGetter = (ref float value) =>
                 {
@@ -120,7 +124,7 @@ namespace Microsoft.ML.Trainers
                 };
                 getters[0] = responseGetter;
             }
-            if (predicate(1))
+            if (active1)
             {
                 ValueGetter<float> probGetter = (ref float value) =>
                 {

--- a/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Simple/SimpleTrainers.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ML.Trainers
             using (var cursor = data.Data.GetRowCursor(cols))
             {
                 var getLab = cursor.GetLabelFloatGetter(data);
-                var getWeight = colWeight >= 0 ? cursor.GetGetter<float>(colWeight) : null;
+                var getWeight = colWeight >= 0 ? cursor.GetGetter<float>(data.Schema.Weight.Value) : null;
                 float lab = default;
                 float weight = 1;
                 while (cursor.MoveNext())

--- a/src/Microsoft.ML.StaticPipe/StaticSchemaShape.cs
+++ b/src/Microsoft.ML.StaticPipe/StaticSchemaShape.cs
@@ -247,13 +247,13 @@ namespace Microsoft.ML.StaticPipe
                     // Check to see if the column is normalized.
                     // Once we shift to metadata being a row globally we can also make this a bit more efficient:
                     var meta = col.Annotations;
-                    if (meta.Schema.TryGetColumnIndex(AnnotationUtils.Kinds.IsNormalized, out int normcol))
+                    var normalizedColumn = meta.Schema.GetColumnOrNull(AnnotationUtils.Kinds.IsNormalized);
+                    if (normalizedColumn.HasValue)
                     {
-                        var normtype = meta.Schema[normcol].Type;
-                        if (normtype == BooleanDataViewType.Instance)
+                        if (normalizedColumn.Value.Type == BooleanDataViewType.Instance)
                         {
                             bool val = default;
-                            meta.GetGetter<bool>(normcol)(ref val);
+                            meta.GetGetter<bool>(normalizedColumn.Value)(ref val);
                             if (val)
                                 vecType = typeof(NormVector<>);
                         }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -900,7 +900,7 @@ namespace Microsoft.ML.Transforms
 
             public TensorValueGetter(DataViewRow input, int colIndex, TFShape tfShape)
             {
-                _srcgetter = input.GetGetter<T>(colIndex);
+                _srcgetter = input.GetGetter<T>(input.Schema[colIndex]);
                 _tfShape = tfShape;
                 long size = 0;
                 _position = 0;
@@ -946,7 +946,7 @@ namespace Microsoft.ML.Transforms
 
             public TensorValueGetterVec(DataViewRow input, int colIndex, TFShape tfShape)
             {
-                _srcgetter = input.GetGetter<VBuffer<T>>(colIndex);
+                _srcgetter = input.GetGetter<VBuffer<T>>(input.Schema[colIndex]);
                 _tfShape = tfShape;
                 _vBuffer = default;
                 _denseData = default;

--- a/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
+++ b/src/Microsoft.ML.TimeSeries/AdaptiveSingularSpectrumSequenceModeler.cs
@@ -1236,7 +1236,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             int count = 0;
             using (var cursor = data.Data.GetRowCursor(featureCol))
             {
-                var getVal = cursor.GetGetter<Single>(featureCol.Index);
+                var getVal = cursor.GetGetter<Single>(featureCol);
                 Single val = default;
                 while (cursor.MoveNext() && count < _trainSize)
                 {

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             if (mapper is CompositeRowToRowMapper compositeMapper)
                 innerMappers = compositeMapper.InnerMappers;
 
-            var activeIndices = activeColumns.Select(c => c.Index);
+            var activeIndices = new HashSet<int>(activeColumns.Select(c => c.Index));
             if (innerMappers.Length == 0)
             {
                 bool differentActive = false;

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -108,21 +108,22 @@ namespace Microsoft.ML.Transforms.TimeSeries
         {
         }
 
-        internal DataViewRow GetStatefulRows(DataViewRow input, IRowToRowMapper mapper, Func<int, bool> active, List<StatefulRow> rows)
+        internal DataViewRow GetStatefulRows(DataViewRow input, IRowToRowMapper mapper, IEnumerable<DataViewSchema.Column> activeColumns, List<StatefulRow> rows)
         {
             Contracts.CheckValue(input, nameof(input));
-            Contracts.CheckValue(active, nameof(active));
+            Contracts.CheckValue(activeColumns, nameof(activeColumns));
 
             IRowToRowMapper[] innerMappers = new IRowToRowMapper[0];
             if (mapper is CompositeRowToRowMapper compositeMapper)
                 innerMappers = compositeMapper.InnerMappers;
 
+            var activeIndices = activeColumns.Select(c => c.Index);
             if (innerMappers.Length == 0)
             {
                 bool differentActive = false;
                 for (int c = 0; c < input.Schema.Count; ++c)
                 {
-                    bool wantsActive = active(c);
+                    bool wantsActive = activeIndices.Contains(c);
                     bool isActive = input.IsColumnActive(c);
                     differentActive |= wantsActive != isActive;
 
@@ -130,7 +131,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                         throw Contracts.ExceptParam(nameof(input), $"Mapper required column '{input.Schema[c].Name}' active but it was not.");
                 }
 
-                var row = mapper.GetRow(input, active);
+                var row = mapper.GetRow(input, activeColumns);
                 if (row is StatefulRow statefulRow)
                     rows.Add(statefulRow);
                 return row;
@@ -139,14 +140,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
             // For each of the inner mappers, we will be calling their GetRow method, but to do so we need to know
             // what we need from them. The last one will just have the input, but the rest will need to be
             // computed based on the dependencies of the next one in the chain.
-            var deps = new Func<int, bool>[innerMappers.Length];
-            deps[deps.Length - 1] = active;
+            var deps = new IEnumerable<DataViewSchema.Column>[innerMappers.Length];
+            deps[deps.Length - 1] = activeColumns;
             for (int i = deps.Length - 1; i >= 1; --i)
-            {
-                var inputCols = innerMappers[i].OutputSchema.Where(c => deps[i](c.Index));
-                var cols = innerMappers[i].GetDependencies(inputCols).ToArray();
-                deps[i - 1] = c => cols.Length > 0 ? cols.Any(col => col.Index == c) : false;
-            }
+                deps[i - 1] = innerMappers[i].GetDependencies(deps[i]);
 
             DataViewRow result = input;
             for (int i = 0; i < innerMappers.Length; ++i)
@@ -172,7 +169,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                  SchemaDefinition inputSchemaDefinition, SchemaDefinition outputSchemaDefinition, out Action disposer, out IRowReadableAs<TDst> outputRow)
         {
             List<StatefulRow> rows = new List<StatefulRow>();
-            DataViewRow outputRowLocal = outputRowLocal = GetStatefulRows(inputRow, mapper, col => true, rows);
+            DataViewRow outputRowLocal = outputRowLocal = GetStatefulRows(inputRow, mapper, mapper.OutputSchema, rows);
             var cursorable = TypedCursorable<TDst>.Create(env, new EmptyDataView(env, mapper.OutputSchema), ignoreMissingColumns, outputSchemaDefinition);
             _pinger = CreatePinger(rows);
             disposer = outputRowLocal.Dispose;

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 for (int c = 0; c < input.Schema.Count; ++c)
                 {
                     bool wantsActive = activeIndices.Contains(c);
-                    bool isActive = input.IsColumnActive(c);
+                    bool isActive = input.IsColumnActive(input.Schema[c]);
                     differentActive |= wantsActive != isActive;
 
                     if (wantsActive && !isActive)

--- a/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialAnomalyDetectionTransformBase.cs
@@ -365,7 +365,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 private Delegate MakeGetter(DataViewRow input, AnomalyDetectionStateBase state)
                 {
                     _host.AssertValue(input);
-                    var srcGetter = input.GetGetter<TInput>(_inputColumnIndex);
+                    var srcGetter = input.GetGetter<TInput>(input.Schema[_inputColumnIndex]);
                     ProcessData processData = _parent.WindowSize > 0 ?
                         (ProcessData)state.Process : state.ProcessWithoutBuffer;
 
@@ -391,7 +391,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 private Action<long> MakePinger(DataViewRow input, AnomalyDetectionStateBase state)
                 {
                     _host.AssertValue(input);
-                    var srcGetter = input.GetGetter<TInput>(_inputColumnIndex);
+                    var srcGetter = input.GetGetter<TInput>(input.Schema[_inputColumnIndex]);
                     Action<long> pinger = (long rowPosition) =>
                     {
                         TInput src = default;

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -385,16 +385,26 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
             public override DataViewSchema Schema { get { return _parent.OutputSchema; } }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < Schema.Count, "col");
-                return Input.IsColumnActive(col);
+                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
+                return Input.IsColumnActive(columnIndex);
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col), "col");
-                return Input.GetGetter<TValue>(col);
+                Ch.Check(IsColumnActive(columnIndex), nameof(columnIndex));
+                return Input.GetGetter<TValue>(columnIndex);
             }
         }
     }

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -395,16 +395,16 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex), nameof(columnIndex));
-                return Input.GetGetter<TValue>(columnIndex);
+                Ch.Check(IsColumnActive(column.Index), nameof(column));
+                return Input.GetGetter<TValue>(column);
             }
         }
     }

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -399,7 +399,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformBase.cs
@@ -388,10 +388,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
-                return Input.IsColumnActive(columnIndex);
+                Ch.Check(column.Index < Schema.Count, nameof(column));
+                return Input.IsColumnActive(column);
             }
 
             /// <summary>
@@ -403,7 +403,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index), nameof(column));
+                Ch.Check(IsColumnActive(column), nameof(column));
                 return Input.GetGetter<TValue>(column);
             }
         }

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -540,7 +540,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             public override ValueGetter<T> GetGetter<T>(DataViewSchema.Column column)
             {
                 Contracts.CheckParam(column.Index < _getters.Length, nameof(column), "Invalid col value in GetGetter");
-                Contracts.Check(IsColumnActive(column.Index));
+                Contracts.Check(IsColumnActive(column));
                 var fn = _getters[column.Index] as ValueGetter<T>;
                 if (fn == null)
                     throw Contracts.Except("Unexpected TValue in GetGetter");
@@ -553,10 +553,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Contracts.Check(0 <= columnIndex && columnIndex < _getters.Length);
-                return _getters[columnIndex] != null;
+                Contracts.Check(column.Index < _getters.Length);
+                return _getters[column.Index] != null;
             }
         }
 
@@ -579,10 +579,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
-                return Input.IsColumnActive(columnIndex);
+                Ch.Check(column.Index < Schema.Count, nameof(column));
+                return Input.IsColumnActive(column);
             }
 
             /// <summary>
@@ -594,7 +594,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index), nameof(column));
+                Ch.Check(IsColumnActive(column), nameof(column));
                 return Input.GetGetter<TValue>(column);
             }
         }
@@ -877,12 +877,12 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return _input.IsColumnActive((index));
+                    return _input.IsColumnActive(_input.Schema[index]);
                 return _getters[index] != null;
             }
         }
@@ -909,10 +909,10 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _bindings.Schema.Count);
-                return _active[columnIndex];
+                Ch.Check(column.Index < _bindings.Schema.Count);
+                return _active[column.Index];
             }
 
             /// <summary>
@@ -924,7 +924,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 bool isSrc;
                 int index = _bindings.MapColumnIndex(out isSrc, column.Index);

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -550,10 +550,13 @@ namespace Microsoft.ML.Transforms.TimeSeries
             public override Action<long> GetPinger() =>
                 _pinger as Action<long> ?? throw Contracts.Except("Invalid TValue in GetPinger: '{0}'", typeof(long));
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Contracts.Check(0 <= col && col < _getters.Length);
-                return _getters[col] != null;
+                Contracts.Check(0 <= columnIndex && columnIndex < _getters.Length);
+                return _getters[columnIndex] != null;
             }
         }
 
@@ -573,16 +576,26 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
             public override DataViewSchema Schema => _parent.OutputSchema;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < Schema.Count, "col");
-                return Input.IsColumnActive(col);
+                Ch.Check(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
+                return Input.IsColumnActive(columnIndex);
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col), "col");
-                return Input.GetGetter<TValue>(col);
+                Ch.Check(IsColumnActive(columnIndex), nameof(columnIndex));
+                return Input.GetGetter<TValue>(columnIndex);
             }
         }
     }
@@ -835,10 +848,17 @@ namespace Microsoft.ML.Transforms.TimeSeries
                     _disposer?.Invoke();
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, col);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return _input.GetGetter<TValue>(index);
 
@@ -854,10 +874,13 @@ namespace Microsoft.ML.Transforms.TimeSeries
 
             public override ValueGetter<DataViewRowId> GetIdGetter() => _input.GetIdGetter();
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, col);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return _input.IsColumnActive((index));
                 return _getters[index] != null;
@@ -883,18 +906,28 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 _bindings = parent._bindings;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.Schema.Count);
-                return _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.Schema.Count);
+                return _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -537,11 +537,11 @@ namespace Microsoft.ML.Transforms.TimeSeries
             public override ValueGetter<DataViewRowId> GetIdGetter()
                 => _input.GetIdGetter();
 
-            public override ValueGetter<T> GetGetter<T>(int col)
+            public override ValueGetter<T> GetGetter<T>(DataViewSchema.Column column)
             {
-                Contracts.CheckParam(0 <= col && col < _getters.Length, nameof(col), "Invalid col value in GetGetter");
-                Contracts.Check(IsColumnActive(col));
-                var fn = _getters[col] as ValueGetter<T>;
+                Contracts.CheckParam(column.Index < _getters.Length, nameof(column), "Invalid col value in GetGetter");
+                Contracts.Check(IsColumnActive(column.Index));
+                var fn = _getters[column.Index] as ValueGetter<T>;
                 if (fn == null)
                     throw Contracts.Except("Unexpected TValue in GetGetter");
                 return fn;
@@ -586,16 +586,16 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex), nameof(columnIndex));
-                return Input.GetGetter<TValue>(columnIndex);
+                Ch.Check(IsColumnActive(column.Index), nameof(column));
+                return Input.GetGetter<TValue>(column);
             }
         }
     }
@@ -849,18 +849,18 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
                 bool isSrc;
-                int index = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _parent._bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return _input.GetGetter<TValue>(index);
+                    return _input.GetGetter<TValue>(column);
 
                 Contracts.Assert(_getters[index] != null);
                 var fn = _getters[index] as ValueGetter<TValue>;
@@ -916,20 +916,20 @@ namespace Microsoft.ML.Transforms.TimeSeries
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(columnIndex));
+                Ch.Check(IsColumnActive(column.Index));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return Input.GetGetter<TValue>(index);
+                    return Input.GetGetter<TValue>(column);
 
                 Ch.AssertValue(_getters);
                 var getter = _getters[index];

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -488,7 +488,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
                 return InputSchema;
             }
 
-            public DataViewRow GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
+            DataViewRow IRowToRowMapper.GetRow(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns)
             {
                 var active = RowCursorUtils.FromColumnsToPredicate(activeColumns, OutputSchema);
                 var getters = _mapper.CreateGetters(input, active, out Action disposer);

--- a/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
+++ b/src/Microsoft.ML.TimeSeries/SequentialTransformerBase.cs
@@ -590,7 +590,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
@@ -853,7 +853,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
@@ -920,7 +920,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -309,7 +309,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
 
         private static CountAggregator GetOneAggregator<T>(DataViewRow row, DataViewType colType, int colSrc)
         {
-            return new CountAggregator<T>(colType, row.GetGetter<T>(colSrc));
+            return new CountAggregator<T>(colType, row.GetGetter<T>(row.Schema[colSrc]));
         }
 
         private static CountAggregator GetVecAggregator(DataViewRow row, VectorType colType, int colSrc)
@@ -321,7 +321,7 @@ namespace Microsoft.ML.Transforms.FeatureSelection
 
         private static CountAggregator GetVecAggregator<T>(DataViewRow row, VectorType colType, int colSrc)
         {
-            return new CountAggregator<T>(colType, row.GetGetter<VBuffer<T>>(colSrc));
+            return new CountAggregator<T>(colType, row.GetGetter<VBuffer<T>>(row.Schema[colSrc]));
         }
 
         private abstract class CountAggregator

--- a/src/Microsoft.ML.Transforms/CustomMappingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/CustomMappingTransformer.cs
@@ -166,7 +166,7 @@ namespace Microsoft.ML.Transforms
 
             private Delegate GetDstGetter<T>(DataViewRow input, int colIndex, Action refreshAction)
             {
-                var getter = input.GetGetter<T>(colIndex);
+                var getter = input.GetGetter<T>(input.Schema[colIndex]);
                 ValueGetter<T> combinedGetter = (ref T dst) =>
                 {
                     refreshAction();

--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -370,7 +370,7 @@ namespace Microsoft.ML.Transforms
                 Host.Assert(0 < ex.Scale && ex.Scale < float.PositiveInfinity);
                 Host.Assert(_srcTypes[iinfo] is VectorType);
 
-                var getSrc = input.GetGetter<VBuffer<float>>(_srcCols[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<float>>(input.Schema[_srcCols[iinfo]]);
                 var src = default(VBuffer<float>);
                 ValueGetter<VBuffer<float>> del;
                 float scale = ex.Scale;

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -563,10 +563,11 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                _parent._groupBinding.CheckColumnInRange(columnIndex);
-                return _active[columnIndex];
+                Ch.CheckParam(column.Index < _active.Length, nameof(column));
+                _parent._groupBinding.CheckColumnInRange(column.Index);
+                return _active[column.Index];
             }
 
             protected override bool MoveNextCore()

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -560,10 +560,13 @@ namespace Microsoft.ML.Transforms
                 return _trailingCursor.GetIdGetter();
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                _parent._groupBinding.CheckColumnInRange(col);
-                return _active[col];
+                _parent._groupBinding.CheckColumnInRange(columnIndex);
+                return _active[columnIndex];
             }
 
             protected override bool MoveNextCore()
@@ -634,17 +637,24 @@ namespace Microsoft.ML.Transforms
                 base.Dispose(disposing);
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                _parent._groupBinding.CheckColumnInRange(col);
-                if (!_active[col])
-                    throw Ch.ExceptParam(nameof(col), "Column #{0} is not active", col);
+                _parent._groupBinding.CheckColumnInRange(columnIndex);
+                if (!_active[columnIndex])
+                    throw Ch.ExceptParam(nameof(columnIndex), "Column #{0} is not active", columnIndex);
 
-                if (col < _groupCount)
-                    return _trailingCursor.GetGetter<TValue>(_parent._groupBinding.GroupColumnIndexes[col]);
+                if (columnIndex < _groupCount)
+                    return _trailingCursor.GetGetter<TValue>(_parent._groupBinding.GroupColumnIndexes[columnIndex]);
 
-                Ch.AssertValue(_aggregators[col - _groupCount]);
-                return _aggregators[col - _groupCount].GetGetter<TValue>(Ch);
+                Ch.AssertValue(_aggregators[columnIndex - _groupCount]);
+                return _aggregators[columnIndex - _groupCount].GetGetter<TValue>(Ch);
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/GroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/GroupTransform.cs
@@ -643,7 +643,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueDroppingTransformer.cs
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Transforms
 
             private ValueGetter<VBuffer<TDst>> MakeVecGetter<TDst>(DataViewRow input, int iinfo)
             {
-                var srcGetter = input.GetGetter<VBuffer<TDst>>(_srcCols[iinfo]);
+                var srcGetter = input.GetGetter<VBuffer<TDst>>(input.Schema[_srcCols[iinfo]]);
                 var buffer = default(VBuffer<TDst>);
                 var isNA = (InPredicate<TDst>)_isNAs[iinfo];
                 var def = default(TDst);

--- a/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueIndicatorTransformer.cs
@@ -242,7 +242,7 @@ namespace Microsoft.ML.Transforms
 
             private ValueGetter<bool> ComposeGetterOne<T>(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<T>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<T>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(T);
                 var isNA = (InPredicate<T>)_infos[iinfo].InputIsNA;
 
@@ -264,7 +264,7 @@ namespace Microsoft.ML.Transforms
 
             private ValueGetter<VBuffer<bool>> ComposeGetterVec<T>(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<VBuffer<T>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<T>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var isNA = (InPredicate<T>)_infos[iinfo].InputIsNA;
                 var val = default(T);
                 var defaultIsNA = isNA(in val);

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -634,7 +634,7 @@ namespace Microsoft.ML.Transforms
             /// </summary>
             private Delegate ComposeGetterOne<T>(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<T>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<T>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(T);
                 var isNA = (InPredicate<T>)_isNAs[iinfo];
                 Host.Assert(_parent._repValues[iinfo] is T);
@@ -660,7 +660,7 @@ namespace Microsoft.ML.Transforms
             /// </summary>
             private Delegate ComposeGetterVec<T>(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<VBuffer<T>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<T>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var isNA = (InPredicate<T>)_isNAs[iinfo];
                 var isDefault = Data.Conversion.Conversions.Instance.GetIsDefaultPredicate<T>(_infos[iinfo].TypeSrc.GetItemType());
 

--- a/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacingUtils.cs
@@ -166,7 +166,7 @@ namespace Microsoft.ML.Transforms
             {
                 Ch.AssertValue(cursor);
                 Ch.Assert(0 <= col);
-                _getter = cursor.GetGetter<TValue>(col);
+                _getter = cursor.GetGetter<TValue>(cursor.Schema[col]);
             }
 
             public sealed override void ProcessRow()

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -443,18 +443,28 @@ namespace Microsoft.ML.Transforms
 
             public override DataViewSchema Schema => _bindings.AsSchema;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _bindings.ColumnCount);
-                return _active == null || _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _bindings.ColumnCount);
+                return _active == null || _active[columnIndex];
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.Check(IsColumnActive(col));
+                Ch.Check(IsColumnActive(columnIndex));
 
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
 

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -447,10 +447,10 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _bindings.ColumnCount);
-                return _active == null || _active[columnIndex];
+                Ch.Check(column.Index < _bindings.ColumnCount);
+                return _active == null || _active[column.Index];
             }
 
             /// <summary>
@@ -462,7 +462,7 @@ namespace Microsoft.ML.Transforms
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.Check(IsColumnActive(column.Index));
+                Ch.Check(IsColumnActive(column));
 
                 bool isSrc;
                 int index = _bindings.MapColumnIndex(out isSrc, column.Index);

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -363,13 +363,13 @@ namespace Microsoft.ML.Transforms
             return _bindings.MapColumnIndex(out isSrc, col);
         }
 
-        protected override Delegate[] CreateGetters(DataViewRow input, Func<int, bool> active, out Action disposer)
+        protected override Delegate[] CreateGetters(DataViewRow input, IEnumerable<DataViewSchema.Column> activeColumns, out Action disposer)
         {
             Func<int, bool> activeInfos =
                 iinfo =>
                 {
                     int col = _bindings.MapIinfoToCol(iinfo);
-                    return active(col);
+                    return activeColumns.Select(c => c.Index).Contains(col);
                 };
 
             var getters = new Delegate[_bindings.InfoCount];

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -458,7 +458,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
@@ -141,7 +141,7 @@ namespace Microsoft.ML.Transforms
                 // In which case probably erroring out is probably the most useful thing.
                 using (var cursor = data.GetRowCursor(featuresColumn))
                 {
-                    var featuresGetter = cursor.GetGetter<VBuffer<float>>(featuresColumnIndex);
+                    var featuresGetter = cursor.GetGetter<VBuffer<float>>(featuresColumn);
                     var featuresBuffer = default(VBuffer<float>);
 
                     while (initialfeatureValuesList.Count < maxSize && cursor.MoveNext())

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -205,7 +205,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -201,20 +201,20 @@ namespace Microsoft.ML.Transforms
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _bindings.ColumnCount, nameof(columnIndex));
-                Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex));
+                Ch.CheckParam(column.Index < _bindings.ColumnCount, nameof(column));
+                Ch.CheckParam(IsColumnActive(column.Index), nameof(column.Index));
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return Input.GetGetter<TValue>(index);
+                    return Input.GetGetter<TValue>(Input.Schema[index]);
                 Ch.Assert(index == 0);
                 Delegate idGetter = Input.GetIdGetter();
                 Ch.AssertValue(idGetter);

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -189,13 +189,13 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.CheckParam(0 <= columnIndex && columnIndex < _bindings.ColumnCount, nameof(columnIndex));
+                Ch.CheckParam(column.Index < _bindings.ColumnCount, nameof(column));
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
+                int index = _bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return Input.IsColumnActive(index);
+                    return Input.IsColumnActive(Input.Schema[index]);
                 Ch.Assert(index == 0);
                 return _active;
             }
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Transforms
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
                 Ch.CheckParam(column.Index < _bindings.ColumnCount, nameof(column));
-                Ch.CheckParam(IsColumnActive(column.Index), nameof(column.Index));
+                Ch.CheckParam(IsColumnActive(column), nameof(column.Index));
                 bool isSrc;
                 int index = _bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)

--- a/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
+++ b/src/Microsoft.ML.Transforms/ProduceIdTransform.cs
@@ -186,23 +186,33 @@ namespace Microsoft.ML.Transforms
                 _active = active;
             }
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _bindings.ColumnCount, nameof(col));
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _bindings.ColumnCount, nameof(columnIndex));
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.IsColumnActive(index);
                 Ch.Assert(index == 0);
                 return _active;
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Ch.CheckParam(0 <= col && col < _bindings.ColumnCount, nameof(col));
-                Ch.CheckParam(IsColumnActive(col), nameof(col));
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _bindings.ColumnCount, nameof(columnIndex));
+                Ch.CheckParam(IsColumnActive(columnIndex), nameof(columnIndex));
                 bool isSrc;
-                int index = _bindings.MapColumnIndex(out isSrc, col);
+                int index = _bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return Input.GetGetter<TValue>(index);
                 Ch.Assert(index == 0);

--- a/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
+++ b/src/Microsoft.ML.Transforms/RandomFourierFeaturizing.cs
@@ -307,12 +307,12 @@ namespace Microsoft.ML.Transforms
                     var srcType = input.Schema[srcCols[i]].Type;
                     if (srcType is VectorType)
                     {
-                        var get = cursor.GetGetter<VBuffer<float>>(srcCols[i]);
+                        var get = cursor.GetGetter<VBuffer<float>>(cursor.Schema[srcCols[i]]);
                         reservoirSamplers[i] = new ReservoirSamplerWithReplacement<VBuffer<float>>(rng, reservoirSize, get);
                     }
                     else
                     {
-                        var getOne = cursor.GetGetter<float>(srcCols[i]);
+                        var getOne = cursor.GetGetter<float>(cursor.Schema[srcCols[i]]);
                         float val = 0;
                         ValueGetter<VBuffer<float>> get =
                             (ref VBuffer<float> dst) =>
@@ -516,7 +516,7 @@ namespace Microsoft.ML.Transforms
 
             private ValueGetter<VBuffer<float>> GetterFromVectorType(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<VBuffer<float>>(_srcCols[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<float>>(input.Schema[_srcCols[iinfo]]);
                 var src = default(VBuffer<float>);
 
                 var featuresAligned = new AlignedArray(RoundUp(_srcTypes[iinfo].GetValueCount(), _cfltAlign), CpuMathUtils.GetVectorAlignment());
@@ -533,7 +533,7 @@ namespace Microsoft.ML.Transforms
 
             private ValueGetter<VBuffer<float>> GetterFromFloatType(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<float>(_srcCols[iinfo]);
+                var getSrc = input.GetGetter<float>(input.Schema[_srcCols[iinfo]]);
                 var src = default(float);
 
                 var featuresAligned = new AlignedArray(RoundUp(1, _cfltAlign), CpuMathUtils.GetVectorAlignment());

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -229,14 +229,14 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Contracts.CheckParam(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
+                Contracts.CheckParam(column.Index < Schema.Count, nameof(column));
                 bool isSrc;
-                int iCol = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
+                int iCol = _parent._bindings.MapColumnIndex(out isSrc, column.Index);
                 if (isSrc)
-                    return _input.IsColumnActive(iCol);
-                return _appendedRow.IsColumnActive(iCol);
+                    return _input.IsColumnActive(_input.Schema[iCol]);
+                return _appendedRow.IsColumnActive(_appendedRow.Schema[iCol]);
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -244,7 +244,7 @@ namespace Microsoft.ML.Transforms
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
-            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <typeparam name="TValue"> is the column's content type.</typeparam>
             /// <param name="column"> is the output column whose getter should be returned.</param>
             public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -226,21 +226,31 @@ namespace Microsoft.ML.Transforms
 
             public override DataViewSchema Schema => _parent._bindings.Schema;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Contracts.CheckParam(0 <= col && col < Schema.Count, nameof(col));
+                Contracts.CheckParam(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
                 bool isSrc;
-                int iCol = _parent._bindings.MapColumnIndex(out isSrc, col);
+                int iCol = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
                 if (isSrc)
                     return _input.IsColumnActive(iCol);
                 return _appendedRow.IsColumnActive(iCol);
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                Contracts.CheckParam(0 <= col && col < Schema.Count, nameof(col));
+                Contracts.CheckParam(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
                 bool isSrc;
-                int iCol = _parent._bindings.MapColumnIndex(out isSrc, col);
+                int iCol = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
                 return isSrc ?
                     _input.GetGetter<TValue>(iCol)
                     : _appendedRow.GetGetter<TValue>(iCol);

--- a/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
+++ b/src/Microsoft.ML.Transforms/StatefulFilterTransform.cs
@@ -240,20 +240,20 @@ namespace Microsoft.ML.Transforms
             }
 
             /// <summary>
-            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// Returns a value getter delegate to fetch the value of column with the given columnIndex, from the row.
             /// This throws if the column is not active in this row, or if the type
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                Contracts.CheckParam(0 <= columnIndex && columnIndex < Schema.Count, nameof(columnIndex));
+                Contracts.CheckParam(column.Index < Schema.Count, nameof(column));
                 bool isSrc;
-                int iCol = _parent._bindings.MapColumnIndex(out isSrc, columnIndex);
+                int iCol = _parent._bindings.MapColumnIndex(out isSrc, column.Index);
                 return isSrc ?
-                    _input.GetGetter<TValue>(iCol)
-                    : _appendedRow.GetGetter<TValue>(iCol);
+                    _input.GetGetter<TValue>(_input.Schema[iCol])
+                    : _appendedRow.GetGetter<TValue>(_appendedRow.Schema[iCol]);
             }
         }
     }

--- a/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/StopWordsRemovingTransformer.cs
@@ -408,8 +408,8 @@ namespace Microsoft.ML.Transforms.Text
 
                 StopWordsRemovingEstimator.Language stopWordslang = _parent._columns[iinfo].Language;
                 var lang = default(ReadOnlyMemory<char>);
-                var getLang = _languageColumns[iinfo] >= 0 ? input.GetGetter<ReadOnlyMemory<char>>(_languageColumns[iinfo]) : null;
-                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(_colMapNewToOld[iinfo]);
+                var getLang = _languageColumns[iinfo] >= 0 ? input.GetGetter<ReadOnlyMemory<char>>(input.Schema[_languageColumns[iinfo]]) : null;
+                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(input.Schema[_colMapNewToOld[iinfo]]);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);
                 var buffer = new StringBuilder();
                 var list = new List<ReadOnlyMemory<char>>();
@@ -804,7 +804,7 @@ namespace Microsoft.ML.Transforms.Text
                 using (var cursor = loader.GetRowCursor(loader.Schema[srcCol]))
                 {
                     bool warnEmpty = true;
-                    var getter = cursor.GetGetter<ReadOnlyMemory<char>>(colSrcIndex);
+                    var getter = cursor.GetGetter<ReadOnlyMemory<char>>(cursor.Schema[colSrcIndex]);
                     while (cursor.MoveNext())
                     {
                         getter(ref src);
@@ -1027,7 +1027,7 @@ namespace Microsoft.ML.Transforms.Text
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
                 disposer = null;
 
-                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);
                 var buffer = new StringBuilder();
                 var list = new List<ReadOnlyMemory<char>>();

--- a/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextNormalizing.cs
@@ -303,7 +303,7 @@ namespace Microsoft.ML.Transforms.Text
 
             private ValueGetter<ReadOnlyMemory<char>> MakeGetterOne(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(input.Schema[ColMapNewToOld[iinfo]]);
                 Host.AssertValue(getSrc);
                 var src = default(ReadOnlyMemory<char>);
                 var buffer = new StringBuilder();
@@ -317,7 +317,7 @@ namespace Microsoft.ML.Transforms.Text
 
             private ValueGetter<VBuffer<ReadOnlyMemory<char>>> MakeGetterVec(DataViewRow input, int iinfo)
             {
-                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(input.Schema[ColMapNewToOld[iinfo]]);
                 Host.AssertValue(getSrc);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);
                 var buffer = new StringBuilder();

--- a/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
+++ b/src/Microsoft.ML.Transforms/Text/TokenizingByCharacters.cs
@@ -412,7 +412,7 @@ namespace Microsoft.ML.Transforms.Text
             private ValueGetter<VBuffer<ushort>> MakeGetterOne(DataViewRow input, int iinfo)
             {
                 Host.AssertValue(input);
-                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(ReadOnlyMemory<char>);
                 return
                     (ref VBuffer<ushort> dst) =>
@@ -445,7 +445,7 @@ namespace Microsoft.ML.Transforms.Text
                 int cv = input.Schema[ColMapNewToOld[iinfo]].Type.GetVectorSize();
                 Contracts.Assert(cv >= 0);
 
-                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);
 
                 ValueGetter<VBuffer<ushort>> getterWithStartEndSep = (ref VBuffer<ushort> dst) =>

--- a/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordEmbeddingsExtractor.cs
@@ -555,11 +555,11 @@ namespace Microsoft.ML.Transforms.Text
                 Host.AssertValue(input);
                 Host.Assert(0 <= iinfo && iinfo < _parent.ColumnPairs.Length);
 
-                var colType = input.Schema[ColMapNewToOld[iinfo]].Type;
-                Host.Assert(colType is VectorType);
-                Host.Assert(colType.GetItemType() is TextDataViewType);
+                var column = input.Schema[ColMapNewToOld[iinfo]];
+                Host.Assert(column.Type is VectorType);
+                Host.Assert(column.Type.GetItemType() is TextDataViewType);
 
-                var srcGetter = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);
+                var srcGetter = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(column);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);
                 int dimension = _parent._currentVocab.Dimension;
                 float[] wordVector = new float[_parent._currentVocab.Dimension];

--- a/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordTokenizing.cs
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Transforms.Text
             private ValueGetter<VBuffer<ReadOnlyMemory<char>>> MakeGetterOne(DataViewRow input, int iinfo)
             {
                 Host.AssertValue(input);
-                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<ReadOnlyMemory<char>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(ReadOnlyMemory<char>);
                 var terms = new List<ReadOnlyMemory<char>>();
                 var separators = _parent._columns[iinfo].SeparatorsArray;
@@ -280,7 +280,7 @@ namespace Microsoft.ML.Transforms.Text
 
                 int cv = input.Schema[ColMapNewToOld[iinfo]].Type.GetVectorSize();
                 Contracts.Assert(cv >= 0);
-                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(ColMapNewToOld[iinfo]);
+                var getSrc = input.GetGetter<VBuffer<ReadOnlyMemory<char>>>(input.Schema[ColMapNewToOld[iinfo]]);
                 var src = default(VBuffer<ReadOnlyMemory<char>>);
                 var terms = new List<ReadOnlyMemory<char>>();
                 var separators = _parent._columns[iinfo].SeparatorsArray;

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -596,10 +596,10 @@ namespace Microsoft.ML.Transforms
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                Ch.Check(0 <= columnIndex && columnIndex < _ungroupBinding.InputColumnCount);
-                return _active[columnIndex];
+                Ch.Check(column.Index < _ungroupBinding.InputColumnCount);
+                return _active[column.Index];
             }
 
             /// <summary>

--- a/src/Microsoft.ML.Transforms/UngroupTransform.cs
+++ b/src/Microsoft.ML.Transforms/UngroupTransform.cs
@@ -593,31 +593,33 @@ namespace Microsoft.ML.Transforms
 
             public override DataViewSchema Schema => _ungroupBinding.OutputSchema;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                Ch.Check(0 <= col && col < _ungroupBinding.InputColumnCount);
-                return _active[col];
+                Ch.Check(0 <= columnIndex && columnIndex < _ungroupBinding.InputColumnCount);
+                return _active[columnIndex];
             }
 
             /// <summary>
-            /// Returns getter to an output column.
+            /// Returns the getter of an output column.
             /// </summary>
-            /// <typeparam name="TValue">Output column's content type, for example, <see cref="VBuffer{T}"/>.</typeparam>
-            /// <param name="col">Index of a output column whose getter will be returned.</param>
-            /// <returns></returns>
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <typeparam name="TValue"> is the output column's content type, for example, <see cref="VBuffer{T}"/>.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
                 // Although the input argument, col, is a output index, we check its range as if it's an input column index.
                 // It makes sense because the i-th output column is produced by either expanding or copying the i-th input column.
-                Ch.CheckParam(0 <= col && col < _ungroupBinding.InputColumnCount, nameof(col));
+                Ch.CheckParam(0 <= columnIndex && columnIndex < _ungroupBinding.InputColumnCount, nameof(columnIndex));
 
-                if (!_ungroupBinding.IsPivot(col))
-                    return Input.GetGetter<TValue>(col);
+                if (!_ungroupBinding.IsPivot(columnIndex))
+                    return Input.GetGetter<TValue>(columnIndex);
 
-                if (_cachedGetters[col] == null)
-                    _cachedGetters[col] = MakeGetter<TValue>(col, _ungroupBinding.GetPivotColumnOptionsByCol(col).ItemType);
+                if (_cachedGetters[columnIndex] == null)
+                    _cachedGetters[columnIndex] = MakeGetter<TValue>(columnIndex, _ungroupBinding.GetPivotColumnOptionsByCol(columnIndex).ItemType);
 
-                var result = _cachedGetters[col] as ValueGetter<TValue>;
+                var result = _cachedGetters[columnIndex] as ValueGetter<TValue>;
                 Ch.Check(result != null, "Unexpected getter type requested");
                 return result;
             }

--- a/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
+++ b/test/Microsoft.ML.Benchmarks/CacheDataViewBench.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Benchmarks
             // First do one pass through.
             using (var cursor = cacheDv.GetRowCursor(col))
             {
-                var getter = cursor.GetGetter<int>(col.Index);
+                var getter = cursor.GetGetter<int>(col);
                 int val = 0;
                 int count = 0;
                 while (cursor.MoveNext())
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Benchmarks
 
             _col = _cacheDataView.Schema["A"];
             _seeker = ((IRowSeekable)_cacheDataView).GetSeeker(colIndex => colIndex == _col.Index);
-            _seekerGetter = _seeker.GetGetter<int>(_col.Index);
+            _seekerGetter = _seeker.GetGetter<int>(_col);
         }
 
         [Benchmark]
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Benchmarks
            // This setup takes very less time to execute as compared to the actual _cursorGetter.
             // The most preferable position for this setup will be in GlobalSetup.
             _cursor = _cacheDataView.GetRowCursor(_col);
-            _cursorGetter = _cursor.GetGetter<int>(_col.Index);
+            _cursorGetter = _cursor.GetGetter<int>(_col);
 
             int val = 0;
             while (_cursor.MoveNext())

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Benchmarks
             var xf = new HashingTransformer(_env, new[] { info });
             var mapper = ((ITransformer)xf).GetRowToRowMapper(_inRow.Schema);
             var column = mapper.OutputSchema["Bar"];
-            var outRow = mapper.GetRow(_inRow, c => c == column.Index);
+            var outRow = mapper.GetRow(_inRow, column);
             if (type is VectorType)
                 _vecGetter = outRow.GetGetter<VBuffer<uint>>(column.Index);
             else

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -27,16 +27,26 @@ namespace Microsoft.ML.Benchmarks
 
             private readonly Delegate _getter;
 
-            public override bool IsColumnActive(int col)
+            /// <summary>
+            /// Returns whether the given column is active in this row.
+            /// </summary>
+            public override bool IsColumnActive(int columnIndex)
             {
-                if (col != 0)
+                if (columnIndex != 0)
                     throw new Exception();
                 return true;
             }
 
-            public override ValueGetter<TValue> GetGetter<TValue>(int col)
+            /// <summary>
+            /// Returns a value getter delegate to fetch the valueof column with the given columnIndex, from the row.
+            /// This throws if the column is not active in this row, or if the type
+            /// <typeparamref name="TValue"/> differs from this column's type.
+            /// </summary>
+            /// <typeparam name="TValue"> is the output column's content type.</typeparam>
+            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
             {
-                if (col != 0)
+                if (columnIndex != 0)
                     throw new Exception();
                 if (_getter is ValueGetter<TValue> typedGetter)
                     return typedGetter;

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -43,10 +43,10 @@ namespace Microsoft.ML.Benchmarks
             /// <typeparamref name="TValue"/> differs from this column's type.
             /// </summary>
             /// <typeparam name="TValue"> is the output column's content type.</typeparam>
-            /// <param name="columnIndex"> is the index of a output column whose getter should be returned.</param>
-            public override ValueGetter<TValue> GetGetter<TValue>(int columnIndex)
+            /// <param name="column"> is the index of a output column whose getter should be returned.</param>
+            public override ValueGetter<TValue> GetGetter<TValue>(DataViewSchema.Column column)
             {
-                if (columnIndex != 0)
+                if (column.Index != 0)
                     throw new Exception();
                 if (_getter is ValueGetter<TValue> typedGetter)
                     return typedGetter;
@@ -89,9 +89,9 @@ namespace Microsoft.ML.Benchmarks
             var column = mapper.OutputSchema["Bar"];
             var outRow = mapper.GetRow(_inRow, column);
             if (type is VectorType)
-                _vecGetter = outRow.GetGetter<VBuffer<uint>>(column.Index);
+                _vecGetter = outRow.GetGetter<VBuffer<uint>>(column);
             else
-                _getter = outRow.GetGetter<uint>(column.Index);
+                _getter = outRow.GetGetter<uint>(column);
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -30,9 +30,9 @@ namespace Microsoft.ML.Benchmarks
             /// <summary>
             /// Returns whether the given column is active in this row.
             /// </summary>
-            public override bool IsColumnActive(int columnIndex)
+            public override bool IsColumnActive(DataViewSchema.Column column)
             {
-                if (columnIndex != 0)
+                if (column.Index != 0)
                     throw new Exception();
                 return true;
             }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
@@ -53,8 +53,8 @@ namespace Microsoft.ML.Core.Tests.UnitTests
 
         protected Func<bool> GetComparerOne<T>(DataViewRow r1, DataViewRow r2, int col, Func<T, T, bool> fn)
         {
-            var g1 = r1.GetGetter<T>(col);
-            var g2 = r2.GetGetter<T>(col);
+            var g1 = r1.GetGetter<T>(r1.Schema[col]);
+            var g2 = r2.GetGetter<T>(r2.Schema[col]);
             T v1 = default(T);
             T v2 = default(T);
             return
@@ -76,8 +76,8 @@ namespace Microsoft.ML.Core.Tests.UnitTests
         }
         protected Func<bool> GetComparerVec<T>(DataViewRow r1, DataViewRow r2, int col, int size, Func<T, T, bool> fn)
         {
-            var g1 = r1.GetGetter<VBuffer<T>>(col);
-            var g2 = r2.GetGetter<VBuffer<T>>(col);
+            var g1 = r1.GetGetter<VBuffer<T>>(r1.Schema[col]);
+            var g2 = r2.GetGetter<VBuffer<T>>(r2.Schema[col]);
             var v1 = default(VBuffer<T>);
             var v2 = default(VBuffer<T>);
             return

--- a/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/CoreBaseTestClass.cs
@@ -324,8 +324,8 @@ namespace Microsoft.ML.Core.Tests.UnitTests
             Func<bool>[] comps = new Func<bool>[colLim];
             for (int col = 0; col < colLim; col++)
             {
-                var f1 = curs1.IsColumnActive(col);
-                var f2 = curs2.IsColumnActive(col);
+                var f1 = curs1.IsColumnActive(curs1.Schema[col]);
+                var f2 = curs2.IsColumnActive(curs2.Schema[col]);
 
                 if (f1 && f2)
                 {
@@ -407,7 +407,7 @@ namespace Microsoft.ML.Core.Tests.UnitTests
                 for (int col = 0; col < colLim; col++)
                 {
                     // curs1 should have all columns active (for simplicity of the code here).
-                    Contracts.Assert(curs1.IsColumnActive(col));
+                    Contracts.Assert(curs1.IsColumnActive(curs1.Schema[col]));
                     cursors[col] = view2.GetRowCursor(view2.Schema[col]);
                 }
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/ScoreSchemaTest.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/ScoreSchemaTest.cs
@@ -67,18 +67,18 @@ namespace Microsoft.ML.RunTests
             Assert.Equal(TextDataViewType.Instance, scoreColumn.Annotations.Schema[2].Type);
 
             // Check metadata columns' values.
-            var keyNamesGetter = scoreMetadata.GetGetter<VBuffer<ReadOnlyMemory<char>>>(0);
+            var keyNamesGetter = scoreMetadata.GetGetter<VBuffer<ReadOnlyMemory<char>>>(scoreMetadata.Schema[0]);
             var actualKeyNames = new VBuffer<ReadOnlyMemory<char>>();
             keyNamesGetter(ref actualKeyNames);
             Assert.Equal(keyNames.Length, actualKeyNames.Length);
             Assert.Equal(keyNames.DenseValues(), actualKeyNames.DenseValues());
 
-            var scoreColumnKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(1);
+            var scoreColumnKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(scoreMetadata.Schema[1]);
             ReadOnlyMemory<char> scoreColumnKindValue = null;
             scoreColumnKindGetter(ref scoreColumnKindValue);
             Assert.Equal(AnnotationUtils.Const.ScoreColumnKind.SequenceClassification, scoreColumnKindValue.ToString());
 
-            var scoreValueKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(2);
+            var scoreValueKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(scoreMetadata.Schema[2]);
             ReadOnlyMemory<char> scoreValueKindValue = null;
             scoreValueKindGetter(ref scoreValueKindValue);
             Assert.Equal(AnnotationUtils.Const.ScoreValueKind.PredictedLabel, scoreValueKindValue.ToString());
@@ -120,12 +120,12 @@ namespace Microsoft.ML.RunTests
             Assert.Equal(TextDataViewType.Instance, scoreColumn.Annotations.Schema[1].Type);
 
             // Check metadata columns' values.
-            var scoreColumnKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(0);
+            var scoreColumnKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(scoreMetadata.Schema[0]);
             ReadOnlyMemory<char> scoreColumnKindValue = null;
             scoreColumnKindGetter(ref scoreColumnKindValue);
             Assert.Equal(AnnotationUtils.Const.ScoreColumnKind.SequenceClassification, scoreColumnKindValue.ToString());
 
-            var scoreValueKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(1);
+            var scoreValueKindGetter = scoreMetadata.GetGetter<ReadOnlyMemory<char>>(scoreMetadata.Schema[1]);
             ReadOnlyMemory<char> scoreValueKindValue = null;
             scoreValueKindGetter(ref scoreValueKindValue);
             Assert.Equal(AnnotationUtils.Const.ScoreValueKind.PredictedLabel, scoreValueKindValue.ToString());

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -470,21 +470,21 @@ namespace Microsoft.ML.RunTests
             {
                 var scoreColumn = curs1.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var avgScoreGetter = curs1.GetGetter<Single>(scoreColumn.Value.Index);
+                var avgScoreGetter = curs1.GetGetter<Single>(scoreColumn.Value);
 
                 scoreColumn = curs2.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var medScoreGetter = curs2.GetGetter<Single>(scoreColumn.Value.Index);
+                var medScoreGetter = curs2.GetGetter<Single>(scoreColumn.Value);
 
                 scoreColumn = curs3.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var regScoreGetter = curs3.GetGetter<Single>(scoreColumn.Value.Index);
+                var regScoreGetter = curs3.GetGetter<Single>(scoreColumn.Value);
 
                 var individualScoreGetters = new ValueGetter<Single>[nModels];
                 for (int i = 0; i < nModels; i++)
                 {
                     scoreColumn = curs4.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score + i);
-                    individualScoreGetters[i] = curs4.GetGetter<Single>(scoreColumn.Value.Index);
+                    individualScoreGetters[i] = curs4.GetGetter<Single>(scoreColumn.Value);
                 }
 
                 var scoreBuffer = new Single[nModels];
@@ -852,34 +852,34 @@ namespace Microsoft.ML.RunTests
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter0 = curs0.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter0 = curs0.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs1.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter1 = curs1.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter1 = curs1.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs2.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter2 = curs2.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter2 = curs2.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs3.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter3 = curs3.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter3 = curs3.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs4.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter4 = curs4.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter4 = curs4.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursReg.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterReg = cursReg.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterReg = cursReg.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursBin.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterBin = cursBin.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterBin = cursBin.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursBinCali.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterBinCali = cursBinCali.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterBinCali = cursBinCali.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursSaved.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterSaved = cursSaved.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterSaved = cursSaved.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursAnom.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterAnom = cursAnom.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterAnom = cursAnom.GetGetter<Single>(scoreColumn.Value);
 
                 var c = new Average(Env).GetCombiner();
                 while (cursReg.MoveNext())
@@ -1073,31 +1073,31 @@ namespace Microsoft.ML.RunTests
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter0 = curs0.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter0 = curs0.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs1.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter1 = curs1.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter1 = curs1.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs2.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter2 = curs2.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter2 = curs2.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs3.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter3 = curs3.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter3 = curs3.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = curs4.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter4 = curs4.GetGetter<Single>(scoreColumn.Value.Index);
+                var getter4 = curs4.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursReg.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterReg = cursReg.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterReg = cursReg.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursBin.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterBin = cursBin.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterBin = cursBin.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursBinCali.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterBinCali = cursBinCali.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterBinCali = cursBinCali.GetGetter<Single>(scoreColumn.Value);
                 scoreColumn = cursSaved.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterSaved = cursSaved.GetGetter<Single>(scoreColumn.Value.Index);
+                var getterSaved = cursSaved.GetGetter<Single>(scoreColumn.Value);
 
                 var c = new Average(Env).GetCombiner();
                 while (cursReg.MoveNext())
@@ -1231,25 +1231,25 @@ namespace Microsoft.ML.RunTests
             {
                 var scoreColumn = curs0.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter0 = curs0.GetGetter<VBuffer<Single>>(scoreColumn.Value.Index);
+                var getter0 = curs0.GetGetter<VBuffer<Single>>(scoreColumn.Value);
                 scoreColumn = curs1.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter1 = curs1.GetGetter<VBuffer<Single>>(scoreColumn.Value.Index);
+                var getter1 = curs1.GetGetter<VBuffer<Single>>(scoreColumn.Value);
                 scoreColumn = curs2.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter2 = curs2.GetGetter<VBuffer<Single>>(scoreColumn.Value.Index);
+                var getter2 = curs2.GetGetter<VBuffer<Single>>(scoreColumn.Value);
                 scoreColumn = curs3.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter3 = curs3.GetGetter<VBuffer<Single>>(scoreColumn.Value.Index);
+                var getter3 = curs3.GetGetter<VBuffer<Single>>(scoreColumn.Value);
                 scoreColumn = curs4.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter4 = curs4.GetGetter<VBuffer<Single>>(scoreColumn.Value.Index);
+                var getter4 = curs4.GetGetter<VBuffer<Single>>(scoreColumn.Value);
                 scoreColumn = curs.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getter = curs.GetGetter<VBuffer<Single>>(scoreColumn.Value.Index);
+                var getter = curs.GetGetter<VBuffer<Single>>(scoreColumn.Value);
                 scoreColumn = cursSaved.Schema.GetColumnOrNull(AnnotationUtils.Const.ScoreValueKind.Score);
                 Assert.True(scoreColumn.HasValue);
-                var getterSaved = cursSaved.GetGetter<VBuffer<Single>>(scoreColumn.Value.Index);
+                var getterSaved = cursSaved.GetGetter<VBuffer<Single>>(scoreColumn.Value);
 
                 var c = new MultiAverage(Env, new MultiAverage.Options()).GetCombiner();
                 VBuffer<Single> score = default(VBuffer<Single>);
@@ -1640,13 +1640,13 @@ namespace Microsoft.ML.RunTests
 
                     var catColumn = loader.Schema.GetColumnOrNull("Cat");
                     Assert.True(catColumn.HasValue);
-                    var catGetter = cursor.GetGetter<ReadOnlyMemory<char>>(catColumn.Value.Index);
+                    var catGetter = cursor.GetGetter<ReadOnlyMemory<char>>(catColumn.Value);
                     var catValueCol = loader.Schema.GetColumnOrNull("CatValue");
                     Assert.True(catValueCol.HasValue);
-                    var catValueGetter = cursor.GetGetter<ReadOnlyMemory<char>>(catValueCol.Value.Index);
+                    var catValueGetter = cursor.GetGetter<ReadOnlyMemory<char>>(catValueCol.Value);
                     var keyColumn = loader.Schema.GetColumnOrNull("Key");
                     Assert.True(keyColumn.HasValue);
-                    var keyGetter = cursor.GetGetter<uint>(keyColumn.Value.Index);
+                    var keyGetter = cursor.GetGetter<uint>(keyColumn.Value);
 
                     while (cursor.MoveNext())
                     {
@@ -2686,7 +2686,7 @@ namespace Microsoft.ML.RunTests
             {
                 var aucCol = cursor.Schema.GetColumnOrNull("AUC");
                 Assert.True(aucCol.HasValue);
-                var aucGetter = cursor.GetGetter<double>(aucCol.Value.Index);
+                var aucGetter = cursor.GetGetter<double>(aucCol.Value);
                 Assert.True(cursor.MoveNext());
                 double auc = 0;
                 aucGetter(ref auc);
@@ -2791,7 +2791,7 @@ namespace Microsoft.ML.RunTests
             {
                 var aucCol = cursor.Schema.GetColumnOrNull("AUC");
                 Assert.True(aucCol.HasValue);
-                var aucGetter = cursor.GetGetter<double>(aucCol.Value.Index);
+                var aucGetter = cursor.GetGetter<double>(aucCol.Value);
                 Assert.True(cursor.MoveNext());
                 double auc = 0;
                 aucGetter(ref auc);
@@ -2957,7 +2957,7 @@ namespace Microsoft.ML.RunTests
                 using (var cursor = metricsIdv.GetRowCursorForAllColumns())
                 {
                     var aucCol = cursor.Schema.GetColumnOrNull("AUC");
-                    var aucGetter = cursor.GetGetter<double>(aucCol.Value.Index);
+                    var aucGetter = cursor.GetGetter<double>(aucCol.Value);
                     Assert.True(cursor.MoveNext());
                     double auc = 0;
                     aucGetter(ref auc);
@@ -3149,7 +3149,7 @@ namespace Microsoft.ML.RunTests
                 {
                     var aucColumn = cursor.Schema.GetColumnOrNull("AUC");
                     Assert.True(aucColumn.HasValue);
-                    var aucGetter = cursor.GetGetter<double>(aucColumn.Value.Index);
+                    var aucGetter = cursor.GetGetter<double>(aucColumn.Value);
                     Assert.True(cursor.MoveNext());
                     double auc = 0;
                     aucGetter(ref auc);
@@ -3493,7 +3493,7 @@ namespace Microsoft.ML.RunTests
 
                     var predictedLabelCol = loader.Schema.GetColumnOrNull("PredictedLabel");
                     Assert.True(predictedLabelCol.HasValue);
-                    var predictedLabelGetter = cursor.GetGetter<ReadOnlyMemory<char>>(predictedLabelCol.Value.Index);
+                    var predictedLabelGetter = cursor.GetGetter<ReadOnlyMemory<char>>(predictedLabelCol.Value);
 
                     while (cursor.MoveNext())
                     {
@@ -3562,9 +3562,9 @@ namespace Microsoft.ML.RunTests
             VBuffer<float> pathIndicators = default(VBuffer<float>);
             using (var curs = view.GetRowCursor(treesCol.Value, leavesCol.Value, pathsCol.Value))
             {
-                var treesGetter = curs.GetGetter<VBuffer<float>>(treesCol.Value.Index);
-                var leavesGetter = curs.GetGetter<VBuffer<float>>(leavesCol.Value.Index);
-                var pathsGetter = curs.GetGetter<VBuffer<float>>(pathsCol.Value.Index);
+                var treesGetter = curs.GetGetter<VBuffer<float>>(treesCol.Value);
+                var leavesGetter = curs.GetGetter<VBuffer<float>>(leavesCol.Value);
+                var pathsGetter = curs.GetGetter<VBuffer<float>>(pathsCol.Value);
                 while (curs.MoveNext())
                 {
                     treesGetter(ref treeValues);
@@ -3613,7 +3613,7 @@ namespace Microsoft.ML.RunTests
             {
                 var featColumn = result.Schema.GetColumnOrNull("Features");
                 Assert.True(featColumn.HasValue);
-                var featGetter = cursor.GetGetter<VBuffer<float>>(featColumn.Value.Index);
+                var featGetter = cursor.GetGetter<VBuffer<float>>(featColumn.Value);
                 VBuffer<float> feat = default;
                 while (cursor.MoveNext())
                 {
@@ -4033,7 +4033,7 @@ namespace Microsoft.ML.RunTests
             Assert.True(aucCol.HasValue);
             using (var cursor = data.GetRowCursor(aucCol.Value))
             {
-                var getter = cursor.GetGetter<double>(aucCol.Value.Index);
+                var getter = cursor.GetGetter<double>(aucCol.Value);
                 var b = cursor.MoveNext();
                 Assert.True(b);
                 double auc = 0;
@@ -4211,10 +4211,10 @@ namespace Microsoft.ML.RunTests
             Assert.True(isWeightedCol.HasValue);
             using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value, isWeightedCol.Value))
             {
-                var getter = cursor.GetGetter<double>(metricCol.Value.Index);
-                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
+                var getter = cursor.GetGetter<double>(metricCol.Value);
+                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value);
                 ReadOnlyMemory<char> fold = default;
-                var isWeightedGetter = cursor.GetGetter<bool>(isWeightedCol.Value.Index);
+                var isWeightedGetter = cursor.GetGetter<bool>(isWeightedCol.Value);
                 bool isWeighted = default;
                 double avg = 0;
                 double weightedAvg = 0;
@@ -4393,8 +4393,8 @@ namespace Microsoft.ML.RunTests
             Assert.True(foldCol.HasValue);
             using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value))
             {
-                var getter = cursor.GetGetter<double>(metricCol.Value.Index);
-                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
+                var getter = cursor.GetGetter<double>(metricCol.Value);
+                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value);
                 ReadOnlyMemory<char> fold = default;
 
                 // Get the average.
@@ -4447,8 +4447,8 @@ namespace Microsoft.ML.RunTests
             }
             using (var curs = confusion.GetRowCursorForAllColumns())
             {
-                var countGetter = curs.GetGetter<VBuffer<double>>(countCol.Value.Index);
-                var foldGetter = curs.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
+                var countGetter = curs.GetGetter<VBuffer<double>>(countCol.Value);
+                var foldGetter = curs.GetGetter<ReadOnlyMemory<char>>(foldCol.Value);
                 var confCount = default(VBuffer<double>);
                 var foldIndex = default(ReadOnlyMemory<char>);
                 int rowCount = 0;
@@ -4619,7 +4619,7 @@ namespace Microsoft.ML.RunTests
             Assert.True(warningCol.HasValue);
             using (var cursor = warnings.GetRowCursor(warningCol.Value))
             {
-                var getter = cursor.GetGetter<ReadOnlyMemory<char>>(warningCol.Value.Index);
+                var getter = cursor.GetGetter<ReadOnlyMemory<char>>(warningCol.Value);
 
                 var b = cursor.MoveNext();
                 Assert.True(b);
@@ -4802,8 +4802,8 @@ namespace Microsoft.ML.RunTests
             bool b;
             using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value))
             {
-                var getter = cursor.GetGetter<double>(metricCol.Value.Index);
-                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
+                var getter = cursor.GetGetter<double>(metricCol.Value);
+                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value);
                 ReadOnlyMemory<char> fold = default;
 
                 // Get the verage.
@@ -5102,8 +5102,8 @@ namespace Microsoft.ML.RunTests
             bool b;
             using (var cursor = data.GetRowCursor(metricCol.Value, foldCol.Value))
             {
-                var getter = cursor.GetGetter<VBuffer<double>>(metricCol.Value.Index);
-                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value.Index);
+                var getter = cursor.GetGetter<VBuffer<double>>(metricCol.Value);
+                var foldGetter = cursor.GetGetter<ReadOnlyMemory<char>>(foldCol.Value);
                 ReadOnlyMemory<char> fold = default;
 
                 // Get the verage.
@@ -5154,7 +5154,7 @@ namespace Microsoft.ML.RunTests
             Assert.True(nameCol.HasValue);
             using (var cursor = data.GetRowCursor(nameCol.Value))
             {
-                var getter = cursor.GetGetter<ReadOnlyMemory<char>>(nameCol.Value.Index);
+                var getter = cursor.GetGetter<ReadOnlyMemory<char>>(nameCol.Value);
                 while (cursor.MoveNext())
                 {
                     ReadOnlyMemory<char> name = default;
@@ -5319,7 +5319,7 @@ namespace Microsoft.ML.RunTests
             bool b;
             using (var cursor = data.GetRowCursor(accCol.Value))
             {
-                var getter = cursor.GetGetter<double>(accCol.Value.Index);
+                var getter = cursor.GetGetter<double>(accCol.Value);
                 b = cursor.MoveNext();
                 Assert.True(b);
                 double acc = 0;
@@ -5490,7 +5490,7 @@ namespace Microsoft.ML.RunTests
             bool b;
             using (var cursor = data.GetRowCursor(accCol.Value))
             {
-                var getter = cursor.GetGetter<double>(accCol.Value.Index);
+                var getter = cursor.GetGetter<double>(accCol.Value);
                 b = cursor.MoveNext();
                 Assert.True(b);
                 double acc = 0;

--- a/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
@@ -111,11 +111,10 @@ namespace Microsoft.ML.Tests
             TestEstimatorCore(pipe.AsDynamic, data.AsDynamic);
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
-            result.Schema.TryGetColumnIndex("output_1", out int output);
             using (var cursor = result.GetRowCursor(result.Schema["output_1"]))
             {
                 var buffer = default(VBuffer<float>);
-                var getter = cursor.GetGetter<VBuffer<float>>(output);
+                var getter = cursor.GetGetter<VBuffer<float>>(result.Schema["output_1"]);
                 var numRows = 0;
                 while (cursor.MoveNext())
                 {
@@ -153,11 +152,10 @@ namespace Microsoft.ML.Tests
                 ms.Position = 0;
                 var loadedView = ModelFileUtils.LoadTransforms(Env, dataView, ms);
 
-                loadedView.Schema.TryGetColumnIndex(outputNames, out int softMaxOut1);
                 using (var cursor = loadedView.GetRowCursor(loadedView.Schema[outputNames]))
                 {
                     VBuffer<float> softMaxValue = default;
-                    var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);
+                    var softMaxGetter = cursor.GetGetter<VBuffer<float>>(loadedView.Schema[outputNames]);
                     float sum = 0f;
                     int i = 0;
                     while (cursor.MoveNext())

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -146,12 +146,12 @@ namespace Microsoft.ML.Tests
                 ms.Position = 0;
                 var loadedView = ModelFileUtils.LoadTransforms(Env, dataView, ms);
 
-                loadedView.Schema.TryGetColumnIndex(outputNames[0], out int softMaxOut1);
+                var sofMaxOut1Col = loadedView.Schema[outputNames[0]];
 
-                using (var cursor = loadedView.GetRowCursor(loadedView.Schema[softMaxOut1]))
+                using (var cursor = loadedView.GetRowCursor(sofMaxOut1Col))
                 {
                     VBuffer<float> softMaxValue = default;
-                    var softMaxGetter = cursor.GetGetter<VBuffer<float>>(softMaxOut1);
+                    var softMaxGetter = cursor.GetGetter<VBuffer<float>>(sofMaxOut1Col);
                     float sum = 0f;
                     int i = 0;
                     while (cursor.MoveNext())
@@ -201,12 +201,12 @@ namespace Microsoft.ML.Tests
             TestEstimatorCore(pipe.AsDynamic, data.AsDynamic);
 
             var result = pipe.Fit(data).Transform(data).AsDynamic;
-            result.Schema.TryGetColumnIndex("softmaxout_1", out int output);
+            var softmaxOutCol = result.Schema["softmaxout_1"];
 
-            using (var cursor = result.GetRowCursor(result.Schema["softmaxout_1"]))
+            using (var cursor = result.GetRowCursor(softmaxOutCol))
             {
                 var buffer = default(VBuffer<float>);
-                var getter = cursor.GetGetter<VBuffer<float>>(output);
+                var getter = cursor.GetGetter<VBuffer<float>>(softmaxOutCol);
                 var numRows = 0;
                 while (cursor.MoveNext())
                 {
@@ -241,12 +241,11 @@ namespace Microsoft.ML.Tests
                 });
 
             var onnx = ML.Transforms.ApplyOnnxModel(modelFile, "softmaxout_1", "data_0").Fit(dataView).Transform(dataView);
+            var scoreCol = onnx.Schema["softmaxout_1"];
 
-            onnx.Schema.TryGetColumnIndex("softmaxout_1", out int score);
-
-            using (var curs = onnx.GetRowCursor(onnx.Schema["softmaxout_1"]))
+            using (var curs = onnx.GetRowCursor(scoreCol))
             {
-                var getScores = curs.GetGetter<VBuffer<float>>(score);
+                var getScores = curs.GetGetter<VBuffer<float>>(scoreCol);
                 var buffer = default(VBuffer<float>);
                 while (curs.MoveNext())
                 {
@@ -273,12 +272,12 @@ namespace Microsoft.ML.Tests
                 });
             var onnx = ML.Transforms.ApplyOnnxModel(modelFile, new[] { "outa", "outb" }, new[] { "ina", "inb" }).Fit(dataView).Transform(dataView);
 
-            onnx.Schema.TryGetColumnIndex("outa", out int scoresa);
-            onnx.Schema.TryGetColumnIndex("outb", out int scoresb);
-            using (var curs = onnx.GetRowCursor(onnx.Schema["outa"], onnx.Schema["outb"]))
+            var outaCol = onnx.Schema["outa"];
+            var outbCol = onnx.Schema["outb"];
+            using (var curs = onnx.GetRowCursor(outaCol, onnx.Schema["outb"]))
             {
-                var getScoresa = curs.GetGetter<VBuffer<float>>(scoresa);
-                var getScoresb = curs.GetGetter<VBuffer<float>>(scoresb);
+                var getScoresa = curs.GetGetter<VBuffer<float>>(outaCol);
+                var getScoresb = curs.GetGetter<VBuffer<float>>(outbCol);
                 var buffera = default(VBuffer<float>);
                 var bufferb = default(VBuffer<float>);
 

--- a/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestTransposer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.RunTests
             {
                 if (type is VectorType)
                 {
-                    var getter = cursor.GetGetter<VBuffer<T>>(col);
+                    var getter = cursor.GetGetter<VBuffer<T>>(cursor.Schema[col]);
                     VBuffer<T> temp = default;
                     int offset = 0;
                     while (cursor.MoveNext())
@@ -52,7 +52,7 @@ namespace Microsoft.ML.RunTests
                 }
                 else
                 {
-                    var getter = cursor.GetGetter<T>(col);
+                    var getter = cursor.GetGetter<T>(cursor.Schema[col]);
                     while (cursor.MoveNext())
                     {
                         Assert.True(0 <= cursor.Position && cursor.Position < rc);

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeTests.cs
@@ -51,9 +51,6 @@ namespace Microsoft.ML.StaticPipelineTesting
         {
         }
 
-        private void CheckSchemaHasColumn(DataViewSchema schema, string name, out int idx)
-            => Assert.True(schema.TryGetColumnIndex(name, out idx), "Could not find column '" + name + "'");
-
         [Fact]
         public void SimpleTextLoaderCopyColumnsTest()
         {
@@ -74,22 +71,27 @@ namespace Microsoft.ML.StaticPipelineTesting
             // For now, just operate over the actual `IDataView`.
             var textData = text.Load(dataSource).AsDynamic;
 
+            Action<DataViewSchema, string> CheckSchemaHasColumn = (dataSchema, name) =>
+            {
+                Assert.True(dataSchema.GetColumnOrNull(name).HasValue, "Could not find column '" + name + "'");
+            };
+
             var schema = textData.Schema;
             // First verify that the columns are there. There ought to be at least one column corresponding to the identifiers in the tuple.
-            CheckSchemaHasColumn(schema, "label", out int labelIdx);
-            CheckSchemaHasColumn(schema, "text", out int textIdx);
-            CheckSchemaHasColumn(schema, "numericFeatures", out int numericFeaturesIdx);
+            CheckSchemaHasColumn(schema, "label");
+            CheckSchemaHasColumn(schema, "text");
+            CheckSchemaHasColumn(schema, "numericFeatures");
             // Next verify they have the expected types.
-            Assert.Equal(BooleanDataViewType.Instance, schema[labelIdx].Type);
-            Assert.Equal(TextDataViewType.Instance, schema[textIdx].Type);
-            Assert.Equal(new VectorType(NumberDataViewType.Single, 3), schema[numericFeaturesIdx].Type);
+            Assert.Equal(BooleanDataViewType.Instance, schema["label"].Type);
+            Assert.Equal(TextDataViewType.Instance, schema["text"].Type);
+            Assert.Equal(new VectorType(NumberDataViewType.Single, 3), schema["numericFeatures"].Type);
             // Next actually inspect the data.
             using (var cursor = textData.GetRowCursorForAllColumns())
             {
-                var textGetter = cursor.GetGetter<ReadOnlyMemory<char>>(textIdx);
-                var numericFeaturesGetter = cursor.GetGetter<VBuffer<float>>(numericFeaturesIdx);
+                var textGetter = cursor.GetGetter<ReadOnlyMemory<char>>(schema["text"]);
+                var numericFeaturesGetter = cursor.GetGetter<VBuffer<float>>(schema["numericFeatures"]);
                 ReadOnlyMemory<char> textVal = default;
-                var labelGetter = cursor.GetGetter<bool>(labelIdx);
+                var labelGetter = cursor.GetGetter<bool>(schema["label"]);
                 bool labelVal = default;
                 VBuffer<float> numVal = default;
 
@@ -122,11 +124,11 @@ namespace Microsoft.ML.StaticPipelineTesting
 
             schema = newTextData.AsDynamic.Schema;
             // First verify that the columns are there. There ought to be at least one column corresponding to the identifiers in the tuple.
-            CheckSchemaHasColumn(schema, "label", out labelIdx);
-            CheckSchemaHasColumn(schema, "text", out textIdx);
+            CheckSchemaHasColumn(schema, "label");
+            CheckSchemaHasColumn(schema, "text");
             // Next verify they have the expected types.
-            Assert.Equal(BooleanDataViewType.Instance, schema[textIdx].Type);
-            Assert.Equal(new VectorType(NumberDataViewType.Single, 3), schema[labelIdx].Type);
+            Assert.Equal(BooleanDataViewType.Instance, schema["text"].Type);
+            Assert.Equal(new VectorType(NumberDataViewType.Single, 3), schema["label"].Type);
         }
 
         private sealed class Obnoxious1

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -1112,8 +1112,8 @@ namespace Microsoft.ML.RunTests
 
         protected Func<bool> GetComparerOne<T>(DataViewRow r1, DataViewRow r2, int col, Func<T, T, bool> fn)
         {
-            var g1 = r1.GetGetter<T>(col);
-            var g2 = r2.GetGetter<T>(col);
+            var g1 = r1.GetGetter<T>(r1.Schema[col]);
+            var g2 = r2.GetGetter<T>(r2.Schema[col]);
             T v1 = default(T);
             T v2 = default(T);
             return
@@ -1129,8 +1129,8 @@ namespace Microsoft.ML.RunTests
 
         protected Func<bool> GetComparerVec<T>(DataViewRow r1, DataViewRow r2, int col, int size, Func<T, T, bool> fn)
         {
-            var g1 = r1.GetGetter<VBuffer<T>>(col);
-            var g2 = r2.GetGetter<VBuffer<T>>(col);
+            var g1 = r1.GetGetter<VBuffer<T>>(r1.Schema[col]);
+            var g2 = r2.GetGetter<VBuffer<T>>(r2.Schema[col]);
             var v1 = default(VBuffer<T>);
             var v2 = default(VBuffer<T>);
             return

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -825,8 +825,8 @@ namespace Microsoft.ML.RunTests
             Func<bool>[] comps = new Func<bool>[colLim];
             for (int col = 0; col < colLim; col++)
             {
-                var f1 = curs1.IsColumnActive(col);
-                var f2 = curs2.IsColumnActive(col);
+                var f1 = curs1.IsColumnActive(curs1.Schema[col]);
+                var f2 = curs2.IsColumnActive(curs2.Schema[col]);
 
                 if (f1 && f2)
                 {
@@ -909,7 +909,7 @@ namespace Microsoft.ML.RunTests
                 for (int col = 0; col < colLim; col++)
                 {
                     // curs1 should have all columns active (for simplicity of the code here).
-                    Contracts.Assert(curs1.IsColumnActive(col));
+                    Contracts.Assert(curs1.IsColumnActive(curs1.Schema[col]));
                     cursors[col] = view2.GetRowCursorForAllColumns();
                 }
 

--- a/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
+++ b/test/Microsoft.ML.TestFramework/TestSparseDataView.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.RunTests
             int n = 0;
             using (var cur = data.GetRowCursorForAllColumns())
             {
-                var getter = cur.GetGetter<VBuffer<T>>(0);
+                var getter = cur.GetGetter<VBuffer<T>>(cur.Schema[0]);
                 while (cur.MoveNext())
                 {
                     getter(ref value);
@@ -93,7 +93,7 @@ namespace Microsoft.ML.RunTests
             int n = 0;
             using (var cur = data.GetRowCursorForAllColumns())
             {
-                var getter = cur.GetGetter<VBuffer<T>>(0);
+                var getter = cur.GetGetter<VBuffer<T>>(cur.Schema[0]);
                 while (cur.MoveNext())
                 {
                     getter(ref value);

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -110,13 +110,11 @@ namespace Microsoft.ML.Tests
             var images = new ImageLoadingTransformer(env, imageFolder, ("ImageReal", "ImagePath")).Transform(data);
             var cropped = new ImageResizingTransformer(env, "ImageCropped", 100, 100, "ImageReal", ImageResizingEstimator.ResizingKind.IsoPad).Transform(images);
 
-            cropped.Schema.TryGetColumnIndex("ImagePath", out int pathColumn);
-            cropped.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = cropped.GetRowCursorForAllColumns())
             {
-                var pathGetter = cursor.GetGetter<ReadOnlyMemory<char>>(pathColumn);
+                var pathGetter = cursor.GetGetter<ReadOnlyMemory<char>>(cropped.Schema["ImagePath"]);
                 ReadOnlyMemory<char> path = default;
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropped.Schema["ImageCropped"]);
                 Bitmap bitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -163,7 +161,7 @@ namespace Microsoft.ML.Tests
             grey.Schema.TryGetColumnIndex("ImageGrey", out int greyColumn);
             using (var cursor = grey.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(greyColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(grey.Schema["ImageGrey"]);
                 Bitmap bitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -213,15 +211,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -273,15 +268,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -333,15 +325,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -395,15 +384,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -455,15 +441,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -516,15 +499,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -576,15 +556,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -637,15 +614,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {
@@ -696,15 +670,12 @@ namespace Microsoft.ML.Tests
             backToBitmaps = ModelFileUtils.LoadPipeline(env, fh.OpenReadStream(), new MultiFileSource(dataFile));
             DeleteOutputPath(fname);
 
-
-            backToBitmaps.Schema.TryGetColumnIndex("ImageRestored", out int bitmapColumn);
-            backToBitmaps.Schema.TryGetColumnIndex("ImageCropped", out int cropBitmapColumn);
             using (var cursor = backToBitmaps.GetRowCursorForAllColumns())
             {
-                var bitmapGetter = cursor.GetGetter<Bitmap>(bitmapColumn);
+                var bitmapGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageRestored"]);
                 Bitmap restoredBitmap = default;
 
-                var bitmapCropGetter = cursor.GetGetter<Bitmap>(cropBitmapColumn);
+                var bitmapCropGetter = cursor.GetGetter<Bitmap>(backToBitmaps.Schema["ImageCropped"]);
                 Bitmap croppedBitmap = default;
                 while (cursor.MoveNext())
                 {

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -488,16 +488,16 @@ namespace Microsoft.ML.Tests
 
         private void CompareSelectedR4VectorColumns(string leftColumnName, string rightColumnName, IDataView left, IDataView right, int precision = 6)
         {
-            var leftColumnIndex = left.Schema[leftColumnName].Index;
-            var rightColumnIndex = right.Schema[rightColumnName].Index;
+            var leftColumn = left.Schema[leftColumnName];
+            var rightColumn = right.Schema[rightColumnName];
 
-            using (var expectedCursor = left.GetRowCursor(left.Schema[leftColumnIndex]))
-            using (var actualCursor = right.GetRowCursor(right.Schema[rightColumnIndex]))
+            using (var expectedCursor = left.GetRowCursor(leftColumn))
+            using (var actualCursor = right.GetRowCursor(rightColumn))
             {
                 VBuffer<float> expected = default;
                 VBuffer<float> actual = default;
-                var expectedGetter = expectedCursor.GetGetter<VBuffer<float>>(leftColumnIndex);
-                var actualGetter = actualCursor.GetGetter<VBuffer<float>>(rightColumnIndex);
+                var expectedGetter = expectedCursor.GetGetter<VBuffer<float>>(leftColumn);
+                var actualGetter = actualCursor.GetGetter<VBuffer<float>>(rightColumn);
                 while (expectedCursor.MoveNext() && actualCursor.MoveNext())
                 {
                     expectedGetter(ref expected);
@@ -512,16 +512,16 @@ namespace Microsoft.ML.Tests
 
         private void CompareSelectedR4ScalarColumns(string leftColumnName, string rightColumnName, IDataView left, IDataView right, int precision = 6)
         {
-            var leftColumnIndex = left.Schema[leftColumnName].Index;
-            var rightColumnIndex = right.Schema[rightColumnName].Index;
+            var leftColumn = left.Schema[leftColumnName];
+            var rightColumn = right.Schema[rightColumnName];
 
-            using (var expectedCursor = left.GetRowCursor(left.Schema[leftColumnIndex]))
-            using (var actualCursor = right.GetRowCursor(right.Schema[rightColumnIndex]))
+            using (var expectedCursor = left.GetRowCursor(leftColumn))
+            using (var actualCursor = right.GetRowCursor(rightColumn))
             {
                 float expected = default;
                 VBuffer<float> actual = default;
-                var expectedGetter = expectedCursor.GetGetter<float>(leftColumnIndex);
-                var actualGetter = actualCursor.GetGetter<VBuffer<float>>(rightColumnIndex);
+                var expectedGetter = expectedCursor.GetGetter<float>(leftColumn);
+                var actualGetter = actualCursor.GetGetter<VBuffer<float>>(rightColumn);
                 while (expectedCursor.MoveNext() && actualCursor.MoveNext())
                 {
                     expectedGetter(ref expected);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Scenarios
 
             using (var cursor = trans.GetRowCursorForAllColumns())
             {
-                var cgetter = cursor.GetGetter<VBuffer<float>>(2);
+                var cgetter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[2]);
                 Assert.True(cursor.MoveNext());
                 VBuffer<float> c = default;
                 cgetter(ref c);
@@ -138,11 +138,11 @@ namespace Microsoft.ML.Scenarios
             using (var cursor = trans.GetRowCursorForAllColumns())
             {
                 int outColIndex = 5;
-                var oneDimgetter = cursor.GetGetter<VBuffer<float>>(outColIndex);
-                var twoDimgetter = cursor.GetGetter<VBuffer<float>>(outColIndex + 1);
-                var threeDimgetter = cursor.GetGetter<VBuffer<float>>(outColIndex + 2);
-                var fourDimgetter = cursor.GetGetter<VBuffer<float>>(outColIndex + 3);
-                var fourDimKnowngetter = cursor.GetGetter<VBuffer<float>>(outColIndex + 4);
+                var oneDimgetter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[outColIndex]);
+                var twoDimgetter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[outColIndex + 1]);
+                var threeDimgetter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[outColIndex + 2]);
+                var fourDimgetter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[outColIndex + 3]);
+                var fourDimKnowngetter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[outColIndex + 4]);
 
                 VBuffer<float> oneDim = default;
                 VBuffer<float> twoDim = default;
@@ -257,17 +257,17 @@ namespace Microsoft.ML.Scenarios
 
             using (var cursor = trans.GetRowCursorForAllColumns())
             {
-                var f64getter = cursor.GetGetter<VBuffer<double>>(11);
-                var f32getter = cursor.GetGetter<VBuffer<float>>(12);
-                var i64getter = cursor.GetGetter<VBuffer<long>>(13);
-                var i32getter = cursor.GetGetter<VBuffer<int>>(14);
-                var i16getter = cursor.GetGetter<VBuffer<short>>(15);
-                var i8getter = cursor.GetGetter<VBuffer<sbyte>>(16);
-                var u64getter = cursor.GetGetter<VBuffer<ulong>>(17);
-                var u32getter = cursor.GetGetter<VBuffer<uint>>(18);
-                var u16getter = cursor.GetGetter<VBuffer<ushort>>(19);
-                var u8getter = cursor.GetGetter<VBuffer<byte>>(20);
-                var boolgetter = cursor.GetGetter<VBuffer<bool>>(21);
+                var f64getter = cursor.GetGetter<VBuffer<double>>(cursor.Schema[11]);
+                var f32getter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[12]);
+                var i64getter = cursor.GetGetter<VBuffer<long>>(cursor.Schema[13]);
+                var i32getter = cursor.GetGetter<VBuffer<int>>(cursor.Schema[14]);
+                var i16getter = cursor.GetGetter<VBuffer<short>>(cursor.Schema[15]);
+                var i8getter = cursor.GetGetter<VBuffer<sbyte>>(cursor.Schema[16]);
+                var u64getter = cursor.GetGetter<VBuffer<ulong>>(cursor.Schema[17]);
+                var u32getter = cursor.GetGetter<VBuffer<uint>>(cursor.Schema[18]);
+                var u16getter = cursor.GetGetter<VBuffer<ushort>>(cursor.Schema[19]);
+                var u8getter = cursor.GetGetter<VBuffer<byte>>(cursor.Schema[20]);
+                var boolgetter = cursor.GetGetter<VBuffer<bool>>(cursor.Schema[21]);
 
 
                 VBuffer<double> f64 = default;
@@ -351,19 +351,13 @@ namespace Microsoft.ML.Scenarios
             var tf = mlContext.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel(
                 new[] { "detection_boxes", "detection_scores", "num_detections", "detection_classes" }, new[] { "image_tensor" }).Fit(pixels).Transform(pixels);
 
-            tf.Schema.TryGetColumnIndex("image_tensor", out int input);
-            tf.Schema.TryGetColumnIndex("detection_boxes", out int boxes);
-            tf.Schema.TryGetColumnIndex("detection_scores", out int scores);
-            tf.Schema.TryGetColumnIndex("num_detections", out int num);
-            tf.Schema.TryGetColumnIndex("detection_classes", out int classes);
-
             using (var curs = tf.GetRowCursor(tf.Schema["image_tensor"], tf.Schema["detection_boxes"], tf.Schema["detection_scores"], tf.Schema["detection_classes"], tf.Schema["num_detections"]))
             {
-                var getInput = curs.GetGetter<VBuffer<byte>>(input);
-                var getBoxes = curs.GetGetter<VBuffer<float>>(boxes);
-                var getScores = curs.GetGetter<VBuffer<float>>(scores);
-                var getNum = curs.GetGetter<VBuffer<float>>(num);
-                var getClasses = curs.GetGetter<VBuffer<float>>(classes);
+                var getInput = curs.GetGetter<VBuffer<byte>>(tf.Schema["image_tensor"]);
+                var getBoxes = curs.GetGetter<VBuffer<float>>(tf.Schema["detection_boxes"]);
+                var getScores = curs.GetGetter<VBuffer<float>>(tf.Schema["detection_scores"]);
+                var getNum = curs.GetGetter<VBuffer<float>>(tf.Schema["num_detections"]);
+                var getClasses = curs.GetGetter<VBuffer<float>>(tf.Schema["detection_classes"]);
                 var buffer = default(VBuffer<float>);
                 var inputBuffer = default(VBuffer<byte>);
                 while (curs.MoveNext())
@@ -390,12 +384,10 @@ namespace Microsoft.ML.Scenarios
             var pixels = mlContext.Transforms.ExtractPixels("input", "ImageCropped").Fit(cropped).Transform(cropped);
             var tf = mlContext.Model.LoadTensorFlowModel(modelLocation).ScoreTensorFlowModel("softmax2_pre_activation", "input").Fit(pixels).Transform(pixels);
 
-            tf.Schema.TryGetColumnIndex("input", out int input);
-            tf.Schema.TryGetColumnIndex("softmax2_pre_activation", out int b);
             using (var curs = tf.GetRowCursor(tf.Schema["input"], tf.Schema["softmax2_pre_activation"]))
             {
-                var get = curs.GetGetter<VBuffer<float>>(b);
-                var getInput = curs.GetGetter<VBuffer<float>>(input);
+                var get = curs.GetGetter<VBuffer<float>>(tf.Schema["softmax2_pre_activation"]);
+                var getInput = curs.GetGetter<VBuffer<float>>(tf.Schema["input"]);
                 var buffer = default(VBuffer<float>);
                 var inputBuffer = default(VBuffer<float>);
                 while (curs.MoveNext())
@@ -574,8 +566,7 @@ namespace Microsoft.ML.Scenarios
                 var trainDataTransformed = trainedModel.Transform(trainData);
                 using (var cursor = trainDataTransformed.GetRowCursorForAllColumns())
                 {
-                    trainDataTransformed.Schema.TryGetColumnIndex("b", out int bias);
-                    var getter = cursor.GetGetter<VBuffer<float>>(bias);
+                    var getter = cursor.GetGetter<VBuffer<float>>(trainDataTransformed.Schema["b"]);
                     if (cursor.MoveNext())
                     {
                         var trainedBias = default(VBuffer<float>);
@@ -861,7 +852,7 @@ namespace Microsoft.ML.Scenarios
             using (var cursor = trans.GetRowCursor(trans.Schema["Output"]))
             {
                 var buffer = default(VBuffer<float>);
-                var getter = cursor.GetGetter<VBuffer<float>>(output);
+                var getter = cursor.GetGetter<VBuffer<float>>(trans.Schema["Output"]);
                 var numRows = 0;
                 while (cursor.MoveNext())
                 {
@@ -898,11 +889,10 @@ namespace Microsoft.ML.Scenarios
             var pixels = mlContext.Transforms.ExtractPixels("Input", "ImageCropped", interleave: true).Fit(cropped).Transform(cropped);
             IDataView trans = tensorFlowModel.ScoreTensorFlowModel("Output", "Input").Fit(pixels).Transform(pixels);
 
-            trans.Schema.TryGetColumnIndex("Output", out int output);
             using (var cursor = trans.GetRowCursorForAllColumns())
             {
                 var buffer = default(VBuffer<float>);
-                var getter = cursor.GetGetter<VBuffer<float>>(output);
+                var getter = cursor.GetGetter<VBuffer<float>>(trans.Schema["Output"]);
                 var numRows = 0;
                 while (cursor.MoveNext())
                 {

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Tests
             using (var cursor = result.GetRowCursor(result.Schema["Output"]))
             {
                 var buffer = default(VBuffer<float>);
-                var getter = cursor.GetGetter<VBuffer<float>>(output);
+                var getter = cursor.GetGetter<VBuffer<float>>(result.Schema["Output"]);
                 var numRows = 0;
                 while (cursor.MoveNext())
                 {
@@ -216,7 +216,7 @@ namespace Microsoft.ML.Tests
             using (var cursor = result.GetRowCursor(result.Schema["Output"]))
             {
                 var buffer = default(VBuffer<float>);
-                var getter = cursor.GetGetter<VBuffer<float>>(output);
+                var getter = cursor.GetGetter<VBuffer<float>>(result.Schema["Output"]);
                 var numRows = 0;
                 while (cursor.MoveNext())
                 {
@@ -230,18 +230,15 @@ namespace Microsoft.ML.Tests
 
         private void ValidateTensorFlowTransformer(IDataView result)
         {
-            result.Schema.TryGetColumnIndex("a", out int ColA);
-            result.Schema.TryGetColumnIndex("b", out int ColB);
-            result.Schema.TryGetColumnIndex("c", out int ColC);
             using (var cursor = result.GetRowCursorForAllColumns())
             {
                 VBuffer<float> avalue = default;
                 VBuffer<float> bvalue = default;
                 VBuffer<float> cvalue = default;
 
-                var aGetter = cursor.GetGetter<VBuffer<float>>(ColA);
-                var bGetter = cursor.GetGetter<VBuffer<float>>(ColB);
-                var cGetter = cursor.GetGetter<VBuffer<float>>(ColC);
+                var aGetter = cursor.GetGetter<VBuffer<float>>(result.Schema["a"]);
+                var bGetter = cursor.GetGetter<VBuffer<float>>(result.Schema["b"]);
+                var cGetter = cursor.GetGetter<VBuffer<float>>(result.Schema["c"]);
                 while (cursor.MoveNext())
                 {
                     aGetter(ref avalue);

--- a/test/Microsoft.ML.Tests/TermEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TermEstimatorTests.cs
@@ -158,18 +158,15 @@ namespace Microsoft.ML.Tests
 
         private void ValidateTermTransformer(IDataView result)
         {
-            result.Schema.TryGetColumnIndex("TermA", out int ColA);
-            result.Schema.TryGetColumnIndex("TermB", out int ColB);
-            result.Schema.TryGetColumnIndex("TermC", out int ColC);
             using (var cursor = result.GetRowCursorForAllColumns())
             {
                 uint avalue = 0;
                 uint bvalue = 0;
                 uint cvalue = 0;
 
-                var aGetter = cursor.GetGetter<uint>(ColA);
-                var bGetter = cursor.GetGetter<uint>(ColB);
-                var cGetter = cursor.GetGetter<uint>(ColC);
+                var aGetter = cursor.GetGetter<uint>(result.Schema["TermA"]);
+                var bGetter = cursor.GetGetter<uint>(result.Schema["TermB"]);
+                var cGetter = cursor.GetGetter<uint>(result.Schema["TermC"]);
                 uint i = 1;
                 while (cursor.MoveNext())
                 {

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -40,10 +40,10 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             using (var cursor = data.GetRowCursorForAllColumns())
             {
-                var col1 = cursor.GetGetter<sbyte>(0);
-                var col2 = cursor.GetGetter<short>(1);
-                var col3 = cursor.GetGetter<int>(2);
-                var col4 = cursor.GetGetter<long>(3);
+                var col1 = cursor.GetGetter<sbyte>(cursor.Schema[0]);
+                var col2 = cursor.GetGetter<short>(cursor.Schema[1]);
+                var col3 = cursor.GetGetter<int>(cursor.Schema[2]);
+                var col4 = cursor.GetGetter<long>(cursor.Schema[3]);
 
                 Assert.True(cursor.MoveNext());
 
@@ -297,8 +297,8 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             using (var cursor = data.GetRowCursorForAllColumns())
             {
-                var IDGetter = cursor.GetGetter<float>(0);
-                var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);
+                var IDGetter = cursor.GetGetter<float>(cursor.Schema[0]);
+                var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(cursor.Schema[1]);
 
                 Assert.True(cursor.MoveNext());
 
@@ -445,11 +445,11 @@ namespace Microsoft.ML.EntryPoints.Tests
             using (var cursor = data.GetRowCursorForAllColumns())
             {
                 var getters = new ValueGetter<float>[]{
-                        cursor.GetGetter<float>(0),
-                        cursor.GetGetter<float>(1),
-                        cursor.GetGetter<float>(2),
-                        cursor.GetGetter<float>(3),
-                        cursor.GetGetter<float>(4)
+                        cursor.GetGetter<float>(cursor.Schema[0]),
+                        cursor.GetGetter<float>(cursor.Schema[1]),
+                        cursor.GetGetter<float>(cursor.Schema[2]),
+                        cursor.GetGetter<float>(cursor.Schema[3]),
+                        cursor.GetGetter<float>(cursor.Schema[4])
                     };
 
 
@@ -558,8 +558,8 @@ namespace Microsoft.ML.EntryPoints.Tests
 
             using (var cursor = data.GetRowCursorForAllColumns())
             {
-                var IDGetter = cursor.GetGetter<float>(0);
-                var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(1);
+                var IDGetter = cursor.GetGetter<float>(cursor.Schema[0]);
+                var TextGetter = cursor.GetGetter<ReadOnlyMemory<char>>(cursor.Schema[1]);
 
                 Assert.True(cursor.MoveNext());
 

--- a/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CopyColumnEstimatorTests.cs
@@ -164,11 +164,11 @@ namespace Microsoft.ML.Tests
                 int dvalue = 0;
                 int evalue = 0;
                 int fvalue = 0;
-                var aGetter = cursor.GetGetter<int>(0);
-                var bGetter = cursor.GetGetter<int>(1);
-                var dGetter = cursor.GetGetter<int>(3);
-                var eGetter = cursor.GetGetter<int>(4);
-                var fGetter = cursor.GetGetter<int>(5);
+                var aGetter = cursor.GetGetter<int>(cursor.Schema[0]);
+                var bGetter = cursor.GetGetter<int>(cursor.Schema[1]);
+                var dGetter = cursor.GetGetter<int>(cursor.Schema[3]);
+                var eGetter = cursor.GetGetter<int>(cursor.Schema[4]);
+                var fGetter = cursor.GetGetter<int>(cursor.Schema[5]);
                 while (cursor.MoveNext())
                 {
                     aGetter(ref avalue);

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -132,26 +132,27 @@ namespace Microsoft.ML.Tests.Transformers
             builder.AddPrimitiveValue("Foo", type, val);
             var inRow = AnnotationUtils.AnnotationsAsRow(builder.ToAnnotations());
 
-            // First do an unordered hash.
-            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits);
-            var xf = new HashingTransformer(Env, new[] { info });
-            var mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
-            mapper.OutputSchema.TryGetColumnIndex("Bar", out int outCol);
-            var outRow = mapper.GetRow(inRow, c => c == outCol);
+            //helper
+            ValueGetter<TType> hashGetter<TType>(HashingEstimator.ColumnOptions colInfo)
+            {
+                var xf = new HashingTransformer(Env, new[] { colInfo });
+                var mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
+                var col = mapper.OutputSchema["Bar"];
+                var outRow = mapper.GetRow(inRow, col);
 
-            var getter = outRow.GetGetter<uint>(outCol);
+                return outRow.GetGetter<TType>(col.Index);
+            };
+
+            // First do an unordered hash.
+            var info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits);
+            var getter = hashGetter<uint>(info);
             uint result = 0;
             getter(ref result);
             Assert.Equal(expected, result);
 
             // Next do an ordered hash.
             info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: true);
-            xf = new HashingTransformer(Env, new[] { info });
-            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
-            mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol);
-
-            getter = outRow.GetGetter<uint>(outCol);
+            getter = hashGetter<uint>(info);
             getter(ref result);
             Assert.Equal(expectedOrdered, result);
 
@@ -164,12 +165,7 @@ namespace Microsoft.ML.Tests.Transformers
             inRow = AnnotationUtils.AnnotationsAsRow(builder.ToAnnotations());
 
             info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: false);
-            xf = new HashingTransformer(Env, new[] { info });
-            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
-            mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol);
-
-            var vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            var vecGetter = hashGetter<VBuffer<uint>>(info);
             VBuffer<uint> vecResult = default;
             vecGetter(ref vecResult);
 
@@ -179,11 +175,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             // Now do ordered with the dense vector.
             info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: true);
-            xf = new HashingTransformer(Env, new[] { info });
-            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
-            mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol);
-            vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 
             Assert.Equal(vecLen, vecResult.Length);
@@ -198,11 +190,7 @@ namespace Microsoft.ML.Tests.Transformers
             inRow = AnnotationUtils.AnnotationsAsRow(builder.ToAnnotations());
 
             info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: false);
-            xf = new HashingTransformer(Env, new[] { info });
-            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
-            mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol);
-            vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 
             Assert.Equal(10, vecResult.Length);
@@ -211,11 +199,7 @@ namespace Microsoft.ML.Tests.Transformers
             Assert.Equal(expected, vecResult.GetItemOrDefault(7));
 
             info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: true);
-            xf = new HashingTransformer(Env, new[] { info });
-            mapper = ((ITransformer)xf).GetRowToRowMapper(inRow.Schema);
-            mapper.OutputSchema.TryGetColumnIndex("Bar", out outCol);
-            outRow = mapper.GetRow(inRow, c => c == outCol);
-            vecGetter = outRow.GetGetter<VBuffer<uint>>(outCol);
+            vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 
             Assert.Equal(10, vecResult.Length);

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -140,11 +140,11 @@ namespace Microsoft.ML.Tests.Transformers
                 var col = mapper.OutputSchema["Bar"];
                 var outRow = mapper.GetRow(inRow, col);
 
-                return outRow.GetGetter<TType>(col.Index);
+                return outRow.GetGetter<TType>(col);
             };
 
             // First do an unordered hash.
-            var info = new HashingEstimator.ColumnInfo("Bar", "Foo", hashBits: bits);
+            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits);
             var getter = hashGetter<uint>(info);
             uint result = 0;
             getter(ref result);

--- a/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.ML.Tests.Transformers
             using (var cursor = xf.GetRowCursorForAllColumns())
             {
                 VBuffer<ReadOnlyMemory<char>> text = default;
-                var getter = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(cursor.Schema["Text"].Index);
+                var getter = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(cursor.Schema["Text"]);
                 while (cursor.MoveNext())
                     getter(ref text);
             }

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -60,9 +60,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<int>(result.Schema["D"].Index);
-            var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
+            var getterD = cursor.GetGetter<int>(result.Schema["D"]);
+            var getterE = cursor.GetGetter<int>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<int>(result.Schema["F"]);
             cursor.MoveNext();
 
             int dValue = 0;
@@ -95,9 +95,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterVecD = cursor.GetGetter<VBuffer<int>>(result.Schema["VecD"].Index);
-            var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
+            var getterVecD = cursor.GetGetter<VBuffer<int>>(result.Schema["VecD"]);
+            var getterE = cursor.GetGetter<int>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<int>(result.Schema["F"]);
             cursor.MoveNext();
 
             VBuffer<int> dValue = default;
@@ -128,9 +128,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterVecD = cursor.GetGetter<VBuffer<uint>>(result.Schema["VecD"].Index);
-            var getterE = cursor.GetGetter<uint>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<uint>(result.Schema["F"].Index);
+            var getterVecD = cursor.GetGetter<VBuffer<uint>>(result.Schema["VecD"]);
+            var getterE = cursor.GetGetter<uint>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<uint>(result.Schema["F"]);
             cursor.MoveNext();
 
             VBuffer<uint> dValue = default;
@@ -169,9 +169,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<VBuffer<int>>(result.Schema["D"].Index);
-            var getterE = cursor.GetGetter<VBuffer<int>>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<VBuffer<int>>(result.Schema["F"].Index);
+            var getterD = cursor.GetGetter<VBuffer<int>>(result.Schema["D"]);
+            var getterE = cursor.GetGetter<VBuffer<int>>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<VBuffer<int>>(result.Schema["F"]);
             cursor.MoveNext();
 
             var valuesArray = values.ToArray();
@@ -210,9 +210,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<int>(result.Schema["D"].Index);
-            var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
+            var getterD = cursor.GetGetter<int>(result.Schema["D"]);
+            var getterE = cursor.GetGetter<int>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<int>(result.Schema["F"]);
             cursor.MoveNext();
 
             int dValue = 0;
@@ -244,9 +244,9 @@ namespace Microsoft.ML.Tests.Transformers
             var result = t.Transform(dataView);
 
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(3);
-            var getterE = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(4);
-            var getterF = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(5);
+            var getterD = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(result.Schema[3]);
+            var getterE = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(result.Schema[4]);
+            var getterF = cursor.GetGetter<VBuffer<ReadOnlyMemory<char>>>(result.Schema[5]);
             cursor.MoveNext();
 
             VBuffer<ReadOnlyMemory<char>> dValue = default;
@@ -276,9 +276,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<int>(result.Schema["D"].Index);
-            var getterE = cursor.GetGetter<int>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<int>(result.Schema["F"].Index);
+            var getterD = cursor.GetGetter<int>(result.Schema["D"]);
+            var getterE = cursor.GetGetter<int>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<int>(result.Schema["F"]);
             cursor.MoveNext();
 
             int dValue = 1;
@@ -376,9 +376,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<uint>(result.Schema["D"].Index);
-            var getterE = cursor.GetGetter<uint>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<uint>(result.Schema["F"].Index);
+            var getterD = cursor.GetGetter<uint>(result.Schema["D"]);
+            var getterE = cursor.GetGetter<uint>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<uint>(result.Schema["F"]);
             cursor.MoveNext();
 
             // The expected values will contain the actual uints and are not generated.
@@ -415,9 +415,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<ulong>(result.Schema["D"].Index);
-            var getterE = cursor.GetGetter<ulong>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<ulong>(result.Schema["F"].Index);
+            var getterD = cursor.GetGetter<ulong>(result.Schema["D"]);
+            var getterE = cursor.GetGetter<ulong>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<ulong>(result.Schema["F"]);
             cursor.MoveNext();
 
             // The expected values will contain the actual uints and are not generated.
@@ -452,9 +452,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<uint>(result.Schema["D"].Index);
-            var getterE = cursor.GetGetter<uint>(result.Schema["E"].Index);
-            var getterF = cursor.GetGetter<uint>(result.Schema["F"].Index);
+            var getterD = cursor.GetGetter<uint>(result.Schema["D"]);
+            var getterE = cursor.GetGetter<uint>(result.Schema["E"]);
+            var getterF = cursor.GetGetter<uint>(result.Schema["F"]);
             cursor.MoveNext();
 
             // The expected values will contain the generated key type values starting from 1.
@@ -490,7 +490,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             var result = t.Transform(dataView);
             var cursor = result.GetRowCursorForAllColumns();
-            var getterD = cursor.GetGetter<ReadOnlyMemory<char>>(result.Schema["DOutput"].Index);
+            var getterD = cursor.GetGetter<ReadOnlyMemory<char>>(result.Schema["DOutput"]);
             cursor.MoveNext();
 
             // The expected values will contain the generated key type values starting from 1.


### PR DESCRIPTION
Closes #1529 

Note to reviewers: The first commit does all the replacement work. 
The second commit, has more files on it, because it deals with renaming the col to columnIndex in the other two methods of IDataView (@eerhardt comment on #1529)
The third commit is me reviewing the first commit, and making sure that GetRow is an explicit implementation everywhere. 

I have had most of the work on this PR done before breaking ISchemaBoundRowMapper deriving from IRowToRowMapper; so I kept the signature change of ISchemaBoundRowMapper.GetRow although that interface is internal. LMK if that is not desirable. 