### PR TITLE
Check for IEstimator/ITransformer schema consistency, fix bugs uncovered

### DIFF
--- a/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
+++ b/src/Microsoft.ML.Core/Data/AnnotationUtils.cs
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Data
         public static IEnumerable<SchemaShape.Column> AnnotationsForMulticlassScoreColumn(SchemaShape.Column? labelColumn = null)
         {
             var cols = new List<SchemaShape.Column>();
-            if (labelColumn != null && labelColumn.Value.IsKey)
+            if (labelColumn.HasValue && labelColumn.Value.IsKey)
             {
                 if (labelColumn.Value.Annotations.TryFindColumn(Kinds.KeyValues, out var metaCol) &&
                     metaCol.Kind == SchemaShape.Column.VectorKind.Vector)

--- a/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
+++ b/src/Microsoft.ML.Data/Scorers/RowToRowScorerBase.cs
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Data
             Contracts.Assert(active.Length == bindings.ColumnCount);
 
             var activeInput = bindings.GetActiveInput(columns);
-            Contracts.Assert(activeInput.Count() == bindings.Input.Count);
+            Contracts.Assert(activeInput.Length == bindings.Input.Count);
 
             // Get a predicate that determines which Mapper outputs are active.
             var predicateMapper = bindings.GetActiveMapperColumns(active);

--- a/src/Microsoft.ML.Data/Transforms/Hashing.cs
+++ b/src/Microsoft.ML.Data/Transforms/Hashing.cs
@@ -1274,7 +1274,7 @@ namespace Microsoft.ML.Transforms
                     metadata.Add(slotMeta);
                 if (colInfo.MaximumNumberOfInverts != 0)
                     metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.KeyValues, SchemaShape.Column.VectorKind.Vector, TextDataViewType.Instance, false));
-                result[colInfo.Name] = new SchemaShape.Column(colInfo.Name, col.ItemType is VectorDataViewType ? SchemaShape.Column.VectorKind.Vector : SchemaShape.Column.VectorKind.Scalar, NumberDataViewType.UInt32, true, new SchemaShape(metadata));
+                result[colInfo.Name] = new SchemaShape.Column(colInfo.Name, col.Kind, NumberDataViewType.UInt32, true, new SchemaShape(metadata));
             }
             return new SchemaShape(result.Values);
         }

--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -533,7 +533,7 @@ namespace Microsoft.ML.Transforms
                     throw Host.ExceptParam(nameof(inputSchema), $"Input column '{colInfo.inputColumnName}' doesn't contain key values metadata");
 
                 SchemaShape metadata = null;
-                if (col.Annotations.TryFindColumn(AnnotationUtils.Kinds.SlotNames, out var slotCol))
+                if (col.HasSlotNames() && col.Annotations.TryFindColumn(AnnotationUtils.Kinds.SlotNames, out var slotCol))
                     metadata = new SchemaShape(new[] { slotCol });
 
                 result[colInfo.outputColumnName] = new SchemaShape.Column(colInfo.outputColumnName, col.Kind, keyMetaCol.ItemType, keyMetaCol.IsKey, metadata);

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -305,7 +305,7 @@ namespace Microsoft.ML.Transforms
                     typeNames = null;
                 }
 
-                if (_parent._columns[iinfo].OutputCountVector || srcValueCount == 1)
+                if (_parent._columns[iinfo].OutputCountVector || srcType is PrimitiveDataViewType)
                 {
                     if (typeNames != null)
                     {
@@ -336,7 +336,7 @@ namespace Microsoft.ML.Transforms
                     builder.Add(AnnotationUtils.Kinds.CategoricalSlotRanges, AnnotationUtils.GetCategoricalType(srcValueCount), getter);
                 }
 
-                if (!_parent._columns[iinfo].OutputCountVector || srcValueCount == 1)
+                if (!_parent._columns[iinfo].OutputCountVector || srcType is PrimitiveDataViewType)
                 {
                     ValueGetter<bool> getter = (ref bool dst) =>
                     {

--- a/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/CountFeatureSelection.cs
@@ -131,7 +131,8 @@ namespace Microsoft.ML.Transforms
                     metadata.Add(slotMeta);
                 if (col.Annotations.TryFindColumn(AnnotationUtils.Kinds.CategoricalSlotRanges, out var categoricalSlotMeta))
                     metadata.Add(categoricalSlotMeta);
-                metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar, BooleanDataViewType.Instance, false));
+                if (col.IsNormalized() && col.Annotations.TryFindColumn(AnnotationUtils.Kinds.IsNormalized, out var isNormalizedAnnotation))
+                    metadata.Add(isNormalizedAnnotation);
                 result[colPair.Name] = new SchemaShape.Column(colPair.Name, col.Kind, col.ItemType, false, new SchemaShape(metadata.ToArray()));
             }
             return new SchemaShape(result.Values);

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -232,7 +232,7 @@ namespace Microsoft.ML.Transforms
                     typeNames = null;
                 }
 
-                if (_infos[iinfo].TypeSrc.GetValueCount() == 1)
+                if (_infos[iinfo].TypeSrc is PrimitiveDataViewType)
                 {
                     if (typeNames != null)
                     {

--- a/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
+++ b/src/Microsoft.ML.Transforms/MutualInformationFeatureSelection.cs
@@ -183,7 +183,8 @@ namespace Microsoft.ML.Transforms
                     metadata.Add(slotMeta);
                 if (col.Annotations.TryFindColumn(AnnotationUtils.Kinds.CategoricalSlotRanges, out var categoricalSlotMeta))
                     metadata.Add(categoricalSlotMeta);
-                metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.IsNormalized, SchemaShape.Column.VectorKind.Scalar, BooleanDataViewType.Instance, false));
+                if (col.IsNormalized() && col.Annotations.TryFindColumn(AnnotationUtils.Kinds.IsNormalized, out var isNormalizedAnnotation))
+                    metadata.Add(isNormalizedAnnotation);
                 result[colPair.outputColumnName] = new SchemaShape.Column(colPair.outputColumnName, col.Kind, col.ItemType, false, new SchemaShape(metadata.ToArray()));
             }
             return new SchemaShape(result.Values);
@@ -198,7 +199,7 @@ namespace Microsoft.ML.Transforms
             var host = env.Register(RegistrationName);
             host.CheckValue(options, nameof(options));
             host.CheckValue(input, nameof(input));
-            host.CheckUserArg(Utils.Size(options.Columns) > 0, nameof(options.Columns));
+            host.CheckNonEmpty(options.Columns, nameof(options.Columns));
             host.CheckUserArg(options.SlotsInOutput > 0, nameof(options.SlotsInOutput));
             host.CheckNonWhiteSpace(options.LabelColumn, nameof(options.LabelColumn));
             host.Check(options.NumBins > 1, "numBins must be greater than 1.");

--- a/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramHashingTransformer.cs
@@ -1208,7 +1208,9 @@ namespace Microsoft.ML.Transforms.Text
                         throw _host.ExceptSchemaMismatch(nameof(inputSchema), "input", input, ExpectedColumnType, col.GetTypeString());
                 }
                 var metadata = new List<SchemaShape.Column>();
-                metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, TextDataViewType.Instance, false));
+                // If this is non-zero, we will be doing invert hashing at some level and so have slot names.
+                if (colInfo.MaximumNumberOfInverts != 0)
+                    metadata.Add(new SchemaShape.Column(AnnotationUtils.Kinds.SlotNames, SchemaShape.Column.VectorKind.Vector, TextDataViewType.Instance, false));
                 result[colInfo.Name] = new SchemaShape.Column(colInfo.Name, SchemaShape.Column.VectorKind.Vector, NumberDataViewType.Single, false, new SchemaShape(metadata));
             }
             return new SchemaShape(result.Values);

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipeBase.cs
@@ -151,14 +151,18 @@ namespace Microsoft.ML.RunTests
         private void CheckSameSchemaShape(SchemaShape promised, SchemaShape delivered)
         {
             Assert.True(promised.Count == delivered.Count);
-            var sortedCols1 = promised.OrderBy(x => x.Name);
-            var sortedCols2 = delivered.OrderBy(x => x.Name);
+            var promisedCols = promised.OrderBy(x => x.Name);
+            var deliveredCols = delivered.OrderBy(x => x.Name);
 
-            foreach (var (x, y) in sortedCols1.Zip(sortedCols2, (x, y) => (x, y)))
+            foreach (var (p, d) in promisedCols.Zip(deliveredCols, (p, d) => (p, d)))
             {
-                Assert.Equal(x.Name, y.Name);
+                Assert.Equal(p.Name, d.Name);
                 // We want the 'promised' metadata to be a superset of 'delivered'.
-                Assert.True(y.IsCompatibleWith(x), $"Mismatch on {x.Name}");
+                Assert.True(d.IsCompatibleWith(p), $"Mismatch on {p.Name}, there was a mismatch, or some unexpected annotations was present.");
+                // We also want the 'delivered' to be a superset of 'promised'. Since the above
+                // test must have worked if we got this far, I believe the only plausible reason
+                // this could happen is if there was something promised but not delivered.
+                Assert.True(p.IsCompatibleWith(d), $"Mismatch on {p.Name}, something was promised in the annotations but not delivered.");
             }
         }
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/CalibratorEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/CalibratorEstimators.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             CheckValidCalibratedData(calibratorTestData.ScoredData, fixedPlattCalibratorTransformer);
 
             //test estimator
-            TestEstimatorCore(calibratorTestData.Pipeline, calibratorTestData.Data);
+            TestEstimatorCore(fixedPlattCalibratorEstimator, calibratorTestData.ScoredData);
 
             Done();
         }
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             CheckValidCalibratedData(calibratorTestData.ScoredData, naiveCalibratorTransformer);
 
             //test estimator
-            TestEstimatorCore(calibratorTestData.Pipeline, calibratorTestData.Data);
+            TestEstimatorCore(naiveCalibratorEstimator, calibratorTestData.ScoredData);
 
             Done();
         }
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             CheckValidCalibratedData(calibratorTestData.ScoredData, pavCalibratorTransformer);
 
             //test estimator
-            TestEstimatorCore(calibratorTestData.Pipeline, calibratorTestData.Data);
+            TestEstimatorCore(pavCalibratorEstimator, calibratorTestData.ScoredData);
 
             Done();
         }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 new SdcaNonCalibratedBinaryTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1 });
 
             pipeline = pipeline.Append(ML.MulticlassClassification.Trainers.PairwiseCoupling(sdcaTrainer))
-                    .Append(ML.Transforms.Conversion.MapKeyToValue("PredictedLabel"));
+                    .Append(ML.Transforms.Conversion.MapKeyToValue("PredictedLabelValue", "PredictedLabel"));
 
             TestEstimatorCore(pipeline, data);
             Done();

--- a/test/Microsoft.ML.Tests/Transformers/CategoricalHashTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/CategoricalHashTests.cs
@@ -65,7 +65,8 @@ namespace Microsoft.ML.Tests.Transformers
             string dataPath = GetDataPath("breast-cancer.txt");
             var reader = TextLoaderStatic.CreateLoader(ML, ctx => (
                 ScalarString: ctx.LoadText(1),
-                VectorString: ctx.LoadText(1, 4)));
+                VectorString: ctx.LoadText(1, 4),
+                SingleVectorString: ctx.LoadText(1, 1)));
             var data = reader.Load(dataPath);
             var wrongCollection = new[] { new TestClass() { A = "1", B = "2", C = "3", }, new TestClass() { A = "4", B = "5", C = "6" } };
 
@@ -74,6 +75,7 @@ namespace Microsoft.ML.Tests.Transformers
                   Append(row => (
                       row.ScalarString,
                       row.VectorString,
+                      row.SingleVectorString,
                       // Create a VarVector column
                       VarVectorString: row.ScalarString.TokenizeIntoWords())).
                   Append(row => (
@@ -82,7 +84,9 @@ namespace Microsoft.ML.Tests.Transformers
                       C: row.VectorString.OneHotHashEncoding(outputKind: CategoricalHashStaticExtensions.OneHotHashVectorOutputKind.Bag),
                       D: row.ScalarString.OneHotHashEncoding(outputKind: CategoricalHashStaticExtensions.OneHotHashScalarOutputKind.Bin),
                       E: row.VectorString.OneHotHashEncoding(outputKind: CategoricalHashStaticExtensions.OneHotHashVectorOutputKind.Bin),
-                      F: row.VarVectorString.OneHotHashEncoding()
+                      F: row.VarVectorString.OneHotHashEncoding(),
+                      // The following column and SingleVectorString are meant to test the special case of a vector that happens to be of length 1.
+                      G: row.SingleVectorString.OneHotHashEncoding(outputKind: CategoricalHashStaticExtensions.OneHotHashVectorOutputKind.Bag)
                   ));
 
             TestEstimatorCore(est.AsDynamic, data.AsDynamic, invalidInput: invalidData);

--- a/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/TextFeaturizerTests.cs
@@ -542,7 +542,10 @@ namespace Microsoft.ML.Tests.Transformers
             var est = new WordTokenizingEstimator(ML, "text", "text")
                 .Append(new ValueToKeyMappingEstimator(ML, "terms", "text"))
                 .Append(new NgramExtractingEstimator(ML, "ngrams", "terms"))
-                .Append(new NgramHashingEstimator(ML, "ngramshash", "terms"));
+                .Append(new NgramHashingEstimator(ML, "ngramshash", "terms"))
+                // Also have a situation where we use invert hashing. However we only write
+                // the original non-inverted column to the actual baseline file.
+                .Append(new NgramHashingEstimator(ML, "ngramshashinvert", "terms", maximumNumberOfInverts: 2));
 
             TestEstimatorCore(est, data.AsDynamic, invalidInput: invalidData.AsDynamic);
 


### PR DESCRIPTION
Fixes #3380.

The commits are one first commit where I change the test of estimators, and subsequent commits are where I fix each of the bugs in `IEstimator`/`ITransformer` pairs that were revealed through that stricter test.

Note that that calibrator change (the last commit at the time of writing), and the `KeyToVector`/`KeyToBinaryVector` change (third commit) result in actual changes to the annotation data produced by the transformers, so could be considered behavioral changes. However I do not anticipate a negative effect.

Some tests were also changed a little bit to give greater coverage.