### PR TITLE
Fix NuGet badge on README to show pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Along with these ML capabilities, this first release of ML.NET also brings the f
 
 ## Installation
 
-[![NuGet Status](https://img.shields.io/nuget/v/Microsoft.ML.svg?style=flat)](https://www.nuget.org/packages/Microsoft.ML/)
+[![NuGet Status](https://img.shields.io/nuget/vpre/Microsoft.ML.svg?style=flat)](https://www.nuget.org/packages/Microsoft.ML/)
 
 ML.NET runs on Windows, Linux, and macOS using [.NET Core](https://github.com/dotnet/core), or Windows using .NET Framework. 64 bit is supported on all platforms. 32 bit is supported on Windows, except for TensorFlow, LightGBM, and ONNX related functionality.
 


### PR DESCRIPTION
Currently, the badge on the README is still showing `v0.11.0`, and not `v1.0.0-preview`.

Use the `vpre` URL to show pre-release versions on the badge, as specified by

https://shields.io/category/version
