### PR TITLE
fixing build warnings.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/Hash.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/Hash.cs
@@ -79,16 +79,16 @@ namespace Microsoft.ML.Samples.Dynamic
             // The original value of the 36205 category is MLB
         }
 
-        private class DataPoint
+        public class DataPoint
         {
-            public string Category;
-            public uint Age;
+            public string Category { get; set; }
+            public uint Age { get; set; }
         }
 
-        private class TransformedDataPoint : DataPoint
+        public class TransformedDataPoint : DataPoint
         {
-            public uint CategoryHashed;
-            public uint AgeHashed;
+            public uint CategoryHashed { get; set; }
+            public uint AgeHashed { get; set; }
         }
 
     }

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <WarningsNotAsErrors>649</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The use of the fields in the Hash sample introduced build warnings. 
Changing to properties to avoid warnings. 

