### PR TITLE
Fixed a rendering issue in the TensorFlow doc.

### DIFF
--- a/src/Microsoft.ML.TensorFlow/doc.xml
+++ b/src/Microsoft.ML.TensorFlow/doc.xml
@@ -59,8 +59,7 @@
           </item>
         </list>
         <para>
-            The inputs and outputs of a TensorFlow model can be obtained using the <see cref="TensorFlowModel.GetModelSchema()"/> or <a href="https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/graph_transforms/README.md#inspecting-graphs">
-            <code>summarize_graph</code> tools</a>.
+            The inputs and outputs of a TensorFlow model can be obtained using the <see cref="TensorFlowModel.GetModelSchema()"/> or <a href="https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/graph_transforms/README.md#inspecting-graphs">summarize_graph</a> tools.
         </para>
       </remarks>
     </member>


### PR DESCRIPTION
There is a rendering issue with TensorFlow documentation where a link appears as code snippet in the doc at the following link. 
https://docs.microsoft.com/en-us/dotnet/api/microsoft.ml.tensorflowcatalog?view=ml-dotnet

This PR fixes it.

