### PR TITLE
Fix marshalling of bool flags in MF

### DIFF
--- a/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
+++ b/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
@@ -133,19 +133,19 @@ namespace Microsoft.ML.Recommender.Internal
             /// Specify if the factor matrices should be non-negative.
             /// </summary>
             [FieldOffset(48)]
-            public int DoNmf;
+            public byte DoNmf;
 
             /// <summary>
             /// Set to true so that LIBMF may produce less information to STDOUT.
             /// </summary>
-            [FieldOffset(52)]
-            public int Quiet;
+            [FieldOffset(49)]
+            public byte Quiet;
 
             /// <summary>
             /// Set to false so that LIBMF may reuse and modifiy the data passed in.
             /// </summary>
-            [FieldOffset(56)]
-            public int CopyData;
+            [FieldOffset(50)]
+            public byte CopyData;
         }
 
         [StructLayout(LayoutKind.Explicit)]
@@ -223,9 +223,9 @@ namespace Microsoft.ML.Recommender.Internal
             _mfParam.Eta = (float)eta;
             _mfParam.Alpha = (float)alpha;
             _mfParam.C = (float)c;
-            _mfParam.DoNmf = doNmf ? 1 : 0;
-            _mfParam.Quiet = quiet ? 1 : 0;
-            _mfParam.CopyData = copyData ? 1 : 0;
+            _mfParam.DoNmf = doNmf ? (byte)1 : (byte)0;
+            _mfParam.Quiet = quiet ? (byte)1 : (byte)0;
+            _mfParam.CopyData = copyData ? (byte)1 : (byte)0;
         }
 
         ~SafeTrainingAndModelBuffer()

--- a/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
+++ b/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
@@ -133,19 +133,19 @@ namespace Microsoft.ML.Recommender.Internal
             /// Specify if the factor matrices should be non-negative.
             /// </summary>
             [FieldOffset(48)]
-            public byte DoNmf;
+            public sbyte DoNmf;
 
             /// <summary>
             /// Set to true so that LIBMF may produce less information to STDOUT.
             /// </summary>
             [FieldOffset(49)]
-            public byte Quiet;
+            public sbyte Quiet;
 
             /// <summary>
             /// Set to false so that LIBMF may reuse and modifiy the data passed in.
             /// </summary>
             [FieldOffset(50)]
-            public byte CopyData;
+            public sbyte CopyData;
         }
 
         [StructLayout(LayoutKind.Explicit)]
@@ -223,9 +223,9 @@ namespace Microsoft.ML.Recommender.Internal
             _mfParam.Eta = (float)eta;
             _mfParam.Alpha = (float)alpha;
             _mfParam.C = (float)c;
-            _mfParam.DoNmf = doNmf ? (byte)1 : (byte)0;
-            _mfParam.Quiet = quiet ? (byte)1 : (byte)0;
-            _mfParam.CopyData = copyData ? (byte)1 : (byte)0;
+            _mfParam.DoNmf = doNmf ? (sbyte)1 : (sbyte)0;
+            _mfParam.Quiet = quiet ? (sbyte)1 : (sbyte)0;
+            _mfParam.CopyData = copyData ? (sbyte)1 : (sbyte)0;
         }
 
         ~SafeTrainingAndModelBuffer()

--- a/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
+++ b/src/Microsoft.ML.Recommender/SafeTrainingAndModelBuffer.cs
@@ -133,19 +133,19 @@ namespace Microsoft.ML.Recommender.Internal
             /// Specify if the factor matrices should be non-negative.
             /// </summary>
             [FieldOffset(48)]
-            public sbyte DoNmf;
+            public byte DoNmf;
 
             /// <summary>
             /// Set to true so that LIBMF may produce less information to STDOUT.
             /// </summary>
             [FieldOffset(49)]
-            public sbyte Quiet;
+            public byte Quiet;
 
             /// <summary>
             /// Set to false so that LIBMF may reuse and modifiy the data passed in.
             /// </summary>
             [FieldOffset(50)]
-            public sbyte CopyData;
+            public byte CopyData;
         }
 
         [StructLayout(LayoutKind.Explicit)]
@@ -223,9 +223,9 @@ namespace Microsoft.ML.Recommender.Internal
             _mfParam.Eta = (float)eta;
             _mfParam.Alpha = (float)alpha;
             _mfParam.C = (float)c;
-            _mfParam.DoNmf = doNmf ? (sbyte)1 : (sbyte)0;
-            _mfParam.Quiet = quiet ? (sbyte)1 : (sbyte)0;
-            _mfParam.CopyData = copyData ? (sbyte)1 : (sbyte)0;
+            _mfParam.DoNmf = doNmf ? (byte)1 : (byte)0;
+            _mfParam.Quiet = quiet ? (byte)1 : (byte)0;
+            _mfParam.CopyData = copyData ? (byte)1 : (byte)0;
         }
 
         ~SafeTrainingAndModelBuffer()

--- a/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
+++ b/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
@@ -9,25 +9,48 @@
 
 using namespace mf;
 
+EXPORT_API(mf_parameter) make_param(const mf_parameter_bridge *param_bridge)
+{
+    mf_parameter param;
+    param.fun = param_bridge->fun;
+    param.k = param_bridge->k;
+    param.nr_threads = param_bridge->nr_threads;
+    param.nr_bins = param_bridge->nr_bins;
+    param.nr_iters = param_bridge->nr_iters;
+    param.lambda_p1 = param_bridge->lambda_p1;
+    param.lambda_p2 = param_bridge->lambda_p2;
+    param.lambda_q1 = param_bridge->lambda_q1;
+    param.lambda_q2 = param_bridge->lambda_q2;
+    param.eta = param_bridge->eta;
+    param.alpha = param_bridge->alpha;
+    param.c = param_bridge->c;
+    param.do_nmf = static_cast<bool>(param_bridge->do_nmf);
+    param.quiet = static_cast<bool>(param_bridge->quiet);
+    param.copy_data = static_cast<bool>(param_bridge->copy_data);
+    return param;
+}
+
 EXPORT_API(void) MFDestroyModel(mf_model *&model)
 {
     return mf_destroy_model(&model);
 }
 
-EXPORT_API(mf_model*) MFTrain(const mf_problem *prob, const mf_parameter *param)
+EXPORT_API(mf_model*) MFTrain(const mf_problem *prob, const mf_parameter_bridge *param_bridge)
 {
-    return mf_train(prob, *param);
+    auto param = make_param(param_bridge);
+    return mf_train(prob, param);
 }
 
-EXPORT_API(mf_model*) MFTrainWithValidation(const mf_problem *tr, const mf_problem *va, const mf_parameter *param)
+EXPORT_API(mf_model*) MFTrainWithValidation(const mf_problem *tr, const mf_problem *va, const mf_parameter_bridge *param_bridge)
 {
-    return mf_train_with_validation(tr, va, *param);
+    auto param = make_param(param_bridge);
+    return mf_train_with_validation(tr, va, param);
 }
 
-
-EXPORT_API(float) MFCrossValidation(const mf_problem *prob, int nr_folds, const mf_parameter *param)
+EXPORT_API(float) MFCrossValidation(const mf_problem *prob, int nr_folds, const mf_parameter_bridge *param_bridge)
 {
-    return mf_cross_validation(prob, nr_folds, *param);
+    auto param = make_param(param_bridge);
+    return mf_cross_validation(prob, nr_folds, param);
 }
 
 EXPORT_API(float) MFPredict(const mf_model *model, int p_idx, int q_idx)

--- a/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
+++ b/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
@@ -9,7 +9,7 @@
 
 using namespace mf;
 
-EXPORT_API(mf_parameter) make_param(const mf_parameter_bridge *param_bridge)
+mf_parameter make_param(const mf_parameter_bridge *param_bridge)
 {
     mf_parameter param;
     param.fun = param_bridge->fun;
@@ -24,9 +24,9 @@ EXPORT_API(mf_parameter) make_param(const mf_parameter_bridge *param_bridge)
     param.eta = param_bridge->eta;
     param.alpha = param_bridge->alpha;
     param.c = param_bridge->c;
-    param.do_nmf = static_cast<bool>(param_bridge->do_nmf);
-    param.quiet = static_cast<bool>(param_bridge->quiet);
-    param.copy_data = static_cast<bool>(param_bridge->copy_data);
+    param.do_nmf = param_bridge->do_nmf != 0 ? true : false;
+    param.quiet = param_bridge->quiet != 0 ? true : false;
+    param.copy_data = param_bridge->copy_data != 0 ? true : false;
     return param;
 }
 

--- a/src/Native/MatrixFactorizationNative/UnmanagedMemory.h
+++ b/src/Native/MatrixFactorizationNative/UnmanagedMemory.h
@@ -8,12 +8,31 @@
 
 using namespace mf;
 
+struct mf_parameter_bridge
+{
+    int32_t fun;
+    int32_t k;
+    int32_t nr_threads;
+    int32_t nr_bins;
+    int32_t nr_iters;
+    float lambda_p1;
+    float lambda_p2;
+    float lambda_q1;
+    float lambda_q2;
+    float eta;
+    float alpha;
+    float c;
+    int8_t do_nmf;
+    int8_t quiet;
+    int8_t copy_data;
+};
+
 EXPORT_API(void) MFDestroyModel(mf_model *&model);
 
-EXPORT_API(mf_model*) MFTrain(const mf_problem *prob, const mf_parameter *param);
+EXPORT_API(mf_model*) MFTrain(const mf_problem *prob, const mf_parameter_bridge *parameter_bridge);
 
-EXPORT_API(mf_model*) MFTrainWithValidation(const mf_problem *tr, const mf_problem *va, const mf_parameter *param);
+EXPORT_API(mf_model*) MFTrainWithValidation(const mf_problem *tr, const mf_problem *va, const mf_parameter_bridge *parameter_bridge);
     
-EXPORT_API(float) MFCrossValidation(const mf_problem *prob, int nr_folds, const mf_parameter* param);
+EXPORT_API(float) MFCrossValidation(const mf_problem *prob, int nr_folds, const mf_parameter_bridge* parameter_bridge);
 
 EXPORT_API(float) MFPredict(const mf_model *model, int p_idx, int q_idx);

--- a/src/Native/MatrixFactorizationNative/UnmanagedMemory.h
+++ b/src/Native/MatrixFactorizationNative/UnmanagedMemory.h
@@ -22,9 +22,9 @@ struct mf_parameter_bridge
     float eta;
     float alpha;
     float c;
-    int8_t do_nmf;
-    int8_t quiet;
-    int8_t copy_data;
+    uint8_t do_nmf;
+    uint8_t quiet;
+    uint8_t copy_data;
 };
 
 EXPORT_API(void) MFDestroyModel(mf_model *&model);


### PR DESCRIPTION
Fix #3003. The marshalled Boolean size from C# to C should be 1 byte, not 4. Also, the change from LIBMF is for supporting quiet option in new implicit-feedback MF.
