### PR TITLE
Rename sample methods to Example

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Dynamic
 {
     public static partial class TransformSamples
     {
-        public static void NgramTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Samples.Dynamic
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
         // This estimator can account for temporal seasonality in the data.
-        public static void SsaSpikeDetectorTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Static/AveragedPerceptronBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/AveragedPerceptronBinaryClassification.cs
@@ -5,7 +5,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class AveragedPerceptronBinaryClassificationExample
     {
-        public static void AveragedPerceptronBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/FastTreeBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FastTreeBinaryClassification.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Static
     public class FastTreeBinaryClassificationExample
     {
         // This example requires installation of additional nuget package <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
-        public static void FastTreeBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ML.Samples.Static
     public class FastTreeRegressionExample
     {
         // This example requires installation of additional nuget package <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
-        public static void FastTreeRegression()
+        public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem this code will run

--- a/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ML.Samples.Dynamic
 {
     public class FeatureSelectionTransformStaticExample
     {
-        public static void FeatureSelectionTransform()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMBinaryClassification.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class LightGbmBinaryClassificationExample
     {
-        public static void LightGbmBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Samples.Static
 {
     class LightGBMMulticlassWithInMemoryData
     {
-        public void MulticlassLightGbmStaticPipelineWithInMemoryData()
+        public void Example()
         {
             // Create a general context for ML.NET operations. It can be used for exception tracking and logging,
             // as a catalog of available operations and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class LightGbmRegressionExample
     {
-        public static void LightGbmRegression()
+        public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem.

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCABinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCABinaryClassification.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class SdcaBinaryClassificationExample
     {
-        public static void SdcaBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class SdcaRegressionExample
     {
-        public static void SdcaRegression()
+        public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem this code will run


### PR DESCRIPTION
Make our samples follow the convention that method name should be called "Example", this PR fixes samples that have any other method name.
