### PR TITLE
Ensable the uses of SSE and OpenMP in LIBMF

### DIFF
--- a/src/Native/MatrixFactorizationNative/CMakeLists.txt
+++ b/src/Native/MatrixFactorizationNative/CMakeLists.txt
@@ -1,5 +1,7 @@
 project (MatrixFactorizationNative)
 add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+add_definitions(-DUSESSE)
+add_definitions(-DUSEOMP)
 
 include_directories(libmf)
 

--- a/src/Native/MatrixFactorizationNative/CMakeLists.txt
+++ b/src/Native/MatrixFactorizationNative/CMakeLists.txt
@@ -3,12 +3,15 @@ add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 add_definitions(-DUSESSE)
 add_definitions(-DUSEOMP)
 
+find_package(OPENMP REQUIRED)
+
+
 include_directories(libmf)
 
-set(SOURCES
-    UnmanagedMemory.cpp
-    libmf/mf.cpp
-)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+set(SOURCES UnmanagedMemory.cpp libmf/mf.cpp)
 
 if(NOT WIN32)
     list(APPEND SOURCES ${VERSION_FILE_PATH})

--- a/src/Native/MatrixFactorizationNative/CMakeLists.txt
+++ b/src/Native/MatrixFactorizationNative/CMakeLists.txt
@@ -1,16 +1,19 @@
 project (MatrixFactorizationNative)
 add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-add_definitions(-DUSESSE)
 add_definitions(-DUSEOMP)
-
-find_package(OPENMP REQUIRED)
-
+add_definitions(-DUSESSE)
 
 include_directories(libmf)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+if(UNIX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -pthread -std=c++0x -march=native")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fopenmp")
+endif()
+if(WIN32)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /nologo /O2 /EHsc /D \"_CRT_SECURE_NO_DEPRECATE\" /openmp")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+
 set(SOURCES UnmanagedMemory.cpp libmf/mf.cpp)
 
 if(NOT WIN32)

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 // Linux case
-                var expectedUnixL2Error = 0.616821448679879; // Linux baseline
+                var expectedUnixL2Error = 0.614457914950479; // Linux baseline
                 Assert.InRange(metrices.MeanSquaredError, expectedUnixL2Error - tolerance, expectedUnixL2Error + tolerance);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MatrixFactorizationTests.cs
@@ -92,10 +92,10 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // MF produce different matrixes on different platforms, so at least test thier content on windows.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Assert.Equal(leftMatrix[0], (double)0.3091519, 5);
-                Assert.Equal(leftMatrix[leftMatrix.Count - 1], (double)0.5639161, 5);
-                Assert.Equal(rightMatrix[0], (double)0.243584976, 5);
-                Assert.Equal(rightMatrix[rightMatrix.Count - 1], (double)0.380032182, 5);
+                Assert.Equal(0.33491, leftMatrix[0], 5);
+                Assert.Equal(0.571346991, leftMatrix[leftMatrix.Count - 1], 5);
+                Assert.Equal(0.2433036714792256, rightMatrix[0], 5);
+                Assert.Equal(0.381277978420258, rightMatrix[rightMatrix.Count - 1], 5);
             }
             // Read the test data set as an IDataView
             var testData = reader.Load(new MultiFileSource(GetDataPath(TestDatasets.trivialMatrixFactorization.testFilename)));
@@ -136,7 +136,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Windows case
-                var expectedWindowsL2Error = 0.61528733643754685; // Windows baseline
+                var expectedWindowsL2Error = 0.6098110249191965; // Windows baseline
                 Assert.InRange(metrices.MeanSquaredError, expectedWindowsL2Error - tolerance, expectedWindowsL2Error + tolerance);
             }
 


### PR DESCRIPTION
Fix #1408 by compiling LIBMF with SSE and OpenMP.
