### PR TITLE
ImageModels in tensorflow are 4 dimensional.

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -730,7 +730,7 @@ namespace Microsoft.ML.Transforms
                     var originalShape = _parent.TFInputShapes[i];
                     var shape = originalShape.ToIntArray();
 
-                    var colTypeDims = vecType.Dimensions.Select(dim => (long)dim).ToArray();
+                    var colTypeDims = vecType.Dimensions.Prepend(1).Select(dim => (long)dim).ToArray();
                     if (shape == null)
                         _fullySpecifiedShapes[i] = new TFShape(colTypeDims);
                     else


### PR DESCRIPTION
Fixes https://github.com/dotnet/machinelearning/issues/2778
Well, not exactly fixes, it's more like a hack.
Proper solution would be to implement Reshape transform https://github.com/dotnet/machinelearning/issues/765