### PR TITLE
Updating the FunctionalTests to clearly explain why they are not strong named signed.

### DIFF
--- a/test/Microsoft.ML.Functional.Tests/Microsoft.ML.Functional.Tests.csproj
+++ b/test/Microsoft.ML.Functional.Tests/Microsoft.ML.Functional.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- We are turning off strong naming to ensure we never add `InternalsVisibleTo` for these tests -->
-    <SignAssembly>true</SignAssembly>
+    <!-- DON'T CHANGE THIS!!! We are turning off strong naming to ensure we never add `InternalsVisibleTo` for these tests -->
+    <SignAssembly>false</SignAssembly>
+    <!-- DON'T CHANGE THIS!!! We are turning off strong naming to ensure we never add `InternalsVisibleTo` for these tests -->
     <PublicSign>false</PublicSign>
   </PropertyGroup>
 


### PR DESCRIPTION
See https://github.com/dotnet/machinelearning/pull/2858#discussion_r264738643 for an example of why this is necessary.