### PR TITLE
Make array values intended to be immutable IReadOnlyList

### DIFF
--- a/src/Microsoft.ML.Core/Data/IProgressChannel.cs
+++ b/src/Microsoft.ML.Core/Data/IProgressChannel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.ML
 {
@@ -77,13 +78,13 @@ namespace Microsoft.ML
         /// For example, neural network might have {'epoch', 'example'} and FastTree might have {'tree', 'split', 'feature'}.
         /// Will never be null, but can be empty.
         /// </summary>
-        public readonly string[] UnitNames;
+        public readonly IReadOnlyList<string> UnitNames;
 
         /// <summary>
         /// These are the names of the reported metrics. For example, this could be the 'loss', 'weight updates/sec' etc.
         /// Will never be null, but can be empty.
         /// </summary>
-        public readonly string[] MetricNames;
+        public readonly IReadOnlyList<string> MetricNames;
 
         /// <summary>
         /// Initialize the header. This will take ownership of the arrays.

--- a/src/Microsoft.ML.Core/Data/ProgressReporter.cs
+++ b/src/Microsoft.ML.Core/Data/ProgressReporter.cs
@@ -25,8 +25,6 @@ namespace Microsoft.ML.Data
         {
             private readonly IExceptionContext _ectx;
 
-            private readonly string _name;
-
             /// <summary>
             /// The pair of (header, fill action) is updated atomically.
             /// </summary>
@@ -41,7 +39,7 @@ namespace Microsoft.ML.Data
             private volatile int _maxSubId;
             private bool _isDisposed;
 
-            public string Name { get { return _name; } }
+            public string Name { get; }
 
             /// <summary>
             /// Initialize a <see cref="ProgressChannel"/> for the process identified by <paramref name="computationName"/>.
@@ -56,7 +54,7 @@ namespace Microsoft.ML.Data
                 _ectx.CheckValue(tracker, nameof(tracker));
                 _ectx.CheckNonEmpty(computationName, nameof(computationName));
 
-                _name = computationName;
+                Name = computationName;
                 _tracker = tracker;
                 _subChannels = new ConcurrentDictionary<int, SubChannel>();
                 _maxSubId = 0;
@@ -132,7 +130,7 @@ namespace Microsoft.ML.Data
                 var entry = new ProgressEntry(false, cache.Item1);
 
                 if (fillAction == null)
-                    Contracts.Assert(entry.Header.MetricNames.Length == 0 && entry.Header.UnitNames.Length == 0);
+                    Contracts.Assert(entry.Header.MetricNames.Count == 0 && entry.Header.UnitNames.Count == 0);
                 else
                     fillAction(entry);
 
@@ -232,7 +230,7 @@ namespace Microsoft.ML.Data
                     var entry = new ProgressEntry(false, cache.Item1);
 
                     if (fillAction == null)
-                        Contracts.Assert(entry.Header.MetricNames.Length == 0 && entry.Header.UnitNames.Length == 0);
+                        Contracts.Assert(entry.Header.MetricNames.Count == 0 && entry.Header.UnitNames.Count == 0);
                     else
                         fillAction(entry);
                     return entry;
@@ -558,9 +556,9 @@ namespace Microsoft.ML.Data
                 Contracts.CheckValue(header, nameof(header));
                 Header = header;
                 IsCheckpoint = isCheckpoint;
-                Progress = new Double?[header.UnitNames.Length];
-                ProgressLim = new Double?[header.UnitNames.Length];
-                Metrics = new Double?[header.MetricNames.Length];
+                Progress = new Double?[header.UnitNames.Count];
+                ProgressLim = new Double?[header.UnitNames.Count];
+                Metrics = new Double?[header.MetricNames.Count];
             }
         }
 

--- a/src/Microsoft.ML.Core/Environment/ConsoleEnvironment.cs
+++ b/src/Microsoft.ML.Core/Environment/ConsoleEnvironment.cs
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Data
 
                 // Progress units.
                 bool first = true;
-                for (int i = 0; i < ev.ProgressEntry.Header.UnitNames.Length; i++)
+                for (int i = 0; i < ev.ProgressEntry.Header.UnitNames.Count; i++)
                 {
                     if (ev.ProgressEntry.Progress[i] == null)
                         continue;
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Data
                 }
 
                 // Metrics.
-                for (int i = 0; i < ev.ProgressEntry.Header.MetricNames.Length; i++)
+                for (int i = 0; i < ev.ProgressEntry.Header.MetricNames.Count; i++)
                 {
                     if (ev.ProgressEntry.Metrics[i] == null)
                         continue;

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/MultiClassClassifierMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/MultiClassClassifierMetrics.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.Data.DataView;
 
 namespace Microsoft.ML.Data
@@ -78,7 +80,7 @@ namespace Microsoft.ML.Data
         /// p[i] is the probability returned by the classifier if the instance belongs to the class,
         /// and 1 minus the probability returned by the classifier if the instance does not belong to the class.
         /// </remarks>
-        public double[] PerClassLogLoss { get; }
+        public IReadOnlyList<double> PerClassLogLoss { get; }
 
         internal MultiClassClassifierMetrics(IExceptionContext ectx, DataViewRow overallResult, int topK)
         {
@@ -92,8 +94,7 @@ namespace Microsoft.ML.Data
                 TopKAccuracy = FetchDouble(MultiClassClassifierEvaluator.TopKAccuracy);
 
             var perClassLogLoss = RowCursorUtils.Fetch<VBuffer<double>>(ectx, overallResult, MultiClassClassifierEvaluator.PerClassLogLoss);
-            PerClassLogLoss = new double[perClassLogLoss.Length];
-            perClassLogLoss.CopyTo(PerClassLogLoss);
+            PerClassLogLoss = perClassLogLoss.DenseValues().ToImmutableArray();
         }
 
         internal MultiClassClassifierMetrics(double accuracyMicro, double accuracyMacro, double logLoss, double logLossReduction,
@@ -105,8 +106,7 @@ namespace Microsoft.ML.Data
             LogLossReduction = logLossReduction;
             TopK = topK;
             TopKAccuracy = topKAccuracy;
-            PerClassLogLoss = new double[perClassLogLoss.Length];
-            perClassLogLoss.CopyTo(PerClassLogLoss, 0);
+            PerClassLogLoss = perClassLogLoss.ToImmutableArray();
         }
     }
 }

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/RankingMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/RankingMetrics.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.Data.DataView;
 
 namespace Microsoft.ML.Data
@@ -15,7 +17,7 @@ namespace Microsoft.ML.Data
         /// Array of normalized discounted cumulative gains where i-th element represent NDCG@i.
         /// <image src="https://github.com/dotnet/machinelearning/tree/master/docs/images/NDCG.png"></image>
         /// </summary>
-        public double[] NormalizedDiscountedCumulativeGains { get; }
+        public IReadOnlyList<double> NormalizedDiscountedCumulativeGains { get; }
 
         /// <summary>
         /// Array of discounted cumulative gains where i-th element represent DCG@i.
@@ -25,7 +27,7 @@ namespace Microsoft.ML.Data
         /// <image src="https://github.com/dotnet/machinelearning/tree/master/docs/images/DCG.png"></image>
         /// </summary>
         /// <remarks><a href="https://en.wikipedia.org/wiki/Discounted_cumulative_gain">Discounted Cumulative gain.</a></remarks>
-        public double[] DiscountedCumulativeGains { get; }
+        public IReadOnlyList<double> DiscountedCumulativeGains { get; }
 
         private static T Fetch<T>(IExceptionContext ectx, DataViewRow row, string name)
         {
@@ -40,16 +42,14 @@ namespace Microsoft.ML.Data
         {
             VBuffer<double> Fetch(string name) => Fetch<VBuffer<double>>(ectx, overallResult, name);
 
-            DiscountedCumulativeGains = Fetch(RankingEvaluator.Dcg).GetValues().ToArray();
-            NormalizedDiscountedCumulativeGains = Fetch(RankingEvaluator.Ndcg).GetValues().ToArray();
+            DiscountedCumulativeGains = Fetch(RankingEvaluator.Dcg).DenseValues().ToImmutableArray();
+            NormalizedDiscountedCumulativeGains = Fetch(RankingEvaluator.Ndcg).DenseValues().ToImmutableArray();
         }
 
         internal RankingMetrics(double[] dcg, double[] ndcg)
         {
-            DiscountedCumulativeGains = new double[dcg.Length];
-            dcg.CopyTo(DiscountedCumulativeGains, 0);
-            NormalizedDiscountedCumulativeGains = new double[ndcg.Length];
-            ndcg.CopyTo(NormalizedDiscountedCumulativeGains, 0);
+            DiscountedCumulativeGains = dcg.ToImmutableArray();
+            NormalizedDiscountedCumulativeGains = ndcg.ToImmutableArray();
         }
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML.Data;
@@ -38,7 +39,8 @@ namespace Microsoft.ML.Transforms
             public readonly string InputColumnName;
             public readonly SortOrder Sort;
             public readonly int MaxNumKeys;
-            public readonly string[] Term;
+            public IReadOnlyList<string> Term => TermArray;
+            internal readonly string[] TermArray;
             public readonly bool TextKeyValues;
 
             [BestFriend]
@@ -53,7 +55,7 @@ namespace Microsoft.ML.Transforms
                 InputColumnName = inputColumnName ?? outputColumnName;
                 Sort = sort;
                 MaxNumKeys = maxNumKeys;
-                Term = term;
+                TermArray = term;
                 TextKeyValues = textKeyValues;
             }
         }

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -532,7 +532,7 @@ namespace Microsoft.ML.Transforms
             {
                 // First check whether we have a terms argument, and handle it appropriately.
                 var terms = columns[iinfo].Terms.AsMemory();
-                var termsArray = columns[iinfo].Term;
+                var termsArray = columns[iinfo].TermArray;
 
                 terms = ReadOnlyMemoryUtils.TrimSpaces(terms);
                 if (!terms.IsEmpty || (termsArray != null && termsArray.Length > 0))

--- a/src/Microsoft.ML.Transforms/MetricStatistics.cs
+++ b/src/Microsoft.ML.Transforms/MetricStatistics.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.ML.Internal.Utilities;
 
 namespace Microsoft.ML.Data
@@ -51,11 +52,11 @@ namespace Microsoft.ML.Data
 
     internal static class MetricsStatisticsUtils
     {
-        public static void AddArray(double[] src, MetricStatistics[] dest)
+        public static void AddToEach(IReadOnlyList<double> src, IReadOnlyList<MetricStatistics> dest)
         {
-            Contracts.Assert(src.Length == dest.Length, "Array sizes do not match.");
+            Contracts.Assert(src.Count == dest.Count);
 
-            for (int i = 0; i < dest.Length; i++)
+            for (int i = 0; i < dest.Count; i++)
                 dest[i].Add(src[i]);
         }
 
@@ -242,7 +243,7 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Summary statistics for <see cref="MultiClassClassifierMetrics.PerClassLogLoss"/>.
         /// </summary>
-        public MetricStatistics[] PerClassLogLoss { get; private set; }
+        public IReadOnlyList<MetricStatistics> PerClassLogLoss { get; private set; }
 
         internal MultiClassClassifierMetricsStatistics()
         {
@@ -266,8 +267,8 @@ namespace Microsoft.ML.Data
             TopKAccuracy.Add(metrics.TopKAccuracy);
 
             if (PerClassLogLoss == null)
-                PerClassLogLoss = MetricsStatisticsUtils.InitializeArray(metrics.PerClassLogLoss.Length);
-            MetricsStatisticsUtils.AddArray(metrics.PerClassLogLoss, PerClassLogLoss);
+                PerClassLogLoss = MetricsStatisticsUtils.InitializeArray(metrics.PerClassLogLoss.Count);
+            MetricsStatisticsUtils.AddToEach(metrics.PerClassLogLoss, PerClassLogLoss);
         }
     }
 
@@ -280,12 +281,12 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Summary statistics for <see cref="RankingMetrics.DiscountedCumulativeGains"/>.
         /// </summary>
-        public MetricStatistics[] DiscountedCumulativeGains { get; private set; }
+        public IReadOnlyList<MetricStatistics> DiscountedCumulativeGains { get; private set; }
 
         /// <summary>
         /// Summary statistics for <see cref="RankingMetrics.NormalizedDiscountedCumulativeGains"/>.
         /// </summary>
-        public MetricStatistics[] NormalizedDiscountedCumulativeGains { get; private set; }
+        public IReadOnlyList<MetricStatistics> NormalizedDiscountedCumulativeGains { get; private set; }
 
         internal RankingMetricsStatistics()
         {
@@ -298,13 +299,13 @@ namespace Microsoft.ML.Data
         void IMetricsStatistics<RankingMetrics>.Add(RankingMetrics metrics)
         {
             if (DiscountedCumulativeGains == null)
-                DiscountedCumulativeGains = MetricsStatisticsUtils.InitializeArray(metrics.DiscountedCumulativeGains.Length);
+                DiscountedCumulativeGains = MetricsStatisticsUtils.InitializeArray(metrics.DiscountedCumulativeGains.Count);
 
             if (NormalizedDiscountedCumulativeGains == null)
-                NormalizedDiscountedCumulativeGains = MetricsStatisticsUtils.InitializeArray(metrics.NormalizedDiscountedCumulativeGains.Length);
+                NormalizedDiscountedCumulativeGains = MetricsStatisticsUtils.InitializeArray(metrics.NormalizedDiscountedCumulativeGains.Count);
 
-            MetricsStatisticsUtils.AddArray(metrics.DiscountedCumulativeGains, DiscountedCumulativeGains);
-            MetricsStatisticsUtils.AddArray(metrics.NormalizedDiscountedCumulativeGains, NormalizedDiscountedCumulativeGains);
+            MetricsStatisticsUtils.AddToEach(metrics.DiscountedCumulativeGains, DiscountedCumulativeGains);
+            MetricsStatisticsUtils.AddToEach(metrics.NormalizedDiscountedCumulativeGains, NormalizedDiscountedCumulativeGains);
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.Data.DataView;
 using Microsoft.ML.Data;
@@ -236,7 +237,7 @@ namespace Microsoft.ML
             if (a.TopK != b.TopK)
                 Contracts.Assert(a.TopK == b.TopK, "TopK to compare must be the same length.");
 
-            var perClassLogLoss = ComputeArrayDeltas(a.PerClassLogLoss, b.PerClassLogLoss);
+            var perClassLogLoss = ComputeSequenceDeltas(a.PerClassLogLoss, b.PerClassLogLoss);
 
             return new MultiClassClassifierMetrics(
                 accuracyMicro: a.MicroAccuracy - b.MicroAccuracy,
@@ -315,8 +316,8 @@ namespace Microsoft.ML
         private static RankingMetrics RankingDelta(
             RankingMetrics a, RankingMetrics b)
         {
-            var dcg = ComputeArrayDeltas(a.DiscountedCumulativeGains, b.DiscountedCumulativeGains);
-            var ndcg = ComputeArrayDeltas(a.NormalizedDiscountedCumulativeGains, b.NormalizedDiscountedCumulativeGains);
+            var dcg = ComputeSequenceDeltas(a.DiscountedCumulativeGains, b.DiscountedCumulativeGains);
+            var ndcg = ComputeSequenceDeltas(a.NormalizedDiscountedCumulativeGains, b.NormalizedDiscountedCumulativeGains);
 
             return new RankingMetrics(dcg: dcg, ndcg: ndcg);
         }
@@ -325,12 +326,12 @@ namespace Microsoft.ML
 
         #region Helpers
 
-        private static double[] ComputeArrayDeltas(double[] a, double[] b)
+        private static double[] ComputeSequenceDeltas(IReadOnlyList<double> a, IReadOnlyList<double> b)
         {
-            Contracts.Assert(a.Length == b.Length, "Arrays to compare must be of the same length.");
+            Contracts.Assert(a.Count == b.Count);
 
-            var delta = new double[a.Length];
-            for (int i = 0; i < a.Length; i++)
+            var delta = new double[a.Count];
+            for (int i = 0; i < a.Count; i++)
                 delta[i] = a[i] - b[i];
             return delta;
         }

--- a/test/Microsoft.ML.StaticPipelineTesting/Training.cs
+++ b/test/Microsoft.ML.StaticPipelineTesting/Training.cs
@@ -860,7 +860,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var metrics = catalog.Evaluate(data, r => r.label, r => r.groupId, r => r.score);
             Assert.NotNull(metrics);
 
-            Assert.True(metrics.NormalizedDiscountedCumulativeGains.Length == metrics.DiscountedCumulativeGains.Length && metrics.DiscountedCumulativeGains.Length == 3);
+            Assert.True(metrics.NormalizedDiscountedCumulativeGains.Count == metrics.DiscountedCumulativeGains.Count && metrics.DiscountedCumulativeGains.Count == 3);
 
             Assert.InRange(metrics.DiscountedCumulativeGains[0], 1.4, 1.6);
             Assert.InRange(metrics.DiscountedCumulativeGains[1], 1.4, 1.8);
@@ -901,7 +901,7 @@ namespace Microsoft.ML.StaticPipelineTesting
             var metrics = catalog.Evaluate(data, r => r.label, r => r.groupId, r => r.score);
             Assert.NotNull(metrics);
 
-            Assert.True(metrics.NormalizedDiscountedCumulativeGains.Length == metrics.DiscountedCumulativeGains.Length && metrics.DiscountedCumulativeGains.Length == 3);
+            Assert.True(metrics.NormalizedDiscountedCumulativeGains.Count == metrics.DiscountedCumulativeGains.Count && metrics.DiscountedCumulativeGains.Count == 3);
 
             Assert.InRange(metrics.DiscountedCumulativeGains[0], 1.4, 1.6);
             Assert.InRange(metrics.DiscountedCumulativeGains[1], 1.4, 1.8);

--- a/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
+++ b/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.ML.Tests
             //  Because they are _negative_, the difference will be positive for worse classifiers.
             Assert.Equal(1, MaxDeltaIndex(pfi, m => m.LogLoss.Mean));
             Assert.Equal(3, MinDeltaIndex(pfi, m => m.LogLoss.Mean));
-            for (int i = 0; i < pfi[0].PerClassLogLoss.Length; i++)
+            for (int i = 0; i < pfi[0].PerClassLogLoss.Count; i++)
             {
                 Assert.True(MaxDeltaIndex(pfi, m => m.PerClassLogLoss[i].Mean) == 1);
                 Assert.True(MinDeltaIndex(pfi, m => m.PerClassLogLoss[i].Mean) == 3);
@@ -293,7 +293,7 @@ namespace Microsoft.ML.Tests
             //  Because they are negative metrics, the _difference_ will be positive for worse classifiers.
             Assert.Equal(5, MaxDeltaIndex(pfi, m => m.LogLoss.Mean));
             Assert.Equal(2, MinDeltaIndex(pfi, m => m.LogLoss.Mean));
-            for (int i = 0; i < pfi[0].PerClassLogLoss.Length; i++)
+            for (int i = 0; i < pfi[0].PerClassLogLoss.Count; i++)
             {
                 Assert.Equal(5, MaxDeltaIndex(pfi, m => m.PerClassLogLoss[i].Mean));
                 Assert.Equal(2, MinDeltaIndex(pfi, m => m.PerClassLogLoss[i].Mean));
@@ -321,12 +321,12 @@ namespace Microsoft.ML.Tests
             // X4Rand: 3
 
             // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
-            for (int i = 0; i < pfi[0].DiscountedCumulativeGains.Length; i++)
+            for (int i = 0; i < pfi[0].DiscountedCumulativeGains.Count; i++)
             {
                 Assert.Equal(0, MaxDeltaIndex(pfi, m => m.DiscountedCumulativeGains[i].Mean));
                 Assert.Equal(1, MinDeltaIndex(pfi, m => m.DiscountedCumulativeGains[i].Mean));
             }
-            for (int i = 0; i < pfi[0].NormalizedDiscountedCumulativeGains.Length; i++)
+            for (int i = 0; i < pfi[0].NormalizedDiscountedCumulativeGains.Count; i++)
             {
                 Assert.Equal(0, MaxDeltaIndex(pfi, m => m.NormalizedDiscountedCumulativeGains[i].Mean));
                 Assert.Equal(1, MinDeltaIndex(pfi, m => m.NormalizedDiscountedCumulativeGains[i].Mean));
@@ -354,12 +354,12 @@ namespace Microsoft.ML.Tests
             // X3Important: 5 // Most important
 
             // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
-            for (int i = 0; i < pfi[0].DiscountedCumulativeGains.Length; i++)
+            for (int i = 0; i < pfi[0].DiscountedCumulativeGains.Count; i++)
             {
                 Assert.Equal(2, MaxDeltaIndex(pfi, m => m.DiscountedCumulativeGains[i].Mean));
                 Assert.Equal(5, MinDeltaIndex(pfi, m => m.DiscountedCumulativeGains[i].Mean));
             }
-            for (int i = 0; i < pfi[0].NormalizedDiscountedCumulativeGains.Length; i++)
+            for (int i = 0; i < pfi[0].NormalizedDiscountedCumulativeGains.Count; i++)
             {
                 Assert.Equal(2, MaxDeltaIndex(pfi, m => m.NormalizedDiscountedCumulativeGains[i].Mean));
                 Assert.Equal(5, MinDeltaIndex(pfi, m => m.NormalizedDiscountedCumulativeGains[i].Mean));

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Scenarios
             Assert.Equal(.06, metrics.LogLoss, 2);
             Assert.Equal(1, metrics.TopKAccuracy);
 
-            Assert.Equal(3, metrics.PerClassLogLoss.Length);
+            Assert.Equal(3, metrics.PerClassLogLoss.Count);
             Assert.Equal(0, metrics.PerClassLogLoss[0], 1);
             Assert.Equal(.1, metrics.PerClassLogLoss[1], 1);
             Assert.Equal(.1, metrics.PerClassLogLoss[2], 1);

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Scenarios
             Assert.InRange(metrics.LogLossReduction, 94, 96);
             Assert.Equal(1, metrics.TopKAccuracy);
 
-            Assert.Equal(3, metrics.PerClassLogLoss.Length);
+            Assert.Equal(3, metrics.PerClassLogLoss.Count);
             Assert.Equal(0, metrics.PerClassLogLoss[0], 1);
             Assert.Equal(.1, metrics.PerClassLogLoss[1], 1);
             Assert.Equal(.1, metrics.PerClassLogLoss[2], 1);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Scenarios
             Assert.InRange(metrics.LogLoss, .05, .06);
             Assert.InRange(metrics.LogLossReduction, 94, 96);
 
-            Assert.Equal(3, metrics.PerClassLogLoss.Length);
+            Assert.Equal(3, metrics.PerClassLogLoss.Count);
             Assert.Equal(0, metrics.PerClassLogLoss[0], 1);
             Assert.Equal(.1, metrics.PerClassLogLoss[1], 1);
             Assert.Equal(.1, metrics.PerClassLogLoss[2], 1);


### PR DESCRIPTION
Just a bit of relatively minor polish of something revealed during review of the public surface. In a handful of places we were returning arrays as values intended to be immutable. As elsewhere where perf isn't critical I've shifted to having the return value be `IReadOnlyList`. We've been doing this elsewhere but evidently missed a handful spots.

In an *ideal* world we'd make them actually immutable, as via `System.Collections.Immutable`, as I indeed did one or two places, but for the time being I think it suffices that we just make them read-only (even if the user could technically still muck with them with a cast, I'd consider fixing that problem later to be a non-breaking change in the API).

I only undertook this review in the Core/Data/Transform assemblies.