### PR TITLE
Cleaning TrainCatalog and RecommenderCatalog

### DIFF
--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -376,7 +376,7 @@ var testData = mlContext.Data.LoadFromTextFile<AdultData>(testDataPath,
     separatorChar: ','
 );
 // Calculate metrics of the model on the test data.
-var metrics = mlContext.Regression.Evaluate(model.Transform(testData), label: "Target");
+var metrics = mlContext.Regression.Evaluate(model.Transform(testData), labelColumnName: "Target");
 ```
 
 ## How do I save and load the model?

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainerSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainerSample.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Step 4: Evaluate on the test set
             var transformedData = trainedPipeline.Transform(loader.Load(testFile));
-            var evalMetrics = mlContext.BinaryClassification.Evaluate(transformedData, label: "Sentiment");
+            var evalMetrics = mlContext.BinaryClassification.Evaluate(transformedData, labelColumnName: "Sentiment");
             SamplesUtils.ConsoleUtils.PrintMetrics(evalMetrics);
 
             // The Prior trainer outputs the proportion of a label in the dataset as the probability of that label.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscent.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
                     .Append(mlContext.BinaryClassification.Trainers.SdcaNonCalibrated(labelColumnName: "Sentiment", featureColumnName: "Features", l2Regularization: 0.001f));
 
             // Step 3: Run Cross-Validation on this pipeline.
-            var cvResults = mlContext.BinaryClassification.CrossValidate(data, pipeline, labelColumn: "Sentiment");
+            var cvResults = mlContext.BinaryClassification.CrossValidate(data, pipeline, labelColumnName: "Sentiment");
 
             var accuracies = cvResults.Select(r => r.Metrics.Accuracy);
             Console.WriteLine(accuracies.Average());
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
                                       }));
 
             // Run Cross-Validation on this second pipeline.
-            var cvResults_advancedPipeline = mlContext.BinaryClassification.CrossValidate(data, pipeline, labelColumn: "Sentiment", numFolds: 3);
+            var cvResults_advancedPipeline = mlContext.BinaryClassification.CrossValidate(data, pipeline, labelColumnName: "Sentiment", numberOfFolds: 3);
             accuracies = cvResults_advancedPipeline.Select(r => r.Metrics.Accuracy);
             Console.WriteLine(accuracies.Average());
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
             var dataWithPredictions = model.Transform(split.TestSet);
 
             // Evaluate the trained model using the test set.
-            var metrics = mlContext.MulticlassClassification.Evaluate(dataWithPredictions, label: "LabelIndex");
+            var metrics = mlContext.MulticlassClassification.Evaluate(dataWithPredictions, labelColumnName: "LabelIndex");
 
             // Check if metrics are reasonable.
             Console.WriteLine($"Macro accuracy: {metrics.MacroAccuracy:F4}, Micro accuracy: {metrics.MicroAccuracy:F4}.");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
             var dataWithPredictions = model.Transform(split.TestSet);
 
             // Evaluate the trained model using the test set.
-            var metrics = mlContext.MulticlassClassification.Evaluate(dataWithPredictions, label: "LabelIndex");
+            var metrics = mlContext.MulticlassClassification.Evaluate(dataWithPredictions, labelColumnName: "LabelIndex");
 
             // Check if metrics are reasonable.
             Console.WriteLine($"Macro accuracy: {metrics.MacroAccuracy:F4}, Micro accuracy: {metrics.MicroAccuracy:F4}.");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbm.cs
@@ -14,7 +14,7 @@
             // Leave out 10% of the dataset for testing. Since this is a ranking problem, we must ensure that the split
             // respects the GroupId column, i.e. rows with the same GroupId are either all in the train split or all in
             // the test split. The samplingKeyColumn parameter in Data.TrainTestSplit is used for this purpose.
-            var split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.1, samplingKeyColumn: "GroupId");
+            var split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.1, samplingKeyColumnName: "GroupId");
 
             // Create the Estimator pipeline. For simplicity, we will train a small tree with 4 leaves and 2 boosting iterations.
             var pipeline = mlContext.Ranking.Trainers.LightGbm(

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbmWithOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Ranking
             // Leave out 10% of the dataset for testing. Since this is a ranking problem, we must ensure that the split
             // respects the GroupId column, i.e. rows with the same GroupId are either all in the train split or all in
             // the test split. The samplingKeyColumn parameter in Data.TrainTestSplit is used for this purpose.
-            var split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.1, samplingKeyColumn: "GroupId");
+            var split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.1, samplingKeyColumnName: "GroupId");
 
             // Create the Estimator pipeline. For simplicity, we will train a small tree with 4 leaves and 2 boosting iterations.
             var pipeline = mlContext.Ranking.Trainers.LightGbm(

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
 
             // Calculate regression matrices for the prediction result.
             var metrics = mlContext.Recommendation().Evaluate(prediction,
-                label: nameof(MatrixElement.Value), score: nameof(MatrixElementForScore.Score));
+                labelColumnName: nameof(MatrixElement.Value), scoreColumnName: nameof(MatrixElementForScore.Score));
             // Print out some metrics for checking the model's quality.
             SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             // L1: 0.17

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
 
             // Calculate regression matrices for the prediction result.
             var metrics = mlContext.Recommendation().Evaluate(prediction,
-                label: nameof(MatrixElement.Value), score: nameof(MatrixElementForScore.Score));
+                labelColumnName: nameof(MatrixElement.Value), scoreColumnName: nameof(MatrixElementForScore.Score));
             // Print out some metrics for checking the model's quality.
             SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             // L1: 0.16

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(split.TestSet);
-            var metrics = mlContext.Regression.Evaluate(dataWithPredictions, label: labelName);
+            var metrics = mlContext.Regression.Evaluate(dataWithPredictions, labelColumnName: labelName);
             SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(split.TestSet);
-            var metrics = mlContext.Regression.Evaluate(dataWithPredictions, label: labelName);
+            var metrics = mlContext.Regression.Evaluate(dataWithPredictions, labelColumnName: labelName);
             SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output

--- a/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
@@ -365,32 +365,32 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Split the dataset into the train set and test set according to the given fraction.
-        /// Respects the <paramref name="samplingKeyColumn"/> if provided.
+        /// Respects the <paramref name="samplingKeyColumnName"/> if provided.
         /// </summary>
         /// <param name="data">The dataset to split.</param>
         /// <param name="testFraction">The fraction of data to go into the test set.</param>
-        /// <param name="samplingKeyColumn">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumn"/>,
+        /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for the train-test split.</param>
-        public TrainTestData TrainTestSplit(IDataView data, double testFraction = 0.1, string samplingKeyColumn = null, int? seed = null)
+        public TrainTestData TrainTestSplit(IDataView data, double testFraction = 0.1, string samplingKeyColumnName = null, int? seed = null)
         {
             _env.CheckValue(data, nameof(data));
             _env.CheckParam(0 < testFraction && testFraction < 1, nameof(testFraction), "Must be between 0 and 1 exclusive");
-            _env.CheckValueOrNull(samplingKeyColumn);
+            _env.CheckValueOrNull(samplingKeyColumnName);
 
-            EnsureGroupPreservationColumn(_env, ref data, ref samplingKeyColumn, seed);
+            EnsureGroupPreservationColumn(_env, ref data, ref samplingKeyColumnName, seed);
 
             var trainFilter = new RangeFilter(_env, new RangeFilter.Options()
             {
-                Column = samplingKeyColumn,
+                Column = samplingKeyColumnName,
                 Min = 0,
                 Max = testFraction,
                 Complement = true
             }, data);
             var testFilter = new RangeFilter(_env, new RangeFilter.Options()
             {
-                Column = samplingKeyColumn,
+                Column = samplingKeyColumnName,
                 Min = 0,
                 Max = testFraction,
                 Complement = false

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -188,89 +188,89 @@ namespace Microsoft.ML
         /// Evaluates scored binary classification data.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
-        /// <param name="probability">The name of the probability column in <paramref name="data"/>, the calibrated version of <paramref name="score"/>.</param>
-        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="probabilityColumnName">The name of the probability column in <paramref name="data"/>, the calibrated version of <paramref name="scoreColumnName"/>.</param>
+        /// <param name="predictedLabelColumnName">The name of the predicted label column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these calibrated outputs.</returns>
-        public CalibratedBinaryClassificationMetrics Evaluate(IDataView data, string label = DefaultColumnNames.Label, string score = DefaultColumnNames.Score,
-            string probability = DefaultColumnNames.Probability, string predictedLabel = DefaultColumnNames.PredictedLabel)
+        public CalibratedBinaryClassificationMetrics Evaluate(IDataView data, string labelColumnName = DefaultColumnNames.Label, string scoreColumnName = DefaultColumnNames.Score,
+            string probabilityColumnName = DefaultColumnNames.Probability, string predictedLabelColumnName = DefaultColumnNames.PredictedLabel)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(label, nameof(label));
-            Environment.CheckNonEmpty(score, nameof(score));
-            Environment.CheckNonEmpty(probability, nameof(probability));
-            Environment.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            Environment.CheckNonEmpty(scoreColumnName, nameof(scoreColumnName));
+            Environment.CheckNonEmpty(probabilityColumnName, nameof(probabilityColumnName));
+            Environment.CheckNonEmpty(predictedLabelColumnName, nameof(predictedLabelColumnName));
 
             var eval = new BinaryClassifierEvaluator(Environment, new BinaryClassifierEvaluator.Arguments() { });
-            return eval.Evaluate(data, label, score, probability, predictedLabel);
+            return eval.Evaluate(data, labelColumnName, scoreColumnName, probabilityColumnName, predictedLabelColumnName);
         }
 
         /// <summary>
         /// Evaluates scored binary classification data, without probability-based metrics.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
-        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="predictedLabelColumnName">The name of the predicted label column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these uncalibrated outputs.</returns>
-        public BinaryClassificationMetrics EvaluateNonCalibrated(IDataView data, string label = DefaultColumnNames.Label, string score = DefaultColumnNames.Score,
-            string predictedLabel = DefaultColumnNames.PredictedLabel)
+        public BinaryClassificationMetrics EvaluateNonCalibrated(IDataView data, string labelColumnName = DefaultColumnNames.Label, string scoreColumnName = DefaultColumnNames.Score,
+            string predictedLabelColumnName = DefaultColumnNames.PredictedLabel)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(label, nameof(label));
-            Environment.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            Environment.CheckNonEmpty(predictedLabelColumnName, nameof(predictedLabelColumnName));
 
             var eval = new BinaryClassifierEvaluator(Environment, new BinaryClassifierEvaluator.Arguments() { });
-            return eval.Evaluate(data, label, score, predictedLabel);
+            return eval.Evaluate(data, labelColumnName, scoreColumnName, predictedLabelColumnName);
         }
 
         /// <summary>
-        /// Run cross-validation over <paramref name="numFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumn"/> if provided.
-        /// Then evaluate each sub-model against <paramref name="labelColumn"/> and return metrics.
+        /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
+        /// and respecting <paramref name="samplingKeyColumnName"/> if provided.
+        /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
-        /// <param name="numFolds">Number of cross-validation folds.</param>
-        /// <param name="labelColumn">The label column (for evaluation).</param>
-        /// <param name="samplingKeyColumn">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumn"/>,
+        /// <param name="numberOfFolds">Number of cross-validation folds.</param>
+        /// <param name="labelColumnName">The label column (for evaluation).</param>
+        /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public CrossValidationResult<BinaryClassificationMetrics>[] CrossValidateNonCalibrated(
-            IDataView data, IEstimator<ITransformer> estimator, int numFolds = 5, string labelColumn = DefaultColumnNames.Label,
-            string samplingKeyColumn = null, int? seed = null)
+            IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
+            string samplingKeyColumnName = null, int? seed = null)
         {
-            Environment.CheckNonEmpty(labelColumn, nameof(labelColumn));
-            var result = CrossValidateTrain(data, estimator, numFolds, samplingKeyColumn, seed);
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumnName, seed);
             return result.Select(x => new CrossValidationResult<BinaryClassificationMetrics>(x.Model,
-                EvaluateNonCalibrated(x.Scores, labelColumn), x.Scores, x.Fold)).ToArray();
+                EvaluateNonCalibrated(x.Scores, labelColumnName), x.Scores, x.Fold)).ToArray();
         }
 
         /// <summary>
-        /// Run cross-validation over <paramref name="numFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumn"/> if provided.
-        /// Then evaluate each sub-model against <paramref name="labelColumn"/> and return metrics.
+        /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
+        /// and respecting <paramref name="samplingKeyColumnName"/> if provided.
+        /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
-        /// <param name="numFolds">Number of cross-validation folds.</param>
-        /// <param name="labelColumn">The label column (for evaluation).</param>
-        /// <param name="samplingKeyColumn">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumn"/>,
+        /// <param name="numberOfFolds">Number of cross-validation folds.</param>
+        /// <param name="labelColumnName">The label column (for evaluation).</param>
+        /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public CrossValidationResult<CalibratedBinaryClassificationMetrics>[] CrossValidate(
-            IDataView data, IEstimator<ITransformer> estimator, int numFolds = 5, string labelColumn = DefaultColumnNames.Label,
-            string samplingKeyColumn = null, int? seed = null)
+            IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
+            string samplingKeyColumnName = null, int? seed = null)
         {
-            Environment.CheckNonEmpty(labelColumn, nameof(labelColumn));
-            var result = CrossValidateTrain(data, estimator, numFolds, samplingKeyColumn, seed);
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumnName, seed);
             return result.Select(x => new CrossValidationResult<CalibratedBinaryClassificationMetrics>(x.Model,
-                Evaluate(x.Scores, labelColumn), x.Scores, x.Fold)).ToArray();
+                Evaluate(x.Scores, labelColumnName), x.Scores, x.Fold)).ToArray();
         }
 
         /// <summary>
@@ -405,51 +405,51 @@ namespace Microsoft.ML
         /// Evaluates scored clustering data.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
-        /// <param name="label">The name of the optional label column in <paramref name="data"/>.
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the optional label column in <paramref name="data"/>.
         /// If present, the <see cref="ClusteringMetrics.NormalizedMutualInformation"/> metric will be computed.</param>
-        /// <param name="features">The name of the optional features column in <paramref name="data"/>.
+        /// <param name="featureColumnName">The name of the optional features column in <paramref name="data"/>.
         /// If present, the <see cref="ClusteringMetrics.DaviesBouldinIndex"/> metric will be computed.</param>
         /// <returns>The evaluation result.</returns>
         public ClusteringMetrics Evaluate(IDataView data,
-            string label = null,
-            string score = DefaultColumnNames.Score,
-            string features = null)
+            string labelColumnName = null,
+            string scoreColumnName = DefaultColumnNames.Score,
+            string featureColumnName = null)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(score, nameof(score));
+            Environment.CheckNonEmpty(scoreColumnName, nameof(scoreColumnName));
 
-            if (features != null)
-                Environment.CheckNonEmpty(features, nameof(features), "The features column name should be non-empty if you want to calculate the Dbi metric.");
+            if (featureColumnName != null)
+                Environment.CheckNonEmpty(featureColumnName, nameof(featureColumnName), "The features column name should be non-empty if you want to calculate the Dbi metric.");
 
-            if (label != null)
-                Environment.CheckNonEmpty(label, nameof(label), "The label column name should be non-empty if you want to calculate the Nmi metric.");
+            if (labelColumnName != null)
+                Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName), "The label column name should be non-empty if you want to calculate the Nmi metric.");
 
-            var eval = new ClusteringEvaluator(Environment, new ClusteringEvaluator.Arguments() { CalculateDbi = !string.IsNullOrEmpty(features) });
-            return eval.Evaluate(data, score, label, features);
+            var eval = new ClusteringEvaluator(Environment, new ClusteringEvaluator.Arguments() { CalculateDbi = !string.IsNullOrEmpty(featureColumnName) });
+            return eval.Evaluate(data, scoreColumnName, labelColumnName, featureColumnName);
         }
 
         /// <summary>
-        /// Run cross-validation over <paramref name="numFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumn"/> if provided.
-        /// Then evaluate each sub-model against <paramref name="labelColumn"/> and return metrics.
+        /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
+        /// and respecting <paramref name="samplingKeyColumnName"/> if provided.
+        /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
-        /// <param name="numFolds">Number of cross-validation folds.</param>
-        /// <param name="labelColumn">Optional label column for evaluation (clustering tasks may not always have a label).</param>
-        /// <param name="featuresColumn">Optional features column for evaluation (needed for calculating Dbi metric)</param>
-        /// <param name="samplingKeyColumn">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumn"/>,
+        /// <param name="numberOfFolds">Number of cross-validation folds.</param>
+        /// <param name="labelColumnName">Optional label column for evaluation (clustering tasks may not always have a label).</param>
+        /// <param name="featuresColumnName">Optional features column for evaluation (needed for calculating Dbi metric)</param>
+        /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
         public CrossValidationResult<ClusteringMetrics>[] CrossValidate(
-            IDataView data, IEstimator<ITransformer> estimator, int numFolds = 5, string labelColumn = null, string featuresColumn = null,
-            string samplingKeyColumn = null, int? seed = null)
+            IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = null, string featuresColumnName = null,
+            string samplingKeyColumnName = null, int? seed = null)
         {
-            var result = CrossValidateTrain(data, estimator, numFolds, samplingKeyColumn, seed);
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumnName, seed);
             return result.Select(x => new CrossValidationResult<ClusteringMetrics>(x.Model,
-                Evaluate(x.Scores, label: labelColumn, features: featuresColumn), x.Scores, x.Fold)).ToArray();
+                Evaluate(x.Scores, labelColumnName: labelColumnName, featureColumnName: featuresColumnName), x.Scores, x.Fold)).ToArray();
         }
     }
 
@@ -481,51 +481,51 @@ namespace Microsoft.ML
         /// Evaluates scored multiclass classification data.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
-        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="predictedLabelColumnName">The name of the predicted label column in <paramref name="data"/>.</param>
         /// <param name="topK">If given a positive value, the <see cref="MulticlassClassificationMetrics.TopKAccuracy"/> will be filled with
         /// the top-K accuracy, that is, the accuracy assuming we consider an example with the correct class within
         /// the top-K values as being stored "correctly."</param>
         /// <returns>The evaluation results for these calibrated outputs.</returns>
-        public MulticlassClassificationMetrics Evaluate(IDataView data, string label = DefaultColumnNames.Label, string score = DefaultColumnNames.Score,
-            string predictedLabel = DefaultColumnNames.PredictedLabel, int topK = 0)
+        public MulticlassClassificationMetrics Evaluate(IDataView data, string labelColumnName = DefaultColumnNames.Label, string scoreColumnName = DefaultColumnNames.Score,
+            string predictedLabelColumnName = DefaultColumnNames.PredictedLabel, int topK = 0)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(label, nameof(label));
-            Environment.CheckNonEmpty(score, nameof(score));
-            Environment.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            Environment.CheckNonEmpty(scoreColumnName, nameof(scoreColumnName));
+            Environment.CheckNonEmpty(predictedLabelColumnName, nameof(predictedLabelColumnName));
 
             var args = new MulticlassClassificationEvaluator.Arguments() { };
             if (topK > 0)
                 args.OutputTopKAcc = topK;
             var eval = new MulticlassClassificationEvaluator(Environment, args);
-            return eval.Evaluate(data, label, score, predictedLabel);
+            return eval.Evaluate(data, labelColumnName, scoreColumnName, predictedLabelColumnName);
         }
 
         /// <summary>
-        /// Run cross-validation over <paramref name="numFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumn"/> if provided.
-        /// Then evaluate each sub-model against <paramref name="labelColumn"/> and return metrics.
+        /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
+        /// and respecting <paramref name="samplingKeyColumnName"/> if provided.
+        /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
-        /// <param name="numFolds">Number of cross-validation folds.</param>
-        /// <param name="labelColumn">The label column (for evaluation).</param>
-        /// <param name="samplingKeyColumn">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumn"/>,
+        /// <param name="numberOfFolds">Number of cross-validation folds.</param>
+        /// <param name="labelColumnName">The label column (for evaluation).</param>
+        /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public CrossValidationResult<MulticlassClassificationMetrics>[] CrossValidate(
-            IDataView data, IEstimator<ITransformer> estimator, int numFolds = 5, string labelColumn = DefaultColumnNames.Label,
-            string samplingKeyColumn = null, int? seed = null)
+            IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
+            string samplingKeyColumnName = null, int? seed = null)
         {
-            Environment.CheckNonEmpty(labelColumn, nameof(labelColumn));
-            var result = CrossValidateTrain(data, estimator, numFolds, samplingKeyColumn, seed);
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumnName, seed);
             return result.Select(x => new CrossValidationResult<MulticlassClassificationMetrics>(x.Model,
-                Evaluate(x.Scores, labelColumn), x.Scores, x.Fold)).ToArray();
+                Evaluate(x.Scores, labelColumnName), x.Scores, x.Fold)).ToArray();
         }
     }
 
@@ -557,41 +557,41 @@ namespace Microsoft.ML
         /// Evaluates scored regression data.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these calibrated outputs.</returns>
-        public RegressionMetrics Evaluate(IDataView data, string label = DefaultColumnNames.Label, string score = DefaultColumnNames.Score)
+        public RegressionMetrics Evaluate(IDataView data, string labelColumnName = DefaultColumnNames.Label, string scoreColumnName = DefaultColumnNames.Score)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(label, nameof(label));
-            Environment.CheckNonEmpty(score, nameof(score));
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            Environment.CheckNonEmpty(scoreColumnName, nameof(scoreColumnName));
 
             var eval = new RegressionEvaluator(Environment, new RegressionEvaluator.Arguments() { });
-            return eval.Evaluate(data, label, score);
+            return eval.Evaluate(data, labelColumnName, scoreColumnName);
         }
 
         /// <summary>
-        /// Run cross-validation over <paramref name="numFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumn"/> if provided.
-        /// Then evaluate each sub-model against <paramref name="labelColumn"/> and return metrics.
+        /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
+        /// and respecting <paramref name="samplingKeyColumname"/> if provided.
+        /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
-        /// <param name="numFolds">Number of cross-validation folds.</param>
-        /// <param name="labelColumn">The label column (for evaluation).</param>
-        /// <param name="samplingKeyColumn">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumn"/>,
+        /// <param name="numberOfFolds">Number of cross-validation folds.</param>
+        /// <param name="labelColumnName">The label column (for evaluation).</param>
+        /// <param name="samplingKeyColumname">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumname"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public CrossValidationResult<RegressionMetrics>[] CrossValidate(
-            IDataView data, IEstimator<ITransformer> estimator, int numFolds = 5, string labelColumn = DefaultColumnNames.Label,
-            string samplingKeyColumn = null, int? seed = null)
+            IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
+            string samplingKeyColumname = null, int? seed = null)
         {
-            Environment.CheckNonEmpty(labelColumn, nameof(labelColumn));
-            var result = CrossValidateTrain(data, estimator, numFolds, samplingKeyColumn, seed);
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumname, seed);
             return result.Select(x => new CrossValidationResult<RegressionMetrics>(x.Model,
-                Evaluate(x.Scores, labelColumn), x.Scores, x.Fold)).ToArray();
+                Evaluate(x.Scores, labelColumnName), x.Scores, x.Fold)).ToArray();
         }
     }
 
@@ -623,22 +623,22 @@ namespace Microsoft.ML
         /// Evaluates scored ranking data.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
-        /// <param name="groupId">The name of the groupId column in <paramref name="data"/>.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="rowGroupColumnName">The name of the groupId column in <paramref name="data"/>.</param>
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these calibrated outputs.</returns>
         public RankingMetrics Evaluate(IDataView data,
-            string label = DefaultColumnNames.Label,
-            string groupId = DefaultColumnNames.GroupId,
-            string score = DefaultColumnNames.Score)
+            string labelColumnName = DefaultColumnNames.Label,
+            string rowGroupColumnName = DefaultColumnNames.GroupId,
+            string scoreColumnName = DefaultColumnNames.Score)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(label, nameof(label));
-            Environment.CheckNonEmpty(score, nameof(score));
-            Environment.CheckNonEmpty(groupId, nameof(groupId));
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            Environment.CheckNonEmpty(scoreColumnName, nameof(scoreColumnName));
+            Environment.CheckNonEmpty(rowGroupColumnName, nameof(rowGroupColumnName));
 
             var eval = new RankingEvaluator(Environment, new RankingEvaluator.Arguments() { });
-            return eval.Evaluate(data, label, groupId, score);
+            return eval.Evaluate(data, labelColumnName, rowGroupColumnName, scoreColumnName);
         }
     }
 
@@ -670,24 +670,24 @@ namespace Microsoft.ML
         /// Evaluates scored anomaly detection data.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
-        /// <param name="predictedLabel">The name of the predicted label column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="predictedLabelColumnName">The name of the predicted label column in <paramref name="data"/>.</param>
         /// <param name="k">The number of false positives to compute the <see cref="AnomalyDetectionMetrics.DetectionRateAtKFalsePositives"/> metric. </param>
         /// <returns>Evaluation results.</returns>
-        public AnomalyDetectionMetrics Evaluate(IDataView data, string label = DefaultColumnNames.Label, string score = DefaultColumnNames.Score,
-            string predictedLabel = DefaultColumnNames.PredictedLabel, int k = 10)
+        public AnomalyDetectionMetrics Evaluate(IDataView data, string labelColumnName = DefaultColumnNames.Label, string scoreColumnName = DefaultColumnNames.Score,
+            string predictedLabelColumnName = DefaultColumnNames.PredictedLabel, int k = 10)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(label, nameof(label));
-            Environment.CheckNonEmpty(score, nameof(score));
-            Environment.CheckNonEmpty(predictedLabel, nameof(predictedLabel));
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            Environment.CheckNonEmpty(scoreColumnName, nameof(scoreColumnName));
+            Environment.CheckNonEmpty(predictedLabelColumnName, nameof(predictedLabelColumnName));
 
             var args = new AnomalyDetectionEvaluator.Arguments();
             args.K = k;
 
             var eval = new AnomalyDetectionEvaluator(Environment, args);
-            return eval.Evaluate(data, label, score, predictedLabel);
+            return eval.Evaluate(data, labelColumnName, scoreColumnName, predictedLabelColumnName);
         }
     }
 }

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -572,24 +572,24 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumname"/> if provided.
+        /// and respecting <paramref name="samplingKeyColumnName"/> if provided.
         /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
         /// <param name="numberOfFolds">Number of cross-validation folds.</param>
         /// <param name="labelColumnName">The label column (for evaluation).</param>
-        /// <param name="samplingKeyColumname">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumname"/>,
+        /// <param name="samplingKeyColumnName">Name of a column to use for grouping rows. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>,
         /// they are guaranteed to appear in the same subset (train or test). This can be used to ensure no label leakage from the train to the test set.
         /// If <see langword="null"/> no row grouping will be performed.</param>
         /// <param name="seed">Seed for the random number generator used to select rows for cross-validation folds.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public CrossValidationResult<RegressionMetrics>[] CrossValidate(
             IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
-            string samplingKeyColumname = null, int? seed = null)
+            string samplingKeyColumnName = null, int? seed = null)
         {
             Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
-            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumname, seed);
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumnName, seed);
             return result.Select(x => new CrossValidationResult<RegressionMetrics>(x.Model,
                 Evaluate(x.Scores, labelColumnName), x.Scores, x.Fold)).ToArray();
         }

--- a/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ML
             /// and the value at the location specified by the two indexes.
             /// </para>
             /// </remarks>
-            /// <param name="labelColumn">The name of the label column.</param>
+            /// <param name="labelColumnName">The name of the label column.</param>
             /// <param name="matrixColumnIndexColumnName">The name of the column hosting the matrix's column IDs.</param>
             /// <param name="matrixRowIndexColumnName">The name of the column hosting the matrix's row IDs.</param>
             /// <param name="approximationRank">Rank of approximation matrixes.</param>
@@ -63,13 +63,13 @@ namespace Microsoft.ML
             /// ]]></format>
             /// </example>
             public MatrixFactorizationTrainer MatrixFactorization(
-                string labelColumn,
+                string labelColumnName,
                 string matrixColumnIndexColumnName,
                 string matrixRowIndexColumnName,
                 int approximationRank = MatrixFactorizationTrainer.Defaults.ApproximationRank,
                 double learningRate = MatrixFactorizationTrainer.Defaults.LearningRate,
                 int numberOfIterations = MatrixFactorizationTrainer.Defaults.NumIterations)
-                    => new MatrixFactorizationTrainer(Owner.GetEnvironment(), labelColumn, matrixColumnIndexColumnName, matrixRowIndexColumnName,
+                    => new MatrixFactorizationTrainer(Owner.GetEnvironment(), labelColumnName, matrixColumnIndexColumnName, matrixRowIndexColumnName,
                         approximationRank, learningRate, numberOfIterations);
 
             /// <summary>
@@ -97,42 +97,42 @@ namespace Microsoft.ML
         /// Evaluates the scored recommendation data.
         /// </summary>
         /// <param name="data">The scored data.</param>
-        /// <param name="label">The name of the label column in <paramref name="data"/>.</param>
-        /// <param name="score">The name of the score column in <paramref name="data"/>.</param>
+        /// <param name="labelColumnName">The name of the label column in <paramref name="data"/>.</param>
+        /// <param name="scoreColumnName">The name of the score column in <paramref name="data"/>.</param>
         /// <returns>The evaluation results for these calibrated outputs.</returns>
-        public RegressionMetrics Evaluate(IDataView data, string label = DefaultColumnNames.Label, string score = DefaultColumnNames.Score)
+        public RegressionMetrics Evaluate(IDataView data, string labelColumnName = DefaultColumnNames.Label, string scoreColumnName = DefaultColumnNames.Score)
         {
             Environment.CheckValue(data, nameof(data));
-            Environment.CheckNonEmpty(label, nameof(label));
-            Environment.CheckNonEmpty(score, nameof(score));
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            Environment.CheckNonEmpty(scoreColumnName, nameof(scoreColumnName));
 
             var eval = new RegressionEvaluator(Environment, new RegressionEvaluator.Arguments() { });
-            return eval.Evaluate(data, label, score);
+            return eval.Evaluate(data, labelColumnName, scoreColumnName);
         }
 
         /// <summary>
-        /// Run cross-validation over <paramref name="numFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="stratificationColumn"/> if provided.
-        /// Then evaluate each sub-model against <paramref name="labelColumn"/> and return metrics.
+        /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
+        /// and respecting <paramref name="samplingKeyColumn"/> if provided.
+        /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
-        /// <param name="numFolds">Number of cross-validation folds.</param>
-        /// <param name="labelColumn">The label column (for evaluation).</param>
-        /// <param name="stratificationColumn">Optional name of the column to use as a stratification column. If two examples share the same value of the <paramref name="stratificationColumn"/>
+        /// <param name="numberOfFolds">Number of cross-validation folds.</param>
+        /// <param name="labelColumnName">The label column (for evaluation).</param>
+        /// <param name="samplingKeyColumn">Optional name of the column to use as a stratification column. If two examples share the same value of the <paramref name="samplingKeyColumn"/>
         /// (if provided), they are guaranteed to appear in the same subset (train or test). Use this to make sure there is no label leakage from train to the test set.
         /// If this optional parameter is not provided, a stratification columns will be generated, and its values will be random numbers .</param>
-        /// <param name="seed">Optional parameter used in combination with the <paramref name="stratificationColumn"/>.
-        /// If the <paramref name="stratificationColumn"/> is not provided, the random numbers generated to create it, will use this seed as value.
+        /// <param name="seed">Optional parameter used in combination with the <paramref name="samplingKeyColumn"/>.
+        /// If the <paramref name="samplingKeyColumn"/> is not provided, the random numbers generated to create it, will use this seed as value.
         /// And if it is not provided, the default value will be used.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public CrossValidationResult<RegressionMetrics>[] CrossValidate(
-            IDataView data, IEstimator<ITransformer> estimator, int numFolds = 5, string labelColumn = DefaultColumnNames.Label,
-            string stratificationColumn = null, int? seed = null)
+            IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
+            string samplingKeyColumn = null, int? seed = null)
         {
-            Environment.CheckNonEmpty(labelColumn, nameof(labelColumn));
-            var result = CrossValidateTrain(data, estimator, numFolds, stratificationColumn, seed);
-            return result.Select(x => new CrossValidationResult<RegressionMetrics>(x.Model, Evaluate(x.Scores, labelColumn), x.Scores, x.Fold)).ToArray();
+            Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumn, seed);
+            return result.Select(x => new CrossValidationResult<RegressionMetrics>(x.Model, Evaluate(x.Scores, labelColumnName), x.Scores, x.Fold)).ToArray();
         }
     }
 }

--- a/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
@@ -112,26 +112,26 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Run cross-validation over <paramref name="numberOfFolds"/> folds of <paramref name="data"/>, by fitting <paramref name="estimator"/>,
-        /// and respecting <paramref name="samplingKeyColumn"/> if provided.
+        /// and respecting <paramref name="samplingKeyColumnName"/> if provided.
         /// Then evaluate each sub-model against <paramref name="labelColumnName"/> and return metrics.
         /// </summary>
         /// <param name="data">The data to run cross-validation on.</param>
         /// <param name="estimator">The estimator to fit.</param>
         /// <param name="numberOfFolds">Number of cross-validation folds.</param>
         /// <param name="labelColumnName">The label column (for evaluation).</param>
-        /// <param name="samplingKeyColumn">Optional name of the column to use as a stratification column. If two examples share the same value of the <paramref name="samplingKeyColumn"/>
+        /// <param name="samplingKeyColumnName">Optional name of the column to use as a stratification column. If two examples share the same value of the <paramref name="samplingKeyColumnName"/>
         /// (if provided), they are guaranteed to appear in the same subset (train or test). Use this to make sure there is no label leakage from train to the test set.
         /// If this optional parameter is not provided, a stratification columns will be generated, and its values will be random numbers .</param>
-        /// <param name="seed">Optional parameter used in combination with the <paramref name="samplingKeyColumn"/>.
-        /// If the <paramref name="samplingKeyColumn"/> is not provided, the random numbers generated to create it, will use this seed as value.
+        /// <param name="seed">Optional parameter used in combination with the <paramref name="samplingKeyColumnName"/>.
+        /// If the <paramref name="samplingKeyColumnName"/> is not provided, the random numbers generated to create it, will use this seed as value.
         /// And if it is not provided, the default value will be used.</param>
         /// <returns>Per-fold results: metrics, models, scored datasets.</returns>
         public CrossValidationResult<RegressionMetrics>[] CrossValidate(
             IDataView data, IEstimator<ITransformer> estimator, int numberOfFolds = 5, string labelColumnName = DefaultColumnNames.Label,
-            string samplingKeyColumn = null, int? seed = null)
+            string samplingKeyColumnName = null, int? seed = null)
         {
             Environment.CheckNonEmpty(labelColumnName, nameof(labelColumnName));
-            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumn, seed);
+            var result = CrossValidateTrain(data, estimator, numberOfFolds, samplingKeyColumnName, seed);
             return result.Select(x => new CrossValidationResult<RegressionMetrics>(x.Model, Evaluate(x.Scores, labelColumnName), x.Scores, x.Fold)).ToArray();
         }
     }

--- a/test/Microsoft.ML.Benchmarks/RffTransform.cs
+++ b/test/Microsoft.ML.Benchmarks/RffTransform.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Benchmarks
             .Append(new ValueToKeyMappingEstimator(mlContext, "Label"))
             .Append(mlContext.MulticlassClassification.Trainers.OneVersusAll(mlContext.BinaryClassification.Trainers.AveragedPerceptron(numberOfIterations: 10)));
 
-            var cvResults = mlContext.MulticlassClassification.CrossValidate(data, pipeline, numFolds: 5);
+            var cvResults = mlContext.MulticlassClassification.CrossValidate(data, pipeline, numberOfFolds: 5);
         }
     }
 }

--- a/test/Microsoft.ML.Functional.Tests/Evaluation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Evaluation.cs
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Functional.Tests
 
             // Evaluate the model.
             var scoredData = model.Transform(data);
-            var metrics = mlContext.Ranking.Evaluate(scoredData, label: "Label", groupId: "GroupId");
+            var metrics = mlContext.Ranking.Evaluate(scoredData, labelColumnName: "Label", rowGroupColumnName: "GroupId");
 
             // Check that the metrics returned are valid.
             Common.AssertMetrics(metrics);

--- a/test/Microsoft.ML.Functional.Tests/Validation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Validation.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Functional.Tests
                 .Append(mlContext.Regression.Trainers.Ols());
 
             // Compute the CV result.
-            var cvResult = mlContext.Regression.CrossValidate(data, pipeline, numFolds: 5);
+            var cvResult = mlContext.Regression.CrossValidate(data, pipeline, numberOfFolds: 5);
 
             // Check that the results are valid
             Assert.IsType<RegressionMetrics>(cvResult[0].Metrics);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -118,7 +118,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
                 hasHeader: true);
 
             // Calculate metrics of the model on the test data.
-            var metrics = mlContext.Regression.Evaluate(model.Transform(testData), label: "Target");
+            var metrics = mlContext.Regression.Evaluate(model.Transform(testData), labelColumnName: "Target");
 
             using (var stream = File.Create(modelPath))
             {
@@ -434,7 +434,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             Console.WriteLine(metrics.MicroAccuracy);
 
             // Now run the 5-fold cross-validation experiment, using the same pipeline.
-            var cvResults = mlContext.MulticlassClassification.CrossValidate(data, pipeline, numFolds: 5);
+            var cvResults = mlContext.MulticlassClassification.CrossValidate(data, pipeline, numberOfFolds: 5);
 
             // The results object is an array of 5 elements. For each of the 5 folds, we have metrics, model and scored test data.
             // Let's compute the average micro-accuracy.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -324,7 +324,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             // Now let's do same thing but with presence of stratificationColumn.
             // Rows with same values in this stratificationColumn should end up in same subset (train or test).
             // So let's break dataset by "Workclass" column.
-            var stratSplit = mlContext.Data.TrainTestSplit(input, samplingKeyColumn: "Workclass");
+            var stratSplit = mlContext.Data.TrainTestSplit(input, samplingKeyColumnName: "Workclass");
             var stratTrainWorkclass = getWorkclass(stratSplit.TrainSet);
             var stratTestWorkClass = getWorkclass(stratSplit.TestSet);
             // Let's get unique values for "Workclass" column from train subset.
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             // Let's do same thing, but this time we will choose different seed.
             // Stratification column should still break dataset properly without same values in both subsets.
-            var stratSeed = mlContext.Data.TrainTestSplit(input, samplingKeyColumn:"Workclass", seed: 1000000);
+            var stratSeed = mlContext.Data.TrainTestSplit(input, samplingKeyColumnName:"Workclass", seed: 1000000);
             var stratTrainWithSeedWorkclass = getWorkclass(stratSeed.TrainSet);
             var stratTestWithSeedWorkClass = getWorkclass(stratSeed.TestSet);
             // Let's get unique values for "Workclass" column from train subset.

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -567,7 +567,7 @@ namespace Microsoft.ML.Scenarios
 
                 var trainedModel = pipe.Fit(trainData);
                 var predicted = trainedModel.Transform(testData);
-                var metrics = mlContext.MulticlassClassification.Evaluate(predicted, label: "KeyLabel");
+                var metrics = mlContext.MulticlassClassification.Evaluate(predicted, labelColumnName: "KeyLabel");
                 Assert.InRange(metrics.MicroAccuracy, expectedMicroAccuracy, 1);
                 Assert.InRange(metrics.MacroAccuracy, expectedMacroAccruacy, 1);
                 var predictionFunction = trainedModel.CreatePredictionEngine<MNISTData, MNISTPrediction>(mlContext);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             prediction.Schema.TryGetColumnIndex(scoreColumnName, out int scoreColumnId);
 
             // Compute prediction errors
-            var metrices = mlContext.Recommendation().Evaluate(prediction, label: labelColumnName, score: scoreColumnName);
+            var metrices = mlContext.Recommendation().Evaluate(prediction, labelColumnName: labelColumnName, scoreColumnName: scoreColumnName);
 
             // Determine if the selected metric is reasonable for different platforms
             double tolerance = Math.Pow(10, -7);
@@ -234,8 +234,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var prediction = model.Transform(dataView);
 
             // Calculate regression matrices for the prediction result
-            var metrics = mlContext.Recommendation().Evaluate(prediction, label: nameof(MatrixElement.Value),
-                score: nameof(MatrixElementForScore.Score));
+            var metrics = mlContext.Recommendation().Evaluate(prediction, labelColumnName: nameof(MatrixElement.Value),
+                scoreColumnName: nameof(MatrixElementForScore.Score));
 
             // Native test. Just check the pipeline runs.
             Assert.True(metrics.MeanSquaredError < 0.1);
@@ -325,7 +325,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var prediction = model.Transform(dataView);
 
             // Calculate regression matrices for the prediction result. It's a global
-            var metrics = mlContext.Recommendation().Evaluate(prediction, label: "Value", score: "Score");
+            var metrics = mlContext.Recommendation().Evaluate(prediction, labelColumnName: "Value", scoreColumnName: "Score");
 
             // Make sure the prediction error is not too large.
             Assert.InRange(metrics.MeanSquaredError, 0, 0.1);
@@ -438,7 +438,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var prediction = model.Transform(dataView);
 
             // Calculate regression matrices for the prediction result.
-            var metrics = mlContext.Recommendation().Evaluate(prediction, label: "Value", score: "Score");
+            var metrics = mlContext.Recommendation().Evaluate(prediction, labelColumnName: "Value", scoreColumnName: "Score");
 
             // Make sure the prediction error is not too large.
             Assert.InRange(metrics.MeanSquaredError, 0, 0.0016);
@@ -574,7 +574,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var prediction = model.Transform(dataView);
 
             // Calculate regression matrices for the prediction result.
-            var metrics = mlContext.Recommendation().Evaluate(prediction, label: "Value", score: "Score");
+            var metrics = mlContext.Recommendation().Evaluate(prediction, labelColumnName: "Value", scoreColumnName: "Score");
 
             // Make sure the prediction error is not too large.
             Assert.InRange(metrics.MeanSquaredError, 0, 0.0016);


### PR DESCRIPTION
Fixes #2972.

In this PR I clean `TrainCatalog` (commit 1) and `RecommenderCatalog` (commit 2).
The other commits are simply the adjustments in the code that need to be done to compile. 