### PR TITLE
Fix bug in ONNX scorer sample.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -13,7 +13,8 @@ namespace Microsoft.ML.Samples.Dynamic
         public static void Example()
         {
             // Download the squeeznet image model from ONNX model zoo, version 1.2
-            // https://github.com/onnx/models/tree/master/squeezenet
+            // https://github.com/onnx/models/tree/master/squeezenet or use
+            // Microsoft.ML.Onnx.TestModels nuget.
             var modelPath = @"squeezenet\00000001\model.onnx";
 
             // Inspect the model's inputs and outputs

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic
         {
             // Download the squeeznet image model from ONNX model zoo, version 1.2
             // https://github.com/onnx/models/tree/master/squeezenet
-            var modelPath = @"squeezenet\model.onnx";
+            var modelPath = @"squeezenet\00000001\model.onnx";
 
             // Inspect the model's inputs and outputs
             var session = new InferenceSession(modelPath);

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -183,4 +183,8 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
+  </ItemGroup>
+  
 </Project>

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.ML.Samples.Dynamic;
+using Samples.Dynamic;
 
 namespace Microsoft.ML.Samples
 {
@@ -6,7 +7,7 @@ namespace Microsoft.ML.Samples
     {
         static void Main(string[] args)
         {
-            ReplaceMissingValues.Example();
+            OnnxTransformExample.Example();
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ML.Samples
     {
         static void Main(string[] args)
         {
-            OnnxTransformExample.Example();
+            ReplaceMissingValues.Example();
         }
     }
 }


### PR DESCRIPTION
ONNX scorer transformer sample throws an exception today because it cannot find the model file. This PR fixes that.