### PR TITLE
Cherry-pick bug fixes and samples from master to release/1.0

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -43,3 +43,26 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License notice for SharpZipLib
+------------------------------
+
+https://github.com/icsharpcode/SharpZipLib
+
+Copyright © 2000-2018 SharpZipLib Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class BootstrapSample
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable and them read it as ML.NET's data type.
-            IEnumerable<SamplesUtils.DatasetUtils.BinaryLabelFloatFeatureVectorFloatWeightSample> enumerableOfData = SamplesUtils.DatasetUtils.GenerateBinaryLabelFloatFeatureVectorFloatWeightSamples(5);
+            IEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.BinaryLabelFloatFeatureVectorFloatWeightSample> enumerableOfData = Microsoft.ML.SamplesUtils.DatasetUtils.GenerateBinaryLabelFloatFeatureVectorFloatWeightSamples(5);
             var data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
             // Look at the original dataset
@@ -43,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic
             {
                 var resample = mlContext.Data.BootstrapSample(data, seed: i);
 
-                var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.BinaryLabelFloatFeatureVectorFloatWeightSample>(resample, reuseRowObject: false);
+                var enumerable = mlContext.Data.CreateEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.BinaryLabelFloatFeatureVectorFloatWeightSample>(resample, reuseRowObject: false);
                 Console.WriteLine($"Label\tFeatures[0]");
                 foreach (var row in enumerable)
                 {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class Cache
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/CrossValidationSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/CrossValidationSplit.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using static Microsoft.ML.DataOperationsCatalog;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     /// <summary>
     /// Sample class showing how to use CrossValidationSplit.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -54,8 +54,6 @@ namespace Samples.Dynamic
             //  1/4/2012        34      0
             //  1/5/2012        35      0
             //  1/6/2012        35      0
-
-            Console.ReadLine();
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     /// <summary>
     /// Sample class showing how to use ShuffleRows.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     /// <summary>
     /// Sample class showing how to use FilterRowsByColumn.
@@ -15,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
-            IEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData> enumerableOfData = SamplesUtils.DatasetUtils.GetSampleTemperatureData(10);
+            IEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleTemperatureData> enumerableOfData = Microsoft.ML.SamplesUtils.DatasetUtils.GetSampleTemperatureData(10);
             var data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
             // Before we apply a filter, examine all the records in the dataset.
@@ -42,7 +43,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.FilterRowsByColumn(data, columnName: "Temperature", lowerBound: 34, upperBound: 37);
 
             // Look at the filtered data and observe that values outside [34,37) have been dropped.
-            var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByKeyColumnFraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByKeyColumnFraction.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     using MulticlassClassificationExample = DatasetUtils.MulticlassClassificationExample;
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByMissingValues.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByMissingValues.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public class FilterRowsByMissingValues
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     /// <summary>
     /// Sample class showing how to use ShuffleRows.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-namespace Microsoft.ML.Samples.Dynamic
+using Microsoft.ML;
+
+namespace Samples.Dynamic
 {
     /// <summary>
     /// Sample class showing how to use Skip.
@@ -13,7 +15,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
-            var enumerableOfData = SamplesUtils.DatasetUtils.GetSampleTemperatureData(10);
+            var enumerableOfData = Microsoft.ML.SamplesUtils.DatasetUtils.GetSampleTemperatureData(10);
             var data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
             // Before we apply a filter, examine all the records in the dataset.
@@ -40,7 +42,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.SkipRows(data, 5);
 
             // Look at the filtered data and observe that the first 5 rows have been dropped
-            var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-namespace Microsoft.ML.Samples.Dynamic
+using Microsoft.ML;
+
+namespace Samples.Dynamic
 {
     /// <summary>
     /// Sample class showing how to use Take.
@@ -13,7 +15,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
-            var enumerableOfData = SamplesUtils.DatasetUtils.GetSampleTemperatureData(10);
+            var enumerableOfData = Microsoft.ML.SamplesUtils.DatasetUtils.GetSampleTemperatureData(10);
             var data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
             // Before we apply a filter, examine all the records in the dataset.
@@ -40,7 +42,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var filteredData = mlContext.Data.TakeRows(data, 5);
 
             // Look at the filtered data and observe that only the first 5 rows are in the resulting dataset.
-            var enumerable = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
+            var enumerable = mlContext.Data.CreateEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TrainTestSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TrainTestSplit.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.ML.Data;
+using Microsoft.ML;
 using static Microsoft.ML.DataOperationsCatalog;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     /// <summary>
     /// Sample class showing how to use TrainTestSplit.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class FeatureContributionCalculationTransform
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/FeatureContributionCalculationTransform.cs
@@ -2,7 +2,6 @@
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
-using Microsoft.ML.Trainers;
 
 namespace Samples.Dynamic
 {
@@ -77,7 +76,6 @@ namespace Samples.Dynamic
 
                 index++;
             }
-            Console.ReadLine();
 
             // The output of the above code is:
             // Label Score   BiggestFeature Value   Weight Contribution

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Dynamic
 {
     public static partial class TransformSamples
     {
-        public static void NgramTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/NgramExtraction.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static partial class TransformSamples
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext();
 
             // Get a small dataset as an IEnumerable and convert to IDataView.
-            IEnumerable<SamplesUtils.DatasetUtils.SampleSentimentData> data = SamplesUtils.DatasetUtils.GetSentimentData();
+            IEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleSentimentData> data = Microsoft.ML.SamplesUtils.DatasetUtils.GetSentimentData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
@@ -56,8 +56,8 @@ namespace Microsoft.ML.Samples.Dynamic
 
             // Composing a different pipeline if we wanted to normalize more than one column at a time. 
             // Using log scale as the normalization mode. 
-            var multiColPipeline = ml.Transforms.NormalizeMinMax("LogInduced", "Induced")
-                .Append(ml.Transforms.NormalizeMinMax("LogSpontaneous", "Spontaneous"));
+            var multiColPipeline = ml.Transforms.NormalizeLogMeanVariance(new[] { new InputOutputColumnPair("LogInduced", "Induced"), new InputOutputColumnPair("LogSpontaneous", "Spontaneous") });
+
             // The transformed data.
             var multiColtransformer = multiColPipeline.Fit(trainData);
             var multiColtransformedData = multiColtransformer.Transform(trainData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class NormalizerTransform
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext();
 
             // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            IEnumerable<SamplesUtils.DatasetUtils.SampleInfertData> data = SamplesUtils.DatasetUtils.GetInfertData();
+            IEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleInfertData> data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -13,8 +13,9 @@ namespace Microsoft.ML.Samples.Dynamic
         public static void Example()
         {
             // Download the squeeznet image model from ONNX model zoo, version 1.2
-            // https://github.com/onnx/models/tree/master/squeezenet
-            var modelPath = @"squeezenet\model.onnx";
+            // https://github.com/onnx/models/tree/master/squeezenet or use
+            // Microsoft.ML.Onnx.TestModels nuget.
+            var modelPath = @"squeezenet\00000001\model.onnx";
 
             // Inspect the model's inputs and outputs
             var session = new InferenceSession(modelPath);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/OnnxTransform.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.OnnxRuntime;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class OnnxTransformExample
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIHelper.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIHelper.cs
@@ -2,8 +2,9 @@
 using System.Linq;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.SamplesUtils;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
+namespace Samples.Dynamic.PermutationFeatureImportance
 {
     public static class PfiHelper
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIRegressionExample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PFIRegressionExample.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
+namespace Samples.Dynamic.PermutationFeatureImportance
 {
     public static class PfiRegression
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/PermutationFeatureImportance/PfiBinaryClassificationExample.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.PermutationFeatureImportance
+namespace Samples.Dynamic.PermutationFeatureImportance
 {
     public static class PfiBinaryClassification
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ProjectionTransforms.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class ProjectionTransforms
     {
@@ -14,7 +15,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext();
 
             // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            IEnumerable<SamplesUtils.DatasetUtils.SampleVectorOfNumbersData> data = SamplesUtils.DatasetUtils.GetVectorOfNumbersData();
+            IEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData> data = Microsoft.ML.SamplesUtils.DatasetUtils.GetVectorOfNumbersData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.
@@ -37,13 +38,13 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // A pipeline to project Features column into Random fourier space.
-            var rffPipeline = ml.Transforms.ApproximatedKernelMap(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), rank: 4);
+            var rffPipeline = ml.Transforms.ApproximatedKernelMap(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), rank: 4);
             // The transformed (projected) data.
             var transformedData = rffPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var randomFourier = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
+            var randomFourier = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
-            printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), randomFourier);
+            printHelper(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), randomFourier);
 
             // Features column obtained post-transformation.
             //
@@ -55,13 +56,15 @@ namespace Microsoft.ML.Samples.Dynamic
             //0.165 0.117 -0.547  0.014
 
             // A pipeline to project Features column into L-p normalized vector.
-            var lpNormalizePipeline = ml.Transforms.NormalizeLpNorm(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), norm: Transforms.LpNormNormalizingEstimatorBase.NormFunction.L1);
+            var lpNormalizePipeline = ml.Transforms.NormalizeLpNorm(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features),
+                norm: Microsoft.ML.Transforms.LpNormNormalizingEstimatorBase.NormFunction.L1);
+
             // The transformed (projected) data.
             transformedData = lpNormalizePipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var lpNormalize= transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
+            var lpNormalize= transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
-            printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), lpNormalize);
+            printHelper(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), lpNormalize);
 
             // Features column obtained post-transformation.
             //
@@ -73,13 +76,13 @@ namespace Microsoft.ML.Samples.Dynamic
             // 0.133 0.156 0.178 0.200 0.000 0.022 0.044 0.067 0.089 0.111
 
             // A pipeline to project Features column into L-p normalized vector.
-            var gcNormalizePipeline = ml.Transforms.NormalizeGlobalContrast(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), ensureZeroMean:false);
+            var gcNormalizePipeline = ml.Transforms.NormalizeGlobalContrast(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), ensureZeroMean:false);
             // The transformed (projected) data.
             transformedData = gcNormalizePipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var gcNormalize = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
+            var gcNormalize = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
-            printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), gcNormalize);
+            printHelper(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), gcNormalize);
 
             // Features column obtained post-transformation.
             //

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/ImageClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/ImageClassification.cs
@@ -4,9 +4,10 @@ using System.Linq;
 using System.Net;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class ImageClassification
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.IO;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class TextClassification
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic
         /// </summary>
         public static void Example()
         {
-            string modelLocation = SamplesUtils.DatasetUtils.DownloadTensorFlowSentimentModel();
+            string modelLocation = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadTensorFlowSentimentModel();
 
             var mlContext = new MLContext();
             var data = new[] { new IMDBSentiment() {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/TextTransform.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms.Text;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class TextTransform
     {
@@ -14,7 +15,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext();
 
             // Get a small dataset as an IEnumerable and convert to IDataView.
-            var data = SamplesUtils.DatasetUtils.GetSentimentData();
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetSentimentData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
+namespace Samples.Dynamic.Trainers.AnomalyDetection
 {
     public static class RandomizedPcaSample
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
+namespace Samples.Dynamic.Trainers.AnomalyDetection
 {
     public static class RandomizedPcaSampleWithOptions
     {
@@ -28,7 +29,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.AnomalyDetection
             // Convert the List<DataPoint> to IDataView, a consumble format to ML.NET functions.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
-            var options = new ML.Trainers.RandomizedPcaTrainer.Options()
+            var options = new Microsoft.ML.Trainers.RandomizedPcaTrainer.Options()
             {
                 FeatureColumnName = nameof(DataPoint.Features),
                 Rank = 1,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+﻿using Microsoft.ML;
+
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class AveragedPerceptron
     {
@@ -13,7 +15,7 @@
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -27,7 +29,7 @@
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(trainTestData.TestSet);
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Accuracy: 0.86

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.ML.Trainers;
+﻿using Microsoft.ML;
+using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class AveragedPerceptronWithOptions
     {
@@ -15,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -39,7 +40,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(trainTestData.TestSet);
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //  Accuracy: 0.86

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
@@ -56,7 +56,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.BinaryClassification.<#=Evaluator#>(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
             <#=ExpectedOutput#>
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
@@ -3,14 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
-using Microsoft.ML.Trainers.FastTree;
+<# if (TrainerOptions != null) { #>
+<#=OptionsInclude#>
+<# } #>
 
 namespace Samples.Dynamic.Trainers.BinaryClassification
 {
-    public static class FastTreeWithOptions
-    {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+    public static class <#=ClassName#>
+    {<#=Comments#>
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
@@ -24,19 +24,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
+<# if (TrainerOptions == null) { #>
+            // Define the trainer.
+            var pipeline = mlContext.BinaryClassification.Trainers.<#=Trainer#>();
+<# } else { #>
             // Define trainer options.
-            var options = new FastTreeBinaryTrainer.Options
-            {
-                // Use L2Norm for early stopping.
-                EarlyStoppingMetric = EarlyStoppingMetric.L2Norm,
-                // Create a simpler model by penalizing usage of new features.
-                FeatureFirstUsePenalty = 0.1,
-                // Reduce the number of trees to 50.
-                NumberOfTrees = 50
-            };
+            var options = new <#=TrainerOptions#>;
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FastTree(options);
+            var pipeline = mlContext.BinaryClassification.Trainers.<#=Trainer#>(options);
+<# } #>
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -54,28 +51,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
 
-            // Expected output:
-            //   Label: True, Prediction: True
-            //   Label: False, Prediction: False
-            //   Label: True, Prediction: True
-            //   Label: True, Prediction: True
-            //   Label: False, Prediction: False
-            
+            <#=ExpectedOutputPerInstance#>
+            <# string Evaluator = IsCalibrated ? "Evaluate" : "EvaluateNonCalibrated"; #>
+
             // Evaluate the overall metrics
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
-            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            var metrics = mlContext.BinaryClassification.<#=Evaluator#>(transformedTestData);
+            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
-            // Expected output:
-            //   Accuracy: 0.78
-            //   AUC: 0.88
-            //   F1 Score: 0.79
-            //   Negative Precision: 0.83
-            //   Negative Recall: 0.74
-            //   Positive Precision: 0.74
-            //   Positive Recall: 0.84
-            //   Log Loss: 0.62
-            //   Log Loss Reduction: 37.77
-            //   Entropy: 1.00
+            <#=ExpectedOutput#>
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
@@ -90,7 +73,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + <#=DataSepValue#>).ToArray()
                 };
             }
         }
@@ -113,4 +96,3 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
     }
 }
-

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/FixedPlatt.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/FixedPlatt.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
+namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
 {
     public static class FixedPlatt
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
 
@@ -53,11 +54,11 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // Score   5.36571   Probability 0.9955735
         }
 
-        private static void PrintRowViewValues(Data.DataDebuggerPreview data)
+        private static void PrintRowViewValues(Microsoft.ML.Data.DataDebuggerPreview data)
         {
             var firstRows = data.RowView.Take(5);
 
-            foreach (Data.DataDebuggerPreview.RowInfo row in firstRows)
+            foreach (Microsoft.ML.Data.DataDebuggerPreview.RowInfo row in firstRows)
             {
                 foreach (var kvPair in row.Values)
                 {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
+namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
 {
     public static class Isotonic
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
 
@@ -53,11 +54,11 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // Score   5.36571   Probability 0.8958333
         }
 
-        private static void PrintRowViewValues(Data.DataDebuggerPreview data)
+        private static void PrintRowViewValues(Microsoft.ML.Data.DataDebuggerPreview data)
         {
             var firstRows = data.RowView.Take(5);
 
-            foreach (Data.DataDebuggerPreview.RowInfo row in firstRows)
+            foreach (Microsoft.ML.Data.DataDebuggerPreview.RowInfo row in firstRows)
             {
                 foreach (var kvPair in row.Values)
                 {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Naive.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Naive.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
+namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
 {
     public static class Naive
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
 
@@ -53,11 +54,11 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
            // Score   5.36571   Probability 0.9117647
         }
 
-        private static void PrintRowViewValues(Data.DataDebuggerPreview data)
+        private static void PrintRowViewValues(Microsoft.ML.Data.DataDebuggerPreview data)
         {
             var firstRows = data.RowView.Take(5);
 
-            foreach (Data.DataDebuggerPreview.RowInfo row in firstRows)
+            foreach (Microsoft.ML.Data.DataDebuggerPreview.RowInfo row in firstRows)
             {
                 foreach (var kvPair in row.Values)
                 {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Platt.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Platt.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
+namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
 {
     public static class Platt
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
 
@@ -53,11 +54,11 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // Score   5.36571   Probability 0.9065308
         }
 
-        private static void PrintRowViewValues(Data.DataDebuggerPreview data)
+        private static void PrintRowViewValues(Microsoft.ML.Data.DataDebuggerPreview data)
         {
             var firstRows = data.RowView.Take(5);
 
-            foreach (Data.DataDebuggerPreview.RowInfo row in firstRows)
+            foreach (Microsoft.ML.Data.DataDebuggerPreview.RowInfo row in firstRows)
             {
                 foreach (var kvPair in row.Values)
                 {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastForest
     {
@@ -50,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
             // Expected output:
             //   Accuracy: 0.74

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.FastTree;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastForestWithOptions
     {
@@ -62,7 +63,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
             // Expected output:
             //   Accuracy: 0.73

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastTree
     {
@@ -50,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics
             var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
             // Expected output:
             //   Accuracy: 0.81

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class FFMBinaryClassification
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Download and featurize the dataset.
-            var dataviews = SamplesUtils.DatasetUtils.LoadFeaturizedSentimentDataset(mlContext);
+            var dataviews = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedSentimentDataset(mlContext);
             var trainData = dataviews[0];
             var testData = dataviews[1];
 
@@ -61,7 +62,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var dataWithPredictions = model.Transform(testData);
 
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions, "Sentiment");
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             //  Accuracy: 0.72
             //  AUC: 0.75

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithoutArguments.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithoutArguments.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Linq;
-using Microsoft.ML.Data;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class FFMBinaryClassificationWithoutArguments
     {
@@ -13,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Download and featurize the dataset.
-            var dataviews = SamplesUtils.DatasetUtils.LoadFeaturizedSentimentDataset(mlContext);
+            var dataviews = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedSentimentDataset(mlContext);
             var trainData = dataviews[0];
             var testData = dataviews[1];
 
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var dataWithPredictions = model.Transform(testData);
 
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions, "Sentiment");
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //  Accuracy: 0.61

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachinewWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachinewWithOptions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class FFMBinaryClassificationWithOptions
     {
@@ -14,7 +15,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Download and featurize the dataset.
-            var dataviews = SamplesUtils.DatasetUtils.LoadFeaturizedSentimentDataset(mlContext);
+            var dataviews = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedSentimentDataset(mlContext);
             var trainData = dataviews[0];
             var testData = dataviews[1];
 
@@ -69,7 +70,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var dataWithPredictions = model.Transform(testData);
 
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions, "Sentiment");
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             //  Accuracy: 0.78
             //  AUC: 0.81

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
@@ -3,14 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
-using Microsoft.ML.Trainers.FastTree;
 
 namespace Samples.Dynamic.Trainers.BinaryClassification
 {
-    public static class FastTreeWithOptions
+    public static class LbfgsLogisticRegression
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
@@ -24,19 +21,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // Define trainer options.
-            var options = new FastTreeBinaryTrainer.Options
-            {
-                // Use L2Norm for early stopping.
-                EarlyStoppingMetric = EarlyStoppingMetric.L2Norm,
-                // Create a simpler model by penalizing usage of new features.
-                FeatureFirstUsePenalty = 0.1,
-                // Reduce the number of trees to 50.
-                NumberOfTrees = 50
-            };
-
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FastTree(options);
+            var pipeline = mlContext.BinaryClassification.Trainers.LbfgsLogisticRegression();
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -56,7 +42,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Expected output:
             //   Label: True, Prediction: True
-            //   Label: False, Prediction: False
+            //   Label: False, Prediction: True
             //   Label: True, Prediction: True
             //   Label: True, Prediction: True
             //   Label: False, Prediction: False
@@ -66,15 +52,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
             // Expected output:
-            //   Accuracy: 0.78
-            //   AUC: 0.88
-            //   F1 Score: 0.79
-            //   Negative Precision: 0.83
-            //   Negative Recall: 0.74
-            //   Positive Precision: 0.74
-            //   Positive Recall: 0.84
-            //   Log Loss: 0.62
-            //   Log Loss Reduction: 37.77
+            //   Accuracy: 0.88
+            //   AUC: 0.96
+            //   F1 Score: 0.87
+            //   Negative Precision: 0.90
+            //   Negative Recall: 0.87
+            //   Positive Precision: 0.86
+            //   Positive Recall: 0.89
+            //   Log Loss: 0.38
+            //   Log Loss Reduction: 0.62
             //   Entropy: 1.00
         }
 
@@ -90,7 +76,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
                 };
             }
         }
@@ -113,4 +99,3 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
     }
 }
-

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -3,14 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
-using Microsoft.ML.Trainers.FastTree;
+using Microsoft.ML.Trainers;
 
 namespace Samples.Dynamic.Trainers.BinaryClassification
 {
-    public static class FastTreeWithOptions
+    public static class LbfgsLogisticRegressionWithOptions
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
@@ -25,18 +23,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
-            var options = new FastTreeBinaryTrainer.Options
+            var options = new LbfgsLogisticRegressionBinaryTrainer.Options()
             {
-                // Use L2Norm for early stopping.
-                EarlyStoppingMetric = EarlyStoppingMetric.L2Norm,
-                // Create a simpler model by penalizing usage of new features.
-                FeatureFirstUsePenalty = 0.1,
-                // Reduce the number of trees to 50.
-                NumberOfTrees = 50
+                MaximumNumberOfIterations = 100,
+                OptimizationTolerance = 1e-8f,
+                L2Regularization = 0.01f
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FastTree(options);
+            var pipeline = mlContext.BinaryClassification.Trainers.LbfgsLogisticRegression(options);
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -56,7 +51,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Expected output:
             //   Label: True, Prediction: True
-            //   Label: False, Prediction: False
+            //   Label: False, Prediction: True
             //   Label: True, Prediction: True
             //   Label: True, Prediction: True
             //   Label: False, Prediction: False
@@ -66,15 +61,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
             // Expected output:
-            //   Accuracy: 0.78
-            //   AUC: 0.88
-            //   F1 Score: 0.79
-            //   Negative Precision: 0.83
-            //   Negative Recall: 0.74
-            //   Positive Precision: 0.74
-            //   Positive Recall: 0.84
-            //   Log Loss: 0.62
-            //   Log Loss Reduction: 37.77
+            //   Accuracy: 0.87
+            //   AUC: 0.96
+            //   F1 Score: 0.87
+            //   Negative Precision: 0.89
+            //   Negative Recall: 0.87
+            //   Positive Precision: 0.86
+            //   Positive Recall: 0.88
+            //   Log Loss: 0.37
+            //   Log Loss Reduction: 0.63
             //   Entropy: 1.00
         }
 
@@ -90,7 +85,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
                 };
             }
         }
@@ -113,4 +108,3 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
     }
 }
-

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -26,7 +26,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var options = new LbfgsLogisticRegressionBinaryTrainer.Options()
             {
                 MaximumNumberOfIterations = 100,
-                OptimizationTolerance = 1e-8f,
+                OptmizationTolerance = 1e-8f,
                 L2Regularization = 0.01f
             };
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+﻿using Microsoft.ML;
+
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public class LightGbm
     {
@@ -9,7 +11,7 @@
             var mlContext = new MLContext();
 
             // Download and featurize the dataset.
-            var dataview = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var dataview = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.1);
@@ -24,7 +26,7 @@
             var dataWithPredictions = model.Transform(split.TestSet);
 
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Accuracy: 0.88

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
@@ -1,6 +1,7 @@
-﻿﻿using Microsoft.ML.Trainers.LightGbm;
+﻿using Microsoft.ML;
+using Microsoft.ML.Trainers.LightGbm;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     class LightGbmWithOptions
     {
@@ -11,7 +12,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             var mlContext = new MLContext();
 
             // Download and featurize the dataset.
-            var dataview = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var dataview = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.1);
@@ -34,7 +35,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             var dataWithPredictions = model.Transform(split.TestSet);
 
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Accuracy: 0.88

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainerSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainerSample.cs
@@ -26,7 +26,7 @@ namespace Samples.Dynamic
             var loader = mlContext.Data.CreateTextLoader(
                 columns: new[]
                     {
-                        new TextLoader.Column("Sentiment", DataKind.Single, 0),
+                        new TextLoader.Column("Sentiment", DataKind.Boolean, 0),
                         new TextLoader.Column("SentimentText", DataKind.String, 1)
                     },
                 hasHeader: true
@@ -63,7 +63,7 @@ namespace Samples.Dynamic
             //  Positive Precision: 0.50
             //  Positive Recall: 1.00
             //  LogLoss: 1.05
-            //  LogLossReduction: -4.89
+            //  LogLossReduction: -0.05
             //  Entropy: 1.00
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainerSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainerSample.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.ML.Data;
+﻿using Microsoft.ML;
+using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public class PriorTrainer
     {
@@ -11,7 +12,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Download and featurize the dataset.
-            var dataFiles = SamplesUtils.DatasetUtils.DownloadSentimentDataset();
+            var dataFiles = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadSentimentDataset();
             var trainFile = dataFiles[0];
             var testFile = dataFiles[1];
 
@@ -48,7 +49,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Step 4: Evaluate on the test set
             var transformedData = trainedPipeline.Transform(loader.Load(testFile));
             var evalMetrics = mlContext.BinaryClassification.Evaluate(transformedData, labelColumnName: "Sentiment");
-            SamplesUtils.ConsoleUtils.PrintMetrics(evalMetrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(evalMetrics);
 
             // The Prior trainer outputs the proportion of a label in the dataset as the probability of that label.
             // In this case 'Accuracy: 0.50' means that there is a split of around 50%-50% of positive and negative labels in the test dataset.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscent.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class StochasticDualCoordinateAscent
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             // Downloading the dataset from github.com/dotnet/machinelearning.
             // This will create a sentiment.tsv file in the filesystem.
             // You can open this file, if you want to see the data. 
-            string dataFile = SamplesUtils.DatasetUtils.DownloadSentimentDataset()[0];
+            string dataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadSentimentDataset()[0];
 
             // A preview of the data. 
             // Sentiment	SentimentText

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscent.cs
@@ -47,9 +47,9 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             // Featurize the text column through the FeaturizeText API. 
             // Then append a binary classifier, setting the "Label" column as the label of the dataset, and 
             // the "Features" column produced by FeaturizeText as the features column.
-            var pipeline = mlContext.Transforms.Text.FeaturizeText("SentimentText", "Features")
+            var pipeline = mlContext.Transforms.Text.FeaturizeText("Features", "SentimentText")
                     .AppendCacheCheckpoint(mlContext) // Add a data-cache step within a pipeline.
-                    .Append(mlContext.BinaryClassification.Trainers.SdcaNonCalibrated(labelColumnName: "Sentiment", featureColumnName: "Features", l2Regularization: 0.001f));
+                    .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(labelColumnName: "Sentiment", featureColumnName: "Features", l2Regularization: 0.001f));
 
             // Step 3: Run Cross-Validation on this pipeline.
             var cvResults = mlContext.BinaryClassification.CrossValidate(data, pipeline, labelColumnName: "Sentiment");
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
 
             // If we wanted to specify more advanced parameters for the algorithm, 
             // we could do so by tweaking the 'advancedSetting'.
-            var advancedPipeline = mlContext.Transforms.Text.FeaturizeText("SentimentText", "Features")
+            var advancedPipeline = mlContext.Transforms.Text.FeaturizeText("Features", "SentimentText")
                                   .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
                                       new SdcaLogisticRegressionBinaryTrainer.Options { 
                                         LabelColumnName = "Sentiment",
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
                                       }));
 
             // Run Cross-Validation on this second pipeline.
-            var cvResults_advancedPipeline = mlContext.BinaryClassification.CrossValidate(data, pipeline, labelColumnName: "Sentiment", numberOfFolds: 3);
+            var cvResults_advancedPipeline = mlContext.BinaryClassification.CrossValidate(data, advancedPipeline, labelColumnName: "Sentiment", numberOfFolds: 3);
             accuracies = cvResults_advancedPipeline.Select(r => r.Metrics.Accuracy);
             Console.WriteLine(accuracies.Average());
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscentNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscentNonCalibrated.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class StochasticDualCoordinateAscentNonCalibrated
     {
         public static void Example()
         {
             // Generate IEnumerable<BinaryLabelFloatFeatureVectorSample> as training examples.
-            var rawData = SamplesUtils.DatasetUtils.GenerateBinaryLabelFloatFeatureVectorFloatWeightSamples(100);
+            var rawData = Microsoft.ML.SamplesUtils.DatasetUtils.GenerateBinaryLabelFloatFeatureVectorFloatWeightSamples(100);
 
             // Information in first example.
             // Label: true
@@ -49,7 +50,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             // Step 4: Make prediction and evaluate its quality (on training set).
             var prediction = model.Transform(data);
 
-            var rawPrediction = mlContext.Data.CreateEnumerable<SamplesUtils.DatasetUtils.NonCalibratedBinaryClassifierOutput>(prediction, false);
+            var rawPrediction = mlContext.Data.CreateEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.NonCalibratedBinaryClassifierOutput>(prediction, false);
 
             // Step 5: Inspect the prediction of the first example.
             // Note that positive/negative label may be associated with positive/negative score

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscentWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticDualCoordinateAscentWithOptions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.ML;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class StochasticDualCoordinateAscentWithOptions
     {
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(trainTestData.TestSet);
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Accuracy: 0.85

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescent.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+﻿using Microsoft.ML;
+
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class StochasticGradientDescent
     {
@@ -13,7 +15,7 @@
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -27,7 +29,7 @@
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(trainTestData.TestSet);
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Accuracy: 0.85

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescentNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescentNonCalibrated.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ML.Samples.Dynamic
+﻿using Microsoft.ML;
+
+namespace Samples.Dynamic
 {
     public static class StochasticGradientDescentNonCalibrated
     {
@@ -13,7 +15,7 @@
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -27,7 +29,7 @@
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(trainTestData.TestSet);
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //  Accuracy: 0.85

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescentNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescentNonCalibratedWithOptions.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.ML.Trainers;
+﻿using Microsoft.ML;
+using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class StochasticGradientDescentNonCalibratedWithOptions
     {
@@ -15,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -37,7 +38,7 @@ namespace Microsoft.ML.Samples.Dynamic
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(trainTestData.TestSet);
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //  Accuracy: 0.85

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescentWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/StochasticGradientDescentWithOptions.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.ML.Trainers;
+﻿using Microsoft.ML;
+using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class StochasticGradientDescentWithOptions
     {
@@ -15,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -40,7 +41,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(trainTestData.TestSet);
             var metrics = mlContext.BinaryClassification.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Accuracy: 0.85

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicStochasticGradientDescent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicStochasticGradientDescent.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+﻿using Microsoft.ML;
+
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class SymbolicStochasticGradientDescent
     {
@@ -14,7 +16,7 @@
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var split = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
@@ -25,7 +27,7 @@
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(split.TestSet);
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             
             // Expected output:
             //   Accuracy: 0.85

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicStochasticGradientDescentWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicStochasticGradientDescentWithOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ML.Samples.Dynamic.Trainers.BinaryClassification
+﻿using Microsoft.ML;
+
+namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class SymbolicStochasticGradientDescentWithOptions
     {
@@ -14,13 +16,13 @@
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
 
             // Leave out 10% of data for testing.
             var split = mlContext.Data.TrainTestSplit(data, testFraction: 0.1);
             // Create data training pipeline
             var pipeline = mlContext.BinaryClassification.Trainers.SymbolicSgdLogisticRegression(
-                    new ML.Trainers.SymbolicSgdLogisticRegressionBinaryTrainer.Options()
+                    new Microsoft.ML.Trainers.SymbolicSgdLogisticRegressionBinaryTrainer.Options()
                     {
                         LearningRate = 0.2f,
                         NumberOfIterations = 10,
@@ -33,7 +35,7 @@
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(split.TestSet);
             var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Accuracy: 0.84

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public class KMeans
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext(seed: 1);
 
             // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            var data = SamplesUtils.DatasetUtils.GetInfertData();
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public class KMeansWithOptions
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext(seed: 1);
 
             // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            var data = SamplesUtils.DatasetUtils.GetInfertData();
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
+namespace Samples.Dynamic.Trainers.MulticlassClassification
 {
     public static class LightGbm
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
 using Microsoft.ML.Trainers.LightGbm;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
+namespace Samples.Dynamic.Trainers.MulticlassClassification
 {
     public static class LightGbmWithOptions
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/StochasticDualCoordinateAscent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/StochasticDualCoordinateAscent.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.ML.Data;
+﻿using Microsoft.ML;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
+namespace Samples.Dynamic.Trainers.MulticlassClassification
 {
     public static class StochasticDualCoordinateAscent
     {
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the trained model using the test set.
             var metrics = mlContext.MulticlassClassification.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Micro Accuracy: 0.82

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/StochasticDualCoordinateAscentWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/StochasticDualCoordinateAscentWithOptions.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.ML.SamplesUtils;
+﻿using Microsoft.ML;
+using Microsoft.ML.SamplesUtils;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
+namespace Samples.Dynamic.Trainers.MulticlassClassification
 {
     public static class StochasticDualCoordinateAscentWithOptions
     {
@@ -54,7 +55,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the trained model using the test set.
             var metrics = mlContext.MulticlassClassification.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Micro Accuracy: 0.82

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbm.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ML.Samples.Dynamic.Trainers.Ranking
+﻿using Microsoft.ML;
+
+namespace Samples.Dynamic.Trainers.Ranking
 {
     public class LightGbm
     {
@@ -9,7 +11,7 @@
             var mlContext = new MLContext();
 
             // Download and featurize the dataset.
-            var dataview = SamplesUtils.DatasetUtils.LoadFeaturizedMslrWeb10kDataset(mlContext);
+            var dataview = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedMslrWeb10kDataset(mlContext);
 
             // Leave out 10% of the dataset for testing. Since this is a ranking problem, we must ensure that the split
             // respects the GroupId column, i.e. rows with the same GroupId are either all in the train split or all in
@@ -30,7 +32,7 @@
             var dataWithPredictions = model.Transform(split.TestSet);
 
             var metrics = mlContext.Ranking.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   DCG: @1:1.71, @2:3.88, @3:7.93

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbmWithOptions.cs
@@ -29,7 +29,8 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Ranking
                     Booster = new GradientBooster.Options
                     {
                         FeatureFraction = 0.9
-                    }
+                    },
+                    RowGroupColumnName = "GroupId"
                 });
 
             // Fit this pipeline to the training Data.
@@ -43,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Ranking
 
             // Expected output:
             //   DCG: @1:1.71, @2:3.88, @3:7.93
-            //   NDCG: @1:7.98, @2:12.14, @3:16.62
+            //   NDCG: @1:0.08, @2:0.12, @3:0.17
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Ranking/LightGbmWithOptions.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.ML.Trainers.LightGbm;
+﻿using Microsoft.ML;
+using Microsoft.ML.Trainers.LightGbm;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Ranking
+namespace Samples.Dynamic.Trainers.Ranking
 {
     public class LightGbmWithOptions
     {
@@ -11,7 +12,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Ranking
             var mlContext = new MLContext();
 
             // Download and featurize the train and validation datasets.
-            var dataview = SamplesUtils.DatasetUtils.LoadFeaturizedMslrWeb10kDataset(mlContext);
+            var dataview = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedMslrWeb10kDataset(mlContext);
 
             // Leave out 10% of the dataset for testing. Since this is a ranking problem, we must ensure that the split
             // respects the GroupId column, i.e. rows with the same GroupId are either all in the train split or all in
@@ -40,7 +41,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Ranking
             var dataWithPredictions = model.Transform(split.TestSet);
 
             var metrics = mlContext.Ranking.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   DCG: @1:1.71, @2:3.88, @3:7.93

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorization.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using static Microsoft.ML.SamplesUtils.DatasetUtils;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
+namespace Samples.Dynamic.Trainers.Recommendation
 {
     public static class MatrixFactorization
     {
@@ -38,7 +39,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
             var metrics = mlContext.Recommendation().Evaluate(prediction,
                 labelColumnName: nameof(MatrixElement.Value), scoreColumnName: nameof(MatrixElementForScore.Score));
             // Print out some metrics for checking the model's quality.
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             // L1: 0.17
             // L2: 0.05
             // LossFunction: 0.05

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Recommendation/MatrixFactorizationWithOptions.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Trainers;
 using static Microsoft.ML.SamplesUtils.DatasetUtils;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
+namespace Samples.Dynamic.Trainers.Recommendation
 {
     public static class MatrixFactorizationWithOptions
     {
@@ -48,7 +49,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Recommendation
             var metrics = mlContext.Recommendation().Evaluate(prediction,
                 labelColumnName: nameof(MatrixElement.Value), scoreColumnName: nameof(MatrixElementForScore.Score));
             // Print out some metrics for checking the model's quality.
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
             // L1: 0.16
             // L2: 0.04
             // LossFunction: 0.04

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForest.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForest.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class FastForest
     {
@@ -50,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Mean Absolute Error: 0.06

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastForestWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.FastTree;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class FastForestWithOptions
     {
@@ -62,7 +63,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Mean Absolute Error: 0.06

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTree.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class FastTree
     {
@@ -50,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Mean Absolute Error: 0.05

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedie.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedie.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class FastTreeTweedie
     {
@@ -50,7 +51,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Mean Absolute Error: 0.05

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedieWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeTweedieWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.FastTree;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class FastTreeTweedieWithOptions
     {
@@ -62,7 +63,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Mean Absolute Error: 0.05

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/FastTreeWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.FastTree;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class FastTreeWithOptions
     {
@@ -62,7 +63,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Mean Absolute Error: 0.05

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Gam.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/Gam.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class Gam
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/GamWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/GamWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.FastTree;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class GamWithOptions
     {
@@ -60,7 +61,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   Mean Absolute Error: 0.06

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbm.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     class LightGbm
     {
@@ -14,7 +15,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             var mlContext = new MLContext();
 
             // Download and load the housing dataset into an IDataView.
-            var dataView = SamplesUtils.DatasetUtils.LoadHousingRegressionDataset(mlContext);
+            var dataView = Microsoft.ML.SamplesUtils.DatasetUtils.LoadHousingRegressionDataset(mlContext);
 
             //////////////////// Data Preview ////////////////////
             /// Only 6 columns are displayed here.
@@ -52,7 +53,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(split.TestSet);
             var metrics = mlContext.Regression.Evaluate(dataWithPredictions, labelColumnName: labelName);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output
             //   L1: 4.97

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/LightGbmWithOptions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.LightGbm;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     class LightGbmWithOptions
     {
@@ -15,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             var mlContext = new MLContext();
 
             // Download and load the housing dataset into an IDataView.
-            var dataView = SamplesUtils.DatasetUtils.LoadHousingRegressionDataset(mlContext);
+            var dataView = Microsoft.ML.SamplesUtils.DatasetUtils.LoadHousingRegressionDataset(mlContext);
 
             //////////////////// Data Preview ////////////////////
             /// Only 6 columns are displayed here.
@@ -61,7 +62,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             // Evaluate how the model is doing on the test data.
             var dataWithPredictions = model.Transform(split.TestSet);
             var metrics = mlContext.Regression.Evaluate(dataWithPredictions, labelColumnName: labelName);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output
             //   L1: 4.97

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OnlineGradientDescent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OnlineGradientDescent.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class OnlineGradientDescent
     {
@@ -43,7 +44,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // TODO #2425: OGD is missing baseline tests and seems numerically unstable
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OnlineGradientDescentWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OnlineGradientDescentWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class OnlineGradientDescentWithOptions
     {
@@ -57,7 +58,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // TODO #2425: OGD is missing baseline tests and seems numerically unstable
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquares.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquares.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class OrdinaryLeastSquares
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
         public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
-            string dataFile = SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
+            string dataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
 
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquaresWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/OrdinaryLeastSquaresWithOptions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.SamplesUtils;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class OrdinaryLeastSquaresWithOptions
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
         public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
-            string dataFile = SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
+            string dataFile = DatasetUtils.DownloadHousingRegressionDataset();
 
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/PoissonRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/PoissonRegression.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class PoissonRegression
     {
@@ -48,8 +49,8 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
-            
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+
             // Expected output:
             //   Mean Absolute Error: 0.07
             //   Mean Squared Error: 0.01

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/PoissonRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/PoissonRegressionWithOptions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class PoissonRegressionWithOptions
     {
@@ -60,8 +61,8 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
-            
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+
             // Expected output:
             //   Mean Absolute Error: 0.07
             //   Mean Squared Error: 0.01

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/RegressionSamplesTemplate.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/RegressionSamplesTemplate.ttinclude
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 <# if (TrainerOptions != null) { #>
 using Microsoft.ML.Trainers;
 <# } #>
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class <#=ClassName#>
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/RegressionSamplesTemplate.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/RegressionSamplesTemplate.ttinclude
@@ -55,7 +55,7 @@ namespace Samples.Dynamic.Trainers.Regression
 
             // Evaluate the overall metrics
             var metrics = mlContext.Regression.Evaluate(transformedTestData);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             <#=ExpectedOutput#>
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/StochasticDualCoordinateAscent.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/StochasticDualCoordinateAscent.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Linq;
-using Microsoft.ML.Data;
+﻿using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class StochasticDualCoordinateAscent
     {
@@ -14,7 +12,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             var mlContext = new MLContext(seed: 0);
 
             // Create in-memory examples as C# native class and convert to IDataView
-            var data = SamplesUtils.DatasetUtils.GenerateFloatLabelFloatFeatureVectorSamples(1000);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GenerateFloatLabelFloatFeatureVectorSamples(1000);
             var dataView = mlContext.Data.LoadFromEnumerable(data);
 
             // Split the data into training and test sets. Only training set is used in fitting
@@ -30,7 +28,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the trained model using the test set.
             var metrics = mlContext.Regression.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   L1: 0.27

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/StochasticDualCoordinateAscentWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Regression/StochasticDualCoordinateAscentWithOptions.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.ML.Data;
+﻿using Microsoft.ML;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
+namespace Samples.Dynamic.Trainers.Regression
 {
     public static class StochasticDualCoordinateAscentWithOptions
     {
@@ -13,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
             var mlContext = new MLContext(seed: 0);
 
             // Create in-memory examples as C# native class and convert to IDataView
-            var data = SamplesUtils.DatasetUtils.GenerateFloatLabelFloatFeatureVectorSamples(1000);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GenerateFloatLabelFloatFeatureVectorSamples(1000);
             var dataView = mlContext.Data.LoadFromEnumerable(data);
 
             // Split the data into training and test sets. Only training set is used in fitting
@@ -40,7 +40,7 @@ namespace Microsoft.ML.Samples.Dynamic.Trainers.Regression
 
             // Evaluate the trained model using the test set.
             var metrics = mlContext.Regression.Evaluate(dataWithPredictions);
-            SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
+            Microsoft.ML.SamplesUtils.ConsoleUtils.PrintMetrics(metrics);
 
             // Expected output:
             //   L1: 0.26

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Concatenate.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Concatenate.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class ConcatTransform
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable and them read it as ML.NET's data type.
-            var data = SamplesUtils.DatasetUtils.GetInfertData();
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var trainData = mlContext.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapKeyToVector.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapKeyToVector.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+
+namespace Samples.Dynamic
+{
+    class MapKeyToVector
+    {
+        /// This example demonstrates the use of MapKeyToVector by mapping keys to floats[]. 
+        /// Because the ML.NET KeyType maps the missing value to zero, counting starts at 1, so the uint values
+        /// converted to KeyTypes will appear skewed by one. 
+        /// See https://github.com/dotnet/machinelearning/blob/master/docs/code/IDataViewTypeSystem.md#key-types
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var mlContext = new MLContext();
+
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Timeframe = 9, Category = 5 },
+                new DataPoint() { Timeframe = 8, Category = 4 },
+                new DataPoint() { Timeframe = 8, Category = 4 },
+                new DataPoint() { Timeframe = 9, Category = 3 },
+                new DataPoint() { Timeframe = 2, Category = 3 },
+                new DataPoint() { Timeframe = 3, Category = 5 }
+            };
+
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            // Constructs the ML.net pipeline
+            var pipeline = mlContext.Transforms.Conversion.MapKeyToVector("TimeframeVector", "Timeframe")
+                           .Append(mlContext.Transforms.Conversion.MapKeyToVector("CategoryVector", "Category", outputCountVector: true));
+
+            // Fits the pipeline to the data.
+            IDataView transformedData = pipeline.Fit(data).Transform(data);
+
+            // Getting the resulting data as an IEnumerable.
+            // This will contain the newly created columns.
+            IEnumerable<TransformedData> features = mlContext.Data.CreateEnumerable<TransformedData>(transformedData, reuseRowObject: false);
+
+            Console.WriteLine($" Timeframe           TimeframeVector         Category    CategoryVector");
+            foreach (var featureRow in features)
+                Console.WriteLine($"{featureRow.Timeframe}\t\t\t{string.Join(',', featureRow.TimeframeVector)}\t\t\t{featureRow.Category}\t\t{string.Join(',', featureRow.CategoryVector)}");
+
+            // TransformedData obtained post-transformation.
+            //
+            // Timeframe          TimeframeVector    Category    CategoryVector
+            //  10              0,0,0,0,0,0,0,0,0,1       6          0,0,0,0,0
+            //  9               0,0,0,0,0,0,0,0,1,0       5          0,0,0,0,1
+            //  9               0,0,0,0,0,0,0,0,1,0       5          0,0,0,0,1
+            //  10              0,0,0,0,0,0,0,0,0,1       4          0,0,0,1,0
+            //  3               0,0,1,0,0,0,0,0,0,0       4          0,0,0,1,0
+            //  4               0,0,0,1,0,0,0,0,0,0       6          0,0,0,0,0
+         }
+
+        private class DataPoint
+        {
+            [KeyType(10)]
+            public uint Timeframe { get; set; }
+
+            [KeyType(6)]
+            public uint Category { get; set; }
+
+        }
+
+        private class TransformedData : DataPoint
+        {
+            public float[] TimeframeVector { get; set; }
+            public float[] CategoryVector { get; set; }
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CopyColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CopyColumns.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class CopyColumns
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable and them read it as ML.NET's data type.
-            IEnumerable<SamplesUtils.DatasetUtils.SampleInfertData> data = SamplesUtils.DatasetUtils.GetInfertData();
+            IEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleInfertData> data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var trainData = mlContext.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CustomMappingSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/CustomMappingSample.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-namespace Microsoft.ML.Samples.Dynamic
+using Microsoft.ML;
+
+namespace Samples.Dynamic
 {
     public static class CustomMapping
     {
@@ -10,7 +12,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            var data = SamplesUtils.DatasetUtils.GetInfertData();
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var trainData = mlContext.Data.LoadFromEnumerable(data);
 
             // Preview of the data.
@@ -22,7 +24,7 @@ namespace Microsoft.ML.Samples.Dynamic
             //  35       4       6-11yrs    ...
 
             // We define the custom mapping between input and output rows that will be applied by the transformation.
-            Action<SamplesUtils.DatasetUtils.SampleInfertData, OutputRow> mapping =
+            Action<Microsoft.ML.SamplesUtils.DatasetUtils.SampleInfertData, OutputRow> mapping =
                 (input, output) => output.IsUnderThirty = input.Age < 30;
 
             // Custom transformations can be used to transform data directly, or as part of a pipeline. Below we transform data directly.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/DropColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/DropColumns.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class DropColumns
     {
@@ -12,7 +13,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable and them read it as ML.NET's data type.
-            IEnumerable<SamplesUtils.DatasetUtils.SampleInfertData> data = SamplesUtils.DatasetUtils.GetInfertData();
+            IEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleInfertData> data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var trainData = mlContext.Data.LoadFromEnumerable(data);
 
             // Preview of the data.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/IndicateMissingValues.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/IndicateMissingValues.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class IndicateMissingValues
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhiten.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhiten.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public sealed class VectorWhiten
     {
@@ -16,7 +17,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext();
 
             // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            var data = SamplesUtils.DatasetUtils.GetVectorOfNumbersData();
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetVectorOfNumbersData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.
@@ -39,14 +40,14 @@ namespace Microsoft.ML.Samples.Dynamic
             };
 
             // A pipeline to project Features column into white noise vector.
-            var whiteningPipeline = ml.Transforms.VectorWhiten(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features),
-                kind: Transforms.WhiteningKind.ZeroPhaseComponentAnalysis);
+            var whiteningPipeline = ml.Transforms.VectorWhiten(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features),
+                kind: Microsoft.ML.Transforms.WhiteningKind.ZeroPhaseComponentAnalysis);
             // The transformed (projected) data.
             var transformedData = whiteningPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var whitening = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
+            var whitening = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
-            printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
+            printHelper(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
 
             // Features column obtained post-transformation.
             //

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhitenWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Projection/VectorWhitenWithOptions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public sealed class VectorWhitenWithOptions
     {
@@ -15,7 +16,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var ml = new MLContext();
 
             // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            var data = SamplesUtils.DatasetUtils.GetVectorOfNumbersData();
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetVectorOfNumbersData();
             var trainData = ml.Data.LoadFromEnumerable(data);
 
             // Preview of the data.
@@ -39,13 +40,13 @@ namespace Microsoft.ML.Samples.Dynamic
 
 
             // A pipeline to project Features column into white noise vector.
-            var whiteningPipeline = ml.Transforms.VectorWhiten(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), kind: Transforms.WhiteningKind.PrincipalComponentAnalysis, rank: 4);
+            var whiteningPipeline = ml.Transforms.VectorWhiten(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), kind: Microsoft.ML.Transforms.WhiteningKind.PrincipalComponentAnalysis, rank: 4);
             // The transformed (projected) data.
             var transformedData = whiteningPipeline.Fit(trainData).Transform(trainData);
             // Getting the data of the newly created column, so we can preview it.
-            var whitening = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
+            var whitening = transformedData.GetColumn<VBuffer<float>>(transformedData.Schema[nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features)]);
 
-            printHelper(nameof(SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
+            printHelper(nameof(Microsoft.ML.SamplesUtils.DatasetUtils.SampleVectorOfNumbersData.Features), whitening);
 
             // Features column obtained post-transformation.
             // -0.979  0.867  1.449  1.236

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ReplaceMissingValues.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ReplaceMissingValues.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     class ReplaceMissingValues
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/SelectColumns.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-namespace Microsoft.ML.Samples.Dynamic
+using Microsoft.ML;
+
+namespace Samples.Dynamic
 {
     public static class SelectColumns
     {
@@ -10,7 +12,7 @@ namespace Microsoft.ML.Samples.Dynamic
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable and them read it as ML.NET's data type.
-            var enumerableData = SamplesUtils.DatasetUtils.GetInfertData();
+            var enumerableData = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
             var data = mlContext.Data.LoadFromEnumerable(enumerableData);
 
             // Before transformation, take a look at the dataset

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class DetectChangePointBySsa
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs
@@ -1,29 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Samples.Dynamic
 {
     public static class DetectChangePointBySsa
     {
-        class ChangePointPrediction
-        {
-            [VectorType(4)]
-            public double[] Prediction { get; set; }
-        }
-
-        class SsaChangePointData
-        {
-            public float Value;
-
-            public SsaChangePointData(float value)
-            {
-                Value = value;
-            }
-        }
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // It demostrates stateful prediction engine that updates the state of the model and allows for saving/reloading.
         // The estimator is applied then to identify points where data distribution changed.
         // This estimator can account for temporal seasonality in the data.
         public static void Example()
@@ -32,60 +19,119 @@ namespace Samples.Dynamic
             // as well as the source of randomness.
             var ml = new MLContext();
 
-            // Generate sample series data with a recurring pattern and then a change in trend
+            // Generate sample series data with a recurring pattern
             const int SeasonalitySize = 5;
             const int TrainingSeasons = 3;
             const int TrainingSize = SeasonalitySize * TrainingSeasons;
-            var data = new List<SsaChangePointData>();
-            for (int i = 0; i < TrainingSeasons; i++)
-                for (int j = 0; j < SeasonalitySize; j++)
-                    data.Add(new SsaChangePointData(j));
-            // This is a change point
-            for (int i = 0; i < SeasonalitySize; i++)
-                data.Add(new SsaChangePointData(i * 100));
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+            };
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
-            // Setup estimator arguments
-            var inputColumnName = nameof(SsaChangePointData.Value);
+            // Setup SsaChangePointDetector arguments
+            var inputColumnName = nameof(TimeSeriesData.Value);
             var outputColumnName = nameof(ChangePointPrediction.Prediction);
 
-            // The transformed data.
-            var transformedData = ml.Transforms.DetectChangePointBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+            // Train the change point detector.
+            ITransformer model = ml.Transforms.DetectChangePointBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView);
 
-            // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
-            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+            // Create a prediction engine from the model for feeding new data.
+            var engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, ChangePointPrediction>(ml);
 
-            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            // Start streaming new data points with no change point to the prediction engine.
+            Console.WriteLine($"Output from ChangePoint predictions on new data:");
             Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
-            int k = 0;
-            foreach (var prediction in predictionColumn)
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
-            Console.WriteLine("");
-
-            // Prediction column obtained post-transformation.
+            
+            // Output from ChangePoint predictions on new data:
             // Data    Alert   Score   P-Value Martingale value
-            // 0       0     - 2.53    0.50    0.00
-            // 1       0     - 0.01    0.01    0.00
-            // 2       0       0.76    0.14    0.00
-            // 3       0       0.69    0.28    0.00
-            // 4       0       1.44    0.18    0.00
-            // 0       0     - 1.84    0.17    0.00
-            // 1       0       0.22    0.44    0.00
-            // 2       0       0.20    0.45    0.00
-            // 3       0       0.16    0.47    0.00
-            // 4       0       1.33    0.18    0.00
-            // 0       0     - 1.79    0.07    0.00
-            // 1       0       0.16    0.50    0.00
-            // 2       0       0.09    0.50    0.00
-            // 3       0       0.08    0.45    0.00
-            // 4       0       1.31    0.12    0.00
-            // 0       0     - 1.79    0.07    0.00
-            // 100     1      99.16    0.00    4031.94     <-- alert is on, predicted changepoint
-            // 200     0     185.23    0.00    731260.87
-            // 300     0     270.40    0.01    3578470.47
-            // 400     0     357.11    0.03    45298370.86
+
+            for (int i = 0; i < 5; i++)
+                PrintPrediction(i, engine.Predict(new TimeSeriesData(i)));
+
+            // 0       0      -1.01    0.50    0.00
+            // 1       0      -0.24    0.22    0.00
+            // 2       0      -0.31    0.30    0.00
+            // 3       0       0.44    0.01    0.00
+            // 4       0       2.16    0.00    0.24
+
+            // Now stream data points that reflect a change in trend.
+            for (int i = 0; i < 5; i++)
+            {
+                int value = (i + 1) * 100;
+                PrintPrediction(value, engine.Predict(new TimeSeriesData(value)));
+            }
+            // 100     0      86.23    0.00    2076098.24
+            // 200     0     171.38    0.00    809668524.21
+            // 300     1     256.83    0.01    22130423541.93    <-- alert is on, note that delay is expected
+            // 400     0     326.55    0.04    241162710263.29
+            // 500     0     364.82    0.08    597660527041.45   <-- saved to disk
+
+            // Now we demonstrate saving and loading the model.
+
+            // Save the model that exists within the prediction engine.
+            // The engine has been updating this model with every new data point.
+            var modelPath = "model.zip";
+            engine.CheckPoint(ml, modelPath);
+
+            // Load the model.
+            using (var file = File.OpenRead(modelPath))
+                model = ml.Model.Load(file, out DataViewSchema schema);
+
+            // We must create a new prediction engine from the persisted model.
+            engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, ChangePointPrediction>(ml);
+
+            // Run predictions on the loaded model.
+            for (int i = 0; i < 5; i++)
+            {
+                int value = (i + 1) * 100;
+                PrintPrediction(value, engine.Predict(new TimeSeriesData(value)));
+            }
+
+            // 100     0     -58.58    0.15    1096021098844.34  <-- loaded from disk and running new predictions
+            // 200     0     -41.24    0.20    97579154688.98
+            // 300     0     -30.61    0.24    95319753.87
+            // 400     0      58.87    0.38    14.24
+            // 500     0     219.28    0.36    0.05
+
+        }
+
+        private static void PrintPrediction(float value, ChangePointPrediction prediction) =>
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0],
+                prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+
+        class ChangePointPrediction
+        {
+            [VectorType(4)]
+            public double[] Prediction { get; set; }
+        }
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+
+namespace Samples.Dynamic
+{
+    public static class DetectChangePointBySsaBatchPrediction
+    {
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // The estimator is applied then to identify points where data distribution changed.
+        // This estimator can account for temporal seasonality in the data.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a recurring pattern and then a change in trend
+            const int SeasonalitySize = 5;
+            const int TrainingSeasons = 3;
+            const int TrainingSize = SeasonalitySize * TrainingSeasons;
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                //This is a change point
+                new TimeSeriesData(0),
+                new TimeSeriesData(100),
+                new TimeSeriesData(200),
+                new TimeSeriesData(300),
+                new TimeSeriesData(400),
+            };
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup estimator arguments
+            var inputColumnName = nameof(TimeSeriesData.Value);
+            var outputColumnName = nameof(ChangePointPrediction.Prediction);
+
+            // The transformed data.
+            var transformedData = ml.Transforms.DetectChangePointBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+
+            // Getting the data of the newly created column as an IEnumerable of ChangePointPrediction.
+            var predictionColumn = ml.Data.CreateEnumerable<ChangePointPrediction>(transformedData, reuseRowObject: false);
+
+            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            Console.WriteLine("Data\tAlert\tScore\tP-Value\tMartingale value");
+            int k = 0;
+            foreach (var prediction in predictionColumn)
+                PrintPrediction(data[k++].Value, prediction);
+
+            // Prediction column obtained post-transformation.
+            // Data    Alert   Score   P-Value Martingale value
+            // 0       0      -2.53    0.50    0.00
+            // 1       0      -0.01    0.01    0.00
+            // 2       0       0.76    0.14    0.00
+            // 3       0       0.69    0.28    0.00
+            // 4       0       1.44    0.18    0.00
+            // 0       0      -1.84    0.17    0.00
+            // 1       0       0.22    0.44    0.00
+            // 2       0       0.20    0.45    0.00
+            // 3       0       0.16    0.47    0.00
+            // 4       0       1.33    0.18    0.00
+            // 0       0      -1.79    0.07    0.00
+            // 1       0       0.16    0.50    0.00
+            // 2       0       0.09    0.50    0.00
+            // 3       0       0.08    0.45    0.00
+            // 4       0       1.31    0.12    0.00
+            // 0       0      -1.79    0.07    0.00
+            // 100     1      99.16    0.00    4031.94     <-- alert is on, predicted changepoint
+            // 200     0     185.23    0.00    731260.87
+            // 300     0     270.40    0.01    3578470.47
+            // 400     0     357.11    0.03    45298370.86
+        }
+
+        private static void PrintPrediction(float value, ChangePointPrediction prediction) => 
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}\t{4:0.00}", value, prediction.Prediction[0], 
+                prediction.Prediction[1], prediction.Prediction[2], prediction.Prediction[3]);
+
+        class ChangePointPrediction
+        {
+            [VectorType(4)]
+            public double[] Prediction { get; set; }
+        }
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs
@@ -4,9 +4,10 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class DetectIidChangePoint
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Transforms.TimeSeries;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class DetectIidSpike
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.ML;
 using Microsoft.ML.Data;
-using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Samples.Dynamic
 {
-    public static class DetectIidSpike
+    public static class DetectIidSpikeBatchPrediction
     {
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
@@ -40,60 +38,36 @@ namespace Samples.Dynamic
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
-            // Setup IidSpikeDetector arguments
+            // Setup the estimator arguments
             string outputColumnName = nameof(IidSpikePrediction.Prediction);
             string inputColumnName = nameof(TimeSeriesData.Value);
 
-            // The transformed model.
-            ITransformer model = ml.Transforms.DetectIidSpike(outputColumnName, inputColumnName, 95, Size).Fit(dataView);
+            // The transformed data.
+            var transformedData = ml.Transforms.DetectIidSpike(outputColumnName, inputColumnName, 95, Size / 4).Fit(dataView).Transform(dataView);
 
-            // Create a time series prediction engine from the model.
-            var engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, IidSpikePrediction>(ml);
+            // Getting the data of the newly created column as an IEnumerable of IidSpikePrediction.
+            var predictionColumn = ml.Data.CreateEnumerable<IidSpikePrediction>(transformedData, reuseRowObject: false);
 
             Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
             Console.WriteLine("Data\tAlert\tScore\tP-Value");
-            
+
+            int k = 0;
+            foreach (var prediction in predictionColumn)
+                PrintPrediction(data[k++].Value, prediction);
+
             // Prediction column obtained post-transformation.
-            // Data Alert   Score   P-Value
-
-            // Create non-anomalous data and check for anomaly.
-            for (int index = 0; index < 5; index++)
-            {
-                // Anomaly spike detection.
-                PrintPrediction(5, engine.Predict(new TimeSeriesData(5)));
-            }
-
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-
-            // Spike.
-            PrintPrediction(10, engine.Predict(new TimeSeriesData(10)));
-            
-            // 10     1      10.00    0.00  <-- alert is on, predicted spike (check-point model)
-
-            // Checkpoint the model.
-            var modelPath = "temp.zip";
-            engine.CheckPoint(ml, modelPath);
-
-            // Load the model.
-            using (var file = File.OpenRead(modelPath))
-                model = ml.Model.Load(file, out DataViewSchema schema);
-
-            for (int index = 0; index < 5; index++)
-            {
-                // Anomaly spike detection.
-                PrintPrediction(5, engine.Predict(new TimeSeriesData(5)));
-            }
-
-            // 5      0       5.00    0.26  <-- load model from disk.
-            // 5      0       5.00    0.26
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-            // 5      0       5.00    0.50
-
+            // Data    Alert   Score P-Value
+            // 5       0       5.00    0.50
+            // 5       0       5.00    0.50
+            // 5       0       5.00    0.50
+            // 5       0       5.00    0.50
+            // 5       0       5.00    0.50
+            // 10      1       10.00   0.00   <-- alert is on, predicted spike
+            // 5       0       5.00    0.26
+            // 5       0       5.00    0.26
+            // 5       0       5.00    0.50
+            // 5       0       5.00    0.50
+            // 5       0       5.00    0.50
         }
 
         private static void PrintPrediction(float value, IidSpikePrediction prediction) => 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Dynamic
 {
     public static class DetectSpikeBySsa
     {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
@@ -1,28 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+using Microsoft.ML.Transforms.TimeSeries;
 
 namespace Samples.Dynamic
 {
     public static class DetectSpikeBySsa
     {
-        class SsaSpikeData
-        {
-            public float Value;
-
-            public SsaSpikeData(float value)
-            {
-                Value = value;
-            }
-        }
-
-        class SsaSpikePrediction
-        {
-            [VectorType(3)]
-            public double[] Prediction { get; set; }
-        }
-
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
         // This estimator can account for temporal seasonality in the data.
@@ -32,62 +18,113 @@ namespace Samples.Dynamic
             // as well as the source of randomness.
             var ml = new MLContext();
 
-            // Generate sample series data with a recurring pattern and a spike within the pattern
+            // Generate sample series data with a recurring pattern
             const int SeasonalitySize = 5;
             const int TrainingSeasons = 3;
             const int TrainingSize = SeasonalitySize * TrainingSeasons;
-            var data = new List<SsaSpikeData>();
-            for (int i = 0; i < TrainingSeasons; i++)
-                for (int j = 0; j < SeasonalitySize; j++)
-                    data.Add(new SsaSpikeData(j));
-            // This is a spike
-            data.Add(new SsaSpikeData(100));
-            for (int i = 0; i < SeasonalitySize; i++)
-                data.Add(new SsaSpikeData(i));
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+            };
 
             // Convert data to IDataView.
             var dataView = ml.Data.LoadFromEnumerable(data);
 
-            // Setup estimator arguments
-            var inputColumnName = nameof(SsaSpikeData.Value);
+            // Setup IidSpikeDetector arguments
+            var inputColumnName = nameof(TimeSeriesData.Value);
             var outputColumnName = nameof(SsaSpikePrediction.Prediction);
 
-            // The transformed data.
-            var transformedData = ml.Transforms.DetectSpikeBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+            // Train the change point detector.
+            ITransformer model = ml.Transforms.DetectSpikeBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView);
 
-            // Getting the data of the newly created column as an IEnumerable of SsaSpikePrediction.
-            var predictionColumn = ml.Data.CreateEnumerable<SsaSpikePrediction>(transformedData, reuseRowObject: false);
+            // Create a prediction engine from the model for feeding new data.
+            var engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, SsaSpikePrediction>(ml);
 
-            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            // Start streaming new data points with no change point to the prediction engine.
+            Console.WriteLine($"Output from spike predictions on new data:");
             Console.WriteLine("Data\tAlert\tScore\tP-Value");
-            int k = 0;
-            foreach (var prediction in predictionColumn)
-                Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", data[k++].Value, prediction.Prediction[0], prediction.Prediction[1], prediction.Prediction[2]);
-            Console.WriteLine("");
 
-            // Prediction column obtained post-transformation.
+            // Output from spike predictions on new data:
             // Data    Alert   Score   P-Value
-            // 0       0     - 2.53    0.50
-            // 1       0     - 0.01    0.01
-            // 2       0       0.76    0.14
-            // 3       0       0.69    0.28
-            // 4       0       1.44    0.18
-            // 0       0     - 1.84    0.17
-            // 1       0       0.22    0.44
-            // 2       0       0.20    0.45
-            // 3       0       0.16    0.47
-            // 4       0       1.33    0.18
-            // 0       0     - 1.79    0.07
-            // 1       0       0.16    0.50
-            // 2       0       0.09    0.50
-            // 3       0       0.08    0.45
-            // 4       0       1.31    0.12
-            // 100     1      98.21    0.00   <-- alert is on, predicted spike
-            // 0       0    - 13.83    0.29
-            // 1       0     - 1.74    0.44
-            // 2       0     - 0.47    0.46
-            // 3       0    - 16.50    0.29
-            // 4       0    - 29.82    0.21
+
+            for (int j = 0; j < 2; j++)
+                for (int i = 0; i < 5; i++)
+                    PrintPrediction(i, engine.Predict(new TimeSeriesData(i)));
+
+            // 0       0      -1.01    0.50
+            // 1       0      -0.24    0.22
+            // 2       0      -0.31    0.30
+            // 3       0       0.44    0.01
+            // 4       0       2.16    0.00
+            // 0       0      -0.78    0.27
+            // 1       0      -0.80    0.30
+            // 2       0      -0.84    0.31
+            // 3       0       0.33    0.31
+            // 4       0       2.21    0.07
+
+            // Now send a data point that reflects a spike.
+            PrintPrediction(100, engine.Predict(new TimeSeriesData(100)));
+
+            // 100     1      86.17    0.00   <-- alert is on, predicted spike
+
+            // Now we demonstrate saving and loading the model.
+            // Save the model that exists within the prediction engine.
+            // The engine has been updating this model with every new data point.
+            var modelPath = "model.zip";
+            engine.CheckPoint(ml, modelPath);
+
+            // Load the model.
+            using (var file = File.OpenRead(modelPath))
+                model = ml.Model.Load(file, out DataViewSchema schema);
+
+            // We must create a new prediction engine from the persisted model.
+            engine = model.CreateTimeSeriesPredictionFunction<TimeSeriesData, SsaSpikePrediction>(ml);
+
+            // Run predictions on the loaded model.
+            for (int i = 0; i < 5; i++)
+                PrintPrediction(i, engine.Predict(new TimeSeriesData(i)));
+            
+            // 0       0      -2.74    0.40   <-- saved to disk, re-loaded, and running new predictions
+            // 1       0      -1.47    0.42
+            // 2       0     -17.50    0.24
+            // 3       0     -30.82    0.16
+            // 4       0     -23.24    0.28
+        }
+
+        private static void PrintPrediction(float value, SsaSpikePrediction prediction) => 
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], 
+                prediction.Prediction[1], prediction.Prediction[2]);
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        class SsaSpikePrediction
+        {
+            [VectorType(3)]
+            public double[] Prediction { get; set; }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Samples.Dynamic
         // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
         // The estimator is applied then to identify spiking points in the series.
         // This estimator can account for temporal seasonality in the data.
-        public static void SsaSpikeDetectorTransform()
+        public static void Example()
         {
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsaBatchPrediction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsaBatchPrediction.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+
+namespace Samples.Dynamic
+{
+    public static class DetectSpikeBySsaBatchPrediction
+    {
+        // This example creates a time series (list of Data with the i-th element corresponding to the i-th time slot). 
+        // The estimator is applied then to identify spiking points in the series.
+        // This estimator can account for temporal seasonality in the data.
+        public static void Example()
+        {
+            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
+            // as well as the source of randomness.
+            var ml = new MLContext();
+
+            // Generate sample series data with a recurring pattern and a spike within the pattern
+            const int SeasonalitySize = 5;
+            const int TrainingSeasons = 3;
+            const int TrainingSize = SeasonalitySize * TrainingSeasons;
+            var data = new List<TimeSeriesData>()
+            {
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+
+                //This is a spike.
+                new TimeSeriesData(100),
+
+                new TimeSeriesData(0),
+                new TimeSeriesData(1),
+                new TimeSeriesData(2),
+                new TimeSeriesData(3),
+                new TimeSeriesData(4),
+            };
+
+            // Convert data to IDataView.
+            var dataView = ml.Data.LoadFromEnumerable(data);
+
+            // Setup estimator arguments
+            var inputColumnName = nameof(TimeSeriesData.Value);
+            var outputColumnName = nameof(SsaSpikePrediction.Prediction);
+
+            // The transformed data.
+            var transformedData = ml.Transforms.DetectSpikeBySsa(outputColumnName, inputColumnName, 95, 8, TrainingSize, SeasonalitySize + 1).Fit(dataView).Transform(dataView);
+
+            // Getting the data of the newly created column as an IEnumerable of SsaSpikePrediction.
+            var predictionColumn = ml.Data.CreateEnumerable<SsaSpikePrediction>(transformedData, reuseRowObject: false);
+
+            Console.WriteLine($"{outputColumnName} column obtained post-transformation.");
+            Console.WriteLine("Data\tAlert\tScore\tP-Value");
+            int k = 0;
+            foreach (var prediction in predictionColumn)
+                PrintPrediction(data[k++].Value, prediction);
+
+            // Prediction column obtained post-transformation.
+            // Data    Alert   Score   P-Value
+            // 0       0      -2.53    0.50
+            // 1       0      -0.01    0.01
+            // 2       0       0.76    0.14
+            // 3       0       0.69    0.28
+            // 4       0       1.44    0.18
+            // 0       0      -1.84    0.17
+            // 1       0       0.22    0.44
+            // 2       0       0.20    0.45
+            // 3       0       0.16    0.47
+            // 4       0       1.33    0.18
+            // 0       0      -1.79    0.07
+            // 1       0       0.16    0.50
+            // 2       0       0.09    0.50
+            // 3       0       0.08    0.45
+            // 4       0       1.31    0.12
+            // 100     1      98.21    0.00   <-- alert is on, predicted spike
+            // 0       0     -13.83    0.29
+            // 1       0      -1.74    0.44
+            // 2       0      -0.47    0.46
+            // 3       0     -16.50    0.29
+            // 4       0     -29.82    0.21
+        }
+
+        private static void PrintPrediction(float value, SsaSpikePrediction prediction) => 
+            Console.WriteLine("{0}\t{1}\t{2:0.00}\t{3:0.00}", value, prediction.Prediction[0], 
+                prediction.Prediction[1], prediction.Prediction[2]);
+
+        class TimeSeriesData
+        {
+            public float Value;
+
+            public TimeSeriesData(float value)
+            {
+                Value = value;
+            }
+        }
+
+        class SsaSpikePrediction
+        {
+            [VectorType(3)]
+            public double[] Prediction { get; set; }
+        }
+    }
+}

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -141,4 +141,18 @@
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
   </ItemGroup>
   
+    <ItemGroup>
+    <Content Include="$(ObjDir)DnnImageModels\ResNet18Onnx\ResNet18.onnx">
+      <Link>DnnImageModels\ResNet18Onnx\ResNet18.onnx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+    <ItemGroup>
+    <Content Include="$(ObjDir)DnnImageModels\ResNetPrepOnnx\ResNetPreprocess.onnx">
+      <Link>DnnImageModels\ResNetPrepOnnx\ResNetPreprocess.onnx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
 </Project>

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -137,4 +137,8 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
+  </ItemGroup>
+  
 </Project>

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.ML.Samples.Dynamic;
+using Samples.Dynamic;
 
 namespace Microsoft.ML.Samples
 {

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.ML.Samples.Dynamic;
-using Samples.Dynamic;
+﻿using Samples.Dynamic;
 
 namespace Microsoft.ML.Samples
 {

--- a/docs/samples/Microsoft.ML.Samples/Static/AveragedPerceptronBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/AveragedPerceptronBinaryClassification.cs
@@ -5,7 +5,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class AveragedPerceptronBinaryClassificationExample
     {
-        public static void AveragedPerceptronBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/AveragedPerceptronBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/AveragedPerceptronBinaryClassification.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.StaticPipe;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     public class AveragedPerceptronBinaryClassificationExample
     {
@@ -9,7 +10,7 @@ namespace Microsoft.ML.Samples.Static
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable
-            string dataFilePath = SamplesUtils.DatasetUtils.DownloadAdultDataset();
+            string dataFilePath = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadAdultDataset();
 
             // Data Preview
             // 1. Column [Label]: IsOver50K (boolean)

--- a/docs/samples/Microsoft.ML.Samples/Static/FastTreeBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FastTreeBinaryClassification.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Microsoft.ML;
 using Microsoft.ML.StaticPipe;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     public class FastTreeBinaryClassificationExample
     {
@@ -10,7 +11,7 @@ namespace Microsoft.ML.Samples.Static
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable
-            string dataFilePath = SamplesUtils.DatasetUtils.DownloadAdultDataset();
+            string dataFilePath = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadAdultDataset();
 
             // Data Preview
             // 1. Column [Label]: IsOver50K (boolean)

--- a/docs/samples/Microsoft.ML.Samples/Static/FastTreeBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FastTreeBinaryClassification.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Static
     public class FastTreeBinaryClassificationExample
     {
         // This example requires installation of additional nuget package <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
-        public static void FastTreeBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.ML;
 using Microsoft.ML.StaticPipe;
 using Microsoft.ML.Trainers.FastTree;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     public class FastTreeRegressionExample
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Static
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem this code will run
             // you can open the file to see the data. 
-            string dataFile = SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
+            string dataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
 
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FastTreeRegression.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ML.Samples.Static
     public class FastTreeRegressionExample
     {
         // This example requires installation of additional nuget package <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
-        public static void FastTreeRegression()
+        public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem this code will run

--- a/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.StaticPipe;
 
-namespace Microsoft.ML.Samples.Dynamic
+namespace Samples.Static
 {
     public class FeatureSelectionTransformStaticExample
     {
@@ -11,7 +12,7 @@ namespace Microsoft.ML.Samples.Dynamic
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable
-            string dataFilePath = SamplesUtils.DatasetUtils.DownloadBreastCancerDataset();
+            string dataFilePath = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadBreastCancerDataset();
 
             // Data Preview
             //    1. Label							0=benign, 1=malignant

--- a/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/FeatureSelectionTransform.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ML.Samples.Dynamic
 {
     public class FeatureSelectionTransformStaticExample
     {
-        public static void FeatureSelectionTransform()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMBinaryClassification.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class LightGbmBinaryClassificationExample
     {
-        public static void LightGbmBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMBinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMBinaryClassification.cs
@@ -1,8 +1,9 @@
 using System;
 using Microsoft.ML.Trainers.LightGbm.StaticPipe;
 using Microsoft.ML.StaticPipe;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     public class LightGbmBinaryClassificationExample
     {
@@ -10,7 +11,7 @@ namespace Microsoft.ML.Samples.Static
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable
-            string dataFilePath = SamplesUtils.DatasetUtils.DownloadAdultDataset();
+            string dataFilePath = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadAdultDataset();
 
             // Data Preview
             // 1. Column [Label]: IsOver50K (boolean)

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Samples.Static
 {
     class LightGBMMulticlassWithInMemoryData
     {
-        public void MulticlassLightGbmStaticPipelineWithInMemoryData()
+        public void Example()
         {
             // Create a general context for ML.NET operations. It can be used for exception tracking and logging,
             // as a catalog of available operations and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMMulticlassWithInMemoryData.cs
@@ -4,8 +4,9 @@ using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.LightGbm.StaticPipe;
 using Microsoft.ML.SamplesUtils;
 using Microsoft.ML.StaticPipe;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     class LightGBMMulticlassWithInMemoryData
     {

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
@@ -3,8 +3,9 @@ using Microsoft.ML.Data;
 using Microsoft.ML.Trainers.LightGbm;
 using Microsoft.ML.Trainers.LightGbm.StaticPipe;
 using Microsoft.ML.StaticPipe;
+using Microsoft.ML;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     public class LightGbmRegressionExample
     {
@@ -13,7 +14,7 @@ namespace Microsoft.ML.Samples.Static
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem.
             // You can open the file to see the data. 
-            string dataFile = SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
+            string dataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
 
             // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
             // as well as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/LightGBMRegression.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class LightGbmRegressionExample
     {
-        public static void LightGbmRegression()
+        public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem.

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCABinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCABinaryClassification.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.StaticPipe;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     public class SdcaBinaryClassificationExample
     {
@@ -11,7 +12,7 @@ namespace Microsoft.ML.Samples.Static
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable
-            string dataFilePath = SamplesUtils.DatasetUtils.DownloadAdultDataset();
+            string dataFilePath = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadAdultDataset();
 
             // Data Preview
             // 1. Column [Label]: IsOver50K (boolean)

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCABinaryClassification.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCABinaryClassification.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class SdcaBinaryClassificationExample
     {
-        public static void SdcaBinaryClassification()
+        public static void Example()
         {
             // Downloading a classification dataset from github.com/dotnet/machinelearning.
             // It will be stored in the same path as the executable

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
@@ -6,7 +6,7 @@ namespace Microsoft.ML.Samples.Static
 {
     public class SdcaRegressionExample
     {
-        public static void SdcaRegression()
+        public static void Example()
         {
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem this code will run

--- a/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Static/SDCARegression.cs
@@ -1,8 +1,9 @@
 using System;
+using Microsoft.ML;
 using Microsoft.ML.StaticPipe;
 using Microsoft.ML.Trainers;
 
-namespace Microsoft.ML.Samples.Static
+namespace Samples.Static
 {
     public class SdcaRegressionExample
     {
@@ -11,7 +12,7 @@ namespace Microsoft.ML.Samples.Static
             // Downloading a regression dataset from github.com/dotnet/machinelearning
             // this will create a housing.txt file in the filsystem this code will run
             // you can open the file to see the data. 
-            string dataFile = SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
+            string dataFile = Microsoft.ML.SamplesUtils.DatasetUtils.DownloadHousingRegressionDataset();
 
             // Creating the ML.Net IHostEnvironment object, needed for the pipeline
             var mlContext = new MLContext();

--- a/src/Microsoft.ML.SamplesUtils/Microsoft.ML.SamplesUtils.csproj
+++ b/src/Microsoft.ML.SamplesUtils/Microsoft.ML.SamplesUtils.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SharpZipLib.NETStandard" Version="1.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Transforms\Microsoft.ML.Transforms.csproj" />

--- a/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
@@ -230,7 +230,7 @@ namespace Microsoft.ML.Trainers
             data.CheckBinaryLabel();
             _host.CheckParam(data.Schema.Label.HasValue, nameof(data), "Missing Label column");
             var labelCol = data.Schema.Label.Value;
-            _host.CheckParam(labelCol.Type == NumberDataViewType.Single, nameof(data), "Invalid type for Label column");
+            _host.CheckParam(labelCol.Type == BooleanDataViewType.Instance, nameof(data), "Invalid type for Label column");
 
             double pos = 0;
             double neg = 0;
@@ -243,9 +243,9 @@ namespace Microsoft.ML.Trainers
 
             using (var cursor = data.Data.GetRowCursor(cols))
             {
-                var getLab = cursor.GetLabelFloatGetter(data);
+                var getLab = cursor.GetGetter<bool>(data.Schema.Label.Value);
                 var getWeight = colWeight >= 0 ? cursor.GetGetter<float>(data.Schema.Weight.Value) : null;
-                float lab = default;
+                bool lab = default;
                 float weight = 1;
                 while (cursor.MoveNext())
                 {
@@ -258,9 +258,9 @@ namespace Microsoft.ML.Trainers
                     }
 
                     // Testing both directions effectively ignores NaNs.
-                    if (lab > 0)
+                    if (lab)
                         pos += weight;
-                    else if (lab <= 0)
+                    else
                         neg += weight;
                 }
             }

--- a/src/Microsoft.ML.TimeSeries.StaticPipe/TimeSeriesStatic.cs
+++ b/src/Microsoft.ML.TimeSeries.StaticPipe/TimeSeriesStatic.cs
@@ -230,7 +230,7 @@ namespace Microsoft.ML.StaticPipe
     /// <summary>
     /// Static API extension methods for <see cref="SsaSpikeEstimator"/>.
     /// </summary>
-    public static class SsaSpikeDetecotStaticExtensions
+    public static class SsaSpikeDetectorStaticExtensions
     {
         private sealed class OutColumn : Vector<double>
         {

--- a/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.TimeSeries/ExtensionsCatalog.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectIidChangePoint](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePoint.cs)]
+        /// [!code-csharp[DetectIidChangePoint](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidChangePointBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -47,7 +47,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectIidSpike](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpike.cs)]
+        /// [!code-csharp[DetectIidSpike](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectIidSpikeBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -73,7 +73,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectChangePointBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
+        /// [!code-csharp[DetectChangePointBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsaBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>
@@ -110,7 +110,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[DetectSpikeBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsa.cs)]
+        /// [!code-csharp[DetectSpikeBySsa](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectSpikeBySsaBatchPrediction.cs)]
         /// ]]>
         /// </format>
         /// </example>

--- a/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
+++ b/src/Microsoft.ML.TimeSeries/PredictionFunction.cs
@@ -65,6 +65,14 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// </summary>
         /// <param name="env">Usually <see cref="MLContext"/>.</param>
         /// <param name="modelPath">Path to file on disk where the updated model needs to be saved.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// This is an example for checkpointing time series that detects change point using Singular Spectrum Analysis (SSA) model.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
         public void CheckPoint(IHostEnvironment env, string modelPath)
         {
             using (var file = File.Create(modelPath))
@@ -261,8 +269,8 @@ namespace Microsoft.ML.Transforms.TimeSeries
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/IidSpikeDetectorTransform.cs)]
-        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/IidChangePointDetectorTransform.cs)]
+        /// This is an example for detecting change point using Singular Spectrum Analysis (SSA) model.
+        /// [!code-csharp[MF](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/TimeSeries/DetectChangePointBySsa.cs)]
         /// ]]>
         /// </format>
         /// </example>

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -1,4 +1,9 @@
-﻿using Microsoft.ML.Data;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.ML.Data;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
@@ -57,6 +62,20 @@ namespace Microsoft.ML
         }
 
         /// <summary>
+        /// It normalizes the data based on the observed minimum and maximum values of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">List of Output and Input column pairs.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
+        public static NormalizingEstimator NormalizeMinMax(this TransformsCatalog catalog, InputOutputColumnPair[] columns,
+           long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+           bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched) =>
+            new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog),
+                columns.Select(column =>
+                    new NormalizingEstimator.MinMaxColumnOptions(column.OutputColumnName, column.InputColumnName, maximumExampleCount, fixZero)).ToArray());
+
+        /// <summary>
         /// It normalizes the data based on the computed mean and variance of the data.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
@@ -76,6 +95,22 @@ namespace Microsoft.ML
         }
 
         /// <summary>
+        /// It normalizes the data based on the computed mean and variance of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">List of Output and Input column pairs.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="useCdf">Whether to use CDF as the output.</param>
+        public static NormalizingEstimator NormalizeMeanVariance(this TransformsCatalog catalog, InputOutputColumnPair[] columns,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            bool useCdf = NormalizingEstimator.Defaults.MeanVarCdf) =>
+                new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog),
+                    columns.Select(column =>
+                        new NormalizingEstimator.MeanVarianceColumnOptions(column.OutputColumnName, column.InputColumnName, maximumExampleCount, fixZero, useCdf)).ToArray());
+
+        /// <summary>
         /// It normalizes the data based on the computed mean and variance of the logarithm of the data.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
@@ -91,6 +126,27 @@ namespace Microsoft.ML
             var columnOptions = new NormalizingEstimator.LogMeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, useCdf);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
+
+        /// <summary>
+        /// It normalizes the data based on the computed mean and variance of the logarithm of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">List of Output and Input column pairs.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="useCdf">Whether to use CDF as the output.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[Normalize](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Normalizer.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog, InputOutputColumnPair[] columns,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool useCdf = NormalizingEstimator.Defaults.LogMeanVarCdf) =>
+            new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog),
+                columns.Select(column =>
+                    new NormalizingEstimator.LogMeanVarianceColumnOptions(column.OutputColumnName, column.InputColumnName, maximumExampleCount, useCdf)).ToArray());
 
         /// <summary>
         /// The values are assigned into bins with equal density.
@@ -110,6 +166,22 @@ namespace Microsoft.ML
             var columnOptions = new NormalizingEstimator.BinningColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, fixZero, maximumBinCount);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
+
+        /// <summary>
+        /// The values are assigned into bins with equal density.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">List of Output and Input column pairs.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
+        public static NormalizingEstimator NormalizeBinning(this TransformsCatalog catalog, InputOutputColumnPair[] columns,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount) =>
+            new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog),
+                columns.Select(column =>
+                    new NormalizingEstimator.BinningColumnOptions(column.OutputColumnName, column.InputColumnName, maximumExampleCount, fixZero, maximumBinCount)).ToArray());
 
         /// <summary>
         /// The values are assigned into bins based on correlation with the <paramref name="labelColumnName"/> column.
@@ -133,6 +205,27 @@ namespace Microsoft.ML
             var columnOptions = new NormalizingEstimator.SupervisedBinningColumOptions(outputColumnName, inputColumnName, labelColumnName, maximumExampleCount, fixZero, maximumBinCount, mininimumExamplesPerBin);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
+
+        /// <summary>
+        /// The values are assigned into bins based on correlation with the <paramref name="labelColumnName"/> column.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">List of Output and Input column pairs.</param>
+        /// <param name="labelColumnName">Name of the label column for supervised binning.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
+        /// <param name="maximumBinCount">Maximum number of bins (power of 2 recommended).</param>
+        /// <param name="mininimumExamplesPerBin">Minimum number of examples per bin.</param>
+        public static NormalizingEstimator NormalizeSupervisedBinning(this TransformsCatalog catalog, InputOutputColumnPair[] columns,
+            string labelColumnName = DefaultColumnNames.Label,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool fixZero = NormalizingEstimator.Defaults.EnsureZeroUntouched,
+            int maximumBinCount = NormalizingEstimator.Defaults.MaximumBinCount,
+            int mininimumExamplesPerBin = NormalizingEstimator.Defaults.MininimumBinSize) =>
+                new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog),
+                    columns.Select(column =>
+                        new NormalizingEstimator.SupervisedBinningColumOptions(
+                            column.OutputColumnName, column.InputColumnName, labelColumnName, maximumExampleCount, fixZero, maximumBinCount, mininimumExamplesPerBin)).ToArray());
 
         /// <summary>
         /// Normalize (rescale) columns according to specified custom parameters.

--- a/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-CV-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-CV-breast-cancer-out.txt
@@ -1,4 +1,4 @@
-maml.exe CV tr=PriorPredictor threads=- dout=%Output% data=%Data% seed=1
+maml.exe CV tr=PriorPredictor threads=- dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% seed=1
 Not adding a normalizer.
 Not training a calibrator because it is not needed.
 Not adding a normalizer.

--- a/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-CV-breast-cancer-rp.txt
+++ b/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-CV-breast-cancer-rp.txt
@@ -1,4 +1,4 @@
 PriorPredictor
 AUC	Accuracy	Positive precision	Positive recall	Negative precision	Negative recall	Log-loss	Log-loss reduction	F1 Score	AUPRC	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-0.5	0.656163	0	0	0.656163	1	0.935104	-0.00959	NaN	0.418968	PriorPredictor	%Data%		%Output%	99	0	0	maml.exe CV tr=PriorPredictor threads=- dout=%Output% data=%Data% seed=1		
+0.5	0.656163	0	0	0.656163	1	0.935104	-0.00959	NaN	0.418968	PriorPredictor	%Data%		%Output%	99	0	0	maml.exe CV tr=PriorPredictor threads=- dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% seed=1		
 

--- a/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-out.txt
@@ -1,4 +1,4 @@
-maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% data=%Data% out=%Output% seed=1
+maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% out=%Output% seed=1
 Not adding a normalizer.
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))

--- a/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-rp.txt
+++ b/test/BaselineOutput/SingleDebug/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-rp.txt
@@ -1,4 +1,4 @@
 PriorPredictor
 AUC	Accuracy	Positive precision	Positive recall	Negative precision	Negative recall	Log-loss	Log-loss reduction	F1 Score	AUPRC	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-0.5	0.655222	0	0	0.655222	1	0.929318	0	NaN	0.415719	PriorPredictor	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% data=%Data% out=%Output% seed=1		
+0.5	0.655222	0	0	0.655222	1	0.929318	0	NaN	0.415719	PriorPredictor	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% out=%Output% seed=1		
 

--- a/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-CV-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-CV-breast-cancer-out.txt
@@ -1,4 +1,4 @@
-maml.exe CV tr=PriorPredictor threads=- dout=%Output% data=%Data% seed=1
+maml.exe CV tr=PriorPredictor threads=- dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% seed=1
 Not adding a normalizer.
 Not training a calibrator because it is not needed.
 Not adding a normalizer.

--- a/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-CV-breast-cancer-rp.txt
+++ b/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-CV-breast-cancer-rp.txt
@@ -1,4 +1,4 @@
 PriorPredictor
 AUC	Accuracy	Positive precision	Positive recall	Negative precision	Negative recall	Log-loss	Log-loss reduction	F1 Score	AUPRC	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-0.5	0.656163	0	0	0.656163	1	0.935104	-0.00959	NaN	0.418968	PriorPredictor	%Data%		%Output%	99	0	0	maml.exe CV tr=PriorPredictor threads=- dout=%Output% data=%Data% seed=1		
+0.5	0.656163	0	0	0.656163	1	0.935104	-0.00959	NaN	0.418968	PriorPredictor	%Data%		%Output%	99	0	0	maml.exe CV tr=PriorPredictor threads=- dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% seed=1		
 

--- a/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-out.txt
+++ b/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-out.txt
@@ -1,4 +1,4 @@
-maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% data=%Data% out=%Output% seed=1
+maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% out=%Output% seed=1
 Not adding a normalizer.
 Not training a calibrator because it is not needed.
 TEST POSITIVE RATIO:	0.3448 (241.0/(241.0+458.0))

--- a/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-rp.txt
+++ b/test/BaselineOutput/SingleRelease/PriorPredictor/BinaryPrior-TrainTest-breast-cancer-rp.txt
@@ -1,4 +1,4 @@
 PriorPredictor
 AUC	Accuracy	Positive precision	Positive recall	Negative precision	Negative recall	Log-loss	Log-loss reduction	F1 Score	AUPRC	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-0.5	0.655222	0	0	0.655222	1	0.929318	0	NaN	0.415719	PriorPredictor	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% data=%Data% out=%Output% seed=1		
+0.5	0.655222	0	0	0.655222	1	0.929318	0	NaN	0.415719	PriorPredictor	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=PriorPredictor dout=%Output% loader=Text{col=Label:BL:0 col=Features:~} data=%Data% out=%Output% seed=1		
 

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -120,8 +120,7 @@ namespace Microsoft.ML.RunTests
         {
             var predictors = new[] {
                 TestLearners.binaryPrior};
-            var datasets = GetDatasetsForBinaryClassifierBaseTest();
-            RunAllTests(predictors, datasets);
+            RunAllTests(predictors, new[] { TestDatasets.breastCancerBoolLabel });
             Done();
         }
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/PriorRandomTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/PriorRandomTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                         HasHeader = true,
                         Columns = new[]
                         {
-                            new TextLoader.Column("Label", DataKind.Single, 0),
+                            new TextLoader.Column("Label", DataKind.Boolean, 0),
                             new TextLoader.Column("F1", DataKind.String, 1),
                             new TextLoader.Column("F2", DataKind.Int32, 2),
                             new TextLoader.Column("Rest", DataKind.Single, new [] { new TextLoader.Range(3, 9) })


### PR DESCRIPTION
Cherry pick for the below PRs from master branch, most of these PRs are related to samples and none related to API except for #3172 multi-column mapping API for normalizer estimator and #3291 that makes Prior trainer accept only Boolean type label column to make it consistent with every other binary trainer. I also did speak with @shauheen prior to cherry-picking and he agreed ideally these sample fixes should be in the release.

#3172 
#3215 
#3212 
#3230 
#3237 
#3257 
#3259 
#3249 
#3267 
#3278 
#3213 
#3285 
#3287 
#3291 
#3295 



