### PR TITLE
Updating .tt file due to renaming of LbfgsPoissonRegression.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.cs
@@ -5,7 +5,7 @@ using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 {
-    public static class PoissonRegression
+    public static class LbfgsPoissonRegression
     {
         public static void Example()
         {
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
             SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Mean Absolute Error: 0.07
             //   Mean Squared Error: 0.01

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.tt
@@ -1,8 +1,8 @@
 ﻿<#@ include file="RegressionSamplesTemplate.ttinclude"#>
 
 <#+
-string ClassName="PoissonRegression";
-string Trainer = "PoissonRegression";
+string ClassName="LbfgsPoissonRegression";
+string Trainer = "LbfgsPoissonRegression";
 string TrainerOptions = null;
 
 string ExpectedOutputPerInstance= @"// Expected output:

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.ML.Trainers;
 
 namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 {
-    public static class PoissonRegressionWithOptions
+    public static class LbfgsPoissonRegressionWithOptions
     {
         public static void Example()
         {
@@ -61,7 +61,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
             SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Mean Absolute Error: 0.07
             //   Mean Squared Error: 0.01

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.tt
@@ -1,9 +1,9 @@
 ﻿<#@ include file="RegressionSamplesTemplate.ttinclude"#>
 
 <#+
-string ClassName="PoissonRegressionWithOptions";
-string Trainer = "PoissonRegression";
-string TrainerOptions = @"PoissonRegressionTrainer.Options
+string ClassName="LbfgsPoissonRegressionWithOptions";
+string Trainer = "LbfgsPoissonRegression";
+string TrainerOptions = @"LbfgsPoissonRegressionTrainer.Options
             {
                 // Reduce optimization tolerance to speed up training at the cost of accuracy.
                 OptmizationTolerance = 1e-4f,

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -102,9 +102,9 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>LbfgsPoissonRegression.cs</LastGenOutput>
     </None>
-    <None Update="Dynamic\Trainers\Regression\PoissonRegressionWithOptions.tt">
+    <None Update="Dynamic\Trainers\Regression\LbfgsPoissonRegressionWithOptions.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>PoissonRegressionWithOptions.cs</LastGenOutput>
+      <LastGenOutput>LbfgsPoissonRegressionWithOptions.cs</LastGenOutput>
     </None>
   </ItemGroup>
 
@@ -158,10 +158,10 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>LbfgsPoissonRegression.tt</DependentUpon>
     </Compile>
-    <Compile Update="Dynamic\Trainers\Regression\PoissonRegressionWithOptions.cs">
+    <Compile Update="Dynamic\Trainers\Regression\LbfgsPoissonRegressionWithOptions.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
-      <DependentUpon>PoissonRegressionWithOptions.tt</DependentUpon>
+      <DependentUpon>LbfgsPoissonRegressionWithOptions.tt</DependentUpon>
     </Compile>
   </ItemGroup>
 

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -98,9 +98,9 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>OnlineGradientDescentWithOptions.cs</LastGenOutput>
     </None>
-    <None Update="Dynamic\Trainers\Regression\PoissonRegression.tt">
+    <None Update="Dynamic\Trainers\Regression\LbfgsPoissonRegression.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>PoissonRegression.cs</LastGenOutput>
+      <LastGenOutput>LbfgsPoissonRegression.cs</LastGenOutput>
     </None>
     <None Update="Dynamic\Trainers\Regression\PoissonRegressionWithOptions.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
@@ -153,10 +153,10 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>OnlineGradientDescentWithOptions.tt</DependentUpon>
     </Compile>
-    <Compile Update="Dynamic\Trainers\Regression\PoissonRegression.cs">
+    <Compile Update="Dynamic\Trainers\Regression\LbfgsPoissonRegression.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
-      <DependentUpon>PoissonRegression.tt</DependentUpon>
+      <DependentUpon>LbfgsPoissonRegression.tt</DependentUpon>
     </Compile>
     <Compile Update="Dynamic\Trainers\Regression\PoissonRegressionWithOptions.cs">
       <DesignTime>True</DesignTime>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -567,7 +567,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        ///  [!code-csharp[PoissonRegression](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/PoissonRegression.cs)]
+        ///  [!code-csharp[PoissonRegression](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegression.cs)]
         /// ]]></format>
         /// </example>
         public static LbfgsPoissonRegressionTrainer LbfgsPoissonRegression(this RegressionCatalog.RegressionTrainers catalog,

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -593,7 +593,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        ///  [!code-csharp[PoissonRegression](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/PoissonRegressionWithOptions.cs)]
+        ///  [!code-csharp[PoissonRegression](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.cs)]
         /// ]]></format>
         /// </example>
         public static LbfgsPoissonRegressionTrainer LbfgsPoissonRegression(this RegressionCatalog.RegressionTrainers catalog, LbfgsPoissonRegressionTrainer.Options options)


### PR DESCRIPTION
This PR fixes the issue related to renaming done in #3034. Currently, we are finding a way to forcing people to update the .tt file instead of .cs file generated from .tt.


