### PR TITLE
[Tiny] Use string[] instead of IEnumerable<string> in column names

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Another pipeline, that customizes the advanced settings of the FeaturizeText transformer.
             string customizedColumnName = "CustomizedTextFeatures";
-            var customized_pipeline = ml.Transforms.Text.FeaturizeText(customizedColumnName, new List<string> { "SentimentText" }, 
+            var customized_pipeline = ml.Transforms.Text.FeaturizeText(customizedColumnName, new string[] { "SentimentText" }, 
                 new TextFeaturizingEstimator.Options { 
                     KeepPunctuations = false,
                     KeepNumbers = false,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
@@ -31,13 +31,13 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Another pipeline, that customizes the advanced settings of the FeaturizeText transformer.
             string customizedColumnName = "CustomizedTextFeatures";
-            var customized_pipeline = ml.Transforms.Text.FeaturizeText(customizedColumnName, new string[] { "SentimentText" }, 
-                new TextFeaturizingEstimator.Options { 
-                    KeepPunctuations = false,
-                    KeepNumbers = false,
-                    OutputTokens = true,
-                    TextLanguage = TextFeaturizingEstimator.Language.English, // supports  English, French, German, Dutch, Italian, Spanish, Japanese
-            });
+            var customized_pipeline = ml.Transforms.Text.FeaturizeText(customizedColumnName, new TextFeaturizingEstimator.Options
+            {
+                KeepPunctuations = false,
+                KeepNumbers = false,
+                OutputTokens = true,
+                TextLanguage = TextFeaturizingEstimator.Language.English, // supports  English, French, German, Dutch, Italian, Spanish, Japanese
+            }, "SentimentText");
 
             // The transformed data for both pipelines.
             var transformedData_default = default_pipeline.Fit(trainData).Transform(trainData);

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML
         /// </example>
         public static TextFeaturizingEstimator FeaturizeText(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
-            IEnumerable<string> inputColumnNames,
+            string[] inputColumnNames,
             TextFeaturizingEstimator.Options options)
             => new TextFeaturizingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
                 outputColumnName, inputColumnNames, options);

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -34,8 +34,8 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnNames"/>.</param>
-        /// <param name="inputColumnNames">Name of the columns to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="options">Advanced options to the algorithm.</param>
+        /// <param name="inputColumnNames">Name of the columns to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -45,8 +45,8 @@ namespace Microsoft.ML
         /// </example>
         public static TextFeaturizingEstimator FeaturizeText(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
-            string[] inputColumnNames,
-            TextFeaturizingEstimator.Options options)
+            TextFeaturizingEstimator.Options options,
+            params string[] inputColumnNames)
             => new TextFeaturizingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
                 outputColumnName, inputColumnNames, options);
 

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -93,15 +93,15 @@ namespace Microsoft.ML.Benchmarks
             };
 
             var loader = mlContext.Data.LoadFromTextFile(_sentimentDataPath, arguments);
-            var text = mlContext.Transforms.Text.FeaturizeText("WordEmbeddings", new string[] { "SentimentText" }, 
-                new TextFeaturizingEstimator.Options { 
-                    OutputTokens = true,
-                    KeepPunctuations = false,
-                    UseStopRemover = true,
-                    VectorNormalizer = TextFeaturizingEstimator.TextNormKind.None,
-                    UseCharExtractor = false,
-                    UseWordExtractor = false,
-                }).Fit(loader).Transform(loader);
+            var text = mlContext.Transforms.Text.FeaturizeText("WordEmbeddings", new TextFeaturizingEstimator.Options
+            {
+                OutputTokens = true,
+                KeepPunctuations = false,
+                UseStopRemover = true,
+                VectorNormalizer = TextFeaturizingEstimator.TextNormKind.None,
+                UseCharExtractor = false,
+                UseWordExtractor = false,
+            }, "SentimentText").Fit(loader).Transform(loader);
 
             var trans = mlContext.Transforms.Text.ExtractWordEmbeddings("Features", "WordEmbeddings_TransformedText", 
                 WordEmbeddingsExtractingEstimator.PretrainedModelKind.Sswe).Fit(text).Transform(text);

--- a/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/test/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Benchmarks
             };
 
             var loader = mlContext.Data.LoadFromTextFile(_sentimentDataPath, arguments);
-            var text = mlContext.Transforms.Text.FeaturizeText("WordEmbeddings", new List<string> { "SentimentText" }, 
+            var text = mlContext.Transforms.Text.FeaturizeText("WordEmbeddings", new string[] { "SentimentText" }, 
                 new TextFeaturizingEstimator.Options { 
                     OutputTokens = true,
                     KeepPunctuations = false,

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
@@ -25,8 +25,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
             var pipeline = ml.Data.CreateTextLoader(TestDatasets.Sentiment.GetLoaderColumns(), hasHeader: true)
-                .Append(ml.Transforms.Text.FeaturizeText("Features", new string[] { "SentimentText" }, 
-                                                        new Transforms.Text.TextFeaturizingEstimator.Options { OutputTokens = true }));
+                .Append(ml.Transforms.Text.FeaturizeText(
+                    "Features", new Transforms.Text.TextFeaturizingEstimator.Options { OutputTokens = true }, "SentimentText"));
 
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));
             var data = pipeline.Fit(src).Load(src);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Visibility.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
         {
             var ml = new MLContext(seed: 1, conc: 1);
             var pipeline = ml.Data.CreateTextLoader(TestDatasets.Sentiment.GetLoaderColumns(), hasHeader: true)
-                .Append(ml.Transforms.Text.FeaturizeText("Features", new List<string> { "SentimentText" }, 
+                .Append(ml.Transforms.Text.FeaturizeText("Features", new string[] { "SentimentText" }, 
                                                         new Transforms.Text.TextFeaturizingEstimator.Options { OutputTokens = true }));
 
             var src = new MultiFileSource(GetDataPath(TestDatasets.Sentiment.trainFilename));


### PR DESCRIPTION
There are three possible ways to denote input column names, `string[]`, `IEnumerable<string>`, and `params`. I personally like `string[]` because

- `IEnumerable<string>` is not used elsewhere for the same purpose.
- `params` makes signature less typed and it forces input column names to be the last argument group.

Fix #2801, Fix #2460.

