### PR TITLE
[WIP] Matrix factorization transformer

### DIFF
--- a/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationPredictor.cs
@@ -110,7 +110,7 @@ namespace Microsoft.ML.Trainers.Recommender
             MatrixRowIndexType = matrixRowIndexType;
         }
 
-        private MatrixFactorizationModelParameters(IHostEnvironment env, ModelLoadContext ctx)
+        internal MatrixFactorizationModelParameters(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             _host = env.Register(RegistrationName);

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.ML.Trainers
         /// <summary>
         /// Advanced options for the <see cref="MatrixFactorizationTrainer"/>.
         /// </summary>
-        public sealed class Options
+        public class Options
         {
             /// <summary>
             /// The name of variable (i.e., Column in a <see cref="IDataView"/> type system) used as matrix's column index.

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTransformer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTransformer.cs
@@ -1,0 +1,643 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.ML;
+using Microsoft.ML.CommandLine;
+using Microsoft.ML.Data;
+using Microsoft.ML.EntryPoints;
+using Microsoft.ML.Internal.Utilities;
+using Microsoft.ML.Runtime;
+using Microsoft.ML.Trainers;
+using Microsoft.ML.Trainers.Recommender;
+using Microsoft.ML.Transforms;
+
+namespace Microsoft.ML.Recommender
+{
+    public sealed class MatrixFactorizationTransformer : RowToRowTransformerBase
+    {
+        internal const string Summary = "Transforms to map row/column index to its latent representations and column/row indexes with similar latent representations.";
+        internal const string UserName = "Matrix Factorization Transform";
+        internal const string ShortName = "MaFaTrans";
+        internal const string LoaderSignature = "MatrixFactorizationTransform";
+
+        internal sealed class Options : MatrixFactorizationTrainer.Options
+        {
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Output column name of the row index's latent representation.")]
+            public string ColumnIndexLatentOutputColumnName = nameof(ColumnIndexLatentOutputColumnName).Replace("ColumnName", "");
+
+            [Argument(ArgumentType.AtMostOnce | ArgumentType.Required, HelpText = "Output column name of the row index's latent representation.")]
+            public string RowIndexLatentOutputColumnName = nameof(RowIndexLatentOutputColumnName).Replace("ColumnName", "");
+
+            [Argument(ArgumentType.AtMostOnce | ArgumentType.Required, HelpText = "This is an output column's name. The associated output column carries row indexes whose " +
+                "latent representations are similar to that of the given input column index.")]
+            public string SimilarColumnIndexesOutputColumnName = nameof(SimilarColumnIndexesOutputColumnName).Replace("ColumnName", "");
+
+            [Argument(ArgumentType.AtMostOnce | ArgumentType.Required, HelpText = "This is an output column's name. The associated output column carries column indexes whose " +
+                "latent representations are similar to that of the given input row index.")]
+            public string SimilarRowIndexesOutputColumnName = nameof(SimilarRowIndexesOutputColumnName).Replace("ColumnName", "");
+
+            [Argument(ArgumentType.AtMostOnce | ArgumentType.Required, HelpText = "The number of similar indexes.")]
+            public int SimilarIndexCount = 3;
+
+            [Argument(ArgumentType.AtMostOnce | ArgumentType.Required, HelpText = "Whether to include known index pairs.")]
+            public bool ExcludeKnownIndexPairs = true;
+        }
+
+        private readonly string _matrixRowIndexColumnName;
+        private readonly string _matrixColumnIndexColumnName;
+        private readonly string _labelColumnName;
+
+        /// <summary>
+        /// Vector length of columns called <see cref="_similarRowIndexesOutputColumnName"/> and <see cref="_similarColumnIndexesOutputColumnName"/>.
+        /// </summary>
+        private readonly int _similarIndexCount;
+
+        private readonly bool _excludeKnownIndexPairs;
+
+        /// <summary>
+        /// Column name of <see cref="RowIndexLatentOutputColumnType"/>.
+        /// </summary>
+        private readonly string _rowIndexLatentOutputColumnName;
+
+        /// <summary>
+        /// Column name of <see cref="ColumnIndexLatentOutputColumnType"/>.
+        /// </summary>
+        private readonly string _columnIndexLatentOutputColumnName;
+
+        /// <summary>
+        /// Column name of <see cref="SimilarRowIndexesOutputColumnType"/>.
+        /// </summary>
+        private readonly string _similarRowIndexesOutputColumnName;
+
+        /// <summary>
+        /// Column name of <see cref="SimilarColumnIndexesOutputColumnType"/>.
+        /// </summary>
+        private readonly string _similarColumnIndexesOutputColumnName;
+
+        /// <summary>
+        /// The underlying matrix factorization model.
+        /// </summary>
+        private MatrixFactorizationModelParameters _model;
+
+        private uint[] _similarRowsAtColumn;
+        private uint[] _similarColumnsAtRow;
+
+        private DataViewType RowIndexLatentOutputColumnType => new VectorDataViewType(NumberDataViewType.Single, _model.ApproximationRank);
+        private DataViewType ColumnIndexLatentOutputColumnType => new VectorDataViewType(NumberDataViewType.Single, _model.ApproximationRank);
+        private DataViewType SimilarRowIndexesOutputColumnType => new VectorDataViewType((KeyDataViewType)_model.MatrixRowIndexType, _similarIndexCount);
+        private DataViewType SimilarColumnIndexesOutputColumnType => new VectorDataViewType((KeyDataViewType)_model.MatrixColumnIndexType, _similarIndexCount);
+
+        private static VersionInfo GetVersionInfo()
+        {
+            return new VersionInfo(
+                modelSignature: "MaFaTran",
+                verWrittenCur: 0x00010001,
+                verReadableCur: 0x00010001,
+                verWeCanReadBack: 0x00010001,
+                loaderSignature: LoaderSignature,
+            loaderAssemblyName: typeof(MatrixFactorizationTransformer).Assembly.FullName);
+        }
+
+        private void CheckInitialConfiguration()
+        {
+            // Output column names cannot be null.
+            Host.CheckValue(_columnIndexLatentOutputColumnName, nameof(_columnIndexLatentOutputColumnName), "Cannot be null");
+            Host.CheckValue(_rowIndexLatentOutputColumnName, nameof(_rowIndexLatentOutputColumnName), "Cannot be null");
+            Host.CheckValue(_similarColumnIndexesOutputColumnName, nameof(_similarColumnIndexesOutputColumnName), "Cannot be null");
+            Host.CheckValue(_similarRowIndexesOutputColumnName, nameof(_similarRowIndexesOutputColumnName), "Cannot be null");
+
+            // Output column names must be unique.
+            var outputColumnNames = new HashSet<string>(GetNewColumnNames);
+            var errMsg = string.Format("Output column names {0} conflict", outputColumnNames.ToList());
+            Host.Check(outputColumnNames.Count == 4, errMsg);
+        }
+
+        internal MatrixFactorizationTransformer(IHostEnvironment env, Options options) :
+            base(Contracts.CheckRef(env, nameof(env)).Register(nameof(MatrixFactorizationModelParameters)))
+        {
+            // Input column names.
+            _matrixColumnIndexColumnName = options.MatrixColumnIndexColumnName;
+            _matrixRowIndexColumnName = options.MatrixRowIndexColumnName;
+            _labelColumnName = options.LabelColumnName;
+
+            _similarIndexCount = options.SimilarIndexCount;
+            _excludeKnownIndexPairs = options.ExcludeKnownIndexPairs;
+            _columnIndexLatentOutputColumnName = options.ColumnIndexLatentOutputColumnName;
+            _rowIndexLatentOutputColumnName = options.RowIndexLatentOutputColumnName;
+            _similarColumnIndexesOutputColumnName = options.SimilarColumnIndexesOutputColumnName;
+            _similarRowIndexesOutputColumnName = options.SimilarRowIndexesOutputColumnName;
+
+            CheckInitialConfiguration();
+
+        }
+
+        internal void Fit(IDataView data, Options options)
+        {
+            // Do matrix factorization and extract the trained model.
+            var trainer = new MatrixFactorizationTrainer(Host, options);
+            _model = trainer.Fit(data).Model;
+
+            // In the training matrix, row indexes can be found at the i-th column are stored at knownIndexesAtColumns[i].
+            var knownRowsAtColumn = new HashSet<uint>[_model.NumberOfColumns].Select(set => new HashSet<uint>()).ToArray();
+
+            // In the training matrix, column indexes can be found at the i-th row are stored at knownIndexesAtRows[i].
+            var knownColumnsAtRow = new HashSet<uint>[_model.NumberOfRows].Select(set => new HashSet<uint>()).ToArray();
+
+            // Fill knownRowsAtColumn and knowColumnsAtRow if know row-column pairs should be excluded from the similar row-column
+            // pairs identified by this transform. This is useful when user only wants to discover relations not told by the training
+            // data.
+            if (options.ExcludeKnownIndexPairs)
+                PrepareKnownSimilarIndexes(data, options.MatrixColumnIndexColumnName, options.MatrixRowIndexColumnName,
+                    _model.NumberOfColumns, _model.NumberOfRows, ref knownRowsAtColumn, ref knownColumnsAtRow);
+
+            // Shared buffer to store latent vector.
+            var queryVector = new float[_model.ApproximationRank];
+
+            // Column indexes with latent representations similar to the i-th row's are stored at knownSimilarColumnIndexes[i].
+            var similarColumnsAtRow = new List<uint>();
+            for (int u = 0; u < _model.NumberOfRows; ++u)
+            {
+                // Extract the u-th row's latent vector.
+                int pos = u * _model.ApproximationRank;
+                for (int k = 0; k < _model.ApproximationRank; ++k)
+                    queryVector[k] = _model.LeftFactorMatrix[pos + k];
+
+                // Find u-th row's similar columns' indexes.
+                similarColumnsAtRow.AddRange(ComputeSimilarIndexes(_similarIndexCount, queryVector, _model.RightFactorMatrix, knownColumnsAtRow[u]));
+            }
+            _similarColumnsAtRow = similarColumnsAtRow.ToArray();
+
+            // Row indexes similar to the i-th row is stored at knownIndexesAtRows[i].
+            var similarRowsAtColumn = new List<uint>();
+            for (int v = 0; v < _model.NumberOfColumns; ++v)
+            {
+                // Extract the v-th column's latent vector.
+                int pos = v * _model.ApproximationRank;
+                for (int k = 0; k < _model.ApproximationRank; ++k)
+                    queryVector[k] = _model.RightFactorMatrix[pos + k];
+
+                // Find v-th column's similar columns.
+                similarRowsAtColumn.AddRange(ComputeSimilarIndexes(_similarIndexCount, queryVector, _model.LeftFactorMatrix, knownRowsAtColumn[v]));
+            }
+            _similarRowsAtColumn = similarRowsAtColumn.ToArray();
+        }
+
+        /// <summary>
+        /// This function extracts
+        ///   (1) column indexes at one row, and
+        ///   (2) row indexes at one column.
+        /// The row indexes at the v-th column will be stored in <paramref name="knownRowsAtColumn"/>[v].
+        /// The column indexes at the u-th row will be stored in <paramref name="knownColumnsAtRow"/>[u].
+        /// </summary>
+        private static void PrepareKnownSimilarIndexes(IDataView data, string matrixColumnName, string matrixRowName, int numberOfColumns, int numberOfRows,
+            ref HashSet<uint>[] knownRowsAtColumn, ref HashSet<uint>[] knownColumnsAtRow)
+        {
+            var matrixColumnIndexColumn = data.Schema[matrixColumnName];
+            var matrixRowIndexColumn = data.Schema[matrixRowName];
+            var cursor = data.GetRowCursor(matrixColumnIndexColumn, matrixRowIndexColumn);
+
+            var matrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, cursor, matrixColumnIndexColumn.Index);
+            var matrixRowIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, cursor, matrixRowIndexColumn.Index);
+
+            // Buffer variable.
+            uint matrixColumnIndex = 0u;
+            // Buffer variable.
+            uint matrixRowIndex = 0u;
+            // Scan through all matrix elements.
+            while (cursor.MoveNext())
+            {
+                matrixColumnIndexGetter(ref matrixColumnIndex);
+                matrixRowIndexGetter(ref matrixRowIndex);
+                if (matrixColumnIndex == 0 || matrixRowIndex == 0)
+                    continue;
+                knownRowsAtColumn[matrixColumnIndex - 1].Add(matrixRowIndex - 1);
+                knownColumnsAtRow[matrixRowIndex - 1].Add(matrixColumnIndex - 1);
+            }
+        }
+
+        /// <summary>
+        /// Let <paramref name="queryVector"/> be p and <paramref name="latentMatrix"/> be Q = [q_1, ..., q_n].
+        /// This function returns q_v, v = 1, ..., <paramref name="selectedCount"/> which can make largest inner products with p.
+        /// The returned value may not contain any index in <paramref name="bannedIndexes"/>.
+        /// </summary>
+        private static uint[] ComputeSimilarIndexes(int selectedCount, IReadOnlyList<float> queryVector, IReadOnlyList<float> latentMatrix, HashSet<uint> bannedIndexes)
+        {
+            Contracts.Assert(selectedCount > 0);
+            Contracts.AssertValue(queryVector);
+            Contracts.AssertValue(latentMatrix);
+
+            // Length of latent vector.
+            int d = queryVector.Count;
+            // Q is a flattened d-by-n matrix.
+            int n = latentMatrix.Count / d;
+
+            // Compute scores.
+            var scores = new float[n];
+            for (int v = 0; v < n; ++v)
+            {
+                var pos = v * d;
+                for (int k = 0; k < d; ++k)
+                    scores[v] += queryVector[k] * latentMatrix[pos + k];
+            }
+
+            // Filter out banned indexes and then sort remained indexes by their scores.
+            var indexes = Enumerable.Range(0, n).Where(index => !bannedIndexes.Contains((uint)index)).
+                OrderByDescending(index => scores[index]).ToArray();
+
+            var selectedIndexes = new uint[selectedCount];
+            for (int i = 0; i < selectedCount; ++i)
+            {
+                if (i > scores.Length)
+                    break;
+                selectedIndexes[i] = (uint)indexes[i];
+            }
+
+            return selectedIndexes;
+        }
+
+        private MatrixFactorizationTransformer(IHostEnvironment env, ModelLoadContext ctx) :
+            base(Contracts.CheckRef(env, nameof(env)).Register(nameof(MatrixFactorizationModelParameters)))
+        {
+            ctx.CheckAtModel(GetVersionInfo());
+
+            _matrixColumnIndexColumnName = ctx.Reader.ReadString();
+            _matrixRowIndexColumnName = ctx.Reader.ReadString();
+            _similarIndexCount = ctx.Reader.ReadInt32();
+            _excludeKnownIndexPairs = ctx.Reader.ReadBoolean();
+            _columnIndexLatentOutputColumnName = ctx.Reader.ReadString();
+            _rowIndexLatentOutputColumnName = ctx.Reader.ReadString();
+            _similarColumnIndexesOutputColumnName = ctx.Reader.ReadString();
+            _similarRowIndexesOutputColumnName = ctx.Reader.ReadString();
+
+            CheckInitialConfiguration();
+
+            _model = new MatrixFactorizationModelParameters(env, ctx);
+
+            _similarColumnsAtRow = Utils.ReadUIntArray(ctx.Reader, checked(_model.NumberOfRows * _model.ApproximationRank));
+            _similarRowsAtColumn = Utils.ReadUIntArray(ctx.Reader, checked(_model.NumberOfColumns * _model.ApproximationRank));
+        }
+
+        private protected override void SaveModel(ModelSaveContext ctx)
+        {
+            Host.CheckValue(ctx, nameof(ctx));
+            ctx.CheckAtModel();
+            ctx.SetVersionInfo(GetVersionInfo());
+
+            ctx.Writer.Write(_matrixColumnIndexColumnName);
+            ctx.Writer.Write(_matrixRowIndexColumnName);
+            ctx.Writer.Write(_similarIndexCount);
+            ctx.Writer.Write(_excludeKnownIndexPairs);
+            ctx.Writer.Write(_columnIndexLatentOutputColumnName);
+            ctx.Writer.Write(_rowIndexLatentOutputColumnName);
+            ctx.Writer.Write(_similarColumnIndexesOutputColumnName);
+            ctx.Writer.Write(_similarRowIndexesOutputColumnName);
+            ((ICanSaveModel)_model).Save(ctx);
+            Utils.WriteUIntStream(ctx.Writer, _similarColumnsAtRow);
+            Utils.WriteUIntStream(ctx.Writer, _similarRowsAtColumn);
+        }
+
+        private string[] GetNewColumnNames => new[] { _columnIndexLatentOutputColumnName, _rowIndexLatentOutputColumnName,
+                _similarColumnIndexesOutputColumnName, _similarRowIndexesOutputColumnName };
+
+        private DataViewType[] GetNewColumnTypes => new[] { RowIndexLatentOutputColumnType, ColumnIndexLatentOutputColumnType, SimilarRowIndexesOutputColumnType, SimilarColumnIndexesOutputColumnType };
+
+        private protected override IRowMapper MakeRowMapper(DataViewSchema schema)
+        {
+            return new MatrixFactorizationMapper(Host, this, schema);
+        }
+
+        private class MatrixFactorizationMapper : MapperBase
+        {
+            /*
+            private Dictionary<int, int> _outputToSourceIndexMap;
+            private Dictionary<int, int> _sourceToOutputIndexMap;
+            private Dictionary<int, string> _outputIndexToNameMap;
+            private Dictionary<int, DataViewType> _outputIndexToTypeMap;
+            */
+
+            private MatrixFactorizationTransformer _parent;
+
+            internal MatrixFactorizationMapper(IHost host, MatrixFactorizationTransformer parent, DataViewSchema inputSchema) :
+                base(host, inputSchema, parent)
+            {
+                Contracts.AssertValue(parent);
+                _parent = parent;
+            }
+
+            /*
+            private void ComputeIndexMap(DataViewSchema inputSchema, out Dictionary<int, int> outputToSourceIndexMap, out Dictionary<int, int> sourceToOutputIndexMap,
+                out Dictionary<int, string> outputIndexToNameMap, out Dictionary<int, DataViewType> outputIndexToTypeMap)
+            {
+                outputToSourceIndexMap = new Dictionary<int, int>();
+                sourceToOutputIndexMap = new Dictionary<int, int>();
+                outputIndexToNameMap = new Dictionary<int, string>();
+                outputIndexToTypeMap = new Dictionary<int, DataViewType>();
+
+                // Pass all input columns to output schema.
+                for (int i = 0; i < inputSchema.Count; ++i)
+                {
+                    outputToSourceIndexMap[i] = inputSchema[i].Index;
+                    sourceToOutputIndexMap[inputSchema[i].Index] = i;
+                    outputIndexToNameMap[i] = inputSchema[i].Name;
+                    outputIndexToTypeMap[i] = inputSchema[i].Type;
+                }
+
+                // Add new columns to output schema and possiblyh overwrite input columns passed by.
+                for (int i = 0; i < _parent.GetNewColumnNames.Length; ++i)
+                {
+                    var newColumnName = _parent.GetNewColumnNames[i];
+                    var newColumnType = _parent.GetNewColumnTypes[i];
+                    var newColumnSourceIndex = -(i + 1);
+                    var column = inputSchema.GetColumnOrNull(_parent._columnIndexLatentOutputColumnName);
+                    if (column.HasValue)
+                    {
+                        // Overwrite input column.
+                        var outputIndex = sourceToOutputIndexMap[column.Value.Index];
+                        outputToSourceIndexMap[outputIndex] = newColumnSourceIndex;
+                        sourceToOutputIndexMap[newColumnSourceIndex] = outputIndex;
+                        outputIndexToNameMap[outputIndex] = newColumnName;
+                        outputIndexToTypeMap[outputIndex] = newColumnType;
+                    }
+                    else
+                    {
+                        // Add new output column. No column will be overwritten at this round.
+                        var newOutputIndex = sourceToOutputIndexMap.Values.Max() + 1;
+                        outputToSourceIndexMap[newOutputIndex] = newColumnSourceIndex;
+                        sourceToOutputIndexMap[newColumnSourceIndex] = newOutputIndex;
+                        outputIndexToNameMap[newOutputIndex] = newColumnName;
+                        outputIndexToTypeMap[newOutputIndex] = newColumnType;
+                    }
+                }
+            }
+            */
+
+            /// <summary>
+            /// Returns columns generated by <see cref="MatrixFactorizationMapper"/>.
+            /// </summary>
+            protected override DataViewSchema.DetachedColumn[] GetOutputColumnsCore()
+            {
+                var outputColumns = new DataViewSchema.DetachedColumn[4];
+
+                for (int i = 0; i < _parent.GetNewColumnNames.Count() ; ++i)
+                    outputColumns[i] = new DataViewSchema.DetachedColumn(_parent.GetNewColumnNames[i], _parent.GetNewColumnTypes[i]);
+
+                return outputColumns;
+            }
+
+            private Delegate MakeRowLatentVectorGetter(DataViewRow input)
+            {
+                // Get the getter of the row index.
+                var column = input.Schema[_parent._matrixRowIndexColumnName];
+                var matrixRowIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
+
+                // Buffer used to store row index being mapped to a latent vector.
+                uint matrixRowIndex = 0;
+
+                // Rank of matrix factorization trained.
+                var rank = _parent._model.ApproximationRank;
+
+                // Starting position of a row's latent vector in the left factor matrix.
+                var position = 0;
+
+                // Row indexes' latent vectors, which is a flattened matrix.
+                var leftFactorMatrix = _parent._model.LeftFactorMatrix;
+
+                ValueGetter<VBuffer<float>> del =
+                    (ref VBuffer<float> value) =>
+                    {
+                        var editor = VBufferEditor.Create(ref value, rank);
+                        matrixRowIndexGetter(ref matrixRowIndex);
+                        position = (int)(matrixRowIndex - 1) * rank;
+                        for (int i = 0; i < _parent._model.ApproximationRank; ++i)
+                            editor.Values[i] = leftFactorMatrix[position + i];
+                        value = editor.Commit();
+                    };
+
+                return del;
+            }
+
+            private Delegate MakeColumnLatentVectorGetter(DataViewRow input)
+            {
+                // Get the getter of the column index.
+                var column = input.Schema[_parent._matrixColumnIndexColumnName];
+                var matrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
+
+                // Buffer used to store column index being mapped to a latent vector.
+                uint matrixColumnIndex = 0;
+
+                // Rank of matrix factorization trained.
+                var rank = _parent._model.ApproximationRank;
+
+                // Starting position of a row's latent vector in the right factor matrix.
+                var position = 0;
+
+                // Column indexes' latent vectors, which is a flattened matrix.
+                var rightFactorMatrix = _parent._model.RightFactorMatrix;
+
+                ValueGetter<VBuffer<float>> del = (ref VBuffer<float> value) =>
+                    {
+                        var editor = VBufferEditor.Create(ref value, rank);
+                        matrixColumnIndexGetter(ref matrixColumnIndex);
+                        position = (int)(matrixColumnIndex - 1) * rank;
+                        for (int i = 0; i < _parent._model.ApproximationRank; ++i)
+                            editor.Values[i] = rightFactorMatrix[position + i];
+                        value = editor.Commit();
+                    };
+
+                return del;
+            }
+
+            /// <summary>
+            /// Map matrix-row index to its similar columns' indexes.
+            /// </summary>
+            private Delegate MakeSimilarColumnIndexesGetter(DataViewRow input)
+            {
+                // Get the getter of the matrix-row index.
+                var column = input.Schema[_parent._matrixRowIndexColumnName];
+                var matrixRowIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
+
+                uint matrixRowIndex = 0;
+                int position = 0;
+                ValueGetter<VBuffer<uint>> del =
+                    (ref VBuffer<uint> value) =>
+                    {
+                        var editor = VBufferEditor.Create(ref value, _parent._similarIndexCount);
+                        matrixRowIndexGetter(ref matrixRowIndex);
+
+                        // Because layout of _parent._similarColumnIndexes is [column ids similar to row 0, column ids simialr to row 1, ...],
+                        // the starting position of the u-th row's similar columns start at u * (# of similar indexes per row).
+                        position = (int)(matrixRowIndex - 1) * _parent._similarIndexCount;
+                        for (int i = 0; i < _parent._similarIndexCount; ++i)
+                            editor.Values[i] = _parent._similarColumnsAtRow[position + i];
+                        value = editor.Commit();
+                    };
+
+                return del;
+            }
+
+            /// <summary>
+            /// Map matrix-column index to its similar rows' indexes.
+            /// </summary>
+            private Delegate MakeSimilarRowIndexesGetter(DataViewRow input)
+            {
+                // Get the getter of the matrix-row index.
+                var column = input.Schema[_parent._matrixColumnIndexColumnName];
+                var matrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
+
+                uint matrixColumnIndex = 0;
+                int position = 0;
+
+                ValueGetter<VBuffer<uint>> del = (ref VBuffer<uint> value) =>
+                    {
+                        var editor = VBufferEditor.Create(ref value, _parent._similarIndexCount);
+                        matrixColumnIndexGetter(ref matrixColumnIndex);
+
+                        // Because layout of _parent._similarColumnIndexes is [row ids similar to column 0, row ids simialr to column 1, ...],
+                        // the starting position of the u-th column's similar rows start at v * (# of similar indexes per row).
+                        position = (int)(matrixColumnIndex - 1) * _parent._similarIndexCount;
+                        for (int i = 0; i < _parent._similarIndexCount; ++i)
+                            editor.Values[i] = _parent._similarRowsAtColumn[position + i];
+                        value = editor.Commit();
+                    };
+
+                return del;
+            }
+
+            /// <summary>
+            /// Create getters for columns generated by <see cref="MatrixFactorizationMapper"/>.
+            /// </summary>
+            protected override Delegate MakeGetter(DataViewRow input, int iinfo, Func<int, bool> activeOutput, out Action disposer)
+            {
+                disposer = null;
+                Host.Assert(0 <= iinfo && iinfo < _parent.GetNewColumnNames.Count());
+
+                switch (iinfo)
+                {
+                    case 0:
+                        return MakeColumnLatentVectorGetter(input);
+                    case 1:
+                        return MakeRowLatentVectorGetter(input);
+                    case 2:
+                        return MakeSimilarRowIndexesGetter(input);
+                    case 3:
+                        return MakeSimilarColumnIndexesGetter(input);
+                    default:
+                        return null;
+                }
+            }
+
+            private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
+            {
+                /*
+                var outputColumnActiveFlags = new bool[_outputToSourceIndexMap.Count];
+                for (int outputColumnIndex = 0; outputColumnIndex < _outputToSourceIndexMap.Count; ++outputColumnIndex)
+                    outputColumnActiveFlags[outputColumnIndex] = activeOutput(outputColumnIndex);
+
+                var inputColumnActiveFlags = new bool[InputSchema.Count];
+
+                for (int outputColumnIndex = 0; outputColumnIndex < _outputToSourceIndexMap.Count; ++outputColumnIndex)
+                {
+                    int sourceIndex = _outputToSourceIndexMap[outputColumnIndex];
+                    if (sourceIndex >= 0)
+                        inputColumnActiveFlags[sourceIndex] = true;
+                    else
+                    {
+                        var matrixRowIndexSourceColumn = InputSchema[_parent._matrixRowIndexColumnName];
+                        inputColumnActiveFlags[matrixRowIndexSourceColumn.Index] = true;
+
+                        var matrixColumnIndexSourceColumn = InputSchema[_parent._matrixColumnIndexColumnName];
+                        inputColumnActiveFlags[matrixColumnIndexSourceColumn.Index] = true;
+
+                        var labelSourceColumn = InputSchema[_parent._labelColumnName];
+                        inputColumnActiveFlags[labelSourceColumn.Index] = true;
+                    }
+                }
+                */
+                var indexesOfUsedInputColumns = new HashSet<int>();
+                indexesOfUsedInputColumns.Add(InputSchema[_parent._matrixColumnIndexColumnName].Index);
+                indexesOfUsedInputColumns.Add(InputSchema[_parent._matrixRowIndexColumnName].Index);
+                indexesOfUsedInputColumns.Add(InputSchema[_parent._labelColumnName].Index);
+
+                return i => indexesOfUsedInputColumns.Contains(i);
+            }
+
+            private protected override void SaveModel(ModelSaveContext ctx) => _parent.SaveModel(ctx);
+        }
+    }
+
+    /// <summary>
+    /// A class implementing the estimator interface of the <see cref="MatrixFactorizationTransformer"/>.
+    /// </summary>
+    public sealed class MatrixFactorizationEstimator : IEstimator<MatrixFactorizationTransformer>
+    {
+        private MatrixFactorizationTransformer.Options _options;
+        private MatrixFactorizationTransformer _transformer;
+        private IHost _host;
+
+        internal MatrixFactorizationEstimator(IHostEnvironment env,
+                string columnIndexLatentOutputColumnName,
+                string rowIndexLatentOutputColumnName,
+                string similarColumnIndexesOutputColumnName,
+                string similarRowIndexesOutputColumnName,
+                string labelColumnName,
+                string matrixColumnIndexColumnName,
+                string matrixRowIndexColumnName,
+                int similarIndexCount,
+                bool excludeKnownIndexPairs,
+                int approximationRank = MatrixFactorizationTrainer.Defaults.ApproximationRank,
+                double learningRate = MatrixFactorizationTrainer.Defaults.LearningRate,
+                int numberOfIterations = MatrixFactorizationTrainer.Defaults.NumIterations)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            _host = env.Register(nameof(MatrixFactorizationEstimator));
+
+            _options = new MatrixFactorizationTransformer.Options
+            {
+                ColumnIndexLatentOutputColumnName = columnIndexLatentOutputColumnName,
+                RowIndexLatentOutputColumnName = rowIndexLatentOutputColumnName,
+                SimilarColumnIndexesOutputColumnName = similarColumnIndexesOutputColumnName,
+                SimilarRowIndexesOutputColumnName = similarRowIndexesOutputColumnName,
+                LabelColumnName = labelColumnName,
+                MatrixColumnIndexColumnName = matrixColumnIndexColumnName,
+                MatrixRowIndexColumnName = matrixRowIndexColumnName,
+                SimilarIndexCount = similarIndexCount,
+                ExcludeKnownIndexPairs = excludeKnownIndexPairs,
+                ApproximationRank = approximationRank,
+                LearningRate = learningRate
+            };
+            _transformer = new MatrixFactorizationTransformer(env, _options);
+        }
+
+        internal MatrixFactorizationEstimator(IHostEnvironment env, MatrixFactorizationTransformer.Options options)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            Contracts.CheckValue(options, nameof(options));
+            _host = env.Register(nameof(MatrixFactorizationEstimator));
+            _options = options;
+            _transformer = new MatrixFactorizationTransformer(env, _options);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="SchemaShape"/> of the schema which will be produced by the transformer.
+        /// Used for schema propagation and verification in a pipeline.
+        /// </summary>
+        public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+        {
+            var result = inputSchema.ToDictionary(x => x.Name);
+
+            result[_options.ColumnIndexLatentOutputColumnName] = new SchemaShape.Column(_options.ColumnIndexLatentOutputColumnName, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.Single, false);
+            result[_options.RowIndexLatentOutputColumnName] = new SchemaShape.Column(_options.RowIndexLatentOutputColumnName, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.Single, false);
+            result[_options.SimilarColumnIndexesOutputColumnName] = new SchemaShape.Column(_options.SimilarColumnIndexesOutputColumnName, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.UInt32, true);
+            result[_options.SimilarRowIndexesOutputColumnName] = new SchemaShape.Column(_options.SimilarRowIndexesOutputColumnName, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.UInt32, true);
+
+            return new SchemaShape(result.Values);
+        }
+
+        public MatrixFactorizationTransformer Fit(IDataView input)
+        {
+            _transformer.Fit(input, _options);
+            return _transformer;
+        }
+    }
+}

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTransformer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTransformer.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using Microsoft.ML;
 using Microsoft.ML.CommandLine;
 using Microsoft.ML.Data;
-using Microsoft.ML.EntryPoints;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.Recommender;
-using Microsoft.ML.Transforms;
 
 namespace Microsoft.ML.Recommender
 {
@@ -21,7 +17,7 @@ namespace Microsoft.ML.Recommender
         internal const string ShortName = "MaFaTrans";
         internal const string LoaderSignature = "MatrixFactorizationTransform";
 
-        internal sealed class Options : MatrixFactorizationTrainer.Options
+        public class Options : MatrixFactorizationTrainer.Options
         {
             [Argument(ArgumentType.AtMostOnce, HelpText = "Output column name of the row index's latent representation.")]
             public string ColumnIndexLatentOutputColumnName = nameof(ColumnIndexLatentOutputColumnName).Replace("ColumnName", "");
@@ -78,15 +74,17 @@ namespace Microsoft.ML.Recommender
         /// <summary>
         /// The underlying matrix factorization model.
         /// </summary>
-        private MatrixFactorizationModelParameters _model;
+        private MatrixFactorizationModelParameters _submodel;
+
+        public MatrixFactorizationModelParameters SubModel => _submodel;
 
         private uint[] _similarRowsAtColumn;
         private uint[] _similarColumnsAtRow;
 
-        private DataViewType RowIndexLatentOutputColumnType => new VectorDataViewType(NumberDataViewType.Single, _model.ApproximationRank);
-        private DataViewType ColumnIndexLatentOutputColumnType => new VectorDataViewType(NumberDataViewType.Single, _model.ApproximationRank);
-        private DataViewType SimilarRowIndexesOutputColumnType => new VectorDataViewType((KeyDataViewType)_model.MatrixRowIndexType, _similarIndexCount);
-        private DataViewType SimilarColumnIndexesOutputColumnType => new VectorDataViewType((KeyDataViewType)_model.MatrixColumnIndexType, _similarIndexCount);
+        private DataViewType RowIndexLatentOutputColumnType => new VectorDataViewType(NumberDataViewType.Single, _submodel.ApproximationRank);
+        private DataViewType ColumnIndexLatentOutputColumnType => new VectorDataViewType(NumberDataViewType.Single, _submodel.ApproximationRank);
+        private DataViewType SimilarRowIndexesOutputColumnType => new VectorDataViewType((KeyDataViewType)_submodel.MatrixRowIndexType, _similarIndexCount);
+        private DataViewType SimilarColumnIndexesOutputColumnType => new VectorDataViewType((KeyDataViewType)_submodel.MatrixColumnIndexType, _similarIndexCount);
 
         private static VersionInfo GetVersionInfo()
         {
@@ -136,49 +134,49 @@ namespace Microsoft.ML.Recommender
         {
             // Do matrix factorization and extract the trained model.
             var trainer = new MatrixFactorizationTrainer(Host, options);
-            _model = trainer.Fit(data).Model;
+            _submodel = trainer.Fit(data).Model;
 
             // In the training matrix, row indexes can be found at the i-th column are stored at knownIndexesAtColumns[i].
-            var knownRowsAtColumn = new HashSet<uint>[_model.NumberOfColumns].Select(set => new HashSet<uint>()).ToArray();
+            var knownRowsAtColumn = new HashSet<uint>[_submodel.NumberOfColumns].Select(set => new HashSet<uint>()).ToArray();
 
             // In the training matrix, column indexes can be found at the i-th row are stored at knownIndexesAtRows[i].
-            var knownColumnsAtRow = new HashSet<uint>[_model.NumberOfRows].Select(set => new HashSet<uint>()).ToArray();
+            var knownColumnsAtRow = new HashSet<uint>[_submodel.NumberOfRows].Select(set => new HashSet<uint>()).ToArray();
 
             // Fill knownRowsAtColumn and knowColumnsAtRow if know row-column pairs should be excluded from the similar row-column
             // pairs identified by this transform. This is useful when user only wants to discover relations not told by the training
             // data.
             if (options.ExcludeKnownIndexPairs)
-                PrepareKnownSimilarIndexes(data, options.MatrixColumnIndexColumnName, options.MatrixRowIndexColumnName,
-                    _model.NumberOfColumns, _model.NumberOfRows, ref knownRowsAtColumn, ref knownColumnsAtRow);
+                PrepareKnownIndexPairs(data, options.MatrixColumnIndexColumnName, options.MatrixRowIndexColumnName,
+                    _submodel.NumberOfColumns, _submodel.NumberOfRows, ref knownRowsAtColumn, ref knownColumnsAtRow);
 
             // Shared buffer to store latent vector.
-            var queryVector = new float[_model.ApproximationRank];
+            var queryVector = new float[_submodel.ApproximationRank];
 
             // Column indexes with latent representations similar to the i-th row's are stored at knownSimilarColumnIndexes[i].
             var similarColumnsAtRow = new List<uint>();
-            for (int u = 0; u < _model.NumberOfRows; ++u)
+            for (int u = 0; u < _submodel.NumberOfRows; ++u)
             {
                 // Extract the u-th row's latent vector.
-                int pos = u * _model.ApproximationRank;
-                for (int k = 0; k < _model.ApproximationRank; ++k)
-                    queryVector[k] = _model.LeftFactorMatrix[pos + k];
+                int pos = u * _submodel.ApproximationRank;
+                for (int k = 0; k < _submodel.ApproximationRank; ++k)
+                    queryVector[k] = _submodel.LeftFactorMatrix[pos + k];
 
                 // Find u-th row's similar columns' indexes.
-                similarColumnsAtRow.AddRange(ComputeSimilarIndexes(_similarIndexCount, queryVector, _model.RightFactorMatrix, knownColumnsAtRow[u]));
+                similarColumnsAtRow.AddRange(ComputeSimilarIndexes(_similarIndexCount, queryVector, _submodel.RightFactorMatrix, knownColumnsAtRow[u]));
             }
             _similarColumnsAtRow = similarColumnsAtRow.ToArray();
 
             // Row indexes similar to the i-th row is stored at knownIndexesAtRows[i].
             var similarRowsAtColumn = new List<uint>();
-            for (int v = 0; v < _model.NumberOfColumns; ++v)
+            for (int v = 0; v < _submodel.NumberOfColumns; ++v)
             {
                 // Extract the v-th column's latent vector.
-                int pos = v * _model.ApproximationRank;
-                for (int k = 0; k < _model.ApproximationRank; ++k)
-                    queryVector[k] = _model.RightFactorMatrix[pos + k];
+                int pos = v * _submodel.ApproximationRank;
+                for (int k = 0; k < _submodel.ApproximationRank; ++k)
+                    queryVector[k] = _submodel.RightFactorMatrix[pos + k];
 
                 // Find v-th column's similar columns.
-                similarRowsAtColumn.AddRange(ComputeSimilarIndexes(_similarIndexCount, queryVector, _model.LeftFactorMatrix, knownRowsAtColumn[v]));
+                similarRowsAtColumn.AddRange(ComputeSimilarIndexes(_similarIndexCount, queryVector, _submodel.LeftFactorMatrix, knownRowsAtColumn[v]));
             }
             _similarRowsAtColumn = similarRowsAtColumn.ToArray();
         }
@@ -190,7 +188,7 @@ namespace Microsoft.ML.Recommender
         /// The row indexes at the v-th column will be stored in <paramref name="knownRowsAtColumn"/>[v].
         /// The column indexes at the u-th row will be stored in <paramref name="knownColumnsAtRow"/>[u].
         /// </summary>
-        private static void PrepareKnownSimilarIndexes(IDataView data, string matrixColumnName, string matrixRowName, int numberOfColumns, int numberOfRows,
+        private static void PrepareKnownIndexPairs(IDataView data, string matrixColumnName, string matrixRowName, int numberOfColumns, int numberOfRows,
             ref HashSet<uint>[] knownRowsAtColumn, ref HashSet<uint>[] knownColumnsAtRow)
         {
             var matrixColumnIndexColumn = data.Schema[matrixColumnName];
@@ -250,7 +248,8 @@ namespace Microsoft.ML.Recommender
             {
                 if (i > scores.Length)
                     break;
-                selectedIndexes[i] = (uint)indexes[i];
+                // Key values are 1-based indexes.
+                selectedIndexes[i] = (uint)indexes[i] + 1;
             }
 
             return selectedIndexes;
@@ -272,10 +271,10 @@ namespace Microsoft.ML.Recommender
 
             CheckInitialConfiguration();
 
-            _model = new MatrixFactorizationModelParameters(env, ctx);
+            _submodel = new MatrixFactorizationModelParameters(env, ctx);
 
-            _similarColumnsAtRow = Utils.ReadUIntArray(ctx.Reader, checked(_model.NumberOfRows * _model.ApproximationRank));
-            _similarRowsAtColumn = Utils.ReadUIntArray(ctx.Reader, checked(_model.NumberOfColumns * _model.ApproximationRank));
+            _similarColumnsAtRow = Utils.ReadUIntArray(ctx.Reader, checked(_submodel.NumberOfRows * _submodel.ApproximationRank));
+            _similarRowsAtColumn = Utils.ReadUIntArray(ctx.Reader, checked(_submodel.NumberOfColumns * _submodel.ApproximationRank));
         }
 
         private protected override void SaveModel(ModelSaveContext ctx)
@@ -292,7 +291,7 @@ namespace Microsoft.ML.Recommender
             ctx.Writer.Write(_rowIndexLatentOutputColumnName);
             ctx.Writer.Write(_similarColumnIndexesOutputColumnName);
             ctx.Writer.Write(_similarRowIndexesOutputColumnName);
-            ((ICanSaveModel)_model).Save(ctx);
+            ((ICanSaveModel)_submodel).Save(ctx);
             Utils.WriteUIntStream(ctx.Writer, _similarColumnsAtRow);
             Utils.WriteUIntStream(ctx.Writer, _similarRowsAtColumn);
         }
@@ -309,13 +308,6 @@ namespace Microsoft.ML.Recommender
 
         private class MatrixFactorizationMapper : MapperBase
         {
-            /*
-            private Dictionary<int, int> _outputToSourceIndexMap;
-            private Dictionary<int, int> _sourceToOutputIndexMap;
-            private Dictionary<int, string> _outputIndexToNameMap;
-            private Dictionary<int, DataViewType> _outputIndexToTypeMap;
-            */
-
             private MatrixFactorizationTransformer _parent;
 
             internal MatrixFactorizationMapper(IHost host, MatrixFactorizationTransformer parent, DataViewSchema inputSchema) :
@@ -324,53 +316,6 @@ namespace Microsoft.ML.Recommender
                 Contracts.AssertValue(parent);
                 _parent = parent;
             }
-
-            /*
-            private void ComputeIndexMap(DataViewSchema inputSchema, out Dictionary<int, int> outputToSourceIndexMap, out Dictionary<int, int> sourceToOutputIndexMap,
-                out Dictionary<int, string> outputIndexToNameMap, out Dictionary<int, DataViewType> outputIndexToTypeMap)
-            {
-                outputToSourceIndexMap = new Dictionary<int, int>();
-                sourceToOutputIndexMap = new Dictionary<int, int>();
-                outputIndexToNameMap = new Dictionary<int, string>();
-                outputIndexToTypeMap = new Dictionary<int, DataViewType>();
-
-                // Pass all input columns to output schema.
-                for (int i = 0; i < inputSchema.Count; ++i)
-                {
-                    outputToSourceIndexMap[i] = inputSchema[i].Index;
-                    sourceToOutputIndexMap[inputSchema[i].Index] = i;
-                    outputIndexToNameMap[i] = inputSchema[i].Name;
-                    outputIndexToTypeMap[i] = inputSchema[i].Type;
-                }
-
-                // Add new columns to output schema and possiblyh overwrite input columns passed by.
-                for (int i = 0; i < _parent.GetNewColumnNames.Length; ++i)
-                {
-                    var newColumnName = _parent.GetNewColumnNames[i];
-                    var newColumnType = _parent.GetNewColumnTypes[i];
-                    var newColumnSourceIndex = -(i + 1);
-                    var column = inputSchema.GetColumnOrNull(_parent._columnIndexLatentOutputColumnName);
-                    if (column.HasValue)
-                    {
-                        // Overwrite input column.
-                        var outputIndex = sourceToOutputIndexMap[column.Value.Index];
-                        outputToSourceIndexMap[outputIndex] = newColumnSourceIndex;
-                        sourceToOutputIndexMap[newColumnSourceIndex] = outputIndex;
-                        outputIndexToNameMap[outputIndex] = newColumnName;
-                        outputIndexToTypeMap[outputIndex] = newColumnType;
-                    }
-                    else
-                    {
-                        // Add new output column. No column will be overwritten at this round.
-                        var newOutputIndex = sourceToOutputIndexMap.Values.Max() + 1;
-                        outputToSourceIndexMap[newOutputIndex] = newColumnSourceIndex;
-                        sourceToOutputIndexMap[newColumnSourceIndex] = newOutputIndex;
-                        outputIndexToNameMap[newOutputIndex] = newColumnName;
-                        outputIndexToTypeMap[newOutputIndex] = newColumnType;
-                    }
-                }
-            }
-            */
 
             /// <summary>
             /// Returns columns generated by <see cref="MatrixFactorizationMapper"/>.
@@ -385,66 +330,79 @@ namespace Microsoft.ML.Recommender
                 return outputColumns;
             }
 
-            private Delegate MakeRowLatentVectorGetter(DataViewRow input)
+            /// <summary>
+            /// Helper function shared by <see cref="MakeRowLatentVectorGetter(DataViewRow)"/> and <see cref="MakeColumnLatentVectorGetter(DataViewRow)"/>.
+            /// </summary>
+            private Delegate MakeLatentVectorGetter(DataViewRow input, DataViewSchema.Column indexColumn, IReadOnlyList<float> factorMatrix)
             {
                 // Get the getter of the row index.
-                var column = input.Schema[_parent._matrixRowIndexColumnName];
-                var matrixRowIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
+                var indexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, indexColumn.Index);
 
-                // Buffer used to store row index being mapped to a latent vector.
-                uint matrixRowIndex = 0;
+                // Buffer used to store index being mapped to a latent vector.
+                uint index = 0;
 
                 // Rank of matrix factorization trained.
-                var rank = _parent._model.ApproximationRank;
+                var rank = _parent._submodel.ApproximationRank;
 
-                // Starting position of a row's latent vector in the left factor matrix.
+                // Starting position of a index's latent vector in the factor matrix.
                 var position = 0;
-
-                // Row indexes' latent vectors, which is a flattened matrix.
-                var leftFactorMatrix = _parent._model.LeftFactorMatrix;
 
                 ValueGetter<VBuffer<float>> del =
                     (ref VBuffer<float> value) =>
                     {
                         var editor = VBufferEditor.Create(ref value, rank);
-                        matrixRowIndexGetter(ref matrixRowIndex);
-                        position = (int)(matrixRowIndex - 1) * rank;
-                        for (int i = 0; i < _parent._model.ApproximationRank; ++i)
-                            editor.Values[i] = leftFactorMatrix[position + i];
+                        // Find the index.
+                        indexGetter(ref index);
+                        // We compute the starting position of the found index's latent vector and
+                        // then the latent vector is copied to the input buffer.
+                        position = (int)(index - 1) * rank;
+                        for (int i = 0; i < rank; ++i)
+                            editor.Values[i] = factorMatrix[position + i];
                         value = editor.Commit();
                     };
 
                 return del;
             }
 
+            private Delegate MakeRowLatentVectorGetter(DataViewRow input)
+            {
+                // Get the getter of the row index.
+                var indexColumn = input.Schema[_parent._matrixRowIndexColumnName];
+                // Row indexes' latent vectors, which is a flattened matrix.
+                var leftFactorMatrix = _parent._submodel.LeftFactorMatrix;
+
+                return MakeLatentVectorGetter(input, indexColumn, leftFactorMatrix);
+            }
+
             private Delegate MakeColumnLatentVectorGetter(DataViewRow input)
             {
                 // Get the getter of the column index.
-                var column = input.Schema[_parent._matrixColumnIndexColumnName];
-                var matrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
-
-                // Buffer used to store column index being mapped to a latent vector.
-                uint matrixColumnIndex = 0;
-
-                // Rank of matrix factorization trained.
-                var rank = _parent._model.ApproximationRank;
-
-                // Starting position of a row's latent vector in the right factor matrix.
-                var position = 0;
-
+                var indexColumn = input.Schema[_parent._matrixColumnIndexColumnName];
                 // Column indexes' latent vectors, which is a flattened matrix.
-                var rightFactorMatrix = _parent._model.RightFactorMatrix;
+                var rightFactorMatrix = _parent._submodel.RightFactorMatrix;
 
-                ValueGetter<VBuffer<float>> del = (ref VBuffer<float> value) =>
+                return MakeLatentVectorGetter(input, indexColumn, rightFactorMatrix);
+            }
+
+            private Delegate MakeSimilarIndexGetter(DataViewRow input, DataViewSchema.Column column, IReadOnlyList<uint> candidates)
+            {
+                // Get the getter of the index.
+                var indexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
+
+                uint index = 0;
+                int position = 0;
+                ValueGetter<VBuffer<uint>> del =
+                    (ref VBuffer<uint> value) =>
                     {
-                        var editor = VBufferEditor.Create(ref value, rank);
-                        matrixColumnIndexGetter(ref matrixColumnIndex);
-                        position = (int)(matrixColumnIndex - 1) * rank;
-                        for (int i = 0; i < _parent._model.ApproximationRank; ++i)
-                            editor.Values[i] = rightFactorMatrix[position + i];
+                        var editor = VBufferEditor.Create(ref value, _parent._similarIndexCount);
+                        indexGetter(ref index);
+                        // Because layout of _parent._similarColumnIndexes is [column ids similar to row 0, column ids simialr to row 1, ...],
+                        // the starting position of the u-th row's similar columns start at u * (# of similar indexes per row).
+                        position = (int)(index - 1) * _parent._similarIndexCount;
+                        for (int i = 0; i < _parent._similarIndexCount; ++i)
+                            editor.Values[i] = candidates[position + i];
                         value = editor.Commit();
                     };
-
                 return del;
             }
 
@@ -453,27 +411,7 @@ namespace Microsoft.ML.Recommender
             /// </summary>
             private Delegate MakeSimilarColumnIndexesGetter(DataViewRow input)
             {
-                // Get the getter of the matrix-row index.
-                var column = input.Schema[_parent._matrixRowIndexColumnName];
-                var matrixRowIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
-
-                uint matrixRowIndex = 0;
-                int position = 0;
-                ValueGetter<VBuffer<uint>> del =
-                    (ref VBuffer<uint> value) =>
-                    {
-                        var editor = VBufferEditor.Create(ref value, _parent._similarIndexCount);
-                        matrixRowIndexGetter(ref matrixRowIndex);
-
-                        // Because layout of _parent._similarColumnIndexes is [column ids similar to row 0, column ids simialr to row 1, ...],
-                        // the starting position of the u-th row's similar columns start at u * (# of similar indexes per row).
-                        position = (int)(matrixRowIndex - 1) * _parent._similarIndexCount;
-                        for (int i = 0; i < _parent._similarIndexCount; ++i)
-                            editor.Values[i] = _parent._similarColumnsAtRow[position + i];
-                        value = editor.Commit();
-                    };
-
-                return del;
+                return MakeSimilarIndexGetter(input, input.Schema[_parent._matrixRowIndexColumnName], _parent._similarColumnsAtRow);
             }
 
             /// <summary>
@@ -481,27 +419,7 @@ namespace Microsoft.ML.Recommender
             /// </summary>
             private Delegate MakeSimilarRowIndexesGetter(DataViewRow input)
             {
-                // Get the getter of the matrix-row index.
-                var column = input.Schema[_parent._matrixColumnIndexColumnName];
-                var matrixColumnIndexGetter = RowCursorUtils.GetGetterAs<uint>(NumberDataViewType.UInt32, input, column.Index);
-
-                uint matrixColumnIndex = 0;
-                int position = 0;
-
-                ValueGetter<VBuffer<uint>> del = (ref VBuffer<uint> value) =>
-                    {
-                        var editor = VBufferEditor.Create(ref value, _parent._similarIndexCount);
-                        matrixColumnIndexGetter(ref matrixColumnIndex);
-
-                        // Because layout of _parent._similarColumnIndexes is [row ids similar to column 0, row ids simialr to column 1, ...],
-                        // the starting position of the u-th column's similar rows start at v * (# of similar indexes per row).
-                        position = (int)(matrixColumnIndex - 1) * _parent._similarIndexCount;
-                        for (int i = 0; i < _parent._similarIndexCount; ++i)
-                            editor.Values[i] = _parent._similarRowsAtColumn[position + i];
-                        value = editor.Commit();
-                    };
-
-                return del;
+                return MakeSimilarIndexGetter(input, input.Schema[_parent._matrixColumnIndexColumnName], _parent._similarRowsAtColumn);
             }
 
             /// <summary>
@@ -529,31 +447,6 @@ namespace Microsoft.ML.Recommender
 
             private protected override Func<int, bool> GetDependenciesCore(Func<int, bool> activeOutput)
             {
-                /*
-                var outputColumnActiveFlags = new bool[_outputToSourceIndexMap.Count];
-                for (int outputColumnIndex = 0; outputColumnIndex < _outputToSourceIndexMap.Count; ++outputColumnIndex)
-                    outputColumnActiveFlags[outputColumnIndex] = activeOutput(outputColumnIndex);
-
-                var inputColumnActiveFlags = new bool[InputSchema.Count];
-
-                for (int outputColumnIndex = 0; outputColumnIndex < _outputToSourceIndexMap.Count; ++outputColumnIndex)
-                {
-                    int sourceIndex = _outputToSourceIndexMap[outputColumnIndex];
-                    if (sourceIndex >= 0)
-                        inputColumnActiveFlags[sourceIndex] = true;
-                    else
-                    {
-                        var matrixRowIndexSourceColumn = InputSchema[_parent._matrixRowIndexColumnName];
-                        inputColumnActiveFlags[matrixRowIndexSourceColumn.Index] = true;
-
-                        var matrixColumnIndexSourceColumn = InputSchema[_parent._matrixColumnIndexColumnName];
-                        inputColumnActiveFlags[matrixColumnIndexSourceColumn.Index] = true;
-
-                        var labelSourceColumn = InputSchema[_parent._labelColumnName];
-                        inputColumnActiveFlags[labelSourceColumn.Index] = true;
-                    }
-                }
-                */
                 var indexesOfUsedInputColumns = new HashSet<int>();
                 indexesOfUsedInputColumns.Add(InputSchema[_parent._matrixColumnIndexColumnName].Index);
                 indexesOfUsedInputColumns.Add(InputSchema[_parent._matrixRowIndexColumnName].Index);

--- a/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
@@ -111,6 +111,9 @@ namespace Microsoft.ML
                         columnIndexLatentOutputColumnName, rowIndexLatentOutputColumnName, similarColumnIndexesOutputColumnName, similarRowIndexesOutputColumnName,
                         labelColumnName, matrixColumnIndexColumnName, matrixRowIndexColumnName, similarIndexCount, excludeKnownIndexPairs,
                         approximationRank, learningRate, numberOfIterations);
+
+            public MatrixFactorizationEstimator MatrixFactorizationMap(MatrixFactorizationTransformer.Options options)
+                    => new MatrixFactorizationEstimator(Owner.GetEnvironment(), options);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
+++ b/src/Microsoft.ML.Recommender/RecommenderCatalog.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML.Data;
+using Microsoft.ML.Recommender;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Trainers;
 
@@ -92,6 +93,24 @@ namespace Microsoft.ML
             public MatrixFactorizationTrainer MatrixFactorization(
                 MatrixFactorizationTrainer.Options options)
                     => new MatrixFactorizationTrainer(Owner.GetEnvironment(), options);
+
+            public MatrixFactorizationEstimator MatrixFactorizationMap(
+                string columnIndexLatentOutputColumnName,     // output 0
+                string rowIndexLatentOutputColumnName,        // output 1
+                string similarColumnIndexesOutputColumnName,  // output 2
+                string similarRowIndexesOutputColumnName,     // output 3
+                string labelColumnName,                       // input 0
+                string matrixColumnIndexColumnName,           // input 1
+                string matrixRowIndexColumnName,              // input 2
+                int similarIndexCount,
+                bool excludeKnownIndexPairs,
+                int approximationRank = MatrixFactorizationTrainer.Defaults.ApproximationRank,
+                double learningRate = MatrixFactorizationTrainer.Defaults.LearningRate,
+                int numberOfIterations = MatrixFactorizationTrainer.Defaults.NumIterations)
+                    => new MatrixFactorizationEstimator(Owner.GetEnvironment(),
+                        columnIndexLatentOutputColumnName, rowIndexLatentOutputColumnName, similarColumnIndexesOutputColumnName, similarRowIndexesOutputColumnName,
+                        labelColumnName, matrixColumnIndexColumnName, matrixRowIndexColumnName, similarIndexCount, excludeKnownIndexPairs,
+                        approximationRank, learningRate, numberOfIterations);
         }
 
         /// <summary>


### PR DESCRIPTION
In addition to a scorer, matrix factorization also commonly acts like a featurizer. It can map matrix row/column index to its representation. If we factorize matrix `R` into `P^TQ`, then the row index u's latent representation is defined as the u-th column of P. Similarly, the column index v's latent representation is the v-th column of Q. In addition, this transformer can find columns/rows similar to the given row/column by computing the inner products between row/column and all other columns/rows. The following data structure summarizes this transformer's output schema.
```csharp
        private class LatentVectorAndNeighbors
        {
            [VectorType(2)]
            public float[] ColumnLatentVector { get; set; }

            [VectorType(2)]
            public float[] RowLatentVector { get; set; }

            [VectorType(1)]
            [KeyType(_oneClassMatrixRowCount)]
            public uint[] SimilarRows { get; set; }

            [VectorType(1)]
            [KeyType(_oneClassMatrixColumnCount)]
            public uint[] SImilarColumns { get; set; }
        }
```
This PR fix partially #1795 because we still need another evaluator.
