### PR TITLE
FeaturizeText: Add instructions to turn off char- or word-gram generation to the tooltip.

### DIFF
--- a/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
@@ -128,7 +128,7 @@ namespace Microsoft.ML.Transforms.Text
 
             /// <summary>
             /// Ngram feature extractor to use for words (WordBag/WordHashBag).
-            /// Set to null to turn off n-gram generation for words.
+            /// Set to <see langword="null" /> to turn off n-gram generation for words.
             /// </summary>
             public WordBagEstimator.Options WordFeatureExtractor
             {
@@ -161,7 +161,7 @@ namespace Microsoft.ML.Transforms.Text
 
             /// <summary>
             /// Ngram feature extractor to use for characters (WordBag/WordHashBag).
-            /// Set to null to turn off n-gram generation for characters.
+            /// Set to <see langword="null" /> to turn off n-gram generation for characters.
             /// </summary>
             public WordBagEstimator.Options CharFeatureExtractor
             {

--- a/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextFeaturizingEstimator.cs
@@ -128,6 +128,7 @@ namespace Microsoft.ML.Transforms.Text
 
             /// <summary>
             /// Ngram feature extractor to use for words (WordBag/WordHashBag).
+            /// Set to null to turn off n-gram generation for words.
             /// </summary>
             public WordBagEstimator.Options WordFeatureExtractor
             {
@@ -160,6 +161,7 @@ namespace Microsoft.ML.Transforms.Text
 
             /// <summary>
             /// Ngram feature extractor to use for characters (WordBag/WordHashBag).
+            /// Set to null to turn off n-gram generation for characters.
             /// </summary>
             public WordBagEstimator.Options CharFeatureExtractor
             {


### PR DESCRIPTION
Adding a note on how to turn off char-grams and word-grams in `FeaturizeText`.

Fixes #2946 