### PR TITLE
Remove duplicate NormalizeFeatures from FFM trainer

### DIFF
--- a/src/Microsoft.ML.EntryPoints/JsonUtils/JsonManifestUtils.cs
+++ b/src/Microsoft.ML.EntryPoints/JsonUtils/JsonManifestUtils.cs
@@ -153,15 +153,24 @@ namespace Microsoft.ML.EntryPoints
 
             // Instantiate a value of the input, to pull defaults out of.
             var defaults = Activator.CreateInstance(inputType);
-
+            var collectedFields = new HashSet<string>();
             var inputs = new List<KeyValuePair<Double, JObject>>();
             foreach (var fieldInfo in inputType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
             {
                 var inputAttr = fieldInfo.GetCustomAttributes(typeof(ArgumentAttribute), false).FirstOrDefault() as ArgumentAttribute;
                 if (inputAttr == null || inputAttr.Visibility == ArgumentAttribute.VisibilityType.CmdLineOnly)
                     continue;
+                var name = inputAttr.Name ?? fieldInfo.Name;
+                // The order of GetFields is stable, meaning that
+                // fields are always returned in the same order and for this reason
+                // unit tests to compare manifest are passing. For the same reason
+                // duplicate name skipped are always in the same correct order.
+                // Same name field can bubble up from base class even though
+                // its overidden / hidden, skip it.
+                if (collectedFields.Contains(name))
+                    continue;
                 var jo = new JObject();
-                jo[FieldNames.Name] = inputAttr.Name ?? fieldInfo.Name;
+                jo[FieldNames.Name] = name;
                 jo[FieldNames.Type] = BuildTypeToken(ectx, fieldInfo, fieldInfo.FieldType, catalog);
                 jo[FieldNames.Desc] = inputAttr.HelpText;
                 if (inputAttr.Aliases != null)
@@ -262,6 +271,7 @@ namespace Microsoft.ML.EntryPoints
                 }
 
                 inputs.Add(new KeyValuePair<Double, JObject>(inputAttr.SortOrder, jo));
+                collectedFields.Add(name);
             }
             return new JArray(inputs.OrderBy(x => x.Key).Select(x => x.Value).ToArray());
         }

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -78,12 +78,6 @@ namespace Microsoft.ML.Trainers
             public float LambdaLatent = 0.0001f;
 
             /// <summary>
-            /// Whether to normalize the input vectors so that the concatenation of all fields' feature vectors is unit-length.
-            /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Whether to normalize the input vectors so that the concatenation of all fields' feature vectors is unit-length", ShortName = "norm", SortOrder = 6)]
-            public bool Normalize = true;
-
-            /// <summary>
             /// Extra feature column names. The column named <see cref="TrainerInputBase.FeatureColumnName"/> stores features from the first field.
             /// The i-th string in <see cref="ExtraFeatureColumns"/> stores the name of the (i+1)-th field's feature column.
             /// </summary>
@@ -225,7 +219,7 @@ namespace Microsoft.ML.Trainers
             _lambdaLatent = options.LambdaLatent;
             _learningRate = options.LearningRate;
             _numIterations = options.NumberOfIterations;
-            _norm = options.Normalize;
+            _norm = (options.NormalizeFeatures == NormalizeOption.Yes || options.NormalizeFeatures == NormalizeOption.Auto);
             _shuffle = options.Shuffle;
             _verbose = options.Verbose;
             _radius = options.Radius;

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -139,6 +139,7 @@ namespace Microsoft.ML.Trainers
         private float _lambdaLatent;
         private float _learningRate;
         private int _numIterations;
+        // whether to normalize input vectors so that the concatenation of all fields' feature vectors is unit-length
         private bool _norm;
         private bool _shuffle;
         private bool _verbose;

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Trainers
         /// The <see cref="TrainerInfo"/> containing at least the training data for this trainer.
         /// </summary>
         TrainerInfo ITrainer.Info => _info;
-        private static readonly TrainerInfo _info = new TrainerInfo(supportValid: true, supportIncrementalTrain: true);
+        private static readonly TrainerInfo _info = new TrainerInfo(normalization: false, supportValid: true, supportIncrementalTrain: true);
 
         private int _latentDim;
         private int _latentDimAligned;

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -78,6 +78,12 @@ namespace Microsoft.ML.Trainers
             public float LambdaLatent = 0.0001f;
 
             /// <summary>
+            /// Whether to normalize the input vectors so that the concatenation of all fields' feature vectors is unit-length.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Whether to normalize the input vectors so that the concatenation of all fields' feature vectors is unit-length", ShortName = "norm", SortOrder = 6)]
+            public new bool NormalizeFeatures = true;
+
+            /// <summary>
             /// Extra feature column names. The column named <see cref="TrainerInputBase.FeatureColumnName"/> stores features from the first field.
             /// The i-th string in <see cref="ExtraFeatureColumns"/> stores the name of the (i+1)-th field's feature column.
             /// </summary>
@@ -139,7 +145,6 @@ namespace Microsoft.ML.Trainers
         private float _lambdaLatent;
         private float _learningRate;
         private int _numIterations;
-        // whether to normalize input vectors so that the concatenation of all fields' feature vectors is unit-length
         private bool _norm;
         private bool _shuffle;
         private bool _verbose;
@@ -220,7 +225,7 @@ namespace Microsoft.ML.Trainers
             _lambdaLatent = options.LambdaLatent;
             _learningRate = options.LearningRate;
             _numIterations = options.NumberOfIterations;
-            _norm = (options.NormalizeFeatures == NormalizeOption.Yes);
+            _norm = options.NormalizeFeatures;
             _shuffle = options.Shuffle;
             _verbose = options.Verbose;
             _radius = options.Radius;

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Trainers
             _lambdaLatent = options.LambdaLatent;
             _learningRate = options.LearningRate;
             _numIterations = options.NumberOfIterations;
-            _norm = (options.NormalizeFeatures == NormalizeOption.Yes || options.NormalizeFeatures == NormalizeOption.Auto);
+            _norm = (options.NormalizeFeatures == NormalizeOption.Yes);
             _shuffle = options.Shuffle;
             _verbose = options.Verbose;
             _radius = options.Radius;

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -10155,23 +10155,15 @@
         },
         {
           "Name": "NormalizeFeatures",
-          "Type": {
-            "Kind": "Enum",
-            "Values": [
-              "No",
-              "Warn",
-              "Auto",
-              "Yes"
-            ]
-          },
-          "Desc": "Normalize option for the feature column",
+          "Type": "Bool",
+          "Desc": "Whether to normalize the input vectors so that the concatenation of all fields' feature vectors is unit-length",
           "Aliases": [
             "norm"
           ],
           "Required": false,
-          "SortOrder": 5.0,
+          "SortOrder": 6.0,
           "IsNullable": false,
-          "Default": "Auto"
+          "Default": true
         },
         {
           "Name": "Caching",

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -10174,18 +10174,6 @@
           "Default": "Auto"
         },
         {
-          "Name": "Normalize",
-          "Type": "Bool",
-          "Desc": "Whether to normalize the input vectors so that the concatenation of all fields' feature vectors is unit-length",
-          "Aliases": [
-            "norm"
-          ],
-          "Required": false,
-          "SortOrder": 6.0,
-          "IsNullable": false,
-          "Default": true
-        },
-        {
           "Name": "Caching",
           "Type": {
             "Kind": "Enum",


### PR DESCRIPTION
Fixes #2958. There are two flags controlling normalization steps right before and in FFM trainer. We decide to disable the former one because FFM has its own built-in normalization for multiple feature columns and the other normalization only works with a single feature column.