### PR TITLE
Samples and unit test for image-related  transform estimators

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
@@ -41,20 +41,32 @@ namespace Microsoft.ML.Samples.Dynamic
                            .Append(mlContext.Transforms.ConvertToGrayscale("Grayscale", "ImageObject"));
 
             var transformedData = pipeline.Fit(data).Transform(data);
-
             // The transformedData IDataView contains the loaded images column, and the grayscaled column.
             
-            // Preview 1 row of the transformedData. 
-            var transformedDataPreview = transformedData.Preview(1);
-            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
+            // Preview the transformedData. 
+            var transformedDataPreview = transformedData.Preview();
+            PrintPreview(transformedDataPreview);
+            // ImagePath    Name         ImageObject            Grayscale
+            // tomato.bmp   tomato       System.Drawing.Bitmap  System.Drawing.Bitmap
+            // banana.jpg   banana       System.Drawing.Bitmap  System.Drawing.Bitmap
+            // hotdog.jpg   hotdog       System.Drawing.Bitmap  System.Drawing.Bitmap
+            // tomato.jpg   tomato       System.Drawing.Bitmap  System.Drawing.Bitmap
+        }
+
+        private static void PrintPreview(DataDebuggerPreview data)
+        {
+            foreach (var colInfo in data.ColumnView)
+                Console.Write("{0, -25}", colInfo.Column.Name);
+
+            Console.WriteLine();
+            foreach (var row in data.RowView)
             {
-                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
+                foreach (var kvPair in row.Values)
+                {
+                    Console.Write("{0, -25}", kvPair.Value);
+                }
+                Console.WriteLine();
             }
-            
-            // ImagePath : tomato.bmp
-            // Name : tomato
-            // ImageObject : System.Drawing.Bitmap
-            // Grayscale : System.Drawing.Bitmap
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
@@ -42,18 +43,18 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // The transformedData IDataView contains the loaded images column, and the grayscaled column.
-            // Preview of the transformedData
-            var transformedDataPreview = transformedData.Preview();
-
-            // Preview of the content of the images.tsv file
-            // The actual images, in the Grayscale column are of type System.Drawing.Bitmap.
-            //
-            // ImagePath    Name        ImageObject                   Grayscale
-            // tomato.bmp   tomato      {System.Drawing.Bitmap}     {System.Drawing.Bitmap}
-            // banana.jpg   banana      {System.Drawing.Bitmap}     {System.Drawing.Bitmap}
-            // hotdog.jpg   hotdog      {System.Drawing.Bitmap}     {System.Drawing.Bitmap}
-            // tomato.jpg   tomato      {System.Drawing.Bitmap}     {System.Drawing.Bitmap}
-
+            
+            // Preview 1 row of the transformedData. 
+            var transformedDataPreview = transformedData.Preview(1);
+            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
+            {
+                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
+            }
+            
+            // ImagePath : tomato.bmp
+            // Name : tomato
+            // ImageObject : System.Drawing.Bitmap
+            // Grayscale : System.Drawing.Bitmap
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var transformedData = pipeline.Fit(data).Transform(data);
             // The transformedData IDataView contains the loaded images column, and the grayscaled column.
-            
+
             // Preview the transformedData. 
             var transformedDataPreview = transformedData.Preview();
             PrintPreview(transformedDataPreview);
@@ -56,15 +56,13 @@ namespace Microsoft.ML.Samples.Dynamic
         private static void PrintPreview(DataDebuggerPreview data)
         {
             foreach (var colInfo in data.ColumnView)
-                Console.Write("{0, -25}", colInfo.Column.Name);
+                Console.Write("{0,-25}", colInfo.Column.Name);
 
             Console.WriteLine();
             foreach (var row in data.RowView)
             {
                 foreach (var kvPair in row.Values)
-                {
-                    Console.Write("{0, -25}", kvPair.Value);
-                }
+                    Console.Write("{0,-25}", kvPair.Value);
                 Console.WriteLine();
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
@@ -7,17 +7,66 @@ namespace Microsoft.ML.Samples.Dynamic
 {
     public static class ConvertToImage
     {
-        private const int inputSize = 3 * 224 * 224;
+        private const int imageHeight = 224;
+        private const int imageWidth = 224;
+        private const int numberOfChannels = 3;
+        private const int inputSize = imageHeight * imageWidth * numberOfChannels;
+
+        // Sample that shows how an input array (of doubles) can be used to interop with image related estimators in ML.NET.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var mlContext = new MLContext();
+
+            // Create a list of training data points.
+            var dataPoints = GenerateRandomDataPoints(4);
+
+            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            var data = mlContext.Data.LoadFromEnumerable(dataPoints);
+
+            // Image loading pipeline. 
+            var pipeline = mlContext.Transforms.ConvertToImage(imageHeight, imageWidth, "Image", "Features")
+                          .Append(mlContext.Transforms.ExtractPixels("Pixels", "Image"));
+
+            var transformedData = pipeline.Fit(data).Transform(data);
+
+            // Preview the transformedData. 
+            var transformedDataPreview = transformedData.Preview();
+            PrintPreview(transformedDataPreview);
+            // Features                 Image                    Pixels
+            // 185,209,196,142,52       System.Drawing.Bitmap    185,209,196,142,52
+            // 182,235,84,23,87         System.Drawing.Bitmap    182,235,84,23,87
+            // 192,214,247,22,38        System.Drawing.Bitmap    192,214,247,22,38
+            // 242,161,141,223,192      System.Drawing.Bitmap    242,161,141,223,192
+        }
+
+        private static void PrintPreview(DataDebuggerPreview data)
+        {
+            foreach (var colInfo in data.ColumnView)
+                Console.Write("{0, -25}", colInfo.Column.Name);
+
+            Console.WriteLine();
+            foreach (var row in data.RowView)
+            {
+                foreach (var kvPair in row.Values)
+                {
+                    if (kvPair.Key == "Pixels" || kvPair.Key == "Features")
+                    {
+                        var rawValues = ((VBuffer<float>)kvPair.Value).DenseValues().Take(5);
+                        Console.Write("{0, -25}", string.Join(",", rawValues));
+                    }
+                    else
+                        Console.Write("{0, -25}", kvPair.Value);
+                }
+                Console.WriteLine();
+            }
+        }
 
         private class DataPoint
         {
             [VectorType(inputSize)]
-            public double[] Features { get; set; }
-        }
-
-        private sealed class TransformedData
-        {
-            public float[] Pixels { get; set; }
+            public float[] Features { get; set; }
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
@@ -28,67 +77,9 @@ namespace Microsoft.ML.Samples.Dynamic
             {
                 yield return new DataPoint
                 {
-                    Features = Enumerable.Repeat(0, inputSize).Select(x => random.NextDouble() * 100).ToArray()
+                    Features = Enumerable.Repeat(0, inputSize).Select(x => (float)random.Next(0, 256)).ToArray()
                 };
             }
-        }
-
-        // Sample that shows how an input array (of doubles) can be used to interop with image related estimators in ML.NET.
-        public static void Example()
-        {
-            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
-            // as well as the source of randomness.
-            var mlContext = new MLContext();
-
-            // Create a list of training data points.
-            var dataPoints = GenerateRandomDataPoints(10);
-
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
-            var data = mlContext.Data.LoadFromEnumerable(dataPoints);
-
-            // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.ConvertToImage(224, 224, "Image", "Features")
-                          .Append(mlContext.Transforms.ResizeImages("ImageResized", inputColumnName: "Image", imageWidth: 100, imageHeight: 100))
-                          .Append(mlContext.Transforms.ExtractPixels("Pixels", "ImageResized"));
-
-
-            var transformedData = pipeline.Fit(data).Transform(data);
-
-            // The transformedData IDataView contains the loaded and resized raw values
-
-            // Preview 1 row of the transformedData. 
-            var transformedDataPreview = transformedData.Preview(1);
-            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
-            {
-                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
-            }
-
-            // Features: Dense vector of size 150528
-            // Image: System.Drawing.Bitmap
-            // ImageResized : System.Drawing.Bitmap
-            // Pixels : Dense vector of size 30000
-
-            Console.WriteLine("--------------------------------------------------");
-
-            // Using schema comprehension to display raw pixels for each row.
-            // Display extracted pixels in column 'Pixels'.
-            var convertedData = mlContext.Data.CreateEnumerable<TransformedData>(transformedData, true);
-            foreach (var item in convertedData)
-            {
-                var pixels = item.Pixels.Take(5);
-                Console.WriteLine("pixels:{0}...", string.Join(",", pixels));
-            }
-
-            // pixels:72,71,37,57,30...
-            // pixels:71,26,61,40,71...
-            // pixels:75,75,35,27,93...
-            // pixels:94,63,39,63,63...
-            // pixels:78,83,11,46,94...
-            // pixels:15,29,25,67,35...
-            // pixels:44,74,59,42,26...
-            // pixels:62,85,46,46,16...
-            // pixels:71,64,57,45,91...
-            // pixels:52,19,6,35,81...
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
         private static void PrintPreview(DataDebuggerPreview data)
         {
             foreach (var colInfo in data.ColumnView)
-                Console.Write("{0, -25}", colInfo.Column.Name);
+                Console.Write("{0,-25}", colInfo.Column.Name);
 
             Console.WriteLine();
             foreach (var row in data.RowView)
@@ -54,10 +54,10 @@ namespace Microsoft.ML.Samples.Dynamic
                     if (kvPair.Key == "Pixels" || kvPair.Key == "Features")
                     {
                         var rawValues = ((VBuffer<float>)kvPair.Value).DenseValues().Take(5);
-                        Console.Write("{0, -25}", string.Join(",", rawValues));
+                        Console.Write("{0,-25}", string.Join(",", rawValues));
                     }
                     else
-                        Console.Write("{0, -25}", kvPair.Value);
+                        Console.Write("{0,-25}", kvPair.Value);
                 }
                 Console.WriteLine();
             }
@@ -74,12 +74,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var random = new Random(seed);
 
             for (int i = 0; i < count; i++)
-            {
-                yield return new DataPoint
-                {
-                    Features = Enumerable.Repeat(0, inputSize).Select(x => (float)random.Next(0, 256)).ToArray()
-                };
-            }
+                yield return new DataPoint { Features = Enumerable.Repeat(0, inputSize).Select(x => (float)random.Next(0, 256)).ToArray() };
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    public static class ConvertToImage
+    {
+        private const int inputSize = 3 * 224 * 224;
+
+        private class DataPoint
+        {
+            [VectorType(inputSize)]
+            public double[] Features { get; set; }
+        }
+
+        private sealed class TransformedData
+        {
+            public float[] Pixels { get; set; }
+        }
+
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
+        {
+            var random = new Random(seed);
+
+            for (int i = 0; i < count; i++)
+            {
+                yield return new DataPoint
+                {
+                    Features = Enumerable.Repeat(0, inputSize).Select(x => random.NextDouble() * 100).ToArray()
+                };
+            }
+        }
+
+        // Sample that shows how an input array (of doubles) can be used to interop with image related estimators in ML.NET.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var mlContext = new MLContext();
+
+            // Create a list of training data points.
+            var dataPoints = GenerateRandomDataPoints(10);
+
+            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            var data = mlContext.Data.LoadFromEnumerable(dataPoints);
+
+            // Image loading pipeline. 
+            var pipeline = mlContext.Transforms.ConvertToImage(224, 224, "Image", "Features")
+                          .Append(mlContext.Transforms.ResizeImages("ImageResized", inputColumnName: "Image", imageWidth: 100, imageHeight: 100))
+                          .Append(mlContext.Transforms.ExtractPixels("Pixels", "ImageResized"));
+
+
+            var transformedData = pipeline.Fit(data).Transform(data);
+
+            // The transformedData IDataView contains the loaded and resized raw values
+
+            // Preview 1 row of the transformedData. 
+            var transformedDataPreview = transformedData.Preview(1);
+            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
+            {
+                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
+            }
+
+            // Features: Dense vector of size 150528
+            // Image: System.Drawing.Bitmap
+            // ImageResized : System.Drawing.Bitmap
+            // Pixels : Dense vector of size 30000
+
+            Console.WriteLine("--------------------------------------------------");
+
+            // Using schema comprehension to display raw pixels for each row.
+            // Display extracted pixels in column 'Pixels'.
+            var convertedData = mlContext.Data.CreateEnumerable<TransformedData>(transformedData, true);
+            foreach (var item in convertedData)
+            {
+                var pixels = item.Pixels.Take(5);
+                Console.WriteLine("pixels:{0}...", string.Join(",", pixels));
+            }
+
+            // pixels:72,71,37,57,30...
+            // pixels:71,26,61,40,71...
+            // pixels:75,75,35,27,93...
+            // pixels:94,63,39,63,63...
+            // pixels:78,83,11,46,94...
+            // pixels:15,29,25,67,35...
+            // pixels:44,74,59,42,26...
+            // pixels:62,85,46,46,16...
+            // pixels:71,64,57,45,91...
+            // pixels:52,19,6,35,81...
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
             var pipeline = mlContext.Transforms.LoadImages("ImageObject", imagesFolder, "ImagePath")
-                          .Append(mlContext.Transforms.ResizeImages("ImageObjectResized", inputColumnName:"ImageObject", imageWidth: 100, imageHeight: 100 ))
+                          .Append(mlContext.Transforms.ResizeImages("ImageObjectResized", inputColumnName: "ImageObject", imageWidth: 100, imageHeight: 100))
                           .Append(mlContext.Transforms.ExtractPixels("Pixels", "ImageObjectResized"));
 
             var transformedData = pipeline.Fit(data).Transform(data);
@@ -58,20 +58,20 @@ namespace Microsoft.ML.Samples.Dynamic
         private static void PrintPreview(DataDebuggerPreview data)
         {
             foreach (var colInfo in data.ColumnView)
-                Console.Write("{0, -25}", colInfo.Column.Name);
+                Console.Write("{0,-25}", colInfo.Column.Name);
 
             Console.WriteLine();
             foreach (var row in data.RowView)
             {
                 foreach (var kvPair in row.Values)
                 {
-                    if(kvPair.Key == "Pixels")
+                    if (kvPair.Key == "Pixels")
                     {
                         var pixels = ((VBuffer<float>)kvPair.Value).DenseValues().Take(5);
                         Console.Write("{0}...", string.Join(",", pixels));
                     }
                     else
-                        Console.Write("{0, -25}", kvPair.Value);
+                        Console.Write("{0,-25}", kvPair.Value);
                 }
                 Console.WriteLine();
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
@@ -43,46 +43,38 @@ namespace Microsoft.ML.Samples.Dynamic
                           .Append(mlContext.Transforms.ResizeImages("ImageObjectResized", inputColumnName:"ImageObject", imageWidth: 100, imageHeight: 100 ))
                           .Append(mlContext.Transforms.ExtractPixels("Pixels", "ImageObjectResized"));
 
-
             var transformedData = pipeline.Fit(data).Transform(data);
 
-            // The transformedData IDataView contains the loaded images now
-
-            // Preview 1 row of the transformedData. 
-            var transformedDataPreview = transformedData.Preview(1);
-            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
-            {
-                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
-            }
-
-            // ImagePath: tomato.bmp
-            // Name : tomato
-            // ImageObject : System.Drawing.Bitmap
-            // ImageObjectResized : System.Drawing.Bitmap
-            // Pixels : Dense vector of size 30000
-
-            Console.WriteLine("--------------------------------------------------");
-
-            // Using schema comprehension to display raw pixels for each row.
-            // Display original columns 'ImagePath' and 'Name', and extracted pixels in column 'Pixels'.
-            var convertedData = mlContext.Data.CreateEnumerable<TransformedData>(transformedData, true);
-            foreach (var item in convertedData)
-            {
-                var pixels = item.Pixels.Take(5);
-                Console.WriteLine("{0} {1}  pixels:{2}...", item.ImagePath, item.Name, string.Join(",", pixels));
-            }
-
-            // tomato.bmp tomato pixels:255,255,255,255,255...
-            // banana.jpg banana pixels:255,255,255,255,255...
-            // hotdog.jpg hotdog pixels:255,255,255,255,255...
-            // tomato.jpg tomato pixels:255,255,255,255,255...
+            // Preview the transformedData. 
+            var transformedDataPreview = transformedData.Preview();
+            PrintPreview(transformedDataPreview);
+            // ImagePath    Name         ImageObject            ImageObjectResized      Pixels
+            // tomato.bmp   tomato       System.Drawing.Bitmap  System.Drawing.Bitmap   255,255,255,255,255...
+            // banana.jpg   banana       System.Drawing.Bitmap  System.Drawing.Bitmap   255,255,255,255,255...
+            // hotdog.jpg   hotdog       System.Drawing.Bitmap  System.Drawing.Bitmap   255,255,255,255,255...
+            // tomato.jpg   tomato       System.Drawing.Bitmap  System.Drawing.Bitmap   255,255,255,255,255...
         }
 
-        private sealed class TransformedData
+        private static void PrintPreview(DataDebuggerPreview data)
         {
-            public string ImagePath { get; set; }
-            public string Name { get; set; }
-            public float[] Pixels { get; set; }
+            foreach (var colInfo in data.ColumnView)
+                Console.Write("{0, -25}", colInfo.Column.Name);
+
+            Console.WriteLine();
+            foreach (var row in data.RowView)
+            {
+                foreach (var kvPair in row.Values)
+                {
+                    if(kvPair.Key == "Pixels")
+                    {
+                        var pixels = ((VBuffer<float>)kvPair.Value).DenseValues().Take(5);
+                        Console.Write("{0}...", string.Join(",", pixels));
+                    }
+                    else
+                        Console.Write("{0, -25}", kvPair.Value);
+                }
+                Console.WriteLine();
+            }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
@@ -37,21 +37,35 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages("ImageReal", imagesFolder, "ImagePath");
-            var transformedData = pipeline.Fit(data).Transform(data);
+            var pipeline = mlContext.Transforms.LoadImages("ImageObject", imagesFolder, "ImagePath");
 
+            var transformedData = pipeline.Fit(data).Transform(data);
             // The transformedData IDataView contains the loaded images now
 
-            // Preview 1 row of the transformedData. 
-            var transformedDataPreview = transformedData.Preview(1);
-            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
+            // Preview the transformedData. 
+            var transformedDataPreview = transformedData.Preview();
+            PrintPreview(transformedDataPreview);
+            // ImagePath    Name         ImageObject           
+            // tomato.bmp   tomato       System.Drawing.Bitmap
+            // banana.jpg   banana       System.Drawing.Bitmap
+            // hotdog.jpg   hotdog       System.Drawing.Bitmap
+            // tomato.jpg   tomato       System.Drawing.Bitmap
+        }
+
+        private static void PrintPreview(DataDebuggerPreview data)
+        {
+            foreach (var colInfo in data.ColumnView)
+                Console.Write("{0, -25}", colInfo.Column.Name);
+
+            Console.WriteLine();
+            foreach (var row in data.RowView)
             {
-                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
+                foreach (var kvPair in row.Values)
+                {
+                    Console.Write("{0, -25}", kvPair.Value);
+                }
+                Console.WriteLine();
             }
-            
-            // ImagePath : tomato.bmp
-            // Name : tomato
-            // ImageReal : System.Drawing.Bitmap
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
@@ -55,15 +55,13 @@ namespace Microsoft.ML.Samples.Dynamic
         private static void PrintPreview(DataDebuggerPreview data)
         {
             foreach (var colInfo in data.ColumnView)
-                Console.Write("{0, -25}", colInfo.Column.Name);
+                Console.Write("{0,-25}", colInfo.Column.Name);
 
             Console.WriteLine();
             foreach (var row in data.RowView)
             {
                 foreach (var kvPair in row.Values)
-                {
-                    Console.Write("{0, -25}", kvPair.Value);
-                }
+                    Console.Write("{0,-25}", kvPair.Value);
                 Console.WriteLine();
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
@@ -40,18 +41,17 @@ namespace Microsoft.ML.Samples.Dynamic
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // The transformedData IDataView contains the loaded images now
-            //Preview of the transformedData
-            var transformedDataPreview = transformedData.Preview();
 
-            // Preview of the content of the images.tsv file
-            // The actual images, in the ImageReal column are of type System.Drawing.Bitmap.
-            //
-            // ImagePath    Name        ImageReal
-            // tomato.bmp   tomato      {System.Drawing.Bitmap}
-            // banana.jpg   banana      {System.Drawing.Bitmap}
-            // hotdog.jpg   hotdog      {System.Drawing.Bitmap}
-            // tomato.jpg   tomato      {System.Drawing.Bitmap}
-
+            // Preview 1 row of the transformedData. 
+            var transformedDataPreview = transformedData.Preview(1);
+            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
+            {
+                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
+            }
+            
+            // ImagePath : tomato.bmp
+            // Name : tomato
+            // ImageReal : System.Drawing.Bitmap
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var pipeline = mlContext.Transforms.LoadImages("ImageObject", imagesFolder, "ImagePath");
 
             var transformedData = pipeline.Fit(data).Transform(data);
-            // The transformedData IDataView contains the loaded images now
+            // The transformedData IDataView contains the loaded images now.
 
             // Preview the transformedData. 
             var transformedDataPreview = transformedData.Preview();

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.ML.Data;
 
 namespace Microsoft.ML.Samples.Dynamic
@@ -37,24 +38,22 @@ namespace Microsoft.ML.Samples.Dynamic
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
             var pipeline = mlContext.Transforms.LoadImages("ImageReal", imagesFolder, "ImagePath")
-                        .Append(mlContext.Transforms.ResizeImages("ImageReal", imageWidth: 100, imageHeight: 100));
-                                
+                        .Append(mlContext.Transforms.ResizeImages("ImageResized", inputColumnName: "ImageReal", imageWidth: 100, imageHeight: 100));
+
 
             var transformedData = pipeline.Fit(data).Transform(data);
 
-            // The transformedData IDataView contains the loaded images now
-            //Preview of the transformedData
-            var transformedDataPreview = transformedData.Preview();
-
-            // Preview of the content of the images.tsv file
-            // The actual images, in the ImageReal column are of type System.Drawing.Bitmap.
-            //
-            // ImagePath    Name        ImageReal
-            // tomato.bmp   tomato      {System.Drawing.Bitmap}
-            // banana.jpg   banana      {System.Drawing.Bitmap}
-            // hotdog.jpg   hotdog      {System.Drawing.Bitmap}
-            // tomato.jpg   tomato      {System.Drawing.Bitmap}
-
+            // Preview 1 row of the transformedData. 
+            var transformedDataPreview = transformedData.Preview(1);
+            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
+            {
+                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
+            }
+            
+            // ImagePath : tomato.bmp
+            // Name : tomato
+            // ImageReal : System.Drawing.Bitmap
+            // ImageResized : System.Drawing.Bitmap
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
@@ -56,15 +56,13 @@ namespace Microsoft.ML.Samples.Dynamic
         private static void PrintPreview(DataDebuggerPreview data)
         {
             foreach (var colInfo in data.ColumnView)
-                Console.Write("{0, -25}", colInfo.Column.Name);
+                Console.Write("{0,-25}", colInfo.Column.Name);
 
             Console.WriteLine();
             foreach (var row in data.RowView)
             {
                 foreach (var kvPair in row.Values)
-                {
-                    Console.Write("{0, -25}", kvPair.Value);
-                }
+                    Console.Write("{0,-25}", kvPair.Value);
                 Console.WriteLine();
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Samples.Dynamic
                         .Append(mlContext.Transforms.ResizeImages("ImageObjectResized", inputColumnName: "ImageObject", imageWidth: 100, imageHeight: 100));
 
             var transformedData = pipeline.Fit(data).Transform(data);
-            // The transformedData IDataView contains the resized images now
+            // The transformedData IDataView contains the resized images now.
 
             // Preview the transformedData. 
             var transformedDataPreview = transformedData.Preview();

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
@@ -37,23 +37,36 @@ namespace Microsoft.ML.Samples.Dynamic
 
             var imagesFolder = Path.GetDirectoryName(imagesDataFile);
             // Image loading pipeline. 
-            var pipeline = mlContext.Transforms.LoadImages("ImageReal", imagesFolder, "ImagePath")
-                        .Append(mlContext.Transforms.ResizeImages("ImageResized", inputColumnName: "ImageReal", imageWidth: 100, imageHeight: 100));
-
+            var pipeline = mlContext.Transforms.LoadImages("ImageObject", imagesFolder, "ImagePath")
+                        .Append(mlContext.Transforms.ResizeImages("ImageObjectResized", inputColumnName: "ImageObject", imageWidth: 100, imageHeight: 100));
 
             var transformedData = pipeline.Fit(data).Transform(data);
+            // The transformedData IDataView contains the resized images now
 
-            // Preview 1 row of the transformedData. 
-            var transformedDataPreview = transformedData.Preview(1);
-            foreach (var kvPair in transformedDataPreview.RowView[0].Values)
+            // Preview the transformedData. 
+            var transformedDataPreview = transformedData.Preview();
+            PrintPreview(transformedDataPreview);
+            // ImagePath    Name         ImageObject            ImageObjectResized
+            // tomato.bmp   tomato       System.Drawing.Bitmap  System.Drawing.Bitmap
+            // banana.jpg   banana       System.Drawing.Bitmap  System.Drawing.Bitmap
+            // hotdog.jpg   hotdog       System.Drawing.Bitmap  System.Drawing.Bitmap
+            // tomato.jpg   tomato       System.Drawing.Bitmap  System.Drawing.Bitmap
+        }
+
+        private static void PrintPreview(DataDebuggerPreview data)
+        {
+            foreach (var colInfo in data.ColumnView)
+                Console.Write("{0, -25}", colInfo.Column.Name);
+
+            Console.WriteLine();
+            foreach (var row in data.RowView)
             {
-                Console.WriteLine("{0} : {1}", kvPair.Key, kvPair.Value);
+                foreach (var kvPair in row.Values)
+                {
+                    Console.Write("{0, -25}", kvPair.Value);
+                }
+                Console.WriteLine();
             }
-            
-            // ImagePath : tomato.bmp
-            // Name : tomato
-            // ImageReal : System.Drawing.Bitmap
-            // ImageResized : System.Drawing.Bitmap
         }
     }
 }

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -213,6 +213,12 @@ namespace Microsoft.ML
         /// <param name="defaultRed">Default value for red color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Red"/>.</param>
         /// <param name="defaultGreen">Default value for grenn color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Green"/>.</param>
         /// <param name="defaultBlue">Default value for blue color, would be overriden if <paramref name="colorsPresent"/> contains <see cref="ImagePixelExtractingEstimator.ColorBits.Blue"/>.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[ConvertToImage](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs)]
+        /// ]]></format>
+        /// </example>
         public static VectorToImageConvertingEstimator ConvertToImage(this TransformsCatalog catalog, int imageHeight, int imageWidth, string outputColumnName, string inputColumnName = null,
             ImagePixelExtractingEstimator.ColorBits colorsPresent = ImagePixelExtractingEstimator.Defaults.Colors,
             ImagePixelExtractingEstimator.ColorsOrder orderOfColors = ImagePixelExtractingEstimator.Defaults.Order,

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -753,6 +754,44 @@ namespace Microsoft.ML.Tests
             }
 
             Done();
+        }
+
+        [Fact]
+        public void TestConvertToImage()
+        {
+            var mlContext = new MLContext(0);
+
+            // Create a list of training data points.
+            var dataPoints = GenerateRandomDataPoints(10);
+
+            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            var data = mlContext.Data.LoadFromEnumerable(dataPoints);
+
+            var pipeline = mlContext.Transforms.ConvertToImage(224, 224, "Features");
+
+            TestEstimatorCore(pipeline, data);
+            Done();
+        }
+
+        private const int inputSize = 3 * 224 * 224;
+
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
+        {
+            var random = new Random(seed);
+
+            for (int i = 0; i < count; i++)
+            {
+                yield return new DataPoint
+                {
+                    Features = Enumerable.Repeat(0, inputSize).Select(x => random.NextDouble()*100).ToArray()
+                };
+            }
+        }
+
+        private class DataPoint
+        {
+            [VectorType(inputSize)]
+            public double[] Features { get; set; }
         }
     }
 }


### PR DESCRIPTION
Towards #1209

The PR makes the following changes

- Adds unit test and  sample  for the `ConvertToImage` transform estimator.   

- Fixes the info presented to the user for the 4 existing image samples   {ConvertToGrayscale, LoadImages, ExtractPixels, ResizeImages}

