### PR TITLE
Fixing namespace for image samples

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
@@ -17,7 +17,7 @@ namespace Samples.Dynamic
             // Downloading a few images, and an images.tsv file, which contains a list of the files from the dotnet/machinelearning/test/data/images/.
             // If you inspect the fileSystem, after running this line, an "images" folder will be created, containing 4 images, and a .tsv file
             // enumerating the images. 
-            var imagesDataFile = SamplesUtils.DatasetUtils.DownloadImages();
+            var imagesDataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadImages();
 
             // Preview of the content of the images.tsv file
             //

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToGrayScale.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.IO;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class ConvertToGrayscale
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ConvertToImage.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class ConvertToImage
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/DnnFeaturizeImage.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/DnnFeaturizeImage.cs
@@ -1,8 +1,9 @@
 ﻿using System.IO;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class DnnFeaturizeImage
     {
@@ -15,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Downloading a few images, and an images.tsv file, which contains a list of the files from the dotnet/machinelearning/test/data/images/.
             // If you inspect the fileSystem, after running this line, an "images" folder will be created, containing 4 images, and a .tsv file
             // enumerating the images. 
-            var imagesDataFile = SamplesUtils.DatasetUtils.DownloadImages();
+            var imagesDataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadImages();
 
             // Preview of the content of the images.tsv file, which lists the images to operate on
             //

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ExtractPixels.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class ExtractPixels
     {
@@ -18,7 +19,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Downloading a few images, and an images.tsv file, which contains a list of the files from the dotnet/machinelearning/test/data/images/.
             // If you inspect the fileSystem, after running this line, an "images" folder will be created, containing 4 images, and a .tsv file
             // enumerating the images. 
-            var imagesDataFile = SamplesUtils.DatasetUtils.DownloadImages();
+            var imagesDataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadImages();
 
             // Preview of the content of the images.tsv file
             //

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.IO;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class LoadImages
     {
@@ -16,7 +17,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Downloading a few images, and an images.tsv file, which contains a list of the files from the dotnet/machinelearning/test/data/images/.
             // If you inspect the fileSystem, after running this line, an "images" folder will be created, containing 4 images, and a .tsv file
             // enumerating the images. 
-            var imagesDataFile = SamplesUtils.DatasetUtils.DownloadImages();
+            var imagesDataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadImages();
 
             // Preview of the content of the images.tsv file
             //

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/ResizeImages.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.IO;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class ResizeImages
     {
@@ -16,7 +17,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Downloading a few images, and an images.tsv file, which contains a list of the files from the dotnet/machinelearning/test/data/images/.
             // If you inspect the fileSystem, after running this line, an "images" folder will be created, containing 4 images, and a .tsv file
             // enumerating the images. 
-            var imagesDataFile = SamplesUtils.DatasetUtils.DownloadImages();
+            var imagesDataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadImages();
 
             // Preview of the content of the images.tsv file
             //


### PR DESCRIPTION
Towards #3205 

- fixing the Image samples (which were previously updated via #3165)

