### PR TITLE
Logistic Regression NumberOfIterations to MaximumNumberOfIterations

### DIFF
--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Trainers
             /// <summary>
             /// Maximum number of iterations.
             /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of iterations.", ShortName = "maxiter")]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of iterations.", ShortName = "maxiter, NumberOfIterations")]
             [TGUI(Label = "Max Number of Iterations")]
             public int MaximumNumberOfIterations = 1000;
 

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Trainers
             [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum iterations.", ShortName = "maxiter, MaxIterations")]
             [TGUI(Label = "Max Number of Iterations")]
             [TlcModule.SweepableLongParamAttribute("MaxIterations", 1, int.MaxValue)]
-            public int NumberOfIterations = Defaults.NumberOfIterations;
+            public int MaximumNumberOfIterations = Defaults.MaximumNumberOfIterations;
 
             /// <summary>
             /// Run SGD to initialize LR weights, converging to this tolerance.
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Trainers
                 public const float L1Regularization = 1;
                 public const float OptimizationTolerance = 1e-7f;
                 public const int HistorySize = 20;
-                public const int NumberOfIterations = int.MaxValue;
+                public const int MaximumNumberOfIterations = int.MaxValue;
                 public const bool EnforceNonNegativity = false;
             }
         }
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Trainers
             Host.CheckUserArg(LbfgsTrainerOptions.L1Regularization >= 0, nameof(LbfgsTrainerOptions.L1Regularization), "Must be non-negative");
             Host.CheckUserArg(LbfgsTrainerOptions.OptmizationTolerance > 0, nameof(LbfgsTrainerOptions.OptmizationTolerance), "Must be positive");
             Host.CheckUserArg(LbfgsTrainerOptions.HistorySize > 0, nameof(LbfgsTrainerOptions.HistorySize), "Must be positive");
-            Host.CheckUserArg(LbfgsTrainerOptions.NumberOfIterations > 0, nameof(LbfgsTrainerOptions.NumberOfIterations), "Must be positive");
+            Host.CheckUserArg(LbfgsTrainerOptions.MaximumNumberOfIterations > 0, nameof(LbfgsTrainerOptions.MaximumNumberOfIterations), "Must be positive");
             Host.CheckUserArg(LbfgsTrainerOptions.StochasticGradientDescentInitilaizationTolerance >= 0, nameof(LbfgsTrainerOptions.StochasticGradientDescentInitilaizationTolerance), "Must be non-negative");
             Host.CheckUserArg(LbfgsTrainerOptions.NumberOfThreads == null || LbfgsTrainerOptions.NumberOfThreads.Value >= 0, nameof(LbfgsTrainerOptions.NumberOfThreads), "Must be non-negative");
 
@@ -234,7 +234,7 @@ namespace Microsoft.ML.Trainers
             L1Weight = LbfgsTrainerOptions.L1Regularization;
             OptTol = LbfgsTrainerOptions.OptmizationTolerance;
             MemorySize =LbfgsTrainerOptions.HistorySize;
-            MaxIterations = LbfgsTrainerOptions.NumberOfIterations;
+            MaxIterations = LbfgsTrainerOptions.MaximumNumberOfIterations;
             SgdInitializationTolerance = LbfgsTrainerOptions.StochasticGradientDescentInitilaizationTolerance;
             Quiet = LbfgsTrainerOptions.Quiet;
             InitWtsDiameter = LbfgsTrainerOptions.InitialWeightsDiameter;

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Trainers
             /// <summary>
             /// Number of iterations.
             /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum iterations.", ShortName = "maxiter, MaxIterations")]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum iterations.", ShortName = "maxiter, MaxIterations, NumberOfIterations")]
             [TGUI(Label = "Max Number of Iterations")]
             [TlcModule.SweepableLongParamAttribute("MaxIterations", 1, int.MaxValue)]
             public int MaximumNumberOfIterations = Defaults.MaximumNumberOfIterations;

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
@@ -198,7 +198,7 @@ namespace Microsoft.ML.Trainers
             /// <value>
             /// Set to 1 to simulate online learning. Defaults to automatic.
             /// </value>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of iterations; set to 1 to simulate online learning. Defaults to automatic.", NullName = "<Auto>", ShortName = "iter, MaxIterations")]
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Maximum number of iterations; set to 1 to simulate online learning. Defaults to automatic.", NullName = "<Auto>", ShortName = "iter, MaxIterations, NumberOfIterations")]
             [TGUI(Label = "Max number of iterations", SuggestedSweeps = "<Auto>,10,20,100")]
             [TlcModule.SweepableDiscreteParam("MaxIterations", new object[] { "<Auto>", 10, 20, 100 })]
             public int? MaximumNumberOfIterations;

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -11026,7 +11026,8 @@
           "Type": "Int",
           "Desc": "Maximum number of iterations.",
           "Aliases": [
-            "maxiter"
+            "maxiter",
+            "NumberOfIterations"
           ],
           "Required": false,
           "SortOrder": 150.0,
@@ -13559,12 +13560,13 @@
           }
         },
         {
-          "Name": "NumberOfIterations",
+          "Name": "MaximumNumberOfIterations",
           "Type": "Int",
           "Desc": "Maximum iterations.",
           "Aliases": [
             "maxiter",
-            "MaxIterations"
+            "MaxIterations",
+            "NumberOfIterations"
           ],
           "Required": false,
           "SortOrder": 150.0,
@@ -13879,12 +13881,13 @@
           }
         },
         {
-          "Name": "NumberOfIterations",
+          "Name": "MaximumNumberOfIterations",
           "Type": "Int",
           "Desc": "Maximum iterations.",
           "Aliases": [
             "maxiter",
-            "MaxIterations"
+            "MaxIterations",
+            "NumberOfIterations"
           ],
           "Required": false,
           "SortOrder": 150.0,
@@ -14907,12 +14910,13 @@
           }
         },
         {
-          "Name": "NumberOfIterations",
+          "Name": "MaximumNumberOfIterations",
           "Type": "Int",
           "Desc": "Maximum iterations.",
           "Aliases": [
             "maxiter",
-            "MaxIterations"
+            "MaxIterations",
+            "NumberOfIterations"
           ],
           "Required": false,
           "SortOrder": 150.0,
@@ -15233,7 +15237,8 @@
           "Desc": "Maximum number of iterations; set to 1 to simulate online learning. Defaults to automatic.",
           "Aliases": [
             "iter",
-            "MaxIterations"
+            "MaxIterations",
+            "NumberOfIterations"
           ],
           "Required": false,
           "SortOrder": 150.0,
@@ -15506,7 +15511,8 @@
           "Desc": "Maximum number of iterations; set to 1 to simulate online learning. Defaults to automatic.",
           "Aliases": [
             "iter",
-            "MaxIterations"
+            "MaxIterations",
+            "NumberOfIterations"
           ],
           "Required": false,
           "SortOrder": 150.0,
@@ -15779,7 +15785,8 @@
           "Desc": "Maximum number of iterations; set to 1 to simulate online learning. Defaults to automatic.",
           "Aliases": [
             "iter",
-            "MaxIterations"
+            "MaxIterations",
+            "NumberOfIterations"
           ],
           "Required": false,
           "SortOrder": 150.0,

--- a/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
+++ b/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
@@ -270,7 +270,7 @@ namespace Microsoft.ML.Tests
         {
             var data = GetSparseDataset(TaskType.MulticlassClassification);
             var model = ML.MulticlassClassification.Trainers.LogisticRegression(
-                new MulticlassLogisticRegression.Options { NumberOfIterations = 1000 }).Fit(data);
+                new MulticlassLogisticRegression.Options { MaximumNumberOfIterations = 1000 }).Fit(data);
             var pfi = ML.MulticlassClassification.PermutationFeatureImportance(model, data);
 
             // Pfi Indices:


### PR DESCRIPTION
This PR updates `Logistic Regression` (multiclass, regression aka poisson, and multiclass) to specify the `MaximumNumberOfIterations` instead of `NumberOfIterations` as it's a stopping criterion and not necessarily a tuning parameter.

I also took a look around the codebase, and this is the last change of this sort that will be needed.

Fixes #2922 