### PR TITLE
Increase Native build warning level  to W3 and fix build warnings

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -32,7 +32,6 @@ if(WIN32)
     add_compile_options(/FC) # use full pathnames in diagnostics
     add_compile_options(/DEBUG)
     add_compile_options(/GS)
-    add_compile_options(/W1)
     add_compile_options(/Zc:inline)
     add_compile_options(/fp:precise)
     add_compile_options(/EHsc)

--- a/src/Native/CpuMathNative/Sse.cpp
+++ b/src/Native/CpuMathNative/Sse.cpp
@@ -158,7 +158,7 @@ EXPORT_API(void) MatMulTran(_In_ const float * pmat, _In_ const float * psrc, _I
     }
 
     pm += 3 * crow;
-    
+
     for (; ps < psLim; ps += 4)
     {
         __m128 x01 = _mm_load_ps(ps);
@@ -219,9 +219,9 @@ EXPORT_API(void) Scale(float a, _Inout_ float * pd, int c)
     {
         switch (c)
         {
-            case 3: pd[2] *= a;
-            case 2: pd[1] *= a;
-            case 1: pd[0] *= a;
+        case 3: pd[2] *= a;
+        case 2: pd[1] *= a;
+        case 1: pd[0] *= a;
         }
         return;
     }
@@ -266,7 +266,7 @@ EXPORT_API(void) Scale(float a, _Inout_ float * pd, int c)
             _mm_storeu_ps(pd, result);
 
             pd += misalignment;
-			// safe to downcast as misalignment < 16.
+            // safe to downcast as misalignment <= 128.
             c -= static_cast<int>(misalignment);
         }
 
@@ -490,9 +490,9 @@ EXPORT_API(float) Sum(const float* pValues, int length)
 
         switch (length)
         {
-            case 3: result += pValues[2];
-            case 2: result += pValues[1];
-            case 1: result += pValues[0];
+        case 3: result += pValues[2];
+        case 2: result += pValues[1];
+        case 1: result += pValues[0];
         }
 
         return result;
@@ -533,8 +533,8 @@ EXPORT_API(float) Sum(const float* pValues, int length)
             result = _mm_add_ps(result, temp);
 
             pValues += misalignment;
-			// safe to downcastcast as misalignment < 16.
-			length -= static_cast<int>(misalignment);
+            // safe to downcast as misalignment < 16.
+            length -= static_cast<int>(misalignment);
         }
 
         if (length > 3)

--- a/src/Native/CpuMathNative/Sse.cpp
+++ b/src/Native/CpuMathNative/Sse.cpp
@@ -266,7 +266,8 @@ EXPORT_API(void) Scale(float a, _Inout_ float * pd, int c)
             _mm_storeu_ps(pd, result);
 
             pd += misalignment;
-            c -= misalignment;
+			// safe to downcast as misalignment < 16.
+            c -= static_cast<int>(misalignment);
         }
 
         if (c > 3)
@@ -532,7 +533,8 @@ EXPORT_API(float) Sum(const float* pValues, int length)
             result = _mm_add_ps(result, temp);
 
             pValues += misalignment;
-            length -= misalignment;
+			// safe to downcastcast as misalignment < 16.
+			length -= static_cast<int>(misalignment);
         }
 
         if (length > 3)

--- a/src/Native/LdaNative/alias_multinomial_rng_int.cpp
+++ b/src/Native/LdaNative/alias_multinomial_rng_int.cpp
@@ -23,13 +23,13 @@ namespace wood
             delete[]internal_memory_;
         }
     }
-    
+
     int32_t AliasMultinomialRNGInt::Next(xorshift_rng& rng, std::vector<alias_k_v>& alias_kv)
     {
         // NOTE: stl uniform_real_distribution generates the highest quality random numbers
         // yet, the other two are much faster
         auto sample = rng.rand();
-        
+
         // NOTE: use std::floor is too slow
         // here we guarantee sample * n_ is nonnegative, this makes cast work
         int idx = sample / a_int_;

--- a/src/Native/LdaNative/alias_multinomial_rng_int.hpp
+++ b/src/Native/LdaNative/alias_multinomial_rng_int.hpp
@@ -21,6 +21,8 @@ Fast generation of discrete random variables
 */
 namespace wood
 {
+	using namespace std;
+
     struct alias_k_v
     {
         int32_t k_;
@@ -108,7 +110,7 @@ namespace wood
             int32_t H_head = 0;
             int32_t H_tail = 0;
 
-			if (proportion_int_.size() > numeric_limits<int32_t>::max())
+			if (proportion_int_.size() > static_cast<uint32_t>(numeric_limits<int32_t>::max()))
 				bad_array_new_length();
 
 			int32_t size = static_cast<int32_t>(proportion_int_.size());

--- a/src/Native/LdaNative/alias_multinomial_rng_int.hpp
+++ b/src/Native/LdaNative/alias_multinomial_rng_int.hpp
@@ -108,7 +108,11 @@ namespace wood
             int32_t H_head = 0;
             int32_t H_tail = 0;
 
-            for (size_t i = 0; i < proportion_int_.size(); ++i)
+			if (proportion_int_.size() > numeric_limits<int32_t>::max())
+				bad_array_new_length();
+
+			int32_t size = static_cast<int32_t>(proportion_int_.size());
+            for (int32_t i = 0; i < size; ++i)
             {
                 auto val = proportion_int_[i];
                 if (val < a_int_)

--- a/src/Native/LdaNative/alias_multinomial_rng_int.hpp
+++ b/src/Native/LdaNative/alias_multinomial_rng_int.hpp
@@ -110,7 +110,7 @@ namespace wood
 
 
             // note that i must fit into int32_t of L_[L_tail].first
-            if (std::numeric_limits<int32_t>::max() < proportion_int_.size() )
+            if (static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) < proportion_int_.size() )
                 throw std::bad_alloc();
             int32_t size = static_cast<int32_t>(proportion_int_.size());
             for (int32_t i = 0; i < size; ++i)

--- a/src/Native/LdaNative/alias_multinomial_rng_int.hpp
+++ b/src/Native/LdaNative/alias_multinomial_rng_int.hpp
@@ -14,15 +14,13 @@
 #include <iostream>
 #include <assert.h>
 /*
-Algorithm described in 
+Algorithm described in
 https://www.jstatsoft.org/v11/i03/paper
 George Marsaglia
 Fast generation of discrete random variables
 */
 namespace wood
 {
-	using namespace std;
-
     struct alias_k_v
     {
         int32_t k_;
@@ -110,7 +108,11 @@ namespace wood
             int32_t H_head = 0;
             int32_t H_tail = 0;
 
-			int32_t size = static_cast<int32_t>(proportion_int_.size());
+
+            // note that i must fit into int32_t of L_[L_tail].first
+            if (std::numeric_limits<int32_t>::max() < proportion_int_.size() )
+                throw std::bad_alloc();
+            int32_t size = static_cast<int32_t>(proportion_int_.size());
             for (int32_t i = 0; i < size; ++i)
             {
                 auto val = proportion_int_[i];
@@ -157,7 +159,7 @@ namespace wood
                 auto first = L_[L_head].first;
                 auto second = L_[L_head].second;
                 alias_kv[first].k_ = first;
-                alias_kv[first].v_ = first  * a_int_ + second;
+                alias_kv[first].v_ = first * a_int_ + second;
                 ++L_head;
             }
             while (H_head != H_tail)
@@ -230,7 +232,7 @@ namespace wood
                 *p = i;  p++;
                 *p = (i + 1) * a_int_;
             }
-            
+
             int32_t L_head = 0;
             int32_t L_tail = 0;
 
@@ -298,8 +300,8 @@ namespace wood
                 *p = first; p++;
                 *p = first * a_int_ + second;
                 ++H_head;
-            }    
-            memcpy(memory, internal_memory_, sizeof(int32_t)* 2 * n_);
+            }
+            memcpy(memory, internal_memory_, sizeof(int32_t) * 2 * n_);
         }
 
         inline void SetProportionMass(std::vector<float> &proportion,

--- a/src/Native/LdaNative/alias_multinomial_rng_int.hpp
+++ b/src/Native/LdaNative/alias_multinomial_rng_int.hpp
@@ -108,7 +108,7 @@ namespace wood
             int32_t H_head = 0;
             int32_t H_tail = 0;
 
-            for (auto i = 0; i < proportion_int_.size(); ++i)
+            for (size_t i = 0; i < proportion_int_.size(); ++i)
             {
                 auto val = proportion_int_[i];
                 if (val < a_int_)

--- a/src/Native/LdaNative/alias_multinomial_rng_int.hpp
+++ b/src/Native/LdaNative/alias_multinomial_rng_int.hpp
@@ -110,9 +110,6 @@ namespace wood
             int32_t H_head = 0;
             int32_t H_tail = 0;
 
-			if (proportion_int_.size() > static_cast<uint32_t>(numeric_limits<int32_t>::max()))
-				bad_array_new_length();
-
 			int32_t size = static_cast<int32_t>(proportion_int_.size());
             for (int32_t i = 0; i < size; ++i)
             {

--- a/src/Native/LdaNative/data_block.cpp
+++ b/src/Native/LdaNative/data_block.cpp
@@ -51,7 +51,7 @@ namespace lda
     {
 		num_documents_ = num_document;
 
-		if (corpus_size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+		if (corpus_size < 0 || static_cast<uint64_t>(corpus_size) > numeric_limits<size_t>::max())
 			bad_alloc();
         corpus_size_ = static_cast<size_t>(corpus_size);
 

--- a/src/Native/LdaNative/data_block.cpp
+++ b/src/Native/LdaNative/data_block.cpp
@@ -3,11 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 #include <iostream>
+#include <stdexcept>
+#include <limits>
 #include "data_block.h"
 #include "lda_document.h"
 
 namespace lda
 {
+	using namespace std;
+
     LDADataBlock::LDADataBlock(int32_t num_threads) : 
         num_threads_(num_threads), has_read_(false), index_document_(0), documents_buffer_(nullptr), offset_buffer_(nullptr)
     {
@@ -45,8 +49,12 @@ namespace lda
 
     void LDADataBlock::Allocate(const int32_t num_document, const int64_t corpus_size)
     {
-        num_documents_ = num_document;
-        corpus_size_ = corpus_size;
+		num_documents_ = num_document;
+
+		if (corpus_size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+			bad_alloc();
+        corpus_size_ = static_cast<size_t>(corpus_size);
+
 
         offset_buffer_ = new int64_t[num_documents_ + 1]; // +1: one for the end of last document,
         documents_buffer_ = new int32_t[corpus_size_];

--- a/src/Native/LdaNative/data_block.cpp
+++ b/src/Native/LdaNative/data_block.cpp
@@ -55,7 +55,7 @@ namespace lda
             throw bad_alloc();
         corpus_size_ = static_cast<size_t>(corpus_size);
 
-        if (num_documents_ < 0 || static_cast<uint32_t>(num_documents_) > numeric_limits<size_t>::max() - 1)
+        if (num_documents_ < 0 || static_cast<uint64_t>(num_documents_) > (numeric_limits<size_t>::max() - 1))
             throw bad_alloc();
 
         offset_buffer_ = new int64_t[num_documents_ + 1]; // +1: one for the end of last document,

--- a/src/Native/LdaNative/data_block.cpp
+++ b/src/Native/LdaNative/data_block.cpp
@@ -55,7 +55,7 @@ namespace lda
             throw bad_alloc();
         corpus_size_ = static_cast<size_t>(corpus_size);
 
-        if (num_documents_ < 0 || static_cast<uint64_t>(num_documents_) > (numeric_limits<size_t>::max() - 1))
+        if (num_documents_ < 0 || static_cast<uint64_t>(num_documents_) >(numeric_limits<size_t>::max() - 1))
             throw bad_alloc();
 
         offset_buffer_ = new int64_t[num_documents_ + 1]; // +1: one for the end of last document,

--- a/src/Native/LdaNative/data_block.cpp
+++ b/src/Native/LdaNative/data_block.cpp
@@ -10,14 +10,14 @@
 
 namespace lda
 {
-	using namespace std;
+    using namespace std;
 
-    LDADataBlock::LDADataBlock(int32_t num_threads) : 
+    LDADataBlock::LDADataBlock(int32_t num_threads) :
         num_threads_(num_threads), has_read_(false), index_document_(0), documents_buffer_(nullptr), offset_buffer_(nullptr)
     {
     }
 
-    LDADataBlock::~LDADataBlock() 
+    LDADataBlock::~LDADataBlock()
     {
         if (has_read_)
         {
@@ -49,10 +49,10 @@ namespace lda
 
     void LDADataBlock::Allocate(const int32_t num_document, const int64_t corpus_size)
     {
-		num_documents_ = num_document;
+        num_documents_ = num_document;
 
-		if (corpus_size < 0 || static_cast<uint64_t>(corpus_size) > numeric_limits<size_t>::max())
-			bad_alloc();
+        if (corpus_size < 0 || static_cast<uint64_t>(corpus_size) > numeric_limits<size_t>::max())
+            throw bad_alloc();
         corpus_size_ = static_cast<size_t>(corpus_size);
 
 
@@ -94,7 +94,7 @@ namespace lda
     int LDADataBlock::AddDense(int32_t* term_freq, int32_t term_num)
     {
         int64_t data_length = 1;
-        
+
         int64_t idx = offset_buffer_[index_document_] + 1;
         for (int i = 0; i < term_num; ++i)
         {

--- a/src/Native/LdaNative/data_block.cpp
+++ b/src/Native/LdaNative/data_block.cpp
@@ -55,6 +55,8 @@ namespace lda
             throw bad_alloc();
         corpus_size_ = static_cast<size_t>(corpus_size);
 
+        if (num_documents_ < 0 || static_cast<uint32_t>(num_documents_) > numeric_limits<size_t>::max() - 1)
+            throw bad_alloc();
 
         offset_buffer_ = new int64_t[num_documents_ + 1]; // +1: one for the end of last document,
         documents_buffer_ = new int32_t[corpus_size_];

--- a/src/Native/LdaNative/data_block.h
+++ b/src/Native/LdaNative/data_block.h
@@ -44,7 +44,7 @@ namespace lda
         int64_t used_size_;
 
         int32_t num_documents_; 
-        int64_t corpus_size_;
+        size_t corpus_size_;
 
         int64_t* offset_buffer_;    // offset_buffer_ size = num_document_ + 1
         int32_t* documents_buffer_; // documents_buffer_ size = corpus_size_;

--- a/src/Native/LdaNative/data_block.h
+++ b/src/Native/LdaNative/data_block.h
@@ -17,10 +17,10 @@ namespace lda
     public:
         explicit LDADataBlock(int32_t num_threads);
         ~LDADataBlock();
-        
+
         void Clear();
         //in data feedin scenario
-        void Allocate(const int32_t num_document, const int64_t corpus_size);        
+        void Allocate(const int32_t num_document, const int64_t corpus_size);
         //port the data from external process, for example, c#
         int AddDense(int32_t* term_freq, int32_t term_num);
         int Add(int32_t* term_id, int32_t* term_freq, int32_t term_num);
@@ -28,7 +28,7 @@ namespace lda
 
         inline int32_t num_documents() const;
         // Return the first document for thread thread_id
-        inline int32_t Begin(int32_t thread_id) const;        
+        inline int32_t Begin(int32_t thread_id) const;
         // Return the next to last document for thread thread_i
         inline int32_t End(int32_t thread_id) const;
 
@@ -43,7 +43,7 @@ namespace lda
         int32_t index_document_;
         int64_t used_size_;
 
-        int32_t num_documents_; 
+        int32_t num_documents_;
         size_t corpus_size_;
 
         int64_t* offset_buffer_;    // offset_buffer_ size = num_document_ + 1

--- a/src/Native/LdaNative/lda_engine.cpp
+++ b/src/Native/LdaNative/lda_engine.cpp
@@ -377,9 +377,9 @@ namespace lda {
         std::vector<std::pair<int, double>> llcontainer;
         // Set core affinity which helps performance improvement
 #ifdef _MSC_VER
-        long long maskLL = 0;
+		DWORD maskLL = 0;
         maskLL |= (1LL << (thread_id));
-        DWORD_PTR mask = maskLL;
+		DWORD_PTR mask = maskLL;
         SetThreadAffinityMask(GetCurrentThread(), mask);
 #elif defined(__APPLE__)
         thread_port_t thread = pthread_mach_thread_np(pthread_self());
@@ -542,7 +542,7 @@ namespace lda {
         if (thread_id == 0)
         {
             //output the ll once
-            for (int i = 0; i < llcontainer.size(); i++)
+            for (size_t i = 0; i < llcontainer.size(); i++)
             {
                 printf("loglikelihood @iter%04d = %f\n", llcontainer[i].first, llcontainer[i].second);
             }
@@ -560,7 +560,7 @@ namespace lda {
 
         // Set core affinity which helps performance improvement
 #ifdef _MSC_VER
-        long long maskLL = 0;
+        DWORD maskLL = 0;
         maskLL |= (1LL << (thread_id));
         DWORD_PTR mask = maskLL;
         SetThreadAffinityMask(GetCurrentThread(), mask);

--- a/src/Native/LdaNative/lda_engine.cpp
+++ b/src/Native/LdaNative/lda_engine.cpp
@@ -377,9 +377,9 @@ namespace lda {
         std::vector<std::pair<int, double>> llcontainer;
         // Set core affinity which helps performance improvement
 #ifdef _MSC_VER
-		DWORD maskLL = 0;
+        DWORD maskLL = 0;
         maskLL |= (1LL << (thread_id));
-		DWORD_PTR mask = maskLL;
+        DWORD_PTR mask = maskLL;
         SetThreadAffinityMask(GetCurrentThread(), mask);
 #elif defined(__APPLE__)
         thread_port_t thread = pthread_mach_thread_np(pthread_self());

--- a/src/Native/LdaNative/model_block.cpp
+++ b/src/Native/LdaNative/model_block.cpp
@@ -138,8 +138,8 @@ namespace lda
         alias_mem_block_size_ = static_cast<size_t>(alias_mem_block_size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
 
-        cout << "mem_block_size = " << mem_block_size_ * sizeof(int32_t) << endl;
-        cout << "alias_mem_block_size = " << alias_mem_block_size_ * sizeof(int32_t) << endl;
+        cout << "mem_block_size = " << sizeof(mem_block_size_) << endl;
+        cout << "alias_mem_block_size = " << sizeof(alias_mem_block_size_)<< endl;
 
         offset_ = 0;
         alias_offset_ = 0;
@@ -349,8 +349,8 @@ namespace lda
         alias_mem_block_size_ = static_cast<size_t>(size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
 
-        cout << "mem_block_size = " << mem_block_size_ * 4 << endl;
-        cout << "alias_mem_block_size = " << alias_mem_block_size_ * 4 << endl;
+        cout << "mem_block_size = " << sizeof(mem_block_size_) << endl;
+        cout << "alias_mem_block_size = " << sizeof(alias_mem_block_size_) << endl;
     }
 
     void LDAModelBlock::InitFromDataBlock(const LDADataBlock *data_block, int32_t num_vocabs, int32_t num_topics)

--- a/src/Native/LdaNative/model_block.cpp
+++ b/src/Native/LdaNative/model_block.cpp
@@ -138,8 +138,8 @@ namespace lda
         alias_mem_block_size_ = static_cast<size_t>(alias_mem_block_size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
 
-        cout << "mem_block_size = " << mem_block_size_ * 4 << endl;
-        cout << "alias_mem_block_size = " << alias_mem_block_size_ * 4 << endl;
+        cout << "mem_block_size = " << mem_block_size_ * sizeof(int32_t) << endl;
+        cout << "alias_mem_block_size = " << alias_mem_block_size_ * sizeof(int32_t) << endl;
 
         offset_ = 0;
         alias_offset_ = 0;
@@ -170,7 +170,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of word-topic-table using a sparse representation
-            hot_thresh = numeric_limits<int>::max();
+            hot_thresh = numeric_limits<int32_t>::max();
         }
         else
         {
@@ -180,7 +180,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of alias table using a sparse representation
-            alias_hot_thresh = numeric_limits<int>::max();
+            alias_hot_thresh = numeric_limits<int32_t>::max();
         }
         else
         {
@@ -253,7 +253,7 @@ namespace lda
         {
             // totally sparse
             // use a very large threshold to ensure every row of word-topic-table using a sparse representation
-            hot_thresh = numeric_limits<int>::max();
+            hot_thresh = numeric_limits<int32_t>::max();
         }
         else
         {
@@ -264,7 +264,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of alias table using a sparse representation
-            alias_hot_thresh = numeric_limits<int>::max();
+            alias_hot_thresh = numeric_limits<int32_t>::max();
         }
         else
         {
@@ -400,7 +400,7 @@ namespace lda
         {
             // totally sparse
             // use a very large threshold to ensure every row of word-topic-table using a sparse representation
-            hot_thresh = numeric_limits<int>::max();
+            hot_thresh = numeric_limits<int32_t>::max();
         }
         else
         {
@@ -412,7 +412,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of alias table using a sparse representation
-            alias_hot_thresh = numeric_limits<int>::max();
+            alias_hot_thresh = numeric_limits<int32_t>::max();
         }
         else
         {

--- a/src/Native/LdaNative/model_block.cpp
+++ b/src/Native/LdaNative/model_block.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 #include <vector>
+#include <stdexcept>
+#include <limits>
 #include "utils.hpp"
 #include <stdlib.h>
 #include "model_block.h"
@@ -13,6 +15,8 @@
 
 namespace lda
 {
+	using namespace std;
+
     int64_t upper_bound(int64_t x)
     {
         if (x == 0)
@@ -92,14 +96,21 @@ namespace lda
         dict_ = new WordEntry[num_vocabs_];
         for (int i = 0; i < num_vocabs_; ++i)
         {
-            // This warning is a false positive. Supressing it similar to the existing one on Line 140 below.
-#pragma warning(suppress: 6386)
             dict_[i].is_dense_ = 0;
             dict_[i].is_alias_dense_ = 0;
         }
 
-        mem_block_size_ = 2 * upper_bound(load_factor_ * nonzero_num);
-        alias_mem_block_size_ = nonzero_num * 3; 
+		int64_t size = 2 * upper_bound(load_factor_ * nonzero_num);
+		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+			throw bad_alloc();
+
+        mem_block_size_ = static_cast<size_t>(size);
+
+		size = nonzero_num * 3;
+		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+			throw bad_alloc();
+
+        alias_mem_block_size_ = static_cast<size_t>(size);
 
         mem_block_ = new int32_t[mem_block_size_]();                // NOTE: force to initialize the values to be zero
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    // NOTE: force to initialize the values to be zero
@@ -113,20 +124,23 @@ namespace lda
         dict_ = new WordEntry[num_vocabs_];
         for (int i = 0; i < num_vocabs_; ++i)
         {
-            // This warning is a false positive. Supressing it similar to the existing one on Line 140 below.
-#pragma warning(suppress: 6386)
             dict_[i].is_dense_ = 0;
             dict_[i].is_alias_dense_ = 0;
         }
 
-        mem_block_size_ = mem_block_size;
+		if (mem_block_size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+			throw bad_alloc();
+        mem_block_size_ = static_cast<size_t>(mem_block_size);
+
         mem_block_ = new int32_t[mem_block_size_]();   // NOTE : force to initialize the values to be zero
 
-        alias_mem_block_size_ = alias_mem_block_size;
+		if (alias_mem_block_size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+			throw bad_alloc();
+        alias_mem_block_size_ = static_cast<size_t>(alias_mem_block_size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
 
-        std::cout << "mem_block_size = " << mem_block_size_ * 4 << std::endl;
-        std::cout << "alias_mem_block_size = " << alias_mem_block_size_ * 4 << std::endl;
+        cout << "mem_block_size = " << mem_block_size_ * 4 << endl;
+        cout << "alias_mem_block_size = " << alias_mem_block_size_ * 4 << endl;
 
         offset_ = 0;
         alias_offset_ = 0;
@@ -157,7 +171,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of word-topic-table using a sparse representation
-            hot_thresh = std::numeric_limits<int>::max();
+            hot_thresh = numeric_limits<int>::max();
         }
         else
         {
@@ -167,7 +181,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of alias table using a sparse representation
-            alias_hot_thresh = std::numeric_limits<int>::max();
+            alias_hot_thresh = numeric_limits<int>::max();
         }
         else
         {
@@ -234,13 +248,13 @@ namespace lda
     // in other times, we use hybrid structure (in training phase), fullSparse == false
     void LDAModelBlock::InitModelBlockByTFS(bool fullSparse)
     {
-        const int32_t max_tf_thresh = std::numeric_limits<int32_t>::max();
+        const int32_t max_tf_thresh = numeric_limits<int32_t>::max();
         int32_t hot_thresh;
         if (fullSparse)
         {
             // totally sparse
             // use a very large threshold to ensure every row of word-topic-table using a sparse representation
-            hot_thresh = std::numeric_limits<int>::max();
+            hot_thresh = numeric_limits<int>::max();
         }
         else
         {
@@ -251,7 +265,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of alias table using a sparse representation
-            alias_hot_thresh = std::numeric_limits<int>::max();
+            alias_hot_thresh = numeric_limits<int>::max();
         }
         else
         {
@@ -324,14 +338,20 @@ namespace lda
             alias_offset += alias_row_size;
         }
 
-        mem_block_size_ = dict_[num_vocabs_ - 1].end_offset_;
+		int64_t size = dict_[num_vocabs_ - 1].end_offset_;
+		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+			throw bad_alloc();
+        mem_block_size_ = static_cast<size_t>(size);
         mem_block_ = new int32_t[mem_block_size_]();                // NOTE: force to initialize the values to be zero
 
-        alias_mem_block_size_ = dict_[num_vocabs_ - 1].alias_end_offset_;
+		size = dict_[num_vocabs_ - 1].alias_end_offset_;
+		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+			bad_alloc();
+        alias_mem_block_size_ = static_cast<size_t>(size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
 
-        std::cout << "mem_block_size = " << mem_block_size_ * 4 << std::endl;
-        std::cout << "alias_mem_block_size = " << alias_mem_block_size_ * 4 << std::endl;
+        cout << "mem_block_size = " << mem_block_size_ * 4 << endl;
+        cout << "alias_mem_block_size = " << alias_mem_block_size_ * 4 << endl;
     }
 
     void LDAModelBlock::InitFromDataBlock(const LDADataBlock *data_block, int32_t num_vocabs, int32_t num_topics)
@@ -348,7 +368,7 @@ namespace lda
 
         for (int i = 0; i < doc_num; ++i)
         {
-            std::shared_ptr<LDADocument> doc = data_block->GetOneDoc(i);
+            shared_ptr<LDADocument> doc = data_block->GetOneDoc(i);
             int32_t doc_size = doc->size();
             for (int j = 0; j < doc_size; ++j)
             {
@@ -360,7 +380,7 @@ namespace lda
         InitModelBlockByTFS(false);
     }
     // Count the number of nonzero values in each row
-    void LDAModelBlock::CountNonZero(std::vector<int32_t> &tfs)
+    void LDAModelBlock::CountNonZero(vector<int32_t> &tfs)
     {
         for (int i = 0; i < num_vocabs_; ++i)
         {
@@ -373,15 +393,15 @@ namespace lda
         }
     }
 
-    void LDAModelBlock::GetModelSizeByTFS(bool fullSparse, std::vector<int32_t> &tfs, int64_t &mem_block_size, int64_t &alias_mem_block_size)
+    void LDAModelBlock::GetModelSizeByTFS(bool fullSparse, vector<int32_t> &tfs, int64_t &mem_block_size, int64_t &alias_mem_block_size)
     {
-        const int32_t max_tf_thresh = std::numeric_limits<int32_t>::max();
+        const int32_t max_tf_thresh = numeric_limits<int32_t>::max();
         int32_t hot_thresh;
         if (fullSparse)
         {
             // totally sparse
             // use a very large threshold to ensure every row of word-topic-table using a sparse representation
-            hot_thresh = std::numeric_limits<int>::max();
+            hot_thresh = numeric_limits<int>::max();
         }
         else
         {
@@ -393,7 +413,7 @@ namespace lda
         if (fullSparse)
         {
             // use a very large threshold to ensure every row of alias table using a sparse representation
-            alias_hot_thresh = std::numeric_limits<int>::max();
+            alias_hot_thresh = numeric_limits<int>::max();
         }
         else
         {
@@ -454,7 +474,7 @@ namespace lda
     // This function should not change the internal state of model_block_
     void LDAModelBlock::GetModelStat(int64_t &mem_block_size, int64_t &alias_mem_block_size)
     {
-        std::vector<int32_t> tfs(num_vocabs_, 0);
+        vector<int32_t> tfs(num_vocabs_, 0);
         CountNonZero(tfs);
 
         // calculate the mem_block_size, alias_mem_block_size

--- a/src/Native/LdaNative/model_block.cpp
+++ b/src/Native/LdaNative/model_block.cpp
@@ -100,14 +100,14 @@ namespace lda
             dict_[i].is_alias_dense_ = 0;
         }
 
-		int64_t size = 2 * upper_bound(load_factor_ * nonzero_num);
-		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+		uint64_t size = 2 * upper_bound(load_factor_ * nonzero_num);
+		if (nonzero_num < 0 || size > numeric_limits<size_t>::max())
 			throw bad_alloc();
 
         mem_block_size_ = static_cast<size_t>(size);
 
 		size = nonzero_num * 3;
-		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+		if (size > numeric_limits<size_t>::max())
 			throw bad_alloc();
 
         alias_mem_block_size_ = static_cast<size_t>(size);
@@ -128,13 +128,12 @@ namespace lda
             dict_[i].is_alias_dense_ = 0;
         }
 
-		if (mem_block_size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+		if (mem_block_size < 0 || static_cast<uint64_t>(mem_block_size) > numeric_limits<size_t>::max())
 			throw bad_alloc();
         mem_block_size_ = static_cast<size_t>(mem_block_size);
-
         mem_block_ = new int32_t[mem_block_size_]();   // NOTE : force to initialize the values to be zero
 
-		if (alias_mem_block_size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+		if (mem_block_size < 0 || static_cast<uint64_t>(alias_mem_block_size) > numeric_limits<size_t>::max())
 			throw bad_alloc();
         alias_mem_block_size_ = static_cast<size_t>(alias_mem_block_size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
@@ -338,14 +337,14 @@ namespace lda
             alias_offset += alias_row_size;
         }
 
-		int64_t size = dict_[num_vocabs_ - 1].end_offset_;
-		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+		uint64_t size = dict_[num_vocabs_ - 1].end_offset_;
+		if (size > numeric_limits<size_t>::max())
 			throw bad_alloc();
         mem_block_size_ = static_cast<size_t>(size);
         mem_block_ = new int32_t[mem_block_size_]();                // NOTE: force to initialize the values to be zero
 
 		size = dict_[num_vocabs_ - 1].alias_end_offset_;
-		if (size > numeric_limits<size_t>::max() / sizeof(int64_t) + 1)
+		if (size > numeric_limits<size_t>::max())
 			bad_alloc();
         alias_mem_block_size_ = static_cast<size_t>(size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero

--- a/src/Native/LdaNative/model_block.cpp
+++ b/src/Native/LdaNative/model_block.cpp
@@ -15,7 +15,7 @@
 
 namespace lda
 {
-	using namespace std;
+    using namespace std;
 
     int64_t upper_bound(int64_t x)
     {
@@ -100,15 +100,15 @@ namespace lda
             dict_[i].is_alias_dense_ = 0;
         }
 
-		uint64_t size = 2 * upper_bound(load_factor_ * nonzero_num);
-		if (nonzero_num < 0 || size > numeric_limits<size_t>::max())
-			throw bad_alloc();
+        uint64_t size = 2 * upper_bound(load_factor_ * nonzero_num);
+        if (nonzero_num < 0 || size > numeric_limits<size_t>::max())
+            throw bad_alloc();
 
         mem_block_size_ = static_cast<size_t>(size);
 
-		size = nonzero_num * 3;
-		if (size > numeric_limits<size_t>::max())
-			throw bad_alloc();
+        size = nonzero_num * 3;
+        if (static_cast<uint64_t>(nonzero_num) > numeric_limits<size_t>::max() / 3)
+            throw bad_alloc();
 
         alias_mem_block_size_ = static_cast<size_t>(size);
 
@@ -128,13 +128,13 @@ namespace lda
             dict_[i].is_alias_dense_ = 0;
         }
 
-		if (mem_block_size < 0 || static_cast<uint64_t>(mem_block_size) > numeric_limits<size_t>::max())
-			throw bad_alloc();
+        if (mem_block_size < 0 || static_cast<uint64_t>(mem_block_size) > numeric_limits<size_t>::max())
+            throw bad_alloc();
         mem_block_size_ = static_cast<size_t>(mem_block_size);
         mem_block_ = new int32_t[mem_block_size_]();   // NOTE : force to initialize the values to be zero
 
-		if (mem_block_size < 0 || static_cast<uint64_t>(alias_mem_block_size) > numeric_limits<size_t>::max())
-			throw bad_alloc();
+        if (mem_block_size < 0 || static_cast<uint64_t>(alias_mem_block_size) > numeric_limits<size_t>::max())
+            throw bad_alloc();
         alias_mem_block_size_ = static_cast<size_t>(alias_mem_block_size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
 
@@ -337,15 +337,15 @@ namespace lda
             alias_offset += alias_row_size;
         }
 
-		uint64_t size = dict_[num_vocabs_ - 1].end_offset_;
-		if (size > numeric_limits<size_t>::max())
-			throw bad_alloc();
+        uint64_t size = dict_[num_vocabs_ - 1].end_offset_;
+        if (size > numeric_limits<size_t>::max())
+            throw bad_alloc();
         mem_block_size_ = static_cast<size_t>(size);
         mem_block_ = new int32_t[mem_block_size_]();                // NOTE: force to initialize the values to be zero
 
-		size = dict_[num_vocabs_ - 1].alias_end_offset_;
-		if (size > numeric_limits<size_t>::max())
-			bad_alloc();
+        size = dict_[num_vocabs_ - 1].alias_end_offset_;
+        if (size > numeric_limits<size_t>::max())
+            throw bad_alloc();
         alias_mem_block_size_ = static_cast<size_t>(size);
         alias_mem_block_ = new int32_t[alias_mem_block_size_]();    //NOTE: force to initialize the values to be zero
 
@@ -444,7 +444,7 @@ namespace lda
                 row_size = capacity * 2;
             }
             else
-            {    
+            {
                 capacity = 0;
                 row_size = 0;
             }

--- a/src/Native/LdaNative/model_block.h
+++ b/src/Native/LdaNative/model_block.h
@@ -62,10 +62,10 @@ namespace lda
         int32_t num_topics_;
         WordEntry *dict_;
         int32_t *mem_block_;
-        int64_t mem_block_size_;
+        size_t mem_block_size_;
 
         int32_t *alias_mem_block_;
-        int64_t alias_mem_block_size_;
+        size_t alias_mem_block_size_;
 
         int64_t offset_;
         int64_t alias_offset_;

--- a/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
+++ b/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
@@ -73,7 +73,7 @@ EXPORT_API(void) MFDestroyModel(mf_model_bridge *&model_bridge)
 
     // Delete bridge class allocated in MFTrain, MFTrainWithValidation, or MFCrossValidation.
     delete model_bridge;
-	model_bridge = nullptr;
+    model_bridge = nullptr;
 }
 
 EXPORT_API(mf_model_bridge*) MFTrain(const mf_problem_bridge *prob_bridge, const mf_parameter_bridge *param_bridge)

--- a/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
+++ b/src/Native/MatrixFactorizationNative/UnmanagedMemory.cpp
@@ -115,7 +115,7 @@ EXPORT_API(float) MFCrossValidation(const mf_problem_bridge *prob_bridge, int32_
 {
     auto param = TranslateToParam(param_bridge);
     auto prob = TranslateToProblem(prob_bridge);
-    return mf_cross_validation(&prob, nr_folds, param);
+    return static_cast<float>(mf_cross_validation(&prob, nr_folds, param));
 }
 
 EXPORT_API(float) MFPredict(const mf_model_bridge *model_bridge, int32_t p_idx, int32_t q_idx)


### PR DESCRIPTION
Before, we actually only reported W1 warning level during native build.
Now we warn on L3 warnings
Fixed three warnings from downcasting variables. In all cases the downcasting was deemed safe and replaced with ```static_cast<>```
Note that all those warnings were deemed required to fix for compliance criteria.
This tracks #3370 

