### PR TITLE
WIP: Refactoring of ColumnOptions for ImagePixelExtractor

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnBindingsBase.cs
@@ -15,7 +15,7 @@ using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML.Data
 {
-    internal abstract class SourceNameColumnBase
+    public abstract class SourceNameColumnBase
     {
         [Argument(ArgumentType.AtMostOnce, HelpText = "Name of the new column", ShortName = "name")]
         public string Name;
@@ -104,8 +104,7 @@ namespace Microsoft.ML.Data
         }
     }
 
-    [BestFriend]
-    internal abstract class OneToOneColumn : SourceNameColumnBase
+    public abstract class OneToOneColumn : SourceNameColumnBase
     {
         [BestFriend]
         private protected OneToOneColumn() { }

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -69,8 +69,21 @@ namespace Microsoft.ML
             bool interleave = false,
             float offset = ImagePixelExtractingEstimator.Defaults.Offset,
             float scale = ImagePixelExtractingEstimator.Defaults.Scale,
-            bool asFloat = ImagePixelExtractingEstimator.Defaults.Convert)
-            => new ImagePixelExtractingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, colors, order, interleave, offset, scale, asFloat);
+            bool asFloat = ImagePixelExtractingEstimator.Defaults.AsFloat)
+        {
+            var column = new ImagePixelExtractingEstimator.ColumnOptions()
+            {
+                Name = outputColumnName,
+                Source = inputColumnName,
+                Colors = colors,
+                Order = order,
+                Interleave = interleave,
+                Offset = offset,
+                Scale = scale,
+                AsFloat = asFloat
+            };
+            return new ImagePixelExtractingEstimator(CatalogUtils.GetEnvironment(catalog), column);
+        }
 
         /// <include file='doc.xml' path='doc/members/member[@name="ImagePixelExtractingEstimator"]/*' />
         /// <param name="catalog">The transform's catalog.</param>

--- a/src/Microsoft.ML.StaticPipe/ImageStaticPipe.cs
+++ b/src/Microsoft.ML.StaticPipe/ImageStaticPipe.cs
@@ -126,7 +126,7 @@ namespace Microsoft.ML.StaticPipe
         public static Vector<float> ExtractPixels(this Custom<Bitmap> input, bool useAlpha = false, bool useRed = true,
             bool useGreen = true, bool useBlue = true, ImagePixelExtractingEstimator.ColorsOrder order = ImagePixelExtractingEstimator.Defaults.Order, bool interleave = false, float scale = 1.0f, float offset = 0.0f)
         {
-            var colParams = new ImagePixelExtractingTransformer.Column
+            var colParams = new ImagePixelExtractingEstimator.ColumnOptions
             {
                 UseAlpha = useAlpha,
                 UseRed = useRed,
@@ -135,7 +135,7 @@ namespace Microsoft.ML.StaticPipe
                 Interleave = interleave,
                 Scale = scale,
                 Offset = offset,
-                Convert = true
+                AsFloat = true
             };
             return new ImagePixelExtractingStaticExtensions.OutPipelineColumn<float>(input, colParams);
         }
@@ -157,14 +157,14 @@ namespace Microsoft.ML.StaticPipe
         public static Vector<byte> ExtractPixelsAsBytes(this Custom<Bitmap> input, bool useAlpha = false, bool useRed = true,
             bool useGreen = true, bool useBlue = true, ImagePixelExtractingEstimator.ColorsOrder order = ImagePixelExtractingEstimator.Defaults.Order, bool interleave = false)
         {
-            var colParams = new ImagePixelExtractingTransformer.Column
+            var colParams = new ImagePixelExtractingEstimator.ColumnOptions
             {
                 UseAlpha = useAlpha,
                 UseRed = useRed,
                 UseGreen = useGreen,
                 UseBlue = useBlue,
                 Interleave = interleave,
-                Convert = false
+                AsFloat = false
             };
             return new ImagePixelExtractingStaticExtensions.OutPipelineColumn<byte>(input, colParams);
         }

--- a/src/Microsoft.ML.StaticPipe/ImageTransformsStatic.cs
+++ b/src/Microsoft.ML.StaticPipe/ImageTransformsStatic.cs
@@ -187,10 +187,9 @@ namespace Microsoft.ML.StaticPipe
         internal sealed class OutPipelineColumn<T> : Vector<T>, IColInput
         {
             public Custom<Bitmap> Input { get; }
-            private static readonly ImagePixelExtractingTransformer.Options _defaultArgs = new ImagePixelExtractingTransformer.Options();
-            private readonly ImagePixelExtractingTransformer.Column _colParam;
+            private readonly ImagePixelExtractingEstimator.ColumnOptions _colParam;
 
-            public OutPipelineColumn(Custom<Bitmap> input, ImagePixelExtractingTransformer.Column col)
+            public OutPipelineColumn(Custom<Bitmap> input, ImagePixelExtractingEstimator.ColumnOptions col)
                 : base(Reconciler.Inst, input)
             {
                 Contracts.AssertValue(input);
@@ -207,7 +206,7 @@ namespace Microsoft.ML.StaticPipe
 
                 _colParam.Name = outputColumnName;
                 _colParam.Source = inputColumnName;
-                return new ImagePixelExtractingEstimator.ColumnOptions(_colParam, _defaultArgs);
+                return _colParam;
             }
         }
 

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -18794,52 +18794,23 @@
               "Kind": "Struct",
               "Fields": [
                 {
-                  "Name": "UseAlpha",
-                  "Type": "Bool",
-                  "Desc": "Whether to use alpha channel",
-                  "Aliases": [
-                    "alpha"
-                  ],
+                  "Name": "Colors",
+                  "Type": {
+                    "Kind": "Enum",
+                    "Values": [
+                      "Alpha",
+                      "Red",
+                      "Green",
+                      "Blue",
+                      "Rgb",
+                      "All"
+                    ]
+                  },
+                  "Desc": null,
                   "Required": false,
                   "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
-                },
-                {
-                  "Name": "UseRed",
-                  "Type": "Bool",
-                  "Desc": "Whether to use red channel",
-                  "Aliases": [
-                    "red"
-                  ],
-                  "Required": false,
-                  "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
-                },
-                {
-                  "Name": "UseGreen",
-                  "Type": "Bool",
-                  "Desc": "Whether to use green channel",
-                  "Aliases": [
-                    "green"
-                  ],
-                  "Required": false,
-                  "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
-                },
-                {
-                  "Name": "UseBlue",
-                  "Type": "Bool",
-                  "Desc": "Whether to use blue channel",
-                  "Aliases": [
-                    "blue"
-                  ],
-                  "Required": false,
-                  "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
+                  "IsNullable": false,
+                  "Default": "Rgb"
                 },
                 {
                   "Name": "Order",
@@ -18857,8 +18828,8 @@
                   "Desc": "Order of channels",
                   "Required": false,
                   "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
+                  "IsNullable": false,
+                  "Default": "ARGB"
                 },
                 {
                   "Name": "Interleave",
@@ -18866,11 +18837,11 @@
                   "Desc": "Whether to separate each channel or interleave in specified order",
                   "Required": false,
                   "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
+                  "IsNullable": false,
+                  "Default": false
                 },
                 {
-                  "Name": "Convert",
+                  "Name": "AsFloat",
                   "Type": "Bool",
                   "Desc": "Whether to convert to floating point",
                   "Aliases": [
@@ -18878,8 +18849,8 @@
                   ],
                   "Required": false,
                   "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
+                  "IsNullable": false,
+                  "Default": true
                 },
                 {
                   "Name": "Offset",
@@ -18887,8 +18858,8 @@
                   "Desc": "Offset (pre-scale)",
                   "Required": false,
                   "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
+                  "IsNullable": false,
+                  "Default": 0.0
                 },
                 {
                   "Name": "Scale",
@@ -18896,8 +18867,56 @@
                   "Desc": "Scale factor",
                   "Required": false,
                   "SortOrder": 150.0,
-                  "IsNullable": true,
-                  "Default": null
+                  "IsNullable": false,
+                  "Default": 1.0
+                },
+                {
+                  "Name": "UseAlpha",
+                  "Type": "Bool",
+                  "Desc": "Whether to use alpha channel",
+                  "Aliases": [
+                    "alpha"
+                  ],
+                  "Required": false,
+                  "SortOrder": 150.0,
+                  "IsNullable": false,
+                  "Default": false
+                },
+                {
+                  "Name": "UseRed",
+                  "Type": "Bool",
+                  "Desc": "Whether to use red channel",
+                  "Aliases": [
+                    "red"
+                  ],
+                  "Required": false,
+                  "SortOrder": 150.0,
+                  "IsNullable": false,
+                  "Default": false
+                },
+                {
+                  "Name": "UseGreen",
+                  "Type": "Bool",
+                  "Desc": "Whether to use green channel",
+                  "Aliases": [
+                    "green"
+                  ],
+                  "Required": false,
+                  "SortOrder": 150.0,
+                  "IsNullable": false,
+                  "Default": false
+                },
+                {
+                  "Name": "UseBlue",
+                  "Type": "Bool",
+                  "Desc": "Whether to use blue channel",
+                  "Aliases": [
+                    "blue"
+                  ],
+                  "Required": false,
+                  "SortOrder": 150.0,
+                  "IsNullable": false,
+                  "Default": false
                 },
                 {
                   "Name": "Name",
@@ -18951,8 +18970,8 @@
           ],
           "Required": false,
           "SortOrder": 150.0,
-          "IsNullable": false,
-          "Default": false
+          "IsNullable": true,
+          "Default": null
         },
         {
           "Name": "UseRed",
@@ -18963,8 +18982,8 @@
           ],
           "Required": false,
           "SortOrder": 150.0,
-          "IsNullable": false,
-          "Default": true
+          "IsNullable": true,
+          "Default": null
         },
         {
           "Name": "UseGreen",
@@ -18975,8 +18994,8 @@
           ],
           "Required": false,
           "SortOrder": 150.0,
-          "IsNullable": false,
-          "Default": true
+          "IsNullable": true,
+          "Default": null
         },
         {
           "Name": "UseBlue",
@@ -18987,8 +19006,8 @@
           ],
           "Required": false,
           "SortOrder": 150.0,
-          "IsNullable": false,
-          "Default": true
+          "IsNullable": true,
+          "Default": null
         },
         {
           "Name": "Order",
@@ -19006,8 +19025,8 @@
           "Desc": "Order of colors.",
           "Required": false,
           "SortOrder": 150.0,
-          "IsNullable": false,
-          "Default": "ARGB"
+          "IsNullable": true,
+          "Default": null
         },
         {
           "Name": "Interleave",
@@ -19015,11 +19034,11 @@
           "Desc": "Whether to separate each channel or interleave in specified order",
           "Required": false,
           "SortOrder": 150.0,
-          "IsNullable": false,
-          "Default": false
+          "IsNullable": true,
+          "Default": null
         },
         {
-          "Name": "Convert",
+          "Name": "AsFloat",
           "Type": "Bool",
           "Desc": "Whether to convert to floating point",
           "Aliases": [
@@ -19027,8 +19046,8 @@
           ],
           "Required": false,
           "SortOrder": 150.0,
-          "IsNullable": false,
-          "Default": true
+          "IsNullable": true,
+          "Default": null
         },
         {
           "Name": "Offset",

--- a/test/Microsoft.ML.Tests/Scenarios/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/TensorflowTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Scenarios
 
             var pipeEstimator = new ImageLoadingEstimator(mlContext, imageFolder, ("ImageReal", "ImagePath"))
                     .Append(new ImageResizingEstimator(mlContext, "ImageCropped", imageHeight, imageWidth, "ImageReal"))
-                    .Append(new ImagePixelExtractingEstimator(mlContext, "Input", "ImageCropped", interleave: true))
+                    .Append(mlContext.Transforms.ExtractPixels("Input", "ImageCropped", interleave: true))
                     .Append(mlContext.Model.LoadTensorFlowModel(model_location).ScoreTensorFlowModel("Output", "Input"))
                     .Append(new ColumnConcatenatingEstimator(mlContext, "Features", "Output"))
                     .Append(new ValueToKeyMappingEstimator(mlContext, "Label"))

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -843,7 +843,7 @@ namespace Microsoft.ML.Scenarios
 
             var pipeEstimator = new ImageLoadingEstimator(mlContext, imageFolder, ("ImageReal", "ImagePath"))
                 .Append(new ImageResizingEstimator(mlContext, "ImageCropped", imageWidth, imageHeight, "ImageReal"))
-                .Append(new ImagePixelExtractingEstimator(mlContext, "Input", "ImageCropped", interleave: true));
+                .Append(mlContext.Transforms.ExtractPixels("Input", "ImageCropped", interleave: true));
 
             var pixels = pipeEstimator.Fit(data).Transform(data);
             IDataView trans = tensorFlowModel.ScoreTensorFlowModel("Output", "Input").Fit(pixels).Transform(pixels);
@@ -937,7 +937,7 @@ namespace Microsoft.ML.Scenarios
             );
             var images = new ImageLoadingTransformer(mlContext, imageFolder, ("ImageReal", "ImagePath")).Transform(data);
             var cropped = new ImageResizingTransformer(mlContext, "ImageCropped", imageWidth, imageHeight, "ImageReal").Transform(images);
-            var pixels = new ImagePixelExtractingTransformer(mlContext, "Input", "ImageCropped").Transform(cropped);
+            var pixels = mlContext.Transforms.ExtractPixels("Input", "ImageCropped").Fit(cropped).Transform(cropped);
 
             var thrown = false;
             try


### PR DESCRIPTION
Related to #2884.

The change does the following things:
1. Internalizes the immutable class `ColumnInfos` and moves it to the transformer
2. Exposes the previously named `Column` class and renames it `ColumnOptions`
3. Internalizes entrypoint only fields in `ColumnOptions`, renames those that did not match the public API
4. Refactored the constructor so that it takes the new `ColumnOptions` class


The overall behavior of the Estimator/Transformer API is unchanged (besides the use of the new mutable class).
However, this change alters the entrypoints API behavior in the following way.
Past behavior:
- Can set column specific options.
- Can set overall options for all columns
- Can set overall options for some column and column specific options for others. 

After this change: 
- Can set column specific options.
- Can set overall options for all columns

I would also like to change the name of the input and output columns (in `SourceNameColumnBase`) to something more appropriate than `Name` and `Source`, but since that will touch a lot of files, I would like some feedback on the approach first. 