### PR TITLE
Fixing API call in LoadImages sample

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, "ImageObject", "ImagePath")
+            var pipeline = mlContext.Transforms.LoadImages("ImageObject", imagesFolder, "ImagePath")
                            .Append(mlContext.Transforms.ConvertToGrayscale("Grayscale", "ImageObject"));
 
             var transformedData = pipeline.Fit(data).Transform(data);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/DnnFeaturizeImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/DnnFeaturizeImage.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
 using Microsoft.ML.Data;
-using Microsoft.ML.Transforms.Onnx;
 
 namespace Microsoft.ML.Samples.Dynamic
 {
@@ -40,7 +39,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Installing the Microsoft.ML.DNNImageFeaturizer packages copies the models in the
             // `DnnImageModels` folder. 
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, "ImageObject", "ImagePath")
+            var pipeline = mlContext.Transforms.LoadImages("ImageObject", imagesFolder, "ImagePath")
                           .Append(mlContext.Transforms.ResizeImages("ImageObject", imageWidth: 224, imageHeight: 224))
                           .Append(mlContext.Transforms.ExtractPixels("Pixels", "ImageObject"))
                           .Append(mlContext.Transforms.DnnFeaturizeImage("FeaturizedImage", m => m.ModelSelector.ResNet18(mlContext, m.OutputColumn, m.InputColumn), "Pixels"));

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, "ImageObject", "ImagePath")
+            var pipeline = mlContext.Transforms.LoadImages("ImageObject", imagesFolder, "ImagePath")
                           .Append(mlContext.Transforms.ResizeImages("ImageObject", imageWidth: 100, imageHeight: 100 ))
                           .Append(mlContext.Transforms.ExtractPixels("Pixels", "ImageObject"));
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, "ImageReal", "ImagePath");
+            var pipeline = mlContext.Transforms.LoadImages("ImageReal", imagesFolder, "ImagePath");
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // The transformedData IDataView contains the loaded images now

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages(imagesFolder, "ImageReal", "ImagePath")
+            var pipeline = mlContext.Transforms.LoadImages("ImageReal", imagesFolder, "ImagePath")
                         .Append(mlContext.Transforms.ResizeImages("ImageReal", imageWidth: 100, imageHeight: 100));
                                 
 


### PR DESCRIPTION
The `LoadImages` sample had the wrong API call. This PR fixes it so that the sample runs correctly.

Fixes #3079 