### PR TITLE
Make accessor of linear coefficients unique to the public

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -44,8 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var outData = featureContributionCalculator.Fit(scoredData).Transform(scoredData);
 
             // Let's extract the weights from the linear model to use as a comparison
-            var weights = new VBuffer<float>();
-            model.Model.GetFeatureWeights(ref weights);
+            var weights = model.Model.Weights;
 
             // Let's now walk through the first ten records and see which feature drove the values the most
             // Get prediction scores and contributions
@@ -63,7 +62,7 @@ namespace Microsoft.ML.Samples.Dynamic
                 var value = row.Features[featureOfInterest];
                 var contribution = row.FeatureContributions[featureOfInterest];
                 var name = data.Schema[featureOfInterest + 1].Name;
-                var weight = weights.GetValues()[featureOfInterest];
+                var weight = weights[featureOfInterest];
 
                 Console.WriteLine("{0:0.00}\t{1:0.00}\t{2}\t{3:0.00}\t{4:0.00}\t{5:0.00}",
                     row.MedianHomeValue,

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
@@ -46,12 +46,10 @@ namespace Microsoft.ML.Samples.Static
             var model = learningPipeline.Fit(trainData);
 
             // Check the weights that the model learned
-            VBuffer<float> weights = default;
-            pred.GetFeatureWeights(ref weights);
+            var weights = pred.Weights;
 
-            var weightsValues = weights.GetValues();
-            Console.WriteLine($"weight 0 - {weightsValues[0]}");
-            Console.WriteLine($"weight 1 - {weightsValues[1]}");
+            Console.WriteLine($"weight 0 - {weights[0]}");
+            Console.WriteLine($"weight 1 - {weights[1]}");
 
             // Evaluate how the model is doing on the test data
             var dataWithPredictions = model.Transform(testData);

--- a/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
+++ b/src/Microsoft.ML.Data/Dirty/PredictorInterfaces.cs
@@ -146,7 +146,8 @@ namespace Microsoft.ML.Model
     /// <summary>
     /// Interface implemented by components that can assign weights to features.
     /// </summary>
-    public interface IHaveFeatureWeights
+    [BestFriend]
+    internal interface IHaveFeatureWeights
     {
         /// <summary>
         /// Returns the weights for the features.

--- a/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
+++ b/src/Microsoft.ML.HalLearners/SymSgdClassificationTrainer.cs
@@ -671,7 +671,7 @@ namespace Microsoft.ML.Trainers.HalLearners
             float bias = 0.0f;
             if (predictor != null)
             {
-                predictor.GetFeatureWeights(ref weights);
+                ((IHaveFeatureWeights)predictor).GetFeatureWeights(ref weights);
                 VBufferUtils.Densify(ref weights);
                 bias = predictor.Bias;
             }

--- a/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/LinearModelParameters.cs
@@ -11,7 +11,6 @@ using Microsoft.Data.DataView;
 using Microsoft.ML;
 using Microsoft.ML.Calibrators;
 using Microsoft.ML.Data;
-using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Model;
 using Microsoft.ML.Model.OnnxConverter;
@@ -384,7 +383,7 @@ namespace Microsoft.ML.Trainers
 
         void ICanSaveInIniFormat.SaveAsIni(TextWriter writer, RoleMappedSchema schema, ICalibrator calibrator) => SaveAsIni(writer, schema, calibrator);
 
-        public void GetFeatureWeights(ref VBuffer<float> weights)
+        void IHaveFeatureWeights.GetFeatureWeights(ref VBuffer<float> weights)
         {
             Weight.CopyTo(ref weights);
         }

--- a/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/ModelStatistics.cs
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Trainers
             builder.AddPrimitiveValue("BiasPValue", NumberDataViewType.Single, biasPValue);
 
             var weights = default(VBuffer<float>);
-            parent.GetFeatureWeights(ref weights);
+            ((IHaveFeatureWeights)parent).GetFeatureWeights(ref weights);
             var estimate = default(VBuffer<float>);
             var stdErr = default(VBuffer<float>);
             var zScore = default(VBuffer<float>);

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
 using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.Internal.Utilities;
+using Microsoft.ML.Model;
 using Microsoft.ML.Numeric;
 
 namespace Microsoft.ML.Trainers
@@ -130,7 +131,7 @@ namespace Microsoft.ML.Trainers
                 // unless we have a lot of features.
                 if (predictor != null)
                 {
-                    predictor.GetFeatureWeights(ref Weights);
+                    ((IHaveFeatureWeights)parent).GetFeatureWeights(ref Weights);
                     VBufferUtils.Densify(ref Weights);
                     Bias = predictor.Bias;
                 }

--- a/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/Online/OnlineLinear.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Trainers
                 // unless we have a lot of features.
                 if (predictor != null)
                 {
-                    ((IHaveFeatureWeights)parent).GetFeatureWeights(ref Weights);
+                    ((IHaveFeatureWeights)predictor).GetFeatureWeights(ref Weights);
                     VBufferUtils.Densify(ref Weights);
                     Bias = predictor.Bias;
                 }

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -1937,7 +1937,7 @@ namespace Microsoft.ML.Trainers
             float bias = 0.0f;
             if (predictor != null)
             {
-                predictor.GetFeatureWeights(ref weights);
+                ((IHaveFeatureWeights)predictor).GetFeatureWeights(ref weights);
                 VBufferUtils.Densify(ref weights);
                 bias = predictor.Bias;
             }

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -627,9 +627,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
             // 11 input features, so we ought to have 11 weights.
-            VBuffer<float> weights = new VBuffer<float>();
-            pred.GetFeatureWeights(ref weights);
-            Assert.Equal(11, weights.Length);
+            Assert.Equal(11, pred.Weights.Count);
 
             var data = model.Load(dataSource);
 
@@ -751,9 +749,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var model = pipe.Fit(dataSource);
             Assert.NotNull(pred);
             // 11 input features, so we ought to have 11 weights.
-            VBuffer<float> weights = new VBuffer<float>();
-            pred.GetFeatureWeights(ref weights);
-            Assert.Equal(11, weights.Length);
+            Assert.Equal(11, pred.Weights.Count);
 
             var data = model.Load(dataSource);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/IntrospectiveTraining.cs
@@ -42,8 +42,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var model = pipeline.Fit(data);
 
             // Get feature weights.
-            VBuffer<float> weights = default;
-            model.LastTransformer.Model.GetFeatureWeights(ref weights);
+            var weights = model.LastTransformer.Model.Weights;
         }
 
         [Fact]


### PR DESCRIPTION
To fix #2763, we plan to hide one accessor in `LinearModelParameters` which is
```csharp
volid GetFeatureWeights(ref VBuffer<float> weights)
```
and make the its containing interface a best friend.
```csharp
internal interface IHaveFeatureWeights
```

