### PR TITLE
Scrubbing of the key related transforms

### DIFF
--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -512,7 +512,7 @@ var pipeline =
     // Convert each categorical feature into one-hot encoding independently.
     mlContext.Transforms.Categorical.OneHotEncoding("CategoricalOneHot", "CategoricalFeatures")
     // Convert all categorical features into indices, and build a 'word bag' of these.
-    .Append(mlContext.Transforms.Categorical.OneHotEncoding("CategoricalBag", "CategoricalFeatures", OneHotEncodingTransformer.OutputKind.Bag))
+    .Append(mlContext.Transforms.Categorical.OneHotEncoding("CategoricalBag", "CategoricalFeatures", OneHotEncodingEstimator.OutputKind.Bag))
     // One-hot encode the workclass column, then drop all the categories that have fewer than 10 instances in the train set.
     .Append(mlContext.Transforms.Categorical.OneHotEncoding("WorkclassOneHot", "Workclass"))
     .Append(mlContext.Transforms.FeatureSelection.SelectFeaturesBasedOnCount("WorkclassOneHotTrimmed", "WorkclassOneHot", count: 10));

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
@@ -35,11 +35,11 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Another pipeline, that customizes the advanced settings of the ValueToKeyMappingEstimator.
             // We can change the maximumNumberOfKeys to limit how many keys will get generated out of the set of words, 
-            // and condition the order in which they get evaluated by changing mappingOrder from the default ByOccurence (order in which they get encountered) 
+            // and condition the order in which they get evaluated by changing keyOrdinality from the default ByOccurence (order in which they get encountered) 
             // to value/alphabetically.
             string customizedColumnName = "CustomizedKeys";
             var customized_pipeline = ml.Transforms.Text.TokenizeWords("Review")
-                .Append(ml.Transforms.Conversion.MapValueToKey(customizedColumnName, "Review", maximumNumberOfKeys: 10, mappingOrder: ValueToKeyMappingEstimator.MappingOrder.ByValue));
+                .Append(ml.Transforms.Conversion.MapValueToKey(customizedColumnName, "Review", maximumNumberOfKeys: 10, keyOrdinality: ValueToKeyMappingEstimator.KeyOrdinality.ByValue));
 
             // The transformed data.
             var transformedData_default = default_pipeline.Fit(trainData).Transform(trainData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
@@ -34,12 +34,12 @@ namespace Microsoft.ML.Samples.Dynamic
                 .Append(ml.Transforms.Conversion.MapValueToKey(defaultColumnName, "Review"));
 
             // Another pipeline, that customizes the advanced settings of the ValueToKeyMappingEstimator.
-            // We can change the maxNumTerm to limit how many keys will get generated out of the set of words, 
-            // and condition the order in which they get evaluated by changing sort from the default Occurence (order in which they get encountered) 
+            // We can change the maximumNumberOfKeys to limit how many keys will get generated out of the set of words, 
+            // and condition the order in which they get evaluated by changing mappingOrder from the default ByOccurence (order in which they get encountered) 
             // to value/alphabetically.
             string customizedColumnName = "CustomizedKeys";
             var customized_pipeline = ml.Transforms.Text.TokenizeWords("Review")
-                .Append(ml.Transforms.Conversion.MapValueToKey(customizedColumnName, "Review", maxNumberOfKeys: 10, sort: ValueToKeyMappingEstimator.SortOrder.Value));
+                .Append(ml.Transforms.Conversion.MapValueToKey(customizedColumnName, "Review", maximumNumberOfKeys: 10, mappingOrder: ValueToKeyMappingEstimator.MappingOrder.ByValue));
 
             // The transformed data.
             var transformedData_default = default_pipeline.Fit(trainData).Transform(trainData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/KeyToValueValueToKey.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // to value/alphabetically.
             string customizedColumnName = "CustomizedKeys";
             var customized_pipeline = ml.Transforms.Text.TokenizeWords("Review")
-                .Append(ml.Transforms.Conversion.MapValueToKey(customizedColumnName, "Review", maxNumKeys: 10, sort: ValueToKeyMappingEstimator.SortOrder.Value));
+                .Append(ml.Transforms.Conversion.MapValueToKey(customizedColumnName, "Review", maxNumberOfKeys: 10, sort: ValueToKeyMappingEstimator.SortOrder.Value));
 
             // The transformed data.
             var transformedData_default = default_pipeline.Fit(trainData).Transform(trainData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             var engine = mlContext.Transforms.Text.TokenizeWords("TokenizedWords", "Sentiment_Text")
-                .Append(mlContext.Transforms.Conversion.ValueMap(lookupMap, "Words", "Ids", new ColumnOptions[] { ("VariableLenghtFeatures", "TokenizedWords") }))
+                .Append(mlContext.Transforms.Conversion.MapValue(lookupMap, "Words", "Ids", new ColumnOptions[] { ("VariableLenghtFeatures", "TokenizedWords") }))
                 .Append(mlContext.Transforms.CustomMapping(ResizeFeaturesAction, "Resize"))
                 .Append(tensorFlowModel.ScoreTensorFlowModel(new[] { "Prediction/Softmax" }, new[] { "Features" }))
                 .Append(mlContext.Transforms.CopyColumns(("Prediction", "Prediction/Softmax")))

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMapping.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMapping.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Constructs the ValueMappingEstimator making the ML.net pipeline
-            var pipeline = mlContext.Transforms.Conversion.ValueMap(educationKeys, educationValues, ("EducationCategory", "Education"));
+            var pipeline = mlContext.Transforms.Conversion.MapValue(educationKeys, educationValues, ("EducationCategory", "Education"));
 
             // Fits the ValueMappingEstimator and transforms the data converting the Education to EducationCategory.
             IDataView transformedData = pipeline.Fit(trainData).Transform(trainData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingFloatToString.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingFloatToString.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Constructs the ValueMappingEstimator making the ML.net pipeline
-            var pipeline = mlContext.Transforms.Conversion.ValueMap(temperatureKeys, classificationValues, ("TemperatureCategory", "Temperature"));
+            var pipeline = mlContext.Transforms.Conversion.MapValue(temperatureKeys, classificationValues, ("TemperatureCategory", "Temperature"));
 
             // Fits the ValueMappingEstimator and transforms the data adding the TemperatureCategory column.
             IDataView transformedData = pipeline.Fit(trainData).Transform(trainData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // Constructs the ValueMappingEstimator making the ML.net pipeline
-            var pipeline = mlContext.Transforms.Conversion.ValueMap<string, int>(educationKeys, educationValues, ("EducationFeature", "Education"));
+            var pipeline = mlContext.Transforms.Conversion.MapValue<string, int>(educationKeys, educationValues, ("EducationFeature", "Education"));
 
             // Fits the ValueMappingEstimator and transforms the data adding the EducationFeature column.
             IDataView transformedData = pipeline.Fit(trainData).Transform(trainData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Generate the ValueMappingEstimator that will output KeyTypes even though our values are strings.
             // The KeyToValueMappingEstimator is added to provide a reverse lookup of the KeyType, converting the KeyType value back
             // to the original value.
-            var pipeline = mlContext.Transforms.Conversion.ValueMap<string, string>(educationKeys, educationValues, true, ("EducationKeyType", "Education"))
+            var pipeline = mlContext.Transforms.Conversion.MapValue<string, string>(educationKeys, educationValues, true, ("EducationKeyType", "Education"))
                               .Append(mlContext.Transforms.Conversion.MapKeyToValue(("EducationCategory", "EducationKeyType")));
 
             // Fits the ValueMappingEstimator and transforms the data adding the EducationKeyType column.

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The categorical transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="maxNumKeys">Maximum number of keys to keep per column when auto-training.</param>
+        /// <param name="maxNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
         /// <param name="sort">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.SortOrder.Occurrence"/> choosen they will be in the order encountered.
         /// If <see cref="ValueToKeyMappingEstimator.SortOrder.Value"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
         /// <example>
@@ -134,9 +134,9 @@ namespace Microsoft.ML
         public static ValueToKeyMappingEstimator MapValueToKey(this TransformsCatalog.ConversionTransforms catalog,
             string outputColumnName,
             string inputColumnName = null,
-            int maxNumKeys = ValueToKeyMappingEstimator.Defaults.MaxNumKeys,
+            int maxNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys,
             ValueToKeyMappingEstimator.SortOrder sort = ValueToKeyMappingEstimator.Defaults.Sort)
-           => new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, maxNumKeys, sort);
+           => new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, maxNumberOfKeys, sort);
 
         /// <summary>
         /// Converts value types into <see cref="KeyType"/>, optionally loading the keys to use from <paramref name="keyData"/>.
@@ -244,8 +244,8 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The categorical transform's catalog</param>
         /// <param name="lookupMap">An instance of <see cref="IDataView"/> that contains the key and value columns.</param>
-        /// <param name="keyColumn">Name of the key column in <paramref name="lookupMap"/>.</param>
-        /// <param name="valueColumn">Name of the value column in <paramref name="lookupMap"/>.</param>
+        /// <param name="keyColumnName">Name of the key column in <paramref name="lookupMap"/>.</param>
+        /// <param name="valueColumnName">Name of the value column in <paramref name="lookupMap"/>.</param>
         /// <param name="columns">The columns to apply this transform on.</param>
         /// <returns>A instance of the ValueMappingEstimator</returns>
         /// <example>
@@ -259,8 +259,8 @@ namespace Microsoft.ML
         /// </example>
         public static ValueMappingEstimator ValueMap(
             this TransformsCatalog.ConversionTransforms catalog,
-            IDataView lookupMap, string keyColumn, string valueColumn, params ColumnOptions[] columns)
-            => new ValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), lookupMap, keyColumn, valueColumn,
+            IDataView lookupMap, string keyColumnName, string valueColumnName, params ColumnOptions[] columns)
+            => new ValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), lookupMap, keyColumnName, valueColumnName,
                 ColumnOptions.ConvertToValueTuples(columns));
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -24,13 +24,13 @@ namespace Microsoft.ML
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/>Specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/>Specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static HashingEstimator Hash(this TransformsCatalog.ConversionTransforms catalog, string outputColumnName, string inputColumnName = null,
-            int numberOfHashBits = HashDefaults.NumberOfHashBits, int invertHash = HashDefaults.InvertHash)
-            => new HashingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, numberOfHashBits, invertHash);
+            int numberOfHashBits = HashDefaults.NumberOfHashBits, int maximumNumberOfInverts = HashDefaults.MaximumNumberOfInverts)
+            => new HashingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, numberOfHashBits, maximumNumberOfInverts);
 
         /// <summary>
         /// Hashes the values in the input column.

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -23,14 +23,14 @@ namespace Microsoft.ML
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
         /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="invertHash"/>Specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static HashingEstimator Hash(this TransformsCatalog.ConversionTransforms catalog, string outputColumnName, string inputColumnName = null,
-            int hashBits = HashDefaults.HashBits, int invertHash = HashDefaults.InvertHash)
-            => new HashingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, hashBits, invertHash);
+            int numberOfHashBits = HashDefaults.NumberOfHashBits, int invertHash = HashDefaults.InvertHash)
+            => new HashingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, numberOfHashBits, invertHash);
 
         /// <summary>
         /// Hashes the values in the input column.
@@ -110,10 +110,10 @@ namespace Microsoft.ML
         /// <param name="catalog">The categorical transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="bag">Whether bagging is used for the conversion. </param>
+        /// <param name="useBagging">Whether bagging is used for the conversion. </param>
         public static KeyToVectorMappingEstimator MapKeyToVector(this TransformsCatalog.ConversionTransforms catalog,
-            string outputColumnName, string inputColumnName = null, bool bag = KeyToVectorMappingEstimator.Defaults.Bag)
-            => new KeyToVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, bag);
+            string outputColumnName, string inputColumnName = null, bool useBagging = KeyToVectorMappingEstimator.Defaults.UseBagging)
+            => new KeyToVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, useBagging);
 
         /// <summary>
         /// Converts value types into <see cref="KeyType"/>.
@@ -121,9 +121,9 @@ namespace Microsoft.ML
         /// <param name="catalog">The categorical transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="maxNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-        /// <param name="sort">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.SortOrder.Occurrence"/> choosen they will be in the order encountered.
-        /// If <see cref="ValueToKeyMappingEstimator.SortOrder.Value"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+        /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
+        /// <param name="mappingOrder">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
+        /// If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -134,9 +134,9 @@ namespace Microsoft.ML
         public static ValueToKeyMappingEstimator MapValueToKey(this TransformsCatalog.ConversionTransforms catalog,
             string outputColumnName,
             string inputColumnName = null,
-            int maxNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys,
-            ValueToKeyMappingEstimator.SortOrder sort = ValueToKeyMappingEstimator.Defaults.Sort)
-           => new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, maxNumberOfKeys, sort);
+            int maximumNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys,
+            ValueToKeyMappingEstimator.MappingOrder mappingOrder = ValueToKeyMappingEstimator.Defaults.Order)
+           => new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, maximumNumberOfKeys, mappingOrder);
 
         /// <summary>
         /// Converts value types into <see cref="KeyType"/>, optionally loading the keys to use from <paramref name="keyData"/>.

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -13,14 +13,14 @@ namespace Microsoft.ML
     using HashDefaults = HashingEstimator.Defaults;
 
     /// <summary>
-    /// Extensions for the HashEstimator.
+    /// Extensions for the conversion transformations.
     /// </summary>
     public static class ConversionsExtensionsCatalog
     {
         /// <summary>
         /// Hashes the values in the input column.
         /// </summary>
-        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
@@ -35,7 +35,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Hashes the values in the input column.
         /// </summary>
-        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">Description of dataset columns and how to process them.</param>
         public static HashingEstimator Hash(this TransformsCatalog.ConversionTransforms catalog, params HashingEstimator.ColumnOptions[] columns)
             => new HashingEstimator(CatalogUtils.GetEnvironment(catalog), columns);
@@ -43,7 +43,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Changes column type of the input column.
         /// </summary>
-        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="outputKind">The expected kind of the output column.</param>
@@ -60,7 +60,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Changes column type of the input column.
         /// </summary>
-        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">Description of dataset columns and how to process them.</param>
         public static TypeConvertingEstimator ConvertType(this TransformsCatalog.ConversionTransforms catalog, params TypeConvertingEstimator.ColumnOptions[] columns)
             => new TypeConvertingEstimator(CatalogUtils.GetEnvironment(catalog), columns);
@@ -68,7 +68,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Convert the key types back to their original values.
         /// </summary>
-        /// <param name="catalog">The categorical transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <example>
@@ -84,7 +84,7 @@ namespace Microsoft.ML
         ///  Convert the key types (name of the column specified in the first item of the tuple) back to their original values
         ///  (named as specified in the second item of the tuple).
         /// </summary>
-        /// <param name="catalog">The categorical transform's catalog</param>
+        /// <param name="catalog">The conversion transform's catalog</param>
         /// <param name="columns">The pairs of input and output columns.</param>
         /// <example>
         /// <format type="text/markdown">
@@ -98,7 +98,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Maps key types or key values into a floating point vector.
         /// </summary>
-        /// <param name="catalog">The categorical transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">The input column to map back to vectors.</param>
         public static KeyToVectorMappingEstimator MapKeyToVector(this TransformsCatalog.ConversionTransforms catalog,
             params KeyToVectorMappingEstimator.ColumnOptions[] columns)
@@ -107,18 +107,19 @@ namespace Microsoft.ML
         /// <summary>
         /// Maps key types or key values into a floating point vector.
         /// </summary>
-        /// <param name="catalog">The categorical transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="useBagging">Whether bagging is used for the conversion. </param>
+        /// <param name="outputCountVector">Whether to combine multiple indicator vectors into a single vector of counts instead of concatenating them.
+        /// This is only relevant when the input column is a vector of keys.</param>
         public static KeyToVectorMappingEstimator MapKeyToVector(this TransformsCatalog.ConversionTransforms catalog,
-            string outputColumnName, string inputColumnName = null, bool useBagging = KeyToVectorMappingEstimator.Defaults.UseBagging)
-            => new KeyToVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, useBagging);
+            string outputColumnName, string inputColumnName = null, bool outputCountVector = KeyToVectorMappingEstimator.Defaults.OutputCountVector)
+            => new KeyToVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, outputCountVector);
 
         /// <summary>
         /// Converts value types into <see cref="KeyType"/>.
         /// </summary>
-        /// <param name="catalog">The categorical transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
@@ -141,7 +142,7 @@ namespace Microsoft.ML
         /// <summary>
         /// Converts value types into <see cref="KeyType"/>, optionally loading the keys to use from <paramref name="keyData"/>.
         /// </summary>
-        /// <param name="catalog">The categorical transform's catalog.</param>
+        /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">The data columns to map to keys.</param>
         /// <param name="keyData">The data view containing the terms. If specified, this should be a single column data
         /// view, and the key-values will be taken from that column. If unspecified, the key-values will be determined
@@ -162,7 +163,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <typeparam name="TInputType">The key type.</typeparam>
         /// <typeparam name="TOutputType">The value type.</typeparam>
-        /// <param name="catalog">The categorical transform's catalog</param>
+        /// <param name="catalog">The conversion transform's catalog</param>
         /// <param name="keys">The list of keys to use for the mapping. The mapping is 1-1 with <paramref name="values"/>. The length of this list must be the same length as <paramref name="values"/> and
         /// cannot contain duplicate keys.</param>
         /// <param name="values">The list of values to pair with the keys for the mapping. The length of this list must be equal to the same length as <paramref name="keys"/>.</param>
@@ -189,7 +190,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <typeparam name="TInputType">The key type.</typeparam>
         /// <typeparam name="TOutputType">The value type.</typeparam>
-        /// <param name="catalog">The categorical transform's catalog</param>
+        /// <param name="catalog">The conversion transform's catalog</param>
         /// <param name="keys">The list of keys to use for the mapping. The mapping is 1-1 with <paramref name="values"/>. The length of this list must be the same length as <paramref name="values"/> and
         /// cannot contain duplicate keys.</param>
         /// <param name="values">The list of values to pair with the keys for the mapping. The length of this list must be equal to the same length as <paramref name="keys"/>.</param>
@@ -216,7 +217,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <typeparam name="TInputType">The key type.</typeparam>
         /// <typeparam name="TOutputType">The value type.</typeparam>
-        /// <param name="catalog">The categorical transform's catalog</param>
+        /// <param name="catalog">The conversion transform's catalog</param>
         /// <param name="keys">The list of keys to use for the mapping. The mapping is 1-1 with <paramref name="values"/>. The length of this list  must be the same length as <paramref name="values"/> and
         /// cannot contain duplicate keys.</param>
         /// <param name="values">The list of values to pair with the keys for the mapping of TOutputType[]. The length of this list  must be equal to the same length as <paramref name="keys"/>.</param>
@@ -242,7 +243,7 @@ namespace Microsoft.ML
         /// <summary>
         /// <see cref="ValueMappingEstimator"/>
         /// </summary>
-        /// <param name="catalog">The categorical transform's catalog</param>
+        /// <param name="catalog">The conversion transform's catalog</param>
         /// <param name="lookupMap">An instance of <see cref="IDataView"/> that contains the key and value columns.</param>
         /// <param name="keyColumnName">Name of the key column in <paramref name="lookupMap"/>.</param>
         /// <param name="valueColumnName">Name of the value column in <paramref name="lookupMap"/>.</param>

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -23,14 +23,14 @@ namespace Microsoft.ML
         /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
         /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
         /// <paramref name="maximumNumberOfInverts"/>Specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static HashingEstimator Hash(this TransformsCatalog.ConversionTransforms catalog, string outputColumnName, string inputColumnName = null,
-            int numberOfHashBits = HashDefaults.NumberOfHashBits, int maximumNumberOfInverts = HashDefaults.MaximumNumberOfInverts)
-            => new HashingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, numberOfHashBits, maximumNumberOfInverts);
+            int numberOfBits = HashDefaults.NumberOfBits, int maximumNumberOfInverts = HashDefaults.MaximumNumberOfInverts)
+            => new HashingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, numberOfBits, maximumNumberOfInverts);
 
         /// <summary>
         /// Hashes the values in the input column.
@@ -123,8 +123,8 @@ namespace Microsoft.ML
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-        /// <param name="mappingOrder">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
-        /// If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+        /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
+        /// If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -136,8 +136,8 @@ namespace Microsoft.ML
             string outputColumnName,
             string inputColumnName = null,
             int maximumNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys,
-            ValueToKeyMappingEstimator.MappingOrder mappingOrder = ValueToKeyMappingEstimator.Defaults.Order)
-           => new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, maximumNumberOfKeys, mappingOrder);
+            ValueToKeyMappingEstimator.KeyOrdinality keyOrdinality = ValueToKeyMappingEstimator.Defaults.Ordinality)
+           => new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, maximumNumberOfKeys, keyOrdinality);
 
         /// <summary>
         /// Converts value types into <see cref="KeyType"/>, optionally loading the keys to use from <paramref name="keyData"/>.
@@ -178,7 +178,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[ValueMappingEstimator](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs)]
         /// ]]></format>
         /// </example>
-        public static ValueMappingEstimator<TInputType, TOutputType> ValueMap<TInputType, TOutputType>(
+        public static ValueMappingEstimator<TInputType, TOutputType> MapValue<TInputType, TOutputType>(
             this TransformsCatalog.ConversionTransforms catalog,
             IEnumerable<TInputType> keys,
             IEnumerable<TOutputType> values,
@@ -203,7 +203,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[ValueMappingEstimator](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs)]
         /// ]]></format>
         /// </example>
-        public static ValueMappingEstimator<TInputType, TOutputType> ValueMap<TInputType, TOutputType>(
+        public static ValueMappingEstimator<TInputType, TOutputType> MapValue<TInputType, TOutputType>(
             this TransformsCatalog.ConversionTransforms catalog,
             IEnumerable<TInputType> keys,
             IEnumerable<TOutputType> values,
@@ -232,7 +232,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[ValueMappingEstimator](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs)]
         /// ]]></format>
         /// </example>
-        public static ValueMappingEstimator<TInputType, TOutputType> ValueMap<TInputType, TOutputType>(
+        public static ValueMappingEstimator<TInputType, TOutputType> MapValue<TInputType, TOutputType>(
             this TransformsCatalog.ConversionTransforms catalog,
             IEnumerable<TInputType> keys,
             IEnumerable<TOutputType[]> values,
@@ -258,7 +258,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[ValueMappingEstimator](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToArray.cs)]
         /// ]]></format>
         /// </example>
-        public static ValueMappingEstimator ValueMap(
+        public static ValueMappingEstimator MapValue(
             this TransformsCatalog.ConversionTransforms catalog,
             IDataView lookupMap, string keyColumnName, string valueColumnName, params ColumnOptions[] columns)
             => new ValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), lookupMap, keyColumnName, valueColumnName,

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -10,7 +10,7 @@ using Microsoft.ML.Transforms;
 namespace Microsoft.ML
 {
     /// <summary>
-    /// Spcifies the names of output and input columns for a transformation.
+    /// Specifies input and output column names for a transformation.
     /// </summary>
     public sealed class ColumnOptions
     {
@@ -18,7 +18,7 @@ namespace Microsoft.ML
         private readonly string _inputColumnName;
 
         /// <summary>
-        /// Spcifies the names of output and input columns for a transformation.
+        /// Specifies input and output column names for a transformation.
         /// </summary>
         /// <param name="outputColumnName">Name of output column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of input column.</param>
@@ -28,6 +28,9 @@ namespace Microsoft.ML
             _inputColumnName = inputColumnName;
         }
 
+        /// <summary>
+        /// Instantiates a <see cref="ColumnOptions"/> from a tuple of input and output column names.
+        /// </summary>
         public static implicit operator ColumnOptions((string outputColumnName, string inputColumnName) value)
         {
             return new ColumnOptions(value.outputColumnName, value.inputColumnName);

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -9,11 +9,19 @@ using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
 {
+    /// <summary>
+    /// Spcifies the names of output and input columns for a transformation.
+    /// </summary>
     public sealed class ColumnOptions
     {
         private readonly string _outputColumnName;
         private readonly string _inputColumnName;
 
+        /// <summary>
+        /// Spcifies the names of output and input columns for a transformation.
+        /// </summary>
+        /// <param name="outputColumnName">Name of output column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of input column.</param>
         public ColumnOptions(string outputColumnName, string inputColumnName)
         {
             _outputColumnName = outputColumnName;

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1136,7 +1136,7 @@ namespace Microsoft.ML.Transforms
             public readonly int NumberOfHashBits;
             /// <summary> Hashing seed.</summary>
             public readonly uint Seed;
-            /// <summary> Whether the position of each term should be included in the hash.</summary>
+            /// <summary> Whether the position of each term should be included in the hash, only applies to inputs of vector type.</summary>
             public readonly bool UseOrderedHashing;
             /// <summary>
             /// During hashing we constuct mappings between original values and the produced hash values.
@@ -1153,7 +1153,7 @@ namespace Microsoft.ML.Transforms
             /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
             /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
             /// <param name="seed">Hashing seed.</param>
-            /// <param name="useOrderedHashing">Whether the position of each term should be included in the hash.</param>
+            /// <param name="useOrderedHashing">Whether the position of each term should be included in the hash, only applies to inputs of vector type..</param>
             /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
             /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
             /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Transforms
         [BestFriend]
         internal const string UserName = "Key To Value Transform";
 
-        public IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
+        internal IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
 
         private static VersionInfo GetVersionInfo()
         {

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -91,7 +91,7 @@ namespace Microsoft.ML.Transforms
 
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Whether to combine multiple indicator vectors into a single bag vector instead of concatenating them. This is only relevant when the input is a vector.")]
-            public bool Bag = KeyToVectorMappingEstimator.Defaults.Bag;
+            public bool Bag = KeyToVectorMappingEstimator.Defaults.UseBagging;
         }
 
         private const string RegistrationName = "KeyToVector";
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Transforms
 
             Host.Assert(_columns.Length == ColumnPairs.Length);
             for (int i = 0; i < _columns.Length; i++)
-                ctx.Writer.WriteBoolByte(_columns[i].Bag);
+                ctx.Writer.WriteBoolByte(_columns[i].UseBagging);
         }
 
         // Factory method for SignatureLoadModel.
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Transforms
                 {
                     int valueCount = _infos[i].TypeSrc.GetValueCount();
                     int keyCount = _infos[i].TypeSrc.GetItemType().GetKeyCountAsInt32(Host);
-                    if (_parent._columns[i].Bag || valueCount == 1)
+                    if (_parent._columns[i].UseBagging || valueCount == 1)
                         _types[i] = new VectorType(NumberDataViewType.Single, keyCount);
                     else
                         _types[i] = new VectorType(NumberDataViewType.Single, valueCount, keyCount);
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Transforms
                     typeNames = null;
                 }
 
-                if (_parent._columns[iinfo].Bag || srcValueCount == 1)
+                if (_parent._columns[iinfo].UseBagging || srcValueCount == 1)
                 {
                     if (typeNames != null)
                     {
@@ -328,7 +328,7 @@ namespace Microsoft.ML.Transforms
                     }
                 }
 
-                if (!_parent._columns[iinfo].Bag && srcValueCount > 0)
+                if (!_parent._columns[iinfo].UseBagging && srcValueCount > 0)
                 {
                     ValueGetter<VBuffer<int>> getter = (ref VBuffer<int> dst) =>
                     {
@@ -337,7 +337,7 @@ namespace Microsoft.ML.Transforms
                     builder.Add(AnnotationUtils.Kinds.CategoricalSlotRanges, AnnotationUtils.GetCategoricalType(srcValueCount), getter);
                 }
 
-                if (!_parent._columns[iinfo].Bag || srcValueCount == 1)
+                if (!_parent._columns[iinfo].UseBagging || srcValueCount == 1)
                 {
                     ValueGetter<bool> getter = (ref bool dst) =>
                     {
@@ -442,7 +442,7 @@ namespace Microsoft.ML.Transforms
                 var info = _infos[iinfo];
                 if (!(info.TypeSrc is VectorType))
                     return MakeGetterOne(input, iinfo);
-                if (_parent._columns[iinfo].Bag)
+                if (_parent._columns[iinfo].UseBagging)
                     return MakeGetterBag(input, iinfo);
                 return MakeGetterInd(input, iinfo);
             }
@@ -493,7 +493,7 @@ namespace Microsoft.ML.Transforms
 
                 KeyType keyTypeSrc = srcVectorType.ItemType as KeyType;
                 Host.Assert(keyTypeSrc != null);
-                Host.Assert(_parent._columns[iinfo].Bag);
+                Host.Assert(_parent._columns[iinfo].UseBagging);
                 int size = keyTypeSrc.GetCountAsInt32(Host);
                 Host.Assert(size == _types[iinfo].Size);
                 Host.Assert(size > 0);
@@ -539,7 +539,7 @@ namespace Microsoft.ML.Transforms
 
                 KeyType keyTypeSrc = srcVectorType.ItemType as KeyType;
                 Host.Assert(keyTypeSrc != null);
-                Host.Assert(!_parent._columns[iinfo].Bag);
+                Host.Assert(!_parent._columns[iinfo].UseBagging);
 
                 int size = keyTypeSrc.GetCountAsInt32(Host);
                 Host.Assert(size > 0);
@@ -666,7 +666,7 @@ namespace Microsoft.ML.Transforms
                     return PfaUtils.Call("cast.fanoutDouble", srcToken, 0, keyCount, false);
 
                 JToken arrType = PfaUtils.Type.Array(PfaUtils.Type.Double);
-                if (!(_parent._columns[iinfo].Bag || srcVectorType.Size == 1))
+                if (!(_parent._columns[iinfo].UseBagging || srcVectorType.Size == 1))
                 {
                     // The concatenation case. We can still use fanout, but we just append them all together.
                     return PfaUtils.Call("a.flatMap", srcToken,
@@ -702,13 +702,13 @@ namespace Microsoft.ML.Transforms
 
                 // If Bag is true, the output of ONNX LabelEncoder needs to be fed into ONNX ReduceSum because
                 // default ONNX LabelEncoder just matches the behavior of Bag=false.
-                var encodedVariableName = _parent._columns[iinfo].Bag ? ctx.AddIntermediateVariable(null, "encoded", true) : dstVariableName;
+                var encodedVariableName = _parent._columns[iinfo].UseBagging ? ctx.AddIntermediateVariable(null, "encoded", true) : dstVariableName;
 
                 string opType = "OneHotEncoder";
                 var node = ctx.CreateNode(opType, srcVariableName, encodedVariableName, ctx.GetNodeName(opType));
                 node.AddAttribute("cats_int64s", Enumerable.Range(0, info.TypeSrc.GetItemType().GetKeyCountAsInt32(Host)).Select(x => (long)x));
                 node.AddAttribute("zeros", true);
-                if (_parent._columns[iinfo].Bag)
+                if (_parent._columns[iinfo].UseBagging)
                 {
                     // If input shape is [1, 3], then OneHotEncoder may produce a 3-D tensor. Thus, we need to do a
                     // reduction along the second last axis to merge the one-hot vectors produced by all input features.
@@ -730,7 +730,7 @@ namespace Microsoft.ML.Transforms
     {
         internal static class Defaults
         {
-            public const bool Bag = false;
+            public const bool UseBagging = false;
         }
 
         /// <summary>
@@ -746,20 +746,20 @@ namespace Microsoft.ML.Transforms
             /// Whether to combine multiple indicator vectors into a single bag vector instead of concatenating them.
             /// This is only relevant when the input column is a vector.
             /// </summary>
-            public readonly bool Bag;
+            public readonly bool UseBagging;
 
             /// <summary>
             /// Describes how the transformer handles one column pair.
             /// </summary>
             /// <param name="name">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
-            /// <param name="bag">Whether to combine multiple indicator vectors into a single bag vector instead of concatenating them. This is only relevant when the input column is a vector.</param>
-            public ColumnOptions(string name, string inputColumnName = null, bool bag = Defaults.Bag)
+            /// <param name="useBagging">Whether to combine multiple indicator vectors into a single bag vector instead of concatenating them. This is only relevant when the input column is a vector.</param>
+            public ColumnOptions(string name, string inputColumnName = null, bool useBagging = Defaults.UseBagging)
             {
                 Contracts.CheckNonWhiteSpace(name, nameof(name));
                 Name = name;
                 InputColumnName = inputColumnName ?? name;
-                Bag = bag;
+                UseBagging = useBagging;
             }
         }
 
@@ -768,8 +768,8 @@ namespace Microsoft.ML.Transforms
         {
         }
 
-        internal KeyToVectorMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, bool bag = Defaults.Bag)
-            : this(env, new KeyToVectorMappingTransformer(env, new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, bag)))
+        internal KeyToVectorMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, bool useBagging = Defaults.UseBagging)
+            : this(env, new KeyToVectorMappingTransformer(env, new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, useBagging)))
         {
         }
 
@@ -797,9 +797,9 @@ namespace Microsoft.ML.Transforms
                 if (col.Annotations.TryFindColumn(AnnotationUtils.Kinds.KeyValues, out var keyMeta))
                     if (col.Kind != SchemaShape.Column.VectorKind.VariableVector && keyMeta.ItemType is TextDataViewType)
                         metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, keyMeta.ItemType, false));
-                if (!colInfo.Bag && (col.Kind == SchemaShape.Column.VectorKind.Scalar || col.Kind == SchemaShape.Column.VectorKind.Vector))
+                if (!colInfo.UseBagging && (col.Kind == SchemaShape.Column.VectorKind.Scalar || col.Kind == SchemaShape.Column.VectorKind.Vector))
                     metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.CategoricalSlotRanges, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.Int32, false));
-                if (!colInfo.Bag || (col.Kind == SchemaShape.Column.VectorKind.Scalar))
+                if (!colInfo.UseBagging || (col.Kind == SchemaShape.Column.VectorKind.Scalar))
                     metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar, BooleanDataViewType.Instance, false));
 
                 result[colInfo.Name] = new SchemaShape.Column(colInfo.Name, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.Single, false, new SchemaShape(metadata));

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -91,7 +91,7 @@ namespace Microsoft.ML.Transforms
 
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Whether to combine multiple indicator vectors into a single bag vector instead of concatenating them. This is only relevant when the input is a vector.")]
-            public bool Bag = KeyToVectorMappingEstimator.Defaults.UseBagging;
+            public bool Bag = KeyToVectorMappingEstimator.Defaults.OutputCountVector;
         }
 
         private const string RegistrationName = "KeyToVector";
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Transforms
 
             Host.Assert(_columns.Length == ColumnPairs.Length);
             for (int i = 0; i < _columns.Length; i++)
-                ctx.Writer.WriteBoolByte(_columns[i].UseBagging);
+                ctx.Writer.WriteBoolByte(_columns[i].OutputCountVector);
         }
 
         // Factory method for SignatureLoadModel.
@@ -251,7 +251,7 @@ namespace Microsoft.ML.Transforms
                 {
                     int valueCount = _infos[i].TypeSrc.GetValueCount();
                     int keyCount = _infos[i].TypeSrc.GetItemType().GetKeyCountAsInt32(Host);
-                    if (_parent._columns[i].UseBagging || valueCount == 1)
+                    if (_parent._columns[i].OutputCountVector || valueCount == 1)
                         _types[i] = new VectorType(NumberDataViewType.Single, keyCount);
                     else
                         _types[i] = new VectorType(NumberDataViewType.Single, valueCount, keyCount);
@@ -306,7 +306,7 @@ namespace Microsoft.ML.Transforms
                     typeNames = null;
                 }
 
-                if (_parent._columns[iinfo].UseBagging || srcValueCount == 1)
+                if (_parent._columns[iinfo].OutputCountVector || srcValueCount == 1)
                 {
                     if (typeNames != null)
                     {
@@ -328,7 +328,7 @@ namespace Microsoft.ML.Transforms
                     }
                 }
 
-                if (!_parent._columns[iinfo].UseBagging && srcValueCount > 0)
+                if (!_parent._columns[iinfo].OutputCountVector && srcValueCount > 0)
                 {
                     ValueGetter<VBuffer<int>> getter = (ref VBuffer<int> dst) =>
                     {
@@ -337,7 +337,7 @@ namespace Microsoft.ML.Transforms
                     builder.Add(AnnotationUtils.Kinds.CategoricalSlotRanges, AnnotationUtils.GetCategoricalType(srcValueCount), getter);
                 }
 
-                if (!_parent._columns[iinfo].UseBagging || srcValueCount == 1)
+                if (!_parent._columns[iinfo].OutputCountVector || srcValueCount == 1)
                 {
                     ValueGetter<bool> getter = (ref bool dst) =>
                     {
@@ -442,7 +442,7 @@ namespace Microsoft.ML.Transforms
                 var info = _infos[iinfo];
                 if (!(info.TypeSrc is VectorType))
                     return MakeGetterOne(input, iinfo);
-                if (_parent._columns[iinfo].UseBagging)
+                if (_parent._columns[iinfo].OutputCountVector)
                     return MakeGetterBag(input, iinfo);
                 return MakeGetterInd(input, iinfo);
             }
@@ -493,7 +493,7 @@ namespace Microsoft.ML.Transforms
 
                 KeyType keyTypeSrc = srcVectorType.ItemType as KeyType;
                 Host.Assert(keyTypeSrc != null);
-                Host.Assert(_parent._columns[iinfo].UseBagging);
+                Host.Assert(_parent._columns[iinfo].OutputCountVector);
                 int size = keyTypeSrc.GetCountAsInt32(Host);
                 Host.Assert(size == _types[iinfo].Size);
                 Host.Assert(size > 0);
@@ -539,7 +539,7 @@ namespace Microsoft.ML.Transforms
 
                 KeyType keyTypeSrc = srcVectorType.ItemType as KeyType;
                 Host.Assert(keyTypeSrc != null);
-                Host.Assert(!_parent._columns[iinfo].UseBagging);
+                Host.Assert(!_parent._columns[iinfo].OutputCountVector);
 
                 int size = keyTypeSrc.GetCountAsInt32(Host);
                 Host.Assert(size > 0);
@@ -666,7 +666,7 @@ namespace Microsoft.ML.Transforms
                     return PfaUtils.Call("cast.fanoutDouble", srcToken, 0, keyCount, false);
 
                 JToken arrType = PfaUtils.Type.Array(PfaUtils.Type.Double);
-                if (!(_parent._columns[iinfo].UseBagging || srcVectorType.Size == 1))
+                if (!(_parent._columns[iinfo].OutputCountVector || srcVectorType.Size == 1))
                 {
                     // The concatenation case. We can still use fanout, but we just append them all together.
                     return PfaUtils.Call("a.flatMap", srcToken,
@@ -702,13 +702,13 @@ namespace Microsoft.ML.Transforms
 
                 // If Bag is true, the output of ONNX LabelEncoder needs to be fed into ONNX ReduceSum because
                 // default ONNX LabelEncoder just matches the behavior of Bag=false.
-                var encodedVariableName = _parent._columns[iinfo].UseBagging ? ctx.AddIntermediateVariable(null, "encoded", true) : dstVariableName;
+                var encodedVariableName = _parent._columns[iinfo].OutputCountVector ? ctx.AddIntermediateVariable(null, "encoded", true) : dstVariableName;
 
                 string opType = "OneHotEncoder";
                 var node = ctx.CreateNode(opType, srcVariableName, encodedVariableName, ctx.GetNodeName(opType));
                 node.AddAttribute("cats_int64s", Enumerable.Range(0, info.TypeSrc.GetItemType().GetKeyCountAsInt32(Host)).Select(x => (long)x));
                 node.AddAttribute("zeros", true);
-                if (_parent._columns[iinfo].UseBagging)
+                if (_parent._columns[iinfo].OutputCountVector)
                 {
                     // If input shape is [1, 3], then OneHotEncoder may produce a 3-D tensor. Thus, we need to do a
                     // reduction along the second last axis to merge the one-hot vectors produced by all input features.
@@ -730,7 +730,7 @@ namespace Microsoft.ML.Transforms
     {
         internal static class Defaults
         {
-            public const bool UseBagging = false;
+            public const bool OutputCountVector = false;
         }
 
         /// <summary>
@@ -743,23 +743,24 @@ namespace Microsoft.ML.Transforms
             /// <summary> Name of column to transform.</summary>
             public readonly string InputColumnName;
             /// <summary>
-            /// Whether to combine multiple indicator vectors into a single bag vector instead of concatenating them.
-            /// This is only relevant when the input column is a vector.
+            /// Whether to combine multiple indicator vectors into a single vector of counts instead of concatenating them.
+            /// This is only relevant when the input column is a vector of keys.
             /// </summary>
-            public readonly bool UseBagging;
+            public readonly bool OutputCountVector;
 
             /// <summary>
             /// Describes how the transformer handles one column pair.
             /// </summary>
             /// <param name="name">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
-            /// <param name="useBagging">Whether to combine multiple indicator vectors into a single bag vector instead of concatenating them. This is only relevant when the input column is a vector.</param>
-            public ColumnOptions(string name, string inputColumnName = null, bool useBagging = Defaults.UseBagging)
+            /// <param name="outputCountVector">Whether to combine multiple indicator vectors into a single vector of counts instead of concatenating them.
+            /// This is only relevant when the input column is a vector of keys.</param>
+            public ColumnOptions(string name, string inputColumnName = null, bool outputCountVector = Defaults.OutputCountVector)
             {
                 Contracts.CheckNonWhiteSpace(name, nameof(name));
                 Name = name;
                 InputColumnName = inputColumnName ?? name;
-                UseBagging = useBagging;
+                OutputCountVector = outputCountVector;
             }
         }
 
@@ -768,8 +769,8 @@ namespace Microsoft.ML.Transforms
         {
         }
 
-        internal KeyToVectorMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, bool useBagging = Defaults.UseBagging)
-            : this(env, new KeyToVectorMappingTransformer(env, new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, useBagging)))
+        internal KeyToVectorMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, bool outputCountVector = Defaults.OutputCountVector)
+            : this(env, new KeyToVectorMappingTransformer(env, new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, outputCountVector)))
         {
         }
 
@@ -797,9 +798,9 @@ namespace Microsoft.ML.Transforms
                 if (col.Annotations.TryFindColumn(AnnotationUtils.Kinds.KeyValues, out var keyMeta))
                     if (col.Kind != SchemaShape.Column.VectorKind.VariableVector && keyMeta.ItemType is TextDataViewType)
                         metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, keyMeta.ItemType, false));
-                if (!colInfo.UseBagging && (col.Kind == SchemaShape.Column.VectorKind.Scalar || col.Kind == SchemaShape.Column.VectorKind.Vector))
+                if (!colInfo.OutputCountVector && (col.Kind == SchemaShape.Column.VectorKind.Scalar || col.Kind == SchemaShape.Column.VectorKind.Vector))
                     metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.CategoricalSlotRanges, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.Int32, false));
-                if (!colInfo.UseBagging || (col.Kind == SchemaShape.Column.VectorKind.Scalar))
+                if (!colInfo.OutputCountVector || (col.Kind == SchemaShape.Column.VectorKind.Scalar))
                     metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar, BooleanDataViewType.Instance, false));
 
                 result[colInfo.Name] = new SchemaShape.Column(colInfo.Name, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.Single, false, new SchemaShape(metadata));

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -96,7 +96,7 @@ namespace Microsoft.ML.Transforms
 
         private const string RegistrationName = "KeyToVector";
 
-        public IReadOnlyCollection<KeyToVectorMappingEstimator.ColumnOptions> Columns => _columns.AsReadOnly();
+        internal IReadOnlyCollection<KeyToVectorMappingEstimator.ColumnOptions> Columns => _columns.AsReadOnly();
         private readonly KeyToVectorMappingEstimator.ColumnOptions[] _columns;
 
         private static (string outputColumnName, string inputColumnName)[] GetColumnPairs(KeyToVectorMappingEstimator.ColumnOptions[] columns)

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -40,24 +40,24 @@ namespace Microsoft.ML.Transforms
             public readonly string InputColumnName;
             public readonly MappingOrder MappingOrder;
             public readonly int MaximumNumberOfKeys;
-            public IReadOnlyList<string> Keys => KeysArray;
-            internal readonly string[] KeysArray;
-            public readonly bool KeyValuesAnnotationsAsText;
+            public readonly bool AddKeyValueAnnotationsAsText;
+
+            [BestFriend]
+            internal string[] Keys { get; set; }
 
             [BestFriend]
             internal string Key { get; set; }
 
             [BestFriend]
             private protected ColumnOptionsBase(string outputColumnName, string inputColumnName,
-                int maxNumberOfKeys, MappingOrder mappingOrder, string[] keys, bool keyValuesAnnotationsAsText)
+                int maxNumberOfKeys, MappingOrder mappingOrder, bool addKeyValueAnnotationsAsText)
             {
                 Contracts.CheckNonWhiteSpace(outputColumnName, nameof(outputColumnName));
                 OutputColumnName = outputColumnName;
                 InputColumnName = inputColumnName ?? outputColumnName;
                 MappingOrder = mappingOrder;
                 MaximumNumberOfKeys = maxNumberOfKeys;
-                Keys = keys;
-                KeyValuesAnnotationsAsText = keyValuesAnnotationsAsText;
+                AddKeyValueAnnotationsAsText = addKeyValueAnnotationsAsText;
             }
         }
 
@@ -74,14 +74,12 @@ namespace Microsoft.ML.Transforms
             /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
             /// <param name="mappingOrder">How items should be ordered when vectorized. If <see cref="MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
             /// If <see cref="MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
-            /// <param name="keys">List of terms.</param>
-            /// <param name="keyValuesAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
+            /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
             public ColumnOptions(string outputColumnName, string inputColumnName = null,
                 int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys,
                 MappingOrder mappingOrder = Defaults.Order,
-                string[] keys = null,
-                bool keyValuesAnnotationsAsText = false)
-                : base(outputColumnName, inputColumnName, maximumNumberOfKeys, mappingOrder, keys, keyValuesAnnotationsAsText)
+                bool addKeyValueAnnotationsAsText = false)
+                : base(outputColumnName, inputColumnName, maximumNumberOfKeys, mappingOrder, addKeyValueAnnotationsAsText)
             {
             }
         }
@@ -148,7 +146,7 @@ namespace Microsoft.ML.Transforms
                 if (!col.IsKey || !col.Annotations.TryFindColumn(AnnotationUtils.Kinds.KeyValues, out var kv) || kv.Kind != SchemaShape.Column.VectorKind.Vector)
                 {
                     kv = new SchemaShape.Column(AnnotationUtils.Kinds.KeyValues, SchemaShape.Column.VectorKind.Vector,
-                        colInfo.KeyValuesAnnotationsAsText ? TextDataViewType.Instance : col.ItemType, col.IsKey);
+                        colInfo.AddKeyValueAnnotationsAsText ? TextDataViewType.Instance : col.ItemType, col.IsKey);
                 }
                 Contracts.Assert(kv.IsValid);
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Transforms
         [BestFriend]
         internal static class Defaults
         {
-            public const int MaxNumKeys = 1000000;
+            public const int MaxNumberOfKeys = 1000000;
             public const SortOrder Sort = SortOrder.Occurrence;
         }
 
@@ -71,17 +71,17 @@ namespace Microsoft.ML.Transforms
             /// </summary>
             /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-            /// <param name="maxNumKeys">Maximum number of keys to keep per column when auto-training.</param>
+            /// <param name="maxNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
             /// <param name="sort">How items should be ordered when vectorized. If <see cref="SortOrder.Occurrence"/> choosen they will be in the order encountered.
             /// If <see cref="SortOrder.Value"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
             /// <param name="term">List of terms.</param>
             /// <param name="textKeyValues">Whether key value metadata should be text, regardless of the actual input type.</param>
             public ColumnOptions(string outputColumnName, string inputColumnName = null,
-                int maxNumKeys = Defaults.MaxNumKeys,
+                int maxNumberOfKeys = Defaults.MaxNumberOfKeys,
                 SortOrder sort = Defaults.Sort,
                 string[] term = null,
                 bool textKeyValues = false)
-                : base(outputColumnName, inputColumnName, maxNumKeys, sort, term, textKeyValues)
+                : base(outputColumnName, inputColumnName, maxNumberOfKeys, sort, term, textKeyValues)
             {
             }
         }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Transforms
             public readonly string OutputColumnName;
             public readonly string InputColumnName;
             public readonly SortOrder Sort;
-            public readonly int MaxNumKeys;
+            public readonly int MaxNumberOfKeys;
             public IReadOnlyList<string> Term => TermArray;
             internal readonly string[] TermArray;
             public readonly bool TextKeyValues;
@@ -49,13 +49,13 @@ namespace Microsoft.ML.Transforms
 
             [BestFriend]
             private protected ColumnOptionsBase(string outputColumnName, string inputColumnName,
-                int maxNumKeys, SortOrder sort, string[] term, bool textKeyValues)
+                int maxNumberOfKeys, SortOrder sort, string[] term, bool textKeyValues)
             {
                 Contracts.CheckNonWhiteSpace(outputColumnName, nameof(outputColumnName));
                 OutputColumnName = outputColumnName;
                 InputColumnName = inputColumnName ?? outputColumnName;
                 Sort = sort;
-                MaxNumKeys = maxNumKeys;
+                MaxNumberOfKeys = maxNumberOfKeys;
                 TermArray = term;
                 TextKeyValues = textKeyValues;
             }
@@ -96,11 +96,11 @@ namespace Microsoft.ML.Transforms
         /// <param name="env">Host Environment.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="maxNumKeys">Maximum number of keys to keep per column when auto-training.</param>
+        /// <param name="maxNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
         /// <param name="sort">How items should be ordered when vectorized. If <see cref="SortOrder.Occurrence"/> choosen they will be in the order encountered.
         /// If <see cref="SortOrder.Value"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
-        internal ValueToKeyMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int maxNumKeys = Defaults.MaxNumKeys, SortOrder sort = Defaults.Sort) :
-           this(env, new[] { new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, maxNumKeys, sort) })
+        internal ValueToKeyMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int maxNumberOfKeys = Defaults.MaxNumberOfKeys, SortOrder sort = Defaults.Sort) :
+           this(env, new[] { new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, maxNumberOfKeys, sort) })
         {
         }
 
@@ -161,18 +161,5 @@ namespace Microsoft.ML.Transforms
 
             return new SchemaShape(result.Values);
         }
-    }
-
-    public enum KeyValueOrder : byte
-    {
-        /// <summary>
-        /// Terms will be assigned ID in the order in which they appear.
-        /// </summary>
-        Occurence = ValueToKeyMappingEstimator.SortOrder.Occurrence,
-
-        /// <summary>
-        /// Terms will be assigned ID according to their sort via an ordinal comparison for the type.
-        /// </summary>
-        Value = ValueToKeyMappingEstimator.SortOrder.Value
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -17,15 +17,22 @@ namespace Microsoft.ML.Transforms
         internal static class Defaults
         {
             public const int MaximumNumberOfKeys = 1000000;
-            public const MappingOrder Order = MappingOrder.ByOccurrence;
+            public const KeyOrdinality Ordinality = KeyOrdinality.ByOccurrence;
         }
 
         /// <summary>
         /// Controls how the order of the output keys.
         /// </summary>
-        public enum MappingOrder : byte
+        public enum KeyOrdinality : byte
         {
+            /// <summary>
+            /// Values will be assigned keys in the order in which they appear.
+            /// </summary>
             ByOccurrence = 0,
+
+            /// <summary>
+            /// Values will be assigned keys according to their sort via an ordinal comparison for the type.
+            /// </summary>
             ByValue = 1,
             // REVIEW: We can think about having a frequency order option. What about
             // other things, like case insensitive (where appropriate), culturally aware, etc.?
@@ -38,7 +45,7 @@ namespace Microsoft.ML.Transforms
         {
             public readonly string OutputColumnName;
             public readonly string InputColumnName;
-            public readonly MappingOrder MappingOrder;
+            public readonly KeyOrdinality KeyOrdinality;
             public readonly int MaximumNumberOfKeys;
             public readonly bool AddKeyValueAnnotationsAsText;
 
@@ -50,13 +57,13 @@ namespace Microsoft.ML.Transforms
 
             [BestFriend]
             private protected ColumnOptionsBase(string outputColumnName, string inputColumnName,
-                int maxNumberOfKeys, MappingOrder mappingOrder, bool addKeyValueAnnotationsAsText)
+                int maximumNumberOfKeys, KeyOrdinality keyOrdinality, bool addKeyValueAnnotationsAsText)
             {
                 Contracts.CheckNonWhiteSpace(outputColumnName, nameof(outputColumnName));
                 OutputColumnName = outputColumnName;
                 InputColumnName = inputColumnName ?? outputColumnName;
-                MappingOrder = mappingOrder;
-                MaximumNumberOfKeys = maxNumberOfKeys;
+                KeyOrdinality = keyOrdinality;
+                MaximumNumberOfKeys = maximumNumberOfKeys;
                 AddKeyValueAnnotationsAsText = addKeyValueAnnotationsAsText;
             }
         }
@@ -72,14 +79,14 @@ namespace Microsoft.ML.Transforms
             /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
             /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-            /// <param name="mappingOrder">How items should be ordered when vectorized. If <see cref="MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
-            /// If <see cref="MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+            /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
+            /// If <see cref="KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
             /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
             public ColumnOptions(string outputColumnName, string inputColumnName = null,
                 int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys,
-                MappingOrder mappingOrder = Defaults.Order,
+                KeyOrdinality keyOrdinality = Defaults.Ordinality,
                 bool addKeyValueAnnotationsAsText = false)
-                : base(outputColumnName, inputColumnName, maximumNumberOfKeys, mappingOrder, addKeyValueAnnotationsAsText)
+                : base(outputColumnName, inputColumnName, maximumNumberOfKeys, keyOrdinality, addKeyValueAnnotationsAsText)
             {
             }
         }
@@ -95,10 +102,10 @@ namespace Microsoft.ML.Transforms
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-        /// <param name="sort">How items should be ordered when vectorized. If <see cref="MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
-        /// If <see cref="MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
-        internal ValueToKeyMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys, MappingOrder sort = Defaults.Order) :
-           this(env, new [] { new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, maximumNumberOfKeys, sort) })
+        /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
+        /// If <see cref="KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+        internal ValueToKeyMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys, KeyOrdinality keyOrdinality = Defaults.Ordinality) :
+           this(env, new [] { new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, maximumNumberOfKeys, keyOrdinality) })
         {
         }
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -569,7 +569,7 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     // Auto train this column. Leave the term map null for now, but set the lim appropriately.
-                    lims[iinfo] = columns[iinfo].MaxNumKeys;
+                    lims[iinfo] = columns[iinfo].MaxNumberOfKeys;
                     ch.CheckUserArg(lims[iinfo] > 0, nameof(Column.MaxNumTerms), "Must be positive");
                     Contracts.Check(trainingData.Schema.TryGetColumnIndex(infos[iinfo].InputColumnName, out int colIndex));
                     Utils.Add(ref toTrain, colIndex);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -262,7 +262,7 @@ namespace Microsoft.ML.Transforms
                 _unboundMaps = Train(Host, ch, infos, keyData, columns, input, autoConvert);
                 _textMetadata = new bool[_unboundMaps.Length];
                 for (int iinfo = 0; iinfo < columns.Length; ++iinfo)
-                    _textMetadata[iinfo] = columns[iinfo].KeyValuesAnnotationsAsText;
+                    _textMetadata[iinfo] = columns[iinfo].AddKeyValueAnnotationsAsText;
                 ch.Assert(_unboundMaps.Length == columns.Length);
             }
         }
@@ -300,8 +300,8 @@ namespace Microsoft.ML.Transforms
                         item.Source ?? item.Name,
                         item.MaxNumTerms ?? options.MaxNumTerms,
                         sortOrder,
-                        item.Terms,
                         item.TextKeyValues ?? options.TextKeyValues);
+                    cols[i].Keys = item.Terms;
                     cols[i].Key = item.Term ?? options.Term;
                 };
                 var keyData = GetKeyDataViewOrNull(env, ch, options.DataFile, options.TermsColumn, options.Loader, out bool autoLoaded);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -532,7 +532,7 @@ namespace Microsoft.ML.Transforms
             {
                 // First check whether we have a terms argument, and handle it appropriately.
                 var terms = columns[iinfo].Key.AsMemory();
-                var termsArray = columns[iinfo].KeysArray;
+                var termsArray = columns[iinfo].Keys;
 
                 terms = ReadOnlyMemoryUtils.TrimSpaces(terms);
                 if (!terms.IsEmpty || (termsArray != null && termsArray.Length > 0))

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -47,18 +47,18 @@ namespace Microsoft.ML.Transforms
         [BestFriend]
         internal abstract class ColumnBase : OneToOneColumn
         {
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of terms to keep when auto-training", ShortName = "max")]
-            public int? MaxNumTerms;
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of keys to keep when auto-training", ShortName = "max")]
+            public int? MaximumNumberOfKeys;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Comma separated list of terms", Name = "Terms", Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
-            public string Term;
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Comma separated list of keys", Name = "Key", Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
+            public string Key;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "List of terms", Name = "Term", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public string[] Terms;
+            [Argument(ArgumentType.AtMostOnce, HelpText = "List of keys", Name = "Keys", Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
+            public string[] Keys;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "How items should be ordered when vectorized. By default, they will be in the order encountered. " +
                 "If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').")]
-            public ValueToKeyMappingEstimator.SortOrder? Sort;
+            public ValueToKeyMappingEstimator.MappingOrder? Sort;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Whether key value metadata should be text, regardless of the actual input type", ShortName = "textkv", Hide = true)]
             public bool? TextKeyValues;
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Transforms
                 // REVIEW: This pattern isn't robust enough. If a new field is added, this code needs
                 // to be updated accordingly, or it will break. The only protection we have against this
                 // is unit tests....
-                if (MaxNumTerms != null || !string.IsNullOrEmpty(Term) || Sort != null || TextKeyValues != null)
+                if (MaximumNumberOfKeys != null || !string.IsNullOrEmpty(Key) || Sort != null || TextKeyValues != null)
                     return false;
                 return base.TryUnparseCore(sb);
             }
@@ -99,26 +99,26 @@ namespace Microsoft.ML.Transforms
         }
 
         [BestFriend]
-        internal abstract class ArgumentsBase : TransformInputBase
+        internal abstract class OptionsBase : TransformInputBase
         {
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of terms to keep per column when auto-training", ShortName = "max", SortOrder = 5)]
-            public int MaxNumTerms = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys;
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of keys to keep per column when auto-training", ShortName = "max", SortOrder = 5)]
+            public int MaximumNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Comma separated list of terms", Name = "Terms", SortOrder = 105, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
-            public string Term;
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Comma separated list of keys", Name = "Key", SortOrder = 105, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
+            public string Key;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "List of terms", Name = "Term", SortOrder = 106, Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
-            public string[] Terms;
+            [Argument(ArgumentType.AtMostOnce, HelpText = "List of keys", Name = "Keys", SortOrder = 106, Visibility = ArgumentAttribute.VisibilityType.EntryPointsOnly)]
+            public string[] Keys;
 
-            [Argument(ArgumentType.AtMostOnce, IsInputFileName = true, HelpText = "Data file containing the terms", ShortName = "data", SortOrder = 110, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
+            [Argument(ArgumentType.AtMostOnce, IsInputFileName = true, HelpText = "Data file containing the keys", ShortName = "data", SortOrder = 110, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
             public string DataFile;
 
             [Argument(ArgumentType.Multiple, HelpText = "Data loader", NullName = "<Auto>", SortOrder = 111, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly, SignatureType = typeof(SignatureDataLoader))]
             [BestFriend]
             internal IComponentFactory<IMultiStreamSource, ILegacyDataLoader> Loader;
 
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Name of the text column containing the terms", ShortName = "termCol", SortOrder = 112, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
-            public string TermsColumn;
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Name of the text column containing the keys", ShortName = "keysCol", SortOrder = 112, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
+            public string KeysColumnName;
 
             // REVIEW: The behavior of sorting when doing term on an input key value is to sort on the key numbers themselves,
             // that is, to maintain the relative order of the key values. The alternative is that, for these, we would sort on the key
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Transforms
             // REVIEW: Should we always sort? Opinions are mixed. See work item 7797429.
             [Argument(ArgumentType.AtMostOnce, HelpText = "How items should be ordered when vectorized. By default, they will be in the order encountered. " +
                 "If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').", SortOrder = 113)]
-            public ValueToKeyMappingEstimator.SortOrder Sort = ValueToKeyMappingEstimator.Defaults.Sort;
+            public ValueToKeyMappingEstimator.MappingOrder MappingOrder = ValueToKeyMappingEstimator.Defaults.Order;
 
             // REVIEW: Should we do this here, or correct the various pieces of code here and in MRS etc. that
             // assume key-values will be string? Once we correct these things perhaps we can see about removing it.
@@ -136,7 +136,7 @@ namespace Microsoft.ML.Transforms
         }
 
         [BestFriend]
-        internal sealed class Options : ArgumentsBase
+        internal sealed class Options : OptionsBase
         {
             [Argument(ArgumentType.Multiple, HelpText = "New column definition(s) (optional form: name:src)", Name = "Column", ShortName = "col", SortOrder = 1)]
             public Column[] Columns;
@@ -262,7 +262,7 @@ namespace Microsoft.ML.Transforms
                 _unboundMaps = Train(Host, ch, infos, keyData, columns, input, autoConvert);
                 _textMetadata = new bool[_unboundMaps.Length];
                 for (int iinfo = 0; iinfo < columns.Length; ++iinfo)
-                    _textMetadata[iinfo] = columns[iinfo].TextKeyValues;
+                    _textMetadata[iinfo] = columns[iinfo].KeyValuesAnnotationsAsText;
                 ch.Assert(_unboundMaps.Length == columns.Length);
             }
         }
@@ -279,32 +279,32 @@ namespace Microsoft.ML.Transforms
             var cols = new ValueToKeyMappingEstimator.ColumnOptions[options.Columns.Length];
             using (var ch = env.Start("ValidateArgs"))
             {
-                if ((options.Terms != null || !string.IsNullOrEmpty(options.Term)) &&
+                if ((options.Keys != null || !string.IsNullOrEmpty(options.Key)) &&
                   (!string.IsNullOrWhiteSpace(options.DataFile) || options.Loader != null ||
-                      !string.IsNullOrWhiteSpace(options.TermsColumn)))
+                      !string.IsNullOrWhiteSpace(options.KeysColumnName)))
                 {
                     ch.Warning("Explicit term list specified. Data file arguments will be ignored");
                 }
-                if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.SortOrder), options.Sort))
-                    throw ch.ExceptUserArg(nameof(options.Sort), "Undefined sorting criteria '{0}' detected", options.Sort);
+                if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.MappingOrder), options.MappingOrder))
+                    throw ch.ExceptUserArg(nameof(options.MappingOrder), "Undefined sorting criteria '{0}' detected", options.MappingOrder);
 
                 for (int i = 0; i < cols.Length; i++)
                 {
                     var item = options.Columns[i];
-                    var sortOrder = item.Sort ?? options.Sort;
-                    if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.SortOrder), sortOrder))
-                        throw env.ExceptUserArg(nameof(options.Sort), "Undefined sorting criteria '{0}' detected for column '{1}'", sortOrder, item.Name);
+                    var sortOrder = item.Sort ?? options.MappingOrder;
+                    if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.MappingOrder), sortOrder))
+                        throw env.ExceptUserArg(nameof(options.MappingOrder), "Undefined sorting criteria '{0}' detected for column '{1}'", sortOrder, item.Name);
 
                     cols[i] = new ValueToKeyMappingEstimator.ColumnOptions(
                         item.Name,
                         item.Source ?? item.Name,
-                        item.MaxNumTerms ?? options.MaxNumTerms,
+                        item.MaximumNumberOfKeys ?? options.MaximumNumberOfKeys,
                         sortOrder,
-                        item.Terms,
+                        item.Keys,
                         item.TextKeyValues ?? options.TextKeyValues);
-                    cols[i].Terms = item.Term ?? options.Term;
+                    cols[i].Key = item.Key ?? options.Key;
                 };
-                var keyData = GetKeyDataViewOrNull(env, ch, options.DataFile, options.TermsColumn, options.Loader, out bool autoLoaded);
+                var keyData = GetKeyDataViewOrNull(env, ch, options.DataFile, options.KeysColumnName, options.Loader, out bool autoLoaded);
                 return new ValueToKeyMappingTransformer(env, input, cols, keyData, autoLoaded).MakeDataTransform(input);
             }
         }
@@ -374,7 +374,7 @@ namespace Microsoft.ML.Transforms
 
         /// <summary>
         /// Returns a single-column <see cref="IDataView"/>, based on values from <see cref="Options"/>,
-        /// in the case where <see cref="ArgumentsBase.DataFile"/> is set. If that is not set, this will
+        /// in the case where <see cref="OptionsBase.DataFile"/> is set. If that is not set, this will
         /// return <see langword="null"/>.
         /// </summary>
         /// <param name="env">The host environment.</param>
@@ -436,7 +436,7 @@ namespace Microsoft.ML.Transforms
                     {
                         ch.Warning(
                             "{0} should not be specified when default loader is " + nameof(TextLoader) + ". Ignoring {0}={1}",
-                            nameof(Options.TermsColumn), src);
+                            nameof(Options.KeysColumnName), src);
                     }
 
                     // Create text loader.
@@ -531,14 +531,14 @@ namespace Microsoft.ML.Transforms
             for (int iinfo = 0; iinfo < infos.Length; iinfo++)
             {
                 // First check whether we have a terms argument, and handle it appropriately.
-                var terms = columns[iinfo].Terms.AsMemory();
-                var termsArray = columns[iinfo].TermArray;
+                var terms = columns[iinfo].Key.AsMemory();
+                var termsArray = columns[iinfo].KeysArray;
 
                 terms = ReadOnlyMemoryUtils.TrimSpaces(terms);
                 if (!terms.IsEmpty || (termsArray != null && termsArray.Length > 0))
                 {
                     // We have terms! Pass it in.
-                    var sortOrder = columns[iinfo].Sort;
+                    var sortOrder = columns[iinfo].MappingOrder;
                     var bldr = Builder.Create(infos[iinfo].TypeSrc, sortOrder);
                     if (!terms.IsEmpty)
                         bldr.ParseAddTermArg(ref terms, ch);
@@ -551,7 +551,7 @@ namespace Microsoft.ML.Transforms
                     // First column using this file.
                     if (termsFromFile == null)
                     {
-                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].Sort);
+                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].MappingOrder);
                         termsFromFile = CreateTermMapFromData(env, ch, keyData, autoConvert, bldr);
                     }
                     if (!termsFromFile.ItemType.Equals(infos[iinfo].TypeSrc.GetItemType()))
@@ -569,8 +569,8 @@ namespace Microsoft.ML.Transforms
                 else
                 {
                     // Auto train this column. Leave the term map null for now, but set the lim appropriately.
-                    lims[iinfo] = columns[iinfo].MaxNumberOfKeys;
-                    ch.CheckUserArg(lims[iinfo] > 0, nameof(Column.MaxNumTerms), "Must be positive");
+                    lims[iinfo] = columns[iinfo].MaximumNumberOfKeys;
+                    ch.CheckUserArg(lims[iinfo] > 0, nameof(Column.MaximumNumberOfKeys), "Must be positive");
                     Contracts.Check(trainingData.Schema.TryGetColumnIndex(infos[iinfo].InputColumnName, out int colIndex));
                     Utils.Add(ref toTrain, colIndex);
                     ++trainsNeeded;
@@ -597,7 +597,7 @@ namespace Microsoft.ML.Transforms
                     {
                         if (termMap[iinfo] != null)
                             continue;
-                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].Sort);
+                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].MappingOrder);
                         trainerInfo[itrainer] = iinfo;
                         trainingData.Schema.TryGetColumnIndex(infos[iinfo].InputColumnName, out int colIndex);
                         trainer[itrainer++] = Trainer.Create(cursor, colIndex, false, lims[iinfo], bldr);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Transforms
         internal abstract class ArgumentsBase : TransformInputBase
         {
             [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of terms to keep per column when auto-training", ShortName = "max", SortOrder = 5)]
-            public int MaxNumTerms = ValueToKeyMappingEstimator.Defaults.MaxNumKeys;
+            public int MaxNumTerms = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Comma separated list of terms", Name = "Terms", SortOrder = 105, Visibility = ArgumentAttribute.VisibilityType.CmdLineOnly)]
             public string Term;

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Transforms
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "How items should be ordered when vectorized. By default, they will be in the order encountered. " +
                 "If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').")]
-            public ValueToKeyMappingEstimator.MappingOrder? Sort;
+            public ValueToKeyMappingEstimator.KeyOrdinality? Sort;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Whether key value metadata should be text, regardless of the actual input type", ShortName = "textkv", Hide = true)]
             public bool? TextKeyValues;
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Transforms
             // REVIEW: Should we always sort? Opinions are mixed. See work item 7797429.
             [Argument(ArgumentType.AtMostOnce, HelpText = "How items should be ordered when vectorized. By default, they will be in the order encountered. " +
                 "If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').", SortOrder = 113)]
-            public ValueToKeyMappingEstimator.MappingOrder Sort = ValueToKeyMappingEstimator.Defaults.Order;
+            public ValueToKeyMappingEstimator.KeyOrdinality Sort = ValueToKeyMappingEstimator.Defaults.Ordinality;
 
             // REVIEW: Should we do this here, or correct the various pieces of code here and in MRS etc. that
             // assume key-values will be string? Once we correct these things perhaps we can see about removing it.
@@ -285,14 +285,14 @@ namespace Microsoft.ML.Transforms
                 {
                     ch.Warning("Explicit term list specified. Data file arguments will be ignored");
                 }
-                if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.MappingOrder), options.Sort))
+                if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.KeyOrdinality), options.Sort))
                     throw ch.ExceptUserArg(nameof(options.Sort), "Undefined sorting criteria '{0}' detected", options.Sort);
 
                 for (int i = 0; i < cols.Length; i++)
                 {
                     var item = options.Columns[i];
                     var sortOrder = item.Sort ?? options.Sort;
-                    if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.MappingOrder), sortOrder))
+                    if (!Enum.IsDefined(typeof(ValueToKeyMappingEstimator.KeyOrdinality), sortOrder))
                         throw env.ExceptUserArg(nameof(options.Sort), "Undefined sorting criteria '{0}' detected for column '{1}'", sortOrder, item.Name);
 
                     cols[i] = new ValueToKeyMappingEstimator.ColumnOptions(
@@ -538,7 +538,7 @@ namespace Microsoft.ML.Transforms
                 if (!terms.IsEmpty || (termsArray != null && termsArray.Length > 0))
                 {
                     // We have terms! Pass it in.
-                    var sortOrder = columns[iinfo].MappingOrder;
+                    var sortOrder = columns[iinfo].KeyOrdinality;
                     var bldr = Builder.Create(infos[iinfo].TypeSrc, sortOrder);
                     if (!terms.IsEmpty)
                         bldr.ParseAddTermArg(ref terms, ch);
@@ -551,7 +551,7 @@ namespace Microsoft.ML.Transforms
                     // First column using this file.
                     if (termsFromFile == null)
                     {
-                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].MappingOrder);
+                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].KeyOrdinality);
                         termsFromFile = CreateTermMapFromData(env, ch, keyData, autoConvert, bldr);
                     }
                     if (!termsFromFile.ItemType.Equals(infos[iinfo].TypeSrc.GetItemType()))
@@ -597,7 +597,7 @@ namespace Microsoft.ML.Transforms
                     {
                         if (termMap[iinfo] != null)
                             continue;
-                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].MappingOrder);
+                        var bldr = Builder.Create(infos[iinfo].TypeSrc, columns[iinfo].KeyOrdinality);
                         trainerInfo[itrainer] = iinfo;
                         trainingData.Schema.TryGetColumnIndex(infos[iinfo].InputColumnName, out int colIndex);
                         trainer[itrainer++] = Trainer.Create(cursor, colIndex, false, lims[iinfo], bldr);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Transforms
                 }
 
                 if (Count == 0)
-                    throw ch.ExceptUserArg(nameof(Options.Key), "Nothing parsed as '{0}'", ItemType);
+                    throw ch.ExceptUserArg(nameof(Options.Term), "Nothing parsed as '{0}'", ItemType);
             }
 
             /// <summary>
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Transforms
                 }
 
                 if (Count == 0)
-                    throw ch.ExceptUserArg(nameof(Options.Key), "Nothing parsed as '{0}'", ItemType);
+                    throw ch.ExceptUserArg(nameof(Options.Term), "Nothing parsed as '{0}'", ItemType);
             }
         }
 

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Transforms
                 ItemType = type;
             }
 
-            public static Builder Create(DataViewType type, ValueToKeyMappingEstimator.MappingOrder sortOrder)
+            public static Builder Create(DataViewType type, ValueToKeyMappingEstimator.KeyOrdinality sortOrder)
             {
                 Contracts.AssertValue(type);
                 Contracts.Assert(type is VectorType || type is PrimitiveDataViewType);
@@ -45,8 +45,8 @@ namespace Microsoft.ML.Transforms
                 // accept any value, but currently the internal implementations of Builder are split
                 // along this being a purely binary option, for now (though this can easily change
                 // with mot implementations of Builder).
-                Contracts.Assert(sortOrder == ValueToKeyMappingEstimator.MappingOrder.ByOccurrence || sortOrder == ValueToKeyMappingEstimator.MappingOrder.ByValue);
-                bool sorted = sortOrder == ValueToKeyMappingEstimator.MappingOrder.ByValue;
+                Contracts.Assert(sortOrder == ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence || sortOrder == ValueToKeyMappingEstimator.KeyOrdinality.ByValue);
+                bool sorted = sortOrder == ValueToKeyMappingEstimator.KeyOrdinality.ByValue;
 
                 PrimitiveDataViewType itemType = type.GetItemType() as PrimitiveDataViewType;
                 Contracts.AssertValue(itemType);

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformerImpl.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Transforms
                 ItemType = type;
             }
 
-            public static Builder Create(DataViewType type, ValueToKeyMappingEstimator.SortOrder sortOrder)
+            public static Builder Create(DataViewType type, ValueToKeyMappingEstimator.MappingOrder sortOrder)
             {
                 Contracts.AssertValue(type);
                 Contracts.Assert(type is VectorType || type is PrimitiveDataViewType);
@@ -45,8 +45,8 @@ namespace Microsoft.ML.Transforms
                 // accept any value, but currently the internal implementations of Builder are split
                 // along this being a purely binary option, for now (though this can easily change
                 // with mot implementations of Builder).
-                Contracts.Assert(sortOrder == ValueToKeyMappingEstimator.SortOrder.Occurrence || sortOrder == ValueToKeyMappingEstimator.SortOrder.Value);
-                bool sorted = sortOrder == ValueToKeyMappingEstimator.SortOrder.Value;
+                Contracts.Assert(sortOrder == ValueToKeyMappingEstimator.MappingOrder.ByOccurrence || sortOrder == ValueToKeyMappingEstimator.MappingOrder.ByValue);
+                bool sorted = sortOrder == ValueToKeyMappingEstimator.MappingOrder.ByValue;
 
                 PrimitiveDataViewType itemType = type.GetItemType() as PrimitiveDataViewType;
                 Contracts.AssertValue(itemType);
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Transforms
                 }
 
                 if (Count == 0)
-                    throw ch.ExceptUserArg(nameof(Options.Term), "Nothing parsed as '{0}'", ItemType);
+                    throw ch.ExceptUserArg(nameof(Options.Key), "Nothing parsed as '{0}'", ItemType);
             }
 
             /// <summary>
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Transforms
                 }
 
                 if (Count == 0)
-                    throw ch.ExceptUserArg(nameof(Options.Term), "Nothing parsed as '{0}'", ItemType);
+                    throw ch.ExceptUserArg(nameof(Options.Key), "Nothing parsed as '{0}'", ItemType);
             }
         }
 

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -253,7 +253,7 @@ namespace Microsoft.ML.EntryPoints
                         Name = input.LabelColumn,
                         Source = input.LabelColumn,
                         TextKeyValues = input.TextKeyValues,
-                        Sort = ValueToKeyMappingEstimator.MappingOrder.ByValue
+                        Sort = ValueToKeyMappingEstimator.KeyOrdinality.ByValue
                     }
                 }
             };

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.EntryPoints
                     new ValueToKeyMappingTransformer.Options()
                     {
                         Columns = ktv
-                            .Select(c => new ValueToKeyMappingTransformer.Column() { Name = c.Name, Source = c.Name, Term = GetTerms(viewTrain, c.InputColumnName) })
+                            .Select(c => new ValueToKeyMappingTransformer.Column() { Name = c.Name, Source = c.Name, Key = GetTerms(viewTrain, c.InputColumnName) })
                             .ToArray(),
                         TextKeyValues = true
                     },
@@ -253,7 +253,7 @@ namespace Microsoft.ML.EntryPoints
                         Name = input.LabelColumn,
                         Source = input.LabelColumn,
                         TextKeyValues = input.TextKeyValues,
-                        Sort = ValueToKeyMappingEstimator.SortOrder.Value
+                        Sort = ValueToKeyMappingEstimator.MappingOrder.ByValue
                     }
                 }
             };

--- a/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
+++ b/src/Microsoft.ML.EntryPoints/FeatureCombiner.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.EntryPoints
                     new ValueToKeyMappingTransformer.Options()
                     {
                         Columns = ktv
-                            .Select(c => new ValueToKeyMappingTransformer.Column() { Name = c.Name, Source = c.Name, Key = GetTerms(viewTrain, c.InputColumnName) })
+                            .Select(c => new ValueToKeyMappingTransformer.Column() { Name = c.Name, Source = c.Name, Term = GetTerms(viewTrain, c.InputColumnName) })
                             .ToArray(),
                         TextKeyValues = true
                     },

--- a/src/Microsoft.ML.EntryPoints/TrainTestSplit.cs
+++ b/src/Microsoft.ML.EntryPoints/TrainTestSplit.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ML.EntryPoints
                     {
                         Columns = new[] { new HashJoiningTransform.Column { Name = stratCol, Source = stratificationColumn } },
                         Join = true,
-                        HashBits = 30
+                        NumberOfBits = 30
                     }, data);
             }
 

--- a/src/Microsoft.ML.StaticPipe/CategoricalHashStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/CategoricalHashStaticExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.StaticPipe
         }
 
         private const OneHotHashVectorOutputKind DefOut = (OneHotHashVectorOutputKind)OneHotHashEncodingEstimator.Defaults.OutputKind;
-        private const int DefHashBits = OneHotHashEncodingEstimator.Defaults.HashBits;
+        private const int DefHashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits;
         private const uint DefSeed = OneHotHashEncodingEstimator.Defaults.Seed;
         private const bool DefOrdered = OneHotHashEncodingEstimator.Defaults.Ordered;
         private const int DefInvertHash = OneHotHashEncodingEstimator.Defaults.InvertHash;

--- a/src/Microsoft.ML.StaticPipe/CategoricalHashStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/CategoricalHashStaticExtensions.cs
@@ -44,8 +44,8 @@ namespace Microsoft.ML.StaticPipe
         private const OneHotHashVectorOutputKind DefOut = (OneHotHashVectorOutputKind)OneHotHashEncodingEstimator.Defaults.OutputKind;
         private const int DefHashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits;
         private const uint DefSeed = OneHotHashEncodingEstimator.Defaults.Seed;
-        private const bool DefOrdered = OneHotHashEncodingEstimator.Defaults.Ordered;
-        private const int DefInvertHash = OneHotHashEncodingEstimator.Defaults.InvertHash;
+        private const bool DefOrdered = OneHotHashEncodingEstimator.Defaults.UseOrderedHashing;
+        private const int DefInvertHash = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts;
 
         private readonly struct Config
         {
@@ -104,7 +104,7 @@ namespace Microsoft.ML.StaticPipe
                 for (int i = 0; i < toOutput.Length; ++i)
                 {
                     var tcol = (ICategoricalCol)toOutput[i];
-                    infos[i] = new OneHotHashEncodingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input], (OneHotEncodingTransformer.OutputKind)tcol.Config.OutputKind,
+                    infos[i] = new OneHotHashEncodingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input], (OneHotEncodingEstimator.OutputKind)tcol.Config.OutputKind,
                         tcol.Config.HashBits, tcol.Config.Seed, tcol.Config.Ordered, tcol.Config.InvertHash);
                 }
                 return new OneHotHashEncodingEstimator(env, infos);

--- a/src/Microsoft.ML.StaticPipe/CategoricalHashStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/CategoricalHashStaticExtensions.cs
@@ -42,26 +42,26 @@ namespace Microsoft.ML.StaticPipe
         }
 
         private const OneHotHashVectorOutputKind DefOut = (OneHotHashVectorOutputKind)OneHotHashEncodingEstimator.Defaults.OutputKind;
-        private const int DefHashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits;
+        private const int DefNumberOfBits = OneHotHashEncodingEstimator.Defaults.NumberOfBits;
         private const uint DefSeed = OneHotHashEncodingEstimator.Defaults.Seed;
         private const bool DefOrdered = OneHotHashEncodingEstimator.Defaults.UseOrderedHashing;
-        private const int DefInvertHash = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts;
+        private const int DefMaximumNumberOfInverts = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts;
 
         private readonly struct Config
         {
-            public readonly int HashBits;
+            public readonly int NumberOfBits;
             public readonly uint Seed;
             public readonly bool Ordered;
-            public readonly int InvertHash;
+            public readonly int MaximumNumberOfInverts;
             public readonly OneHotHashVectorOutputKind OutputKind;
 
-            public Config(OneHotHashVectorOutputKind outputKind, int hashBits, uint seed, bool ordered, int invertHash)
+            public Config(OneHotHashVectorOutputKind outputKind, int numberOfBits, uint seed, bool ordered, int maximumNumberOfInverts)
             {
                 OutputKind = outputKind;
-                HashBits = hashBits;
+                NumberOfBits = numberOfBits;
                 Seed = seed;
                 Ordered = ordered;
-                InvertHash = invertHash;
+                MaximumNumberOfInverts = maximumNumberOfInverts;
             }
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.ML.StaticPipe
                 {
                     var tcol = (ICategoricalCol)toOutput[i];
                     infos[i] = new OneHotHashEncodingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input], (OneHotEncodingEstimator.OutputKind)tcol.Config.OutputKind,
-                        tcol.Config.HashBits, tcol.Config.Seed, tcol.Config.Ordered, tcol.Config.InvertHash);
+                        tcol.Config.NumberOfBits, tcol.Config.Seed, tcol.Config.Ordered, tcol.Config.MaximumNumberOfInverts);
                 }
                 return new OneHotHashEncodingEstimator(env, infos);
             }
@@ -116,18 +116,18 @@ namespace Microsoft.ML.StaticPipe
         /// </summary>
         /// <param name="input">Incoming data.</param>
         /// <param name="outputKind">Specify the output type of indicator array: array or binary encoded data.</param>
-        /// <param name="hashBits">Amount of bits to use for hashing.</param>
+        /// <param name="numberOfBits">Amount of bits to use for hashing.</param>
         /// <param name="seed">Seed value used for hashing.</param>
         /// <param name="ordered">Whether the position of each term should be included in the hash.</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static Vector<float> OneHotHashEncoding(this Scalar<string> input, OneHotHashScalarOutputKind outputKind = (OneHotHashScalarOutputKind)DefOut,
-            int hashBits = DefHashBits, uint seed = DefSeed, bool ordered = DefOrdered, int invertHash = DefInvertHash)
+            int numberOfBits = DefNumberOfBits, uint seed = DefSeed, bool ordered = DefOrdered, int maximumNumberOfInverts = DefMaximumNumberOfInverts)
         {
             Contracts.CheckValue(input, nameof(input));
-            return new ImplScalar<string>(input, new Config((OneHotHashVectorOutputKind)outputKind, hashBits, seed, ordered, invertHash));
+            return new ImplScalar<string>(input, new Config((OneHotHashVectorOutputKind)outputKind, numberOfBits, seed, ordered, maximumNumberOfInverts));
         }
 
         /// <summary>
@@ -135,18 +135,18 @@ namespace Microsoft.ML.StaticPipe
         /// </summary>
         /// <param name="input">Incoming data.</param>
         /// <param name="outputKind">Specify the output type of indicator array: array or binary encoded data.</param>
-        /// <param name="hashBits">Amount of bits to use for hashing.</param>
+        /// <param name="numberOfBits">Amount of bits to use for hashing.</param>
         /// <param name="seed">Seed value used for hashing.</param>
         /// <param name="ordered">Whether the position of each term should be included in the hash.</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static Vector<float> OneHotHashEncoding(this Vector<string> input, OneHotHashVectorOutputKind outputKind = DefOut,
-            int hashBits = DefHashBits, uint seed = DefSeed, bool ordered = DefOrdered, int invertHash = DefInvertHash)
+            int numberOfBits = DefNumberOfBits, uint seed = DefSeed, bool ordered = DefOrdered, int maximumNumberOfInverts = DefMaximumNumberOfInverts)
         {
             Contracts.CheckValue(input, nameof(input));
-            return new ImplVector<string>(input, new Config(outputKind, hashBits, seed, ordered, invertHash));
+            return new ImplVector<string>(input, new Config(outputKind, numberOfBits, seed, ordered, maximumNumberOfInverts));
         }
 
         /// <summary>
@@ -154,18 +154,18 @@ namespace Microsoft.ML.StaticPipe
         /// </summary>
         /// <param name="input">Incoming data.</param>
         /// <param name="outputKind">Specify the output type of indicator array: array or binary encoded data.</param>
-        /// <param name="hashBits">Amount of bits to use for hashing.</param>
+        /// <param name="numberOfBits">Amount of bits to use for hashing.</param>
         /// <param name="seed">Seed value used for hashing.</param>
         /// <param name="ordered">Whether the position of each term should be included in the hash.</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static Vector<float> OneHotHashEncoding(this VarVector<string> input, OneHotHashVectorOutputKind outputKind = DefOut,
-            int hashBits = DefHashBits, uint seed = DefSeed, bool ordered = DefOrdered, int invertHash = DefInvertHash)
+            int numberOfBits = DefNumberOfBits, uint seed = DefSeed, bool ordered = DefOrdered, int maximumNumberOfInverts = DefMaximumNumberOfInverts)
         {
             Contracts.CheckValue(input, nameof(input));
-            return new ImplVector<string>(input, new Config(outputKind, hashBits, seed, ordered, invertHash));
+            return new ImplVector<string>(input, new Config(outputKind, numberOfBits, seed, ordered, maximumNumberOfInverts));
         }
     }
 }

--- a/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.StaticPipe
         }
 
         private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Sort;
-        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumKeys;
+        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys;
         private const OneHotVectorOutputKind DefOut = (OneHotVectorOutputKind)OneHotEncodingEstimator.Defaults.OutKind;
 
         private readonly struct Config

--- a/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
@@ -43,8 +43,8 @@ namespace Microsoft.ML.StaticPipe
             Bin = 4,
         }
 
-        private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Sort;
-        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys;
+        private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Order;
+        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys;
         private const OneHotVectorOutputKind DefOut = (OneHotVectorOutputKind)OneHotEncodingEstimator.Defaults.OutKind;
 
         private readonly struct Config
@@ -114,7 +114,7 @@ namespace Microsoft.ML.StaticPipe
                 {
                     var tcol = (ICategoricalCol)toOutput[i];
                     infos[i] = new OneHotEncodingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input], (OneHotEncodingTransformer.OutputKind)tcol.Config.OutputKind,
-                        tcol.Config.Max, (ValueToKeyMappingEstimator.SortOrder)tcol.Config.Order);
+                        tcol.Config.Max, (ValueToKeyMappingEstimator.MappingOrder)tcol.Config.Order);
                     if (tcol.Config.OnFit != null)
                     {
                         int ii = i; // Necessary because if we capture i that will change to toOutput.Length on call.
@@ -134,13 +134,13 @@ namespace Microsoft.ML.StaticPipe
         /// <param name="input">Incoming data.</param>
         /// <param name="outputKind">Specify the output type of indicator array: array or binary encoded data.</param>
         /// <param name="order">How the Id for each value would be assigined: by occurrence or by value.</param>
-        /// <param name="maxItems">Maximum number of ids to keep during data scanning.</param>
+        /// <param name="maximumNumberOfItems">Maximum number of ids to keep during data scanning.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         public static Vector<float> OneHotEncoding(this Scalar<string> input, OneHotScalarOutputKind outputKind = (OneHotScalarOutputKind)DefOut, KeyValueOrder order = DefSort,
-            int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
+            int maximumNumberOfItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
         {
             Contracts.CheckValue(input, nameof(input));
-            return new ImplScalar<string>(input, new Config((OneHotVectorOutputKind)outputKind, order, maxItems, Wrap(onFit)));
+            return new ImplScalar<string>(input, new Config((OneHotVectorOutputKind)outputKind, order, maximumNumberOfItems, Wrap(onFit)));
         }
 
         /// <summary>
@@ -149,13 +149,13 @@ namespace Microsoft.ML.StaticPipe
         /// <param name="input">Incoming data.</param>
         /// <param name="outputKind">Specify the output type of indicator array: Multiarray, array or binary encoded data.</param>
         /// <param name="order">How the Id for each value would be assigined: by occurrence or by value.</param>
-        /// <param name="maxItems">Maximum number of ids to keep during data scanning.</param>
+        /// <param name="maximumNumberOfItems">Maximum number of ids to keep during data scanning.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
-        public static Vector<float> OneHotEncoding(this Vector<string> input, OneHotVectorOutputKind outputKind = DefOut, KeyValueOrder order = DefSort, int maxItems = DefMax,
+        public static Vector<float> OneHotEncoding(this Vector<string> input, OneHotVectorOutputKind outputKind = DefOut, KeyValueOrder order = DefSort, int maximumNumberOfItems = DefMax,
             ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
         {
             Contracts.CheckValue(input, nameof(input));
-            return new ImplVector<string>(input, new Config(outputKind, order, maxItems, Wrap(onFit)));
+            return new ImplVector<string>(input, new Config(outputKind, order, maximumNumberOfItems, Wrap(onFit)));
         }
     }
 }

--- a/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
@@ -43,18 +43,18 @@ namespace Microsoft.ML.StaticPipe
             Bin = 4,
         }
 
-        private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Order;
+        private const KeyOrdinality DefSort = (KeyOrdinality)ValueToKeyMappingEstimator.Defaults.Ordinality;
         private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys;
         private const OneHotVectorOutputKind DefOut = (OneHotVectorOutputKind)OneHotEncodingEstimator.Defaults.OutKind;
 
         private readonly struct Config
         {
-            public readonly KeyValueOrder Order;
+            public readonly KeyOrdinality Order;
             public readonly int Max;
             public readonly OneHotVectorOutputKind OutputKind;
             public readonly Action<ValueToKeyMappingTransformer.TermMap> OnFit;
 
-            public Config(OneHotVectorOutputKind outputKind, KeyValueOrder order, int max, Action<ValueToKeyMappingTransformer.TermMap> onFit)
+            public Config(OneHotVectorOutputKind outputKind, KeyOrdinality order, int max, Action<ValueToKeyMappingTransformer.TermMap> onFit)
             {
                 OutputKind = outputKind;
                 Order = order;
@@ -114,7 +114,7 @@ namespace Microsoft.ML.StaticPipe
                 {
                     var tcol = (ICategoricalCol)toOutput[i];
                     infos[i] = new OneHotEncodingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input], (OneHotEncodingEstimator.OutputKind)tcol.Config.OutputKind,
-                        tcol.Config.Max, (ValueToKeyMappingEstimator.MappingOrder)tcol.Config.Order);
+                        tcol.Config.Max, (ValueToKeyMappingEstimator.KeyOrdinality)tcol.Config.Order);
                     if (tcol.Config.OnFit != null)
                     {
                         int ii = i; // Necessary because if we capture i that will change to toOutput.Length on call.
@@ -133,14 +133,14 @@ namespace Microsoft.ML.StaticPipe
         /// </summary>
         /// <param name="input">Incoming data.</param>
         /// <param name="outputKind">Specify the output type of indicator array: array or binary encoded data.</param>
-        /// <param name="order">How the Id for each value would be assigined: by occurrence or by value.</param>
+        /// <param name="keyOrdinality">How the Id for each value would be assigined: by occurrence or by value.</param>
         /// <param name="maximumNumberOfItems">Maximum number of ids to keep during data scanning.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
-        public static Vector<float> OneHotEncoding(this Scalar<string> input, OneHotScalarOutputKind outputKind = (OneHotScalarOutputKind)DefOut, KeyValueOrder order = DefSort,
+        public static Vector<float> OneHotEncoding(this Scalar<string> input, OneHotScalarOutputKind outputKind = (OneHotScalarOutputKind)DefOut, KeyOrdinality keyOrdinality = DefSort,
             int maximumNumberOfItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
         {
             Contracts.CheckValue(input, nameof(input));
-            return new ImplScalar<string>(input, new Config((OneHotVectorOutputKind)outputKind, order, maximumNumberOfItems, Wrap(onFit)));
+            return new ImplScalar<string>(input, new Config((OneHotVectorOutputKind)outputKind, keyOrdinality, maximumNumberOfItems, Wrap(onFit)));
         }
 
         /// <summary>
@@ -148,14 +148,14 @@ namespace Microsoft.ML.StaticPipe
         /// </summary>
         /// <param name="input">Incoming data.</param>
         /// <param name="outputKind">Specify the output type of indicator array: Multiarray, array or binary encoded data.</param>
-        /// <param name="order">How the Id for each value would be assigined: by occurrence or by value.</param>
+        /// <param name="keyOrdinality">How the Id for each value would be assigined: by occurrence or by value.</param>
         /// <param name="maximumNumberOfItems">Maximum number of ids to keep during data scanning.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
-        public static Vector<float> OneHotEncoding(this Vector<string> input, OneHotVectorOutputKind outputKind = DefOut, KeyValueOrder order = DefSort, int maximumNumberOfItems = DefMax,
+        public static Vector<float> OneHotEncoding(this Vector<string> input, OneHotVectorOutputKind outputKind = DefOut, KeyOrdinality keyOrdinality = DefSort, int maximumNumberOfItems = DefMax,
             ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
         {
             Contracts.CheckValue(input, nameof(input));
-            return new ImplVector<string>(input, new Config(outputKind, order, maximumNumberOfItems, Wrap(onFit)));
+            return new ImplVector<string>(input, new Config(outputKind, keyOrdinality, maximumNumberOfItems, Wrap(onFit)));
         }
     }
 }

--- a/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/CategoricalStaticExtensions.cs
@@ -113,7 +113,7 @@ namespace Microsoft.ML.StaticPipe
                 for (int i = 0; i < toOutput.Length; ++i)
                 {
                     var tcol = (ICategoricalCol)toOutput[i];
-                    infos[i] = new OneHotEncodingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input], (OneHotEncodingTransformer.OutputKind)tcol.Config.OutputKind,
+                    infos[i] = new OneHotEncodingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input], (OneHotEncodingEstimator.OutputKind)tcol.Config.OutputKind,
                         tcol.Config.Max, (ValueToKeyMappingEstimator.MappingOrder)tcol.Config.Order);
                     if (tcol.Config.OnFit != null)
                     {

--- a/src/Microsoft.ML.StaticPipe/TermStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/TermStaticExtensions.cs
@@ -39,13 +39,13 @@ namespace Microsoft.ML.StaticPipe
         /// Because the empty string is never entered into the dictionary, it will always map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, string> ToKey(this Scalar<string> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
-            => new ImplScalar<string>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
+            => new ImplScalar<string>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -53,13 +53,13 @@ namespace Microsoft.ML.StaticPipe
         /// Because the empty string is never entered into the dictionary, it will always map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, string>> ToKey(this Vector<string> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
-            => new ImplVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
+            => new ImplVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -67,13 +67,13 @@ namespace Microsoft.ML.StaticPipe
         /// Because the empty string is never entered into the dictionary, it will always map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, string>> ToKey(this VarVector<string> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
-            => new ImplVarVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
+            => new ImplVarVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -84,13 +84,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, string> ToKey<T>(this Key<T, string> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
-            => new ImplScalar<string>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
+            => new ImplScalar<string>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -101,13 +101,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, string>> ToKey<T>(this Vector<Key<T, string>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
-            => new ImplVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
+            => new ImplVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -118,13 +118,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, string>> ToKey<T>(this VarVector<Key<T, string>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
-            => new ImplVarVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ReadOnlyMemory<char>>.OnFit onFit = null)
+            => new ImplVarVector<string>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For float inputs.
@@ -134,13 +134,13 @@ namespace Microsoft.ML.StaticPipe
         /// Because <c>NaN</c> floating point values are never entered into the dictionary, and they will always map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, float> ToKey(this Scalar<float> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
-            => new ImplScalar<float>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
+            => new ImplScalar<float>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -150,13 +150,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, float>> ToKey(this Vector<float> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
-            => new ImplVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
+            => new ImplVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -166,13 +166,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, float>> ToKey(this VarVector<float> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
-            => new ImplVarVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
+            => new ImplVarVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -183,13 +183,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, float> ToKey<T>(this Key<T, float> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
-            => new ImplScalar<float>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
+            => new ImplScalar<float>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -200,13 +200,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, float>> ToKey<T>(this Vector<Key<T, float>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
-            => new ImplVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
+            => new ImplVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -217,13 +217,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, float>> ToKey<T>(this VarVector<Key<T, float>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
-            => new ImplVarVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<float>.OnFit onFit = null)
+            => new ImplVarVector<float>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For double inputs.
@@ -233,13 +233,13 @@ namespace Microsoft.ML.StaticPipe
         /// Because <c>NaN</c> floating point values are never entered into the dictionary, and they will always map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, double> ToKey(this Scalar<double> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
-            => new ImplScalar<double>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
+            => new ImplScalar<double>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -249,13 +249,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, double>> ToKey(this Vector<double> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
-            => new ImplVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
+            => new ImplVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -265,13 +265,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, double>> ToKey(this VarVector<double> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
-            => new ImplVarVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
+            => new ImplVarVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -282,13 +282,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, double> ToKey<T>(this Key<T, double> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
-            => new ImplScalar<double>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
+            => new ImplScalar<double>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -299,13 +299,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, double>> ToKey<T>(this Vector<Key<T, double>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
-            => new ImplVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
+            => new ImplVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -316,13 +316,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, double>> ToKey<T>(this VarVector<Key<T, double>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
-            => new ImplVarVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<double>.OnFit onFit = null)
+            => new ImplVarVector<double>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For sbyte inputs.
@@ -331,13 +331,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, sbyte> ToKey(this Scalar<sbyte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
-            => new ImplScalar<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
+            => new ImplScalar<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -346,13 +346,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, sbyte>> ToKey(this Vector<sbyte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
-            => new ImplVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
+            => new ImplVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -361,13 +361,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, sbyte>> ToKey(this VarVector<sbyte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
-            => new ImplVarVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
+            => new ImplVarVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -377,13 +377,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, sbyte> ToKey<T>(this Key<T, sbyte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
-            => new ImplScalar<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
+            => new ImplScalar<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -393,13 +393,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, sbyte>> ToKey<T>(this Vector<Key<T, sbyte>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
-            => new ImplVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
+            => new ImplVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -409,13 +409,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, sbyte>> ToKey<T>(this VarVector<Key<T, sbyte>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
-            => new ImplVarVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<sbyte>.OnFit onFit = null)
+            => new ImplVarVector<sbyte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For short inputs.
@@ -424,13 +424,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, short> ToKey(this Scalar<short> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
-            => new ImplScalar<short>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
+            => new ImplScalar<short>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -439,13 +439,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, short>> ToKey(this Vector<short> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
-            => new ImplVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
+            => new ImplVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -454,13 +454,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, short>> ToKey(this VarVector<short> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
-            => new ImplVarVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
+            => new ImplVarVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -470,13 +470,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, short> ToKey<T>(this Key<T, short> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
-            => new ImplScalar<short>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
+            => new ImplScalar<short>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -486,13 +486,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, short>> ToKey<T>(this Vector<Key<T, short>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
-            => new ImplVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
+            => new ImplVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -502,13 +502,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, short>> ToKey<T>(this VarVector<Key<T, short>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
-            => new ImplVarVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<short>.OnFit onFit = null)
+            => new ImplVarVector<short>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For int inputs.
@@ -517,13 +517,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, int> ToKey(this Scalar<int> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
-            => new ImplScalar<int>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
+            => new ImplScalar<int>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -532,13 +532,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, int>> ToKey(this Vector<int> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
-            => new ImplVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
+            => new ImplVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -547,13 +547,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, int>> ToKey(this VarVector<int> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
-            => new ImplVarVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
+            => new ImplVarVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -563,13 +563,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, int> ToKey<T>(this Key<T, int> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
-            => new ImplScalar<int>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
+            => new ImplScalar<int>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -579,13 +579,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, int>> ToKey<T>(this Vector<Key<T, int>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
-            => new ImplVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
+            => new ImplVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -595,13 +595,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, int>> ToKey<T>(this VarVector<Key<T, int>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
-            => new ImplVarVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<int>.OnFit onFit = null)
+            => new ImplVarVector<int>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For long inputs.
@@ -610,13 +610,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, long> ToKey(this Scalar<long> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
-            => new ImplScalar<long>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
+            => new ImplScalar<long>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -625,13 +625,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, long>> ToKey(this Vector<long> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
-            => new ImplVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
+            => new ImplVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -640,13 +640,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, long>> ToKey(this VarVector<long> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
-            => new ImplVarVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
+            => new ImplVarVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -656,13 +656,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, long> ToKey<T>(this Key<T, long> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
-            => new ImplScalar<long>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
+            => new ImplScalar<long>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -672,13 +672,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, long>> ToKey<T>(this Vector<Key<T, long>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
-            => new ImplVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
+            => new ImplVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -688,13 +688,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, long>> ToKey<T>(this VarVector<Key<T, long>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
-            => new ImplVarVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<long>.OnFit onFit = null)
+            => new ImplVarVector<long>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For byte inputs.
@@ -703,13 +703,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, byte> ToKey(this Scalar<byte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
-            => new ImplScalar<byte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
+            => new ImplScalar<byte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -718,13 +718,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, byte>> ToKey(this Vector<byte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
-            => new ImplVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
+            => new ImplVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -733,13 +733,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, byte>> ToKey(this VarVector<byte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
-            => new ImplVarVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
+            => new ImplVarVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -749,13 +749,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, byte> ToKey<T>(this Key<T, byte> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
-            => new ImplScalar<byte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
+            => new ImplScalar<byte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -765,13 +765,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, byte>> ToKey<T>(this Vector<Key<T, byte>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
-            => new ImplVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
+            => new ImplVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -781,13 +781,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, byte>> ToKey<T>(this VarVector<Key<T, byte>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
-            => new ImplVarVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<byte>.OnFit onFit = null)
+            => new ImplVarVector<byte>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For ushort inputs.
@@ -796,13 +796,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, ushort> ToKey(this Scalar<ushort> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
-            => new ImplScalar<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
+            => new ImplScalar<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -811,13 +811,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, ushort>> ToKey(this Vector<ushort> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
-            => new ImplVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
+            => new ImplVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -826,13 +826,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, ushort>> ToKey(this VarVector<ushort> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
-            => new ImplVarVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
+            => new ImplVarVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -842,13 +842,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, ushort> ToKey<T>(this Key<T, ushort> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
-            => new ImplScalar<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
+            => new ImplScalar<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -858,13 +858,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, ushort>> ToKey<T>(this Vector<Key<T, ushort>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
-            => new ImplVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
+            => new ImplVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -874,13 +874,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, ushort>> ToKey<T>(this VarVector<Key<T, ushort>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
-            => new ImplVarVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ushort>.OnFit onFit = null)
+            => new ImplVarVector<ushort>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For uint inputs.
@@ -889,13 +889,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, uint> ToKey(this Scalar<uint> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
-            => new ImplScalar<uint>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
+            => new ImplScalar<uint>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -904,13 +904,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, uint>> ToKey(this Vector<uint> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
-            => new ImplVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
+            => new ImplVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -919,13 +919,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, uint>> ToKey(this VarVector<uint> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
-            => new ImplVarVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
+            => new ImplVarVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -935,13 +935,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, uint> ToKey<T>(this Key<T, uint> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
-            => new ImplScalar<uint>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
+            => new ImplScalar<uint>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -951,13 +951,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, uint>> ToKey<T>(this Vector<Key<T, uint>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
-            => new ImplVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
+            => new ImplVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -967,13 +967,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, uint>> ToKey<T>(this VarVector<Key<T, uint>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
-            => new ImplVarVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<uint>.OnFit onFit = null)
+            => new ImplVarVector<uint>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For ulong inputs.
@@ -982,13 +982,13 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, ulong> ToKey(this Scalar<ulong> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
-            => new ImplScalar<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
+            => new ImplScalar<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -997,13 +997,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, ulong>> ToKey(this Vector<ulong> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
-            => new ImplVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
+            => new ImplVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -1012,13 +1012,13 @@ namespace Microsoft.ML.StaticPipe
         /// implication in that case is that sparse input numeric vectors will map to dense output key vectors.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, ulong>> ToKey(this VarVector<ulong> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
-            => new ImplVarVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
+            => new ImplVarVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -1028,13 +1028,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, ulong> ToKey<T>(this Key<T, ulong> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
-            => new ImplScalar<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
+            => new ImplScalar<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -1044,13 +1044,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, ulong>> ToKey<T>(this Vector<Key<T, ulong>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
-            => new ImplVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
+            => new ImplVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -1060,13 +1060,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, ulong>> ToKey<T>(this VarVector<Key<T, ulong>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
-            => new ImplVarVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<ulong>.OnFit onFit = null)
+            => new ImplVarVector<ulong>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
 
         #region For bool inputs.
@@ -1075,39 +1075,39 @@ namespace Microsoft.ML.StaticPipe
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, bool> ToKey(this Scalar<bool> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
-            => new ImplScalar<bool>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
+            => new ImplScalar<bool>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, bool>> ToKey(this Vector<bool> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
-            => new ImplVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
+            => new ImplVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
         /// during fitting. During transformation, any values unobserved during fitting will map to the missing key.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, bool>> ToKey(this VarVector<bool> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
-            => new ImplVarVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
+            => new ImplVarVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -1117,13 +1117,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Key<uint, bool> ToKey<T>(this Key<T, bool> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
-            => new ImplScalar<bool>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
+            => new ImplScalar<bool>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -1133,13 +1133,13 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static Vector<Key<uint, bool>> ToKey<T>(this Vector<Key<T, bool>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
-            => new ImplVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
+            => new ImplVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
 
         /// <summary>
         /// Map values to a key-value representation, where the key type's values are those values observed in the input
@@ -1149,26 +1149,26 @@ namespace Microsoft.ML.StaticPipe
         /// will be a subset of the key-values in the input.
         /// </summary>
         /// <param name="input">The input column.</param>
-        /// <param name="order">The ordering policy for what order values will appear in the enumerated set.</param>
+        /// <param name="keyOrdinality">The ordering policy for what order values will appear in the enumerated set.</param>
         /// <param name="maxItems">The maximum number of items.</param>
         /// <param name="onFit">Called upon fitting with the learnt enumeration on the dataset.</param>
         /// <returns>The key-valued column.</returns>
         public static VarVector<Key<uint, bool>> ToKey<T>(this VarVector<Key<T, bool>> input,
-                KeyValueOrder order = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
-            => new ImplVarVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
+                KeyOrdinality keyOrdinality = DefSort, int maxItems = DefMax, ToKeyFitResult<bool>.OnFit onFit = null)
+            => new ImplVarVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(keyOrdinality, maxItems, Wrap(onFit)));
         #endregion
     }
 
-    public enum KeyValueOrder : byte
+    public enum KeyOrdinality : byte
     {
         /// <summary>
         /// Terms will be assigned ID in the order in which they appear.
         /// </summary>
-        Occurence = ValueToKeyMappingEstimator.MappingOrder.ByOccurrence,
+        Occurence = ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence,
 
         /// <summary>
         /// Terms will be assigned ID according to their sort via an ordinal comparison for the type.
         /// </summary>
-        Value = ValueToKeyMappingEstimator.MappingOrder.ByValue
+        Value = ValueToKeyMappingEstimator.KeyOrdinality.ByValue
     }
 }

--- a/src/Microsoft.ML.StaticPipe/TermStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/TermStaticExtensions.cs
@@ -1164,11 +1164,11 @@ namespace Microsoft.ML.StaticPipe
         /// <summary>
         /// Terms will be assigned ID in the order in which they appear.
         /// </summary>
-        Occurence = ValueToKeyMappingEstimator.SortOrder.Occurrence,
+        Occurence = ValueToKeyMappingEstimator.MappingOrder.ByOccurrence,
 
         /// <summary>
         /// Terms will be assigned ID according to their sort via an ordinal comparison for the type.
         /// </summary>
-        Value = ValueToKeyMappingEstimator.SortOrder.Value
+        Value = ValueToKeyMappingEstimator.MappingOrder.ByValue
     }
 }

--- a/src/Microsoft.ML.StaticPipe/TermStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/TermStaticExtensions.cs
@@ -1158,4 +1158,17 @@ namespace Microsoft.ML.StaticPipe
             => new ImplVarVector<bool>(Contracts.CheckRef(input, nameof(input)), new Config(order, maxItems, Wrap(onFit)));
         #endregion
     }
+
+    public enum KeyValueOrder : byte
+    {
+        /// <summary>
+        /// Terms will be assigned ID in the order in which they appear.
+        /// </summary>
+        Occurence = ValueToKeyMappingEstimator.SortOrder.Occurrence,
+
+        /// <summary>
+        /// Terms will be assigned ID according to their sort via an ordinal comparison for the type.
+        /// </summary>
+        Value = ValueToKeyMappingEstimator.SortOrder.Value
+    }
 }

--- a/src/Microsoft.ML.StaticPipe/TextStaticExtensions.cs
+++ b/src/Microsoft.ML.StaticPipe/TextStaticExtensions.cs
@@ -331,14 +331,14 @@ namespace Microsoft.ML.StaticPipe
             public readonly Scalar<string> Input;
 
             public OutPipelineColumn(Scalar<string> input,
-                int hashBits,
+                int numberOfBits,
                 int ngramLength,
                 int skipLength,
                 bool allLengths,
                 uint seed,
                 bool ordered,
-                int invertHash)
-                : base(new Reconciler(hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash), input)
+                int maximumNumberOfInverts)
+                : base(new Reconciler(numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts), input)
             {
                 Input = input;
             }
@@ -346,34 +346,34 @@ namespace Microsoft.ML.StaticPipe
 
         private sealed class Reconciler : EstimatorReconciler, IEquatable<Reconciler>
         {
-            private readonly int _hashBits;
+            private readonly int _numberOfBits;
             private readonly int _ngramLength;
             private readonly int _skipLength;
             private readonly bool _allLengths;
             private readonly uint _seed;
             private readonly bool _ordered;
-            private readonly int _invertHash;
+            private readonly int _maximumNumberOfInverts;
 
-            public Reconciler(int hashBits, int ngramLength, int skipLength, bool allLengths, uint seed, bool ordered, int invertHash)
+            public Reconciler(int numberOfBits, int ngramLength, int skipLength, bool allLengths, uint seed, bool ordered, int maximumNumberOfInverts)
             {
-                _hashBits = hashBits;
+                _numberOfBits = numberOfBits;
                 _ngramLength = ngramLength;
                 _skipLength = skipLength;
                 _allLengths = allLengths;
                 _seed = seed;
                 _ordered = ordered;
-                _invertHash = invertHash;
+                _maximumNumberOfInverts = maximumNumberOfInverts;
             }
 
             public bool Equals(Reconciler other)
             {
-                return _hashBits == other._hashBits &&
+                return _numberOfBits == other._numberOfBits &&
                     _ngramLength == other._ngramLength &&
                     _skipLength == other._skipLength &&
                     _allLengths == other._allLengths &&
                     _seed == other._seed &&
                     _ordered == other._ordered &&
-                    _invertHash == other._invertHash;
+                    _maximumNumberOfInverts == other._maximumNumberOfInverts;
             }
 
             public override IEstimator<ITransformer> Reconcile(IHostEnvironment env,
@@ -388,7 +388,7 @@ namespace Microsoft.ML.StaticPipe
                 foreach (var outCol in toOutput)
                     pairs.Add((outputNames[outCol], new[] { inputNames[((OutPipelineColumn)outCol).Input] }));
 
-                return new WordHashBagEstimator(env, pairs.ToArray(), _hashBits, _ngramLength, _skipLength, _allLengths, _seed, _ordered, _invertHash);
+                return new WordHashBagEstimator(env, pairs.ToArray(), _numberOfBits, _ngramLength, _skipLength, _allLengths, _seed, _ordered, _maximumNumberOfInverts);
             }
         }
 
@@ -397,24 +397,24 @@ namespace Microsoft.ML.StaticPipe
         /// It does so by hashing each ngram and using the hash value as the index in the bag.
         /// </summary>
         /// <param name="input">The column to apply to.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static Vector<float> ToBagofHashedWords(this Scalar<string> input,
-            int hashBits = 16,
+            int numberOfBits = 16,
             int ngramLength = 1,
             int skipLength = 0,
             bool allLengths = true,
             uint seed = 314489979,
             bool ordered = true,
-            int invertHash = 0) => new OutPipelineColumn(input, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+            int maximumNumberOfInverts = 0) => new OutPipelineColumn(input, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
     }
 
     /// <summary>
@@ -512,8 +512,8 @@ namespace Microsoft.ML.StaticPipe
         {
             public readonly VarVector<Key<uint, string>> Input;
 
-            public OutPipelineColumn(VarVector<Key<uint, string>> input, int hashBits, int ngramLength, int skipLength, bool allLengths, uint seed, bool ordered, int invertHash)
-                : base(new Reconciler(hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash), input)
+            public OutPipelineColumn(VarVector<Key<uint, string>> input, int numberOfBits, int ngramLength, int skipLength, bool allLengths, uint seed, bool ordered, int maximumNumberOfInverts)
+                : base(new Reconciler(numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts), input)
             {
                 Input = input;
             }
@@ -521,34 +521,34 @@ namespace Microsoft.ML.StaticPipe
 
         private sealed class Reconciler : EstimatorReconciler, IEquatable<Reconciler>
         {
-            private readonly int _hashBits;
+            private readonly int _numberOfBits;
             private readonly int _ngramLength;
             private readonly int _skipLength;
             private readonly bool _allLengths;
             private readonly uint _seed;
             private readonly bool _ordered;
-            private readonly int _invertHash;
+            private readonly int _maximumNumberOfInverts;
 
-            public Reconciler(int hashBits, int ngramLength, int skipLength, bool allLengths, uint seed, bool ordered, int invertHash)
+            public Reconciler(int numberOfBits, int ngramLength, int skipLength, bool allLengths, uint seed, bool ordered, int maximumNumberOfInverts)
             {
-                _hashBits = hashBits;
+                _numberOfBits = numberOfBits;
                 _ngramLength = ngramLength;
                 _skipLength = skipLength;
                 _allLengths = allLengths;
                 _seed = seed;
                 _ordered = ordered;
-                _invertHash = invertHash;
+                _maximumNumberOfInverts = maximumNumberOfInverts;
             }
 
             public bool Equals(Reconciler other)
             {
-                return _hashBits == other._hashBits &&
+                return _numberOfBits == other._numberOfBits &&
                     _ngramLength == other._ngramLength &&
                     _skipLength == other._skipLength &&
                     _allLengths == other._allLengths &&
                     _seed == other._seed &&
                     _ordered == other._ordered &&
-                    _invertHash == other._invertHash;
+                    _maximumNumberOfInverts == other._maximumNumberOfInverts;
             }
 
             public override IEstimator<ITransformer> Reconcile(IHostEnvironment env,
@@ -561,7 +561,7 @@ namespace Microsoft.ML.StaticPipe
                 var columns = new List<NgramHashingEstimator.ColumnOptions>();
                 foreach (var outCol in toOutput)
                     columns.Add(new NgramHashingEstimator.ColumnOptions(outputNames[outCol], new[] { inputNames[((OutPipelineColumn)outCol).Input] },
-                          _ngramLength, _skipLength, _allLengths, _hashBits, _seed, _ordered, _invertHash));
+                          _ngramLength, _skipLength, _allLengths, _numberOfBits, _seed, _ordered, _maximumNumberOfInverts));
 
                 return new NgramHashingEstimator(env, columns.ToArray());
             }
@@ -575,23 +575,23 @@ namespace Microsoft.ML.StaticPipe
         /// in a way that <see cref="ToNgramsHash"/> takes tokenized text as input while <see cref="WordHashBagEstimatorStaticExtensions.ToBagofHashedWords"/> tokenizes text internally.
         /// </summary>
         /// <param name="input">The column to apply to.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static Vector<float> ToNgramsHash(this VarVector<Key<uint, string>> input,
-            int hashBits = 16,
+            int numberOfBits = 16,
             int ngramLength = 2,
             int skipLength = 0,
             bool allLengths = true,
             uint seed = 314489979,
             bool ordered = true,
-            int invertHash = 0) => new OutPipelineColumn(input, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+            int maximumNumberOfInverts = 0) => new OutPipelineColumn(input, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
     }
 }

--- a/src/Microsoft.ML.StaticPipe/TransformsStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/TransformsStatic.cs
@@ -947,16 +947,16 @@ namespace Microsoft.ML.StaticPipe
         // Raw generics would allow illegal possible inputs, for example, Scalar<Bitmap>. So, this is a partial
         // class, and all the public facing extension methods for each possible type are in a T4 generated result.
 
-        private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Order;
+        private const KeyOrdinality DefSort = (KeyOrdinality)ValueToKeyMappingEstimator.Defaults.Ordinality;
         private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys;
 
         private readonly struct Config
         {
-            public readonly KeyValueOrder Order;
+            public readonly KeyOrdinality Order;
             public readonly int Max;
             public readonly Action<ValueToKeyMappingTransformer.TermMap> OnFit;
 
-            public Config(KeyValueOrder order, int max, Action<ValueToKeyMappingTransformer.TermMap> onFit)
+            public Config(KeyOrdinality order, int max, Action<ValueToKeyMappingTransformer.TermMap> onFit)
             {
                 Order = order;
                 Max = max;
@@ -1028,7 +1028,7 @@ namespace Microsoft.ML.StaticPipe
                 {
                     var tcol = (ITermCol)toOutput[i];
                     infos[i] = new ValueToKeyMappingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input],
-                        tcol.Config.Max, (ValueToKeyMappingEstimator.MappingOrder)tcol.Config.Order);
+                        tcol.Config.Max, (ValueToKeyMappingEstimator.KeyOrdinality)tcol.Config.Order);
                     if (tcol.Config.OnFit != null)
                     {
                         int ii = i; // Necessary because if we capture i that will change to toOutput.Length on call.

--- a/src/Microsoft.ML.StaticPipe/TransformsStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/TransformsStatic.cs
@@ -948,7 +948,7 @@ namespace Microsoft.ML.StaticPipe
         // class, and all the public facing extension methods for each possible type are in a T4 generated result.
 
         private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Sort;
-        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumKeys;
+        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys;
 
         private readonly struct Config
         {

--- a/src/Microsoft.ML.StaticPipe/TransformsStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/TransformsStatic.cs
@@ -947,8 +947,8 @@ namespace Microsoft.ML.StaticPipe
         // Raw generics would allow illegal possible inputs, for example, Scalar<Bitmap>. So, this is a partial
         // class, and all the public facing extension methods for each possible type are in a T4 generated result.
 
-        private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Sort;
-        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys;
+        private const KeyValueOrder DefSort = (KeyValueOrder)ValueToKeyMappingEstimator.Defaults.Order;
+        private const int DefMax = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys;
 
         private readonly struct Config
         {
@@ -1028,7 +1028,7 @@ namespace Microsoft.ML.StaticPipe
                 {
                     var tcol = (ITermCol)toOutput[i];
                     infos[i] = new ValueToKeyMappingEstimator.ColumnOptions(outputNames[toOutput[i]], inputNames[tcol.Input],
-                        tcol.Config.Max, (ValueToKeyMappingEstimator.SortOrder)tcol.Config.Order);
+                        tcol.Config.Max, (ValueToKeyMappingEstimator.MappingOrder)tcol.Config.Order);
                     if (tcol.Config.OnFit != null)
                     {
                         int ii = i; // Necessary because if we capture i that will change to toOutput.Length on call.

--- a/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
         /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
@@ -62,10 +62,10 @@ namespace Microsoft.ML
         public static OneHotHashEncodingEstimator OneHotHashEncoding(this TransformsCatalog.CategoricalTransforms catalog,
                 string outputColumnName,
                 string inputColumnName = null,
-                int numberOfHashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits,
+                int numberOfBits = OneHotHashEncodingEstimator.Defaults.NumberOfBits,
                 int maximumNumberOfInverts = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts,
                 OneHotEncodingEstimator.OutputKind outputKind = OneHotEncodingEstimator.OutputKind.Indicator)
-            => new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName ?? outputColumnName, numberOfHashBits, maximumNumberOfInverts, outputKind);
+            => new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName ?? outputColumnName, numberOfBits, maximumNumberOfInverts, outputKind);
 
         /// <summary>
         /// Convert several text column into hash-based one-hot encoded vectors.

--- a/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
         /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
@@ -62,10 +62,10 @@ namespace Microsoft.ML
         public static OneHotHashEncodingEstimator OneHotHashEncoding(this TransformsCatalog.CategoricalTransforms catalog,
                 string outputColumnName,
                 string inputColumnName = null,
-                int hashBits = OneHotHashEncodingEstimator.Defaults.HashBits,
+                int numberOfHashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits,
                 int invertHash = OneHotHashEncodingEstimator.Defaults.InvertHash,
                 OneHotEncodingTransformer.OutputKind outputKind = OneHotEncodingTransformer.OutputKind.Ind)
-            => new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName ?? outputColumnName, hashBits, invertHash, outputKind);
+            => new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName ?? outputColumnName, numberOfHashBits, invertHash, outputKind);
 
         /// <summary>
         /// Convert several text column into hash-based one-hot encoded vectors.

--- a/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML
         public static OneHotEncodingEstimator OneHotEncoding(this TransformsCatalog.CategoricalTransforms catalog,
                 string outputColumnName,
                 string inputColumnName = null,
-                OneHotEncodingTransformer.OutputKind outputKind = OneHotEncodingTransformer.OutputKind.Ind)
+                OneHotEncodingEstimator.OutputKind outputKind = OneHotEncodingEstimator.OutputKind.Indicator)
             => new OneHotEncodingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, outputKind);
 
         /// <summary>
@@ -54,18 +54,18 @@ namespace Microsoft.ML
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         /// <param name="outputKind">The conversion mode.</param>
         public static OneHotHashEncodingEstimator OneHotHashEncoding(this TransformsCatalog.CategoricalTransforms catalog,
                 string outputColumnName,
                 string inputColumnName = null,
                 int numberOfHashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits,
-                int invertHash = OneHotHashEncodingEstimator.Defaults.InvertHash,
-                OneHotEncodingTransformer.OutputKind outputKind = OneHotEncodingTransformer.OutputKind.Ind)
-            => new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName ?? outputColumnName, numberOfHashBits, invertHash, outputKind);
+                int maximumNumberOfInverts = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts,
+                OneHotEncodingEstimator.OutputKind outputKind = OneHotEncodingEstimator.OutputKind.Indicator)
+            => new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName ?? outputColumnName, numberOfHashBits, maximumNumberOfInverts, outputKind);
 
         /// <summary>
         /// Convert several text column into hash-based one-hot encoded vectors.

--- a/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML
         ///  Convert the key types back to binary vector.
         /// </summary>
         /// <param name="catalog">The categorical transform's catalog.</param>
-        /// <param name="columns">The input column.</param>
+        /// <param name="columns">Specifies the output and input columns on which the transformation should be applied.</param>
         public static KeyToBinaryVectorMappingEstimator MapKeyToBinaryVector(this TransformsCatalog.ConversionTransforms catalog,
             params ColumnOptions[] columns)
             => new KeyToBinaryVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), ColumnOptions.ConvertToValueTuples(columns));

--- a/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
+++ b/src/Microsoft.ML.Transforms/HashJoiningTransform.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Transforms
         private static class Defaults
         {
             public const bool Join = true;
-            public const int HashBits = NumBitsLim - 1;
+            public const int NumberOfBits = NumBitsLim - 1;
             public const uint Seed = 314489979;
             public const bool Ordered = true;
         }
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Transforms
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Number of bits to hash into. Must be between 1 and 31, inclusive.",
                 ShortName = "bits", SortOrder = 2)]
-            public int HashBits = Defaults.HashBits;
+            public int NumberOfBits = Defaults.NumberOfBits;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Hashing seed")]
             public uint Seed = Defaults.Seed;
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Transforms
             public string CustomSlotMap;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Number of bits to hash into. Must be between 1 and 31, inclusive.", ShortName = "bits")]
-            public int? HashBits;
+            public int? NumberOfBits;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Hashing seed")]
             public uint? Seed;
@@ -97,7 +97,7 @@ namespace Microsoft.ML.Transforms
             internal bool TryUnparse(StringBuilder sb)
             {
                 Contracts.AssertValue(sb);
-                if (Join != null || !string.IsNullOrEmpty(CustomSlotMap) || HashBits != null ||
+                if (Join != null || !string.IsNullOrEmpty(CustomSlotMap) || NumberOfBits != null ||
                     Seed != null || Ordered != null)
                 {
                     return false;
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Transforms
             // If # of hash bits is less than 31, the key type will have a positive count.
             public readonly DataViewType OutputColumnType;
 
-            public readonly int HashBits;
+            public readonly int NumberOfBits;
             public readonly uint HashSeed;
             public readonly bool Ordered;
             public readonly int[][] SlotMap; // null if the input is a single column
@@ -124,16 +124,16 @@ namespace Microsoft.ML.Transforms
                 get { return OutputColumnType.GetValueCount(); }
             }
 
-            public ColumnOptions(int[][] slotMap, int hashBits, uint hashSeed, bool ordered)
+            public ColumnOptions(int[][] slotMap, int numberOfBits, uint hashSeed, bool ordered)
             {
                 Contracts.CheckValueOrNull(slotMap);
-                Contracts.Check(NumBitsMin <= hashBits && hashBits < NumBitsLim);
+                Contracts.Check(NumBitsMin <= numberOfBits && numberOfBits < NumBitsLim);
 
                 SlotMap = slotMap;
-                HashBits = hashBits;
+                NumberOfBits = numberOfBits;
                 HashSeed = hashSeed;
                 Ordered = ordered;
-                var itemType = GetItemType(hashBits);
+                var itemType = GetItemType(numberOfBits);
                 if (Utils.Size(SlotMap) <= 1)
                     OutputColumnType = itemType;
                 else
@@ -142,11 +142,11 @@ namespace Microsoft.ML.Transforms
 
             /// <summary>
             /// Constructs the correct KeyType for the given hash bits.
-            /// Because of array size limitation, if hashBits = 31, the key type is not contiguous (not transformable into indicator array)
+            /// Because of array size limitation, if numberOfBits = 31, the key type is not contiguous (not transformable into indicator array)
             /// </summary>
-            private static KeyType GetItemType(int hashBits)
+            private static KeyType GetItemType(int numberOfBits)
             {
-                var keyCount = (ulong)1 << hashBits;
+                var keyCount = (ulong)1 << numberOfBits;
                 return new KeyType(typeof(uint), keyCount);
             }
         }
@@ -183,14 +183,14 @@ namespace Microsoft.ML.Transforms
         /// <param name="name">Name of the output column.</param>
         /// <param name="source">Name of the column to be transformed. If this is null '<paramref name="name"/>' will be used.</param>
         /// <param name="join">Whether the values need to be combined for a single hash.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
         public HashJoiningTransform(IHostEnvironment env,
             IDataView input,
             string name,
             string source = null,
              bool join = Defaults.Join,
-            int hashBits = Defaults.HashBits)
-            : this(env, new Arguments() { Columns = new[] { new Column() { Source = source ?? name, Name = name } }, Join = join, HashBits = hashBits }, input)
+            int numberOfBits = Defaults.NumberOfBits)
+            : this(env, new Arguments() { Columns = new[] { new Column() { Source = source ?? name, Name = name } }, Join = join, NumberOfBits = numberOfBits }, input)
         {
         }
 
@@ -201,18 +201,18 @@ namespace Microsoft.ML.Transforms
             Host.AssertNonEmpty(Infos);
             Host.Assert(Infos.Length == Utils.Size(args.Columns));
 
-            if (args.HashBits < NumBitsMin || args.HashBits >= NumBitsLim)
-                throw Host.ExceptUserArg(nameof(args.HashBits), "hashBits should be between {0} and {1} inclusive", NumBitsMin, NumBitsLim - 1);
+            if (args.NumberOfBits < NumBitsMin || args.NumberOfBits >= NumBitsLim)
+                throw Host.ExceptUserArg(nameof(args.NumberOfBits), "numberOfBits should be between {0} and {1} inclusive", NumBitsMin, NumBitsLim - 1);
 
             _exes = new ColumnOptions[Infos.Length];
             for (int i = 0; i < Infos.Length; i++)
             {
-                var hashBits = args.Columns[i].HashBits ?? args.HashBits;
-                Host.CheckUserArg(NumBitsMin <= hashBits && hashBits < NumBitsLim, nameof(args.HashBits));
+                var numberOfBits = args.Columns[i].NumberOfBits ?? args.NumberOfBits;
+                Host.CheckUserArg(NumBitsMin <= numberOfBits && numberOfBits < NumBitsLim, nameof(args.NumberOfBits));
                 _exes[i] = CreateColumnOptionsEx(
                     args.Columns[i].Join ?? args.Join,
                     args.Columns[i].CustomSlotMap,
-                    args.Columns[i].HashBits ?? args.HashBits,
+                    args.Columns[i].NumberOfBits ?? args.NumberOfBits,
                     args.Columns[i].Seed ?? args.Seed,
                     args.Columns[i].Ordered ?? args.Ordered,
                     Infos[i]);
@@ -241,8 +241,8 @@ namespace Microsoft.ML.Transforms
             _exes = new ColumnOptions[Infos.Length];
             for (int i = 0; i < Infos.Length; i++)
             {
-                int hashBits = ctx.Reader.ReadInt32();
-                Host.CheckDecode(NumBitsMin <= hashBits && hashBits < NumBitsLim);
+                int numberOfBits = ctx.Reader.ReadInt32();
+                Host.CheckDecode(NumBitsMin <= numberOfBits && numberOfBits < NumBitsLim);
 
                 uint hashSeed = ctx.Reader.ReadUInt32();
                 bool ordered = ctx.Reader.ReadBoolByte();
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Transforms
                     }
                 }
 
-                _exes[i] = new ColumnOptions(slotMap, hashBits, hashSeed, ordered);
+                _exes[i] = new ColumnOptions(slotMap, numberOfBits, hashSeed, ordered);
             }
 
             SetMetadata();
@@ -308,8 +308,8 @@ namespace Microsoft.ML.Transforms
             {
                 var ex = _exes[iColumn];
 
-                Host.Assert(NumBitsMin <= ex.HashBits && ex.HashBits < NumBitsLim);
-                ctx.Writer.Write(ex.HashBits);
+                Host.Assert(NumBitsMin <= ex.NumberOfBits && ex.NumberOfBits < NumBitsLim);
+                ctx.Writer.Write(ex.NumberOfBits);
 
                 ctx.Writer.Write(ex.HashSeed);
                 ctx.Writer.WriteBoolByte(ex.Ordered);
@@ -327,7 +327,7 @@ namespace Microsoft.ML.Transforms
             }
         }
 
-        private ColumnOptions CreateColumnOptionsEx(bool join, string customSlotMap, int hashBits, uint hashSeed, bool ordered, ColInfo colInfo)
+        private ColumnOptions CreateColumnOptionsEx(bool join, string customSlotMap, int numberOfBits, uint hashSeed, bool ordered, ColInfo colInfo)
         {
             int[][] slotMap = null;
             if (colInfo.TypeSrc is VectorType vectorType)
@@ -340,7 +340,7 @@ namespace Microsoft.ML.Transforms
                 Host.Assert(Utils.Size(slotMap) >= 1);
             }
 
-            return new ColumnOptions(slotMap, hashBits, hashSeed, ordered);
+            return new ColumnOptions(slotMap, numberOfBits, hashSeed, ordered);
         }
 
         private int[][] CompileSlotMap(string slotMapString, int srcSlotCount)
@@ -520,7 +520,7 @@ namespace Microsoft.ML.Transforms
             var getSrc = GetSrcGetter<TSrc>(input, iinfo);
             var hashFunction = ComposeHashDelegate<TSrc>();
             var src = default(TSrc);
-            var mask = (1U << _exes[iinfo].HashBits) - 1;
+            var mask = (1U << _exes[iinfo].NumberOfBits) - 1;
             var hashSeed = _exes[iinfo].HashSeed;
             return
                 (ref uint dst) =>
@@ -549,7 +549,7 @@ namespace Microsoft.ML.Transforms
             int expectedSrcLength = srcType.Size;
             int[][] slotMap = _exes[iinfo].SlotMap;
             // REVIEW: consider adding a fix-zero functionality (subtract emptyTextHash from all hashes)
-            var mask = (1U << _exes[iinfo].HashBits) - 1;
+            var mask = (1U << _exes[iinfo].NumberOfBits) - 1;
             var hashSeed = _exes[iinfo].HashSeed;
             bool ordered = _exes[iinfo].Ordered;
             var denseSource = default(VBuffer<TSrc>);
@@ -597,7 +597,7 @@ namespace Microsoft.ML.Transforms
             var hashFunction = ComposeHashDelegate<TSrc>();
             var src = default(VBuffer<TSrc>);
             int expectedSrcLength = srcType.Size;
-            var mask = (1U << _exes[iinfo].HashBits) - 1;
+            var mask = (1U << _exes[iinfo].NumberOfBits) - 1;
             var hashSeed = _exes[iinfo].HashSeed;
             bool ordered = _exes[iinfo].Ordered;
             var denseSource = default(VBuffer<TSrc>);

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// The names of the output and input column pairs on which the transformation is performed.
         /// </summary>
-        public IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
+        internal IReadOnlyCollection<(string outputColumnName, string inputColumnName)> Columns => ColumnPairs.AsReadOnly();
 
         private string TestIsKey(DataViewType type)
         {

--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -192,15 +192,15 @@ namespace Microsoft.ML.Transforms
             /// <param name="name">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
             /// <param name="outputKind">Output kind: Bag (multi-set vector), Ind (indicator vector), Key (index), or Binary encoded indicator vector.</param>
-            /// <param name="maxNumTerms">Maximum number of terms to keep per column when auto-training.</param>
+            /// <param name="maxNumberOfTerms">Maximum number of terms to keep per column when auto-training.</param>
             /// <param name="sort">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.SortOrder.Occurrence"/> choosen they will be in the order encountered.
             /// If <see cref="ValueToKeyMappingEstimator.SortOrder.Value"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
             /// <param name="term">List of terms.</param>
             public ColumnOptions(string name, string inputColumnName = null,
                 OneHotEncodingTransformer.OutputKind outputKind = Defaults.OutKind,
-                int maxNumTerms = ValueToKeyMappingEstimator.Defaults.MaxNumKeys, ValueToKeyMappingEstimator.SortOrder sort = ValueToKeyMappingEstimator.Defaults.Sort,
+                int maxNumberOfTerms = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys, ValueToKeyMappingEstimator.SortOrder sort = ValueToKeyMappingEstimator.Defaults.Sort,
                 string[] term = null)
-                : base(name, inputColumnName ?? name, maxNumTerms, sort, term, true)
+                : base(name, inputColumnName ?? name, maxNumberOfTerms, sort, term, true)
             {
                 OutputKind = outputKind;
             }

--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Transforms
             }
         }
 
-        internal sealed class Options : ValueToKeyMappingTransformer.ArgumentsBase
+        internal sealed class Options : ValueToKeyMappingTransformer.OptionsBase
         {
             [Argument(ArgumentType.Multiple | ArgumentType.Required, HelpText = "New column definition(s) (optional form: name:src)", Name = "Column", ShortName = "col", SortOrder = 1)]
             public Column[] Columns;
@@ -132,17 +132,17 @@ namespace Microsoft.ML.Transforms
                     column.Name,
                     column.Source ?? column.Name,
                     column.OutputKind ?? options.OutputKind,
-                    column.MaxNumTerms ?? options.MaxNumTerms,
-                    column.Sort ?? options.Sort,
-                    column.Terms ?? options.Terms);
-                col.SetTerms(column.Term ?? options.Term);
+                    column.MaximumNumberOfKeys ?? options.MaximumNumberOfKeys,
+                    column.Sort ?? options.MappingOrder,
+                    column.Keys ?? options.Keys);
+                col.SetTerms(column.Key ?? options.Key);
                 columns.Add(col);
             }
             IDataView keyData = null;
             if (!string.IsNullOrEmpty(options.DataFile))
             {
                 using (var ch = h.Start("Load term data"))
-                    keyData = ValueToKeyMappingTransformer.GetKeyDataViewOrNull(env, ch, options.DataFile, options.TermsColumn, options.Loader, out bool autoLoaded);
+                    keyData = ValueToKeyMappingTransformer.GetKeyDataViewOrNull(env, ch, options.DataFile, options.KeysColumnName, options.Loader, out bool autoLoaded);
                 h.AssertValue(keyData);
             }
             var transformed = new OneHotEncodingEstimator(env, columns.ToArray(), keyData).Fit(input).Transform(input);
@@ -192,22 +192,22 @@ namespace Microsoft.ML.Transforms
             /// <param name="name">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
             /// <param name="outputKind">Output kind: Bag (multi-set vector), Ind (indicator vector), Key (index), or Binary encoded indicator vector.</param>
-            /// <param name="maxNumberOfTerms">Maximum number of terms to keep per column when auto-training.</param>
-            /// <param name="sort">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.SortOrder.Occurrence"/> choosen they will be in the order encountered.
-            /// If <see cref="ValueToKeyMappingEstimator.SortOrder.Value"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
-            /// <param name="term">List of terms.</param>
+            /// <param name="maxNumberOfKeys">Maximum number of terms to keep per column when auto-training.</param>
+            /// <param name="mappingOrder">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
+            /// If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+            /// <param name="keys">List of terms.</param>
             public ColumnOptions(string name, string inputColumnName = null,
                 OneHotEncodingTransformer.OutputKind outputKind = Defaults.OutKind,
-                int maxNumberOfTerms = ValueToKeyMappingEstimator.Defaults.MaxNumberOfKeys, ValueToKeyMappingEstimator.SortOrder sort = ValueToKeyMappingEstimator.Defaults.Sort,
-                string[] term = null)
-                : base(name, inputColumnName ?? name, maxNumberOfTerms, sort, term, true)
+                int maxNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys, ValueToKeyMappingEstimator.MappingOrder mappingOrder = ValueToKeyMappingEstimator.Defaults.Order,
+                string[] keys = null)
+                : base(name, inputColumnName ?? name, maxNumberOfKeys, mappingOrder, keys, true)
             {
                 OutputKind = outputKind;
             }
 
             internal void SetTerms(string terms)
             {
-                Terms = terms;
+                Key = terms;
             }
 
         }

--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -106,9 +106,8 @@ namespace Microsoft.ML.Transforms
                     column.Source ?? column.Name,
                     column.OutputKind ?? options.OutputKind,
                     column.MaxNumTerms ?? options.MaxNumTerms,
-                    column.Sort ?? options.Sort,
-                    column.Terms ?? options.Terms);
-                col.SetTerms(column.Term ?? options.Term);
+                    column.Sort ?? options.Sort);
+                col.SetKeys(column.Terms ?? options.Terms, column.Term ?? options.Term);
                 columns.Add(col);
             }
             IDataView keyData = null;
@@ -195,19 +194,18 @@ namespace Microsoft.ML.Transforms
             /// <param name="maxNumberOfKeys">Maximum number of terms to keep per column when auto-training.</param>
             /// <param name="mappingOrder">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
             /// If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
-            /// <param name="keys">List of terms.</param>
             public ColumnOptions(string name, string inputColumnName = null,
                 OutputKind outputKind = Defaults.OutKind,
-                int maxNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys, ValueToKeyMappingEstimator.MappingOrder mappingOrder = ValueToKeyMappingEstimator.Defaults.Order,
-                string[] keys = null)
-                : base(name, inputColumnName ?? name, maxNumberOfKeys, mappingOrder, keys, true)
+                int maxNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys, ValueToKeyMappingEstimator.MappingOrder mappingOrder = ValueToKeyMappingEstimator.Defaults.Order)
+                : base(name, inputColumnName ?? name, maxNumberOfKeys, mappingOrder, true)
             {
                 OutputKind = outputKind;
             }
 
-            internal void SetTerms(string terms)
+            internal void SetKeys(string[] keys, string key)
             {
-                Key = terms;
+                Keys = keys;
+                Key = key;
             }
 
         }

--- a/src/Microsoft.ML.Transforms/OneHotEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotEncoding.cs
@@ -191,13 +191,13 @@ namespace Microsoft.ML.Transforms
             /// <param name="name">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
             /// <param name="outputKind">Output kind: Bag (multi-set vector), Ind (indicator vector), Key (index), or Binary encoded indicator vector.</param>
-            /// <param name="maxNumberOfKeys">Maximum number of terms to keep per column when auto-training.</param>
-            /// <param name="mappingOrder">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByOccurrence"/> choosen they will be in the order encountered.
-            /// If <see cref="ValueToKeyMappingEstimator.MappingOrder.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+            /// <param name="maximumNumberOfKeys">Maximum number of terms to keep per column when auto-training.</param>
+            /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
+            /// If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
             public ColumnOptions(string name, string inputColumnName = null,
                 OutputKind outputKind = Defaults.OutKind,
-                int maxNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys, ValueToKeyMappingEstimator.MappingOrder mappingOrder = ValueToKeyMappingEstimator.Defaults.Order)
-                : base(name, inputColumnName ?? name, maxNumberOfKeys, mappingOrder, true)
+                int maximumNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys, ValueToKeyMappingEstimator.KeyOrdinality keyOrdinality = ValueToKeyMappingEstimator.Defaults.Ordinality)
+                : base(name, inputColumnName ?? name, maximumNumberOfKeys, keyOrdinality, true)
             {
                 OutputKind = outputKind;
             }

--- a/src/Microsoft.ML.Transforms/OneHotHashEncoding.cs
+++ b/src/Microsoft.ML.Transforms/OneHotHashEncoding.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Transforms
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Number of bits to hash into. Must be between 1 and 30, inclusive.",
                 ShortName = "bits", SortOrder = 2)]
-            public int HashBits = OneHotHashEncodingEstimator.Defaults.HashBits;
+            public int HashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Hashing seed")]
             public uint Seed = OneHotHashEncodingEstimator.Defaults.Seed;
@@ -134,7 +134,7 @@ namespace Microsoft.ML.Transforms
             IDataView input,
             string name,
             string source = null,
-            int hashBits = OneHotHashEncodingEstimator.Defaults.HashBits,
+            int hashBits = OneHotHashEncodingEstimator.Defaults.NumberOfHashBits,
             int invertHash = OneHotHashEncodingEstimator.Defaults.InvertHash,
             OneHotEncodingTransformer.OutputKind outputKind = OneHotHashEncodingEstimator.Defaults.OutputKind)
         {
@@ -207,7 +207,7 @@ namespace Microsoft.ML.Transforms
         [BestFriend]
         internal static class Defaults
         {
-            public const int HashBits = 16;
+            public const int NumberOfHashBits = 16;
             public const uint Seed = 314489979;
             public const bool Ordered = true;
             public const int InvertHash = 0;
@@ -228,7 +228,7 @@ namespace Microsoft.ML.Transforms
             /// <param name="name">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="name"/> will be used as source.</param>
             /// <param name="outputKind">Kind of output: bag, indicator vector etc.</param>
-            /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
+            /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 31, inclusive.</param>
             /// <param name="seed">Hashing seed.</param>
             /// <param name="ordered">Whether the position of each term should be included in the hash.</param>
             /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
@@ -237,12 +237,12 @@ namespace Microsoft.ML.Transforms
             /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
             public ColumnOptions(string name, string inputColumnName = null,
                 OneHotEncodingTransformer.OutputKind outputKind = Defaults.OutputKind,
-                int hashBits = Defaults.HashBits,
+                int numberOfHashBits = Defaults.NumberOfHashBits,
                 uint seed = Defaults.Seed,
                 bool ordered = Defaults.Ordered,
                 int invertHash = Defaults.InvertHash)
             {
-                HashInfo = new HashingEstimator.ColumnOptions(name, inputColumnName ?? name, hashBits, seed, ordered, invertHash);
+                HashInfo = new HashingEstimator.ColumnOptions(name, inputColumnName ?? name, numberOfHashBits, seed, ordered, invertHash);
                 OutputKind = outputKind;
             }
         }
@@ -267,7 +267,7 @@ namespace Microsoft.ML.Transforms
         internal OneHotHashEncodingEstimator(IHostEnvironment env,
             string outputColumnName,
             string inputColumnName = null,
-            int hashBits = Defaults.HashBits,
+            int hashBits = Defaults.NumberOfHashBits,
             int invertHash = Defaults.InvertHash,
             OneHotEncodingTransformer.OutputKind outputKind = Defaults.OutputKind)
             : this(env, new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, outputKind, hashBits, invertHash: invertHash))

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -394,28 +394,28 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static WordHashBagEstimator ProduceHashedWordBags(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string inputColumnName = null,
-            int numberOfHashBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfHashBits,
+            int numberOfBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfBits,
             int ngramLength = NgramHashExtractingTransformer.DefaultArguments.NgramLength,
             int skipLength = NgramHashExtractingTransformer.DefaultArguments.SkipLength,
             bool allLengths = NgramHashExtractingTransformer.DefaultArguments.AllLengths,
             uint seed = NgramHashExtractingTransformer.DefaultArguments.Seed,
             bool ordered = NgramHashExtractingTransformer.DefaultArguments.Ordered,
-            int invertHash = NgramHashExtractingTransformer.DefaultArguments.InvertHash)
+            int maximumNumberOfInverts = NgramHashExtractingTransformer.DefaultArguments.MaximumNumberOfInverts)
             => new WordHashBagEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                outputColumnName, inputColumnName, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                outputColumnName, inputColumnName, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="inputColumnNames"/>
@@ -424,28 +424,28 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnNames"/>.</param>
         /// <param name="inputColumnNames">Name of the columns to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static WordHashBagEstimator ProduceHashedWordBags(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string[] inputColumnNames,
-            int numberOfHashBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfHashBits,
+            int numberOfBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfBits,
             int ngramLength = NgramHashExtractingTransformer.DefaultArguments.NgramLength,
             int skipLength = NgramHashExtractingTransformer.DefaultArguments.SkipLength,
             bool allLengths = NgramHashExtractingTransformer.DefaultArguments.AllLengths,
             uint seed = NgramHashExtractingTransformer.DefaultArguments.Seed,
             bool ordered = NgramHashExtractingTransformer.DefaultArguments.Ordered,
-            int invertHash = NgramHashExtractingTransformer.DefaultArguments.InvertHash)
+            int maximumNumberOfInverts = NgramHashExtractingTransformer.DefaultArguments.MaximumNumberOfInverts)
             => new WordHashBagEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                outputColumnName, inputColumnNames, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                outputColumnName, inputColumnNames, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="columns.inputs"/>
@@ -453,27 +453,27 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="columns">Pairs of columns to compute bag of word vector.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static WordHashBagEstimator ProduceHashedWordBags(this TransformsCatalog.TextTransforms catalog,
             (string outputColumnName, string[] inputColumnNames)[] columns,
-            int numberOfHashBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfHashBits,
+            int numberOfBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfBits,
             int ngramLength = NgramHashExtractingTransformer.DefaultArguments.NgramLength,
             int skipLength = NgramHashExtractingTransformer.DefaultArguments.SkipLength,
             bool allLengths = NgramHashExtractingTransformer.DefaultArguments.AllLengths,
             uint seed = NgramHashExtractingTransformer.DefaultArguments.Seed,
             bool ordered = NgramHashExtractingTransformer.DefaultArguments.Ordered,
-            int invertHash = NgramHashExtractingTransformer.DefaultArguments.InvertHash)
+            int maximumNumberOfInverts = NgramHashExtractingTransformer.DefaultArguments.MaximumNumberOfInverts)
             => new WordHashBagEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-               columns, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+               columns, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="inputColumnName"/>
@@ -485,28 +485,28 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static NgramHashingEstimator ProduceHashedNgrams(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string inputColumnName = null,
-            int numberOfHashBits = NgramHashingEstimator.Defaults.HashBits,
+            int numberOfBits = NgramHashingEstimator.Defaults.NumberOfBits,
             int ngramLength = NgramHashingEstimator.Defaults.NgramLength,
             int skipLength = NgramHashingEstimator.Defaults.SkipLength,
             bool allLengths = NgramHashingEstimator.Defaults.AllLengths,
             uint seed = NgramHashingEstimator.Defaults.Seed,
             bool ordered = NgramHashingEstimator.Defaults.Ordered,
-            int invertHash = NgramHashingEstimator.Defaults.InvertHash)
+            int maximumNumberOfInverts = NgramHashingEstimator.Defaults.MaximumNumberOfInverts)
             => new NgramHashingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                outputColumnName, inputColumnName, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                outputColumnName, inputColumnName, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="inputColumnNames"/>
@@ -518,28 +518,28 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnNames"/>.</param>
         /// <param name="inputColumnNames">Name of the columns to transform.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static NgramHashingEstimator ProduceHashedNgrams(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string[] inputColumnNames,
-            int numberOfHashBits = NgramHashingEstimator.Defaults.HashBits,
+            int numberOfBits = NgramHashingEstimator.Defaults.NumberOfBits,
             int ngramLength = NgramHashingEstimator.Defaults.NgramLength,
             int skipLength = NgramHashingEstimator.Defaults.SkipLength,
             bool allLengths = NgramHashingEstimator.Defaults.AllLengths,
             uint seed = NgramHashingEstimator.Defaults.Seed,
             bool ordered = NgramHashingEstimator.Defaults.Ordered,
-            int invertHash = NgramHashingEstimator.Defaults.InvertHash)
+            int maximumNumberOfInverts = NgramHashingEstimator.Defaults.MaximumNumberOfInverts)
              => new NgramHashingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                 outputColumnName, inputColumnNames, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                 outputColumnName, inputColumnNames, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="columns.inputs"/>
@@ -550,27 +550,27 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="columns">Pairs of columns to compute bag of word vector.</param>
-        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static NgramHashingEstimator ProduceHashedNgrams(this TransformsCatalog.TextTransforms catalog,
             (string outputColumnName, string[] inputColumnNames)[] columns,
-            int numberOfHashBits = NgramHashingEstimator.Defaults.HashBits,
+            int numberOfBits = NgramHashingEstimator.Defaults.NumberOfBits,
             int ngramLength = NgramHashingEstimator.Defaults.NgramLength,
             int skipLength = NgramHashingEstimator.Defaults.SkipLength,
             bool allLengths = NgramHashingEstimator.Defaults.AllLengths,
             uint seed = NgramHashingEstimator.Defaults.Seed,
             bool ordered = NgramHashingEstimator.Defaults.Ordered,
-            int invertHash = NgramHashingEstimator.Defaults.InvertHash)
+            int maximumNumberOfInverts = NgramHashingEstimator.Defaults.MaximumNumberOfInverts)
              => new NgramHashingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                 columns, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                 columns, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts);
 
         /// <summary>
         /// Uses <a href="https://arxiv.org/abs/1412.1576">LightLDA</a> to transform a document (represented as a vector of floats)

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -394,7 +394,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
@@ -407,7 +407,7 @@ namespace Microsoft.ML
         public static WordHashBagEstimator ProduceHashedWordBags(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string inputColumnName = null,
-            int hashBits = NgramHashExtractingTransformer.DefaultArguments.HashBits,
+            int numberOfHashBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfHashBits,
             int ngramLength = NgramHashExtractingTransformer.DefaultArguments.NgramLength,
             int skipLength = NgramHashExtractingTransformer.DefaultArguments.SkipLength,
             bool allLengths = NgramHashExtractingTransformer.DefaultArguments.AllLengths,
@@ -415,7 +415,7 @@ namespace Microsoft.ML
             bool ordered = NgramHashExtractingTransformer.DefaultArguments.Ordered,
             int invertHash = NgramHashExtractingTransformer.DefaultArguments.InvertHash)
             => new WordHashBagEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                outputColumnName, inputColumnName, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                outputColumnName, inputColumnName, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="inputColumnNames"/>
@@ -424,7 +424,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnNames"/>.</param>
         /// <param name="inputColumnNames">Name of the columns to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
@@ -437,7 +437,7 @@ namespace Microsoft.ML
         public static WordHashBagEstimator ProduceHashedWordBags(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string[] inputColumnNames,
-            int hashBits = NgramHashExtractingTransformer.DefaultArguments.HashBits,
+            int numberOfHashBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfHashBits,
             int ngramLength = NgramHashExtractingTransformer.DefaultArguments.NgramLength,
             int skipLength = NgramHashExtractingTransformer.DefaultArguments.SkipLength,
             bool allLengths = NgramHashExtractingTransformer.DefaultArguments.AllLengths,
@@ -445,7 +445,7 @@ namespace Microsoft.ML
             bool ordered = NgramHashExtractingTransformer.DefaultArguments.Ordered,
             int invertHash = NgramHashExtractingTransformer.DefaultArguments.InvertHash)
             => new WordHashBagEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                outputColumnName, inputColumnNames, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                outputColumnName, inputColumnNames, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="columns.inputs"/>
@@ -453,7 +453,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="columns">Pairs of columns to compute bag of word vector.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
@@ -465,7 +465,7 @@ namespace Microsoft.ML
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static WordHashBagEstimator ProduceHashedWordBags(this TransformsCatalog.TextTransforms catalog,
             (string outputColumnName, string[] inputColumnNames)[] columns,
-            int hashBits = NgramHashExtractingTransformer.DefaultArguments.HashBits,
+            int numberOfHashBits = NgramHashExtractingTransformer.DefaultArguments.NumberOfHashBits,
             int ngramLength = NgramHashExtractingTransformer.DefaultArguments.NgramLength,
             int skipLength = NgramHashExtractingTransformer.DefaultArguments.SkipLength,
             bool allLengths = NgramHashExtractingTransformer.DefaultArguments.AllLengths,
@@ -473,7 +473,7 @@ namespace Microsoft.ML
             bool ordered = NgramHashExtractingTransformer.DefaultArguments.Ordered,
             int invertHash = NgramHashExtractingTransformer.DefaultArguments.InvertHash)
             => new WordHashBagEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-               columns, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+               columns, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="inputColumnName"/>
@@ -485,7 +485,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
@@ -498,7 +498,7 @@ namespace Microsoft.ML
         public static NgramHashingEstimator ProduceHashedNgrams(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string inputColumnName = null,
-            int hashBits = NgramHashingEstimator.Defaults.HashBits,
+            int numberOfHashBits = NgramHashingEstimator.Defaults.HashBits,
             int ngramLength = NgramHashingEstimator.Defaults.NgramLength,
             int skipLength = NgramHashingEstimator.Defaults.SkipLength,
             bool allLengths = NgramHashingEstimator.Defaults.AllLengths,
@@ -506,7 +506,7 @@ namespace Microsoft.ML
             bool ordered = NgramHashingEstimator.Defaults.Ordered,
             int invertHash = NgramHashingEstimator.Defaults.InvertHash)
             => new NgramHashingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                outputColumnName, inputColumnName, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                outputColumnName, inputColumnName, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="inputColumnNames"/>
@@ -518,7 +518,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnNames"/>.</param>
         /// <param name="inputColumnNames">Name of the columns to transform.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
@@ -531,7 +531,7 @@ namespace Microsoft.ML
         public static NgramHashingEstimator ProduceHashedNgrams(this TransformsCatalog.TextTransforms catalog,
             string outputColumnName,
             string[] inputColumnNames,
-            int hashBits = NgramHashingEstimator.Defaults.HashBits,
+            int numberOfHashBits = NgramHashingEstimator.Defaults.HashBits,
             int ngramLength = NgramHashingEstimator.Defaults.NgramLength,
             int skipLength = NgramHashingEstimator.Defaults.SkipLength,
             bool allLengths = NgramHashingEstimator.Defaults.AllLengths,
@@ -539,7 +539,7 @@ namespace Microsoft.ML
             bool ordered = NgramHashingEstimator.Defaults.Ordered,
             int invertHash = NgramHashingEstimator.Defaults.InvertHash)
              => new NgramHashingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                 outputColumnName, inputColumnNames, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                 outputColumnName, inputColumnNames, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="columns.inputs"/>
@@ -550,7 +550,7 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The text-related transform's catalog.</param>
         /// <param name="columns">Pairs of columns to compute bag of word vector.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfHashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
@@ -562,7 +562,7 @@ namespace Microsoft.ML
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         public static NgramHashingEstimator ProduceHashedNgrams(this TransformsCatalog.TextTransforms catalog,
             (string outputColumnName, string[] inputColumnNames)[] columns,
-            int hashBits = NgramHashingEstimator.Defaults.HashBits,
+            int numberOfHashBits = NgramHashingEstimator.Defaults.HashBits,
             int ngramLength = NgramHashingEstimator.Defaults.NgramLength,
             int skipLength = NgramHashingEstimator.Defaults.SkipLength,
             bool allLengths = NgramHashingEstimator.Defaults.AllLengths,
@@ -570,7 +570,7 @@ namespace Microsoft.ML
             bool ordered = NgramHashingEstimator.Defaults.Ordered,
             int invertHash = NgramHashingEstimator.Defaults.InvertHash)
              => new NgramHashingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                 columns, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
+                 columns, numberOfHashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash);
 
         /// <summary>
         /// Uses <a href="https://arxiv.org/abs/1412.1576">LightLDA</a> to transform a document (represented as a vector of floats)

--- a/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
@@ -423,7 +423,7 @@ namespace Microsoft.ML.Transforms.Text
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "How items should be ordered when vectorized. By default, they will be in the order encountered. " +
             "If by value, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').", SortOrder = 5)]
-        public ValueToKeyMappingEstimator.MappingOrder Sort = ValueToKeyMappingEstimator.MappingOrder.ByOccurrence;
+        public ValueToKeyMappingEstimator.KeyOrdinality Sort = ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence;
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "Drop unknown terms instead of mapping them to NA term.", ShortName = "dropna", SortOrder = 6)]
         public bool DropUnknowns = false;

--- a/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
@@ -298,13 +298,13 @@ namespace Microsoft.ML.Transforms.Text
                     termArgs =
                         new ValueToKeyMappingTransformer.Options()
                         {
-                            MaximumNumberOfKeys = int.MaxValue,
-                            Key = termLoaderArgs.Term,
-                            Keys = termLoaderArgs.Terms,
+                            MaxNumTerms = int.MaxValue,
+                            Term = termLoaderArgs.Term,
+                            Terms = termLoaderArgs.Terms,
                             DataFile = termLoaderArgs.DataFile,
                             Loader = termLoaderArgs.Loader,
-                            KeysColumnName = termLoaderArgs.TermsColumn,
-                            MappingOrder = termLoaderArgs.Sort,
+                            TermsColumn = termLoaderArgs.TermsColumn,
+                            Sort = termLoaderArgs.Sort,
                             Columns = new ValueToKeyMappingTransformer.Column[termCols.Count]
                         };
                     if (termLoaderArgs.DropUnknowns)
@@ -315,7 +315,7 @@ namespace Microsoft.ML.Transforms.Text
                     termArgs =
                         new ValueToKeyMappingTransformer.Options()
                         {
-                            MaximumNumberOfKeys = Utils.Size(options.MaxNumTerms) > 0 ? options.MaxNumTerms[0] : NgramExtractingEstimator.Defaults.MaxNumTerms,
+                            MaxNumTerms = Utils.Size(options.MaxNumTerms) > 0 ? options.MaxNumTerms[0] : NgramExtractingEstimator.Defaults.MaxNumTerms,
                             Columns = new ValueToKeyMappingTransformer.Column[termCols.Count]
                         };
                 }
@@ -328,7 +328,7 @@ namespace Microsoft.ML.Transforms.Text
                         {
                             Name = column.Name,
                             Source = column.Source,
-                            MaximumNumberOfKeys = Utils.Size(column.MaxNumTerms) > 0 ? column.MaxNumTerms[0] : default(int?)
+                            MaxNumTerms = Utils.Size(column.MaxNumTerms) > 0 ? column.MaxNumTerms[0] : default(int?)
                         };
 
                     if (missingDropColumns != null)

--- a/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordBagTransform.cs
@@ -298,13 +298,13 @@ namespace Microsoft.ML.Transforms.Text
                     termArgs =
                         new ValueToKeyMappingTransformer.Options()
                         {
-                            MaxNumTerms = int.MaxValue,
-                            Term = termLoaderArgs.Term,
-                            Terms = termLoaderArgs.Terms,
+                            MaximumNumberOfKeys = int.MaxValue,
+                            Key = termLoaderArgs.Term,
+                            Keys = termLoaderArgs.Terms,
                             DataFile = termLoaderArgs.DataFile,
                             Loader = termLoaderArgs.Loader,
-                            TermsColumn = termLoaderArgs.TermsColumn,
-                            Sort = termLoaderArgs.Sort,
+                            KeysColumnName = termLoaderArgs.TermsColumn,
+                            MappingOrder = termLoaderArgs.Sort,
                             Columns = new ValueToKeyMappingTransformer.Column[termCols.Count]
                         };
                     if (termLoaderArgs.DropUnknowns)
@@ -315,7 +315,7 @@ namespace Microsoft.ML.Transforms.Text
                     termArgs =
                         new ValueToKeyMappingTransformer.Options()
                         {
-                            MaxNumTerms = Utils.Size(options.MaxNumTerms) > 0 ? options.MaxNumTerms[0] : NgramExtractingEstimator.Defaults.MaxNumTerms,
+                            MaximumNumberOfKeys = Utils.Size(options.MaxNumTerms) > 0 ? options.MaxNumTerms[0] : NgramExtractingEstimator.Defaults.MaxNumTerms,
                             Columns = new ValueToKeyMappingTransformer.Column[termCols.Count]
                         };
                 }
@@ -328,7 +328,7 @@ namespace Microsoft.ML.Transforms.Text
                         {
                             Name = column.Name,
                             Source = column.Source,
-                            MaxNumTerms = Utils.Size(column.MaxNumTerms) > 0 ? column.MaxNumTerms[0] : default(int?)
+                            MaximumNumberOfKeys = Utils.Size(column.MaxNumTerms) > 0 ? column.MaxNumTerms[0] : default(int?)
                         };
 
                     if (missingDropColumns != null)
@@ -423,7 +423,7 @@ namespace Microsoft.ML.Transforms.Text
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "How items should be ordered when vectorized. By default, they will be in the order encountered. " +
             "If by value, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').", SortOrder = 5)]
-        public ValueToKeyMappingEstimator.SortOrder Sort = ValueToKeyMappingEstimator.SortOrder.Occurrence;
+        public ValueToKeyMappingEstimator.MappingOrder Sort = ValueToKeyMappingEstimator.MappingOrder.ByOccurrence;
 
         [Argument(ArgumentType.AtMostOnce, HelpText = "Drop unknown terms instead of mapping them to NA term.", ShortName = "dropna", SortOrder = 6)]
         public bool DropUnknowns = false;

--- a/src/Microsoft.ML.Transforms/Text/WordHashBagProducingTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordHashBagProducingTransform.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Transforms.Text
                 int bits;
                 if (!int.TryParse(extra, out bits))
                     return false;
-                HashBits = bits;
+                NumberOfBits = bits;
                 return true;
             }
 
@@ -61,21 +61,21 @@ namespace Microsoft.ML.Transforms.Text
             {
                 Contracts.AssertValue(sb);
                 if (NgramLength != null || SkipLength != null || Seed != null ||
-                    Ordered != null || InvertHash != null)
+                    Ordered != null || MaximumNumberOfInverts != null)
                 {
                     return false;
                 }
-                if (HashBits == null)
+                if (NumberOfBits == null)
                     return TryUnparseCore(sb);
 
-                string extra = HashBits.Value.ToString();
+                string extra = NumberOfBits.Value.ToString();
                 return TryUnparseCore(sb, extra);
             }
         }
 
         internal sealed class Options : NgramHashExtractingTransformer.ArgumentsBase
         {
-            [Argument(ArgumentType.Multiple | ArgumentType.Required, HelpText = "New column definition(s) (optional form: name:hashBits:srcs)",
+            [Argument(ArgumentType.Multiple | ArgumentType.Required, HelpText = "New column definition(s) (optional form: name:numberOfBits:srcs)",
                 Name = "Column", ShortName = "col", SortOrder = 1)]
             public Column[] Columns;
         }
@@ -122,12 +122,12 @@ namespace Microsoft.ML.Transforms.Text
                     {
                         Name = column.Name,
                         Source = curTmpNames,
-                        HashBits = column.HashBits,
+                        NumberOfBits = column.NumberOfBits,
                         NgramLength = column.NgramLength,
                         Seed = column.Seed,
                         SkipLength = column.SkipLength,
                         Ordered = column.Ordered,
-                        InvertHash = column.InvertHash,
+                        MaximumNumberOfInverts = column.MaximumNumberOfInverts,
                         FriendlyNames = options.Columns[iinfo].Source,
                         AllLengths = column.AllLengths
                     };
@@ -139,13 +139,13 @@ namespace Microsoft.ML.Transforms.Text
                 new NgramHashExtractingTransformer.Options
                 {
                     AllLengths = options.AllLengths,
-                    HashBits = options.HashBits,
+                    NumberOfBits = options.NumberOfBits,
                     NgramLength = options.NgramLength,
                     SkipLength = options.SkipLength,
                     Ordered = options.Ordered,
                     Seed = options.Seed,
                     Columns = extractorCols.ToArray(),
-                    InvertHash = options.InvertHash
+                    MaximumNumberOfInverts = options.MaximumNumberOfInverts
                 };
 
             view = NgramHashExtractingTransformer.Create(h, featurizeArgs, view);
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Transforms.Text
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Number of bits to hash into. Must be between 1 and 30, inclusive.",
                 ShortName = "bits")]
-            public int? HashBits;
+            public int? NumberOfBits;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Hashing seed")]
             public uint? Seed;
@@ -185,7 +185,7 @@ namespace Microsoft.ML.Transforms.Text
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Limit the number of keys used to generate the slot name to this many. 0 means no invert hashing, -1 means no limit.",
                 ShortName = "ih")]
-            public int? InvertHash;
+            public int? MaximumNumberOfInverts;
 
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Whether to include all ngram lengths up to " + nameof(NgramLength) + " or only " + nameof(NgramLength),
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Transforms.Text
                 int bits;
                 if (!int.TryParse(extra, out bits))
                     return false;
-                HashBits = bits;
+                NumberOfBits = bits;
                 return true;
             }
 
@@ -232,14 +232,14 @@ namespace Microsoft.ML.Transforms.Text
             {
                 Contracts.AssertValue(sb);
                 if (NgramLength != null || SkipLength != null || Seed != null ||
-                    Ordered != null || InvertHash != null)
+                    Ordered != null || MaximumNumberOfInverts != null)
                 {
                     return false;
                 }
-                if (HashBits == null)
+                if (NumberOfBits == null)
                     return TryUnparseCore(sb);
 
-                string extra = HashBits.Value.ToString();
+                string extra = NumberOfBits.Value.ToString();
                 return TryUnparseCore(sb, extra);
             }
         }
@@ -262,7 +262,7 @@ namespace Microsoft.ML.Transforms.Text
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Number of bits to hash into. Must be between 1 and 30, inclusive.",
                 ShortName = "bits", SortOrder = 2)]
-            public int HashBits = 16;
+            public int NumberOfBits = 16;
 
             [Argument(ArgumentType.AtMostOnce, HelpText = "Hashing seed")]
             public uint Seed = 314489979;
@@ -275,7 +275,7 @@ namespace Microsoft.ML.Transforms.Text
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Limit the number of keys used to generate the slot name to this many. 0 means no invert hashing, -1 means no limit.",
                 ShortName = "ih")]
-            public int InvertHash;
+            public int MaximumNumberOfInverts;
 
             [Argument(ArgumentType.AtMostOnce,
                HelpText = "Whether to include all ngram lengths up to ngramLength or only ngramLength",
@@ -287,10 +287,10 @@ namespace Microsoft.ML.Transforms.Text
         {
             public const int NgramLength = 1;
             public const int SkipLength = 0;
-            public const int NumberOfHashBits = 16;
+            public const int NumberOfBits = 16;
             public const uint Seed = 314489979;
             public const bool Ordered = true;
-            public const int InvertHash = 0;
+            public const int MaximumNumberOfInverts = 0;
             public const bool AllLengths = true;
         }
 
@@ -362,7 +362,7 @@ namespace Microsoft.ML.Transforms.Text
                     }
 
                     hashColumns.Add(new HashingEstimator.ColumnOptions(tmpName, termLoaderArgs == null ? column.Source[isrc] : tmpName,
-                        30, column.Seed ?? options.Seed, false, column.InvertHash ?? options.InvertHash));
+                        30, column.Seed ?? options.Seed, false, column.MaximumNumberOfInverts ?? options.MaximumNumberOfInverts));
                 }
 
                 ngramHashColumns[iinfo] =
@@ -370,10 +370,10 @@ namespace Microsoft.ML.Transforms.Text
                     column.NgramLength ?? options.NgramLength,
                     column.SkipLength ?? options.SkipLength,
                     column.AllLengths ?? options.AllLengths,
-                    column.HashBits ?? options.HashBits,
+                    column.NumberOfBits ?? options.NumberOfBits,
                     column.Seed ?? options.Seed,
                     column.Ordered ?? options.Ordered,
-                    column.InvertHash ?? options.InvertHash);
+                    column.MaximumNumberOfInverts ?? options.MaximumNumberOfInverts);
                 ngramHashColumns[iinfo].FriendlyNames = column.FriendlyNames;
             }
 
@@ -435,8 +435,8 @@ namespace Microsoft.ML.Transforms.Text
                 Columns = extractorCols,
                 NgramLength = extractorArgs.NgramLength,
                 SkipLength = extractorArgs.SkipLength,
-                HashBits = extractorArgs.HashBits,
-                InvertHash = extractorArgs.InvertHash,
+                NumberOfBits = extractorArgs.NumberOfBits,
+                MaximumNumberOfInverts = extractorArgs.MaximumNumberOfInverts,
                 Ordered = extractorArgs.Ordered,
                 Seed = extractorArgs.Seed,
                 AllLengths = extractorArgs.AllLengths

--- a/src/Microsoft.ML.Transforms/Text/WordHashBagProducingTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordHashBagProducingTransform.cs
@@ -287,7 +287,7 @@ namespace Microsoft.ML.Transforms.Text
         {
             public const int NgramLength = 1;
             public const int SkipLength = 0;
-            public const int HashBits = 16;
+            public const int NumberOfHashBits = 16;
             public const uint Seed = 314489979;
             public const bool Ordered = true;
             public const int InvertHash = 0;
@@ -383,13 +383,13 @@ namespace Microsoft.ML.Transforms.Text
                 var termArgs =
                     new ValueToKeyMappingTransformer.Options()
                     {
-                        MaxNumTerms = int.MaxValue,
-                        Term = termLoaderArgs.Term,
-                        Terms = termLoaderArgs.Terms,
+                        MaximumNumberOfKeys = int.MaxValue,
+                        Key = termLoaderArgs.Term,
+                        Keys = termLoaderArgs.Terms,
                         DataFile = termLoaderArgs.DataFile,
                         Loader = termLoaderArgs.Loader,
-                        TermsColumn = termLoaderArgs.TermsColumn,
-                        Sort = termLoaderArgs.Sort,
+                        KeysColumnName = termLoaderArgs.TermsColumn,
+                        MappingOrder = termLoaderArgs.Sort,
                         Columns = termCols.ToArray()
                     };
                 view = ValueToKeyMappingTransformer.Create(h, termArgs, view);

--- a/src/Microsoft.ML.Transforms/Text/WordHashBagProducingTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/WordHashBagProducingTransform.cs
@@ -383,13 +383,13 @@ namespace Microsoft.ML.Transforms.Text
                 var termArgs =
                     new ValueToKeyMappingTransformer.Options()
                     {
-                        MaximumNumberOfKeys = int.MaxValue,
-                        Key = termLoaderArgs.Term,
-                        Keys = termLoaderArgs.Terms,
+                        MaxNumTerms = int.MaxValue,
+                        Term = termLoaderArgs.Term,
+                        Terms = termLoaderArgs.Terms,
                         DataFile = termLoaderArgs.DataFile,
                         Loader = termLoaderArgs.Loader,
-                        KeysColumnName = termLoaderArgs.TermsColumn,
-                        MappingOrder = termLoaderArgs.Sort,
+                        TermsColumn = termLoaderArgs.TermsColumn,
+                        Sort = termLoaderArgs.Sort,
                         Columns = termCols.ToArray()
                     };
                 view = ValueToKeyMappingTransformer.Create(h, termArgs, view);

--- a/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
+++ b/src/Microsoft.ML.Transforms/Text/WrappedTextTransformers.cs
@@ -149,13 +149,13 @@ namespace Microsoft.ML.Transforms.Text
     {
         private readonly IHost _host;
         private readonly (string outputColumnName, string[] inputColumnNames)[] _columns;
-        private readonly int _hashBits;
+        private readonly int _numberOfBits;
         private readonly int _ngramLength;
         private readonly int _skipLength;
         private readonly bool _allLengths;
         private readonly uint _seed;
         private readonly bool _ordered;
-        private readonly int _invertHash;
+        private readonly int _maximumNumberOfInverts;
 
         /// <summary>
         /// Produces a bag of counts of hashed ngrams in <paramref name="inputColumnName"/>
@@ -164,27 +164,27 @@ namespace Microsoft.ML.Transforms.Text
         /// <param name="env">The environment.</param>
         /// <param name="outputColumnName">The column containing bag of word vector. Null means <paramref name="inputColumnName"/> is replaced.</param>
         /// <param name="inputColumnName">The column containing text to compute bag of word vector.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         internal WordHashBagEstimator(IHostEnvironment env,
             string outputColumnName,
             string inputColumnName = null,
-            int hashBits = 16,
+            int numberOfBits = 16,
             int ngramLength = 1,
             int skipLength = 0,
             bool allLengths = true,
             uint seed = 314489979,
             bool ordered = true,
-            int invertHash = 0)
-            : this(env, new[] { (outputColumnName, new[] { inputColumnName ?? outputColumnName }) }, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash)
+            int maximumNumberOfInverts = 0)
+            : this(env, new[] { (outputColumnName, new[] { inputColumnName ?? outputColumnName }) }, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts)
         {
         }
 
@@ -195,27 +195,27 @@ namespace Microsoft.ML.Transforms.Text
         /// <param name="env">The environment.</param>
         /// <param name="outputColumnName">The column containing output tokens.</param>
         /// <param name="inputColumnNames">The columns containing text to compute bag of word vector.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         internal WordHashBagEstimator(IHostEnvironment env,
             string outputColumnName,
             string[] inputColumnNames,
-            int hashBits = 16,
+            int numberOfBits = 16,
             int ngramLength = 1,
             int skipLength = 0,
             bool allLengths = true,
             uint seed = 314489979,
             bool ordered = true,
-            int invertHash = 0)
-            : this(env, new[] { (outputColumnName, inputColumnNames) }, hashBits, ngramLength, skipLength, allLengths, seed, ordered, invertHash)
+            int maximumNumberOfInverts = 0)
+            : this(env, new[] { (outputColumnName, inputColumnNames) }, numberOfBits, ngramLength, skipLength, allLengths, seed, ordered, maximumNumberOfInverts)
         {
         }
 
@@ -225,25 +225,25 @@ namespace Microsoft.ML.Transforms.Text
         /// </summary>
         /// <param name="env">The environment.</param>
         /// <param name="columns">Pairs of columns to compute bag of word vector.</param>
-        /// <param name="hashBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
         /// <param name="ngramLength">Ngram length.</param>
         /// <param name="skipLength">Maximum number of tokens to skip when constructing an ngram.</param>
         /// <param name="allLengths">Whether to include all ngram lengths up to <paramref name="ngramLength"/> or only <paramref name="ngramLength"/>.</param>
         /// <param name="seed">Hashing seed.</param>
         /// <param name="ordered">Whether the position of each source column should be included in the hash (when there are multiple source columns).</param>
-        /// <param name="invertHash">During hashing we constuct mappings between original values and the produced hash values.
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
         /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
-        /// <paramref name="invertHash"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
         /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
         internal WordHashBagEstimator(IHostEnvironment env,
             (string outputColumnName, string[] inputColumnNames)[] columns,
-            int hashBits = 16,
+            int numberOfBits = 16,
             int ngramLength = 1,
             int skipLength = 0,
             bool allLengths = true,
             uint seed = 314489979,
             bool ordered = true,
-            int invertHash = 0)
+            int maximumNumberOfInverts = 0)
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(nameof(WordHashBagEstimator));
@@ -255,13 +255,13 @@ namespace Microsoft.ML.Transforms.Text
             }
 
             _columns = columns;
-            _hashBits = hashBits;
+            _numberOfBits = numberOfBits;
             _ngramLength = ngramLength;
             _skipLength = skipLength;
             _allLengths = allLengths;
             _seed = seed;
             _ordered = ordered;
-            _invertHash = invertHash;
+            _maximumNumberOfInverts = maximumNumberOfInverts;
         }
 
         /// <summary> Trains and returns a <see cref="ITransformer"/>.</summary>
@@ -271,13 +271,13 @@ namespace Microsoft.ML.Transforms.Text
             var options = new WordHashBagProducingTransformer.Options
             {
                 Columns = _columns.Select(x => new WordHashBagProducingTransformer.Column { Name = x.outputColumnName, Source = x.inputColumnNames }).ToArray(),
-                HashBits = _hashBits,
+                NumberOfBits = _numberOfBits,
                 NgramLength = _ngramLength,
                 SkipLength = _skipLength,
                 AllLengths = _allLengths,
                 Seed = _seed,
                 Ordered = _ordered,
-                InvertHash = _invertHash
+                MaximumNumberOfInverts = _maximumNumberOfInverts
             };
 
             return new TransformWrapper(_host, WordHashBagProducingTransformer.Create(_host, options, input), true);

--- a/src/Microsoft.ML.Transforms/doc.xml
+++ b/src/Microsoft.ML.Transforms/doc.xml
@@ -16,7 +16,7 @@
         <code language="csharp">
           pipeline.Add(new CategoricalHashOneHotVectorizer(&quot;Text1&quot;) 
           { 
-            HashBits = 10, 
+            NumberOfBits = 10, 
             Seed = 314489979, 
             OutputKind = CategoricalTransformOutputKind.Bag 
           });

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -16696,7 +16696,7 @@
                   "Default": null
                 },
                 {
-                  "Name": "HashBits",
+                  "Name": "NumberOfBits",
                   "Type": "Int",
                   "Desc": "The number of bits to hash into. Must be between 1 and 30, inclusive.",
                   "Aliases": [
@@ -16729,7 +16729,7 @@
                   "Default": null
                 },
                 {
-                  "Name": "InvertHash",
+                  "Name": "MaximumNumberOfInverts",
                   "Type": "Int",
                   "Desc": "Limit the number of keys used to generate the slot name to this many. 0 means no invert hashing, -1 means no limit.",
                   "Aliases": [
@@ -16767,7 +16767,7 @@
               ]
             }
           },
-          "Desc": "New column definition(s) (optional form: name:hashBits:src)",
+          "Desc": "New column definition(s) (optional form: name:numberOfBits:src)",
           "Aliases": [
             "col"
           ],
@@ -16784,7 +16784,7 @@
           "IsNullable": false
         },
         {
-          "Name": "HashBits",
+          "Name": "NumberOfBits",
           "Type": "Int",
           "Desc": "Number of bits to hash into. Must be between 1 and 30, inclusive.",
           "Aliases": [
@@ -16837,7 +16837,7 @@
           "Default": true
         },
         {
-          "Name": "InvertHash",
+          "Name": "MaximumNumberOfInverts",
           "Type": "Int",
           "Desc": "Limit the number of keys used to generate the slot name to this many. 0 means no invert hashing, -1 means no limit.",
           "Aliases": [
@@ -18479,7 +18479,7 @@
                   "Default": null
                 },
                 {
-                  "Name": "HashBits",
+                  "Name": "NumberOfBits",
                   "Type": "Int",
                   "Desc": "Number of bits to hash into. Must be between 1 and 31, inclusive.",
                   "Aliases": [
@@ -18555,7 +18555,7 @@
           "IsNullable": false
         },
         {
-          "Name": "HashBits",
+          "Name": "NumberOfBits",
           "Type": "Int",
           "Desc": "Number of bits to hash into. Must be between 1 and 31, inclusive.",
           "Aliases": [
@@ -28742,7 +28742,7 @@
           ],
           "Settings": [
             {
-              "Name": "HashBits",
+              "Name": "NumberOfBits",
               "Type": "Int",
               "Desc": "Number of bits to hash into. Must be between 1 and 30, inclusive.",
               "Aliases": [
@@ -28811,7 +28811,7 @@
               "Default": true
             },
             {
-              "Name": "InvertHash",
+              "Name": "MaximumNumberOfInverts",
               "Type": "Int",
               "Desc": "Limit the number of keys used to generate the slot name to this many. 0 means no invert hashing, -1 means no limit.",
               "Aliases": [

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -17040,7 +17040,7 @@
           "Default": null
         },
         {
-          "Name": "MappingOrder",
+          "Name": "Sort",
           "Type": {
             "Kind": "Enum",
             "Values": [
@@ -17995,7 +17995,7 @@
           "Default": null
         },
         {
-          "Name": "MappingOrder",
+          "Name": "Sort",
           "Type": {
             "Kind": "Enum",
             "Values": [
@@ -22709,7 +22709,7 @@
           "Default": null
         },
         {
-          "Name": "MappingOrder",
+          "Name": "Sort",
           "Type": {
             "Kind": "Enum",
             "Values": [

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -16681,9 +16681,9 @@
                     "Kind": "Enum",
                     "Values": [
                       "Bag",
-                      "Ind",
+                      "Indicator",
                       "Key",
-                      "Bin"
+                      "Binary"
                     ]
                   },
                   "Desc": "Output kind: Bag (multi-set vector), Ind (indicator vector), or Key (index)",
@@ -16801,9 +16801,9 @@
             "Kind": "Enum",
             "Values": [
               "Bag",
-              "Ind",
+              "Indicator",
               "Key",
-              "Bin"
+              "Binary"
             ]
           },
           "Desc": "Output kind: Bag (multi-set vector), Ind (indicator vector), or Key (index)",
@@ -16887,9 +16887,9 @@
                     "Kind": "Enum",
                     "Values": [
                       "Bag",
-                      "Ind",
+                      "Indicator",
                       "Key",
-                      "Bin"
+                      "Binary"
                     ]
                   },
                   "Desc": "Output kind: Bag (multi-set vector), Ind (indicator vector), Key (index), or Binary encoded indicator vector",
@@ -16930,8 +16930,8 @@
                   "Type": {
                     "Kind": "Enum",
                     "Values": [
-                      "Occurrence",
-                      "Value"
+                      "ByOccurrence",
+                      "ByValue"
                     ]
                   },
                   "Desc": "How items should be ordered when vectorized. By default, they will be in the order encountered. If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').",
@@ -16998,7 +16998,7 @@
         {
           "Name": "MaxNumTerms",
           "Type": "Int",
-          "Desc": "Maximum number of terms to keep per column when auto-training",
+          "Desc": "Maximum number of keys to keep per column when auto-training",
           "Aliases": [
             "max"
           ],
@@ -17013,9 +17013,9 @@
             "Kind": "Enum",
             "Values": [
               "Bag",
-              "Ind",
+              "Indicator",
               "Key",
-              "Bin"
+              "Binary"
             ]
           },
           "Desc": "Output kind: Bag (multi-set vector), Ind (indicator vector), or Key (index)",
@@ -17025,7 +17025,7 @@
           "Required": false,
           "SortOrder": 102.0,
           "IsNullable": false,
-          "Default": "Ind"
+          "Default": "Indicator"
         },
         {
           "Name": "Term",
@@ -17040,19 +17040,19 @@
           "Default": null
         },
         {
-          "Name": "Sort",
+          "Name": "MappingOrder",
           "Type": {
             "Kind": "Enum",
             "Values": [
-              "Occurrence",
-              "Value"
+              "ByOccurrence",
+              "ByValue"
             ]
           },
           "Desc": "How items should be ordered when vectorized. By default, they will be in the order encountered. If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').",
           "Required": false,
           "SortOrder": 113.0,
           "IsNullable": false,
-          "Default": "Occurrence"
+          "Default": "ByOccurrence"
         },
         {
           "Name": "TextKeyValues",
@@ -17904,8 +17904,8 @@
                   "Type": {
                     "Kind": "Enum",
                     "Values": [
-                      "Occurrence",
-                      "Value"
+                      "ByOccurrence",
+                      "ByValue"
                     ]
                   },
                   "Desc": "How items should be ordered when vectorized. By default, they will be in the order encountered. If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').",
@@ -17973,7 +17973,7 @@
         {
           "Name": "MaxNumTerms",
           "Type": "Int",
-          "Desc": "Maximum number of terms to keep per column when auto-training",
+          "Desc": "Maximum number of keys to keep per column when auto-training",
           "Aliases": [
             "max"
           ],
@@ -17995,19 +17995,19 @@
           "Default": null
         },
         {
-          "Name": "Sort",
+          "Name": "MappingOrder",
           "Type": {
             "Kind": "Enum",
             "Values": [
-              "Occurrence",
-              "Value"
+              "ByOccurrence",
+              "ByValue"
             ]
           },
           "Desc": "How items should be ordered when vectorized. By default, they will be in the order encountered. If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').",
           "Required": false,
           "SortOrder": 113.0,
           "IsNullable": false,
-          "Default": "Occurrence"
+          "Default": "ByOccurrence"
         },
         {
           "Name": "TextKeyValues",
@@ -22457,15 +22457,15 @@
                 "Type": {
                   "Kind": "Enum",
                   "Values": [
-                    "Occurrence",
-                    "Value"
+                    "ByOccurrence",
+                    "ByValue"
                   ]
                 },
                 "Desc": "How items should be ordered when vectorized. By default, they will be in the order encountered. If by value, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').",
                 "Required": false,
                 "SortOrder": 5.0,
                 "IsNullable": false,
-                "Default": "Occurrence"
+                "Default": "ByOccurrence"
               },
               {
                 "Name": "DropUnknowns",
@@ -22618,8 +22618,8 @@
                   "Type": {
                     "Kind": "Enum",
                     "Values": [
-                      "Occurrence",
-                      "Value"
+                      "ByOccurrence",
+                      "ByValue"
                     ]
                   },
                   "Desc": "How items should be ordered when vectorized. By default, they will be in the order encountered. If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').",
@@ -22687,7 +22687,7 @@
         {
           "Name": "MaxNumTerms",
           "Type": "Int",
-          "Desc": "Maximum number of terms to keep per column when auto-training",
+          "Desc": "Maximum number of keys to keep per column when auto-training",
           "Aliases": [
             "max"
           ],
@@ -22709,19 +22709,19 @@
           "Default": null
         },
         {
-          "Name": "Sort",
+          "Name": "MappingOrder",
           "Type": {
             "Kind": "Enum",
             "Values": [
-              "Occurrence",
-              "Value"
+              "ByOccurrence",
+              "ByValue"
             ]
           },
           "Desc": "How items should be ordered when vectorized. By default, they will be in the order encountered. If by value items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').",
           "Required": false,
           "SortOrder": 113.0,
           "IsNullable": false,
-          "Default": "Occurrence"
+          "Default": "ByOccurrence"
         },
         {
           "Name": "TextKeyValues",

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -78,13 +78,13 @@ namespace Microsoft.ML.Benchmarks
         private ValueGetter<uint> _getter;
         private ValueGetter<VBuffer<uint>> _vecGetter;
 
-        private void InitMap<T>(T val, DataViewType type, int hashBits = 20, ValueGetter<T> getter = null)
+        private void InitMap<T>(T val, DataViewType type, int numberOfBits = 20, ValueGetter<T> getter = null)
         {
             if (getter == null)
                 getter = (ref T dst) => dst = val;
             _inRow = RowImpl.Create(type, getter);
             // One million features is a nice, typical number.
-            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: hashBits);
+            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfBits: numberOfBits);
             var xf = new HashingTransformer(_env, new[] { info });
             var mapper = ((ITransformer)xf).GetRowToRowMapper(_inRow.Schema);
             var column = mapper.OutputSchema["Bar"];
@@ -108,10 +108,10 @@ namespace Microsoft.ML.Benchmarks
             }
         }
 
-        private void InitDenseVecMap<T>(T[] vals, PrimitiveDataViewType itemType, int hashBits = 20)
+        private void InitDenseVecMap<T>(T[] vals, PrimitiveDataViewType itemType, int numberOfBits = 20)
         {
             var vbuf = new VBuffer<T>(vals.Length, vals);
-            InitMap(vbuf, new VectorType(itemType, vals.Length), hashBits, vbuf.CopyTo);
+            InitMap(vbuf, new VectorType(itemType, vals.Length), numberOfBits, vbuf.CopyTo);
         }
 
         /// <summary>

--- a/test/Microsoft.ML.Benchmarks/HashBench.cs
+++ b/test/Microsoft.ML.Benchmarks/HashBench.cs
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Benchmarks
                 getter = (ref T dst) => dst = val;
             _inRow = RowImpl.Create(type, getter);
             // One million features is a nice, typical number.
-            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: hashBits);
+            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: hashBits);
             var xf = new HashingTransformer(_env, new[] { info });
             var mapper = ((ITransformer)xf).GetRowToRowMapper(_inRow.Schema);
             var column = mapper.OutputSchema["Bar"];

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -1835,7 +1835,7 @@ namespace Microsoft.ML.RunTests
                             ],
                             'Data': '$AllData',
                             'MaxNumTerms': 1000000,
-                            'Sort': 'Occurrence',
+                            'Sort': 'ByOccurrence',
                             'TextKeyValues': false
                         },
                         'Name': 'Transforms.TextToKeyConverter',
@@ -3925,10 +3925,10 @@ namespace Microsoft.ML.RunTests
                                     'Source': 'Categories'
                                 }
                             ],
-                            'OutputKind': 'Ind',
+                            'OutputKind': 'Indicator',
                             'MaxNumTerms': 1000000,
                             'Term': null,
-                            'Sort': 'Occurrence',
+                            'Sort': 'ByOccurrence',
                             'TextKeyValues': true,
                             'Data': '$Var_99eb21288359485f936577da8f2e1061'
                         },
@@ -4524,7 +4524,7 @@ namespace Microsoft.ML.RunTests
                             'Column': [{
                                     'MaxNumTerms': null,
                                     'Term': null,
-                                    'Sort': 'Value',
+                                    'Sort': 'ByValue',
                                     'TextKeyValues': null,
                                     'Name': 'Strat',
                                     'Source': 'Label'
@@ -4532,7 +4532,7 @@ namespace Microsoft.ML.RunTests
                             ],
                             'MaxNumTerms': 1000000,
                             'Term': null,
-                            'Sort': 'Occurrence',
+                            'Sort': 'ByOccurrence',
                             'TextKeyValues': false,
                             'Data': '$Var_64f1865a99b84b9d9e0c72292c14c3af'
                         },
@@ -4928,7 +4928,7 @@ namespace Microsoft.ML.RunTests
                                     ],
                                     'MaxNumTerms': 1000000,
                                     'Term': null,
-                                    'Sort': 'Occurrence',
+                                    'Sort': 'ByOccurrence',
                                     'TextKeyValues': false,
                                     'Data': '$Var_48d35aae527f439398805f51e5f0cfab'
                                 },

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -724,7 +724,7 @@ namespace Microsoft.ML.RunTests
                 }).Fit(data).Transform(data);
 
                 data = new ColumnConcatenatingTransformer(Env, "Features", new[] { "Features1", "Features2" }).Transform(data);
-                data = new ValueToKeyMappingEstimator(Env, "Label", "Label", sort: ValueToKeyMappingEstimator.MappingOrder.ByValue).Fit(data).Transform(data);
+                data = new ValueToKeyMappingEstimator(Env, "Label", "Label", keyOrdinality: ValueToKeyMappingEstimator.KeyOrdinality.ByValue).Fit(data).Transform(data);
 
                 var lrInput = new LogisticRegression.Options
                 {
@@ -4942,7 +4942,7 @@ namespace Microsoft.ML.RunTests
                                     'Column': [{
                                             'Join': null,
                                             'CustomSlotMap': null,
-                                            'HashBits': null,
+                                            'NumberOfBits': null,
                                             'Seed': null,
                                             'Ordered': null,
                                             'Name': 'GroupId1',
@@ -4950,7 +4950,7 @@ namespace Microsoft.ML.RunTests
                                         }
                                     ],
                                     'Join': true,
-                                    'HashBits': 31,
+                                    'NumberOfBits': 31,
                                     'Seed': 314489979,
                                     'Ordered': true,
                                     'Data': '$Var_44ac8ba819da483089dacc0f12bae3d6'

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -724,7 +724,7 @@ namespace Microsoft.ML.RunTests
                 }).Fit(data).Transform(data);
 
                 data = new ColumnConcatenatingTransformer(Env, "Features", new[] { "Features1", "Features2" }).Transform(data);
-                data = new ValueToKeyMappingEstimator(Env, "Label", "Label", sort: ValueToKeyMappingEstimator.SortOrder.Value).Fit(data).Transform(data);
+                data = new ValueToKeyMappingEstimator(Env, "Label", "Label", sort: ValueToKeyMappingEstimator.MappingOrder.ByValue).Fit(data).Transform(data);
 
                 var lrInput = new LogisticRegression.Options
                 {

--- a/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
@@ -339,8 +339,8 @@ namespace Microsoft.ML.Functional.Tests
             // Create the learning pipeline.
             var pipeline = mlContext.Transforms.Concatenate("NumericalFeatures", Adult.NumericalFeatures)
                 .Append(mlContext.Transforms.Concatenate("CategoricalFeatures", Adult.CategoricalFeatures))
-                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CategoricalFeatures", hashBits: 8, // get collisions!
-                    invertHash: -1, outputKind: OneHotEncodingTransformer.OutputKind.Bag));
+                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CategoricalFeatures", numberOfHashBits: 8, // get collisions!
+                    maximumNumberOfInverts: -1, outputKind: OneHotEncodingEstimator.OutputKind.Bag));
 
             // Fit the pipeline.
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
@@ -339,7 +339,7 @@ namespace Microsoft.ML.Functional.Tests
             // Create the learning pipeline.
             var pipeline = mlContext.Transforms.Concatenate("NumericalFeatures", Adult.NumericalFeatures)
                 .Append(mlContext.Transforms.Concatenate("CategoricalFeatures", Adult.CategoricalFeatures))
-                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CategoricalFeatures", numberOfHashBits: 8, // get collisions!
+                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CategoricalFeatures", numberOfBits: 8, // get collisions!
                     maximumNumberOfInverts: -1, outputKind: OneHotEncodingEstimator.OutputKind.Bag));
 
             // Fit the pipeline.

--- a/test/Microsoft.ML.StaticPipelineTesting/StaticPipeFakes.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/StaticPipeFakes.cs
@@ -197,15 +197,15 @@ namespace FakeStaticPipes
 
         public static Key<uint> Hash<T>(this Scalar<T> me)
             => _rec.Key<uint>(me);
-        public static Key<uint, string> Hash<T>(this Scalar<T> me, int invertHashTokens)
+        public static Key<uint, string> Hash<T>(this Scalar<T> me, int maximumNumberOfInvertsTokens)
             => _rec.Key<uint, string>(me);
         public static Vector<Key<uint>> Hash<T>(this Vector<T> me)
             => _rec.Vector<Key<uint>>(me);
-        public static Vector<Key<uint, string>> Hash<T>(this Vector<T> me, int invertHashTokens)
+        public static Vector<Key<uint, string>> Hash<T>(this Vector<T> me, int maximumNumberOfInvertsTokens)
             => _rec.Vector<Key<uint, string>>(me);
         public static VarVector<Key<uint>> Hash<T>(this VarVector<T> me)
             => _rec.VarVector<Key<uint>>(me);
-        public static VarVector<Key<uint, string>> Hash<T>(this VarVector<T> me, int invertHashTokens)
+        public static VarVector<Key<uint, string>> Hash<T>(this VarVector<T> me, int maximumNumberOfInvertsTokens)
             => _rec.VarVector<Key<uint, string>>(me);
     }
 }

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -701,7 +701,7 @@ namespace Microsoft.ML.RunTests
                     loader,
                     "xf=WordToken{col=AT:A}",
                     "xf=Hash{col=AH:AT bits=30}",
-                    "xf=NgramHash{col=AH ngram=3 hashbits=4 all- ih=3}",
+                    "xf=NgramHash{col=AH ngram=3 bits=4 all- ih=3}",
                     "xf=SelectColumns{keepCol=AH}"
                 }, suffix: "6");
 

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -411,7 +411,7 @@ namespace Microsoft.ML.RunTests
             TestCore(null, false,
                 new[] {
                     "loader=Text{quote+ sparse+ col=Text:TX:1-9 col=OneText:TX:1 col=Label:0}",
-                    "xf=Cat{max=5 col={name=Bag src=Text kind=bag} col=One:ind:OneText}",
+                    "xf=Cat{max=5 col={name=Bag src=Text kind=bag} col=One:indicator:OneText}",
                     "xf=Cat{max=7 col=Hot:Text}",
                     "xf=Cat{max=8 col=Key:kEY:Text col=KeyOne:KeY:OneText}",
                 });

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -215,7 +215,7 @@ namespace Microsoft.ML.Tests
                 separatorChar: '\t',
                 hasHeader: true);
 
-            var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.OneHotEncodingTransformer.OutputKind.Bag)
+            var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.OneHotEncodingEstimator.OutputKind.Bag)
             .Append(mlContext.Transforms.ReplaceMissingValues(new MissingValueReplacingEstimator.ColumnOptions("F2")))
             .Append(mlContext.Transforms.Concatenate("Features", "F1", "F2"))
             .Append(mlContext.BinaryClassification.Trainers.FastTree(labelColumnName: "Label", featureColumnName: "Features", numberOfLeaves: 2, numberOfTrees: 1, minimumExampleCountPerLeaf: 2));
@@ -413,7 +413,7 @@ namespace Microsoft.ML.Tests
                 separatorChar: '\t',
                 hasHeader: true);
 
-            var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.OneHotEncodingTransformer.OutputKind.Bag)
+            var pipeline = mlContext.Transforms.Categorical.OneHotEncoding("F2", "F2", Transforms.OneHotEncodingEstimator.OutputKind.Bag)
             .Append(mlContext.Transforms.ReplaceMissingValues(new MissingValueReplacingEstimator.ColumnOptions("F2")))
             .Append(mlContext.Transforms.Concatenate("Features", "F1", "F2"))
             .Append(mlContext.Transforms.Normalize("Features"))

--- a/test/Microsoft.ML.Tests/RangeFilterTests.cs
+++ b/test/Microsoft.ML.Tests/RangeFilterTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Tests
             var cnt = data1.GetColumn<float>(data1.Schema["Floats"]).Count();
             Assert.Equal(2L, cnt);
 
-            data = ML.Transforms.Conversion.Hash("Key", "Strings", numberOfHashBits: 20).Fit(data).Transform(data);
+            data = ML.Transforms.Conversion.Hash("Key", "Strings", numberOfBits: 20).Fit(data).Transform(data);
             var data2 = ML.Data.FilterRowsByKeyColumnFraction(data, "Key", upperBound: 0.5);
             cnt = data2.GetColumn<float>(data.Schema["Floats"]).Count();
             Assert.Equal(1L, cnt);

--- a/test/Microsoft.ML.Tests/RangeFilterTests.cs
+++ b/test/Microsoft.ML.Tests/RangeFilterTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Tests
             var cnt = data1.GetColumn<float>(data1.Schema["Floats"]).Count();
             Assert.Equal(2L, cnt);
 
-            data = ML.Transforms.Conversion.Hash("Key", "Strings", hashBits: 20).Fit(data).Transform(data);
+            data = ML.Transforms.Conversion.Hash("Key", "Strings", numberOfHashBits: 20).Fit(data).Transform(data);
             var data2 = ML.Data.FilterRowsByKeyColumnFraction(data, "Key", upperBound: 0.5);
             cnt = data2.GetColumn<float>(data.Schema["Floats"]).Count();
             Assert.Equal(1L, cnt);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -368,7 +368,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                 // Convert each categorical feature into one-hot encoding independently.
                 mlContext.Transforms.Categorical.OneHotEncoding("CategoricalOneHot", "CategoricalFeatures")
                 // Convert all categorical features into indices, and build a 'word bag' of these.
-                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CategoricalBag", "CategoricalFeatures", OneHotEncodingTransformer.OutputKind.Bag))
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CategoricalBag", "CategoricalFeatures", OneHotEncodingEstimator.OutputKind.Bag))
                 // One-hot encode the workclass column, then drop all the categories that have fewer than 10 instances in the train set.
                 .Append(mlContext.Transforms.Categorical.OneHotEncoding("WorkclassOneHot", "Workclass"))
                 .Append(mlContext.Transforms.FeatureSelection.SelectFeaturesBasedOnCount("WorkclassOneHotTrimmed", "WorkclassOneHot", count: 10));

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -548,7 +548,7 @@ namespace Microsoft.ML.Scenarios
                         learningRate: 0.001f,
                         batchSize: 20))
                     .Append(mlContext.Transforms.Concatenate("Features", "Prediction"))
-                    .Append(mlContext.Transforms.Conversion.MapValueToKey("KeyLabel", "Label", maxNumKeys: 10))
+                    .Append(mlContext.Transforms.Conversion.MapValueToKey("KeyLabel", "Label", maxNumberOfKeys: 10))
                     .Append(mlContext.MulticlassClassification.Trainers.LightGbm("KeyLabel", "Features"));
 
                 var trainedModel = pipe.Fit(trainData);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -985,7 +985,7 @@ namespace Microsoft.ML.Scenarios
             // Then this integer vector is retrieved from the pipeline and resized to fixed length.
             // The second pipeline 'tfEnginePipe' takes the resized integer vector and passes it to TensoFlow and gets the classification scores.
             var estimator = mlContext.Transforms.Text.TokenizeWords("TokenizedWords", "Sentiment_Text")
-                .Append(mlContext.Transforms.Conversion.ValueMap(lookupMap, "Words", "Ids", new ColumnOptions[] { ("Features", "TokenizedWords") }));
+                .Append(mlContext.Transforms.Conversion.MapValue(lookupMap, "Words", "Ids", new ColumnOptions[] { ("Features", "TokenizedWords") }));
             var dataPipe = estimator.Fit(dataView)
                 .CreatePredictionEngine<TensorFlowSentiment, TensorFlowSentiment>(mlContext);
 

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -548,7 +548,7 @@ namespace Microsoft.ML.Scenarios
                         learningRate: 0.001f,
                         batchSize: 20))
                     .Append(mlContext.Transforms.Concatenate("Features", "Prediction"))
-                    .Append(mlContext.Transforms.Conversion.MapValueToKey("KeyLabel", "Label", maxNumberOfKeys: 10))
+                    .Append(mlContext.Transforms.Conversion.MapValueToKey("KeyLabel", "Label", maximumNumberOfKeys: 10))
                     .Append(mlContext.MulticlassClassification.Trainers.LightGbm("KeyLabel", "Features"));
 
                 var trainedModel = pipe.Fit(trainData);

--- a/test/Microsoft.ML.Tests/Transformers/CategoricalHashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CategoricalHashTests.cs
@@ -50,10 +50,10 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Categorical.OneHotHashEncoding(new[]{
-                    new OneHotHashEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingTransformer.OutputKind.Bag),
-                    new OneHotHashEncodingEstimator.ColumnOptions("CatB", "A", OneHotEncodingTransformer.OutputKind.Bin),
-                    new OneHotHashEncodingEstimator.ColumnOptions("CatC", "A", OneHotEncodingTransformer.OutputKind.Ind),
-                    new OneHotHashEncodingEstimator.ColumnOptions("CatD", "A", OneHotEncodingTransformer.OutputKind.Key),
+                    new OneHotHashEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingEstimator.OutputKind.Bag),
+                    new OneHotHashEncodingEstimator.ColumnOptions("CatB", "A", OneHotEncodingEstimator.OutputKind.Binary),
+                    new OneHotHashEncodingEstimator.ColumnOptions("CatC", "A", OneHotEncodingEstimator.OutputKind.Indicator),
+                    new OneHotHashEncodingEstimator.ColumnOptions("CatD", "A", OneHotEncodingEstimator.OutputKind.Key),
                 });
 
             TestEstimatorCore(pipe, dataView);
@@ -108,16 +108,16 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var bagPipe = ML.Transforms.Categorical.OneHotHashEncoding(
-                new OneHotHashEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingTransformer.OutputKind.Bag, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatB", "B", OneHotEncodingTransformer.OutputKind.Bag, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatC", "C", OneHotEncodingTransformer.OutputKind.Bag, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatD", "D", OneHotEncodingTransformer.OutputKind.Bag, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatE", "E", OneHotEncodingTransformer.OutputKind.Ind, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatF", "F", OneHotEncodingTransformer.OutputKind.Ind, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatG", "A", OneHotEncodingTransformer.OutputKind.Key, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatH", "B", OneHotEncodingTransformer.OutputKind.Key, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatI", "A", OneHotEncodingTransformer.OutputKind.Bin, invertHash: -1),
-                new OneHotHashEncodingEstimator.ColumnOptions("CatJ", "B", OneHotEncodingTransformer.OutputKind.Bin, invertHash: -1));
+                new OneHotHashEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingEstimator.OutputKind.Bag, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatB", "B", OneHotEncodingEstimator.OutputKind.Bag, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatC", "C", OneHotEncodingEstimator.OutputKind.Bag, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatD", "D", OneHotEncodingEstimator.OutputKind.Bag, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatE", "E", OneHotEncodingEstimator.OutputKind.Indicator, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatF", "F", OneHotEncodingEstimator.OutputKind.Indicator, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatG", "A", OneHotEncodingEstimator.OutputKind.Key, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatH", "B", OneHotEncodingEstimator.OutputKind.Key, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatI", "A", OneHotEncodingEstimator.OutputKind.Binary, maximumNumberOfInverts: -1),
+                new OneHotHashEncodingEstimator.ColumnOptions("CatJ", "B", OneHotEncodingEstimator.OutputKind.Binary, maximumNumberOfInverts: -1));
 
             var bagResult = bagPipe.Fit(dataView).Transform(dataView);
             ValidateMetadata(bagResult);

--- a/test/Microsoft.ML.Tests/Transformers/CategoricalTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CategoricalTests.cs
@@ -58,10 +58,10 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Categorical.OneHotEncoding(new[]{
-                    new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingTransformer.OutputKind.Bag),
-                    new OneHotEncodingEstimator.ColumnOptions("CatB", "A", OneHotEncodingTransformer.OutputKind.Bin),
-                    new OneHotEncodingEstimator.ColumnOptions("CatC", "A", OneHotEncodingTransformer.OutputKind.Ind),
-                    new OneHotEncodingEstimator.ColumnOptions("CatD", "A", OneHotEncodingTransformer.OutputKind.Key),
+                    new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingEstimator.OutputKind.Bag),
+                    new OneHotEncodingEstimator.ColumnOptions("CatB", "A", OneHotEncodingEstimator.OutputKind.Binary),
+                    new OneHotEncodingEstimator.ColumnOptions("CatC", "A", OneHotEncodingEstimator.OutputKind.Indicator),
+                    new OneHotEncodingEstimator.ColumnOptions("CatD", "A", OneHotEncodingEstimator.OutputKind.Key),
                 });
 
             TestEstimatorCore(pipe, dataView);
@@ -76,10 +76,10 @@ namespace Microsoft.ML.Tests.Transformers
             var mlContext = new MLContext();
             var dataView = mlContext.Data.LoadFromEnumerable(data);
 
-            var pipe = mlContext.Transforms.Categorical.OneHotHashEncoding("CatA", "A", 3, 0, OneHotEncodingTransformer.OutputKind.Bag)
-                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CatB", "A", 2, 0, OneHotEncodingTransformer.OutputKind.Key))
-                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CatC", "A", 3, 0, OneHotEncodingTransformer.OutputKind.Ind))
-                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CatD", "A", 2, 0, OneHotEncodingTransformer.OutputKind.Bin));
+            var pipe = mlContext.Transforms.Categorical.OneHotHashEncoding("CatA", "A", 3, 0, OneHotEncodingEstimator.OutputKind.Bag)
+                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CatB", "A", 2, 0, OneHotEncodingEstimator.OutputKind.Key))
+                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CatC", "A", 3, 0, OneHotEncodingEstimator.OutputKind.Indicator))
+                .Append(mlContext.Transforms.Categorical.OneHotHashEncoding("CatD", "A", 2, 0, OneHotEncodingEstimator.OutputKind.Binary));
 
             TestEstimatorCore(pipe, dataView);
             Done();
@@ -93,10 +93,10 @@ namespace Microsoft.ML.Tests.Transformers
             var mlContext = new MLContext();
             var dataView = mlContext.Data.LoadFromEnumerable(data);
 
-            var pipe = mlContext.Transforms.Categorical.OneHotEncoding("CatA", "A", OneHotEncodingTransformer.OutputKind.Bag)
-                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CatB", "A", OneHotEncodingTransformer.OutputKind.Key))
-                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CatC", "A", OneHotEncodingTransformer.OutputKind.Ind))
-                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CatD", "A", OneHotEncodingTransformer.OutputKind.Bin));
+            var pipe = mlContext.Transforms.Categorical.OneHotEncoding("CatA", "A", OneHotEncodingEstimator.OutputKind.Bag)
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CatB", "A", OneHotEncodingEstimator.OutputKind.Key))
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CatC", "A", OneHotEncodingEstimator.OutputKind.Indicator))
+                .Append(mlContext.Transforms.Categorical.OneHotEncoding("CatD", "A", OneHotEncodingEstimator.OutputKind.Binary));
 
             TestEstimatorCore(pipe, dataView);
             Done();
@@ -119,7 +119,7 @@ namespace Microsoft.ML.Tests.Transformers
             sideDataBuilder.AddColumn("Hello", "hello", "my", "friend");
             var sideData = sideDataBuilder.GetDataView();
 
-            var ci = new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingTransformer.OutputKind.Bag);
+            var ci = new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingEstimator.OutputKind.Bag);
             var pipe = mlContext.Transforms.Categorical.OneHotEncoding(new[] { ci }, sideData);
 
             var output = pipe.Fit(dataView).Transform(dataView);
@@ -178,18 +178,18 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Categorical.OneHotEncoding(new[] {
-                new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingTransformer.OutputKind.Bag),
-                new OneHotEncodingEstimator.ColumnOptions("CatB", "B", OneHotEncodingTransformer.OutputKind.Bag),
-                new OneHotEncodingEstimator.ColumnOptions("CatC", "C", OneHotEncodingTransformer.OutputKind.Bag),
-                new OneHotEncodingEstimator.ColumnOptions("CatD", "D", OneHotEncodingTransformer.OutputKind.Bag),
-                new OneHotEncodingEstimator.ColumnOptions("CatE", "E",OneHotEncodingTransformer.OutputKind.Ind),
-                new OneHotEncodingEstimator.ColumnOptions("CatF", "F", OneHotEncodingTransformer.OutputKind.Ind),
-                new OneHotEncodingEstimator.ColumnOptions("CatG", "G", OneHotEncodingTransformer.OutputKind.Key),
-                new OneHotEncodingEstimator.ColumnOptions("CatH", "H", OneHotEncodingTransformer.OutputKind.Key),
-                new OneHotEncodingEstimator.ColumnOptions("CatI", "A", OneHotEncodingTransformer.OutputKind.Bin),
-                new OneHotEncodingEstimator.ColumnOptions("CatJ", "B", OneHotEncodingTransformer.OutputKind.Bin),
-                new OneHotEncodingEstimator.ColumnOptions("CatK", "C", OneHotEncodingTransformer.OutputKind.Bin),
-                new OneHotEncodingEstimator.ColumnOptions("CatL", "D", OneHotEncodingTransformer.OutputKind.Bin) });
+                new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingEstimator.OutputKind.Bag),
+                new OneHotEncodingEstimator.ColumnOptions("CatB", "B", OneHotEncodingEstimator.OutputKind.Bag),
+                new OneHotEncodingEstimator.ColumnOptions("CatC", "C", OneHotEncodingEstimator.OutputKind.Bag),
+                new OneHotEncodingEstimator.ColumnOptions("CatD", "D", OneHotEncodingEstimator.OutputKind.Bag),
+                new OneHotEncodingEstimator.ColumnOptions("CatE", "E",OneHotEncodingEstimator.OutputKind.Indicator),
+                new OneHotEncodingEstimator.ColumnOptions("CatF", "F", OneHotEncodingEstimator.OutputKind.Indicator),
+                new OneHotEncodingEstimator.ColumnOptions("CatG", "G", OneHotEncodingEstimator.OutputKind.Key),
+                new OneHotEncodingEstimator.ColumnOptions("CatH", "H", OneHotEncodingEstimator.OutputKind.Key),
+                new OneHotEncodingEstimator.ColumnOptions("CatI", "A", OneHotEncodingEstimator.OutputKind.Binary),
+                new OneHotEncodingEstimator.ColumnOptions("CatJ", "B", OneHotEncodingEstimator.OutputKind.Binary),
+                new OneHotEncodingEstimator.ColumnOptions("CatK", "C", OneHotEncodingEstimator.OutputKind.Binary),
+                new OneHotEncodingEstimator.ColumnOptions("CatL", "D", OneHotEncodingEstimator.OutputKind.Binary) });
 
 
             var result = pipe.Fit(dataView).Transform(dataView);

--- a/test/Microsoft.ML.Tests/Transformers/ConvertTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ConvertTests.cs
@@ -205,8 +205,8 @@ namespace Microsoft.ML.Tests.Transformers
             var data = new[] { new MetaClass() { A = 1, B = "A" },
                                new MetaClass() { A = 2, B = "B" }};
             var pipe = ML.Transforms.Categorical.OneHotEncoding(new[] {
-                new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingTransformer.OutputKind.Ind),
-                new OneHotEncodingEstimator.ColumnOptions("CatB", "B", OneHotEncodingTransformer.OutputKind.Key)
+                new OneHotEncodingEstimator.ColumnOptions("CatA", "A", OneHotEncodingEstimator.OutputKind.Indicator),
+                new OneHotEncodingEstimator.ColumnOptions("CatB", "B", OneHotEncodingEstimator.OutputKind.Key)
             }).Append(ML.Transforms.Conversion.ConvertType(new[] {
                 new TypeConvertingEstimator.ColumnOptions("ConvA", DataKind.Double, "CatA"),
                 new TypeConvertingEstimator.ColumnOptions("ConvB", DataKind.UInt16, "CatB")

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[]{
-                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, invertHash:-1),
-                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, ordered:true),
+                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, maximumNumberOfInverts:-1),
+                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, useOrderedHashing:true),
                     new HashingEstimator.ColumnOptions("HashC", "C", seed:42),
                     new HashingEstimator.ColumnOptions("HashD", "A"),
                 });
@@ -69,9 +69,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[] {
-                new HashingEstimator.ColumnOptions("HashA", "A", invertHash:1, numberOfHashBits:10),
-                new HashingEstimator.ColumnOptions("HashAUnlim", "A", invertHash:-1, numberOfHashBits:10),
-                new HashingEstimator.ColumnOptions("HashAUnlimOrdered", "A", invertHash:-1, numberOfHashBits:10, ordered:true)
+                new HashingEstimator.ColumnOptions("HashA", "A", maximumNumberOfInverts:1, numberOfHashBits:10),
+                new HashingEstimator.ColumnOptions("HashAUnlim", "A", maximumNumberOfInverts:-1, numberOfHashBits:10),
+                new HashingEstimator.ColumnOptions("HashAUnlimOrdered", "A", maximumNumberOfInverts:-1, numberOfHashBits:10, useOrderedHashing:true)
             });
             var result = pipe.Fit(dataView).Transform(dataView);
             ValidateMetadata(result);
@@ -109,8 +109,8 @@ namespace Microsoft.ML.Tests.Transformers
             var data = new[] { new TestClass() { A = 1, B = 2, C = 3, }, new TestClass() { A = 4, B = 5, C = 6 } };
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[]{
-                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, invertHash:-1),
-                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, ordered:true),
+                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, maximumNumberOfInverts:-1),
+                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, useOrderedHashing:true),
                     new HashingEstimator.ColumnOptions("HashC", "C", seed:42),
                     new HashingEstimator.ColumnOptions("HashD" ,"A"),
             });

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[]{
-                    new HashingEstimator.ColumnOptions("HashA", "A", hashBits:4, invertHash:-1),
-                    new HashingEstimator.ColumnOptions("HashB", "B", hashBits:3, ordered:true),
+                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, invertHash:-1),
+                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, ordered:true),
                     new HashingEstimator.ColumnOptions("HashC", "C", seed:42),
                     new HashingEstimator.ColumnOptions("HashD", "A"),
                 });
@@ -69,9 +69,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[] {
-                new HashingEstimator.ColumnOptions("HashA", "A", invertHash:1, hashBits:10),
-                new HashingEstimator.ColumnOptions("HashAUnlim", "A", invertHash:-1, hashBits:10),
-                new HashingEstimator.ColumnOptions("HashAUnlimOrdered", "A", invertHash:-1, hashBits:10, ordered:true)
+                new HashingEstimator.ColumnOptions("HashA", "A", invertHash:1, numberOfHashBits:10),
+                new HashingEstimator.ColumnOptions("HashAUnlim", "A", invertHash:-1, numberOfHashBits:10),
+                new HashingEstimator.ColumnOptions("HashAUnlimOrdered", "A", invertHash:-1, numberOfHashBits:10, ordered:true)
             });
             var result = pipe.Fit(dataView).Transform(dataView);
             ValidateMetadata(result);
@@ -109,8 +109,8 @@ namespace Microsoft.ML.Tests.Transformers
             var data = new[] { new TestClass() { A = 1, B = 2, C = 3, }, new TestClass() { A = 4, B = 5, C = 6 } };
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[]{
-                    new HashingEstimator.ColumnOptions("HashA", "A", hashBits:4, invertHash:-1),
-                    new HashingEstimator.ColumnOptions("HashB", "B", hashBits:3, ordered:true),
+                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, invertHash:-1),
+                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, ordered:true),
                     new HashingEstimator.ColumnOptions("HashC", "C", seed:42),
                     new HashingEstimator.ColumnOptions("HashD" ,"A"),
             });

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[]{
-                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, maximumNumberOfInverts:-1),
-                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, useOrderedHashing:true),
+                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfBits:4, maximumNumberOfInverts:-1),
+                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfBits:3, useOrderedHashing:true),
                     new HashingEstimator.ColumnOptions("HashC", "C", seed:42),
                     new HashingEstimator.ColumnOptions("HashD", "A"),
                 });
@@ -69,9 +69,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[] {
-                new HashingEstimator.ColumnOptions("HashA", "A", maximumNumberOfInverts:1, numberOfHashBits:10),
-                new HashingEstimator.ColumnOptions("HashAUnlim", "A", maximumNumberOfInverts:-1, numberOfHashBits:10),
-                new HashingEstimator.ColumnOptions("HashAUnlimOrdered", "A", maximumNumberOfInverts:-1, numberOfHashBits:10, useOrderedHashing:true)
+                new HashingEstimator.ColumnOptions("HashA", "A", maximumNumberOfInverts:1, numberOfBits:10),
+                new HashingEstimator.ColumnOptions("HashAUnlim", "A", maximumNumberOfInverts:-1, numberOfBits:10),
+                new HashingEstimator.ColumnOptions("HashAUnlimOrdered", "A", maximumNumberOfInverts:-1, numberOfBits:10, useOrderedHashing:true)
             });
             var result = pipe.Fit(dataView).Transform(dataView);
             ValidateMetadata(result);
@@ -109,8 +109,8 @@ namespace Microsoft.ML.Tests.Transformers
             var data = new[] { new TestClass() { A = 1, B = 2, C = 3, }, new TestClass() { A = 4, B = 5, C = 6 } };
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Conversion.Hash(new[]{
-                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfHashBits:4, maximumNumberOfInverts:-1),
-                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfHashBits:3, useOrderedHashing:true),
+                    new HashingEstimator.ColumnOptions("HashA", "A", numberOfBits:4, maximumNumberOfInverts:-1),
+                    new HashingEstimator.ColumnOptions("HashB", "B", numberOfBits:3, useOrderedHashing:true),
                     new HashingEstimator.ColumnOptions("HashC", "C", seed:42),
                     new HashingEstimator.ColumnOptions("HashD" ,"A"),
             });
@@ -144,14 +144,14 @@ namespace Microsoft.ML.Tests.Transformers
             };
 
             // First do an unordered hash.
-            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits);
+            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfBits: bits);
             var getter = hashGetter<uint>(info);
             uint result = 0;
             getter(ref result);
             Assert.Equal(expected, result);
 
             // Next do an ordered hash.
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: true);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfBits: bits, useOrderedHashing: true);
             getter = hashGetter<uint>(info);
             getter(ref result);
             Assert.Equal(expectedOrdered, result);
@@ -164,7 +164,7 @@ namespace Microsoft.ML.Tests.Transformers
             builder.Add("Foo", new VectorType(type, vecLen), (ref VBuffer<T> dst) => denseVec.CopyTo(ref dst));
             inRow = AnnotationUtils.AnnotationsAsRow(builder.ToAnnotations());
 
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: false);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfBits: bits, useOrderedHashing: false);
             var vecGetter = hashGetter<VBuffer<uint>>(info);
             VBuffer<uint> vecResult = default;
             vecGetter(ref vecResult);
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Tests.Transformers
             Assert.All(vecResult.DenseValues(), v => Assert.Equal(expected, v));
 
             // Now do ordered with the dense vector.
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: true);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfBits: bits, useOrderedHashing: true);
             vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Tests.Transformers
             builder.Add("Foo", new VectorType(type, vecLen), (ref VBuffer<T> dst) => sparseVec.CopyTo(ref dst));
             inRow = AnnotationUtils.AnnotationsAsRow(builder.ToAnnotations());
 
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: false);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfBits: bits, useOrderedHashing: false);
             vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 
@@ -198,7 +198,7 @@ namespace Microsoft.ML.Tests.Transformers
             Assert.Equal(expected, vecResult.GetItemOrDefault(3));
             Assert.Equal(expected, vecResult.GetItemOrDefault(7));
 
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: true);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfBits: bits, useOrderedHashing: true);
             vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 

--- a/test/Microsoft.ML.Tests/Transformers/HashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/HashTests.cs
@@ -144,14 +144,14 @@ namespace Microsoft.ML.Tests.Transformers
             };
 
             // First do an unordered hash.
-            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits);
+            var info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits);
             var getter = hashGetter<uint>(info);
             uint result = 0;
             getter(ref result);
             Assert.Equal(expected, result);
 
             // Next do an ordered hash.
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: true);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: true);
             getter = hashGetter<uint>(info);
             getter(ref result);
             Assert.Equal(expectedOrdered, result);
@@ -164,7 +164,7 @@ namespace Microsoft.ML.Tests.Transformers
             builder.Add("Foo", new VectorType(type, vecLen), (ref VBuffer<T> dst) => denseVec.CopyTo(ref dst));
             inRow = AnnotationUtils.AnnotationsAsRow(builder.ToAnnotations());
 
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: false);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: false);
             var vecGetter = hashGetter<VBuffer<uint>>(info);
             VBuffer<uint> vecResult = default;
             vecGetter(ref vecResult);
@@ -174,7 +174,7 @@ namespace Microsoft.ML.Tests.Transformers
             Assert.All(vecResult.DenseValues(), v => Assert.Equal(expected, v));
 
             // Now do ordered with the dense vector.
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: true);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: true);
             vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Tests.Transformers
             builder.Add("Foo", new VectorType(type, vecLen), (ref VBuffer<T> dst) => sparseVec.CopyTo(ref dst));
             inRow = AnnotationUtils.AnnotationsAsRow(builder.ToAnnotations());
 
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: false);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: false);
             vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 
@@ -198,7 +198,7 @@ namespace Microsoft.ML.Tests.Transformers
             Assert.Equal(expected, vecResult.GetItemOrDefault(3));
             Assert.Equal(expected, vecResult.GetItemOrDefault(7));
 
-            info = new HashingEstimator.ColumnOptions("Bar", "Foo", hashBits: bits, ordered: true);
+            info = new HashingEstimator.ColumnOptions("Bar", "Foo", numberOfHashBits: bits, useOrderedHashing: true);
             vecGetter = hashGetter<VBuffer<uint>>(info);
             vecGetter(ref vecResult);
 

--- a/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
+++ b/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Tests.Transformers
             dataView = new ValueToKeyMappingEstimator(Env, new[]{
                     new ValueToKeyMappingEstimator.ColumnOptions("TermA", "A"),
                     new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B"),
-                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", keyValuesAnnotationsAsText:true)
+                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", addKeyValueAnnotationsAsText:true)
                 }).Fit(dataView).Transform(dataView);
 
             var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(("CatA", "TermA"), ("CatC", "TermC"));
@@ -99,8 +99,8 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var termEst = new ValueToKeyMappingEstimator(Env, new[] {
-                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", keyValuesAnnotationsAsText: true),
-                new ValueToKeyMappingEstimator.ColumnOptions("TB", "B", keyValuesAnnotationsAsText: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", addKeyValueAnnotationsAsText: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TB", "B", addKeyValueAnnotationsAsText: true),
                 new ValueToKeyMappingEstimator.ColumnOptions("TC", "C"),
                 new ValueToKeyMappingEstimator.ColumnOptions("TD", "D") });
             var termTransformer = termEst.Fit(dataView);
@@ -151,7 +151,7 @@ namespace Microsoft.ML.Tests.Transformers
             var dataView = ML.Data.LoadFromEnumerable(data);
             var est = new ValueToKeyMappingEstimator(Env, new[]{
                     new ValueToKeyMappingEstimator.ColumnOptions("TermA", "A"),
-                    new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B", keyValuesAnnotationsAsText:true),
+                    new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B", addKeyValueAnnotationsAsText:true),
                     new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C")
             });
             var transformer = est.Fit(dataView);

--- a/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
+++ b/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Tests.Transformers
             dataView = new ValueToKeyMappingEstimator(Env, new[]{
                     new ValueToKeyMappingEstimator.ColumnOptions("TermA", "A"),
                     new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B"),
-                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", textKeyValues:true)
+                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", keyValuesAnnotationsAsText:true)
                 }).Fit(dataView).Transform(dataView);
 
             var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(("CatA", "TermA"), ("CatC", "TermC"));
@@ -99,8 +99,8 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var termEst = new ValueToKeyMappingEstimator(Env, new[] {
-                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", textKeyValues: true),
-                new ValueToKeyMappingEstimator.ColumnOptions("TB", "B", textKeyValues: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", keyValuesAnnotationsAsText: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TB", "B", keyValuesAnnotationsAsText: true),
                 new ValueToKeyMappingEstimator.ColumnOptions("TC", "C"),
                 new ValueToKeyMappingEstimator.ColumnOptions("TD", "D") });
             var termTransformer = termEst.Fit(dataView);
@@ -151,7 +151,7 @@ namespace Microsoft.ML.Tests.Transformers
             var dataView = ML.Data.LoadFromEnumerable(data);
             var est = new ValueToKeyMappingEstimator(Env, new[]{
                     new ValueToKeyMappingEstimator.ColumnOptions("TermA", "A"),
-                    new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B", textKeyValues:true),
+                    new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B", keyValuesAnnotationsAsText:true),
                     new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C")
             });
             var transformer = est.Fit(dataView);

--- a/test/Microsoft.ML.Tests/Transformers/KeyToVectorEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/KeyToVectorEstimatorTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Tests.Transformers
             dataView = new ValueToKeyMappingEstimator(Env, new[]{
                     new ValueToKeyMappingEstimator.ColumnOptions("TermA", "A"),
                     new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B"),
-                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", textKeyValues:true)
+                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", keyValuesAnnotationsAsText:true)
                 }).Fit(dataView).Transform(dataView);
 
             var pipe = ML.Transforms.Conversion.MapKeyToVector(new KeyToVectorMappingEstimator.ColumnOptions("CatA", "TermA", false),
@@ -110,14 +110,14 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var termEst = new ValueToKeyMappingEstimator(Env, new[] {
-                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", textKeyValues: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", keyValuesAnnotationsAsText: true),
                 new ValueToKeyMappingEstimator.ColumnOptions("TB", "B"),
-                new ValueToKeyMappingEstimator.ColumnOptions("TC", "C", textKeyValues: true),
-                new ValueToKeyMappingEstimator.ColumnOptions("TD", "D", textKeyValues: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TC", "C", keyValuesAnnotationsAsText: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TD", "D", keyValuesAnnotationsAsText: true),
                 new ValueToKeyMappingEstimator.ColumnOptions("TE", "E"),
                 new ValueToKeyMappingEstimator.ColumnOptions("TF", "F"),
                 new ValueToKeyMappingEstimator.ColumnOptions("TG", "G"),
-                new ValueToKeyMappingEstimator.ColumnOptions("TH", "H", textKeyValues: true) });
+                new ValueToKeyMappingEstimator.ColumnOptions("TH", "H", keyValuesAnnotationsAsText: true) });
             var termTransformer = termEst.Fit(dataView);
             dataView = termTransformer.Transform(dataView);
 

--- a/test/Microsoft.ML.Tests/Transformers/KeyToVectorEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/KeyToVectorEstimatorTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Tests.Transformers
             dataView = new ValueToKeyMappingEstimator(Env, new[]{
                     new ValueToKeyMappingEstimator.ColumnOptions("TermA", "A"),
                     new ValueToKeyMappingEstimator.ColumnOptions("TermB", "B"),
-                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", keyValuesAnnotationsAsText:true)
+                    new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", addKeyValueAnnotationsAsText:true)
                 }).Fit(dataView).Transform(dataView);
 
             var pipe = ML.Transforms.Conversion.MapKeyToVector(new KeyToVectorMappingEstimator.ColumnOptions("CatA", "TermA", false),
@@ -110,14 +110,14 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var termEst = new ValueToKeyMappingEstimator(Env, new[] {
-                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", keyValuesAnnotationsAsText: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TA", "A", addKeyValueAnnotationsAsText: true),
                 new ValueToKeyMappingEstimator.ColumnOptions("TB", "B"),
-                new ValueToKeyMappingEstimator.ColumnOptions("TC", "C", keyValuesAnnotationsAsText: true),
-                new ValueToKeyMappingEstimator.ColumnOptions("TD", "D", keyValuesAnnotationsAsText: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TC", "C", addKeyValueAnnotationsAsText: true),
+                new ValueToKeyMappingEstimator.ColumnOptions("TD", "D", addKeyValueAnnotationsAsText: true),
                 new ValueToKeyMappingEstimator.ColumnOptions("TE", "E"),
                 new ValueToKeyMappingEstimator.ColumnOptions("TF", "F"),
                 new ValueToKeyMappingEstimator.ColumnOptions("TG", "G"),
-                new ValueToKeyMappingEstimator.ColumnOptions("TH", "H", keyValuesAnnotationsAsText: true) });
+                new ValueToKeyMappingEstimator.ColumnOptions("TH", "H", addKeyValueAnnotationsAsText: true) });
             var termTransformer = termEst.Fit(dataView);
             dataView = termTransformer.Transform(dataView);
 

--- a/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.ML.Tests.Transformers
                 .Load(sentimentDataPath);
 
             var est = new WordBagEstimator(ML, "bag_of_words", "text").
-                Append(new WordHashBagEstimator(ML, "bag_of_wordshash", "text", invertHash: -1));
+                Append(new WordHashBagEstimator(ML, "bag_of_wordshash", "text", maximumNumberOfInverts: -1));
 
             // The following call fails because of the following issue
             // https://github.com/dotnet/machinelearning/issues/969

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -511,7 +511,7 @@ namespace Microsoft.ML.Tests.Transformers
             var values = new List<int>() { 1, 2, 3, 4 };
 
             // Workout on value mapping
-            var est = ML.Transforms.Conversion.ValueMap(keys, values, new ColumnOptions[] { ("D", "A"), ("E", "B"), ("F", "C") });
+            var est = ML.Transforms.Conversion.MapValue(keys, values, new ColumnOptions[] { ("D", "A"), ("E", "B"), ("F", "C") });
             TestEstimatorCore(est, validFitInput: dataView, invalidInput: badDataView);
         }
 
@@ -530,7 +530,7 @@ namespace Microsoft.ML.Tests.Transformers
                 new int[] {400, 500, 600, 700 }};
 
             // Workout on value mapping
-            var est = ML.Transforms.Conversion.ValueMap(keys, values, new ColumnOptions[] { ("D", "A"), ("E", "B"), ("F", "C") });
+            var est = ML.Transforms.Conversion.MapValue(keys, values, new ColumnOptions[] { ("D", "A"), ("E", "B"), ("F", "C") });
             TestEstimatorCore(est, validFitInput: dataView, invalidInput: badDataView);
         }
 
@@ -547,7 +547,7 @@ namespace Microsoft.ML.Tests.Transformers
             var values = new List<int>() { 1, 2, 3, 4 };
 
             var est = ML.Transforms.Text.TokenizeWords("TokenizeB", "B")
-                .Append(ML.Transforms.Conversion.ValueMap(keys, values, new ColumnOptions[] { ("VecB", "TokenizeB") }));
+                .Append(ML.Transforms.Conversion.MapValue(keys, values, new ColumnOptions[] { ("VecB", "TokenizeB") }));
             TestEstimatorCore(est, validFitInput: dataView, invalidInput: badDataView);
         }
 


### PR DESCRIPTION
Fixes #2829.

Related to the scrubbing tasks. I focus on the key related transforms in this PR.

Note: in most places the following method is used by the estimator to get the the columns. I kept it but made it internal, despite Ivan suggested deleting it.

```charp
internal IReadOnlyCollection<KeyToVectorMappingEstimator.ColumnOptions> Columns => _columns.AsReadOnly();
```

List of transforms:

- MapKeyToBinaryVector
- MapKeyToBinaryVector
- MapKeyToVector
- MapKeyToValue
- MapValueToKey
- ValueMap
- OneHotEncoding
- Hash
- OneHotHash
