### PR TITLE
Samples second pass for Clustering Trainer

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/Clustering.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/Clustering.ttinclude
@@ -47,7 +47,8 @@ namespace Samples.Dynamic.Trainers.Clustering
             // Convert IDataView object to a list.
             var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
 
-            // Look at 5 predictions
+            // Print 5 predictions. Note that the label is only used as a comparison wiht the predicted label.
+            // It is not used during training.
             foreach (var p in predictions.Take(2))
                 Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
             foreach (var p in predictions.TakeLast(3))
@@ -57,9 +58,7 @@ namespace Samples.Dynamic.Trainers.Clustering
 
             // Evaluate the overall metrics
             var metrics = mlContext.Clustering.Evaluate(transformedTestData, "Label", "Score", "Features");
-            Console.WriteLine($"Normalized Mutual Information: {metrics.NormalizedMutualInformation:F2}");
-            Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
-            Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
+            PrintMetrics(metrics);
             
             <#=ExpectedOutput#>
 
@@ -85,7 +84,7 @@ namespace Samples.Dynamic.Trainers.Clustering
                 {
                     Label = (uint)label,
                     // Create random features with two clusters.
-                    // The first half has feature values cetered around 0.6 the second half has values centered around 0.4.
+                    // The first half has feature values centered around 0.6 the second half has values centered around 0.4.
                     Features = Enumerable.Repeat(label, 50).Select(index => label == 0 ? randomFloat() + 0.1f : randomFloat() - 0.1f).ToArray()
                 };
             }
@@ -94,6 +93,7 @@ namespace Samples.Dynamic.Trainers.Clustering
         // Example with label and 50 feature values. A data set is a collection of such examples.
         private class DataPoint
         {
+            // The label is not used during training, just for comparison with the predicted label.
             [KeyType(2)]
             public uint Label { get; set; }
 
@@ -104,10 +104,18 @@ namespace Samples.Dynamic.Trainers.Clustering
         // Class used to capture predictions.
         private class Prediction
         {
-            // Original label.
+            // Original label (not used during training, just for comparison).
             public uint Label { get; set; }
             // Predicted label from the trainer.
             public uint PredictedLabel { get; set; }
+        }
+
+        // Pretty-print of ClusteringMetrics object.
+        private static void PrintMetrics(ClusteringMetrics metrics)
+        {
+            Console.WriteLine($"Normalized Mutual Information: {metrics.NormalizedMutualInformation:F2}");
+            Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
+            Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/Clustering.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/Clustering.ttinclude
@@ -3,11 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+<# if (TrainerOptions != null) { #>
+<#=OptionsInclude#>
+<# } #>
 
 namespace Samples.Dynamic.Trainers.Clustering
 {
-    public static class KMeans
-    {
+    public static class <#=ClassName#>
+    {<#=Comments#>
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
@@ -16,13 +19,21 @@ namespace Samples.Dynamic.Trainers.Clustering
             var mlContext = new MLContext(seed: 0);
 
             // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
-            var dataPoints = GenerateRandomDataPoints(1000, 123);
+            var dataPoints = GenerateRandomDataPoints(1000, <#=DataSeed#>);
 
             // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
+<# if (TrainerOptions == null) { #>
             // Define the trainer.
-            var pipeline = mlContext.Clustering.Trainers.KMeans(numberOfClusters: 2);
+            var pipeline = mlContext.Clustering.Trainers.<#=Trainer#>(<#=InlineTrainerOptions#>);
+<# } else { #>
+            // Define trainer options.
+            var options = new <#=TrainerOptions#>;
+
+            // Define the trainer.
+            var pipeline = mlContext.Clustering.Trainers.<#=Trainer#>(options);
+<# } #>
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -42,12 +53,7 @@ namespace Samples.Dynamic.Trainers.Clustering
             foreach (var p in predictions.TakeLast(3))
                 Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
 
-            // Expected output:
-            //   Label: 1, Prediction: 1
-            //   Label: 1, Prediction: 1
-            //   Label: 2, Prediction: 2
-            //   Label: 2, Prediction: 2
-            //   Label: 2, Prediction: 2
+            <#=ExpectedOutputPerInstance#>
 
             // Evaluate the overall metrics
             var metrics = mlContext.Clustering.Evaluate(transformedTestData, "Label", "Score", "Features");
@@ -55,10 +61,7 @@ namespace Samples.Dynamic.Trainers.Clustering
             Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
             Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
             
-            // Expected output:
-            //   Normalized Mutual Information: 0.95
-            //   Average Distance: 4.17
-            //   Davies Bouldin Index: 2.87
+            <#=ExpectedOutput#>
 
             // Get cluster centroids and the number of clusters k from KMeansModelParameters.
             VBuffer<float>[] centroids = default;
@@ -68,11 +71,7 @@ namespace Samples.Dynamic.Trainers.Clustering
             Console.WriteLine($"The first 3 coordinates of the first centroid are: ({string.Join(", ", centroids[0].GetValues().ToArray().Take(3))})");
             Console.WriteLine($"The first 3 coordinates of the second centroid are: ({string.Join(", ", centroids[1].GetValues().ToArray().Take(3))})");
 
-            // Expected output similar to:
-            //   The first 3 coordinates of the first centroid are: (0.6035213, 0.6017533, 0.5964218)
-            //   The first 3 coordinates of the second centroid are: (0.4031044, 0.4175443, 0.4082336)
-            //
-            // Note: use the advanced options constructor to set the number of threads to 1 for a deterministic behavior.
+            <#=ExpectedCentroidsOutput#>
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.cs
@@ -36,7 +36,8 @@ namespace Samples.Dynamic.Trainers.Clustering
             // Convert IDataView object to a list.
             var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
 
-            // Look at 5 predictions
+            // Print 5 predictions. Note that the label is only used as a comparison wiht the predicted label.
+            // It is not used during training.
             foreach (var p in predictions.Take(2))
                 Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
             foreach (var p in predictions.TakeLast(3))
@@ -51,9 +52,7 @@ namespace Samples.Dynamic.Trainers.Clustering
 
             // Evaluate the overall metrics
             var metrics = mlContext.Clustering.Evaluate(transformedTestData, "Label", "Score", "Features");
-            Console.WriteLine($"Normalized Mutual Information: {metrics.NormalizedMutualInformation:F2}");
-            Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
-            Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
+            PrintMetrics(metrics);
             
             // Expected output:
             //   Normalized Mutual Information: 0.95
@@ -71,8 +70,6 @@ namespace Samples.Dynamic.Trainers.Clustering
             // Expected output similar to:
             //   The first 3 coordinates of the first centroid are: (0.6035213, 0.6017533, 0.5964218)
             //   The first 3 coordinates of the second centroid are: (0.4031044, 0.4175443, 0.4082336)
-            //
-            // Note: use the advanced options constructor to set the number of threads to 1 for a deterministic behavior.
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
@@ -86,7 +83,7 @@ namespace Samples.Dynamic.Trainers.Clustering
                 {
                     Label = (uint)label,
                     // Create random features with two clusters.
-                    // The first half has feature values cetered around 0.6 the second half has values centered around 0.4.
+                    // The first half has feature values centered around 0.6 the second half has values centered around 0.4.
                     Features = Enumerable.Repeat(label, 50).Select(index => label == 0 ? randomFloat() + 0.1f : randomFloat() - 0.1f).ToArray()
                 };
             }
@@ -95,6 +92,7 @@ namespace Samples.Dynamic.Trainers.Clustering
         // Example with label and 50 feature values. A data set is a collection of such examples.
         private class DataPoint
         {
+            // The label is not used during training, just for comparison with the predicted label.
             [KeyType(2)]
             public uint Label { get; set; }
 
@@ -105,10 +103,18 @@ namespace Samples.Dynamic.Trainers.Clustering
         // Class used to capture predictions.
         private class Prediction
         {
-            // Original label.
+            // Original label (not used during training, just for comparison).
             public uint Label { get; set; }
             // Predicted label from the trainer.
             public uint PredictedLabel { get; set; }
+        }
+
+        // Pretty-print of ClusteringMetrics object.
+        private static void PrintMetrics(ClusteringMetrics metrics)
+        {
+            Console.WriteLine($"Normalized Mutual Information: {metrics.NormalizedMutualInformation:F2}");
+            Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
+            Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.tt
@@ -1,0 +1,29 @@
+﻿<#@ include file="Clustering.ttinclude"#>
+<#+
+string ClassName = "KMeans";
+            string Trainer = "KMeans";
+            string TrainerOptions = null;
+            string InlineTrainerOptions = "numberOfClusters: 2";
+            int DataSeed = 123;
+
+            string OptionsInclude = "";
+            string Comments = "";
+
+            string ExpectedOutputPerInstance = @"// Expected output:
+            //   Label: 1, Prediction: 1
+            //   Label: 1, Prediction: 1
+            //   Label: 2, Prediction: 2
+            //   Label: 2, Prediction: 2
+            //   Label: 2, Prediction: 2";
+
+            string ExpectedOutput = @"// Expected output:
+            //   Normalized Mutual Information: 0.95
+            //   Average Distance: 4.17
+            //   Davies Bouldin Index: 2.87";
+
+            string ExpectedCentroidsOutput = @"// Expected output similar to:
+            //   The first 3 coordinates of the first centroid are: (0.6035213, 0.6017533, 0.5964218)
+            //   The first 3 coordinates of the second centroid are: (0.4031044, 0.4175443, 0.4082336)
+            //
+            // Note: use the advanced options constructor to set the number of threads to 1 for a deterministic behavior.";
+#>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeans.tt
@@ -1,29 +1,27 @@
 ﻿<#@ include file="Clustering.ttinclude"#>
 <#+
 string ClassName = "KMeans";
-            string Trainer = "KMeans";
-            string TrainerOptions = null;
-            string InlineTrainerOptions = "numberOfClusters: 2";
-            int DataSeed = 123;
+string Trainer = "KMeans";
+string TrainerOptions = null;
+string InlineTrainerOptions = "numberOfClusters: 2";
+int DataSeed = 123;
 
-            string OptionsInclude = "";
-            string Comments = "";
+string OptionsInclude = "";
+string Comments = "";
 
-            string ExpectedOutputPerInstance = @"// Expected output:
+string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1
             //   Label: 1, Prediction: 1
             //   Label: 2, Prediction: 2
             //   Label: 2, Prediction: 2
             //   Label: 2, Prediction: 2";
 
-            string ExpectedOutput = @"// Expected output:
+string ExpectedOutput = @"// Expected output:
             //   Normalized Mutual Information: 0.95
             //   Average Distance: 4.17
             //   Davies Bouldin Index: 2.87";
 
-            string ExpectedCentroidsOutput = @"// Expected output similar to:
+string ExpectedCentroidsOutput = @"// Expected output similar to:
             //   The first 3 coordinates of the first centroid are: (0.6035213, 0.6017533, 0.5964218)
-            //   The first 3 coordinates of the second centroid are: (0.4031044, 0.4175443, 0.4082336)
-            //
-            // Note: use the advanced options constructor to set the number of threads to 1 for a deterministic behavior.";
+            //   The first 3 coordinates of the second centroid are: (0.4031044, 0.4175443, 0.4082336)";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.cs
@@ -26,7 +26,6 @@ namespace Samples.Dynamic.Trainers.Clustering
             var options = new KMeansTrainer.Options
             {
                 NumberOfClusters = 2,
-                MaximumNumberOfIterations = 100,
                 OptimizationTolerance = 1e-6f,
                 NumberOfThreads = 1
             };
@@ -46,7 +45,8 @@ namespace Samples.Dynamic.Trainers.Clustering
             // Convert IDataView object to a list.
             var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
 
-            // Look at 5 predictions
+            // Print 5 predictions. Note that the label is only used as a comparison wiht the predicted label.
+            // It is not used during training.
             foreach (var p in predictions.Take(2))
                 Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
             foreach (var p in predictions.TakeLast(3))
@@ -61,9 +61,7 @@ namespace Samples.Dynamic.Trainers.Clustering
 
             // Evaluate the overall metrics
             var metrics = mlContext.Clustering.Evaluate(transformedTestData, "Label", "Score", "Features");
-            Console.WriteLine($"Normalized Mutual Information: {metrics.NormalizedMutualInformation:F2}");
-            Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
-            Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
+            PrintMetrics(metrics);
             
             // Expected output:
             //   Normalized Mutual Information: 0.92
@@ -94,7 +92,7 @@ namespace Samples.Dynamic.Trainers.Clustering
                 {
                     Label = (uint)label,
                     // Create random features with two clusters.
-                    // The first half has feature values cetered around 0.6 the second half has values centered around 0.4.
+                    // The first half has feature values centered around 0.6 the second half has values centered around 0.4.
                     Features = Enumerable.Repeat(label, 50).Select(index => label == 0 ? randomFloat() + 0.1f : randomFloat() - 0.1f).ToArray()
                 };
             }
@@ -103,6 +101,7 @@ namespace Samples.Dynamic.Trainers.Clustering
         // Example with label and 50 feature values. A data set is a collection of such examples.
         private class DataPoint
         {
+            // The label is not used during training, just for comparison with the predicted label.
             [KeyType(2)]
             public uint Label { get; set; }
 
@@ -113,10 +112,18 @@ namespace Samples.Dynamic.Trainers.Clustering
         // Class used to capture predictions.
         private class Prediction
         {
-            // Original label.
+            // Original label (not used during training, just for comparison).
             public uint Label { get; set; }
             // Predicted label from the trainer.
             public uint PredictedLabel { get; set; }
+        }
+
+        // Pretty-print of ClusteringMetrics object.
+        private static void PrintMetrics(ClusteringMetrics metrics)
+        {
+            Console.WriteLine($"Normalized Mutual Information: {metrics.NormalizedMutualInformation:F2}");
+            Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
+            Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.cs
@@ -1,59 +1,122 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 
-namespace Samples.Dynamic
+namespace Samples.Dynamic.Trainers.Clustering
 {
-    public class KMeansWithOptions
+    public static class KMeansWithOptions
     {
         public static void Example()
         {
-            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
-            // as well as the source of randomness.
-            var ml = new MLContext(seed: 1);
+            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // as a catalog of available operations and as the source of randomness.
+            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            var mlContext = new MLContext(seed: 0);
 
-            // Get a small dataset as an IEnumerable and convert it to an IDataView.
-            var data = Microsoft.ML.SamplesUtils.DatasetUtils.GetInfertData();
-            var trainData = ml.Data.LoadFromEnumerable(data);
+            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            var dataPoints = GenerateRandomDataPoints(1000, 0);
 
-            // Preview of the data.
-            //
-            // Age  Case  Education  Induced     Parity  PooledStratum  RowNum  ...
-            // 26   1       0-5yrs      1         6         3             1  ...
-            // 42   1       0-5yrs      1         1         1             2  ...
-            // 39   1       0-5yrs      2         6         4             3  ...
-            // 34   1       0-5yrs      2         4         2             4  ...
-            // 35   1       6-11yrs     1         3         32            5  ...
+            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // A pipeline for concatenating the age, parity and induced columns together in the Features column and training a KMeans model on them.
-            string outputColumnName = "Features";
-            var pipeline = ml.Transforms.Concatenate(outputColumnName, new[] { "Age", "Parity", "Induced" })
-                .Append(ml.Clustering.Trainers.KMeans(
-                    new KMeansTrainer.Options
-                    {
-                        FeatureColumnName = outputColumnName,
-                        NumberOfClusters = 2,
-                        MaximumNumberOfIterations = 100,
-                        OptimizationTolerance = 1e-6f,
-                        NumberOfThreads = 1
-                    }
-                 ));
+            // Define trainer options.
+            var options = new KMeansTrainer.Options
+            {
+                NumberOfClusters = 2,
+                MaximumNumberOfIterations = 100,
+                OptimizationTolerance = 1e-6f,
+                NumberOfThreads = 1
+            };
 
-            var model = pipeline.Fit(trainData);
+            // Define the trainer.
+            var pipeline = mlContext.Clustering.Trainers.KMeans(options);
+
+            // Train the model.
+            var model = pipeline.Fit(trainingData);
+
+            // Create testing data. Use different random seed to make it different from training data.
+            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+
+            // Run the model on test data set.
+            var transformedTestData = model.Transform(testData);
+
+            // Convert IDataView object to a list.
+            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+
+            // Look at 5 predictions
+            foreach (var p in predictions.Take(2))
+                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+            foreach (var p in predictions.TakeLast(3))
+                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+
+            // Expected output:
+            //   Label: 1, Prediction: 1
+            //   Label: 1, Prediction: 1
+            //   Label: 2, Prediction: 2
+            //   Label: 2, Prediction: 2
+            //   Label: 2, Prediction: 2
+
+            // Evaluate the overall metrics
+            var metrics = mlContext.Clustering.Evaluate(transformedTestData, "Label", "Score", "Features");
+            Console.WriteLine($"Normalized Mutual Information: {metrics.NormalizedMutualInformation:F2}");
+            Console.WriteLine($"Average Distance: {metrics.AverageDistance:F2}");
+            Console.WriteLine($"Davies Bouldin Index: {metrics.DaviesBouldinIndex:F2}");
+            
+            // Expected output:
+            //   Normalized Mutual Information: 0.92
+            //   Average Distance: 4.18
+            //   Davies Bouldin Index: 2.87
 
             // Get cluster centroids and the number of clusters k from KMeansModelParameters.
             VBuffer<float>[] centroids = default;
-            int k;
 
-            var modelParams = model.LastTransformer.Model;
-            modelParams.GetClusterCentroids(ref centroids, out k);
+            var modelParams = model.Model;
+            modelParams.GetClusterCentroids(ref centroids, out int k);
+            Console.WriteLine($"The first 3 coordinates of the first centroid are: ({string.Join(", ", centroids[0].GetValues().ToArray().Take(3))})");
+            Console.WriteLine($"The first 3 coordinates of the second centroid are: ({string.Join(", ", centroids[1].GetValues().ToArray().Take(3))})");
 
-            var centroid = centroids[0].GetValues();
-            Console.WriteLine("The coordinates of centroid 0 are: " + string.Join(", ", centroid.ToArray()));
+            // Expected output:
+            //   The first 3 coordinates of the first centroid are: (0.5840713, 0.5678288, 0.6221277)
+            //   The first 3 coordinates of the second centroid are: (0.3705794, 0.4289133, 0.4001645)
+        }
 
-            //  Expected Output:
-            //      The coordinates of centroid 0 are: (26, 6, 1)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
+        {
+            var random = new Random(seed);
+            float randomFloat() => (float)random.NextDouble();
+            for (int i = 0; i < count; i++)
+            {
+                int label = i < count / 2 ? 0 : 1;
+                yield return new DataPoint
+                {
+                    Label = (uint)label,
+                    // Create random features with two clusters.
+                    // The first half has feature values cetered around 0.6 the second half has values centered around 0.4.
+                    Features = Enumerable.Repeat(label, 50).Select(index => label == 0 ? randomFloat() + 0.1f : randomFloat() - 0.1f).ToArray()
+                };
+            }
+        }
+
+        // Example with label and 50 feature values. A data set is a collection of such examples.
+        private class DataPoint
+        {
+            [KeyType(2)]
+            public uint Label { get; set; }
+
+            [VectorType(50)]
+            public float[] Features { get; set; }
+        }
+
+        // Class used to capture predictions.
+        private class Prediction
+        {
+            // Original label.
+            public uint Label { get; set; }
+            // Predicted label from the trainer.
+            public uint PredictedLabel { get; set; }
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.tt
@@ -1,0 +1,33 @@
+﻿<#@ include file="Clustering.ttinclude"#>
+<#+
+string ClassName = "KMeansWithOptions";
+string Trainer = "KMeans";
+string TrainerOptions = @"KMeansTrainer.Options
+            {
+                NumberOfClusters = 2,
+                MaximumNumberOfIterations = 100,
+                OptimizationTolerance = 1e-6f,
+                NumberOfThreads = 1
+            }";
+string InlineTrainerOptions = null;
+int DataSeed = 0;
+
+string OptionsInclude = "using Microsoft.ML.Trainers;";
+string Comments = "";
+
+string ExpectedOutputPerInstance = @"// Expected output:
+            //   Label: 1, Prediction: 1
+            //   Label: 1, Prediction: 1
+            //   Label: 2, Prediction: 2
+            //   Label: 2, Prediction: 2
+            //   Label: 2, Prediction: 2";
+
+string ExpectedOutput = @"// Expected output:
+            //   Normalized Mutual Information: 0.92
+            //   Average Distance: 4.18
+            //   Davies Bouldin Index: 2.87";
+
+string ExpectedCentroidsOutput = @"// Expected output:
+            //   The first 3 coordinates of the first centroid are: (0.5840713, 0.5678288, 0.6221277)
+            //   The first 3 coordinates of the second centroid are: (0.3705794, 0.4289133, 0.4001645)";
+#>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/Clustering/KMeansWithOptions.tt
@@ -5,7 +5,6 @@ string Trainer = "KMeans";
 string TrainerOptions = @"KMeansTrainer.Options
             {
                 NumberOfClusters = 2,
-                MaximumNumberOfIterations = 100,
                 OptimizationTolerance = 1e-6f,
                 NumberOfThreads = 1
             }";

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -195,6 +195,66 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>LightGbmWithOptions.cs</LastGenOutput>
     </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\LightGbm.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>LightGbm.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\LightGbmWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>LightGbmWithOptions.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\LinearSvm.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>LinearSvm.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\LinearSvmWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>LinearSvmWithOptions.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\PriorTrainer.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PriorTrainer.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SdcaLogisticRegression.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SdcaLogisticRegression.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SdcaLogisticRegressionWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SdcaLogisticRegressionWithOptions.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SdcaNonCalibrated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SdcaNonCalibrated.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SdcaNonCalibratedWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SdcaNonCalibratedWithOptions.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SgdCalibrated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SgdCalibrated.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SgdCalibratedWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SgdCalibratedWithOptions.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SgdNonCalibrated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SgdNonCalibrated.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SgdNonCalibratedWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SgdNonCalibratedWithOptions.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SymbolicSgdLogisticRegression.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SymbolicSgdLogisticRegression.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\BinaryClassification\SymbolicSgdLogisticRegressionWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SymbolicSgdLogisticRegressionWithOptions.cs</LastGenOutput>
+    </None>
     <None Update="Dynamic\Trainers\Clustering\KMeans.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>KMeans.cs</LastGenOutput>
@@ -454,6 +514,71 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>LightGbmWithOptions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\LinearSvm.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>LinearSvm.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\LinearSvmWithOptions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>LinearSvmWithOptions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\PriorTrainer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PriorTrainer.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SdcaLogisticRegression.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SdcaLogisticRegression.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SdcaLogisticRegressionWithOptions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SdcaLogisticRegressionWithOptions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SdcaNonCalibrated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SdcaNonCalibrated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SdcaNonCalibratedWithOptions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SdcaNonCalibratedWithOptions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SgdCalibrated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SgdCalibrated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SgdCalibratedWithOptions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SgdCalibratedWithOptions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SgdNonCalibrated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SgdNonCalibrated.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SgdNonCalibratedWithOptions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SgdNonCalibratedWithOptions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SymbolicSgdLogisticRegression.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SymbolicSgdLogisticRegression.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\BinaryClassification\SymbolicSgdLogisticRegressionWithOptions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SymbolicSgdLogisticRegressionWithOptions.tt</DependentUpon>
     </Compile>
     <Compile Update="Dynamic\Trainers\Clustering\KMeans.cs">
       <DesignTime>True</DesignTime>

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -195,6 +195,14 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>LightGbmWithOptions.cs</LastGenOutput>
     </None>
+    <None Update="Dynamic\Trainers\Clustering\KMeans.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>KMeans.cs</LastGenOutput>
+    </None>
+    <None Update="Dynamic\Trainers\Clustering\KMeansWithOptions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>KMeansWithOptions.cs</LastGenOutput>
+    </None>
     <None Update="Dynamic\Trainers\MulticlassClassification\NaiveBayes.tt">
       <LastGenOutput>NaiveBayes.cs</LastGenOutput>
       <Generator>TextTemplatingFileGenerator</Generator>
@@ -446,6 +454,16 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>LightGbmWithOptions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\Clustering\KMeans.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>KMeans.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Dynamic\Trainers\Clustering\KMeansWithOptions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>KMeansWithOptions.tt</DependentUpon>
     </Compile>
     <Compile Update="Dynamic\Trainers\MulticlassClassification\PairwiseCoupling.cs">
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
Tracked in #2522.

This PR removes the dependency on SampleUtils for clustering trainers samples (KMeans samples).
