### PR TITLE
Internalize LpNorm column options.

### DIFF
--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -192,7 +192,7 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// The objects describing how the transformation is applied on the input data.
         /// </summary>
-        public IReadOnlyCollection<LpNormNormalizingEstimatorBase.ColumnOptionsBase> Columns => _columns.AsReadOnly();
+        internal IReadOnlyCollection<LpNormNormalizingEstimatorBase.ColumnOptionsBase> Columns => _columns.AsReadOnly();
         private readonly LpNormNormalizingEstimatorBase.ColumnOptionsBase[] _columns;
 
         private static (string outputColumnName, string inputColumnName)[] GetColumnPairs(LpNormNormalizingEstimatorBase.ColumnOptionsBase[] columns)
@@ -671,7 +671,7 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// Describes base class for one column pair.
         /// </summary>
-        public abstract class ColumnOptionsBase
+        internal abstract class ColumnOptionsBase
         {
             /// <summary>
             /// Name of the column resulting from the transformation of <see cref="InputColumnName"/>.
@@ -812,7 +812,7 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// Describes how the transformer handles one column pair.
         /// </summary>
-        public sealed class ColumnOptions : ColumnOptionsBase
+        internal sealed class ColumnOptions : ColumnOptionsBase
         {
             /// <summary>
             /// Describes how the transformer handles one column pair.
@@ -868,7 +868,7 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// Describes how the transformer handles one Gcn column pair.
         /// </summary>
-        public sealed class ColumnOptions : ColumnOptionsBase
+        internal sealed class ColumnOptions : ColumnOptionsBase
         {
             /// <summary>
             /// Describes how the transformer handles one Gcn column pair.


### PR DESCRIPTION
Small refinement of the PR #2959. I noticed that a few of the `ColumnOptions` classes, including a base class, were still appearing in the public API. Also hide the `IReadOnlyList<...>` to access it through the columns as we do not want to do that per @Ivanidzo4ka.