### PR TITLE
Fix IncludeBuildNumberInPackageVersion for official builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -63,7 +63,7 @@
     <AssemblyFileVersion Condition="'$(AssemblyFileVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</AssemblyFileVersion>
 
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
-    <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
+    <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == '' and '$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition="'$(StabilizePackageVersion)' != 'true'">$(PreReleaseLabel)</VersionSuffix>


### PR DESCRIPTION
When doing an official build and setting a AzDO build variable, the variable turns into an environment variable. When MSBuild props/targets files declare a property, if they don't check if the property is already set, the MSBuild props file will override the environment variable. This causes the AzDO build variable to be ignored.

Adding a check if the IncludeBuildNumberInPackageVersion property is already set before setting it in Directory.Build.props.
