### PR TITLE
Time Series samples for stateful prediction engine.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
@@ -9,7 +9,6 @@ namespace Samples.Dynamic
 {
     public static class DetectChangePointBySsa
     {
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // It demostrates stateful prediction engine that updates the state of the model and allows for saving/reloading.
         // The estimator is applied then to identify points where data distribution changed.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Samples.Dynamic
 {
@@ -24,6 +26,7 @@ namespace Samples.Dynamic
         }
 
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // It demostrates stateful prediction engine that updates the state of the model and allows for saving/reloading.
         // The estimator is applied then to identify points where data distribution changed.
         // This estimator can account for temporal seasonality in the data.
         public static void Example()
@@ -32,7 +35,7 @@ namespace Samples.Dynamic
             // as well as the source of randomness.
             var ml = new MLContext();
 
-            // Generate sample series data with a recurring pattern and then a change in trend
+            // Generate sample series data with a recurring pattern
             const int SeasonalitySize = 5;
             const int TrainingSeasons = 3;
             const int TrainingSize = SeasonalitySize * TrainingSeasons;
@@ -40,52 +43,78 @@ namespace Samples.Dynamic
             for (int i = 0; i < TrainingSeasons; i++)
                 for (int j = 0; j < SeasonalitySize; j++)
                     data.Add(new SsaChangePointData(j));
-            // This is a change point
-            for (int i = 0; i < SeasonalitySize; i++)
-                data.Add(new SsaChangePointData(i * 100));
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
-            // Setup estimator arguments
+            // Setup SsaChangePointDetector arguments
             var inputColumnName = nameof(SsaChangePointData.Value);
             var outputColumnName = nameof(ChangePointPrediction.Prediction);
 
-            // The transformed data.
-            var transformedData = ml.Transforms.DetectChangePointBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+            // Train the change point detector.
+            ITransformer model = ml.Transforms.DetectChangePointBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView);
 
-            // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
-            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+            // Create a prediction engine from the model for feeding new data.
+            var engine = model.CreateTimeSeriesPredictionFunction<SsaChangePointData, ChangePointPrediction>(ml);
 
-            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            // Start streaming new data points with no change point to the prediction engine.
+            Console.WriteLine($"Output from ChangePoint predictions on new data:");
             Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
-            int k = 0;
-            foreach (var prediction in predictionColumn)
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
-            Console.WriteLine("");
+            ChangePointPrediction prediction = null;
+            for (int i = 0; i < 5; i++)
+            {
+                var value = i;
+                prediction = engine.Predict(new SsaChangePointData(value));
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            }
 
-            // Prediction column obtained post-transformation.
+            // Now stream data points that reflect a change in trend.
+            for (int i = 0; i < 5; i++)
+            {
+                var value = (i + 1) * 100;
+                prediction = engine.Predict(new SsaChangePointData(value));
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            }
+
+            // Now we demonstrate saving and loading the model.
+
+            // Save the model that exists within the prediction engine.
+            // The engine has been updating this model with every new data point.
+            var modelPath = "model.zip";
+            engine.CheckPoint(ml, modelPath);
+
+            // Load the model.
+            using (var file = File.OpenRead(modelPath))
+                model = ml.Model.Load(file, out DataViewSchema schema);
+
+            // We must create a new prediction engine from the persisted model.
+            engine = model.CreateTimeSeriesPredictionFunction<SsaChangePointData, ChangePointPrediction>(ml);
+
+            // Run predictions on the loaded model.
+            for (int i = 0; i < 5; i++)
+            {
+                var value = (i + 1) * 100;
+                prediction = engine.Predict(new SsaChangePointData(value));
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            }
+
+            // Output from ChangePoint predictions on new data:
             // Data    Alert   Score   P-Value Martingale value
-            // 0       0     - 2.53    0.50    0.00
-            // 1       0     - 0.01    0.01    0.00
-            // 2       0       0.76    0.14    0.00
-            // 3       0       0.69    0.28    0.00
-            // 4       0       1.44    0.18    0.00
-            // 0       0     - 1.84    0.17    0.00
-            // 1       0       0.22    0.44    0.00
-            // 2       0       0.20    0.45    0.00
-            // 3       0       0.16    0.47    0.00
-            // 4       0       1.33    0.18    0.00
-            // 0       0     - 1.79    0.07    0.00
-            // 1       0       0.16    0.50    0.00
-            // 2       0       0.09    0.50    0.00
-            // 3       0       0.08    0.45    0.00
-            // 4       0       1.31    0.12    0.00
-            // 0       0     - 1.79    0.07    0.00
-            // 100     1      99.16    0.00    4031.94     <-- alert is on, predicted changepoint
-            // 200     0     185.23    0.00    731260.87
-            // 300     0     270.40    0.01    3578470.47
-            // 400     0     357.11    0.03    45298370.86
+            // 0       0     - 1.01    0.50    0.00
+            // 1       0     - 0.24    0.22    0.00
+            // 2       0     - 0.31    0.30    0.00
+            // 3       0       0.44    0.01    0.00
+            // 4       0       2.16    0.00    0.24
+            // 100     0      86.23    0.00    2076098.24
+            // 200     0     171.38    0.00    809668524.21
+            // 300     1     256.83    0.01    22130423541.93    <-- alert is on, note that delay is expected
+            // 400     0     326.55    0.04    241162710263.29
+            // 500     0     364.82    0.08    597660527041.45   <-- saved to disk
+            // 100     0    - 58.58    0.15    1096021098844.34  <-- loaded from disk and running new predictions
+            // 200     0    - 41.24    0.20    97579154688.98
+            // 300     0    - 30.61    0.24    95319753.87
+            // 400     0      58.87    0.38    14.24
+            // 500     0     219.28    0.36    0.05
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
@@ -9,21 +9,6 @@ namespace Samples.Dynamic
 {
     public static class DetectChangePointBySsa
     {
-        class ChangePointPrediction
-        {
-            [VectorType(4)]
-            public double[] Prediction { get; set; }
-        }
-
-        class SsaChangePointData
-        {
-            public float Value;
-
-            public SsaChangePointData(float value)
-            {
-                Value = value;
-            }
-        }
 
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // It demostrates stateful prediction engine that updates the state of the model and allows for saving/reloading.
@@ -39,42 +24,67 @@ namespace Samples.Dynamic
             const int SeasonalitySize = 5;
             const int TrainingSeasons = 3;
             const int TrainingSize = SeasonalitySize * TrainingSeasons;
-            var data = new List<SsaChangePointData>();
-            for (int i = 0; i < TrainingSeasons; i++)
-                for (int j = 0; j < SeasonalitySize; j++)
-                    data.Add(new SsaChangePointData(j));
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+            };
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
             // Setup SsaChangePointDetector arguments
-            var inputColumnName = nameof(SsaChangePointData.Value);
+            var inputColumnName = nameof(TimeSeriesData.Value);
             var outputColumnName = nameof(ChangePointPrediction.Prediction);
 
             // Train the change point detector.
             ITransformer model = ml.Transforms.DetectChangePointBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView);
 
             // Create a prediction engine from the model for feeding new data.
-            var engine = model.CreateTimeSeriesPredictionFunction<SsaChangePointData, ChangePointPrediction>(ml);
+            var engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, ChangePointPrediction>(ml);
 
             // Start streaming new data points with no change point to the prediction engine.
             Console.WriteLine($"Output from ChangePoint predictions on new data:");
             Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
-            ChangePointPrediction prediction = null;
+            
+            // Output from ChangePoint predictions on new data:
+            // Data    Alert   Score   P-Value Martingale value
+
             for (int i = 0; i < 5; i++)
-            {
-                var value = i;
-                prediction = engine.Predict(new SsaChangePointData(value));
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
-            }
+                PrintPrediction(i, engine.Predict(new TimeSeriesData(i)));
+
+            // 0       0      -1.01    0.50    0.00
+            // 1       0      -0.24    0.22    0.00
+            // 2       0      -0.31    0.30    0.00
+            // 3       0       0.44    0.01    0.00
+            // 4       0       2.16    0.00    0.24
 
             // Now stream data points that reflect a change in trend.
             for (int i = 0; i < 5; i++)
             {
-                var value = (i + 1) * 100;
-                prediction = engine.Predict(new SsaChangePointData(value));
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+                int value = (i + 1) * 100;
+                PrintPrediction(value, engine.Predict(new TimeSeriesData(value)));
             }
+            // 100     0      86.23    0.00    2076098.24
+            // 200     0     171.38    0.00    809668524.21
+            // 300     1     256.83    0.01    22130423541.93    <-- alert is on, note that delay is expected
+            // 400     0     326.55    0.04    241162710263.29
+            // 500     0     364.82    0.08    597660527041.45   <-- saved to disk
 
             // Now we demonstrate saving and loading the model.
 
@@ -88,33 +98,41 @@ namespace Samples.Dynamic
                 model = ml.Model.Load(file, out DataViewSchema schema);
 
             // We must create a new prediction engine from the persisted model.
-            engine = model.CreateTimeSeriesPredictionFunction<SsaChangePointData, ChangePointPrediction>(ml);
+            engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, ChangePointPrediction>(ml);
 
             // Run predictions on the loaded model.
             for (int i = 0; i < 5; i++)
             {
-                var value = (i + 1) * 100;
-                prediction = engine.Predict(new SsaChangePointData(value));
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+                int value = (i + 1) * 100;
+                PrintPrediction(value, engine.Predict(new TimeSeriesData(value)));
             }
 
-            // Output from ChangePoint predictions on new data:
-            // Data    Alert   Score   P-Value Martingale value
-            // 0       0     - 1.01    0.50    0.00
-            // 1       0     - 0.24    0.22    0.00
-            // 2       0     - 0.31    0.30    0.00
-            // 3       0       0.44    0.01    0.00
-            // 4       0       2.16    0.00    0.24
-            // 100     0      86.23    0.00    2076098.24
-            // 200     0     171.38    0.00    809668524.21
-            // 300     1     256.83    0.01    22130423541.93    <-- alert is on, note that delay is expected
-            // 400     0     326.55    0.04    241162710263.29
-            // 500     0     364.82    0.08    597660527041.45   <-- saved to disk
-            // 100     0    - 58.58    0.15    1096021098844.34  <-- loaded from disk and running new predictions
-            // 200     0    - 41.24    0.20    97579154688.98
-            // 300     0    - 30.61    0.24    95319753.87
+            // 100     0     -58.58    0.15    1096021098844.34  <-- loaded from disk and running new predictions
+            // 200     0     -41.24    0.20    97579154688.98
+            // 300     0     -30.61    0.24    95319753.87
             // 400     0      58.87    0.38    14.24
             // 500     0     219.28    0.36    0.05
+
+        }
+
+        private static void PrintPrediction(float value, ChangePointPrediction prediction) =>
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0],
+                prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+
+        class ChangePointPrediction
+        {
+            [VectorType(4)]
+            public double[] Prediction { get; set; }
+        }
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Microsoft.Samples.Dynamic
 {
     public static class DetectChangePointBySsaBatchPrediction
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
@@ -1,27 +1,12 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class DetectChangePointBySsaBatchPrediction
     {
-        class ChangePointPrediction
-        {
-            [VectorType(4)]
-            public double[] Prediction { get; set; }
-        }
-
-        class SsaChangePointData
-        {
-            public float Value;
-
-            public SsaChangePointData(float value)
-            {
-                Value = value;
-            }
-        }
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify points where data distribution changed.
         // This estimator can account for temporal seasonality in the data.
@@ -35,19 +20,39 @@ namespace Microsoft.Samples.Dynamic
             const int SeasonalitySize = 5;
             const int TrainingSeasons = 3;
             const int TrainingSize = SeasonalitySize * TrainingSeasons;
-            var data = new List<SsaChangePointData>();
-            for (int i = 0; i < TrainingSeasons; i++)
-                for (int j = 0; j < SeasonalitySize; j++)
-                    data.Add(new SsaChangePointData(j));
-            // This is a change point
-            for (int i = 0; i < SeasonalitySize; i++)
-                data.Add(new SsaChangePointData(i * 100));
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                //This is a change point
+                new TimeSeriesData(0),
+                new TimeSeriesData(100),
+                new TimeSeriesData(200),
+                new TimeSeriesData(300),
+                new TimeSeriesData(400),
+            };
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
             // Setup estimator arguments
-            var inputColumnName = nameof(SsaChangePointData.Value);
+            var inputColumnName = nameof(TimeSeriesData.Value);
             var outputColumnName = nameof(ChangePointPrediction.Prediction);
 
             // The transformed data.
@@ -60,31 +65,50 @@ namespace Microsoft.Samples.Dynamic
             Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
             int k = 0;
             foreach (var prediction in predictionColumn)
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
-            Console.WriteLine("");
+                PrintPrediction(data[k++].Value, prediction);
 
             // Prediction column obtained post-transformation.
             // Data    Alert   Score   P-Value Martingale value
-            // 0       0     - 2.53    0.50    0.00
-            // 1       0     - 0.01    0.01    0.00
+            // 0       0      -2.53    0.50    0.00
+            // 1       0      -0.01    0.01    0.00
             // 2       0       0.76    0.14    0.00
             // 3       0       0.69    0.28    0.00
             // 4       0       1.44    0.18    0.00
-            // 0       0     - 1.84    0.17    0.00
+            // 0       0      -1.84    0.17    0.00
             // 1       0       0.22    0.44    0.00
             // 2       0       0.20    0.45    0.00
             // 3       0       0.16    0.47    0.00
             // 4       0       1.33    0.18    0.00
-            // 0       0     - 1.79    0.07    0.00
+            // 0       0      -1.79    0.07    0.00
             // 1       0       0.16    0.50    0.00
             // 2       0       0.09    0.50    0.00
             // 3       0       0.08    0.45    0.00
             // 4       0       1.31    0.12    0.00
-            // 0       0     - 1.79    0.07    0.00
+            // 0       0      -1.79    0.07    0.00
             // 100     1      99.16    0.00    4031.94     <-- alert is on, predicted changepoint
             // 200     0     185.23    0.00    731260.87
             // 300     0     270.40    0.01    3578470.47
             // 400     0     357.11    0.03    45298370.86
+        }
+
+        private static void PrintPrediction(float value, ChangePointPrediction prediction) => 
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], 
+                prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+
+        class ChangePointPrediction
+        {
+            [VectorType(4)]
+            public double[] Prediction { get; set; }
+        }
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    public static class DetectChangePointBySsaBatchPrediction
+    {
+        class ChangePointPrediction
+        {
+            [VectorType(4)]
+            public double[] Prediction { get; set; }
+        }
+
+        class SsaChangePointData
+        {
+            public float Value;
+
+            public SsaChangePointData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // The estimator is applied then to identify points where data distribution changed.
+        // This estimator can account for temporal seasonality in the data.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a recurring pattern and then a change in trend
+            const int SeasonalitySize = 5;
+            const int TrainingSeasons = 3;
+            const int TrainingSize = SeasonalitySize * TrainingSeasons;
+            var data = new List<SsaChangePointData>();
+            for (int i = 0; i < TrainingSeasons; i++)
+                for (int j = 0; j < SeasonalitySize; j++)
+                    data.Add(new SsaChangePointData(j));
+            // This is a change point
+            for (int i = 0; i < SeasonalitySize; i++)
+                data.Add(new SsaChangePointData(i * 100));
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup estimator arguments
+            var inputColumnName = nameof(SsaChangePointData.Value);
+            var outputColumnName = nameof(ChangePointPrediction.Prediction);
+
+            // The transformed data.
+            var transformedData = ml.Transforms.DetectChangePointBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+
+            // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
+            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+
+            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
+            int k = 0;
+            foreach (var prediction in predictionColumn)
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            Console.WriteLine("");
+
+            // Prediction column obtained post-transformation.
+            // Data    Alert   Score   P-Value Martingale value
+            // 0       0     - 2.53    0.50    0.00
+            // 1       0     - 0.01    0.01    0.00
+            // 2       0       0.76    0.14    0.00
+            // 3       0       0.69    0.28    0.00
+            // 4       0       1.44    0.18    0.00
+            // 0       0     - 1.84    0.17    0.00
+            // 1       0       0.22    0.44    0.00
+            // 2       0       0.20    0.45    0.00
+            // 3       0       0.16    0.47    0.00
+            // 4       0       1.33    0.18    0.00
+            // 0       0     - 1.79    0.07    0.00
+            // 1       0       0.16    0.50    0.00
+            // 2       0       0.09    0.50    0.00
+            // 3       0       0.08    0.45    0.00
+            // 4       0       1.31    0.12    0.00
+            // 0       0     - 1.79    0.07    0.00
+            // 100     1      99.16    0.00    4031.94     <-- alert is on, predicted changepoint
+            // 200     0     185.23    0.00    731260.87
+            // 300     0     270.40    0.01    3578470.47
+            // 400     0     357.11    0.03    45298370.86
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
@@ -13,7 +13,6 @@ namespace Samples.Dynamic
 {
     public static class DetectIidChangePoint
     {
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify points where data distribution changed.
         public static void Example()

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Samples.Dynamic
 {
@@ -47,25 +49,63 @@ namespace Samples.Dynamic
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
-            // Setup estimator arguments
+            // Setup IidSpikeDetector arguments
             string outputColumnName = nameof(ChangePointPrediction.Prediction);
             string inputColumnName = nameof(IidChangePointData.Value);
 
-            // The transformed data.
-            var transformedData = ml.Transforms.DetectIidChangePoint(outputColumnName, inputColumnName, 95, Size / 4).Fit(dataView).Transform(dataView);
+            // Time Series model.
+            ITransformer model = ml.Transforms.DetectIidChangePoint(outputColumnName, inputColumnName, 95, Size / 4).Fit(dataView);
 
-            // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
-            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+            // Create a time series prediction engine from the model.
+            var engine = model.CreateTimeSeriesPredictionFunction<IidChangePointData, ChangePointPrediction>(ml);
+            for (int index = 0; index < 8; index++)
+            {
+                // Anomaly change point detection.
+                var prediction = engine.Predict(new IidChangePointData(5));
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", 5, prediction.Prediction[0],
+                    prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            }
 
-            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
-            Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
-            int k = 0;
-            foreach (var prediction in predictionColumn)
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
-            Console.WriteLine("");
+            // Change point
+            var changePointPrediction = engine.Predict(new IidChangePointData(7));
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", 7, changePointPrediction.Prediction[0],
+                changePointPrediction.Prediction[1], changePointPrediction.Prediction[2], changePointPrediction.Prediction[3]);
 
-            // Prediction column obtained post-transformation.
+            // Checkpoint the model.
+            var modelPath = "temp.zip";
+            engine.CheckPoint(ml, modelPath);
+
+            // Reference to current time series engine because in the next step "engine" will point to the
+            // checkpointed model being loaded from disk.
+            var timeseries1 = engine;
+
+            // Load the model.
+            using (var file = File.OpenRead(modelPath))
+                model = ml.Model.Load(file, out DataViewSchema schema);
+
+            // Create a time series prediction engine from the checkpointed model.
+            engine = model.CreateTimeSeriesPredictionFunction<IidChangePointData, ChangePointPrediction>(ml);
+            for (int index = 0; index < 8; index++)
+            {
+                // Anomaly change point detection.
+                var prediction = engine.Predict(new IidChangePointData(7));
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", 7, prediction.Prediction[0],
+                    prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            }
+
+            // Prediction from the original time series engine should match the prediction from 
+            // check pointed model.
+            engine = timeseries1;
+            for (int index = 0; index < 8; index++)
+            {
+                // Anomaly change point detection.
+                var prediction = engine.Predict(new IidChangePointData(7));
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", 7, prediction.Prediction[0],
+                    prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            }
+
             // Data Alert      Score   P-Value Martingale value
+            // 5       0       5.00    0.50    0.00       <-- Time Series 1.
             // 5       0       5.00    0.50    0.00
             // 5       0       5.00    0.50    0.00
             // 5       0       5.00    0.50    0.00
@@ -73,9 +113,17 @@ namespace Samples.Dynamic
             // 5       0       5.00    0.50    0.00
             // 5       0       5.00    0.50    0.00
             // 5       0       5.00    0.50    0.00
-            // 5       0       5.00    0.50    0.00
-            // 7       1       7.00    0.00    10298.67   <-- alert is on, predicted changepoint
-            // 7       0       7.00    0.13    33950.16
+            // 7       1       7.00    0.00    10298.67   <-- alert is on, predicted changepoint (and model is checkpointed).
+
+            // 7       0       7.00    0.13    33950.16   <-- Time Series 2 : Model loaded back from disk and prediction is made.
+            // 7       0       7.00    0.26    60866.34
+            // 7       0       7.00    0.38    78362.04
+            // 7       0       7.00    0.50    0.01
+            // 7       0       7.00    0.50    0.00
+            // 7       0       7.00    0.50    0.00
+            // 7       0       7.00    0.50    0.00
+
+            // 7       0       7.00    0.13    33950.16   <-- Time Series 1 and prediction is made.
             // 7       0       7.00    0.26    60866.34
             // 7       0       7.00    0.38    78362.04
             // 7       0       7.00    0.50    0.01

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
@@ -58,6 +58,8 @@ namespace Samples.Dynamic
 
             // Create a time series prediction engine from the model.
             var engine = model.CreateTimeSeriesPredictionFunction<IidChangePointData, ChangePointPrediction>(ml);
+
+            // Create non-anomalous data and check for change point.
             for (int index = 0; index < 8; index++)
             {
                 // Anomaly change point detection.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePointBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePointBatchPrediction.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    public static class DetectIidChangePointBatchPrediction
+    {
+        class ChangePointPrediction
+        {
+            [VectorType(4)]
+            public double[] Prediction { get; set; }
+        }
+
+        class IidChangePointData
+        {
+            public float Value;
+
+            public IidChangePointData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // The estimator is applied then to identify points where data distribution changed.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a change
+            const int Size = 16;
+            var data = new List<IidChangePointData>(Size);
+            for (int i = 0; i < Size / 2; i++)
+                data.Add(new IidChangePointData(5));
+            // This is a change point
+            for (int i = 0; i < Size / 2; i++)
+                data.Add(new IidChangePointData(7));
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup estimator arguments
+            string outputColumnName = nameof(ChangePointPrediction.Prediction);
+            string inputColumnName = nameof(IidChangePointData.Value);
+
+            // The transformed data.
+            var transformedData = ml.Transforms.DetectIidChangePoint(outputColumnName, inputColumnName, 95, Size / 4).Fit(dataView).Transform(dataView);
+
+            // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
+            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+
+            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
+            int k = 0;
+            foreach (var prediction in predictionColumn)
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+            Console.WriteLine("");
+
+            // Prediction column obtained post-transformation.
+            // Data Alert      Score   P-Value Martingale value
+            // 5       0       5.00    0.50    0.00
+            // 5       0       5.00    0.50    0.00
+            // 5       0       5.00    0.50    0.00
+            // 5       0       5.00    0.50    0.00
+            // 5       0       5.00    0.50    0.00
+            // 5       0       5.00    0.50    0.00
+            // 5       0       5.00    0.50    0.00
+            // 5       0       5.00    0.50    0.00
+            // 7       1       7.00    0.00    10298.67   <-- alert is on, predicted changepoint
+            // 7       0       7.00    0.13    33950.16
+            // 7       0       7.00    0.26    60866.34
+            // 7       0       7.00    0.38    78362.04
+            // 7       0       7.00    0.50    0.01
+            // 7       0       7.00    0.50    0.00
+            // 7       0       7.00    0.50    0.00
+            // 7       0       7.00    0.50    0.00
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePointBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePointBatchPrediction.cs
@@ -11,7 +11,6 @@ namespace Samples.Dynamic
 {
     public static class DetectIidChangePointBatchPrediction
     {
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify points where data distribution changed.
         public static void Example()

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
@@ -9,7 +9,6 @@ namespace Samples.Dynamic
 {
     public static class DetectIidSpike
     {
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
         public static void Example()

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
@@ -54,6 +54,8 @@ namespace Samples.Dynamic
 
             // Create a time series prediction engine from the model.
             var engine = model.CreateTimeSeriesPredictionFunction<IidSpikeData, IidSpikePrediction>(ml);
+
+            // Create non-anomalous data and check for anomaly.
             for (int index = 0; index < 5; index++)
             {
                 // Anomaly spike detection.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
@@ -9,21 +9,6 @@ namespace Samples.Dynamic
 {
     public static class DetectIidSpike
     {
-        class IidSpikeData
-        {
-            public float Value;
-
-            public IidSpikeData(float value)
-            {
-                Value = value;
-            }
-        }
-
-        class IidSpikePrediction
-        {
-            [VectorType(3)]
-            public double[] Prediction { get; set; }
-        }
 
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
@@ -35,39 +20,60 @@ namespace Samples.Dynamic
 
             // Generate sample series data with a spike
             const int Size = 10;
-            var data = new List<IidSpikeData>(Size);
-            for (int i = 0; i < Size / 2; i++)
-                data.Add(new IidSpikeData(5));
-            // This is a spike
-            data.Add(new IidSpikeData(10));
-            for (int i = 0; i < Size / 2; i++)
-                data.Add(new IidSpikeData(5));
+            var data = new List<TimeSeriesData>(Size + 1)
+            {
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+
+                // This is a spike.
+                new TimeSeriesData(10),
+
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+                new TimeSeriesData(5),
+            };
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
             // Setup IidSpikeDetector arguments
             string outputColumnName = nameof(IidSpikePrediction.Prediction);
-            string inputColumnName = nameof(IidSpikeData.Value);
+            string inputColumnName = nameof(TimeSeriesData.Value);
+
             // The transformed model.
             ITransformer model = ml.Transforms.DetectIidSpike(outputColumnName, inputColumnName, 95, Size).Fit(dataView);
 
             // Create a time series prediction engine from the model.
-            var engine = model.CreateTimeSeriesPredictionFunction<IidSpikeData, IidSpikePrediction>(ml);
+            var engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, IidSpikePrediction>(ml);
+
+            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            Console.WriteLine("Data\tAlert\tScore\tP-Value");
+            
+            // Prediction column obtained post-transformation.
+            // Data Alert   Score   P-Value
 
             // Create non-anomalous data and check for anomaly.
             for (int index = 0; index < 5; index++)
             {
                 // Anomaly spike detection.
-                var prediction = engine.Predict(new IidSpikeData(5));
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", 5, prediction.Prediction[0],
-                    prediction.Prediction[1], prediction.Prediction[2]);
+                PrintPrediction(5, engine.Predict(new TimeSeriesData(5)));
             }
 
+            // 5      0       5.00    0.50
+            // 5      0       5.00    0.50
+            // 5      0       5.00    0.50
+            // 5      0       5.00    0.50
+            // 5      0       5.00    0.50
+
             // Spike.
-            var spikePrediction = engine.Predict(new IidSpikeData(10));
-            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", 10, spikePrediction.Prediction[0],
-                spikePrediction.Prediction[1], spikePrediction.Prediction[2]);
+            PrintPrediction(10, engine.Predict(new TimeSeriesData(10)));
+            
+            // 10     1      10.00    0.00  <-- alert is on, predicted spike (check-point model)
 
             // Checkpoint the model.
             var modelPath = "temp.zip";
@@ -80,23 +86,35 @@ namespace Samples.Dynamic
             for (int index = 0; index < 5; index++)
             {
                 // Anomaly spike detection.
-                var prediction = engine.Predict(new IidSpikeData(5));
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", 5, prediction.Prediction[0],
-                    prediction.Prediction[1], prediction.Prediction[2]);
+                PrintPrediction(5, engine.Predict(new TimeSeriesData(5)));
             }
 
-            // Data Alert   Score   P-Value
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 10     1      10.00    0.00  <-- alert is on, predicted spike (check-point model)
             // 5      0       5.00    0.26  <-- load model from disk.
             // 5      0       5.00    0.26
             // 5      0       5.00    0.50
             // 5      0       5.00    0.50
             // 5      0       5.00    0.50
+
+        }
+
+        private static void PrintPrediction(float value, IidSpikePrediction prediction) => 
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], 
+                prediction.Prediction[1], prediction.Prediction[2]);
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        class IidSpikePrediction
+        {
+            [VectorType(3)]
+            public double[] Prediction { get; set; }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs
@@ -7,7 +7,6 @@ namespace Samples.Dynamic
 {
     public static class DetectIidSpikeBatchPrediction
     {
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
         public static void Example()

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    public static class DetectIidSpikeBatchPrediction
+    {
+        class IidSpikeData
+        {
+            public float Value;
+
+            public IidSpikeData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        class IidSpikePrediction
+        {
+            [VectorType(3)]
+            public double[] Prediction { get; set; }
+        }
+
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // The estimator is applied then to identify spiking points in the series.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a spike
+            const int Size = 10;
+            var data = new List<IidSpikeData>(Size);
+            for (int i = 0; i < Size / 2; i++)
+                data.Add(new IidSpikeData(5));
+            // This is a spike
+            data.Add(new IidSpikeData(10));
+            for (int i = 0; i < Size / 2; i++)
+                data.Add(new IidSpikeData(5));
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup the estimator arguments
+            string outputColumnName = nameof(IidSpikePrediction.Prediction);
+            string inputColumnName = nameof(IidSpikeData.Value);
+
+            // The transformed data.
+            var transformedData = ml.Transforms.DetectIidSpike(outputColumnName, inputColumnName, 95, Size / 4).Fit(dataView).Transform(dataView);
+
+            // Getting the data of the newly created column as an IEnumerable of IidSpikePrediction.
+            var predictionColumn = ml.Data.CreateEnumerable<IidSpikePrediction>(transformedData, reuseRowObject: false);
+
+            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            Console.WriteLine("Alert\tScore\tP-Value");
+            foreach (var prediction in predictionColumn)
+                Console.WriteLine("{0}\t{1:0.00}\t{2:0.00}", prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
+            Console.WriteLine("");
+
+            // Prediction column obtained post-transformation.
+            // Alert   Score   P-Value
+            // 0       5.00    0.50
+            // 0       5.00    0.50
+            // 0       5.00    0.50
+            // 0       5.00    0.50
+            // 0       5.00    0.50
+            // 1       10.00   0.00   <-- alert is on, predicted spike
+            // 0       5.00    0.26
+            // 0       5.00    0.26
+            // 0       5.00    0.50
+            // 0       5.00    0.50
+            // 0       5.00    0.50
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
@@ -9,21 +9,6 @@ namespace Samples.Dynamic
 {
     public static class DetectSpikeBySsa
     {
-        class SsaSpikeData
-        {
-            public float Value;
-
-            public SsaSpikeData(float value)
-            {
-                Value = value;
-            }
-        }
-
-        class SsaSpikePrediction
-        {
-            [VectorType(3)]
-            public double[] Prediction { get; set; }
-        }
 
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
@@ -38,45 +23,68 @@ namespace Samples.Dynamic
             const int SeasonalitySize = 5;
             const int TrainingSeasons = 3;
             const int TrainingSize = SeasonalitySize * TrainingSeasons;
-            var data = new List<SsaSpikeData>();
-            for (int i = 0; i < TrainingSeasons; i++)
-                for (int j = 0; j < SeasonalitySize; j++)
-                    data.Add(new SsaSpikeData(j));
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+            };
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
             // Setup IidSpikeDetector arguments
-            var inputColumnName = nameof(SsaSpikeData.Value);
+            var inputColumnName = nameof(TimeSeriesData.Value);
             var outputColumnName = nameof(SsaSpikePrediction.Prediction);
 
             // Train the change point detector.
             ITransformer model = ml.Transforms.DetectSpikeBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView);
 
             // Create a prediction engine from the model for feeding new data.
-            var engine = model.CreateTimeSeriesPredictionFunction<SsaSpikeData, SsaSpikePrediction>(ml);
+            var engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, SsaSpikePrediction>(ml);
 
             // Start streaming new data points with no change point to the prediction engine.
             Console.WriteLine($"Output from spike predictions on new data:");
             Console.WriteLine("Data\tAlert\tScore\tP-Value");
-            SsaSpikePrediction prediction = null;
+
+            // Output from spike predictions on new data:
+            // Data    Alert   Score   P-Value
+
             for (int j = 0; j < 2; j++)
-            {
                 for (int i = 0; i < 5; i++)
-                {
-                    var value = i;
-                    prediction = engine.Predict(new SsaSpikeData(value));
-                    Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
-                }
-            }
+                    PrintPrediction(i, engine.Predict(new TimeSeriesData(i)));
+
+            // 0       0      -1.01    0.50
+            // 1       0      -0.24    0.22
+            // 2       0      -0.31    0.30
+            // 3       0       0.44    0.01
+            // 4       0       2.16    0.00
+            // 0       0      -0.78    0.27
+            // 1       0      -0.80    0.30
+            // 2       0      -0.84    0.31
+            // 3       0       0.33    0.31
+            // 4       0       2.21    0.07
 
             // Now send a data point that reflects a spike.
-            var newValue = 100;
-            prediction = engine.Predict(new SsaSpikeData(newValue));
-            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", newValue, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
+            PrintPrediction(100, engine.Predict(new TimeSeriesData(100)));
+
+            // 100     1      86.17    0.00   <-- alert is on, predicted spike
 
             // Now we demonstrate saving and loading the model.
-
             // Save the model that exists within the prediction engine.
             // The engine has been updating this model with every new data point.
             var modelPath = "model.zip";
@@ -87,34 +95,37 @@ namespace Samples.Dynamic
                 model = ml.Model.Load(file, out DataViewSchema schema);
 
             // We must create a new prediction engine from the persisted model.
-            engine = model.CreateTimeSeriesPredictionFunction<SsaSpikeData, SsaSpikePrediction>(ml);
+            engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, SsaSpikePrediction>(ml);
 
             // Run predictions on the loaded model.
             for (int i = 0; i < 5; i++)
-            {
-                var value = i;
-                prediction = engine.Predict(new SsaSpikeData(value));
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
-            }
+                PrintPrediction(i, engine.Predict(new TimeSeriesData(i)));
+            
+            // 0       0      -2.74    0.40   <-- saved to disk, re-loaded, and running new predictions
+            // 1       0      -1.47    0.42
+            // 2       0     -17.50    0.24
+            // 3       0     -30.82    0.16
+            // 4       0     -23.24    0.28
+        }
 
-            // Output from spike predictions on new data:
-            // Data    Alert   Score   P-Value
-            // 0       0     - 1.01    0.50
-            // 1       0     - 0.24    0.22
-            // 2       0     - 0.31    0.30
-            // 3       0       0.44    0.01
-            // 4       0       2.16    0.00
-            // 0       0     - 0.78    0.27
-            // 1       0     - 0.80    0.30
-            // 2       0     - 0.84    0.31
-            // 3       0       0.33    0.31
-            // 4       0       2.21    0.07
-            // 100     1      86.17    0.00   <-- alert is on, predicted spike
-            // 0       0     - 2.74    0.40   <-- saved to disk, re-loaded, and running new predictions
-            // 1       0     - 1.47    0.42
-            // 2       0    - 17.50    0.24
-            // 3       0    - 30.82    0.16
-            // 4       0    - 23.24    0.28
+        private static void PrintPrediction(float value, SsaSpikePrediction prediction) => 
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], 
+                prediction.Prediction[1], prediction.Prediction[2]);
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        class SsaSpikePrediction
+        {
+            [VectorType(3)]
+            public double[] Prediction { get; set; }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Samples.Dynamic
 {
@@ -32,7 +34,7 @@ namespace Samples.Dynamic
             // as well as the source of randomness.
             var ml = new MLContext();
 
-            // Generate sample series data with a recurring pattern and a spike within the pattern
+            // Generate sample series data with a recurring pattern
             const int SeasonalitySize = 5;
             const int TrainingSeasons = 3;
             const int TrainingSize = SeasonalitySize * TrainingSeasons;
@@ -40,54 +42,79 @@ namespace Samples.Dynamic
             for (int i = 0; i < TrainingSeasons; i++)
                 for (int j = 0; j < SeasonalitySize; j++)
                     data.Add(new SsaSpikeData(j));
-            // This is a spike
-            data.Add(new SsaSpikeData(100));
-            for (int i = 0; i < SeasonalitySize; i++)
-                data.Add(new SsaSpikeData(i));
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
-            // Setup estimator arguments
+            // Setup IidSpikeDetector arguments
             var inputColumnName = nameof(SsaSpikeData.Value);
             var outputColumnName = nameof(SsaSpikePrediction.Prediction);
 
-            // The transformed data.
-            var transformedData = ml.Transforms.DetectSpikeBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+            // Train the change point detector.
+            ITransformer model = ml.Transforms.DetectSpikeBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView);
 
-            // Getting the data of the newly created column as an IEnumerable of SsaSpikePrediction.
-            var predictionColumn = ml.Data.CreateEnumerable<SsaSpikePrediction>(transformedData, reuseRowObject: false);
+            // Create a prediction engine from the model for feeding new data.
+            var engine = model.CreateTimeSeriesPredictionFunction<SsaSpikeData, SsaSpikePrediction>(ml);
 
-            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            // Start streaming new data points with no change point to the prediction engine.
+            Console.WriteLine($"Output from spike predictions on new data:");
             Console.WriteLine("Data\tAlert\tScore\tP-Value");
-            int k = 0;
-            foreach (var prediction in predictionColumn)
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
-            Console.WriteLine("");
+            SsaSpikePrediction prediction = null;
+            for (int j = 0; j < 2; j++)
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    var value = i;
+                    prediction = engine.Predict(new SsaSpikeData(value));
+                    Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
+                }
+            }
 
-            // Prediction column obtained post-transformation.
+            // Now send a data point that reflects a spike.
+            var newValue = 100;
+            prediction = engine.Predict(new SsaSpikeData(newValue));
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", newValue, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
+
+            // Now we demonstrate saving and loading the model.
+
+            // Save the model that exists within the prediction engine.
+            // The engine has been updating this model with every new data point.
+            var modelPath = "model.zip";
+            engine.CheckPoint(ml, modelPath);
+
+            // Load the model.
+            using (var file = File.OpenRead(modelPath))
+                model = ml.Model.Load(file, out DataViewSchema schema);
+
+            // We must create a new prediction engine from the persisted model.
+            engine = model.CreateTimeSeriesPredictionFunction<SsaSpikeData, SsaSpikePrediction>(ml);
+
+            // Run predictions on the loaded model.
+            for (int i = 0; i < 5; i++)
+            {
+                var value = i;
+                prediction = engine.Predict(new SsaSpikeData(value));
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
+            }
+
+            // Output from spike predictions on new data:
             // Data    Alert   Score   P-Value
-            // 0       0     - 2.53    0.50
-            // 1       0     - 0.01    0.01
-            // 2       0       0.76    0.14
-            // 3       0       0.69    0.28
-            // 4       0       1.44    0.18
-            // 0       0     - 1.84    0.17
-            // 1       0       0.22    0.44
-            // 2       0       0.20    0.45
-            // 3       0       0.16    0.47
-            // 4       0       1.33    0.18
-            // 0       0     - 1.79    0.07
-            // 1       0       0.16    0.50
-            // 2       0       0.09    0.50
-            // 3       0       0.08    0.45
-            // 4       0       1.31    0.12
-            // 100     1      98.21    0.00   <-- alert is on, predicted spike
-            // 0       0    - 13.83    0.29
-            // 1       0     - 1.74    0.44
-            // 2       0     - 0.47    0.46
-            // 3       0    - 16.50    0.29
-            // 4       0    - 29.82    0.21
+            // 0       0     - 1.01    0.50
+            // 1       0     - 0.24    0.22
+            // 2       0     - 0.31    0.30
+            // 3       0       0.44    0.01
+            // 4       0       2.16    0.00
+            // 0       0     - 0.78    0.27
+            // 1       0     - 0.80    0.30
+            // 2       0     - 0.84    0.31
+            // 3       0       0.33    0.31
+            // 4       0       2.21    0.07
+            // 100     1      86.17    0.00   <-- alert is on, predicted spike
+            // 0       0     - 2.74    0.40   <-- saved to disk, re-loaded, and running new predictions
+            // 1       0     - 1.47    0.42
+            // 2       0    - 17.50    0.24
+            // 3       0    - 30.82    0.16
+            // 4       0    - 23.24    0.28
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
@@ -9,7 +9,6 @@ namespace Samples.Dynamic
 {
     public static class DetectSpikeBySsa
     {
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
         // This estimator can account for temporal seasonality in the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsaBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsaBatchPrediction.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ML.Data;
+
+namespace Microsoft.ML.Samples.Dynamic
+{
+    public static class DetectSpikeBySsaBatchPrediction
+    {
+        class SsaSpikeData
+        {
+            public float Value;
+
+            public SsaSpikeData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        class SsaSpikePrediction
+        {
+            [VectorType(3)]
+            public double[] Prediction { get; set; }
+        }
+
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // The estimator is applied then to identify spiking points in the series.
+        // This estimator can account for temporal seasonality in the data.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a recurring pattern and a spike within the pattern
+            const int SeasonalitySize = 5;
+            const int TrainingSeasons = 3;
+            const int TrainingSize = SeasonalitySize * TrainingSeasons;
+            var data = new List<SsaSpikeData>();
+            for (int i = 0; i < TrainingSeasons; i++)
+                for (int j = 0; j < SeasonalitySize; j++)
+                    data.Add(new SsaSpikeData(j));
+            // This is a spike
+            data.Add(new SsaSpikeData(100));
+            for (int i = 0; i < SeasonalitySize; i++)
+                data.Add(new SsaSpikeData(i));
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup estimator arguments
+            var inputColumnName = nameof(SsaSpikeData.Value);
+            var outputColumnName = nameof(SsaSpikePrediction.Prediction);
+
+            // The transformed data.
+            var transformedData = ml.Transforms.DetectSpikeBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+
+            // Getting the data of the newly created column as an IEnumerable of SsaSpikePrediction.
+            var predictionColumn = ml.Data.CreateEnumerable<SsaSpikePrediction>(transformedData, reuseRowObject: false);
+
+            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            Console.WriteLine("Data\tAlert\tScore\tP-Value");
+            int k = 0;
+            foreach (var prediction in predictionColumn)
+                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
+            Console.WriteLine("");
+
+            // Prediction column obtained post-transformation.
+            // Data    Alert   Score   P-Value
+            // 0       0     - 2.53    0.50
+            // 1       0     - 0.01    0.01
+            // 2       0       0.76    0.14
+            // 3       0       0.69    0.28
+            // 4       0       1.44    0.18
+            // 0       0     - 1.84    0.17
+            // 1       0       0.22    0.44
+            // 2       0       0.20    0.45
+            // 3       0       0.16    0.47
+            // 4       0       1.33    0.18
+            // 0       0     - 1.79    0.07
+            // 1       0       0.16    0.50
+            // 2       0       0.09    0.50
+            // 3       0       0.08    0.45
+            // 4       0       1.31    0.12
+            // 100     1      98.21    0.00   <-- alert is on, predicted spike
+            // 0       0    - 13.83    0.29
+            // 1       0     - 1.74    0.44
+            // 2       0     - 0.47    0.46
+            // 3       0    - 16.50    0.29
+            // 4       0    - 29.82    0.21
+        }
+    }
+}

--- a/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectIidChangePoint](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs)]
+        /// [!code-csharp[DetectIidChangePoint](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePointBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -47,7 +47,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectIidSpike](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs)]
+        /// [!code-csharp[DetectIidSpike](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -73,7 +73,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectChangePointBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
+        /// [!code-csharp[DetectChangePointBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -110,7 +110,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectSpikeBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs)]
+        /// [!code-csharp[DetectSpikeBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsaBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -70,12 +70,6 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <![CDATA[
         /// This is an example for checkpointing time series that detects change point using Singular Spectrum Analysis (SSA) model.
         /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
-        /// This is an example for checkpointing time series that detects spike using Singular Spectrum Analysis (SSA) model.
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs)]
-        /// This is an example for checkpointing time series that detects change point in independent and identically distributed(IID) time series.
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs)]
-        /// This is an example for checkpointing time series that detects spike in independent and identically distributed(IID) time series.
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -277,12 +271,6 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <![CDATA[
         /// This is an example for detecting change point using Singular Spectrum Analysis (SSA) model.
         /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
-        /// This is an example for detecting spike using Singular Spectrum Analysis (SSA) model.
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs)]
-        /// This is an example for detecting change point in independent and identically distributed(IID) time series.
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs)]
-        /// This is an example for detecting spike in independent and identically distributed(IID) time series.
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs)]
         /// ]]>
         /// </format>
         /// </example>

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -68,7 +68,14 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[CheckPoint](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
+        /// This is an example for checkpointing time series that detects change point using Singular Spectrum Analysis (SSA) model.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
+        /// This is an example for checkpointing time series that detects spike using Singular Spectrum Analysis (SSA) model.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs)]
+        /// This is an example for checkpointing time series that detects change point in independent and identically distributed(IID) time series.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs)]
+        /// This is an example for checkpointing time series that detects spike in independent and identically distributed(IID) time series.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -268,8 +275,14 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.css)]
+        /// This is an example for detecting change point using Singular Spectrum Analysis (SSA) model.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
+        /// This is an example for detecting spike using Singular Spectrum Analysis (SSA) model.
         /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs)]
+        /// This is an example for detecting change point in independent and identically distributed(IID) time series.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs)]
+        /// This is an example for detecting spike in independent and identically distributed(IID) time series.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs)]
         /// ]]>
         /// </format>
         /// </example>

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -65,6 +65,13 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// </summary>
         /// <param name="env">Usually <see cref="MLContext"/>.</param>
         /// <param name="modelPath">Path to file on disk where the updated model needs to be saved.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[CheckPoint](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
         public void CheckPoint(IHostEnvironment env, string modelPath)
         {
             using (var file = File.Create(modelPath))

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -268,8 +268,8 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/IidSpikeDetectorTransform.cs)]
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/IidChangePointDetectorTransform.cs)]
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.css)]
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs)]
         /// ]]>
         /// </format>
         /// </example>


### PR DESCRIPTION
fixes #3277

Seems like PR #2900 removed the stateful prediction samples as part of refactoring and cleanup. Adding these useful samples back as they are used by customers that want to save time series model to disk and reload the model with up to date state that contains last seen values from prediction phase.