### PR TITLE
TextLoader throws when type is missing LoadColumnAttribute

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1460,7 +1460,8 @@ namespace Microsoft.ML.Data
                 var memberInfo = memberInfos[index];
                 var mappingAttr = memberInfo.GetCustomAttribute<LoadColumnAttribute>();
 
-                host.Assert(mappingAttr != null, $"Field or property {memberInfo.Name} is missing the {nameof(LoadColumnAttribute)} attribute");
+                if (mappingAttr == null)
+                    throw host.Except($"{(memberInfo is FieldInfo ? "Field" : "Property")} '{memberInfo.Name}' is missing the {nameof(LoadColumnAttribute)} attribute");
 
                 var mappingAttrName = memberInfo.GetCustomAttribute<ColumnNameAttribute>();
 

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -617,8 +617,6 @@ namespace Microsoft.ML.EntryPoints.Tests
             {
                 Assert.Contains($"Property 'Feature' is missing the {nameof(LoadColumnAttribute)} attribute", e.Message);
             }
-
-
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -589,34 +589,8 @@ namespace Microsoft.ML.EntryPoints.Tests
         public void ThrowsExceptionWithPropertyName()
         {
             var mlContext = new MLContext(seed: 1);
-            try
-            {
-                mlContext.Data.LoadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt");
-            }
-            // REVIEW: the issue of different exceptions being thrown is tracked under #2037.
-            catch (Xunit.Sdk.TrueException) { }
-            catch (NullReferenceException) { };
-        }
-
-        public class DataWithNoAttribute
-        {
-            [LoadColumn(0)]
-            public float Label { get; set; }
-            public float Feature { get; set; }
-        }
-
-        [Fact]
-        public void ThrowsExceptionWithNoColumnAttribute()
-        {
-            var mlContext = new MLContext(seed: 1);
-            try
-            {
-                var data = mlContext.Data.LoadFromTextFile<DataWithNoAttribute>("path.txt");
-            }
-            catch (InvalidOperationException e)
-            {
-                Assert.Contains($"Property 'Feature' is missing the {nameof(LoadColumnAttribute)} attribute", e.Message);
-            }
+            var ex = Assert.Throws<InvalidOperationException>(() => mlContext.Data.LoadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt"));
+            Assert.StartsWith($"Field 'String1' is missing the {nameof(LoadColumnAttribute)} attribute", ex.Message);
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -598,6 +598,29 @@ namespace Microsoft.ML.EntryPoints.Tests
             catch (NullReferenceException) { };
         }
 
+        public class DataWithNoAttribute
+        {
+            [LoadColumn(0)]
+            public float Label { get; set; }
+            public float Feature { get; set; }
+        }
+
+        [Fact]
+        public void ThrowsExceptionWithNoColumnAttribute()
+        {
+            var mlContext = new MLContext(seed: 1);
+            try
+            {
+                var data = mlContext.Data.LoadFromTextFile<DataWithNoAttribute>("path.txt");
+            }
+            catch (InvalidOperationException e)
+            {
+                Assert.Contains($"Property 'Feature' is missing the {nameof(LoadColumnAttribute)} attribute", e.Message);
+            }
+
+
+        }
+
         [Fact]
         public void ParseSchemaFromTextFile()
         {


### PR DESCRIPTION
Fixes #3051.

Edit: This also fixes #2037.