### PR TITLE
Remove Console.Readline at the end of the samples.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -54,8 +54,6 @@ namespace Samples.Dynamic
             //  1/4/2012        34      0
             //  1/5/2012        35      0
             //  1/6/2012        35      0
-
-            Console.ReadLine();
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -2,7 +2,6 @@
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
-using Microsoft.ML.Trainers;
 
 namespace Samples.Dynamic
 {
@@ -77,7 +76,6 @@ namespace Samples.Dynamic
 
                 index++;
             }
-            Console.ReadLine();
 
             // The output of the above code is:
             // Label Score   BiggestFeature Value   Weight Contribution


### PR DESCRIPTION
fixes #3279

There are two samples that have ReadLine() in the end, presumably to prevent the window from closing but this is not needed because VS prevents the window from closing and also this pattern is inconsistent from rest of the samples.
