### PR TITLE
Hide more of Microsoft.ML.Data

### DIFF
--- a/src/Microsoft.ML.Data/Commands/DefaultColumnNames.cs
+++ b/src/Microsoft.ML.Data/Commands/DefaultColumnNames.cs
@@ -4,7 +4,13 @@
 
 namespace Microsoft.ML.Data
 {
-    public static class DefaultColumnNames
+    /// <summary>
+    /// A set of string literals intended to be "canonical" names for column names intended for particular purpose.
+    /// While not part of the public API surface, its primary purpose is intended to be used in such a way as to encourage
+    /// uniformity on the public API surface, wherever it is judged where columns with default names should be consumed.
+    /// </summary>
+    [BestFriend]
+    internal static class DefaultColumnNames
     {
         public const string Features = "Features";
         public const string Label = "Label";

--- a/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ML.Data.DataLoadSave
     /// It will pretend that all vector sizes are equal to 10, all key value counts are equal to 10,
     /// and all values are defaults (for annotations).
     /// </summary>
+    [BestFriend]
     internal static class FakeSchemaFactory
     {
         private const int AllVectorSizes = 10;

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -15,9 +15,13 @@ using Microsoft.ML.Model;
 
 namespace Microsoft.ML.Data
 {
-    // REVIEW: this class is public, as long as the Wrappers.cs in tests still rely on it.
-    // It needs to become internal.
-    public sealed class TransformWrapper : ITransformer
+    /// <summary>
+    /// This is a shim class to present the legacy <see cref="IDataTransform"/> interface as an <see cref="ITransformer"/>.
+    /// Note that there are some important differences in usages that make this shimming somewhat non-seemless, so the goal
+    /// would be gradual removal of this as we do away with <see cref="IDataTransform"/> based code.
+    /// </summary>
+    [BestFriend]
+    internal sealed class TransformWrapper : ITransformer
     {
         internal const string LoaderSignature = "TransformWrapper";
         private const string TransformDirTemplate = "Step_{0:000}";
@@ -148,7 +152,7 @@ namespace Microsoft.ML.Data
     /// <summary>
     /// Estimator for trained wrapped transformers.
     /// </summary>
-    public abstract class TrainedWrapperEstimatorBase : IEstimator<TransformWrapper>
+    internal abstract class TrainedWrapperEstimatorBase : IEstimator<TransformWrapper>
     {
         [BestFriend]
         private protected readonly IHost Host;

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformWrapper.cs
@@ -150,9 +150,11 @@ namespace Microsoft.ML.Data
     /// </summary>
     public abstract class TrainedWrapperEstimatorBase : IEstimator<TransformWrapper>
     {
-        protected readonly IHost Host;
+        [BestFriend]
+        private protected readonly IHost Host;
 
-        protected TrainedWrapperEstimatorBase(IHost host)
+        [BestFriend]
+        private protected TrainedWrapperEstimatorBase(IHost host)
         {
             Contracts.CheckValue(host, nameof(host));
             Host = host;

--- a/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
@@ -16,10 +16,13 @@ namespace Microsoft.ML.Data
     public abstract class TrivialEstimator<TTransformer> : IEstimator<TTransformer>
         where TTransformer : class, ITransformer
     {
-        protected readonly IHost Host;
-        protected readonly TTransformer Transformer;
+        [BestFriend]
+        private protected readonly IHost Host;
+        [BestFriend]
+        private protected readonly TTransformer Transformer;
 
-        protected TrivialEstimator(IHost host, TTransformer transformer)
+        [BestFriend]
+        private protected TrivialEstimator(IHost host, TTransformer transformer)
         {
             Contracts.AssertValue(host);
 

--- a/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
+++ b/src/Microsoft.ML.Data/DataView/DataViewConstructionUtils.cs
@@ -740,7 +740,7 @@ namespace Microsoft.ML.Data
 
         internal abstract Delegate GetGetterDelegate();
 
-        protected AnnotationInfo(string kind, DataViewType annotationType)
+        private protected AnnotationInfo(string kind, DataViewType annotationType)
         {
             Contracts.AssertValueOrNull(annotationType);
             Contracts.AssertNonEmpty(kind);

--- a/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
@@ -10,20 +10,17 @@ namespace Microsoft.ML
     /// <summary>
     /// An object serving as a 'catalog' of available model operations.
     /// </summary>
-    public sealed class ModelOperationsCatalog
+    public sealed class ModelOperationsCatalog : IInternalCatalog
     {
-        /// <summary>
-        /// This is a best friend because an extension method defined in another assembly needs this field.
-        /// </summary>
-        [BestFriend]
-        internal IHostEnvironment Environment { get; }
+        IHostEnvironment IInternalCatalog.Environment => _env;
+        private readonly IHostEnvironment _env;
 
         public ExplainabilityTransforms Explainability { get; }
 
         internal ModelOperationsCatalog(IHostEnvironment env)
         {
             Contracts.AssertValue(env);
-            Environment = env;
+            _env = env;
 
             Explainability = new ExplainabilityTransforms(this);
         }
@@ -33,25 +30,26 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="model">The trained model to be saved.</param>
         /// <param name="stream">A writeable, seekable stream to save to.</param>
-        public void Save(ITransformer model, Stream stream) => model.SaveTo(Environment, stream);
+        public void Save(ITransformer model, Stream stream) => model.SaveTo(_env, stream);
 
         /// <summary>
         /// Load the model from the stream.
         /// </summary>
         /// <param name="stream">A readable, seekable stream to load from.</param>
         /// <returns>The loaded model.</returns>
-        public ITransformer Load(Stream stream) => TransformerChain.LoadFrom(Environment, stream);
+        public ITransformer Load(Stream stream) => TransformerChain.LoadFrom(_env, stream);
 
         /// <summary>
         /// The catalog of model explainability operations.
         /// </summary>
-        public sealed class ExplainabilityTransforms
+        public sealed class ExplainabilityTransforms : IInternalCatalog
         {
-            internal IHostEnvironment Environment { get; }
+            IHostEnvironment IInternalCatalog.Environment => _env;
+            private readonly IHostEnvironment _env;
 
             internal ExplainabilityTransforms(ModelOperationsCatalog owner)
             {
-                Environment = owner.Environment;
+                _env = owner._env;
             }
         }
 
@@ -68,7 +66,7 @@ namespace Microsoft.ML
             where TSrc : class
             where TDst : class, new()
         {
-            return new PredictionEngine<TSrc, TDst>(Environment, transformer, false, inputSchemaDefinition, outputSchemaDefinition);
+            return new PredictionEngine<TSrc, TDst>(_env, transformer, false, inputSchemaDefinition, outputSchemaDefinition);
         }
     }
 }

--- a/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
@@ -28,16 +28,6 @@ namespace Microsoft.ML
             Explainability = new ExplainabilityTransforms(this);
         }
 
-        public abstract class SubCatalogBase
-        {
-            internal IHostEnvironment Environment { get; }
-
-            protected SubCatalogBase(ModelOperationsCatalog owner)
-            {
-                Environment = owner.Environment;
-            }
-        }
-
         /// <summary>
         /// Save the model to the stream.
         /// </summary>
@@ -55,10 +45,13 @@ namespace Microsoft.ML
         /// <summary>
         /// The catalog of model explainability operations.
         /// </summary>
-        public sealed class ExplainabilityTransforms : SubCatalogBase
+        public sealed class ExplainabilityTransforms
         {
-            internal ExplainabilityTransforms(ModelOperationsCatalog owner) : base(owner)
+            internal IHostEnvironment Environment { get; }
+
+            internal ExplainabilityTransforms(ModelOperationsCatalog owner)
             {
+                Environment = owner.Environment;
             }
         }
 

--- a/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
+++ b/src/Microsoft.ML.Data/Prediction/PredictionEngine.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Provides output schema.
         /// </summary>
-        public DataViewSchema OutputSchema;
+        public DataViewSchema OutputSchema { get; }
 
         [BestFriend]
         private protected ITransformer Transformer { get; }
@@ -180,9 +180,11 @@ namespace Microsoft.ML
             return result;
         }
 
-        protected void ExtractValues(TSrc example) => _inputRow.ExtractValues(example);
+        [BestFriend]
+        private protected void ExtractValues(TSrc example) => _inputRow.ExtractValues(example);
 
-        protected void FillValues(TDst prediction) => _outputRow.FillValues(prediction);
+        [BestFriend]
+        private protected void FillValues(TDst prediction) => _outputRow.FillValues(prediction);
 
         /// <summary>
         /// Run prediction pipeline on one example.

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -52,7 +52,8 @@ namespace Microsoft.ML.Data
         private protected readonly IHost Host;
         [BestFriend]
         private protected ISchemaBindableMapper BindableMapper;
-        protected DataViewSchema TrainSchema;
+        [BestFriend]
+        private protected DataViewSchema TrainSchema;
 
         /// <summary>
         /// Whether a call to <see cref="ITransformer.GetRowToRowMapper(DataViewSchema)"/> should succeed, on an
@@ -142,7 +143,8 @@ namespace Microsoft.ML.Data
 
         private protected abstract void SaveModel(ModelSaveContext ctx);
 
-        protected void SaveModelCore(ModelSaveContext ctx)
+        [BestFriend]
+        private protected void SaveModelCore(ModelSaveContext ctx)
         {
             // *** Binary format ***
             // <base info>
@@ -234,14 +236,14 @@ namespace Microsoft.ML.Data
             return Transform(new EmptyDataView(Host, inputSchema)).Schema;
         }
 
-        private protected override void SaveModel(ModelSaveContext ctx)
+        private protected sealed override void SaveModel(ModelSaveContext ctx)
         {
             Host.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel();
             SaveCore(ctx);
         }
 
-        protected virtual void SaveCore(ModelSaveContext ctx)
+        private protected virtual void SaveCore(ModelSaveContext ctx)
         {
             SaveModelCore(ctx);
             ctx.SaveStringOrNull(FeatureColumn);
@@ -296,7 +298,7 @@ namespace Microsoft.ML.Data
             Scorer = new BinaryClassifierScorer(Host, args, new EmptyDataView(Host, TrainSchema), BindableMapper.Bind(Host, schema), schema);
         }
 
-        protected override void SaveCore(ModelSaveContext ctx)
+        private protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);
             ctx.SetVersionInfo(GetVersionInfo());
@@ -365,7 +367,7 @@ namespace Microsoft.ML.Data
             Scorer = new BinaryClassifierScorer(Host, args, new EmptyDataView(Host, TrainSchema), BindableMapper.Bind(Host, schema), schema);
         }
 
-        protected override void SaveCore(ModelSaveContext ctx)
+        private protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);
             ctx.SetVersionInfo(GetVersionInfo());
@@ -429,7 +431,7 @@ namespace Microsoft.ML.Data
             Scorer = new MultiClassClassifierScorer(Host, args, new EmptyDataView(Host, TrainSchema), BindableMapper.Bind(Host, schema), schema);
         }
 
-        protected override void SaveCore(ModelSaveContext ctx)
+        private protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);
             ctx.SetVersionInfo(GetVersionInfo());
@@ -474,7 +476,7 @@ namespace Microsoft.ML.Data
             Scorer = GetGenericScorer();
         }
 
-        protected override void SaveCore(ModelSaveContext ctx)
+        private protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);
             ctx.SetVersionInfo(GetVersionInfo());
@@ -516,7 +518,7 @@ namespace Microsoft.ML.Data
             Scorer = GetGenericScorer();
         }
 
-        protected override void SaveCore(ModelSaveContext ctx)
+        private protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);
             ctx.SetVersionInfo(GetVersionInfo());
@@ -568,7 +570,7 @@ namespace Microsoft.ML.Data
             Scorer = new ClusteringScorer(Host, args, new EmptyDataView(Host, TrainSchema), BindableMapper.Bind(Host, schema), schema);
         }
 
-        protected override void SaveCore(ModelSaveContext ctx)
+        private protected override void SaveCore(ModelSaveContext ctx)
         {
             Contracts.AssertValue(ctx);
             ctx.SetVersionInfo(GetVersionInfo());

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -85,7 +85,8 @@ namespace Microsoft.ML
         /// <summary>
         /// Results for specific cross-validation fold.
         /// </summary>
-        protected internal struct CrossValidationResult
+        [BestFriend]
+        private protected struct CrossValidationResult
         {
             /// <summary>
             /// Model trained during cross validation fold.
@@ -143,7 +144,8 @@ namespace Microsoft.ML
         /// Train the <paramref name="estimator"/> on <paramref name="numFolds"/> folds of the data sequentially.
         /// Return each model and each scored test dataset.
         /// </summary>
-        protected internal CrossValidationResult[] CrossValidateTrain(IDataView data, IEstimator<ITransformer> estimator,
+        [BestFriend]
+        private protected CrossValidationResult[] CrossValidateTrain(IDataView data, IEstimator<ITransformer> estimator,
             int numFolds, string samplingKeyColumn, uint? seed = null)
         {
             Environment.CheckValue(data, nameof(data));
@@ -248,7 +250,8 @@ namespace Microsoft.ML
             [BestFriend]
             internal TrainCatalogBase Owner { get; }
 
-            internal protected CatalogInstantiatorBase(TrainCatalogBase catalog)
+            [BestFriend]
+            private protected CatalogInstantiatorBase(TrainCatalogBase catalog)
             {
                 Owner = catalog;
             }

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -16,10 +16,12 @@ namespace Microsoft.ML
     /// "area" of machine learning. A subclass would represent a particular task in machine learning. The idea
     /// is that a user can instantiate that particular area, and get trainers and evaluators.
     /// </summary>
-    public abstract class TrainCatalogBase
+    public abstract class TrainCatalogBase : IInternalCatalog
     {
+        IHostEnvironment IInternalCatalog.Environment => Environment;
+
         [BestFriend]
-        internal IHostEnvironment Environment { get; }
+        private protected IHostEnvironment Environment { get; }
 
         /// <summary>
         /// A pair of datasets, for the train and test set.
@@ -245,8 +247,10 @@ namespace Microsoft.ML
         /// through <see cref="CatalogUtils"/> to get more "hidden" information from this object,
         /// for example, the environment.
         /// </summary>
-        public abstract class CatalogInstantiatorBase
+        public abstract class CatalogInstantiatorBase : IInternalCatalog
         {
+            IHostEnvironment IInternalCatalog.Environment => Owner.GetEnvironment();
+
             [BestFriend]
             internal TrainCatalogBase Owner { get; }
 
@@ -402,7 +406,7 @@ namespace Microsoft.ML
                   string labelColumnName = DefaultColumnNames.Label,
                   string scoreColumnName = DefaultColumnNames.Score)
             {
-                return new NaiveCalibratorEstimator(Owner.Environment, labelColumnName, scoreColumnName);
+                return new NaiveCalibratorEstimator(Owner.GetEnvironment(), labelColumnName, scoreColumnName);
             }
             /// <summary>
             /// Adds probability column by training <a href="https://en.wikipedia.org/wiki/Platt_scaling">platt calibrator</a>.
@@ -422,7 +426,7 @@ namespace Microsoft.ML
                   string scoreColumnName = DefaultColumnNames.Score,
                   string exampleWeightColumnName = null)
             {
-                return new PlattCalibratorEstimator(Owner.Environment, labelColumnName, scoreColumnName, exampleWeightColumnName);
+                return new PlattCalibratorEstimator(Owner.GetEnvironment(), labelColumnName, scoreColumnName, exampleWeightColumnName);
             }
 
             /// <summary>
@@ -443,7 +447,7 @@ namespace Microsoft.ML
                 double offset,
                 string scoreColumnName = DefaultColumnNames.Score)
             {
-                return new FixedPlattCalibratorEstimator(Owner.Environment, slope, offset, scoreColumnName);
+                return new FixedPlattCalibratorEstimator(Owner.GetEnvironment(), slope, offset, scoreColumnName);
             }
 
             /// <summary>
@@ -468,7 +472,7 @@ namespace Microsoft.ML
                 string scoreColumnName = DefaultColumnNames.Score,
                 string exampleWeightColumnName = null)
             {
-                return new IsotonicCalibratorEstimator(Owner.Environment, labelColumnName, scoreColumnName, exampleWeightColumnName);
+                return new IsotonicCalibratorEstimator(Owner.GetEnvironment(), labelColumnName, scoreColumnName, exampleWeightColumnName);
             }
         }
     }

--- a/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
+++ b/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs
@@ -21,7 +21,8 @@ namespace Microsoft.ML.Trainers
         /// A standard string to use in errors or warnings by subclasses, to communicate the idea that no valid
         /// instances were able to be found.
         /// </summary>
-        protected const string NoTrainingInstancesMessage = "No valid training instances found, all instances have missing features.";
+        [BestFriend]
+        private protected const string NoTrainingInstancesMessage = "No valid training instances found, all instances have missing features.";
 
         /// <summary>
         /// The feature column that the trainer expects.
@@ -40,7 +41,8 @@ namespace Microsoft.ML.Trainers
         /// </summary>
         public readonly SchemaShape.Column WeightColumn;
 
-        protected readonly IHost Host;
+        [BestFriend]
+        private protected readonly IHost Host;
 
         /// <summary>
         /// The information about the trainer: whether it benefits from normalization, caching etc.
@@ -174,12 +176,13 @@ namespace Microsoft.ML.Trainers
         /// </summary>
         public readonly SchemaShape.Column GroupIdColumn;
 
-        public TrainerEstimatorBaseWithGroupId(IHost host,
+        [BestFriend]
+        private protected TrainerEstimatorBaseWithGroupId(IHost host,
                 SchemaShape.Column feature,
                 SchemaShape.Column label,
                 SchemaShape.Column weight = default,
                 SchemaShape.Column groupId = default)
-            :base(host, feature, label, weight)
+            : base(host, feature, label, weight)
         {
             GroupIdColumn = groupId;
         }

--- a/src/Microsoft.ML.Data/Transforms/CatalogUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/CatalogUtils.cs
@@ -5,17 +5,23 @@
 namespace Microsoft.ML.Data
 {
     /// <summary>
-    /// Set of extension methods to extract <see cref="IHostEnvironment"/> from various catalog classes.
+    /// Convenience method to more easily extract an <see cref="IHostEnvironment"/> from an <see cref="IInternalCatalog"/>
+    /// implementor without requiring an explicit cast.
     /// </summary>
     [BestFriend]
     internal static class CatalogUtils
     {
-        public static IHostEnvironment GetEnvironment(this TransformsCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
-        public static IHostEnvironment GetEnvironment(this TransformsCatalog.SubCatalogBase subCatalog) => Contracts.CheckRef(subCatalog, nameof(subCatalog)).Environment;
-        public static IHostEnvironment GetEnvironment(this ModelOperationsCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
-        public static IHostEnvironment GetEnvironment(this ModelOperationsCatalog.ExplainabilityTransforms catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
-        public static IHostEnvironment GetEnvironment(this DataOperationsCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
-        public static IHostEnvironment GetEnvironment(TrainCatalogBase.CatalogInstantiatorBase obj) => Contracts.CheckRef(obj, nameof(obj)).Owner.Environment;
-        public static IHostEnvironment GetEnvironment(TrainCatalogBase catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
+        public static IHostEnvironment GetEnvironment(this IInternalCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
+    }
+
+    /// <summary>
+    /// An internal interface for the benefit of those <see cref="IHostEnvironment"/>-bearing objects accessible through
+    /// <see cref="MLContext"/>. Because this is meant to consumed by component authors implementations of this interface
+    /// should be explicit.
+    /// </summary>
+    [BestFriend]
+    internal interface IInternalCatalog
+    {
+        IHostEnvironment Environment { get; }
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/CatalogUtils.cs
+++ b/src/Microsoft.ML.Data/Transforms/CatalogUtils.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ML.Data
         public static IHostEnvironment GetEnvironment(this TransformsCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
         public static IHostEnvironment GetEnvironment(this TransformsCatalog.SubCatalogBase subCatalog) => Contracts.CheckRef(subCatalog, nameof(subCatalog)).Environment;
         public static IHostEnvironment GetEnvironment(this ModelOperationsCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
-        public static IHostEnvironment GetEnvironment(this ModelOperationsCatalog.SubCatalogBase subCatalog) => Contracts.CheckRef(subCatalog, nameof(subCatalog)).Environment;
+        public static IHostEnvironment GetEnvironment(this ModelOperationsCatalog.ExplainabilityTransforms catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
         public static IHostEnvironment GetEnvironment(this DataOperationsCatalog catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;
         public static IHostEnvironment GetEnvironment(TrainCatalogBase.CatalogInstantiatorBase obj) => Contracts.CheckRef(obj, nameof(obj)).Owner.Environment;
         public static IHostEnvironment GetEnvironment(TrainCatalogBase catalog) => Contracts.CheckRef(catalog, nameof(catalog)).Environment;

--- a/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/OneToOneTransformerBase.cs
@@ -13,9 +13,11 @@ namespace Microsoft.ML.Data
     /// </summary>
     public abstract class OneToOneTransformerBase : RowToRowTransformerBase
     {
-        protected readonly (string outputColumnName, string inputColumnName)[] ColumnPairs;
+        [BestFriend]
+        private protected readonly (string outputColumnName, string inputColumnName)[] ColumnPairs;
 
-        protected OneToOneTransformerBase(IHost host, params (string outputColumnName, string inputColumnName)[] columns) : base(host)
+        [BestFriend]
+        private protected OneToOneTransformerBase(IHost host, params (string outputColumnName, string inputColumnName)[] columns) : base(host)
         {
             host.CheckValue(columns, nameof(columns));
             var newNames = new HashSet<string>();
@@ -50,7 +52,8 @@ namespace Microsoft.ML.Data
             }
         }
 
-        protected void SaveColumns(ModelSaveContext ctx)
+        [BestFriend]
+        private protected void SaveColumns(ModelSaveContext ctx)
         {
             Host.CheckValue(ctx, nameof(ctx));
 
@@ -84,7 +87,8 @@ namespace Microsoft.ML.Data
             // By default, there are no extra checks.
         }
 
-        protected abstract class OneToOneMapperBase : MapperBase
+        [BestFriend]
+        private protected abstract class OneToOneMapperBase : MapperBase
         {
             protected readonly Dictionary<int, int> ColMapNewToOld;
             private readonly OneToOneTransformerBase _parent;

--- a/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/RowToRowTransformerBase.cs
@@ -14,9 +14,11 @@ namespace Microsoft.ML.Data
     /// </summary>
     public abstract class RowToRowTransformerBase : ITransformer
     {
-        protected readonly IHost Host;
+        [BestFriend]
+        private protected readonly IHost Host;
 
-        protected RowToRowTransformerBase(IHost host)
+        [BestFriend]
+        private protected RowToRowTransformerBase(IHost host)
         {
             Contracts.AssertValue(host);
             Host = host;
@@ -53,7 +55,8 @@ namespace Microsoft.ML.Data
             return new RowToRowMapperTransform(Host, input, MakeRowMapper(input.Schema), MakeRowMapper);
         }
 
-        protected abstract class MapperBase : IRowMapper
+        [BestFriend]
+        private protected abstract class MapperBase : IRowMapper
         {
             protected readonly IHost Host;
             protected readonly DataViewSchema InputSchema;

--- a/src/Microsoft.ML.Data/Transforms/TransformsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformsCatalog.cs
@@ -2,15 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
+
 namespace Microsoft.ML
 {
     /// <summary>
     /// Similar to training context, a transform context is an object serving as a 'catalog' of available transforms.
     /// Individual transforms are exposed as extension methods of this class or its subclasses.
     /// </summary>
-    public sealed class TransformsCatalog
+    public sealed class TransformsCatalog : IInternalCatalog
     {
-        internal IHostEnvironment Environment { get; }
+        IHostEnvironment IInternalCatalog.Environment => _env;
+        private readonly IHostEnvironment _env;
 
         /// <summary>
         /// The list of operations over categorical data.
@@ -40,7 +43,7 @@ namespace Microsoft.ML
         internal TransformsCatalog(IHostEnvironment env)
         {
             Contracts.AssertValue(env);
-            Environment = env;
+            _env = env;
 
             Categorical = new CategoricalTransforms(this);
             Conversion = new ConversionTransforms(this);
@@ -49,65 +52,73 @@ namespace Microsoft.ML
             FeatureSelection = new FeatureSelectionTransforms(this);
         }
 
-        public abstract class SubCatalogBase
-        {
-            internal IHostEnvironment Environment { get; }
-
-            [BestFriend]
-            private protected SubCatalogBase(TransformsCatalog owner)
-            {
-                Environment = owner.Environment;
-            }
-
-        }
-
         /// <summary>
         /// The catalog of operations over categorical data.
         /// </summary>
-        public sealed class CategoricalTransforms : SubCatalogBase
+        public sealed class CategoricalTransforms : IInternalCatalog
         {
-            internal CategoricalTransforms(TransformsCatalog owner) : base(owner)
+            IHostEnvironment IInternalCatalog.Environment => _env;
+            private readonly IHostEnvironment _env;
+
+            internal CategoricalTransforms(TransformsCatalog owner)
             {
+                _env = owner.GetEnvironment();
             }
         }
 
         /// <summary>
         /// The catalog of type conversion operations.
         /// </summary>
-        public sealed class ConversionTransforms : SubCatalogBase
+        public sealed class ConversionTransforms : IInternalCatalog
         {
-            internal ConversionTransforms(TransformsCatalog owner) : base(owner)
+            IHostEnvironment IInternalCatalog.Environment => _env;
+            private readonly IHostEnvironment _env;
+
+            internal ConversionTransforms(TransformsCatalog owner)
             {
+                _env = owner.GetEnvironment();
             }
         }
 
         /// <summary>
         /// The catalog of text processing operations.
         /// </summary>
-        public sealed class TextTransforms : SubCatalogBase
+        public sealed class TextTransforms : IInternalCatalog
         {
-            internal TextTransforms(TransformsCatalog owner) : base(owner)
+            IHostEnvironment IInternalCatalog.Environment => _env;
+            private readonly IHostEnvironment _env;
+
+            internal TextTransforms(TransformsCatalog owner)
             {
+                _env = owner.GetEnvironment();
             }
         }
 
         /// <summary>
         /// The catalog of projection operations.
         /// </summary>
-        public sealed class ProjectionTransforms : SubCatalogBase
+        public sealed class ProjectionTransforms : IInternalCatalog
         {
-            internal ProjectionTransforms(TransformsCatalog owner) : base(owner)
+            IHostEnvironment IInternalCatalog.Environment => _env;
+            private readonly IHostEnvironment _env;
+
+            internal ProjectionTransforms(TransformsCatalog owner)
             {
+                _env = owner.GetEnvironment();
             }
         }
 
         /// <summary>
         /// The catalog of feature selection operations.
         /// </summary>
-        public sealed class FeatureSelectionTransforms : SubCatalogBase
+        public sealed class FeatureSelectionTransforms : IInternalCatalog
         {
-            internal FeatureSelectionTransforms(TransformsCatalog owner) : base(owner)
+            IHostEnvironment IInternalCatalog.Environment => _env;
+            private readonly IHostEnvironment _env;
+
+            internal FeatureSelectionTransforms(TransformsCatalog owner)
             {
+                _env = owner.GetEnvironment();
             }
         }
     }

--- a/src/Microsoft.ML.Data/Transforms/TransformsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/TransformsCatalog.cs
@@ -53,7 +53,8 @@ namespace Microsoft.ML
         {
             internal IHostEnvironment Environment { get; }
 
-            protected SubCatalogBase(TransformsCatalog owner)
+            [BestFriend]
+            private protected SubCatalogBase(TransformsCatalog owner)
             {
                 Environment = owner.Environment;
             }

--- a/src/Microsoft.ML.Data/Transforms/ValueMapping.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueMapping.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Transforms
         /// Returns the <see cref="SchemaShape"/> of the schema which will be produced by the transformer.
         /// Used for schema propagation and verification in a pipeline.
         /// </summary>
-        public override SchemaShape GetOutputSchema(SchemaShape inputSchema)
+        public sealed override SchemaShape GetOutputSchema(SchemaShape inputSchema)
         {
             Host.CheckValue(inputSchema, nameof(inputSchema));
 
@@ -722,7 +722,7 @@ namespace Microsoft.ML.Transforms
         private static IRowMapper Create(IHostEnvironment env, ModelLoadContext ctx, DataViewSchema inputSchema)
             => Create(env, ctx).MakeRowMapper(inputSchema);
 
-        protected static PrimitiveDataViewType GetPrimitiveType(Type rawType, out bool isVectorType)
+        private protected static PrimitiveDataViewType GetPrimitiveType(Type rawType, out bool isVectorType)
         {
             Type type = rawType;
             isVectorType = false;

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -41,7 +41,8 @@ namespace Microsoft.ML.Transforms
             public readonly string[] Term;
             public readonly bool TextKeyValues;
 
-            protected internal string Terms { get; set; }
+            [BestFriend]
+            internal string Terms { get; set; }
 
             /// <summary>
             /// Describes how the transformer handles one column pair.
@@ -57,8 +58,7 @@ namespace Microsoft.ML.Transforms
                 int maxNumKeys = Defaults.MaxNumKeys,
                 SortOrder sort = Defaults.Sort,
                 string[] term = null,
-                bool textKeyValues = false
-                )
+                bool textKeyValues = false)
             {
                 Contracts.CheckNonWhiteSpace(outputColumnName, nameof(outputColumnName));
                 OutputColumnName = outputColumnName;

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// Describes how the transformer handles one column pair.
         /// </summary>
-        public class ColumnOptions
+        public abstract class ColumnOptionsBase
         {
             public readonly string OutputColumnName;
             public readonly string InputColumnName;
@@ -44,6 +44,25 @@ namespace Microsoft.ML.Transforms
             [BestFriend]
             internal string Terms { get; set; }
 
+            [BestFriend]
+            private protected ColumnOptionsBase(string outputColumnName, string inputColumnName,
+                int maxNumKeys, SortOrder sort, string[] term, bool textKeyValues)
+            {
+                Contracts.CheckNonWhiteSpace(outputColumnName, nameof(outputColumnName));
+                OutputColumnName = outputColumnName;
+                InputColumnName = inputColumnName ?? outputColumnName;
+                Sort = sort;
+                MaxNumKeys = maxNumKeys;
+                Term = term;
+                TextKeyValues = textKeyValues;
+            }
+        }
+
+        /// <summary>
+        /// Describes how the transformer handles one column pair.
+        /// </summary>
+        public sealed class ColumnOptions : ColumnOptionsBase
+        {
             /// <summary>
             /// Describes how the transformer handles one column pair.
             /// </summary>
@@ -59,19 +78,13 @@ namespace Microsoft.ML.Transforms
                 SortOrder sort = Defaults.Sort,
                 string[] term = null,
                 bool textKeyValues = false)
+                : base(outputColumnName, inputColumnName, maxNumKeys, sort, term, textKeyValues)
             {
-                Contracts.CheckNonWhiteSpace(outputColumnName, nameof(outputColumnName));
-                OutputColumnName = outputColumnName;
-                InputColumnName = inputColumnName ?? outputColumnName;
-                Sort = sort;
-                MaxNumKeys = maxNumKeys;
-                Term = term;
-                TextKeyValues = textKeyValues;
             }
         }
 
         private readonly IHost _host;
-        private readonly ColumnOptions[] _columns;
+        private readonly ColumnOptionsBase[] _columns;
         private readonly IDataView _keyData;
 
         /// <summary>
@@ -88,7 +101,7 @@ namespace Microsoft.ML.Transforms
         {
         }
 
-        internal ValueToKeyMappingEstimator(IHostEnvironment env, ColumnOptions[] columns, IDataView keyData = null)
+        internal ValueToKeyMappingEstimator(IHostEnvironment env, ColumnOptionsBase[] columns, IDataView keyData = null)
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(nameof(ValueToKeyMappingEstimator));

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -214,7 +214,7 @@ namespace Microsoft.ML.Transforms
         private readonly bool[] _textMetadata;
         private const string RegistrationName = "Term";
 
-        private static (string outputColumnName, string inputColumnName)[] GetColumnPairs(ValueToKeyMappingEstimator.ColumnOptions[] columns)
+        private static (string outputColumnName, string inputColumnName)[] GetColumnPairs(ValueToKeyMappingEstimator.ColumnOptionsBase[] columns)
         {
             Contracts.CheckValue(columns, nameof(columns));
             return columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray();
@@ -253,7 +253,7 @@ namespace Microsoft.ML.Transforms
         { }
 
         internal ValueToKeyMappingTransformer(IHostEnvironment env, IDataView input,
-            ValueToKeyMappingEstimator.ColumnOptions[] columns, IDataView keyData, bool autoConvert)
+            ValueToKeyMappingEstimator.ColumnOptionsBase[] columns, IDataView keyData, bool autoConvert)
             : base(Contracts.CheckRef(env, nameof(env)).Register(RegistrationName), GetColumnPairs(columns))
         {
             using (var ch = Host.Start("Training"))
@@ -513,7 +513,7 @@ namespace Microsoft.ML.Transforms
         /// This builds the <see cref="TermMap"/> instances per column.
         /// </summary>
         private static TermMap[] Train(IHostEnvironment env, IChannel ch, ColInfo[] infos,
-            IDataView keyData, ValueToKeyMappingEstimator.ColumnOptions[] columns, IDataView trainingData, bool autoConvert)
+            IDataView keyData, ValueToKeyMappingEstimator.ColumnOptionsBase[] columns, IDataView trainingData, bool autoConvert)
         {
             Contracts.AssertValue(env);
             env.AssertValue(ch);

--- a/src/Microsoft.ML.FastTree/FastTree.cs
+++ b/src/Microsoft.ML.FastTree/FastTree.cs
@@ -2821,7 +2821,7 @@ namespace Microsoft.ML.Trainers.FastTree
 
         private protected abstract uint VerCategoricalSplitSerialized { get; }
 
-        protected internal readonly DataViewType InputType;
+        internal readonly DataViewType InputType;
         DataViewType IValueMapper.InputType => InputType;
 
         protected readonly DataViewType OutputType;

--- a/src/Microsoft.ML.OnnxConverter/OnnxExportExtensions.cs
+++ b/src/Microsoft.ML.OnnxConverter/OnnxExportExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Google.Protobuf;
 using Microsoft.Data.DataView;
+using Microsoft.ML.Data;
 using Microsoft.ML.Model.OnnxConverter;
 using static Microsoft.ML.Model.OnnxConverter.OnnxCSharpToProtoWrapper;
 
@@ -24,7 +25,7 @@ namespace Microsoft.ML
         [BestFriend]
         internal static ModelProto ConvertToOnnxProtobuf(this ModelOperationsCatalog catalog, ITransformer transform, IDataView inputData)
         {
-            var env = catalog.Environment;
+            var env = catalog.GetEnvironment();
             var ctx = new OnnxContextImpl(env, "model", "ML.NET", "0", 0, "machinelearning.dotnet", OnnxVersion.Stable);
             var outputData = transform.Transform(inputData);
             LinkedList<ITransformCanSaveOnnx> transforms = null;

--- a/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML
                 int approximationRank = MatrixFactorizationTrainer.Defaults.ApproximationRank,
                 double learningRate = MatrixFactorizationTrainer.Defaults.LearningRate,
                 int numberOfIterations = MatrixFactorizationTrainer.Defaults.NumIterations)
-                    => new MatrixFactorizationTrainer(Owner.Environment, labelColumn, matrixColumnIndexColumnName, matrixRowIndexColumnName,
+                    => new MatrixFactorizationTrainer(Owner.GetEnvironment(), labelColumn, matrixColumnIndexColumnName, matrixRowIndexColumnName,
                         approximationRank, learningRate, numberOfIterations);
 
             /// <summary>
@@ -90,7 +90,7 @@ namespace Microsoft.ML
             /// </example>
             public MatrixFactorizationTrainer MatrixFactorization(
                 MatrixFactorizationTrainer.Options options)
-                    => new MatrixFactorizationTrainer(Owner.Environment, options);
+                    => new MatrixFactorizationTrainer(Owner.GetEnvironment(), options);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StaticPipe/DataLoadSaveOperationsExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/DataLoadSaveOperationsExtensions.cs
@@ -36,6 +36,6 @@ namespace Microsoft.ML.StaticPipe
             this DataOperationsCatalog catalog, Func<Context, TShape> func, IMultiStreamSource files = null,
             bool hasHeader = false, char separator = '\t', bool allowQuoting = true, bool allowSparse = true,
             bool trimWhitspace = false)
-         => CreateLoader(catalog.Environment, func, files, separator, hasHeader, allowQuoting, allowSparse, trimWhitspace);
+         => CreateLoader(catalog.GetEnvironment(), func, files, separator, hasHeader, allowQuoting, allowSparse, trimWhitspace);
     }
 }

--- a/src/Microsoft.ML.StaticPipe/SchemaBearing.cs
+++ b/src/Microsoft.ML.StaticPipe/SchemaBearing.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.StaticPipe
     /// <typeparam name="TShape">The shape type parameter.</typeparam>
     public abstract class SchemaBearing<TShape>
     {
-        protected internal readonly IHostEnvironment Env;
+        internal readonly IHostEnvironment Env;
         internal readonly StaticSchemaShape Shape;
 
         private StaticPipeUtils.IndexHelper<TShape> _indexer;

--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// Describes how the transformer handles one column pair.
         /// </summary>
-        public class ColumnOptions : ValueToKeyMappingEstimator.ColumnOptions
+        public sealed class ColumnOptions : ValueToKeyMappingEstimator.ColumnOptionsBase
         {
             public readonly OneHotEncodingTransformer.OutputKind OutputKind;
             /// <summary>

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML
                 int permutationCount = 1)
         {
             return PermutationFeatureImportance<TModel, RegressionMetrics, RegressionMetricsStatistics>.GetImportanceMetricsMatrix(
-                            CatalogUtils.GetEnvironment(catalog),
+                            catalog.GetEnvironment(),
                             model,
                             data,
                             idv => catalog.Evaluate(idv, label),
@@ -143,7 +143,7 @@ namespace Microsoft.ML
                 int permutationCount = 1)
         {
             return PermutationFeatureImportance<TModel, BinaryClassificationMetrics, BinaryClassificationMetricsStatistics>.GetImportanceMetricsMatrix(
-                            CatalogUtils.GetEnvironment(catalog),
+                            catalog.GetEnvironment(),
                             model,
                             data,
                             idv => catalog.Evaluate(idv, label),
@@ -217,7 +217,7 @@ namespace Microsoft.ML
                 int permutationCount = 1)
         {
             return PermutationFeatureImportance<TModel, MultiClassClassifierMetrics, MultiClassClassifierMetricsStatistics>.GetImportanceMetricsMatrix(
-                            CatalogUtils.GetEnvironment(catalog),
+                            catalog.GetEnvironment(),
                             model,
                             data,
                             idv => catalog.Evaluate(idv, label),
@@ -298,7 +298,7 @@ namespace Microsoft.ML
                 int permutationCount = 1)
         {
             return PermutationFeatureImportance<TModel, RankingMetrics, RankingMetricsStatistics>.GetImportanceMetricsMatrix(
-                            CatalogUtils.GetEnvironment(catalog),
+                            catalog.GetEnvironment(),
                             model,
                             data,
                             idv => catalog.Evaluate(idv, label, groupId),

--- a/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
+++ b/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
@@ -126,6 +126,10 @@ namespace Microsoft.ML.Transforms.Text
             return new TransformWrapper(_host, WordBagBuildingTransformer.Create(_host, options, input), true);
         }
 
+        /// <summary>
+        /// Schema propagation for estimators.
+        /// Returns the output schema shape of the estimator, if the input schema shape is like the one provided.
+        /// </summary>
         public SchemaShape GetOutputSchema(SchemaShape inputSchema)
         {
             _host.CheckValue(inputSchema, nameof(inputSchema));
@@ -278,6 +282,10 @@ namespace Microsoft.ML.Transforms.Text
             return new TransformWrapper(_host, WordHashBagProducingTransformer.Create(_host, options, input), true);
         }
 
+        /// <summary>
+        /// Schema propagation for estimators.
+        /// Returns the output schema shape of the estimator, if the input schema shape is like the one provided.
+        /// </summary>
         public SchemaShape GetOutputSchema(SchemaShape inputSchema)
         {
             _host.CheckValue(inputSchema, nameof(inputSchema));

--- a/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
+++ b/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML.Data;
+using Microsoft.ML.Data.DataLoadSave;
 using Microsoft.ML.Internal.Utilities;
 
 namespace Microsoft.ML.Transforms.Text
@@ -14,8 +15,9 @@ namespace Microsoft.ML.Transforms.Text
     /// Produces a bag of counts of ngrams (sequences of consecutive words) in a given text.
     /// It does so by building a dictionary of ngrams and using the id in the dictionary as the index in the bag.
     /// </summary>
-    public sealed class WordBagEstimator : TrainedWrapperEstimatorBase
+    public sealed class WordBagEstimator : IEstimator<ITransformer>
     {
+        private readonly IHost _host;
         private readonly (string outputColumnName, string[] sourceColumnsNames)[] _columns;
         private readonly int _ngramLength;
         private readonly int _skipLength;
@@ -89,12 +91,14 @@ namespace Microsoft.ML.Transforms.Text
             bool allLengths = true,
             int maxNumTerms = 10000000,
             NgramExtractingEstimator.WeightingCriteria weighting = NgramExtractingEstimator.WeightingCriteria.Tf)
-            : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(WordBagEstimator)))
         {
+            Contracts.CheckValue(env, nameof(env));
+            _host = env.Register(nameof(WordBagEstimator));
+
             foreach (var (outputColumnName, inputColumnName) in columns)
             {
-                Host.CheckUserArg(Utils.Size(inputColumnName) > 0, nameof(columns));
-                Host.CheckValue(outputColumnName, nameof(columns));
+                _host.CheckUserArg(Utils.Size(inputColumnName) > 0, nameof(columns));
+                _host.CheckValue(outputColumnName, nameof(columns));
             }
 
             _columns = columns;
@@ -106,7 +110,7 @@ namespace Microsoft.ML.Transforms.Text
         }
 
         /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
-        public override TransformWrapper Fit(IDataView input)
+        public ITransformer Fit(IDataView input)
         {
             // Create arguments.
             var options = new WordBagBuildingTransformer.Options
@@ -119,7 +123,16 @@ namespace Microsoft.ML.Transforms.Text
                 Weighting = _weighting
             };
 
-            return new TransformWrapper(Host, WordBagBuildingTransformer.Create(Host, options, input), true);
+            return new TransformWrapper(_host, WordBagBuildingTransformer.Create(_host, options, input), true);
+        }
+
+        public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+        {
+            _host.CheckValue(inputSchema, nameof(inputSchema));
+
+            var fakeSchema = FakeSchemaFactory.Create(inputSchema);
+            var transformer = Fit(new EmptyDataView(_host, fakeSchema));
+            return SchemaShape.Create(transformer.GetOutputSchema(fakeSchema));
         }
     }
 
@@ -127,8 +140,9 @@ namespace Microsoft.ML.Transforms.Text
     /// Produces a bag of counts of ngrams (sequences of consecutive words of length 1-n) in a given text.
     /// It does so by hashing each ngram and using the hash value as the index in the bag.
     /// </summary>
-    public sealed class WordHashBagEstimator : TrainedWrapperEstimatorBase
+    public sealed class WordHashBagEstimator : IEstimator<ITransformer>
     {
+        private readonly IHost _host;
         private readonly (string outputColumnName, string[] inputColumnNames)[] _columns;
         private readonly int _hashBits;
         private readonly int _ngramLength;
@@ -225,12 +239,14 @@ namespace Microsoft.ML.Transforms.Text
             uint seed = 314489979,
             bool ordered = true,
             int invertHash = 0)
-            : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(WordBagEstimator)))
         {
+            Contracts.CheckValue(env, nameof(env));
+            _host = env.Register(nameof(WordHashBagEstimator));
+
             foreach (var (input, output) in columns)
             {
-                Host.CheckUserArg(Utils.Size(input) > 0, nameof(input));
-                Host.CheckValue(output, nameof(input));
+                _host.CheckUserArg(Utils.Size(input) > 0, nameof(input));
+                _host.CheckValue(output, nameof(input));
             }
 
             _columns = columns;
@@ -244,7 +260,7 @@ namespace Microsoft.ML.Transforms.Text
         }
 
         /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
-        public override TransformWrapper Fit(IDataView input)
+        public ITransformer Fit(IDataView input)
         {
             // Create arguments.
             var options = new WordHashBagProducingTransformer.Options
@@ -259,7 +275,16 @@ namespace Microsoft.ML.Transforms.Text
                 InvertHash = _invertHash
             };
 
-            return new TransformWrapper(Host, WordHashBagProducingTransformer.Create(Host, options, input), true);
+            return new TransformWrapper(_host, WordHashBagProducingTransformer.Create(_host, options, input), true);
+        }
+
+        public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+        {
+            _host.CheckValue(inputSchema, nameof(inputSchema));
+
+            var fakeSchema = FakeSchemaFactory.Create(inputSchema);
+            var transformer = Fit(new EmptyDataView(_host, fakeSchema));
+            return SchemaShape.Create(transformer.GetOutputSchema(fakeSchema));
         }
     }
 }


### PR DESCRIPTION
Towards #1602. When performing what I hope is one of my final reviews of the public surface area of `Microsoft.ML.Data` I saw many "small" items, each too petty to warrant separate issues, but that we nonetheless do not want in the public surface. This is in the vein of #2300 and other similar PRs. Special emphasis was placed on making sure we don't have abstract protected members visible as part of the public surface, and other such things as this.

In my review of the assembly I did not address those types or members I knew were being taken care of through other channels. (E.g., the attribute bearing marker interfaces for `IComponentFactory`, or the calibrator.)