### PR TITLE
Fix runtime exception in LDA sample.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/LdaTransform.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // "car truck driver bus pickup horse"
 
             string review = nameof(SamplesUtils.DatasetUtils.SampleTopicsData.Review);
-            string ldaFeatures = "LdaFeatures";
+            string ldaFeatures = "Review";
 
             // A pipeline for featurizing the "Review" column
             var pipeline = ml.Transforms.Text.ProduceWordBags(review).


### PR DESCRIPTION
LDA sample throws an exception because the API changed after the sample was written. This PR fixes the sample and ensures output matches that of comments in the sample.