### PR TITLE
API reference - Updated trainer docs for AveragedPerceptron

### DIFF
--- a/docs/api-reference/io-columns-binary-classification.md
+++ b/docs/api-reference/io-columns-binary-classification.md
@@ -1,5 +1,5 @@
-### Input/Output Columns
-The label column data must be [System.Boolean](xref:System.Boolean). This trainer outputs the following columns:
+### Input and Output Columns
+The label column data must be <xref:System.Single>. This trainer outputs the following columns:
 
 | Column Name | Column Type | Description|
 | -- | -- | -- |

--- a/docs/api-reference/io-columns-binary-classification.md
+++ b/docs/api-reference/io-columns-binary-classification.md
@@ -1,0 +1,8 @@
+### Input/Output Columns
+The label column data must be [System.Boolean](xref:System.Boolean). This trainer outputs the following columns:
+
+| Column Name | Column Type | Description|
+| -- | -- | -- |
+| `Score` | <xref:System.Single> | The unbounded score that was calculated by the trainer to determine the prediction.|
+| `PredictedLabel` | <xref:System.Boolean> | The label predicted by the trainer. `false` maps to negative score and   `true` maps to positive score.|
+| `Probability` | <xref:System.Single> | The probability of the score in range [0, 1].|

--- a/docs/api-reference/io-columns-binary-classification.md
+++ b/docs/api-reference/io-columns-binary-classification.md
@@ -1,7 +1,7 @@
 ### Input and Output Columns
-The label column data must be <xref:System.Single>. This trainer outputs the following columns:
+The input label column data must be <xref:System.Single>. This trainer outputs the following columns:
 
-| Column Name | Column Type | Description|
+| Output Column Name | Column Type | Description|
 | -- | -- | -- |
 | `Score` | <xref:System.Single> | The unbounded score that was calculated by the trainer to determine the prediction.|
 | `PredictedLabel` | <xref:System.Boolean> | The label predicted by the trainer. `false` maps to negative score and   `true` maps to positive score.|

--- a/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Trainers
     /// | Machine learning task | Binary classification |
     /// | Is normalization required? | Yes |
     /// | Is caching required? | No |
-    /// | Additional required NuGet | None |
+    /// | Required NuGet in addition to Microsoft.ML | None |
     ///
     /// ### Training Algorithm Details
     /// The perceptron is a classification algorithm that makes its predictions by finding a separating hyperplane.

--- a/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
@@ -42,11 +42,11 @@ namespace Microsoft.ML.Trainers
     ///
     /// ### Training Algorithm Details
     /// The perceptron is a classification algorithm that makes its predictions by finding a separating hyperplane.
-    /// For instance, with feature values f0, f1,..., f_D-1, the prediction is given by determining what side of the hyperplane the point falls into.
-    /// That is the same as the sign of sigma[0, D-1] (w_i * f_i), where w_0, w_1,..., w_D-1 are the weights computed by the algorithm.
+    /// For instance, with feature values $f0, f1,..., f_{D-1}$, the prediction is given by determining what side of the hyperplane the point falls into.
+    /// That is the same as the sign of the feautures' weighted sum, i.e. $\sum_{i = 0}^{D-1} (w_i * f_i)$, where $w_0, w_1,..., w_{D-1}$ are the weights computed by the algorithm.
     ///
     /// The perceptron is an online algorithm, which means it processes the instances in the training set one at a time.
-    /// It starts with a set of initial weights (zero, random, or initialized from a previous learner). Then, for each example in the training set, the weighted sum of the features (sigma[0, D-1] (w_i * f_i)) is computed.
+    /// It starts with a set of initial weights (zero, random, or initialized from a previous learner). Then, for each example in the training set, the weighted sum of the features is computed.
     /// If this value has the same sign as the label of the current example, the weights remain the same. If they have opposite signs,
     /// the weights vector is updated by either adding or subtracting (if the label is positive or negative, respectively) the feature vector of the current example,
     /// multiplied by a factor 0 < a <= 1, called the learning rate. In a generalization of this algorithm, the weights are updated by adding the feature vector multiplied by the learning rate,

--- a/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
@@ -23,9 +23,25 @@ using Microsoft.ML.Trainers;
 namespace Microsoft.ML.Trainers
 {
     /// <summary>
-    /// The <see cref="IEstimator{TTransformer}"/> for the averaged perceptron trainer.
+    /// The <see cref="IEstimator{TTransformer}"/> to predict a target using a linear binary classification model trained with the averaged perceptron.
     /// </summary>
     /// <remarks>
+    /// <format type="text/markdown"><![CDATA[
+    /// To create this trainer, use [AveragedPerceptron](xref:Microsoft.ML.StandardTrainersCatalog.AveragedPerceptron(Microsoft.ML.BinaryClassificationCatalog.BinaryClassificationTrainers,System.String,System.String,Microsoft.ML.Trainers.IClassificationLoss,System.Single,System.Boolean,System.Single,System.Int32)
+    /// or [AveragedPerceptron(Options)](xref:Microsoft.ML.StandardTrainersCatalog.AveragedPerceptron(Microsoft.ML.BinaryClassificationCatalog.BinaryClassificationTrainers,Microsoft.ML.Trainers.AveragedPerceptronTrainer.Options).
+    ///
+    /// [!include[io](~/../docs/samples/docs/api-reference/io-columns-binary-classification.md)]
+    ///
+    /// ### Trainer FAQ
+    /// | Question | Answer |
+    /// | -- | -- |
+    /// | Machine learning task | Binary classification |
+    /// | Is normalization required? | Yes |
+    /// | Is caching required? | No |
+    /// | Is convertible to ONNX format? | Yes |
+    /// | Additional required NuGet | None |
+    ///
+    /// ### Training Algorithm Details
     /// The perceptron is a classification algorithm that makes its predictions by finding a separating hyperplane.
     /// For instance, with feature values f0, f1,..., f_D-1, the prediction is given by determining what side of the hyperplane the point falls into.
     /// That is the same as the sign of sigma[0, D-1] (w_i * f_i), where w_0, w_1,..., w_D-1 are the weights computed by the algorithm.
@@ -40,9 +56,14 @@ namespace Microsoft.ML.Trainers
     /// In Averaged Perceptron (aka voted-perceptron), for each iteration, i.e. pass through the training data, a weight vector is calculated as explained above.
     /// The final prediction is then calculate by averaging the weighted sum from each weight vector and looking at the sign of the result.
     ///
-    /// For more information see <a href="https://en.wikipedia.org/wiki/Perceptron">Wikipedia entry for Perceptron</a>
-    /// or <a href="https://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.48.8200">Large Margin Classification Using the Perceptron Algorithm</a>
+    /// For more information see [Wikipedia entry for Perceptron](https://en.wikipedia.org/wiki/Perceptron)
+    /// or [Large Margin Classification Using the Perceptron Algorithm](https://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.48.8200).
+    /// ]]>
+    /// </format>
     /// </remarks>
+    /// <seealso cref="StandardTrainersCatalog.AveragedPerceptron(BinaryClassificationCatalog.BinaryClassificationTrainers, string, string, IClassificationLoss, float, bool, float, int)" />
+    /// <seealso cref="StandardTrainersCatalog.AveragedPerceptron(BinaryClassificationCatalog.BinaryClassificationTrainers, AveragedPerceptronTrainer.Options)"/>
+    /// <seealso cref="Options"/>
     public sealed class AveragedPerceptronTrainer : AveragedLinearTrainer<BinaryPredictionTransformer<LinearBinaryModelParameters>, LinearBinaryModelParameters>
     {
         internal const string LoadNameValue = "AveragedPerceptron";
@@ -53,7 +74,8 @@ namespace Microsoft.ML.Trainers
         private readonly Options _args;
 
         /// <summary>
-        /// Options for the <see cref="AveragedPerceptronTrainer"/>.
+        /// Options for the <see cref="AveragedPerceptronTrainer"/> as used in
+        /// [AveragedPerceptron(Options)](xref:Microsoft.ML.StandardTrainersCatalog.AveragedPerceptron(Microsoft.ML.BinaryClassificationCatalog.BinaryClassificationTrainers,Microsoft.ML.Trainers.AveragedPerceptronTrainer.Options).
         /// </summary>
         public sealed class Options : AveragedLinearOptions
         {

--- a/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Online/AveragedPerceptron.cs
@@ -32,13 +32,12 @@ namespace Microsoft.ML.Trainers
     ///
     /// [!include[io](~/../docs/samples/docs/api-reference/io-columns-binary-classification.md)]
     ///
-    /// ### Trainer FAQ
-    /// | Question | Answer |
+    /// ### Trainer Characteristics
+    /// |  |  |
     /// | -- | -- |
     /// | Machine learning task | Binary classification |
     /// | Is normalization required? | Yes |
     /// | Is caching required? | No |
-    /// | Is convertible to ONNX format? | Yes |
     /// | Additional required NuGet | None |
     ///
     /// ### Training Algorithm Details
@@ -50,7 +49,7 @@ namespace Microsoft.ML.Trainers
     /// It starts with a set of initial weights (zero, random, or initialized from a previous learner). Then, for each example in the training set, the weighted sum of the features (sigma[0, D-1] (w_i * f_i)) is computed.
     /// If this value has the same sign as the label of the current example, the weights remain the same. If they have opposite signs,
     /// the weights vector is updated by either adding or subtracting (if the label is positive or negative, respectively) the feature vector of the current example,
-    /// multiplied by a factor 0 &lt; a &lt;= 1, called the learning rate. In a generalization of this algorithm, the weights are updated by adding the feature vector multiplied by the learning rate,
+    /// multiplied by a factor 0 < a <= 1, called the learning rate. In a generalization of this algorithm, the weights are updated by adding the feature vector multiplied by the learning rate,
     /// and by the gradient of some loss function (in the specific case described above, the loss is hinge-loss, whose gradient is 1 when it is non-zero).
     ///
     /// In Averaged Perceptron (aka voted-perceptron), for each iteration, i.e. pass through the training data, a weight vector is calculated as explained above.

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -383,11 +383,11 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Predict a target using a linear binary classification model trained with <see cref="AveragedPerceptronTrainer"/>.
+        /// Create an <see cref="AveragedPerceptronTrainer"/>, which predicts a target using a linear binary classification model trained over boolean label data.
         /// </summary>
         /// <param name="catalog">The binary classification catalog trainer object.</param>
-        /// <param name="labelColumnName">The name of the label column.</param>
-        /// <param name="featureColumnName">The name of the feature column.</param>
+        /// <param name="labelColumnName">The name of the label column. The column data must be <see cref="System.Boolean"/>.</param>
+        /// <param name="featureColumnName">The name of the feature column. The column data must be a known-sized vector of <see cref="System.Single"/>.</param>
         /// <param name="lossFunction">The <a href="tmpurl_loss">loss</a> function minimized in the training process. If <see langword="null"/>, <see cref="HingeLoss"/> would be used and lead to a max-margin averaged perceptron trainer.</param>
         /// <param name="learningRate">The initial <a href="tmpurl_lr">learning rate</a> used by SGD.</param>
         /// <param name="decreaseLearningRate">
@@ -420,7 +420,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Predict a target using a linear binary classification model trained with <see cref="AveragedPerceptronTrainer"/> and advanced options.
+        /// Create an <see cref="AveragedPerceptronTrainer"/> with advanced options, which predicts a target using a linear binary classification model trained over boolean label data.
         /// </summary>
         /// <param name="catalog">The binary classification catalog trainer object.</param>
         /// <param name="options">Trainer options.</param>


### PR DESCRIPTION
This PR applies the template discussed #3218 to AveragedPerceptron. It serves as reference PR for updating the rest of the trainers.

The following pages are best-effort (90%) recreation of what these changes will look like. Although some changes will only be visible this PR and checked in and preview site is updated.

Extension methods:
* [Page-1-overload1](https://review.docs.microsoft.com/en-us/dotnet/api/microsoft.ml.standardtrainerscatalog.averagedperceptron?view=ml-dotnet&branch=smoke-test-preview#Microsoft_ML_StandardTrainersCatalog_AveragedPerceptron_Microsoft_ML_BinaryClassificationCatalog_BinaryClassificationTrainers_System_String_System_String_Microsoft_ML_Trainers_IClassificationLoss_System_Single_System_Boolean_System_Single_System_Int32_)
* [Page-1-overload2](https://review.docs.microsoft.com/en-us/dotnet/api/microsoft.ml.standardtrainerscatalog.averagedperceptron?view=ml-dotnet&branch=smoke-test-preview#Microsoft_ML_StandardTrainersCatalog_AveragedPerceptron_Microsoft_ML_BinaryClassificationCatalog_BinaryClassificationTrainers_Microsoft_ML_Trainers_AveragedPerceptronTrainer_Options_)

[AveragedPerceptronTrainer](https://review.docs.microsoft.com/en-us/dotnet/api/microsoft.ml.trainers.averagedperceptrontrainer?view=ml-dotnet&branch=smoke-test-preview)

[AveragedPerceptronTrainer.Options](https://review.docs.microsoft.com/en-us/dotnet/api/microsoft.ml.trainers.averagedperceptrontrainer.options?view=ml-dotnet&branch=smoke-test-preview)
