### PR TITLE
Add API to save/load models with their input schema

### DIFF
--- a/src/Microsoft.ML.Core/Data/IEstimator.cs
+++ b/src/Microsoft.ML.Core/Data/IEstimator.cs
@@ -224,7 +224,7 @@ namespace Microsoft.ML
     /// The 'data loader' takes a certain kind of input and turns it into an <see cref="IDataView"/>.
     /// </summary>
     /// <typeparam name="TSource">The type of input the loader takes.</typeparam>
-    public interface IDataLoader<in TSource>
+    public interface IDataLoader<in TSource> : ICanSaveModel
     {
         /// <summary>
         /// Produce the data view from the specified input.

--- a/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/CompositeDataLoader.cs
@@ -4,7 +4,11 @@
 
 using System.IO;
 using Microsoft.Data.DataView;
-using Microsoft.ML.Model;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+
+[assembly: LoadableClass(CompositeDataLoader<IMultiStreamSource, ITransformer>.Summary, typeof(CompositeDataLoader<IMultiStreamSource, ITransformer>), null, typeof(SignatureLoadModel),
+    "Composite Loader", CompositeDataLoader<IMultiStreamSource, ITransformer>.LoaderSignature)]
 
 namespace Microsoft.ML.Data
 {
@@ -15,6 +19,10 @@ namespace Microsoft.ML.Data
     public sealed class CompositeDataLoader<TSource, TLastTransformer> : IDataLoader<TSource>
         where TLastTransformer : class, ITransformer
     {
+        private const string LoaderDirectory = "Loader";
+        private const string LegacyLoaderDirectory = "Reader";
+        private const string TransformerDirectory = TransformerChain.LoaderSignature;
+
         /// <summary>
         /// The underlying data loader.
         /// </summary>
@@ -31,6 +39,24 @@ namespace Microsoft.ML.Data
 
             Loader = loader;
             Transformer = transformerChain ?? new TransformerChain<TLastTransformer>();
+        }
+
+        private CompositeDataLoader(IHost host, ModelLoadContext ctx)
+        {
+            if (!ctx.LoadModelOrNull<IDataLoader<TSource>, SignatureLoadModel>(host, out Loader, LegacyLoaderDirectory))
+                ctx.LoadModel<IDataLoader<TSource>, SignatureLoadModel>(host, out Loader, LoaderDirectory);
+            ctx.LoadModel<TransformerChain<TLastTransformer>, SignatureLoadModel>(host, out Transformer, TransformerDirectory);
+        }
+
+        private static CompositeDataLoader<TSource, TLastTransformer> Create(IHostEnvironment env, ModelLoadContext ctx)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            IHost h = env.Register(LoaderSignature);
+
+            h.CheckValue(ctx, nameof(ctx));
+            ctx.CheckAtModel(GetVersionInfo());
+
+            return h.Apply("Loading Model", ch => new CompositeDataLoader<TSource, TLastTransformer>(h, ctx));
         }
 
         /// <summary>
@@ -62,6 +88,16 @@ namespace Microsoft.ML.Data
             return new CompositeDataLoader<TSource, TNewLast>(Loader, Transformer.Append(transformer));
         }
 
+        void ICanSaveModel.Save(ModelSaveContext ctx)
+        {
+            Contracts.CheckValue(ctx, nameof(ctx));
+            ctx.CheckAtModel();
+            ctx.SetVersionInfo(GetVersionInfo());
+
+            ctx.SaveModel(Loader, LoaderDirectory);
+            ctx.SaveModel(Transformer, TransformerDirectory);
+        }
+
         /// <summary>
         /// Save the contents to a stream, as a "model file".
         /// </summary>
@@ -76,47 +112,27 @@ namespace Microsoft.ML.Data
                 using (var rep = RepositoryWriter.CreateNew(outputStream, ch))
                 {
                     ch.Trace("Saving data loader");
-                    ModelSaveContext.SaveModel(rep, Loader, "Reader");
+                    ModelSaveContext.SaveModel(rep, Loader, LoaderDirectory);
 
                     ch.Trace("Saving transformer chain");
-                    ModelSaveContext.SaveModel(rep, Transformer, TransformerChain.LoaderSignature);
+                    ModelSaveContext.SaveModel(rep, Transformer, TransformerDirectory);
                     rep.Commit();
                 }
             }
         }
-    }
 
-    /// <summary>
-    /// Utility class to facilitate loading from a stream.
-    /// </summary>
-    [BestFriend]
-    internal static class CompositeDataLoader
-    {
-        /// <summary>
-        /// Save the contents to a stream, as a "model file".
-        /// </summary>
-        public static void SaveTo<TSource>(this IDataLoader<TSource> loader, IHostEnvironment env, Stream outputStream)
-            => new CompositeDataLoader<TSource, ITransformer>(loader).SaveTo(env, outputStream);
+        internal const string Summary = "A loader that encapsulates a loader and a transformer chain.";
 
-        /// <summary>
-        /// Load the pipeline from stream.
-        /// </summary>
-        public static CompositeDataLoader<IMultiStreamSource, ITransformer> LoadFrom(IHostEnvironment env, Stream stream)
+        internal const string LoaderSignature = "CompositeLoader";
+        private static VersionInfo GetVersionInfo()
         {
-            Contracts.CheckValue(env, nameof(env));
-            env.CheckValue(stream, nameof(stream));
-
-            env.Check(stream.CanRead && stream.CanSeek, "Need a readable and seekable stream to load");
-            using (var rep = RepositoryReader.Open(stream, env))
-            using (var ch = env.Start("Loading pipeline"))
-            {
-                ch.Trace("Loading data loader");
-                ModelLoadContext.LoadModel<IDataLoader<IMultiStreamSource>, SignatureLoadModel>(env, out var loader, rep, "Reader");
-
-                ch.Trace("Loader transformer chain");
-                ModelLoadContext.LoadModel<TransformerChain<ITransformer>, SignatureLoadModel>(env, out var transformerChain, rep, TransformerChain.LoaderSignature);
-                return new CompositeDataLoader<IMultiStreamSource, ITransformer>(loader, transformerChain);
-            }
+            return new VersionInfo(
+                modelSignature: "CMPSTLDR",
+                verWrittenCur: 0x00010001, // Initial
+                verReadableCur: 0x00010001,
+                verWeCanReadBack: 0x00010001,
+                loaderSignature: LoaderSignature,
+                loaderAssemblyName: typeof(CompositeDataLoader<,>).Assembly.FullName);
         }
     }
 }

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -12,7 +12,6 @@ using Microsoft.ML;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Utilities;
-using Microsoft.ML.Model;
 
 [assembly: LoadableClass(TextLoader.Summary, typeof(ILegacyDataLoader), typeof(TextLoader), typeof(TextLoader.Options), typeof(SignatureDataLoader),
     "Text Loader", "TextLoader", "Text", DocName = "loader/TextLoader.md")]
@@ -20,12 +19,15 @@ using Microsoft.ML.Model;
 [assembly: LoadableClass(TextLoader.Summary, typeof(ILegacyDataLoader), typeof(TextLoader), null, typeof(SignatureLoadDataLoader),
     "Text Loader", TextLoader.LoaderSignature)]
 
+[assembly: LoadableClass(TextLoader.Summary, typeof(TextLoader), null, typeof(SignatureLoadModel),
+    "Text Loader", TextLoader.LoaderSignature)]
+
 namespace Microsoft.ML.Data
 {
     /// <summary>
     /// Loads a text file into an IDataView. Supports basic mapping from input columns to <see cref="IDataView"/> columns.
     /// </summary>
-    public sealed partial class TextLoader : IDataLoader<IMultiStreamSource>, ICanSaveModel
+    public sealed partial class TextLoader : IDataLoader<IMultiStreamSource>
     {
         /// <summary>
         /// Describes how an input column should be mapped to an <see cref="IDataView"/> column.

--- a/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TransformerChain.cs
@@ -255,7 +255,9 @@ namespace Microsoft.ML.Data
             {
                 try
                 {
-                    ModelLoadContext.LoadModel<TransformerChain<ITransformer>, SignatureLoadModel>(env, out var transformerChain, rep, LoaderSignature);
+                    ModelLoadContext.LoadModelOrNull<TransformerChain<ITransformer>, SignatureLoadModel>(env, out var transformerChain, rep, LoaderSignature);
+                    if (transformerChain == null)
+                        ModelLoadContext.LoadModel<TransformerChain<ITransformer>, SignatureLoadModel>(env, out transformerChain, rep, $@"Model\{LoaderSignature}");
                     return transformerChain;
                 }
                 catch (FormatException ex)

--- a/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/PredictorModelImpl.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.EntryPoints
             var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubModel;
+                predictor = calibrated.WeaklyTypedSubModel;
                 calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             }
             var canGetTrainingLabelNames = predictor as ICanGetTrainingLabelNames;

--- a/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/SummarizePredictor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.EntryPoints
             var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubModel;
+                predictor = calibrated.WeaklyTypedSubModel;
                 calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             }
 

--- a/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
@@ -45,12 +45,33 @@ namespace Microsoft.ML
         /// <param name="stream">A writeable, seekable stream to save to.</param>
         public void Save(ITransformer model, Stream stream) => model.SaveTo(Environment, stream);
 
+        public void Save<TSource>(IDataLoader<TSource> model, Stream stream)
+        {
+            using (var rep = RepositoryWriter.CreateNew(stream))
+            {
+                ModelSaveContext.SaveModel(rep, model, "Model");
+                rep.Commit();
+            }
+        }
+
+        public void Save<TSource>(IDataLoader<TSource> loader, ITransformer model, Stream stream) =>
+            Save(new CompositeDataLoader<TSource, ITransformer>(loader, new TransformerChain<ITransformer>(model)), stream);
+
         /// <summary>
         /// Load the model from the stream.
         /// </summary>
         /// <param name="stream">A readable, seekable stream to load from.</param>
         /// <returns>The loaded model.</returns>
         public ITransformer Load(Stream stream) => TransformerChain.LoadFrom(Environment, stream);
+
+        public IDataLoader<IMultiStreamSource> LoadAsCompositeDataLoader(Stream stream)
+        {
+            using (var rep = RepositoryReader.Open(stream))
+            {
+                ModelLoadContext.LoadModel<IDataLoader<IMultiStreamSource>, SignatureLoadModel>(Environment, out var model, rep, "Model");
+                return model;
+            }
+        }
 
         /// <summary>
         /// The catalog of model explainability operations.

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -14,7 +14,6 @@ using Microsoft.ML.Calibrators;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
 using Microsoft.ML.EntryPoints;
-using Microsoft.ML.Internal.Internallearn;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Model;
 using Microsoft.ML.Model.OnnxConverter;
@@ -58,19 +57,19 @@ using Newtonsoft.Json.Linq;
     "Naive Calibration Executor",
     NaiveCalibrator.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(ValueMapperCalibratedModelParameters<IPredictorProducing<float>, ICalibrator>), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(ValueMapperCalibratedModelParameters<object, ICalibrator>), null, typeof(SignatureLoadModel),
     "Calibrated Predictor Executor",
     ValueMapperCalibratedModelParameters<IPredictorProducing<float>, ICalibrator>.LoaderSignature, "BulkCaliPredExec")]
 
-[assembly: LoadableClass(typeof(FeatureWeightsCalibratedModelParameters<IPredictorWithFeatureWeights<float>, ICalibrator>), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(FeatureWeightsCalibratedModelParameters<object, ICalibrator>), null, typeof(SignatureLoadModel),
     "Feature Weights Calibrated Predictor Executor",
     FeatureWeightsCalibratedModelParameters<IPredictorWithFeatureWeights<float>, ICalibrator>.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(ParameterMixingCalibratedModelParameters<IPredictorWithFeatureWeights<float>, ICalibrator>), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(ParameterMixingCalibratedModelParameters<object, ICalibrator>), null, typeof(SignatureLoadModel),
     "Parameter Mixing Calibrated Predictor Executor",
     ParameterMixingCalibratedModelParameters<IPredictorWithFeatureWeights<float>, ICalibrator>.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(SchemaBindableCalibratedModelParameters<IPredictorProducing<float>, ICalibrator>), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(SchemaBindableCalibratedModelParameters<object, ICalibrator>), null, typeof(SignatureLoadModel),
     "Schema Bindable Calibrated Predictor", SchemaBindableCalibratedModelParameters<IPredictorProducing<float>, ICalibrator>.LoaderSignature)]
 
 [assembly: LoadableClass(typeof(void), typeof(Calibrate), null, typeof(SignatureEntryPointModule), "Calibrate")]
@@ -147,8 +146,8 @@ namespace Microsoft.ML.Calibrators
     [BestFriend]
     internal interface IWeaklyTypedCalibratedModelParameters
     {
-        IPredictorProducing<float> WeeklyTypedSubModel { get; }
-        ICalibrator WeeklyTypedCalibrator { get; }
+        IPredictorProducing<float> WeaklyTypedSubModel { get; }
+        ICalibrator WeaklyTypedCalibrator { get; }
     }
 
     /// <summary>
@@ -186,8 +185,8 @@ namespace Microsoft.ML.Calibrators
         public TCalibrator Calibrator { get; }
 
         // Type-unsafed accessors of strongly-typed members.
-        IPredictorProducing<float> IWeaklyTypedCalibratedModelParameters.WeeklyTypedSubModel => (IPredictorProducing<float>)SubModel;
-        ICalibrator IWeaklyTypedCalibratedModelParameters.WeeklyTypedCalibrator => Calibrator;
+        IPredictorProducing<float> IWeaklyTypedCalibratedModelParameters.WeaklyTypedSubModel => (IPredictorProducing<float>)SubModel;
+        ICalibrator IWeaklyTypedCalibratedModelParameters.WeaklyTypedCalibrator => Calibrator;
 
         PredictionKind IPredictor.PredictionKind => ((IPredictorProducing<float>)SubModel).PredictionKind;
 
@@ -198,6 +197,7 @@ namespace Microsoft.ML.Calibrators
             Host = env.Register(name);
             Host.CheckValue(predictor, nameof(predictor));
             Host.CheckValue(calibrator, nameof(calibrator));
+            Host.Assert(predictor is IPredictorProducing<float>);
 
             SubModel = predictor;
             Calibrator = calibrator;
@@ -270,7 +270,7 @@ namespace Microsoft.ML.Calibrators
         CalibratedModelParametersBase<TSubModel, TCalibrator>,
         IValueMapperDist, IFeatureContributionMapper, ICalculateFeatureContribution,
         IDistCanSavePfa, IDistCanSaveOnnx
-        where TSubModel : class, IPredictorProducing<float>
+        where TSubModel : class
         where TCalibrator : class, ICalibrator
     {
         private readonly IValueMapper _mapper;
@@ -380,7 +380,7 @@ namespace Microsoft.ML.Calibrators
     [BestFriend]
     internal sealed class ValueMapperCalibratedModelParameters<TSubModel, TCalibrator> :
         ValueMapperCalibratedModelParametersBase<TSubModel, TCalibrator>, ICanSaveModel
-        where TSubModel : class, IPredictorProducing<float>
+        where TSubModel : class
         where TCalibrator : class, ICalibrator
     {
         internal ValueMapperCalibratedModelParameters(IHostEnvironment env, TSubModel predictor, TCalibrator calibrator)
@@ -442,7 +442,7 @@ namespace Microsoft.ML.Calibrators
         ValueMapperCalibratedModelParametersBase<TSubModel, TCalibrator>,
         IPredictorWithFeatureWeights<float>,
         ICanSaveModel
-        where TSubModel : class, IPredictorWithFeatureWeights<float>
+        where TSubModel : class
         where TCalibrator : class, ICalibrator
     {
         private readonly IPredictorWithFeatureWeights<float> _featureWeights;
@@ -451,7 +451,8 @@ namespace Microsoft.ML.Calibrators
             TCalibrator calibrator)
             : base(env, RegistrationName, predictor, calibrator)
         {
-            _featureWeights = predictor;
+            Host.Assert(predictor is IPredictorWithFeatureWeights<float>);
+            _featureWeights = predictor as IPredictorWithFeatureWeights<float>;
         }
 
         internal const string LoaderSignature = "FeatWCaliPredExec";
@@ -506,7 +507,7 @@ namespace Microsoft.ML.Calibrators
         IParameterMixer<float>,
         IPredictorWithFeatureWeights<float>,
         ICanSaveModel
-        where TSubModel : class, IPredictorWithFeatureWeights<float>
+        where TSubModel : class
         where TCalibrator : class, ICalibrator
     {
         private readonly IPredictorWithFeatureWeights<float> _featureWeights;
@@ -516,7 +517,8 @@ namespace Microsoft.ML.Calibrators
         {
             Host.Check(predictor is IParameterMixer<float>, "Predictor does not implement " + nameof(IParameterMixer<float>));
             Host.Check(calibrator is IParameterMixer, "Calibrator does not implement " + nameof(IParameterMixer));
-            _featureWeights = predictor;
+            Host.Assert(predictor is IPredictorWithFeatureWeights<float>);
+            _featureWeights = predictor as IPredictorWithFeatureWeights<float>;
         }
 
         internal const string LoaderSignature = "PMixCaliPredExec";
@@ -538,7 +540,7 @@ namespace Microsoft.ML.Calibrators
         {
             Host.Check(SubModel is IParameterMixer<float>, "Predictor does not implement " + nameof(IParameterMixer));
             Host.Check(SubModel is IPredictorWithFeatureWeights<float>, "Predictor does not implement " + nameof(IPredictorWithFeatureWeights<float>));
-            _featureWeights = SubModel;
+            _featureWeights = SubModel as IPredictorWithFeatureWeights<float>;
         }
 
         private static ParameterMixingCalibratedModelParameters<TSubModel, TCalibrator> Create(IHostEnvironment env, ModelLoadContext ctx)
@@ -587,7 +589,7 @@ namespace Microsoft.ML.Calibrators
     [BestFriend]
     internal sealed class SchemaBindableCalibratedModelParameters<TSubModel, TCalibrator> : CalibratedModelParametersBase<TSubModel, TCalibrator>, ISchemaBindableMapper, ICanSaveModel,
         IBindableCanSavePfa, IBindableCanSaveOnnx, IFeatureContributionMapper
-        where TSubModel : class, IPredictorProducing<float>
+        where TSubModel : class
         where TCalibrator : class, ICalibrator
     {
         private sealed class Bound : ISchemaBoundRowMapper
@@ -702,14 +704,14 @@ namespace Microsoft.ML.Calibrators
         internal SchemaBindableCalibratedModelParameters(IHostEnvironment env, TSubModel predictor, TCalibrator calibrator)
             : base(env, LoaderSignature, predictor, calibrator)
         {
-            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubModel);
+            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubModel as IPredictorProducing<float>);
             _featureContribution = SubModel as IFeatureContributionMapper;
         }
 
         private SchemaBindableCalibratedModelParameters(IHostEnvironment env, ModelLoadContext ctx)
             : base(env, LoaderSignature, GetPredictor(env, ctx), GetCalibrator(env, ctx))
         {
-            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubModel);
+            _bindable = ScoreUtils.GetSchemaBindableMapper(Host, SubModel as IPredictorProducing<float>);
             _featureContribution = SubModel as IFeatureContributionMapper;
         }
 

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -7,24 +7,23 @@ using Microsoft.Data.DataView;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Data.IO;
-using Microsoft.ML.Model;
 
-[assembly: LoadableClass(typeof(BinaryPredictionTransformer<IPredictorProducing<float>>), typeof(BinaryPredictionTransformer), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(BinaryPredictionTransformer<object>), typeof(BinaryPredictionTransformer), null, typeof(SignatureLoadModel),
     "", BinaryPredictionTransformer.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(MulticlassPredictionTransformer<IPredictorProducing<VBuffer<float>>>), typeof(MulticlassPredictionTransformer), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(MulticlassPredictionTransformer<object>), typeof(MulticlassPredictionTransformer), null, typeof(SignatureLoadModel),
     "", MulticlassPredictionTransformer.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(RegressionPredictionTransformer<IPredictorProducing<float>>), typeof(RegressionPredictionTransformer), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(RegressionPredictionTransformer<object>), typeof(RegressionPredictionTransformer), null, typeof(SignatureLoadModel),
     "", RegressionPredictionTransformer.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(RankingPredictionTransformer<IPredictorProducing<float>>), typeof(RankingPredictionTransformer), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(RankingPredictionTransformer<object>), typeof(RankingPredictionTransformer), null, typeof(SignatureLoadModel),
     "", RankingPredictionTransformer.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(AnomalyPredictionTransformer<IPredictorProducing<float>>), typeof(AnomalyPredictionTransformer), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(AnomalyPredictionTransformer<object>), typeof(AnomalyPredictionTransformer), null, typeof(SignatureLoadModel),
     "", AnomalyPredictionTransformer.LoaderSignature)]
 
-[assembly: LoadableClass(typeof(ClusteringPredictionTransformer<IPredictorProducing<VBuffer<float>>>), typeof(ClusteringPredictionTransformer), null, typeof(SignatureLoadModel),
+[assembly: LoadableClass(typeof(ClusteringPredictionTransformer<object>), typeof(ClusteringPredictionTransformer), null, typeof(SignatureLoadModel),
     "", ClusteringPredictionTransformer.LoaderSignature)]
 
 namespace Microsoft.ML.Data
@@ -595,47 +594,47 @@ namespace Microsoft.ML.Data
     {
         public const string LoaderSignature = "BinaryPredXfer";
 
-        public static BinaryPredictionTransformer<IPredictorProducing<float>> Create(IHostEnvironment env, ModelLoadContext ctx)
-            => new BinaryPredictionTransformer<IPredictorProducing<float>>(env, ctx);
+        public static BinaryPredictionTransformer<object> Create(IHostEnvironment env, ModelLoadContext ctx)
+            => new BinaryPredictionTransformer<object>(env, ctx);
     }
 
     internal static class MulticlassPredictionTransformer
     {
         public const string LoaderSignature = "MulticlassPredXfer";
 
-        public static MulticlassPredictionTransformer<IPredictorProducing<VBuffer<float>>> Create(IHostEnvironment env, ModelLoadContext ctx)
-            => new MulticlassPredictionTransformer<IPredictorProducing<VBuffer<float>>>(env, ctx);
+        public static MulticlassPredictionTransformer<object> Create(IHostEnvironment env, ModelLoadContext ctx)
+            => new MulticlassPredictionTransformer<object>(env, ctx);
     }
 
     internal static class RegressionPredictionTransformer
     {
         public const string LoaderSignature = "RegressionPredXfer";
 
-        public static RegressionPredictionTransformer<IPredictorProducing<float>> Create(IHostEnvironment env, ModelLoadContext ctx)
-            => new RegressionPredictionTransformer<IPredictorProducing<float>>(env, ctx);
+        public static RegressionPredictionTransformer<object> Create(IHostEnvironment env, ModelLoadContext ctx)
+            => new RegressionPredictionTransformer<object>(env, ctx);
     }
 
     internal static class RankingPredictionTransformer
     {
         public const string LoaderSignature = "RankingPredXfer";
 
-        public static RankingPredictionTransformer<IPredictorProducing<float>> Create(IHostEnvironment env, ModelLoadContext ctx)
-            => new RankingPredictionTransformer<IPredictorProducing<float>>(env, ctx);
+        public static RankingPredictionTransformer<object> Create(IHostEnvironment env, ModelLoadContext ctx)
+            => new RankingPredictionTransformer<object>(env, ctx);
     }
 
     internal static class AnomalyPredictionTransformer
     {
         public const string LoaderSignature = "AnomalyPredXfer";
 
-        public static AnomalyPredictionTransformer<IPredictorProducing<float>> Create(IHostEnvironment env, ModelLoadContext ctx)
-            => new AnomalyPredictionTransformer<IPredictorProducing<float>>(env, ctx);
+        public static AnomalyPredictionTransformer<object> Create(IHostEnvironment env, ModelLoadContext ctx)
+            => new AnomalyPredictionTransformer<object>(env, ctx);
     }
 
     internal static class ClusteringPredictionTransformer
     {
         public const string LoaderSignature = "ClusteringPredXfer";
 
-        public static ClusteringPredictionTransformer<IPredictorProducing<VBuffer<float>>> Create(IHostEnvironment env, ModelLoadContext ctx)
-            => new ClusteringPredictionTransformer<IPredictorProducing<VBuffer<float>>>(env, ctx);
+        public static ClusteringPredictionTransformer<object> Create(IHostEnvironment env, ModelLoadContext ctx)
+            => new ClusteringPredictionTransformer<object>(env, ctx);
     }
 }

--- a/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
+++ b/src/Microsoft.ML.Ensemble/EntryPoints/PipelineEnsemble.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Trainers.Ensemble
             var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             while (calibrated != null)
             {
-                predictor = calibrated.WeeklyTypedSubModel;
+                predictor = calibrated.WeaklyTypedSubModel;
                 calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
             }
             var ensemble = predictor as SchemaBindablePipelineEnsembleBase;

--- a/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsemble/TreeEnsembleCombiner.cs
@@ -51,11 +51,11 @@ namespace Microsoft.ML.Trainers.FastTree
                 var calibrated = predictor as IWeaklyTypedCalibratedModelParameters;
                 double paramA = 1;
                 if (calibrated != null)
-                    _host.Check(calibrated.WeeklyTypedCalibrator is PlattCalibrator,
+                    _host.Check(calibrated.WeaklyTypedCalibrator is PlattCalibrator,
                         "Combining FastTree models can only be done when the models are calibrated with Platt calibrator");
 
-                predictor = calibrated.WeeklyTypedSubModel;
-                paramA = -((PlattCalibrator)calibrated.WeeklyTypedCalibrator).Slope;
+                predictor = calibrated.WeaklyTypedSubModel;
+                paramA = -((PlattCalibrator)calibrated.WeaklyTypedCalibrator).Slope;
 
                 var tree = predictor as TreeEnsembleModelParameters;
 

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -590,7 +590,7 @@ namespace Microsoft.ML.Data
 
                     // Make sure that the given predictor has the correct number of input features.
                     if (predictor is IWeaklyTypedCalibratedModelParameters calibrated)
-                        predictor = calibrated.WeeklyTypedSubModel;
+                        predictor = calibrated.WeaklyTypedSubModel;
                     // Predictor should be a TreeEnsembleModelParameters, which implements IValueMapper, so this should
                     // be non-null.
                     var vm = predictor as IValueMapper;

--- a/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/SdcaBinary.cs
@@ -72,7 +72,7 @@ namespace Microsoft.ML.Trainers
             {
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
-                var linInitPred = (initPred as IWeaklyTypedCalibratedModelParameters)?.WeeklyTypedSubModel as LinearModelParameters;
+                var linInitPred = (initPred as IWeaklyTypedCalibratedModelParameters)?.WeaklyTypedSubModel as LinearModelParameters;
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),
                     "Initial predictor was not a linear predictor.");

--- a/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
+++ b/src/Microsoft.ML.StandardLearners/Standard/StochasticTrainerBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Trainers
                 var preparedData = PrepareDataFromTrainingExamples(ch, context.TrainingSet, out int weightSetCount);
                 var initPred = context.InitialPredictor;
                 // Try extract linear model from calibrated predictor.
-                var linInitPred = (initPred as IWeaklyTypedCalibratedModelParameters)?.WeeklyTypedSubModel as LinearModelParameters;
+                var linInitPred = (initPred as IWeaklyTypedCalibratedModelParameters)?.WeaklyTypedSubModel as LinearModelParameters;
                 // If the initial predictor is not calibrated, it should be a linear model.
                 linInitPred = linInitPred ?? initPred as LinearModelParameters;
                 Host.CheckParam(context.InitialPredictor == null || linInitPred != null, nameof(context),

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DeserializationTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DeserializationTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.ML.Calibrators;
+using Microsoft.ML.Data;
+using Microsoft.ML.RunTests;
+using Microsoft.ML.Trainers.FastTree;
+using Xunit;
+
+namespace Microsoft.ML.Tests.Scenarios.Api
+{
+    public partial class ApiScenariosTests
+    {
+        private class InputData
+        {
+            [LoadColumn(0)]
+            public float Label { get; set; }
+            [LoadColumn(9, 14)]
+            [VectorType(6)]
+            public float[] Features { get; set; }
+        }
+
+        [Fact]
+        public void LoadModelAndExtractPredictor()
+        {
+            var ml = new MLContext(seed: 1, conc: 1);
+            var file = new MultiFileSource(GetDataPath(TestDatasets.adult.trainFilename));
+            var loader = ml.Data.CreateTextLoader<InputData>(hasHeader: true, dataSample: file);
+            var data = loader.Load(file);
+
+            // Pipeline.
+            var pipeline = ml.BinaryClassification.Trainers.GeneralizedAdditiveModels();
+
+            // Train.
+            var model = pipeline.Fit(data);
+
+            // Save and reload.
+            string modelPath = GetOutputPath(FullTestName + "-model.zip");
+            using (var fs = File.Create(modelPath))
+                ml.Model.Save(model, fs);
+
+            ITransformer loadedModel;
+            using (var fs = File.OpenRead(modelPath))
+                loadedModel = ml.Model.Load(fs);
+
+            var gam = (((loadedModel as TransformerChain<ITransformer>).LastTransformer
+                as BinaryPredictionTransformer<object>).Model
+                as CalibratedModelParametersBase<object, ICalibrator>).SubModel
+                as BinaryClassificationGamModelParameters;
+            Assert.NotNull(gam);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2735. 

Currently, this PR adds a public API that saves and load an IDataLoader. Later iterations will add APIs to save/load the schema directly.