### PR TITLE
Update VBuffer documentation

### DIFF
--- a/docs/code/VBufferCareFeeding.md
+++ b/docs/code/VBufferCareFeeding.md
@@ -155,9 +155,8 @@ point, probably the first call, `value` is replaced with a `VBuffer<float>`
 that has actual values, stored in freshly allocated buffers. In subsequent
 calls, *perhaps* these are judged as insufficiently large, and new arrays are
 internally allocated, but we would expect at some point the arrays would
-become "large enough" to accommodate many values, so reallocations would
-become increasingly rare. In this way, we avoid nearly all allocations and
-garbage collection.
+become "large enough," and we would no longer have to allocate new buffers and
+garbage collect old ones after that point.
 
 A common mistake made by first time users is to do something like move the
 `var value` declaration inside the `while` loop, thus dooming `getter` to have
@@ -233,11 +232,11 @@ stores the scaled result in `dst`.
 ScaleBy(in VBuffer<float> src, ref VBuffer<float> dst, float c)
 ```
 
-What this does is, copy the values from `src` to `dst`, while scaling each
-value from `src` seen by the factor `c`.
+What this does is, copy the values from `src` to `dst` while scaling the
+values we are copying by the factor `c`.
 
 One possible alternate (wrong) implementation of this would be to just say
-`dst=src` then edit `dst` and scale its contents by `c`. But, then `dst` and
+`dst=src` then edit `dst` and scale each value by `c`. But, then `dst` and
 `src` would share references to their internal arrays, completely compromising
 the caller's ability to do anything useful with `src`: if the caller were to
 pass `dst` into some other method that modified it, this could easily

--- a/docs/code/VBufferCareFeeding.md
+++ b/docs/code/VBufferCareFeeding.md
@@ -10,43 +10,32 @@ A `VBuffer<T>` is a generic type that supports both dense and sparse vectors
 over items of type `T`. This is the representation type for all
 [`VectorType`](IDataViewTypeSystem.md#vector-representations) instances in the
 `IDataView` ecosystem. When an instance of this is passed to a row cursor
-getter, the callee is free to take ownership of and re-use the arrays
-(`Values` and `Indices`).
+getter, the callee is free to take ownership of and re-use the buffers, which
+internally are arrays, and accessed externally as `ReadOnlySpan`s through the
+`GetValues` and `GetIndices` methods.
 
-A `VBuffer<T>` is a struct, and has the following `readonly` fields:
+A `VBuffer<T>` is a struct, and has the following most important members:
 
 * `int Length`: The logical length of the buffer.
 
-* `int Count`: The number of items explicitly represented. This equals `Length`
-when the representation is dense and is less than `Length` when sparse.
+* `bool IsDense`: Whether the vector is dense (if `true`) or sparse (if
+  `false`).
 
-* `T[] Values`: The values. Only the first `Count` of these are valid.
+* `ReadOnlySpan<T> GetValues()`: The values. If `IsDense` is `true`, then this
+  is of length exactly equal to `Length`. Otherwise, it will have length less
+  than `Length`.
 
-* `int[] Indices`: The indices. For a dense representation, this array is not
-  used, and may be `null`. For a sparse representation it is parallel to
-  values and specifies the logical indices for the corresponding values. Only
-  the first `Count` of these are valid.
+* `ReadOnlySpan<int> GetIndices()`: For a dense representation, this span will
+  have length of `0`, but for a sparse representation, this will be of the
+  same length as the span returned from `GetValues()`, and be parallel to it.
 
-`Values` must have length equal to at least `Count`. If the representation is
-sparse, that is, `Count < Length`, then `Indices` must have length also
-greater than or equal to `Count`. If `Count == 0`, then it is entirely legal
-for `Values` or `Indices` to be `null`, and if dense then `Indices` can always
-be `null`.
-
-On the subject of `Count == 0`, note that having no valid values in `Indices`
-and `Values` merely means that no values are explicitly defined, and the
-vector should be treated, logically, as being filled with `default(T)`.
-
-For sparse vectors, `Indices` must have length equal to at least `Count`, and
-the first `Count` indices must be increasing, with all indices between `0`
-inclusive and `Length` exclusive.
-
-Regarding the generic type parameter `T`, the only real assumption made about
-this type is that assignment (that is, using `=`) is sufficient to create an
-*independent* copy of that item. All representation types of the [primitive
-types](IDataViewTypeSystem.md#standard-column-types) have this property (for example,
-`DvText`, `DvInt4`, `Single`, `Double`, etc.), but for example, `VBuffer<>`
-itself does not have this property. So, no `VBuffer` of `VBuffer`s for you.
+Regarding the generic type parameter `T`, the basic assumption made about this
+type is that assignment (that is, using `=`) is sufficient to create an
+*independent* copy of that  item. All representation types of the [primitive
+types](IDataViewTypeSystem.md#standard-column-types) have this property (for
+example, `ReadOnlyMemory<char>`, `int`, `float`, `double`, etc.), but for
+example, `VBuffer<>` itself does not have this property. So, no `VBuffer` of
+`VBuffer`s is possible.
 
 ## Sparse Values as `default(T)`
 
@@ -73,7 +62,7 @@ As a corollary to the above note about equivalence of sparse and dense
 representations, since they are equivalent it follows that any code consuming
 `VBuffer`s must work equally well with *both*. That is, there must never be a
 condition where data is read and assumed to be either sparse, or dense, since
-implementers of `IDataView` and related interfaces are perfectly free to
+implementors of `IDataView` and related interfaces are perfectly free to
 produce either.
 
 The only "exception" to this rule is a necessary acknowledgment of the reality
@@ -83,57 +72,62 @@ not commutative, operations over sparse `VBuffer<float>` or `VBuffer<double>`
 vectors can sometimes result in modestly different results than the "same"
 operation over dense values.
 
-## Why Buffer Reuse
+There is also another point about sparsity, that is, about the increasing
+indices. While it is a *requirement*, it is regrettably not one we can
+practically enforce without a heavy performance cost. So, if you are creating
+your own `VBuffer`s, be careful that you are creating indices that are in
+strictly increasing order, and in the right range (non-negative and less than
+`Length`). We cannot check!
+
+# Buffer Reuse
 
 The question is often asked by people new to this codebase: why bother with
 buffer reuse at all? Without going into too many details, we used to not and
-suffered for it. We had a far simpler system where examples were yielded
-through an
-[`IEnumerable<>`](https://msdn.microsoft.com/en-us/library/9eekhta0.aspx), and
-our vector type at the time had `Indices` and `Values` arrays as well, but
-their sizes were there actual sizes, and being returned through an
-`IEnumerable<>` there was no plausible way to "recycle" the buffers.
+suffered for it. Long ago we had a far simpler system where examples were
+yielded through an [`IEnumerable<>`][1], and our vector type at the time had
+`Indices` and `Values`, but exposed as arrays, and their sizes were the actual
+"logical" sizes, and being returned through an `IEnumerable<>` there was no
+plausible way to reuse buffers.
 
-Also: who "owned" a fetched example (the caller, or callee) was not clear.
-Because it was not clear, code was inevitably written and checked in that made
+Also: who "owned" a fetched example (the caller, or callee) was not clear;
+code was at one time written under both assumptions, which was a mess. Because
+it was not clear, code was inevitably written and checked in that made
 *either* assumption, which meant, ultimately, that everything that touched
-these would try to duplicate everything by default, because doing anything
-else would fail in some case.
+these would try to duplicate everything, because doing anything else would
+fail in *some* case.
 
-The reason why this becomes important is because [garbage
-collection](https://msdn.microsoft.com/en-us/library/0xy59wtx.aspx) in the
-.NET framework is not free. Creating and destroying these arrays *can* be
-cheap, provided that they are sufficiently small, short lived, and only ever
-exist in a single thread. But, violate any of these, there is a possibility
-these arrays could be allocated on the large object heap, or promoted to gen-2
+The reason why this becomes important is because [garbage collection][2] in
+.NET is not free. Creating and destroying these arrays *can* be cheap,
+provided that they are sufficiently small, short lived, and only ever exist in
+a single thread. But, if that ever does not hold, there is a possibility these
+arrays could be allocated on the large object heap, or promoted to gen-2
 collection. The results could be disastrous: in one particularly memorable
 incident regarding neural net training, the move to `IDataView` and its
 `VBuffer`s resulted in a more than tenfold decrease in runtime performance,
 because under the old regime the garbage collection of the feature vectors was
 just taking so much time.
 
-This is somewhat unfortunate: a joke-that's-not-really-a-joke on the team was
-that we were writing C# as though it were C code. Be that as it may, buffer
-reuse is essential to our performance, especially on larger problems.
-
 This design requirement of buffer reuse has deeper implications for the
 ecosystem merely than the type here. For example, it is one crucial reason why
 so many value accessors in the `IDataView` ecosystem fill in values passed in
 through a `ref` parameter, rather than, say, being a return value.
 
+[1]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1?view=netstandard-2.0
+[2]: https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/index
+
 ## Buffer Re-use as a User
 
-Let's imagine we have an `IDataView` in a variable `dataview`, and we just so
+Let's imagine we have an `IDataView` in a variable `data`, and we just so
 happen to know that the column with index 5 has representation type
 `VBuffer<float>`. (In real code, this would presumably we achieved through
-more complicated involving an inspection of `dataview.Schema`, but we omit
-such details here.)
+more complicated involving an inspection of `data.Schema`, but we omit such
+details here.)
 
 ```csharp
-using (IRowCursor cursor = dataview.GetRowCursor(col => col == 5))
+using (DataViewRowCursor cursor = data.GetRowCursor(data.Schema[5]))
 {
     ValueGetter<VBuffer<float>> getter = cursor.GetGetter<VBuffer<float>>(5);
-    var value = default(VBuffer<float>);
+    VBuffer<float> value = default;
     while (cursor.MoveNext())
     {
         getter(ref value);
@@ -142,129 +136,130 @@ using (IRowCursor cursor = dataview.GetRowCursor(col => col == 5))
 }
 ```
 
-In this example, we open a cursor (telling it to make only column 5 active),
-then get the "getter" over this column. What enables buffer re-use for this is
-that, as we go row by row over the data with the `while` loop, we pass in the
-same `value` variable in to the `getter` delegate, again and again. Presumably
-the first time, or several, memory is allocated. Initially `value =
-default(VBuffer<float>)`, that is, it has zero `Length` and `Count` and `null`
-`Indices` and `Values`. Presumably at some point, probably the first call,
-`value` is replaced with a `VBuffer<float>` that has actual values allocated.
-In subsequent calls, perhaps these are judged as insufficiently large, and new
-arrays are allocated, but we would expect at some point the arrays would
+To be explicit, a `ValueGetter` is defined this way:
+
+```csharp
+public delegate void ValueGetter<TValue>(ref TValue value);
+```
+
+Anyway, in this example, we open a cursor (telling it to make only column 5
+active), then get the "getter" over this column. What enables buffer re-use
+for this is that, as we go row by row over the data with the `while` loop, we
+pass in the same `value` variable in to the `getter` delegate, again and
+again. Presumably the first time, or several, memory is allocated (though,
+internally, and invisibly to us). Initially `VBuffer<float> value = default`,
+that is, it has zero `Length` and similarly empty spans. Presumably at some
+point, probably the first call, `value` is replaced with a `VBuffer<float>`
+that has actual values, stored in freshly allocated buffers. In subsequent
+calls, *perhaps* these are judged as insufficiently large, and new arrays are
+internally allocated, but we would expect at some point the arrays would
 become "large enough" to accommodate many values, so reallocations would
-become increasingly rare.
+become increasingly rare. In this way, we eventually avoid nearly all
+allocations and garbage collection.
 
 A common mistake made by first time users is to do something like move the
 `var value` declaration inside the `while` loop, thus dooming `getter` to have
 to allocate the arrays every single time, completely defeating the purpose of
 buffer reuse.
 
-## Buffer Re-use as a Developer
+##  Buffer Re-use as a Developer
 
-Nearly all methods in ML.NET that "return" a `VBuffer<T>` do not really return
-a `VBuffer<T>` *at all*, but instead have a parameter `ref VBuffer<T> dst`,
-where they are expected to put the result. See the above example, with the
-`getter`. A `ValueGetter` is defined:
+So we've seen what it looks like from the user's point of view, but some words
+on what a (well implemented) `getter` delegate is doing is also worthwhile, to
+understand what is going on here.
 
-```csharp
-public delegate void ValueGetter<TValue>(ref TValue value);
-```
+`VBuffer<T>` by itself may appear to be a strictly immutable structure, but
+"buffer reuse" implies it is in some way mutable. This mutability is primarily
+accomplished with the `VBufferEditor`. The `VBufferEditor<T>` actually
+strongly resembles a `VBuffer<T>`, *except* instead of being `ReadOnlySpan`
+for values and indices they are `Span`, so, it is mutable.
 
-Let's describe the typical practice of "returning" a `VBuffer` in, say, a
-`ref` parameter named `dst`: if `dst.Indices` and `dst.Values` are
-sufficiently large to contain the result, they are used, and the value is
-calculated, or sometimes copied, into them. If either is insufficiently large,
-then a new array is allocated in its place. After all the calculation happens,
-a *new* `VBuffer` is constructed and assigned to `dst`. (And possibly, if they
-were large enough, using the same `Indices` and `Values` arrays as were passed
-in, albeit with different values.)
+First, one creates the `VBufferEditor<T>` structure using one of the
+`VBufferEditor.Create` methods. You pass in a `VBuffer<T>` as a `ref`
+parameter. (For this purpose, it is useful to remember that a
+`default(VBuffer<T>)` is itself a completely valid, though completely empty,
+`VBuffer<T>`.) The editor is past that line considered to "own" the internal
+structure of the `VBuffer<T>` you passed in. (So, correct code should not
+continue to use that `VBuffer<T>` structure from that point onwards.)
 
-`VBuffer`s can be either sparse or dense. However, even when returning a dense
-`VBuffer`, you would not discard the `Indices` array of the passed in buffer,
-assuming there was one. The `Indices` array was merely larger than necessary
-to store *this* result: that you happened to not need it this call does not
-justify throwing it away. We don't care about buffer re-use just for a single
-call, after all! The dense constructor for the `VBuffer` accepts an `Indices`
-array for precisely this reason!
+Then, one parties on the `Span<T>` for values and, if in a sparse application,
+the `Span<int>` for indices, on that editor, in whatever way is appropriate
+for the task.
 
-Also note: when you return a `VBuffer` in this fashion, the caller is assumed
-to *own* it at that point. This means they can do whatever they like to it,
-like pass the same variable into some other getter, or modify its values.
+Last, one calls one of the `Commit` methods to get another `VBuffer`, with the
+values and indices accessible through the `VBuffer<T>` methods the same as
+those that had been set in the editor structure.
+
+Similar to how creating a `VBufferEditor<T>` out of a `VBuffer<T>` renders the
+passed in `VBuffer<T>` invalid, likewise, getting the `VBuffer<T>` out of the
+editor out of the `VBufferEditor<T>` through one of the commit methods renders
+the *editor* invalid. In both cases, "ownership" of the internal buffers is
+passed along to the successor structure, rendering the original structure
+invalid, in some sense.
+
+Internally, these buffers are backed by arrays that are reallocated *if
+needed* by the editor upon its creation, but reused if they are large enough.
+
+## Ownership of `VBuffer`
+
+Nonetheless, this does not mean that bugs are impossible, because the concept
+of buffer reuse does carry the implication that we must be quite clear about
+who "owns" a `VBuffer` at any given time, for which we have developed this
+convention:
+
+Unless clearly specified in documentation, a caller is assumed to always own a
+`VBuffer` as returned by `ref`. This means they can do whatever they like to
+it, like pass the same variable into some other getter, or modify its values.
 Indeed, this is quite common: normalizers in ML.NET get values from their
 source, then immediately scale the contents of `Values` appropriately. This
 would hardly be possible if the callee was considered to have some stake in
 that result.
 
+The `ValueGetter` indicated above is the most important example of this
+principle. By passing in an existing `VBuffer<T>` into that delegate by
+reference, they are giving the implementation control over it to use (or,
+reallocate) as necessary to store the resulting value. But, once the delegate
+returns with the value returned, the caller is now considered to own that
+buffer.
+
 There is a corollary on this point: because the caller owns any `VBuffer`,
-then you shouldn't do anything that irrevocably destroys their usefulness to
+then could should not do anything that irrevocably destroys its usefulness to
 the caller. For example, consider this method that takes a vector `src`, and
 stores the scaled result in `dst`.
 
 ```csharp
-VectorUtils.ScaleBy(ref VBuffer<float> src, ref VBuffer<float> dst, float c)
+ScaleBy(in VBuffer<float> src, ref VBuffer<float> dst, float c)
 ```
 
 What this does is, copy the values from `src` to `dst`, while scaling each
-value seen by `c`.
+value from `src` seen by the factor `c`.
 
 One possible alternate (wrong) implementation of this would be to just say
-`dst=src` then scale all contents of `dst.Values` by `c`. But, then `dst` and
+`dst=src` then edit `dst` and scale its contents by `c`. But, then `dst` and
 `src` would share references to their internal arrays, completely compromising
 the caller's ability to do anything useful with them: if the caller were to
 pass `dst` into some other method that modified it, this could easily
 (silently!) modify the contents of `src`. The point is: if you are writing
 code *anywhere* whose end result is that two distinct `VBuffer` structs share
 references to their internal arrays, you've almost certainly introduced a
-**nasty** pernicious bug for your users.
+**nasty** pernicious bug.
 
-## Utilities for Working with `VBuffer`s
+# Internal Utilities for Working with `VBuffer`s
 
-ML.NET's runtime code has a number of utilities for operating over `VBuffer`s
-that we have written to be generally useful. We will not treat on these in
-detail here, but:
+In addition to the public utilities around `VBuffer` and `VBufferEditor`
+already mentioned, ML.NET's internal infrastructure and implementation code
+has a number of utilities for operating over `VBuffer`s that we have written
+to be generally useful. We will not treat on these in detail here, but:
 
-* `Microsoft.ML.Data.VBuffer<T>` itself contains a few methods for
-  accessing and iterating over its values.
-
-* `Microsoft.ML.Internal.Utilities.VBufferUtils` contains utilities
+* `VBufferUtils` contains utilities
   mainly for non-numeric manipulation of `VBuffer`s.
 
-* `Microsoft.ML.Numeric.VectorUtils` contains math operations
-  over `VBuffer<float>` and `float[]`, like computing norms, dot-products, and
-  whatnot.
+* `VectorUtils` contains math operations over `VBuffer<float>` and `float[]`,
+  like computing norms, dot-products, and whatnot.
 
-* `Microsoft.ML.Data.BufferBuilder<T>` is an abstract class whose
-  concrete implementations are used throughout ML.NET to build up `VBuffer<T>`
+* `BufferBuilder<T>` is a class for iteratively building up `VBuffer<T>`
   instances. Note that if one *can* simply build a `VBuffer` oneself easily
   and do not need the niceties provided by the buffer builder, you should
-  probably just do it yourself.
-
-* `Microsoft.MachineLearning.Internal.Utilities.EnsureSize` is often useful to
-ensure that the arrays are of the right size.
-
-## Golden Rules
-
-Here are some golden rules to remember:
-
-Remember the conditions under which `Indices` and `Values` can be `null`! A
-developer forgetting that `null` values for these fields are legal is probably
-the most common error in our code. (And unfortunately one that sometimes takes
-a while to pop up: most users don't feed in empty inputs to our trainers.)
-
-In terms of accessing anything in `Values` or `Indices`, remember, treat
-`Count` as the real length of these arrays, not the actual length of the
-arrays.
-
-If you write code that results in two distinct `VBuffer`s sharing references
-to their internal arrays, (for example, there are two `VBuffer`s `a` and `b`, with
-`a.Indices == b.Indices` with `a.Indices != null`, or `a.Values == b.Values`
-with `a.Values != null`) then you've almost certainly done something wrong.
-
-Structure your code so that `VBuffer`s have their buffers re-used as much as
-possible. If you have code called repeatedly where you are passing in some
-`default(VBuffer<T>)`, there's almost certainly an opportunity there.
-
-When re-using a `VBuffer` that's been passed to you, remember that even when
-constructing a dense vector, you should still re-use the `Indices` array that
-was passed in.
+  probably just do it yourself, since there is a great deal of additional
+  facilities here for combining multiple results at the same indices that many
+  applications will not need.

--- a/docs/code/VBufferCareFeeding.md
+++ b/docs/code/VBufferCareFeeding.md
@@ -225,25 +225,25 @@ buffer.
 
 There is a corollary on this point: because the caller owns any `VBuffer`,
 then code should not do anything that irrevocably destroys its usefulness to
-the caller. For example, consider this method that takes a vector `src`, and
-stores the scaled result in `dst`.
+the caller. For example, consider this method that takes a vector `source`,
+and stores the scaled result in `destination`.
 
 ```csharp
-ScaleBy(in VBuffer<float> src, ref VBuffer<float> dst, float c)
+ScaleBy(in VBuffer<float> source, ref VBuffer<float> destination, float c)
 ```
 
-What this does is, copy the values from `src` to `dst` while scaling the
-values we are copying by the factor `c`.
+What this does is, copy the values from `source` to `destination` while
+scaling the values we are copying by the factor `c`.
 
 One possible alternate (wrong) implementation of this would be to just say
-`dst=src` then edit `dst` and scale each value by `c`. But, then `dst` and
-`src` would share references to their internal arrays, completely compromising
-the caller's ability to do anything useful with `src`: if the caller were to
-pass `dst` into some other method that modified it, this could easily
-(silently!) modify the contents of `src`. The point is: if you are writing
-code *anywhere* whose end result is that two distinct `VBuffer`s share
-references to their internal arrays, you've almost certainly introduced a
-**nasty** pernicious bug.
+`destination=source` then edit `destination` and scale each value by `c`. But,
+then `destination` and `source` would share references to their internal
+arrays, completely compromising the caller's ability to do anything useful
+with `source`: if the caller were to pass `destination` into some other method
+that modified it, this could easily (silently!) modify the contents of
+`source`. The point is: if you are writing code *anywhere* whose end result is
+that two distinct `VBuffer`s share references to their internal arrays, you've
+almost certainly introduced a **nasty** pernicious bug.
 
 # Internal Utilities for Working with `VBuffer`s
 

--- a/src/Microsoft.ML.DataView/VBuffer.cs
+++ b/src/Microsoft.ML.DataView/VBuffer.cs
@@ -401,16 +401,16 @@ namespace Microsoft.ML.Data
             Contracts.CheckParam(valuesCount == null || valuesCount.Value <= newLogicalLength, nameof(valuesCount),
                 "If specified, must be no greater than " + nameof(newLogicalLength));
 
-            int logicallValuesCount = valuesCount ?? newLogicalLength;
+            int logicalValuesCount = valuesCount ?? newLogicalLength;
 
             int maxCapacity = maxValuesCapacity ?? ArrayUtils.ArrayMaxSize;
 
             T[] values = _values;
             bool createdNewValues;
-            ArrayUtils.EnsureSize(ref values, logicallValuesCount, maxCapacity, keepOldOnResize, out createdNewValues);
+            ArrayUtils.EnsureSize(ref values, logicalValuesCount, maxCapacity, keepOldOnResize, out createdNewValues);
 
             int[] indices = _indices;
-            bool isDense = newLogicalLength == logicallValuesCount;
+            bool isDense = newLogicalLength == logicalValuesCount;
             bool createdNewIndices;
             if (isDense && !requireIndicesOnDense)
             {
@@ -418,12 +418,12 @@ namespace Microsoft.ML.Data
             }
             else
             {
-                ArrayUtils.EnsureSize(ref indices, logicallValuesCount, maxCapacity, keepOldOnResize, out createdNewIndices);
+                ArrayUtils.EnsureSize(ref indices, logicalValuesCount, maxCapacity, keepOldOnResize, out createdNewIndices);
             }
 
             return new VBufferEditor<T>(
                 newLogicalLength,
-                logicallValuesCount,
+                logicalValuesCount,
                 values,
                 indices,
                 requireIndicesOnDense,

--- a/src/Microsoft.ML.DataView/VBufferEditor.cs
+++ b/src/Microsoft.ML.DataView/VBufferEditor.cs
@@ -29,10 +29,14 @@ namespace Microsoft.ML.Data
         /// Creates a <see cref="VBufferEditor{T}"/> using
         /// <paramref name="destination"/>'s values and indices buffers.
         /// </summary>
-        /// <param name="destination">The destination buffer. Note that the resulting <see cref="VBufferEditor{T}"/> is assumed to take ownership
+        /// <param name="destination">
+        /// The destination buffer. Note that the resulting <see cref="VBufferEditor{T}"/> is assumed to take ownership
         /// of this passed in object, and so whatever <see cref="VBuffer{T}"/> was passed in as this parameter should not be used again, since its
-        /// underlying buffers are being potentially reused.</param>
-        /// <param name="newLogicalLength">The logical length of the new buffer being edited.</param>
+        /// underlying buffers are being potentially reused.
+        /// </param>
+        /// <param name="newLogicalLength">
+        /// The logical length of the new buffer being edited.
+        /// </param>
         /// <param name="valuesCount">
         /// The optional number of physical values to be represented in the buffer.
         /// The buffer will be dense if <paramref name="valuesCount"/> is omitted.
@@ -71,9 +75,7 @@ namespace Microsoft.ML.Data
     /// </summary>
     /// <remarks>
     /// The <see cref="VBuffer{T}"/> structure by itself is immutable. However, the purpose of <see cref="VBuffer{T}"/>
-    /// in general, and its typical usage through <see cref="ValueGetter{TValue}"/>, is to enable buffer re-use. That is
-    /// the purpose of this structure: for situations where one wants to exploit buffer re-use to avoid costly memory
-    /// allocation and garbage collector cleanup, there is this structure as created through
+    /// is to enable buffer re-use we can edit them through this structure, as created through
     /// <see cref="VBufferEditor.Create{T}(ref VBuffer{T}, int, int?, int?, bool, bool)"/> or
     /// <see cref="VBufferEditor.CreateFromBuffer{T}(ref VBuffer{T})"/>.
     /// </remarks>
@@ -94,8 +96,7 @@ namespace Microsoft.ML.Data
         public readonly Span<int> Indices;
 
         /// <summary>
-        /// Gets a value indicating whether a new <see cref="Values"/> array was allocated. If this is <see langword="false"/>,
-        /// then the resulting <see cref="VBuffer{T}"/> from <see cref="Commit"/>
+        /// Gets a value indicating whether a new <see cref="Values"/> array was allocated.
         /// </summary>
         public bool CreatedNewValues { get; }
 

--- a/src/Microsoft.ML.DataView/VBufferEditor.cs
+++ b/src/Microsoft.ML.DataView/VBufferEditor.cs
@@ -16,6 +16,9 @@ namespace Microsoft.ML.Data
         /// Creates a <see cref="VBufferEditor{T}"/> with the same shape
         /// (length and density) as the <paramref name="destination"/>.
         /// </summary>
+        /// <param name="destination">The destination buffer. Note that the resulting <see cref="VBufferEditor{T}"/> is assumed to take ownership
+        /// of this passed in object, and so whatever <see cref="VBuffer{T}"/> was passed in as this parameter should not be used again, since its
+        /// underlying buffers are being potentially reused.</param>
         public static VBufferEditor<T> CreateFromBuffer<T>(
             ref VBuffer<T> destination)
         {
@@ -26,12 +29,10 @@ namespace Microsoft.ML.Data
         /// Creates a <see cref="VBufferEditor{T}"/> using
         /// <paramref name="destination"/>'s values and indices buffers.
         /// </summary>
-        /// <param name="destination">
-        /// The destination buffer.
-        /// </param>
-        /// <param name="newLogicalLength">
-        /// The logical length of the new buffer being edited.
-        /// </param>
+        /// <param name="destination">The destination buffer. Note that the resulting <see cref="VBufferEditor{T}"/> is assumed to take ownership
+        /// of this passed in object, and so whatever <see cref="VBuffer{T}"/> was passed in as this parameter should not be used again, since its
+        /// underlying buffers are being potentially reused.</param>
+        /// <param name="newLogicalLength">The logical length of the new buffer being edited.</param>
         /// <param name="valuesCount">
         /// The optional number of physical values to be represented in the buffer.
         /// The buffer will be dense if <paramref name="valuesCount"/> is omitted.
@@ -68,6 +69,14 @@ namespace Microsoft.ML.Data
     /// An object capable of editing a <see cref="VBuffer{T}"/> by filling out
     /// <see cref="Values"/> (and <see cref="Indices"/> if the buffer is not dense).
     /// </summary>
+    /// <remarks>
+    /// The <see cref="VBuffer{T}"/> structure by itself is immutable. However, the purpose of <see cref="VBuffer{T}"/>
+    /// in general, and its typical usage through <see cref="ValueGetter{TValue}"/>, is to enable buffer re-use. That is
+    /// the purpose of this structure: for situations where one wants to exploit buffer re-use to avoid costly memory
+    /// allocation and garbage collector cleanup, there is this structure as created through
+    /// <see cref="VBufferEditor.Create{T}(ref VBuffer{T}, int, int?, int?, bool, bool)"/> or
+    /// <see cref="VBufferEditor.CreateFromBuffer{T}(ref VBuffer{T})"/>.
+    /// </remarks>
     public readonly ref struct VBufferEditor<T>
     {
         private readonly int _logicalLength;
@@ -85,12 +94,13 @@ namespace Microsoft.ML.Data
         public readonly Span<int> Indices;
 
         /// <summary>
-        /// Gets a value indicating whether a new Values array was allocated.
+        /// Gets a value indicating whether a new <see cref="Values"/> array was allocated. If this is <see langword="false"/>,
+        /// then the resulting <see cref="VBuffer{T}"/> from <see cref="Commit"/>
         /// </summary>
         public bool CreatedNewValues { get; }
 
         /// <summary>
-        /// Gets a value indicating whether a new Indices array was allocated.
+        /// Gets a value indicating whether a new <see cref="Indices"/> array was allocated.
         /// </summary>
         public bool CreatedNewIndices { get; }
 
@@ -116,12 +126,10 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>
-        /// Commits the edits and creates a new <see cref="VBuffer{T}"/> using
-        /// the current Values and Indices.
+        /// Commits the edits and creates a new <see cref="VBuffer{T}"/> using the current <see cref="Values"/> and <see cref="Indices"/>.
+        /// Note that this structure and its properties should not be used once this is called.
         /// </summary>
-        /// <returns>
-        /// The newly created <see cref="VBuffer{T}"/>.
-        /// </returns>
+        /// <returns>The newly created <see cref="VBuffer{T}"/>.</returns>
         public VBuffer<T> Commit()
         {
             return new VBuffer<T>(_logicalLength, Values.Length, _values, _indices);
@@ -130,7 +138,8 @@ namespace Microsoft.ML.Data
         /// <summary>
         /// Commits the edits and creates a new <see cref="VBuffer{T}"/> using
         /// the current Values and Indices, while allowing to truncate the length
-        /// of Values and Indices.
+        /// of <see cref="Values"/> and, if sparse, <see cref="Indices"/>.
+        /// Like <see cref="Commit"/>, this structure and its properties should not be used once this is called.
         /// </summary>
         /// <param name="physicalValuesCount">
         /// The new number of physical values to be represented in the created buffer.
@@ -139,15 +148,16 @@ namespace Microsoft.ML.Data
         /// The newly created <see cref="VBuffer{T}"/>.
         /// </returns>
         /// <remarks>
-        /// CommitTruncated allows to modify the length of the explicitly
-        /// defined values.
+        /// This method allows to modify the length of the explicitly defined values.
         /// This is useful in sparse situations where the <see cref="VBufferEditor{T}"/>
         /// was created with a larger physical value count than was needed
         /// because the final value count was not known at creation time.
         /// </remarks>
         public VBuffer<T> CommitTruncated(int physicalValuesCount)
         {
-            Contracts.CheckParam(physicalValuesCount <= Values.Length, nameof(physicalValuesCount), "Updating physicalValuesCount during CommitTruncated cannot be greater than the original physicalValuesCount value used in Create.");
+            Contracts.CheckParam(physicalValuesCount <= Values.Length, nameof(physicalValuesCount),
+                "Updating " + nameof(physicalValuesCount) + " during " + nameof(CommitTruncated) +
+                " cannot be greater than the original physicalValuesCount value used in " + nameof(VBufferEditor.Create) + ".");
 
             return new VBuffer<T>(_logicalLength, physicalValuesCount, _values, _indices);
         }


### PR DESCRIPTION
Towards #3095, specifically about `VBuffer`s. Changes documentation to reflect the changes made by @eerhardt in his refactoring of #1580.