### PR TITLE
Multicolumn mapping for some estimators

### DIFF
--- a/docs/code/MlNetCookBook.md
+++ b/docs/code/MlNetCookBook.md
@@ -424,7 +424,7 @@ var pipeline =
     // Use the multi-class SDCA model to predict the label using features.
     .Append(mlContext.MulticlassClassification.Trainers.SdcaCalibrated())
     // Apply the inverse conversion from 'PredictedLabel' column back to string value.
-    .Append(mlContext.Transforms.Conversion.MapKeyToValue(("PredictedLabel", "Data")));
+    .Append(mlContext.Transforms.Conversion.MapKeyToValue("Data", "PredictedLabel"));
 
 // Train the model.
 var model = pipeline.Fit(trainData);

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
@@ -75,8 +76,10 @@ namespace Microsoft.ML
             InputOutputColumnPair[] columns,
             DataKind outputKind = ConvertDefaults.DefaultOutputKind)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var columnOptions = columns.Select(x => new TypeConvertingEstimator.ColumnOptions(x.OutputColumnName, outputKind, x.InputColumnName)).ToArray();
-            return new TypeConvertingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+            return new TypeConvertingEstimator(env, columnOptions);
         }
 
         /// <summary>
@@ -109,7 +112,11 @@ namespace Microsoft.ML
         /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
         public static KeyToValueMappingEstimator MapKeyToValue(this TransformsCatalog.ConversionTransforms catalog, InputOutputColumnPair[] columns)
-            => new KeyToValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new KeyToValueMappingEstimator(env, columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
+        }
 
         /// <summary>
         /// Maps key types or key values into a floating point vector.
@@ -143,8 +150,10 @@ namespace Microsoft.ML
         public static KeyToVectorMappingEstimator MapKeyToVector(this TransformsCatalog.ConversionTransforms catalog,
             InputOutputColumnPair[] columns, bool outputCountVector = KeyToVectorMappingEstimator.Defaults.OutputCountVector)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var columnOptions = columns.Select(x => new KeyToVectorMappingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, outputCountVector)).ToArray();
-            return new KeyToVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+            return new KeyToVectorMappingEstimator(env, columnOptions);
 
         }
 
@@ -197,8 +206,10 @@ namespace Microsoft.ML
             bool addKeyValueAnnotationsAsText = ValueToKeyMappingEstimator.Defaults.AddKeyValueAnnotationsAsText,
             IDataView keyData = null)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var columnOptions = columns.Select(x => new ValueToKeyMappingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, maximumNumberOfKeys, keyOrdinality, addKeyValueAnnotationsAsText)).ToArray();
-            return new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions, keyData);
+            return new ValueToKeyMappingEstimator(env, columnOptions, keyData);
         }
 
         /// <summary>
@@ -278,9 +289,11 @@ namespace Microsoft.ML
             IEnumerable<KeyValuePair<TInputType, TOutputType>> keyValuePairs,
             params InputOutputColumnPair[] columns)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var keys = keyValuePairs.Select(pair => pair.Key);
             var values = keyValuePairs.Select(pair => pair.Value);
-            return new ValueMappingEstimator<TInputType, TOutputType>(CatalogUtils.GetEnvironment(catalog), keys, values, InputOutputColumnPair.ConvertToValueTuples(columns));
+            return new ValueMappingEstimator<TInputType, TOutputType>(env, keys, values, InputOutputColumnPair.ConvertToValueTuples(columns));
         }
 
         /// <summary>
@@ -306,9 +319,11 @@ namespace Microsoft.ML
             bool treatValuesAsKeyType,
             params InputOutputColumnPair[] columns)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var keys = keyValuePairs.Select(pair => pair.Key);
             var values = keyValuePairs.Select(pair => pair.Value);
-            return new ValueMappingEstimator<TInputType, TOutputType>(CatalogUtils.GetEnvironment(catalog), keys, values, treatValuesAsKeyType,
+            return new ValueMappingEstimator<TInputType, TOutputType>(env, keys, values, treatValuesAsKeyType,
                   InputOutputColumnPair.ConvertToValueTuples(columns));
         }
 
@@ -367,9 +382,11 @@ namespace Microsoft.ML
             IEnumerable<KeyValuePair<TInputType, TOutputType[]>> keyValuePairs,
             params InputOutputColumnPair[] columns)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var keys = keyValuePairs.Select(pair => pair.Key);
             var values = keyValuePairs.Select(pair => pair.Value);
-            return new ValueMappingEstimator<TInputType, TOutputType>(CatalogUtils.GetEnvironment(catalog), keys, values,
+            return new ValueMappingEstimator<TInputType, TOutputType>(env, keys, values,
                     InputOutputColumnPair.ConvertToValueTuples(columns));
         }
 
@@ -422,7 +439,11 @@ namespace Microsoft.ML
         internal static ValueMappingEstimator MapValue(
             this TransformsCatalog.ConversionTransforms catalog,
             IDataView lookupMap, DataViewSchema.Column keyColumn, DataViewSchema.Column valueColumn, params InputOutputColumnPair[] columns)
-            => new ValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), lookupMap, keyColumn.Name, valueColumn.Name,
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new ValueMappingEstimator(env, lookupMap, keyColumn.Name, valueColumn.Name,
                 InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -66,6 +66,20 @@ namespace Microsoft.ML
             => new TypeConvertingEstimator(CatalogUtils.GetEnvironment(catalog), new[] { new TypeConvertingEstimator.ColumnOptions(outputColumnName, outputKind, inputColumnName) });
 
         /// <summary>
+        /// Changes column type of the input columns.
+        /// </summary>
+        /// <param name="catalog">The conversion transform's catalog.</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        /// <param name="outputKind">The expected kind of the output column.</param>
+        public static TypeConvertingEstimator ConvertType(this TransformsCatalog.ConversionTransforms catalog,
+            InputOutputColumnPair[] columns,
+            DataKind outputKind = ConvertDefaults.DefaultOutputKind)
+        {
+            var columnOptions = columns.Select(x => new TypeConvertingEstimator.ColumnOptions(x.OutputColumnName, outputKind, x.InputColumnName)).ToArray();
+            return new TypeConvertingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        /// <summary>
         /// Changes column type of the input column.
         /// </summary>
         /// <param name="catalog">The conversion transform's catalog.</param>
@@ -88,6 +102,14 @@ namespace Microsoft.ML
         /// </example>
         public static KeyToValueMappingEstimator MapKeyToValue(this TransformsCatalog.ConversionTransforms catalog, string outputColumnName, string inputColumnName = null)
             => new KeyToValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName);
+
+        /// <summary>
+        /// Convert the key types back to their original values.
+        /// </summary>
+        /// <param name="catalog">The conversion transform's catalog.</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        public static KeyToValueMappingEstimator MapKeyToValue(this TransformsCatalog.ConversionTransforms catalog, InputOutputColumnPair[] columns)
+            => new KeyToValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
 
         /// <summary>
         ///  Convert the key types (name of the column specified in the first item of the tuple) back to their original values
@@ -128,6 +150,21 @@ namespace Microsoft.ML
             => new KeyToVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, outputCountVector);
 
         /// <summary>
+        /// Maps columns of key types or key values into columns of floating point vectors.
+        /// </summary>
+        /// <param name="catalog">The conversion transform's catalog.</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        /// <param name="outputCountVector">Whether to combine multiple indicator vectors into a single vector of counts instead of concatenating them.
+        /// This is only relevant when the input column is a vector of keys.</param>
+        public static KeyToVectorMappingEstimator MapKeyToVector(this TransformsCatalog.ConversionTransforms catalog,
+            InputOutputColumnPair[] columns, bool outputCountVector = KeyToVectorMappingEstimator.Defaults.OutputCountVector)
+        {
+            var columnOptions = columns.Select(x => new KeyToVectorMappingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, outputCountVector)).ToArray();
+            return new KeyToVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+
+        }
+
+        /// <summary>
         /// Converts value types into <see cref="KeyDataViewType"/>.
         /// </summary>
         /// <param name="catalog">The conversion transform's catalog.</param>
@@ -158,7 +195,30 @@ namespace Microsoft.ML
                new[] { new ValueToKeyMappingEstimator.ColumnOptions(outputColumnName, inputColumnName, maximumNumberOfKeys, keyOrdinality, addKeyValueAnnotationsAsText) }, keyData);
 
         /// <summary>
-        /// Converts value types into <see cref="KeyDataViewType"/>, optionally loading the keys to use from <paramref name="keyData"/>.
+        /// Converts value types into <see cref="KeyDataViewType"/>.
+        /// </summary>
+        /// <param name="catalog">The conversion transform's catalog.</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
+        /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
+        /// If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+        /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
+        /// <param name="keyData">The data view containing the terms. If specified, this should be a single column data
+        /// view, and the key-values will be taken from that column. If unspecified, the key-values will be determined
+        /// from the input data upon fitting.</param>
+        public static ValueToKeyMappingEstimator MapValueToKey(this TransformsCatalog.ConversionTransforms catalog,
+            InputOutputColumnPair[] columns,
+            int maximumNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys,
+            ValueToKeyMappingEstimator.KeyOrdinality keyOrdinality = ValueToKeyMappingEstimator.Defaults.Ordinality,
+            bool addKeyValueAnnotationsAsText = ValueToKeyMappingEstimator.Defaults.AddKeyValueAnnotationsAsText,
+            IDataView keyData = null)
+        {
+            var columnOptions = columns.Select(x => new ValueToKeyMappingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, maximumNumberOfKeys, keyOrdinality, addKeyValueAnnotationsAsText)).ToArray();
+            return new ValueToKeyMappingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions, keyData);
+        }
+
+        /// <summary>
+        /// Converts value types into <see cref="KeyType"/>, optionally loading the keys to use from <paramref name="keyData"/>.
         /// </summary>
         /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">The data columns to map to keys.</param>

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -112,22 +112,6 @@ namespace Microsoft.ML
             => new KeyToValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
 
         /// <summary>
-        ///  Convert the key types (name of the column specified in the first item of the tuple) back to their original values
-        ///  (named as specified in the second item of the tuple).
-        /// </summary>
-        /// <param name="catalog">The conversion transform's catalog</param>
-        /// <param name="columns">The pairs of input and output columns.</param>
-        /// <example>
-        /// <format type="text/markdown">
-        /// <![CDATA[
-        ///  [!code-csharp[KeyToValueMappingEstimator](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/ValueMappingStringToKeyType.cs)]
-        /// ]]></format>
-        /// </example>
-        [BestFriend]
-        internal static KeyToValueMappingEstimator MapKeyToValue(this TransformsCatalog.ConversionTransforms catalog, params ColumnOptions[] columns)
-             => new KeyToValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), ColumnOptions.ConvertToValueTuples(columns));
-
-        /// <summary>
         /// Maps key types or key values into a floating point vector.
         /// </summary>
         /// <param name="catalog">The conversion transform's catalog.</param>
@@ -218,7 +202,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Converts value types into <see cref="KeyType"/>, optionally loading the keys to use from <paramref name="keyData"/>.
+        /// Converts value types into <see cref="KeyDataViewType"/>, optionally loading the keys to use from <paramref name="keyData"/>.
         /// </summary>
         /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">The data columns to map to keys.</param>
@@ -292,11 +276,11 @@ namespace Microsoft.ML
         internal static ValueMappingEstimator<TInputType, TOutputType> MapValue<TInputType, TOutputType>(
             this TransformsCatalog.ConversionTransforms catalog,
             IEnumerable<KeyValuePair<TInputType, TOutputType>> keyValuePairs,
-            params ColumnOptions[] columns)
+            params InputOutputColumnPair[] columns)
         {
             var keys = keyValuePairs.Select(pair => pair.Key);
             var values = keyValuePairs.Select(pair => pair.Value);
-            return new ValueMappingEstimator<TInputType, TOutputType>(CatalogUtils.GetEnvironment(catalog), keys, values, ColumnOptions.ConvertToValueTuples(columns));
+            return new ValueMappingEstimator<TInputType, TOutputType>(CatalogUtils.GetEnvironment(catalog), keys, values, InputOutputColumnPair.ConvertToValueTuples(columns));
         }
 
         /// <summary>
@@ -320,12 +304,12 @@ namespace Microsoft.ML
             this TransformsCatalog.ConversionTransforms catalog,
             IEnumerable<KeyValuePair<TInputType, TOutputType>> keyValuePairs,
             bool treatValuesAsKeyType,
-            params ColumnOptions[] columns)
+            params InputOutputColumnPair[] columns)
         {
             var keys = keyValuePairs.Select(pair => pair.Key);
             var values = keyValuePairs.Select(pair => pair.Value);
             return new ValueMappingEstimator<TInputType, TOutputType>(CatalogUtils.GetEnvironment(catalog), keys, values, treatValuesAsKeyType,
-                  ColumnOptions.ConvertToValueTuples(columns));
+                  InputOutputColumnPair.ConvertToValueTuples(columns));
         }
 
         /// <summary>
@@ -381,12 +365,12 @@ namespace Microsoft.ML
         internal static ValueMappingEstimator<TInputType, TOutputType> MapValue<TInputType, TOutputType>(
             this TransformsCatalog.ConversionTransforms catalog,
             IEnumerable<KeyValuePair<TInputType, TOutputType[]>> keyValuePairs,
-            params ColumnOptions[] columns)
+            params InputOutputColumnPair[] columns)
         {
             var keys = keyValuePairs.Select(pair => pair.Key);
             var values = keyValuePairs.Select(pair => pair.Value);
             return new ValueMappingEstimator<TInputType, TOutputType>(CatalogUtils.GetEnvironment(catalog), keys, values,
-                    ColumnOptions.ConvertToValueTuples(columns));
+                    InputOutputColumnPair.ConvertToValueTuples(columns));
         }
 
         /// <summary>
@@ -437,8 +421,8 @@ namespace Microsoft.ML
         [BestFriend]
         internal static ValueMappingEstimator MapValue(
             this TransformsCatalog.ConversionTransforms catalog,
-            IDataView lookupMap, DataViewSchema.Column keyColumn, DataViewSchema.Column valueColumn, params ColumnOptions[] columns)
+            IDataView lookupMap, DataViewSchema.Column keyColumn, DataViewSchema.Column valueColumn, params InputOutputColumnPair[] columns)
             => new ValueMappingEstimator(CatalogUtils.GetEnvironment(catalog), lookupMap, keyColumn.Name, valueColumn.Name,
-                ColumnOptions.ConvertToValueTuples(columns));
+                InputOutputColumnPair.ConvertToValueTuples(columns));
     }
 }

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
@@ -16,11 +17,11 @@ namespace Microsoft.ML
         /// <summary>
         /// Name of the column to transform. If set to <see langword="null"/>, the value of the <see cref="OutputColumnName"/> will be used as source.
         /// </summary>
-        public readonly string InputColumnName;
+        public string InputColumnName { get; }
         /// <summary>
         /// Name of the column resulting from the transformation of <see cref="InputColumnName"/>.
         /// </summary>
-        public readonly string OutputColumnName;
+        public string OutputColumnName { get; }
 
         /// <summary>
         /// Specifies input and output column names for a transformation.
@@ -29,6 +30,7 @@ namespace Microsoft.ML
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         public InputOutputColumnPair(string outputColumnName, string inputColumnName = null)
         {
+            Contracts.CheckNonEmpty(outputColumnName, nameof(outputColumnName));
             InputColumnName = inputColumnName ?? outputColumnName;
             OutputColumnName = outputColumnName;
         }
@@ -76,7 +78,11 @@ namespace Microsoft.ML
         /// </example>
         [BestFriend]
         internal static ColumnCopyingEstimator CopyColumns(this TransformsCatalog catalog, params InputOutputColumnPair[] columns)
-            => new ColumnCopyingEstimator(CatalogUtils.GetEnvironment(catalog), InputOutputColumnPair.ConvertToValueTuples(columns));
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new ColumnCopyingEstimator(env, InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
 
         /// <summary>
         /// Concatenates columns together.

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -11,6 +11,32 @@ namespace Microsoft.ML
     /// <summary>
     /// Specifies input and output column names for a transformation.
     /// </summary>
+    public sealed class InputOutputColumnPair
+    {
+        /// <summary>
+        /// Name of the column to transform. If set to <see langword="null"/>, the value of the <see cref="OutputColumnName"/> will be used as source.
+        /// </summary>
+        public readonly string InputColumnName;
+        /// <summary>
+        /// Name of the column resulting from the transformation of <see cref="InputColumnName"/>.
+        /// </summary>
+        public readonly string OutputColumnName;
+
+        /// <summary>
+        /// Specifies input and output column names for a transformation.
+        /// </summary>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
+        public InputOutputColumnPair(string outputColumnName, string inputColumnName = null)
+        {
+            InputColumnName = inputColumnName;
+            OutputColumnName = outputColumnName;
+        }
+    }
+
+    /// <summary>
+    /// Specifies input and output column names for a transformation.
+    /// </summary>
     [BestFriend]
     internal sealed class ColumnOptions
     {

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -32,40 +32,11 @@ namespace Microsoft.ML
             InputColumnName = inputColumnName ?? outputColumnName;
             OutputColumnName = outputColumnName;
         }
-    }
-
-    /// <summary>
-    /// Specifies input and output column names for a transformation.
-    /// </summary>
-    [BestFriend]
-    internal sealed class ColumnOptions
-    {
-        private readonly string _outputColumnName;
-        private readonly string _inputColumnName;
-
-        /// <summary>
-        /// Specifies input and output column names for a transformation.
-        /// </summary>
-        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
-        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
-        public ColumnOptions(string outputColumnName, string inputColumnName = null)
-        {
-            _outputColumnName = outputColumnName;
-            _inputColumnName = inputColumnName ?? outputColumnName;
-        }
-
-        /// <summary>
-        /// Instantiates a <see cref="ColumnOptions"/> from a tuple of input and output column names.
-        /// </summary>
-        public static implicit operator ColumnOptions((string outputColumnName, string inputColumnName) value)
-        {
-            return new ColumnOptions(value.outputColumnName, value.inputColumnName);
-        }
 
         [BestFriend]
-        internal static (string outputColumnName, string inputColumnName)[] ConvertToValueTuples(ColumnOptions[] infos)
+        internal static (string outputColumnName, string inputColumnName)[] ConvertToValueTuples(InputOutputColumnPair[] infos)
         {
-            return infos.Select(info => (info._outputColumnName, info._inputColumnName)).ToArray();
+            return infos.Select(info => (info.OutputColumnName, info.InputColumnName)).ToArray();
         }
     }
 
@@ -104,8 +75,8 @@ namespace Microsoft.ML
         /// </format>
         /// </example>
         [BestFriend]
-        internal static ColumnCopyingEstimator CopyColumns(this TransformsCatalog catalog, params ColumnOptions[] columns)
-            => new ColumnCopyingEstimator(CatalogUtils.GetEnvironment(catalog), ColumnOptions.ConvertToValueTuples(columns));
+        internal static ColumnCopyingEstimator CopyColumns(this TransformsCatalog catalog, params InputOutputColumnPair[] columns)
+            => new ColumnCopyingEstimator(CatalogUtils.GetEnvironment(catalog), InputOutputColumnPair.ConvertToValueTuples(columns));
 
         /// <summary>
         /// Concatenates columns together.

--- a/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ExtensionsCatalog.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         public InputOutputColumnPair(string outputColumnName, string inputColumnName = null)
         {
-            InputColumnName = inputColumnName;
+            InputColumnName = inputColumnName ?? outputColumnName;
             OutputColumnName = outputColumnName;
         }
     }

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms.Image;
 
 namespace Microsoft.ML
@@ -33,7 +34,11 @@ namespace Microsoft.ML
         /// </example>
         [BestFriend]
         internal static ImageGrayscalingEstimator ConvertToGrayscale(this TransformsCatalog catalog, params InputOutputColumnPair[] columns)
-            => new ImageGrayscalingEstimator(CatalogUtils.GetEnvironment(catalog), InputOutputColumnPair.ConvertToValueTuples(columns));
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new ImageGrayscalingEstimator(env, InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
 
         /// <summary>
         /// Loads the images from the <see cref="ImageLoadingTransformer.ImageFolder" /> into memory.
@@ -81,7 +86,11 @@ namespace Microsoft.ML
         /// </example>
         [BestFriend]
         internal static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string imageFolder, params InputOutputColumnPair[] columns)
-           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, InputOutputColumnPair.ConvertToValueTuples(columns));
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new ImageLoadingEstimator(env, imageFolder, InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
 
         /// <include file='doc.xml' path='doc/members/member[@name="ImagePixelExtractingEstimator"]/*' />
         /// <param name="catalog">The transform's catalog.</param>

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -32,8 +32,8 @@ namespace Microsoft.ML
         /// ]]></format>
         /// </example>
         [BestFriend]
-        internal static ImageGrayscalingEstimator ConvertToGrayscale(this TransformsCatalog catalog, params ColumnOptions[] columns)
-            => new ImageGrayscalingEstimator(CatalogUtils.GetEnvironment(catalog), ColumnOptions.ConvertToValueTuples(columns));
+        internal static ImageGrayscalingEstimator ConvertToGrayscale(this TransformsCatalog catalog, params InputOutputColumnPair[] columns)
+            => new ImageGrayscalingEstimator(CatalogUtils.GetEnvironment(catalog), InputOutputColumnPair.ConvertToValueTuples(columns));
 
         /// <summary>
         /// Loads the images from the <see cref="ImageLoadingTransformer.ImageFolder" /> into memory.
@@ -80,8 +80,8 @@ namespace Microsoft.ML
         /// ]]></format>
         /// </example>
         [BestFriend]
-        internal static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string imageFolder, params ColumnOptions[] columns)
-           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, ColumnOptions.ConvertToValueTuples(columns));
+        internal static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string imageFolder, params InputOutputColumnPair[] columns)
+           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, InputOutputColumnPair.ConvertToValueTuples(columns));
 
         /// <include file='doc.xml' path='doc/members/member[@name="ImagePixelExtractingEstimator"]/*' />
         /// <param name="catalog">The transform's catalog.</param>

--- a/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
@@ -59,8 +60,10 @@ namespace Microsoft.ML
                 ValueToKeyMappingEstimator.KeyOrdinality keyOrdinality = ValueToKeyMappingEstimator.Defaults.Ordinality,
                 IDataView keyData = null)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var columnOptions = columns.Select(x => new OneHotEncodingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, outputKind, maximumNumberOfKeys, keyOrdinality)).ToArray();
-            return new OneHotEncodingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions, keyData);
+            return new OneHotEncodingEstimator(env, columnOptions, keyData);
         }
 
         /// <summary>
@@ -132,8 +135,10 @@ namespace Microsoft.ML
                 bool useOrderedHashing = OneHotHashEncodingEstimator.Defaults.UseOrderedHashing,
                 int maximumNumberOfInverts = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var columnOptions = columns.Select(x => new OneHotHashEncodingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, outputKind, numberOfBits, seed, useOrderedHashing, maximumNumberOfInverts)).ToArray();
-            return new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+            return new OneHotHashEncodingEstimator(env, columnOptions);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
+++ b/src/Microsoft.ML.Transforms/CategoricalCatalog.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms;
 
@@ -39,6 +40,28 @@ namespace Microsoft.ML
                 IDataView keyData = null)
             => new OneHotEncodingEstimator(CatalogUtils.GetEnvironment(catalog),
                 new[] { new OneHotEncodingEstimator.ColumnOptions(outputColumnName, inputColumnName, outputKind, maximumNumberOfKeys, keyOrdinality) }, keyData);
+
+        /// <summary>
+        /// Convert text columns into one-hot encoded vectors.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        /// <param name="outputKind">Output kind: Bag (multi-set vector), Ind (indicator vector), Key (index), or Binary encoded indicator vector.</param>
+        /// <param name="maximumNumberOfKeys">Maximum number of terms to keep per column when auto-training.</param>
+        /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
+        /// If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+        /// <param name="keyData">Specifies an ordering for the encoding. If specified, this should be a single column data view,
+        /// and the key-values will be taken from that column. If unspecified, the ordering will be determined from the input data upon fitting.</param>
+        public static OneHotEncodingEstimator OneHotEncoding(this TransformsCatalog.CategoricalTransforms catalog,
+                InputOutputColumnPair[] columns,
+                OneHotEncodingEstimator.OutputKind outputKind = OneHotEncodingEstimator.Defaults.OutKind,
+                int maximumNumberOfKeys = ValueToKeyMappingEstimator.Defaults.MaximumNumberOfKeys,
+                ValueToKeyMappingEstimator.KeyOrdinality keyOrdinality = ValueToKeyMappingEstimator.Defaults.Ordinality,
+                IDataView keyData = null)
+        {
+            var columnOptions = columns.Select(x => new OneHotEncodingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, outputKind, maximumNumberOfKeys, keyOrdinality)).ToArray();
+            return new OneHotEncodingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions, keyData);
+        }
 
         /// <summary>
         /// Convert several text column into one-hot encoded vectors.
@@ -87,6 +110,31 @@ namespace Microsoft.ML
                 int maximumNumberOfInverts = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts)
             => new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog),
                 new[] { new OneHotHashEncodingEstimator.ColumnOptions(outputColumnName, inputColumnName, outputKind, numberOfBits, seed, useOrderedHashing, maximumNumberOfInverts) });
+
+        /// <summary>
+        /// Convert text columns into hash-based one-hot encoded vector columns.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        /// <param name="outputKind">The conversion mode.</param>
+        /// <param name="numberOfBits">Number of bits to hash into. Must be between 1 and 30, inclusive.</param>
+        /// <param name="seed">Hashing seed.</param>
+        /// <param name="useOrderedHashing">Whether the position of each term should be included in the hash.</param>
+        /// <param name="maximumNumberOfInverts">During hashing we constuct mappings between original values and the produced hash values.
+        /// Text representation of original values are stored in the slot names of the  metadata for the new column.Hashing, as such, can map many initial values to one.
+        /// <paramref name="maximumNumberOfInverts"/> specifies the upper bound of the number of distinct input values mapping to a hash that should be retained.
+        /// <value>0</value> does not retain any input values. <value>-1</value> retains all input values mapping to each hash.</param>
+        public static OneHotHashEncodingEstimator OneHotHashEncoding(this TransformsCatalog.CategoricalTransforms catalog,
+                InputOutputColumnPair[] columns,
+                OneHotEncodingEstimator.OutputKind outputKind = OneHotEncodingEstimator.OutputKind.Indicator,
+                int numberOfBits = OneHotHashEncodingEstimator.Defaults.NumberOfBits,
+                uint seed = OneHotHashEncodingEstimator.Defaults.Seed,
+                bool useOrderedHashing = OneHotHashEncodingEstimator.Defaults.UseOrderedHashing,
+                int maximumNumberOfInverts = OneHotHashEncodingEstimator.Defaults.MaximumNumberOfInverts)
+        {
+            var columnOptions = columns.Select(x => new OneHotHashEncodingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, outputKind, numberOfBits, seed, useOrderedHashing, maximumNumberOfInverts)).ToArray();
+            return new OneHotHashEncodingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
 
         /// <summary>
         /// Convert several text column into hash-based one-hot encoded vectors.

--- a/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
@@ -20,8 +20,8 @@ namespace Microsoft.ML
         /// <param name="columns">Specifies the output and input columns on which the transformation should be applied.</param>
         [BestFriend]
         internal static KeyToBinaryVectorMappingEstimator MapKeyToBinaryVector(this TransformsCatalog.ConversionTransforms catalog,
-            params ColumnOptions[] columns)
-            => new KeyToBinaryVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), ColumnOptions.ConvertToValueTuples(columns));
+            params InputOutputColumnPair[] columns)
+            => new KeyToBinaryVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), InputOutputColumnPair.ConvertToValueTuples(columns));
 
         /// <summary>
         ///  Convert the key types back to binary vector.

--- a/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
@@ -21,7 +22,11 @@ namespace Microsoft.ML
         [BestFriend]
         internal static KeyToBinaryVectorMappingEstimator MapKeyToBinaryVector(this TransformsCatalog.ConversionTransforms catalog,
             params InputOutputColumnPair[] columns)
-            => new KeyToBinaryVectorMappingEstimator(CatalogUtils.GetEnvironment(catalog), InputOutputColumnPair.ConvertToValueTuples(columns));
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new KeyToBinaryVectorMappingEstimator(env, InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
 
         /// <summary>
         ///  Convert the key types back to binary vector.

--- a/src/Microsoft.ML.Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ExtensionsCatalog.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
@@ -38,7 +39,11 @@ namespace Microsoft.ML
         /// <param name="catalog">The transform extensions' catalog.</param>
         /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
         public static MissingValueIndicatorEstimator IndicateMissingValues(this TransformsCatalog catalog, InputOutputColumnPair[] columns)
-            => new MissingValueIndicatorEstimator(CatalogUtils.GetEnvironment(catalog), columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new MissingValueIndicatorEstimator(env, columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
+        }
 
         /// <summary>
         /// Creates a new output column, or replaces the source with a new column
@@ -83,8 +88,10 @@ namespace Microsoft.ML
             MissingValueReplacingEstimator.ReplacementMode replacementMode = MissingValueReplacingEstimator.Defaults.Mode,
             bool imputeBySlot = MissingValueReplacingEstimator.Defaults.ImputeBySlot)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var columnOptions = columns.Select(x => new MissingValueReplacingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, replacementMode, imputeBySlot)).ToArray();
-            return new MissingValueReplacingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+            return new MissingValueReplacingEstimator(env, columnOptions);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Transforms/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ExtensionsCatalog.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms;
 
@@ -9,17 +10,6 @@ namespace Microsoft.ML
 {
     public static class ExtensionsCatalog
     {
-        /// <summary>
-        /// Creates a new output column, of boolean type, with the same number of slots as the input column. The value in the output column
-        /// is true if the value in the input column is missing.
-        /// </summary>
-        /// <param name="catalog">The transform extensions' catalog.</param>
-        /// <param name="columns">The names of the input columns of the transformation and the corresponding names for the output columns.</param>
-        [BestFriend]
-        internal static MissingValueIndicatorEstimator IndicateMissingValues(this TransformsCatalog catalog,
-            params ColumnOptions[] columns)
-            => new MissingValueIndicatorEstimator(CatalogUtils.GetEnvironment(catalog), ColumnOptions.ConvertToValueTuples(columns));
-
         /// <summary>
         /// Creates a new output column, or replaces the source with a new column
         /// (depending on whether the <paramref name="inputColumnName"/> is given a value, or left to null)
@@ -40,6 +30,15 @@ namespace Microsoft.ML
             string outputColumnName,
             string inputColumnName = null)
             => new MissingValueIndicatorEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName);
+
+        /// <summary>
+        /// Creates a new output column, of boolean type, with the same number of slots as the input column. The value in the output column
+        /// is true if the value in the input column is missing.
+        /// </summary>
+        /// <param name="catalog">The transform extensions' catalog.</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        public static MissingValueIndicatorEstimator IndicateMissingValues(this TransformsCatalog catalog, InputOutputColumnPair[] columns)
+            => new MissingValueIndicatorEstimator(CatalogUtils.GetEnvironment(catalog), columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
 
         /// <summary>
         /// Creates a new output column, or replaces the source with a new column
@@ -68,6 +67,25 @@ namespace Microsoft.ML
             MissingValueReplacingEstimator.ReplacementMode replacementMode = MissingValueReplacingEstimator.Defaults.Mode,
             bool imputeBySlot = MissingValueReplacingEstimator.Defaults.ImputeBySlot)
         => new MissingValueReplacingEstimator(CatalogUtils.GetEnvironment(catalog), new[] { new MissingValueReplacingEstimator.ColumnOptions(outputColumnName, inputColumnName, replacementMode, imputeBySlot) });
+
+        /// <summary>
+        /// Creates a new output column, identical to the input column for everything but the missing values.
+        /// The missing values of the input column, in this new column are replaced with <see cref="MissingValueReplacingEstimator.ReplacementMode.DefaultValue"/>.
+        /// </summary>
+        /// <param name="catalog">The transform extensions' catalog.</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        /// <param name="replacementMode">The type of replacement to use as specified in <see cref="MissingValueReplacingEstimator.ReplacementMode"/></param>
+        /// <param name="imputeBySlot">If true, per-slot imputation of replacement is performed.
+        /// Otherwise, replacement value is imputed for the entire vector column. This setting is ignored for scalars and variable vectors,
+        /// where imputation is always for the entire column.</param>
+        public static MissingValueReplacingEstimator ReplaceMissingValues(this TransformsCatalog catalog,
+            InputOutputColumnPair[] columns,
+            MissingValueReplacingEstimator.ReplacementMode replacementMode = MissingValueReplacingEstimator.Defaults.Mode,
+            bool imputeBySlot = MissingValueReplacingEstimator.Defaults.ImputeBySlot)
+        {
+            var columnOptions = columns.Select(x => new MissingValueReplacingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, replacementMode, imputeBySlot)).ToArray();
+            return new MissingValueReplacingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
 
         /// <summary>
         /// Creates a new output column, identical to the input column for everything but the missing values.

--- a/src/Microsoft.ML.Transforms/FeatureSelectionCatalog.cs
+++ b/src/Microsoft.ML.Transforms/FeatureSelectionCatalog.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
@@ -45,8 +46,12 @@ namespace Microsoft.ML
             string labelColumnName = MutualInfoSelectDefaults.LabelColumn,
             int slotsInOutput = MutualInfoSelectDefaults.SlotsInOutput,
             int numberOfBins = MutualInfoSelectDefaults.NumBins)
-            => new MutualInformationFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), labelColumnName, slotsInOutput, numberOfBins,
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new MutualInformationFeatureSelectingEstimator(env, labelColumnName, slotsInOutput, numberOfBins,
                 columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
+        }
 
         /// <include file='doc.xml' path='doc/members/member[@name="CountFeatureSelection"]' />
         /// <param name="catalog">The transform's catalog.</param>
@@ -89,8 +94,10 @@ namespace Microsoft.ML
             InputOutputColumnPair[] columns,
             long count = CountSelectDefaults.Count)
         {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
             var columnOptions = columns.Select(x => new CountFeatureSelectingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, count)).ToArray();
-            return new CountFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+            return new CountFeatureSelectingEstimator(env, columnOptions);
         }
     }
 }

--- a/src/Microsoft.ML.Transforms/FeatureSelectionCatalog.cs
+++ b/src/Microsoft.ML.Transforms/FeatureSelectionCatalog.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms;
 
@@ -12,28 +13,6 @@ namespace Microsoft.ML
 
     public static class FeatureSelectionCatalog
     {
-        /// <include file='doc.xml' path='doc/members/member[@name="MutualInformationFeatureSelection"]/*' />
-        /// <param name="catalog">The transform's catalog.</param>
-        /// <param name="labelColumnName">The name of the label column.</param>
-        /// <param name="slotsInOutput">The maximum number of slots to preserve in the output. The number of slots to preserve is taken across all input columns.</param>
-        /// <param name="numberOfBins">Max number of bins used to approximate mutual information between each input column and the label column. Power of 2 recommended.</param>
-        /// <param name="columns">Specifies the names of the input columns for the transformation, and their respective output column names.</param>
-        /// <example>
-        /// <format type="text/markdown">
-        /// <![CDATA[
-        /// [!code-csharp[SelectFeaturesBasedOnMutualInformation](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureSelectionTransform.cs?range=1-4,10-121)]
-        /// ]]>
-        /// </format>
-        /// </example>
-        [BestFriend]
-        internal static MutualInformationFeatureSelectingEstimator SelectFeaturesBasedOnMutualInformation(this TransformsCatalog.FeatureSelectionTransforms catalog,
-            string labelColumnName = MutualInfoSelectDefaults.LabelColumn,
-            int slotsInOutput = MutualInfoSelectDefaults.SlotsInOutput,
-            int numberOfBins = MutualInfoSelectDefaults.NumBins,
-            params ColumnOptions[] columns)
-            => new MutualInformationFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), labelColumnName, slotsInOutput, numberOfBins,
-                ColumnOptions.ConvertToValueTuples(columns));
-
         /// <include file='doc.xml' path='doc/members/member[@name="MutualInformationFeatureSelection"]/*' />
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
@@ -54,6 +33,20 @@ namespace Microsoft.ML
             int slotsInOutput = MutualInfoSelectDefaults.SlotsInOutput,
             int numberOfBins = MutualInfoSelectDefaults.NumBins)
             => new MutualInformationFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, labelColumnName, slotsInOutput, numberOfBins);
+
+        /// <include file='doc.xml' path='doc/members/member[@name="MutualInformationFeatureSelection"]/*' />
+        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="columns">Specifies the names of the input columns for the transformation, and their respective output column names.</param>
+        /// <param name="labelColumnName">The name of the label column.</param>
+        /// <param name="slotsInOutput">The maximum number of slots to preserve in the output. The number of slots to preserve is taken across all input columns.</param>
+        /// <param name="numberOfBins">Max number of bins used to approximate mutual information between each input column and the label column. Power of 2 recommended.</param>
+        public static MutualInformationFeatureSelectingEstimator SelectFeaturesBasedOnMutualInformation(this TransformsCatalog.FeatureSelectionTransforms catalog,
+            InputOutputColumnPair[] columns,
+            string labelColumnName = MutualInfoSelectDefaults.LabelColumn,
+            int slotsInOutput = MutualInfoSelectDefaults.SlotsInOutput,
+            int numberOfBins = MutualInfoSelectDefaults.NumBins)
+            => new MutualInformationFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), labelColumnName, slotsInOutput, numberOfBins,
+                columns.Select(x => (x.OutputColumnName, x.InputColumnName)).ToArray());
 
         /// <include file='doc.xml' path='doc/members/member[@name="CountFeatureSelection"]' />
         /// <param name="catalog">The transform's catalog.</param>
@@ -87,5 +80,17 @@ namespace Microsoft.ML
             string inputColumnName = null,
             long count = CountSelectDefaults.Count)
             => new CountFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, count);
+
+        /// <include file='doc.xml' path='doc/members/member[@name="CountFeatureSelection"]' />
+        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="columns">Specifies the names of the columns on which to apply the transformation.</param>
+        /// <param name="count">If the count of non-default values for a slot is greater than or equal to this threshold in the training data, the slot is preserved.</param>
+        public static CountFeatureSelectingEstimator SelectFeaturesBasedOnCount(this TransformsCatalog.FeatureSelectionTransforms catalog,
+            InputOutputColumnPair[] columns,
+            long count = CountSelectDefaults.Count)
+        {
+            var columnOptions = columns.Select(x => new CountFeatureSelectingEstimator.ColumnOptions(x.OutputColumnName, x.InputColumnName, count)).ToArray();
+            return new CountFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
     }
 }

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.ML.Data;
+using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML
@@ -44,7 +45,11 @@ namespace Microsoft.ML
         internal static NormalizingEstimator Normalize(this TransformsCatalog catalog,
             NormalizingEstimator.NormalizationMode mode,
             params InputOutputColumnPair[] columns)
-            => new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), mode, InputOutputColumnPair.ConvertToValueTuples(columns));
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new NormalizingEstimator(env, mode, InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
 
         /// <summary>
         /// Normalize (rescale) columns according to specified custom parameters.

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -43,8 +43,8 @@ namespace Microsoft.ML
         [BestFriend]
         internal static NormalizingEstimator Normalize(this TransformsCatalog catalog,
             NormalizingEstimator.NormalizationMode mode,
-            params ColumnOptions[] columns)
-            => new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), mode, ColumnOptions.ConvertToValueTuples(columns));
+            params InputOutputColumnPair[] columns)
+            => new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), mode, InputOutputColumnPair.ConvertToValueTuples(columns));
 
         /// <summary>
         /// Normalize (rescale) columns according to specified custom parameters.

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -75,8 +75,8 @@ namespace Microsoft.ML
         [BestFriend]
         internal static TokenizingByCharactersEstimator TokenizeIntoCharactersAsKeys(this TransformsCatalog.TextTransforms catalog,
             bool useMarkerCharacters = CharTokenizingDefaults.UseMarkerCharacters,
-            params ColumnOptions[] columns)
-            => new TokenizingByCharactersEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(), useMarkerCharacters, ColumnOptions.ConvertToValueTuples(columns));
+            params InputOutputColumnPair[] columns)
+            => new TokenizingByCharactersEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(), useMarkerCharacters, InputOutputColumnPair.ConvertToValueTuples(columns));
 
         /// <summary>
         /// Normalizes incoming text in <paramref name="inputColumnName"/> by changing case, removing diacritical marks, punctuation marks and/or numbers

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -76,7 +76,11 @@ namespace Microsoft.ML
         internal static TokenizingByCharactersEstimator TokenizeIntoCharactersAsKeys(this TransformsCatalog.TextTransforms catalog,
             bool useMarkerCharacters = CharTokenizingDefaults.UseMarkerCharacters,
             params InputOutputColumnPair[] columns)
-            => new TokenizingByCharactersEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(), useMarkerCharacters, InputOutputColumnPair.ConvertToValueTuples(columns));
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new TokenizingByCharactersEstimator(env, useMarkerCharacters, InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
 
         /// <summary>
         /// Normalizes incoming text in <paramref name="inputColumnName"/> by changing case, removing diacritical marks, punctuation marks and/or numbers

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -187,7 +187,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             // 		[2]	-9.709775	float
 
             // Apply the inverse conversion from 'PredictedLabel' column back to string value.
-            var finalPipeline = pipeline.Append(mlContext.Transforms.Conversion.MapKeyToValue(("Data", "PredictedLabel")));
+            var finalPipeline = pipeline.Append(mlContext.Transforms.Conversion.MapKeyToValue("Data", "PredictedLabel"));
             dataPreview = finalPipeline.Preview(trainData);
 
             return finalPipeline.Fit(trainData);

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Scenarios
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.MulticlassClassification.Trainers.SdcaCalibrated(
                     new SdcaCalibratedMulticlassTrainer.Options { NumberOfThreads = 1 }))
-                .Append(mlContext.Transforms.Conversion.MapKeyToValue(("Plant", "PredictedLabel")));
+                .Append(mlContext.Transforms.Conversion.MapKeyToValue("Plant", "PredictedLabel"));
 
             // Train the pipeline
             var trainedModel = pipe.Fit(trainData);

--- a/test/Microsoft.ML.Tests/Transformers/CategoricalTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CategoricalTests.cs
@@ -300,9 +300,9 @@ namespace Microsoft.ML.Tests.Transformers
             var data = new[] { new TestClass() { A = 1, B = 2, C = 3, }, new TestClass() { A = 4, B = 5, C = 6 } };
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Categorical.OneHotEncoding(new[]{
-                    new OneHotEncodingEstimator.ColumnOptions("TermA", "A"),
-                    new OneHotEncodingEstimator.ColumnOptions("TermB", "B"),
-                    new OneHotEncodingEstimator.ColumnOptions("TermC", "C")
+                    new InputOutputColumnPair("TermA", "A"),
+                    new InputOutputColumnPair("TermB", "B"),
+                    new InputOutputColumnPair("TermC", "C")
             });
             var result = pipe.Fit(dataView).Transform(dataView);
             var resultRoles = new RoleMappedData(result);

--- a/test/Microsoft.ML.Tests/Transformers/FeatureSelectionTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/FeatureSelectionTests.cs
@@ -182,9 +182,9 @@ namespace Microsoft.ML.Tests.Transformers
 
             var est = ML.Transforms.FeatureSelection.SelectFeaturesBasedOnMutualInformation("FeatureSelect", "VectorFloat", slotsInOutput: 1, labelColumnName: "Label")
                 .Append(ML.Transforms.FeatureSelection.SelectFeaturesBasedOnMutualInformation(labelColumnName: "Label", slotsInOutput: 2, numberOfBins: 100,
-                    columns: new ColumnOptions[] {
-                        ("out1", "VectorFloat"),
-                        ("out2", "VectorDouble")
+                    columns: new[] {
+                        new InputOutputColumnPair("out1", "VectorFloat"),
+                        new InputOutputColumnPair("out2", "VectorDouble")
                     }));
             TestEstimatorCore(est, data);
 

--- a/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
+++ b/test/Microsoft.ML.Tests/Transformers/KeyToBinaryVectorEstimatorTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Tests.Transformers
                     new ValueToKeyMappingEstimator.ColumnOptions("TermC", "C", addKeyValueAnnotationsAsText:true)
                 }).Fit(dataView).Transform(dataView);
 
-            var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(("CatA", "TermA"), ("CatC", "TermC"));
+            var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(new[] { new InputOutputColumnPair("CatA", "TermA"), new InputOutputColumnPair("CatC", "TermC") });
             TestEstimatorCore(pipe, dataView);
             Done();
         }
@@ -105,7 +105,12 @@ namespace Microsoft.ML.Tests.Transformers
             var termTransformer = termEst.Fit(dataView);
             dataView = termTransformer.Transform(dataView);
 
-            var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(("CatA", "TA"), ("CatB", "TB"), ("CatC", "TC"), ("CatD", "TD"));
+            var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(new[] {
+                new InputOutputColumnPair("CatA", "TA"),
+                new InputOutputColumnPair("CatB", "TB"),
+                new InputOutputColumnPair("CatC", "TC"),
+                new InputOutputColumnPair("CatD", "TD")
+            });
 
             var result = pipe.Fit(dataView).Transform(dataView);
             ValidateMetadata(result);
@@ -155,7 +160,7 @@ namespace Microsoft.ML.Tests.Transformers
             });
             var transformer = est.Fit(dataView);
             dataView = transformer.Transform(dataView);
-            var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(("CatA", "TermA"), ("CatB", "TermB"), ("CatC", "TermC"));
+            var pipe = ML.Transforms.Conversion.MapKeyToBinaryVector(new[] { new InputOutputColumnPair("CatA", "TermA"), new InputOutputColumnPair("CatB", "TermB"), new InputOutputColumnPair("CatC", "TermC") });
             var result = pipe.Fit(dataView).Transform(dataView);
             var resultRoles = new RoleMappedData(result);
             using (var ms = new MemoryStream())

--- a/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NAIndicatorTests.cs
@@ -44,7 +44,12 @@ namespace Microsoft.ML.Tests.Transformers
             };
 
             var dataView = ML.Data.LoadFromEnumerable(data);
-            var pipe = ML.Transforms.IndicateMissingValues(new ColumnOptions[] { ("NAA", "A"), ("NAB", "B"), ("NAC", "C"), ("NAD", "D") });
+            var pipe = ML.Transforms.IndicateMissingValues(new[] {
+                new InputOutputColumnPair("NAA", "A"),
+                new InputOutputColumnPair("NAB", "B"),
+                new InputOutputColumnPair("NAC", "C"),
+                new InputOutputColumnPair("NAD", "D")
+            });
             TestEstimatorCore(pipe, dataView);
             Done();
         }
@@ -67,7 +72,12 @@ namespace Microsoft.ML.Tests.Transformers
             };
 
             var dataView = ML.Data.LoadFromEnumerable(data);
-            var pipe = ML.Transforms.IndicateMissingValues(new ColumnOptions[] { ("NAA", "A"), ("NAB", "B"), ("NAC", "C"), ("NAD", "D") });
+            var pipe = ML.Transforms.IndicateMissingValues(new[] {
+                new InputOutputColumnPair("NAA", "A"),
+                new InputOutputColumnPair("NAB", "B"),
+                new InputOutputColumnPair("NAC", "C"),
+                new InputOutputColumnPair("NAD", "D")
+            });
             var result = pipe.Fit(dataView).Transform(dataView);
             var resultRoles = new RoleMappedData(result);
             using (var ms = new MemoryStream())
@@ -92,10 +102,12 @@ namespace Microsoft.ML.Tests.Transformers
             var data = reader.Load(new MultiFileSource(dataPath)).AsDynamic;
             var wrongCollection = new[] { new TestClass() { A = 1, B = 3, C = new float[2] { 1, 2 }, D = new double[2] { 3, 4 } } };
             var invalidData = ML.Data.LoadFromEnumerable(wrongCollection);
-            var est = ML.Transforms.IndicateMissingValues(new ColumnOptions[] 
+            var est = ML.Transforms.IndicateMissingValues(new[] 
             {
-                ("A", "ScalarFloat"), ("B", "ScalarDouble"),
-                ("C", "VectorFloat"), ("D", "VectorDoulbe")
+                new InputOutputColumnPair("A", "ScalarFloat"),
+                new InputOutputColumnPair("B", "ScalarDouble"),
+                new InputOutputColumnPair("C", "VectorFloat"),
+                new InputOutputColumnPair("D", "VectorDoulbe")
             });
 
             TestEstimatorCore(est, data, invalidInput: invalidData);
@@ -125,7 +137,7 @@ namespace Microsoft.ML.Tests.Transformers
 
             var dataView = ML.Data.LoadFromEnumerable(data);
             var pipe = ML.Transforms.Categorical.OneHotEncoding("CatA", "A");
-            var newpipe = pipe.Append(ML.Transforms.IndicateMissingValues(("NAA", "CatA")));
+            var newpipe = pipe.Append(ML.Transforms.IndicateMissingValues("NAA", "CatA"));
             var result = newpipe.Fit(dataView).Transform(dataView);
             Assert.True(result.Schema.TryGetColumnIndex("NAA", out var col));
             // Check that the column is normalized.

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -225,7 +225,7 @@ namespace Microsoft.ML.Tests.Transformers
             var est1 = new NormalizingEstimator(Env, "float4");
             var est2 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.MinMax, ("float4", "float4"));
             var est3 = new NormalizingEstimator(Env, new NormalizingEstimator.MinMaxColumnOptions("float4"));
-            var est4 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.MinMax, ("float4", "float4"));
+            var est4 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.MinMax);
             var est5 = ML.Transforms.Normalize("float4");
 
             var data1 = est1.Fit(data).Transform(data);
@@ -246,7 +246,7 @@ namespace Microsoft.ML.Tests.Transformers
             // Tests for MeanVariance
             var est6 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.MeanVariance, ("float4", "float4"));
             var est7 = new NormalizingEstimator(Env, new NormalizingEstimator.MeanVarianceColumnOptions("float4"));
-            var est8 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.MeanVariance, ("float4", "float4"));
+            var est8 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.MeanVariance);
 
             var data6 = est6.Fit(data).Transform(data);
             var data7 = est7.Fit(data).Transform(data);
@@ -259,7 +259,7 @@ namespace Microsoft.ML.Tests.Transformers
             // Tests for LogMeanVariance
             var est9 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.LogMeanVariance, ("float4", "float4"));
             var est10 = new NormalizingEstimator(Env, new NormalizingEstimator.LogMeanVarianceColumnOptions("float4"));
-            var est11 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.LogMeanVariance, ("float4", "float4"));
+            var est11 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.LogMeanVariance);
 
             var data9 = est9.Fit(data).Transform(data);
             var data10 = est10.Fit(data).Transform(data);
@@ -272,7 +272,7 @@ namespace Microsoft.ML.Tests.Transformers
             // Tests for Binning
             var est12 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.Binning, ("float4", "float4"));
             var est13 = new NormalizingEstimator(Env, new NormalizingEstimator.BinningColumnOptions("float4"));
-            var est14 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.Binning, ("float4", "float4"));
+            var est14 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.Binning);
 
             var data12 = est12.Fit(data).Transform(data);
             var data13 = est13.Fit(data).Transform(data);
@@ -285,7 +285,7 @@ namespace Microsoft.ML.Tests.Transformers
             // Tests for SupervisedBinning
             var est15 = new NormalizingEstimator(Env, NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
             var est16 = new NormalizingEstimator(Env, new NormalizingEstimator.SupervisedBinningColumOptions("float4"));
-            var est17 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
+            var est17 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.SupervisedBinning);
 
             var data15 = est15.Fit(data).Transform(data);
             var data16 = est16.Fit(data).Transform(data);
@@ -314,11 +314,11 @@ namespace Microsoft.ML.Tests.Transformers
             var data = loader.Load(dataPath);
 
             // Normalizer Extensions
-            var est1 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.MinMax, ("float4", "float4"));
-            var est2 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.MeanVariance, ("float4", "float4"));
-            var est3 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.LogMeanVariance, ("float4", "float4")); 
-            var est4 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.Binning, ("float4", "float4")); 
-            var est5 = ML.Transforms.Normalize(NormalizingEstimator.NormalizationMode.SupervisedBinning, ("float4", "float4"));
+            var est1 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.MinMax);
+            var est2 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.MeanVariance);
+            var est3 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.LogMeanVariance); 
+            var est4 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.Binning); 
+            var est5 = ML.Transforms.Normalize("float4", "float4", NormalizingEstimator.NormalizationMode.SupervisedBinning);
 
             // Normalizer Extensions (Experimental)
             var est6 = ML.Transforms.NormalizeMinMax("float4", "float4");

--- a/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/ValueMappingTests.cs
@@ -515,7 +515,7 @@ namespace Microsoft.ML.Tests.Transformers
                 };
 
             // Workout on value mapping
-            var est = ML.Transforms.Conversion.MapValue(keyValuePairs, new ColumnOptions[] { ("D", "A"), ("E", "B"), ("F", "C") });
+            var est = ML.Transforms.Conversion.MapValue(keyValuePairs, new[] { new InputOutputColumnPair("D", "A"), new InputOutputColumnPair("E", "B"), new InputOutputColumnPair("F", "C") });
             TestEstimatorCore(est, validFitInput: dataView, invalidInput: badDataView);
         }
 
@@ -534,7 +534,7 @@ namespace Microsoft.ML.Tests.Transformers
                 };
 
             // Workout on value mapping
-            var est = ML.Transforms.Conversion.MapValue(keyValuePairs, new ColumnOptions[] { ("D", "A"), ("E", "B"), ("F", "C") });
+            var est = ML.Transforms.Conversion.MapValue(keyValuePairs, new[] { new InputOutputColumnPair("D", "A"), new InputOutputColumnPair("E", "B"), new InputOutputColumnPair("F", "C") });
             TestEstimatorCore(est, validFitInput: dataView, invalidInput: badDataView);
         }
 
@@ -555,7 +555,7 @@ namespace Microsoft.ML.Tests.Transformers
                 };
 
             var est = ML.Transforms.Text.TokenizeIntoWords("TokenizeB", "B")
-                .Append(ML.Transforms.Conversion.MapValue(keyValuePairs, new ColumnOptions[] { ("VecB", "TokenizeB") }));
+                .Append(ML.Transforms.Conversion.MapValue("VecB", keyValuePairs, "TokenizeB"));
             TestEstimatorCore(est, validFitInput: dataView, invalidInput: badDataView);
         }
 


### PR DESCRIPTION
Adding multicolumn mapping for some estimators (as per list by @TomFinley and @glebuk):

- OneHotEncodingEstimator
- TypeConvertingEstimator
- KeyToVectorMappingEstimator
- ValueToKeyMappingEstimator
- OneHotHashEncodingEstimator
- MissingValueEstimator
- FeatureSelectionCatalog.*
- KeyToValueMappingEstiamtor

Leaving out:
- TextFeaturizingEstimator (probably requires column specific settings most of the time)
- NoramlizingEstiamtor (in experimental nuget)


Let me know if I should add more estimators.

Fixes #3068
Related to #2884 

