### PR TITLE
Renaming OptimizationTolerance to fix a spelling error.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             var options = new LbfgsLogisticRegressionBinaryTrainer.Options()
             {
                 MaximumNumberOfIterations = 100,
-                OptmizationTolerance = 1e-8f,
+                OptimizationTolerance = 1e-8f,
                 L2Regularization = 0.01f
             };
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.tt
@@ -5,7 +5,7 @@ string Trainer = "LbfgsLogisticRegression";
 string TrainerOptions = @"LbfgsLogisticRegressionBinaryTrainer.Options()
             {
                 MaximumNumberOfIterations = 100,
-                OptmizationTolerance = 1e-8f,
+                OptimizationTolerance = 1e-8f,
                 L2Regularization = 0.01f
             }";
 bool IsCalibrated = true;

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             var options = new LbfgsPoissonRegressionTrainer.Options
             {
                 // Reduce optimization tolerance to speed up training at the cost of accuracy.
-                OptmizationTolerance = 1e-4f,
+                OptimizationTolerance = 1e-4f,
                 // Decrease history size to speed up training at the cost of accuracy.
                 HistorySize = 30,
                 // Specify scale for initial weights.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LbfgsPoissonRegressionWithOptions.tt
@@ -6,7 +6,7 @@ string Trainer = "LbfgsPoissonRegression";
 string TrainerOptions = @"LbfgsPoissonRegressionTrainer.Options
             {
                 // Reduce optimization tolerance to speed up training at the cost of accuracy.
-                OptmizationTolerance = 1e-4f,
+                OptimizationTolerance = 1e-4f,
                 // Decrease history size to speed up training at the cost of accuracy.
                 HistorySize = 30,
                 // Specify scale for initial weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LbfgsPredictorBase.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LbfgsPredictorBase.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Trainers
                 ShortName = "ot, OptTol", SortOrder = 50)]
             [TGUI(Label = "Optimization Tolerance", Description = "Threshold for optimizer convergence", SuggestedSweeps = "1e-4,1e-7")]
             [TlcModule.SweepableDiscreteParamAttribute(new object[] { 1e-4f, 1e-7f })]
-            public float OptmizationTolerance = Defaults.OptimizationTolerance;
+            public float OptimizationTolerance = Defaults.OptimizationTolerance;
 
             /// <summary>
             /// Number of previous iterations to remember for estimating the Hessian. Lower values mean faster but less accurate estimates.
@@ -198,7 +198,7 @@ namespace Microsoft.ML.Trainers
                             ExampleWeightColumnName = weightColumn,
                             L1Regularization = l1Weight,
                             L2Regularization = l2Weight,
-                            OptmizationTolerance = optimizationTolerance,
+                            OptimizationTolerance = optimizationTolerance,
                             HistorySize = memorySize,
                             EnforceNonNegativity = enforceNoNegativity
                         },
@@ -226,7 +226,7 @@ namespace Microsoft.ML.Trainers
               nameof(LbfgsTrainerOptions.NumberOfThreads), "Must be positive (or empty for default)");
             Host.CheckUserArg(LbfgsTrainerOptions.L2Regularization >= 0, nameof(LbfgsTrainerOptions.L2Regularization), "Must be non-negative");
             Host.CheckUserArg(LbfgsTrainerOptions.L1Regularization >= 0, nameof(LbfgsTrainerOptions.L1Regularization), "Must be non-negative");
-            Host.CheckUserArg(LbfgsTrainerOptions.OptmizationTolerance > 0, nameof(LbfgsTrainerOptions.OptmizationTolerance), "Must be positive");
+            Host.CheckUserArg(LbfgsTrainerOptions.OptimizationTolerance > 0, nameof(LbfgsTrainerOptions.OptimizationTolerance), "Must be positive");
             Host.CheckUserArg(LbfgsTrainerOptions.HistorySize > 0, nameof(LbfgsTrainerOptions.HistorySize), "Must be positive");
             Host.CheckUserArg(LbfgsTrainerOptions.MaximumNumberOfIterations > 0, nameof(LbfgsTrainerOptions.MaximumNumberOfIterations), "Must be positive");
             Host.CheckUserArg(LbfgsTrainerOptions.StochasticGradientDescentInitilaizationTolerance >= 0, nameof(LbfgsTrainerOptions.StochasticGradientDescentInitilaizationTolerance), "Must be non-negative");
@@ -234,12 +234,12 @@ namespace Microsoft.ML.Trainers
 
             Host.CheckParam(!(LbfgsTrainerOptions.L2Regularization < 0), nameof(LbfgsTrainerOptions.L2Regularization), "Must be non-negative, if provided.");
             Host.CheckParam(!(LbfgsTrainerOptions.L1Regularization < 0), nameof(LbfgsTrainerOptions.L1Regularization), "Must be non-negative, if provided");
-            Host.CheckParam(!(LbfgsTrainerOptions.OptmizationTolerance <= 0), nameof(LbfgsTrainerOptions.OptmizationTolerance), "Must be positive, if provided.");
+            Host.CheckParam(!(LbfgsTrainerOptions.OptimizationTolerance <= 0), nameof(LbfgsTrainerOptions.OptimizationTolerance), "Must be positive, if provided.");
             Host.CheckParam(!(LbfgsTrainerOptions.HistorySize <= 0), nameof(LbfgsTrainerOptions.HistorySize), "Must be positive, if provided.");
 
             L2Weight = LbfgsTrainerOptions.L2Regularization;
             L1Weight = LbfgsTrainerOptions.L1Regularization;
-            OptTol = LbfgsTrainerOptions.OptmizationTolerance;
+            OptTol = LbfgsTrainerOptions.OptimizationTolerance;
             MemorySize =LbfgsTrainerOptions.HistorySize;
             MaxIterations = LbfgsTrainerOptions.MaximumNumberOfIterations;
             SgdInitializationTolerance = LbfgsTrainerOptions.StochasticGradientDescentInitilaizationTolerance;
@@ -278,7 +278,7 @@ namespace Microsoft.ML.Trainers
                 ExampleWeightColumnName = weightColumn,
                 L1Regularization = l1Weight,
                 L2Regularization = l2Weight,
-                OptmizationTolerance = optimizationTolerance,
+                OptimizationTolerance = optimizationTolerance,
                 HistorySize = memorySize,
                 EnforceNonNegativity = enforceNoNegativity
             };

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -13390,7 +13390,7 @@
           }
         },
         {
-          "Name": "OptmizationTolerance",
+          "Name": "OptimizationTolerance",
           "Type": "Float",
           "Desc": "Tolerance parameter for optimization convergence. Low = slower, more accurate",
           "Aliases": [
@@ -13711,7 +13711,7 @@
           }
         },
         {
-          "Name": "OptmizationTolerance",
+          "Name": "OptimizationTolerance",
           "Type": "Float",
           "Desc": "Tolerance parameter for optimization convergence. Low = slower, more accurate",
           "Aliases": [
@@ -14740,7 +14740,7 @@
           }
         },
         {
-          "Name": "OptmizationTolerance",
+          "Name": "OptimizationTolerance",
           "Type": "Float",
           "Desc": "Tolerance parameter for optimization convergence. Low = slower, more accurate",
           "Aliases": [

--- a/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
+++ b/test/Microsoft.ML.Benchmarks/KMeansAndLogisticRegressionBench.cs
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Benchmarks
                 .Append(ml.Clustering.Trainers.KMeans("Features"))
                 .Append(ml.Transforms.Concatenate("Features", "Features", "Score"))
                 .Append(ml.BinaryClassification.Trainers.LbfgsLogisticRegression(
-                    new LbfgsLogisticRegressionBinaryTrainer.Options { EnforceNonNegativity = true, OptmizationTolerance = 1e-3f, }));
+                    new LbfgsLogisticRegressionBinaryTrainer.Options { EnforceNonNegativity = true, OptimizationTolerance = 1e-3f, }));
 
             var model = estimatorPipeline.Fit(input);
             // Return the last model in the chain.

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -743,7 +743,7 @@ namespace Microsoft.ML.RunTests
                 {
                     FeatureColumnName = "Features",
                     LabelColumnName = DefaultColumnNames.Label,
-                    OptmizationTolerance = 10e-4F,
+                    OptimizationTolerance = 10e-4F,
                     TrainingData = dataView,
                     NormalizeFeatures = NormalizeOption.No
                 }).PredictorModel,
@@ -751,7 +751,7 @@ namespace Microsoft.ML.RunTests
                 {
                     FeatureColumnName = "Features",
                     LabelColumnName = DefaultColumnNames.Label,
-                    OptmizationTolerance = 10e-3F,
+                    OptimizationTolerance = 10e-3F,
                     TrainingData = dataView,
                     NormalizeFeatures = NormalizeOption.No
                 }).PredictorModel
@@ -780,7 +780,7 @@ namespace Microsoft.ML.RunTests
                 {
                     FeatureColumnName = "Features",
                     LabelColumnName = DefaultColumnNames.Label,
-                    OptmizationTolerance = 10e-4F,
+                    OptimizationTolerance = 10e-4F,
                     TrainingData = dataView,
                     NormalizeFeatures = NormalizeOption.No
                 }).PredictorModel,
@@ -788,7 +788,7 @@ namespace Microsoft.ML.RunTests
                 {
                     FeatureColumnName = "Features",
                     LabelColumnName = DefaultColumnNames.Label,
-                    OptmizationTolerance = 10e-3F,
+                    OptimizationTolerance = 10e-3F,
                     TrainingData = dataView,
                     NormalizeFeatures = NormalizeOption.No
                 }).PredictorModel


### PR DESCRIPTION
In the `LbfgsTrainerBase`, the `OptmizationTolerance` option was misspelled.

Fixes #3198