### PR TITLE
Expose advanced options for the NormalizingEstimator 

### DIFF
--- a/src/Microsoft.ML.Experimental/MLContextExtensions.cs
+++ b/src/Microsoft.ML.Experimental/MLContextExtensions.cs
@@ -16,37 +16,37 @@ namespace Microsoft.ML.Experimental
         public static void CancelExecution(this MLContext ctx) => ctx.CancelExecution();
 
         /// <summary>
-        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.MinMax"/> mode.
+        /// Normalize (rescale) the column according to the <see cref="NormalizingEstimator.NormalizationMode.MinMax"/> mode.
         /// It normalizes the data based on the observed minimum and maximum values of the data.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         public static NormalizingEstimator NormalizeMinMax(this TransformsCatalog catalog,
            string outputColumnName, string inputColumnName = null,
-           bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
-           long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount)
+           long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+           bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched)
         {
             var columnOptions = new NormalizingEstimator.MinMaxColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
 
         /// <summary>
-        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.MeanVariance"/> mode.
+        /// Normalize (rescale) the column according to the <see cref="NormalizingEstimator.NormalizationMode.MeanVariance"/> mode.
         /// It normalizes the data based on the computed mean and variance of the data.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="useCdf">Whether to use CDF as the output.</param>
         public static NormalizingEstimator NormalizeMeanVariance(this TransformsCatalog catalog,
             string outputColumnName, string inputColumnName = null,
-            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf)
         {
             var columnOptions = new NormalizingEstimator.MeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, useCdf);
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Experimental
         }
 
         /// <summary>
-        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.LogMeanVariance"/> mode.
+        /// Normalize (rescale) the column according to the <see cref="NormalizingEstimator.NormalizationMode.LogMeanVariance"/> mode.
         /// It normalizes the data based on the computed mean and variance of the logarithm of the data.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
@@ -72,19 +72,19 @@ namespace Microsoft.ML.Experimental
         }
 
         /// <summary>
-        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.Binning"/> mode.
+        /// Normalize (rescale) the column according to the <see cref="NormalizingEstimator.NormalizationMode.Binning"/> mode.
         /// The values are assigned into bins with equal density.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
         public static NormalizingEstimator NormalizeBinning(this TransformsCatalog catalog,
             string outputColumnName, string inputColumnName = null,
-            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount)
         {
             var columnOptions = new NormalizingEstimator.BinningColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, maximumBinCount);
@@ -92,22 +92,22 @@ namespace Microsoft.ML.Experimental
         }
 
         /// <summary>
-        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.SupervisedBinning"/> mode.
+        /// Normalize (rescale) the column according to the <see cref="NormalizingEstimator.NormalizationMode.SupervisedBinning"/> mode.
         /// The values are assigned into bins based on correlation with the <paramref name="labelColumnName"/> column.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="labelColumnName">Name of the label column for supervised binning.</param>
-        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
         /// <param name="mininimumExamplesPerBin">Minimum number of examples per bin.</param>
         public static NormalizingEstimator NormalizeSupervisedBinning(this TransformsCatalog catalog,
             string outputColumnName, string inputColumnName = null,
             string labelColumnName = DefaultColumnNames.Label,
-            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount,
             int mininimumExamplesPerBin = NormalizingEstimator.Defaults.MininimumBinSize)
         {

--- a/src/Microsoft.ML.Experimental/MLContextExtensions.cs
+++ b/src/Microsoft.ML.Experimental/MLContextExtensions.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Data;
+using Microsoft.ML.Transforms;
+
 namespace Microsoft.ML.Experimental
 {
     public static class MLContextExtensions
@@ -11,5 +14,105 @@ namespace Microsoft.ML.Experimental
         /// </summary>
         /// <param name="ctx"><see cref="MLContext"/> reference.</param>
         public static void CancelExecution(this MLContext ctx) => ctx.CancelExecution();
+
+        /// <summary>
+        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.MinMax"/> mode.
+        /// It normalizes the data based on the observed minimum and maximum values of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
+        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        public static NormalizingEstimator NormalizeMinMax(this TransformsCatalog catalog,
+           string outputColumnName, string inputColumnName = null,
+           bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+           long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount)
+        {
+            var columnOptions = new NormalizingEstimator.MinMaxColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        /// <summary>
+        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.MeanVariance"/> mode.
+        /// It normalizes the data based on the computed mean and variance of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
+        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="useCdf">Whether to use CDF as the output.</param>
+        public static NormalizingEstimator NormalizeMeanVariance(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf)
+        {
+            var columnOptions = new NormalizingEstimator.MeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched, useCdf);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        /// <summary>
+        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.LogMeanVariance"/> mode.
+        /// It normalizes the data based on the computed mean and variance of the logarithm of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="useCdf">Whether to use CDF as the output.</param>
+        public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool useCdf = NormalizingEstimator.Defaults.LogMeanVarCdf)
+        {
+            var columnOptions = new NormalizingEstimator.LogMeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, useCdf);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        /// <summary>
+        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.Binning"/> mode.
+        /// The values are assigned into bins with equal density.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
+        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
+        public static NormalizingEstimator NormalizeBinning(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount)
+        {
+            var columnOptions = new NormalizingEstimator.BinningColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched, maximumBinCount);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        /// <summary>
+        /// Normalize (rescale) the column according the <see cref="NormalizingEstimator.NormalizationMode.SupervisedBinning"/> mode.
+        /// The values are assigned into bins based on correlation with the <paramref name="labelColumnName"/> column.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
+        /// <param name="labelColumnName">Name of the label column for supervised binning.</param>
+        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
+        /// <param name="mininimumExamplesPerBin">Minimum number of examples per bin.</param>
+        public static NormalizingEstimator NormalizeSupervisedBinning(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount,
+            int mininimumExamplesPerBin = NormalizingEstimator.Defaults.MininimumBinSize)
+        {
+            var columnOptions = new NormalizingEstimator.SupervisedBinningColumOptions(outputColumnName, inputColumnName, labelColumnName, maximumExampleCount, ensureZeroUntouched, maximumBinCount, mininimumExamplesPerBin);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
     }
 }

--- a/src/Microsoft.ML.Experimental/MLContextExtensions.cs
+++ b/src/Microsoft.ML.Experimental/MLContextExtensions.cs
@@ -22,14 +22,14 @@ namespace Microsoft.ML.Experimental
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
         public static NormalizingEstimator NormalizeMinMax(this TransformsCatalog catalog,
            string outputColumnName, string inputColumnName = null,
-           bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+           bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount)
         {
-            var columnOptions = new NormalizingEstimator.MinMaxColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched);
+            var columnOptions = new NormalizingEstimator.MinMaxColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
 
@@ -40,16 +40,16 @@ namespace Microsoft.ML.Experimental
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
         /// <param name="useCdf">Whether to use CDF as the output.</param>
         public static NormalizingEstimator NormalizeMeanVariance(this TransformsCatalog catalog,
             string outputColumnName, string inputColumnName = null,
-            bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
             bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf)
         {
-            var columnOptions = new NormalizingEstimator.MeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched, useCdf);
+            var columnOptions = new NormalizingEstimator.MeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, useCdf);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
 
@@ -78,16 +78,16 @@ namespace Microsoft.ML.Experimental
         /// <param name="catalog">The transform catalog</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
         /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
         public static NormalizingEstimator NormalizeBinning(this TransformsCatalog catalog,
             string outputColumnName, string inputColumnName = null,
-            bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
             int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount)
         {
-            var columnOptions = new NormalizingEstimator.BinningColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched, maximumBinCount);
+            var columnOptions = new NormalizingEstimator.BinningColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, maximumBinCount);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
 
@@ -99,19 +99,19 @@ namespace Microsoft.ML.Experimental
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="labelColumnName">Name of the label column for supervised binning.</param>
-        /// <param name="ensureZeroUntouched">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
         /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
         /// <param name="mininimumExamplesPerBin">Minimum number of examples per bin.</param>
         public static NormalizingEstimator NormalizeSupervisedBinning(this TransformsCatalog catalog,
             string outputColumnName, string inputColumnName = null,
             string labelColumnName = DefaultColumnNames.Label,
-            bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
             int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount,
             int mininimumExamplesPerBin = NormalizingEstimator.Defaults.MininimumBinSize)
         {
-            var columnOptions = new NormalizingEstimator.SupervisedBinningColumOptions(outputColumnName, inputColumnName, labelColumnName, maximumExampleCount, ensureZeroUntouched, maximumBinCount, mininimumExamplesPerBin);
+            var columnOptions = new NormalizingEstimator.SupervisedBinningColumOptions(outputColumnName, inputColumnName, labelColumnName, maximumExampleCount, fixZero, maximumBinCount, mininimumExamplesPerBin);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
     }

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -8,6 +8,60 @@ namespace Microsoft.ML
     /// </summary>
     public static class NormalizationCatalog
     {
+        public static NormalizingEstimator NormalizeMinMax(this TransformsCatalog catalog,
+           string outputColumnName, string inputColumnName = null,
+           long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+           bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched) {
+
+            var columnOptions = new NormalizingEstimator.MinMaxColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        public static NormalizingEstimator NormalizeMeanVariance(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf)
+        {
+
+            var columnOptions = new NormalizingEstimator.MeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, useCdf);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf)
+        {
+
+            var columnOptions = new NormalizingEstimator.LogMeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, useCdf);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        public static NormalizingEstimator NormalizeBinning(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount)
+        {
+
+            var columnOptions = new NormalizingEstimator.BinningColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, maximumBinCount);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        public static NormalizingEstimator NormalizeSupervisedBinning(this TransformsCatalog catalog,
+            string outputColumnName, string inputColumnName = null,
+            string labelColumnName = DefaultColumnNames.Label,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount,
+            int mininimumBinSize = NormalizingEstimator.Defaults.MininimumBinSize)
+        {
+
+            var columnOptions = new NormalizingEstimator.SupervisedBinningColumOptions(outputColumnName, inputColumnName, labelColumnName, maximumExampleCount, fixZero, maximumBinCount, mininimumBinSize);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
         /// <summary>
         /// Normalize (rescale) the column according to the specified <paramref name="mode"/>.
         /// </summary>

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -8,60 +8,6 @@ namespace Microsoft.ML
     /// </summary>
     public static class NormalizationCatalog
     {
-        public static NormalizingEstimator NormalizeMinMax(this TransformsCatalog catalog,
-           string outputColumnName, string inputColumnName = null,
-           long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
-           bool ensureZeroUntouched = NormalizingEstimator.Defaults.EnsureZeroUntouched) {
-
-            var columnOptions = new NormalizingEstimator.MinMaxColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, ensureZeroUntouched);
-            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
-        }
-
-        public static NormalizingEstimator NormalizeMeanVariance(this TransformsCatalog catalog,
-            string outputColumnName, string inputColumnName = null,
-            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
-            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
-            bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf)
-        {
-
-            var columnOptions = new NormalizingEstimator.MeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, useCdf);
-            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
-        }
-
-        public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog,
-            string outputColumnName, string inputColumnName = null,
-            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
-            bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf)
-        {
-
-            var columnOptions = new NormalizingEstimator.LogMeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, useCdf);
-            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
-        }
-
-        public static NormalizingEstimator NormalizeBinning(this TransformsCatalog catalog,
-            string outputColumnName, string inputColumnName = null,
-            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
-            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
-            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount)
-        {
-
-            var columnOptions = new NormalizingEstimator.BinningColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, maximumBinCount);
-            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
-        }
-
-        public static NormalizingEstimator NormalizeSupervisedBinning(this TransformsCatalog catalog,
-            string outputColumnName, string inputColumnName = null,
-            string labelColumnName = DefaultColumnNames.Label,
-            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
-            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
-            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount,
-            int mininimumBinSize = NormalizingEstimator.Defaults.MininimumBinSize)
-        {
-
-            var columnOptions = new NormalizingEstimator.SupervisedBinningColumOptions(outputColumnName, inputColumnName, labelColumnName, maximumExampleCount, fixZero, maximumBinCount, mininimumBinSize);
-            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
-        }
-
         /// <summary>
         /// Normalize (rescale) the column according to the specified <paramref name="mode"/>.
         /// </summary>

--- a/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
+++ b/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\src\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.Ensemble\Microsoft.ML.Ensemble.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.EntryPoints\Microsoft.ML.EntryPoints.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.ML.Experimental\Microsoft.ML.Experimental.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.LightGbm\Microsoft.ML.LightGbm.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.Mkl.Components\Microsoft.ML.Mkl.Components.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.ImageAnalytics\Microsoft.ML.ImageAnalytics.csproj" />
@@ -38,7 +39,7 @@
     <NativeAssemblyReference Include="SymSgdNative" />
     <NativeAssemblyReference Include="MklProxyNative" />
     <NativeAssemblyReference Include="MklImports" />
-    <NativeAssemblyReference Condition="'$(OS)' == 'Windows_NT'" Include="libiomp5md"/>
+    <NativeAssemblyReference Condition="'$(OS)' == 'Windows_NT'" Include="libiomp5md" />
   </ItemGroup>
 
   <!-- TensorFlow is 64-bit only -->

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.IO;
 using Microsoft.ML.Data;
 using Microsoft.ML.Data.IO;
+using Microsoft.ML.Experimental;
 using Microsoft.ML.Model;
 using Microsoft.ML.RunTests;
 using Microsoft.ML.StaticPipe;
@@ -242,10 +243,10 @@ namespace Microsoft.ML.Tests.Transformers
             CheckSameValues(data1, data4);
             CheckSameValues(data1, data5);
 
-            // Tests for SupervisedBinning
-            var est6 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
-            var est7 = new NormalizingEstimator(Env, new NormalizingEstimator.SupervisedBinningColumOptions("float4"));
-            var est8 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
+            // Tests for MeanVariance
+            var est6 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.MeanVariance, ("float4", "float4"));
+            var est7 = new NormalizingEstimator(Env, new NormalizingEstimator.MeanVarianceColumnOptions("float4"));
+            var est8 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.MeanVariance, ("float4", "float4"));
 
             var data6 = est6.Fit(data).Transform(data);
             var data7 = est7.Fit(data).Transform(data);
@@ -254,6 +255,71 @@ namespace Microsoft.ML.Tests.Transformers
             CheckSameSchemas(data6.Schema, data8.Schema);
             CheckSameValues(data6, data7);
             CheckSameValues(data6, data8);
+
+            // Tests for LogMeanVariance
+            var est9 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.LogMeanVariance, ("float4", "float4"));
+            var est10 = new NormalizingEstimator(Env, new NormalizingEstimator.LogMeanVarianceColumnOptions("float4"));
+            var est11 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.LogMeanVariance, ("float4", "float4"));
+
+            var data9 = est9.Fit(data).Transform(data);
+            var data10 = est10.Fit(data).Transform(data);
+            var data11 = est11.Fit(data).Transform(data);
+            CheckSameSchemas(data9.Schema, data10.Schema);
+            CheckSameSchemas(data9.Schema, data11.Schema);
+            CheckSameValues(data9, data10);
+            CheckSameValues(data9, data11);
+
+            // Tests for Binning
+            var est12 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.Binning, ("float4", "float4"));
+            var est13 = new NormalizingEstimator(Env, new NormalizingEstimator.BinningColumnOptions("float4"));
+            var est14 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.Binning, ("float4", "float4"));
+
+            var data12 = est12.Fit(data).Transform(data);
+            var data13 = est13.Fit(data).Transform(data);
+            var data14 = est14.Fit(data).Transform(data);
+            CheckSameSchemas(data12.Schema, data13.Schema);
+            CheckSameSchemas(data12.Schema, data14.Schema);
+            CheckSameValues(data12, data13);
+            CheckSameValues(data12, data14);
+
+            // Tests for SupervisedBinning
+            var est15 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
+            var est16 = new NormalizingEstimator(Env, new NormalizingEstimator.SupervisedBinningColumOptions("float4"));
+            var est17 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
+
+            var data15 = est15.Fit(data).Transform(data);
+            var data16 = est16.Fit(data).Transform(data);
+            var data17 = est17.Fit(data).Transform(data);
+            CheckSameSchemas(data15.Schema, data16.Schema);
+            CheckSameSchemas(data15.Schema, data17.Schema);
+            CheckSameValues(data15, data16);
+            CheckSameValues(data15, data17);
+
+            // Tests for Normalizer Extensions (in Experimental nuget)
+            var est18 = ML.Transforms.NormalizeMinMax("float4", "float4");
+            var data18 = est18.Fit(data).Transform(data);
+            CheckSameSchemas(data2.Schema, data18.Schema);
+            CheckSameValues(data2, data18);
+
+            var est19 = ML.Transforms.NormalizeMeanVariance("float4", "float4");
+            var data19 = est19.Fit(data).Transform(data);
+            CheckSameSchemas(data6.Schema, data19.Schema);
+            CheckSameValues(data6, data19);
+
+            var est20 = ML.Transforms.NormalizeLogMeanVariance("float4", "float4");
+            var data20 = est20.Fit(data).Transform(data);
+            CheckSameSchemas(data9.Schema, data20.Schema);
+            CheckSameValues(data9, data20);
+
+            var est21 = ML.Transforms.NormalizeBinning("float4", "float4");
+            var data21 = est21.Fit(data).Transform(data);
+            CheckSameSchemas(data12.Schema, data21.Schema);
+            CheckSameValues(data12, data21);
+
+            var est22 = ML.Transforms.NormalizeSupervisedBinning("float4", "float4");
+            var data22 = est22.Fit(data).Transform(data);
+            CheckSameSchemas(data15.Schema, data22.Schema);
+            CheckSameValues(data15, data22);
 
             Done();
         }

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -295,31 +295,63 @@ namespace Microsoft.ML.Tests.Transformers
             CheckSameValues(data15, data16);
             CheckSameValues(data15, data17);
 
-            // Tests for Normalizer Extensions (in Experimental nuget)
-            var est18 = ML.Transforms.NormalizeMinMax("float4", "float4");
-            var data18 = est18.Fit(data).Transform(data);
-            CheckSameSchemas(data2.Schema, data18.Schema);
-            CheckSameValues(data2, data18);
+            Done();
+        }
 
-            var est19 = ML.Transforms.NormalizeMeanVariance("float4", "float4");
-            var data19 = est19.Fit(data).Transform(data);
-            CheckSameSchemas(data6.Schema, data19.Schema);
-            CheckSameValues(data6, data19);
+        [Fact]
+        public void NormalizerExperimentalExtensions()
+        {
+            string dataPath = GetDataPath(TestDatasets.iris.trainFilename);
 
-            var est20 = ML.Transforms.NormalizeLogMeanVariance("float4", "float4");
-            var data20 = est20.Fit(data).Transform(data);
-            CheckSameSchemas(data9.Schema, data20.Schema);
-            CheckSameValues(data9, data20);
+            var loader = new TextLoader(Env, new TextLoader.Options
+            {
+                Columns = new[] {
+                    new TextLoader.Column("Label", DataKind.Single, 0),
+                    new TextLoader.Column("float4", DataKind.Single, new[]{new TextLoader.Range(1, 4) }),
+                }
+            });
 
-            var est21 = ML.Transforms.NormalizeBinning("float4", "float4");
-            var data21 = est21.Fit(data).Transform(data);
-            CheckSameSchemas(data12.Schema, data21.Schema);
-            CheckSameValues(data12, data21);
+            var data = loader.Load(dataPath);
 
-            var est22 = ML.Transforms.NormalizeSupervisedBinning("float4", "float4");
-            var data22 = est22.Fit(data).Transform(data);
-            CheckSameSchemas(data15.Schema, data22.Schema);
-            CheckSameValues(data15, data22);
+            // Normalizer Extensions
+            var est1 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.MinMax, ("float4", "float4"));
+            var est2 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.MeanVariance, ("float4", "float4"));
+            var est3 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.LogMeanVariance, ("float4", "float4")); 
+            var est4 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.Binning, ("float4", "float4")); 
+            var est5 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
+
+            // Normalizer Extensions (Experimental)
+            var est6 = ML.Transforms.NormalizeMinMax("float4", "float4");
+            var est7 = ML.Transforms.NormalizeMeanVariance("float4", "float4");
+            var est8 = ML.Transforms.NormalizeLogMeanVariance("float4", "float4");
+            var est9 = ML.Transforms.NormalizeBinning("float4", "float4");
+            var est10 = ML.Transforms.NormalizeSupervisedBinning("float4", "float4");
+
+            // Fit and Transpose 
+            var data1 = est1.Fit(data).Transform(data);
+            var data2 = est2.Fit(data).Transform(data);
+            var data3 = est3.Fit(data).Transform(data);
+            var data4 = est4.Fit(data).Transform(data);
+            var data5 = est5.Fit(data).Transform(data);
+            var data6 = est6.Fit(data).Transform(data);
+            var data7 = est7.Fit(data).Transform(data);
+            var data8 = est8.Fit(data).Transform(data);
+            var data9 = est9.Fit(data).Transform(data);
+            var data10 = est10.Fit(data).Transform(data);
+
+            // Schema Checks
+            CheckSameSchemas(data1.Schema, data6.Schema);
+            CheckSameSchemas(data2.Schema, data7.Schema);
+            CheckSameSchemas(data3.Schema, data8.Schema);
+            CheckSameSchemas(data4.Schema, data9.Schema);
+            CheckSameSchemas(data5.Schema, data10.Schema);
+
+            // Value Checks
+            CheckSameValues(data1, data6);
+            CheckSameValues(data2, data7);
+            CheckSameValues(data3, data8);
+            CheckSameValues(data4, data9);
+            CheckSameValues(data5, data10);
 
             Done();
         }


### PR DESCRIPTION
Fixes  #3047 

- Introduces 5 APIs required to expose advanced options for each of the normalizing estimators in ML.NET {MinMax, MeanVariance, LogMeanVariance, Binning, SupervisedBinning}
- The APIs are added into the Experimental nuget, till  we finalize a  proper design for #2884 
- Added tests