### PR TITLE
[AutoML] CLI CodeGen printing L1 instead of RMS

### DIFF
--- a/src/mlnet/Templates/Console/ModelBuilder.tt
+++ b/src/mlnet/Templates/Console/ModelBuilder.tt
@@ -195,11 +195,11 @@ else{#>
             Console.WriteLine($"*************************************************************************************************************");
             Console.WriteLine($"*       Metrics for Regression model      ");
             Console.WriteLine($"*------------------------------------------------------------------------------------------------------------");
-            Console.WriteLine($"*       Average L1 Loss:    {L1.Average():0.###} ");
-            Console.WriteLine($"*       Average L2 Loss:    {L2.Average():0.###}  ");
-            Console.WriteLine($"*       Average RMS:          {RMS.Average():0.###}  ");
+            Console.WriteLine($"*       Average L1 Loss:       {L1.Average():0.###} ");
+            Console.WriteLine($"*       Average L2 Loss:       {L2.Average():0.###}  ");
+            Console.WriteLine($"*       Average RMS:           {RMS.Average():0.###}  ");
             Console.WriteLine($"*       Average Loss Function: {lossFunction.Average():0.###}  ");
-            Console.WriteLine($"*       Average R-squared: {R2.Average():0.###}  ");
+            Console.WriteLine($"*       Average R-squared:     {R2.Average():0.###}  ");
             Console.WriteLine($"*************************************************************************************************************");
         }
 <# } if("BinaryClassification".Equals(TaskType)){ #>

--- a/src/mlnet/Templates/Console/ModelBuilder.tt
+++ b/src/mlnet/Templates/Console/ModelBuilder.tt
@@ -188,7 +188,7 @@ else{#>
         {
             var L1 = crossValidationResults.Select(r => r.Metrics.MeanAbsoluteError);
             var L2 = crossValidationResults.Select(r => r.Metrics.MeanSquaredError);
-            var RMS = crossValidationResults.Select(r => r.Metrics.MeanAbsoluteError);
+            var RMS = crossValidationResults.Select(r => r.Metrics.RootMeanSquaredError);
             var lossFunction = crossValidationResults.Select(r => r.Metrics.LossFunction);
             var R2 = crossValidationResults.Select(r => r.Metrics.RSquared);
 

--- a/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppModelBuilderCSFileContentRegressionTest.approved.txt
+++ b/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppModelBuilderCSFileContentRegressionTest.approved.txt
@@ -119,7 +119,7 @@ namespace TestNamespace.ConsoleApp
         {
             var L1 = crossValidationResults.Select(r => r.Metrics.MeanAbsoluteError);
             var L2 = crossValidationResults.Select(r => r.Metrics.MeanSquaredError);
-            var RMS = crossValidationResults.Select(r => r.Metrics.MeanAbsoluteError);
+            var RMS = crossValidationResults.Select(r => r.Metrics.RootMeanSquaredError);
             var lossFunction = crossValidationResults.Select(r => r.Metrics.LossFunction);
             var R2 = crossValidationResults.Select(r => r.Metrics.RSquared);
 

--- a/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppModelBuilderCSFileContentRegressionTest.approved.txt
+++ b/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppModelBuilderCSFileContentRegressionTest.approved.txt
@@ -126,11 +126,11 @@ namespace TestNamespace.ConsoleApp
             Console.WriteLine($"*************************************************************************************************************");
             Console.WriteLine($"*       Metrics for Regression model      ");
             Console.WriteLine($"*------------------------------------------------------------------------------------------------------------");
-            Console.WriteLine($"*       Average L1 Loss:    {L1.Average():0.###} ");
-            Console.WriteLine($"*       Average L2 Loss:    {L2.Average():0.###}  ");
-            Console.WriteLine($"*       Average RMS:          {RMS.Average():0.###}  ");
+            Console.WriteLine($"*       Average L1 Loss:       {L1.Average():0.###} ");
+            Console.WriteLine($"*       Average L2 Loss:       {L2.Average():0.###}  ");
+            Console.WriteLine($"*       Average RMS:           {RMS.Average():0.###}  ");
             Console.WriteLine($"*       Average Loss Function: {lossFunction.Average():0.###}  ");
-            Console.WriteLine($"*       Average R-squared: {R2.Average():0.###}  ");
+            Console.WriteLine($"*       Average R-squared:     {R2.Average():0.###}  ");
             Console.WriteLine($"*************************************************************************************************************");
         }
     }


### PR DESCRIPTION
CodeGen was printing the L1 Error in the RMS field.

```md
=============== Cross-validating to get model's accuracy metrics ===============
*************************************************************************************************************
*       Metrics for Regression model      
*------------------------------------------------------------------------------------------------------------
*       Average L1 Loss:    298.351 
*       Average L2 Loss:    186688.889  
*       Average RMS:          298.351  
*       Average Loss Function: 186688.889  
*       Average R-squared: 0.687  
*************************************************************************************************************
=============== Training  model ===============
=============== End of training process ===============
=============== Saving the model  ===============
The model is saved to /private/tmp/blah/openfoodfactsIngredientsToCalories/openfoodfactsIngredientsToCalories.ConsoleApp/bin/Release/netcoreapp2.1/../../../../OpenfoodfactsIngredientsToCalories.Model/MLModel.zip
```
Notice the `298.351` twice.
