### PR TITLE
[Fix Latex Code] Use textbr for vectors

### DIFF
--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Trainers
     /// Assume that user IDs and music IDs are used as row and column indexes, respectively, and matrix's values are ratings provided by those users.
     /// That is, rating $r$ at row $u$ and column $v$ means that user $u$ give $r$ to item $v$.
     /// An incomplete matrix is very common because not all users may provide their feedbacks to all products (for example, no one can rate ten million songs).
-    /// Assume that $R\in{\mathcal R}^{m\times n}$ is a m-by-n rating matrix and the [rank](https://en.wikipedia.org/wiki/Rank_(linear_algebra)) of the two factor matrices are $P\in {\mathcal R}^{k\times m}$ and $Q\in {\mathcal R}^{k\times n}$, where $k$ is the approximation rank.
+    /// Assume that $R\in{\mathbb R}^{m\times n}$ is a m-by-n rating matrix and the [rank](https://en.wikipedia.org/wiki/Rank_(linear_algebra)) of the two factor matrices are $P\in {\mathbb R}^{k\times m}$ and $Q\in {\mathbb R}^{k\times n}$, where $k$ is the approximation rank.
     /// The predicted rating at the $u$-th row and the $v$-th column in $R$ would be the inner product of the $u$-th row of $P$ and the $v$-th row of $Q$; that is, $R$ is approximated by the product of $P$'s transpose ($P^T$) and $Q$.
     /// Note that $k$ is usually much smaller than $m$ and $n$, so $P^T Q$ is usually called a low-rank approximation of $R$.
     ///

--- a/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
+++ b/src/Microsoft.ML.Recommender/MatrixFactorizationTrainer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Trainers
     /// Assume that user IDs and music IDs are used as row and column indexes, respectively, and matrix's values are ratings provided by those users.
     /// That is, rating $r$ at row $u$ and column $v$ means that user $u$ give $r$ to item $v$.
     /// An incomplete matrix is very common because not all users may provide their feedbacks to all products (for example, no one can rate ten million songs).
-    /// Assume that $R\in{\mathbb R}^{m\times n}$ is a m-by-n rating matrix and the [rank](https://en.wikipedia.org/wiki/Rank_(linear_algebra)) of the two factor matrices are $P\in {\mathbb R}^{k\times m}$ and $Q\in {\mathbb R}^{k\times n}$, where $k$ is the approximation rank.
+    /// Assume that $R\in{\mathcal R}^{m\times n}$ is a m-by-n rating matrix and the [rank](https://en.wikipedia.org/wiki/Rank_(linear_algebra)) of the two factor matrices are $P\in {\mathcal R}^{k\times m}$ and $Q\in {\mathcal R}^{k\times n}$, where $k$ is the approximation rank.
     /// The predicted rating at the $u$-th row and the $v$-th column in $R$ would be the inner product of the $u$-th row of $P$ and the $v$-th row of $Q$; that is, $R$ is approximated by the product of $P$'s transpose ($P^T$) and $Q$.
     /// Note that $k$ is usually much smaller than $m$ and $n$, so $P^T Q$ is usually called a low-rank approximation of $R$.
     ///

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -67,9 +67,9 @@ namespace Microsoft.ML.Trainers
     ///
     /// ### Scoring Function
     /// Field-aware factorization machine is a scoring function which maps feature vectors from different fields to a scalar score.
-    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\textbf{ {x}} \in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
-    /// The corresponding score is $\hat{y}\left(\textbf{ {x}}\right) = \left\langle \textbf{ {w}}, \textbf{ {x}} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \textbf{ {v}}_{j, {\mathcal F}(j')} , \textbf{ {v}}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
-    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\textbf{ {w}} \in {\mathbb R}^n$ stores the linear coefficients, and $\textbf{ {v}}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
+    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\textbf{x} \in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
+    /// The corresponding score is $\hat{y}\left(\textbf{x}\right) = \left\langle \textbf{w}, \textbf{x} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \textbf{v}_{j, {\mathcal F}(j')} , \textbf{v}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
+    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\textbf{w} \in {\mathbb R}^n$ stores the linear coefficients, and $\textbf{v}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
     /// Note that $k$ is the latent dimension specified by the user.
     /// The predicted label is the sign of $\hat{y}$. If $\hat{y} > 0$, this model predicts true. Otherwise, it predicts false.
     /// For a systematic introduction to field-aware factorization machine, please see [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf)

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -67,9 +67,9 @@ namespace Microsoft.ML.Trainers
     ///
     /// ### Scoring Function
     /// Field-aware factorization machine is a scoring function which maps feature vectors from different fields to a scalar score.
-    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\mathbb{x}\in {\mathcal R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
-    /// The corresponding score is $\hat{y}\left(\mathbb{x}\right) = \left\langle \mathbb{w}, \mathbb{x} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \mathbb{v}_{j, {\mathcal F}(j')} , \mathbb{v}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
-    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\mathbb{w}\in{\mathcal R}^n$ stores the linear coefficients, and $\mathbb{v}_{j, f}\in {\mathcal R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
+    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
+    /// The corresponding score is $\hat{y}\left(\textbf{\textit{x}}\right) = \left\langle \textbf{\textit{w}}, \textbf{\textit{x}} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \textbf{\textit{v}}_{j, {\mathcal F}(j')} , \textbf{\textit{v}}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
+    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\textbf{\textit{w}} \in {\mathcal R}^n$ stores the linear coefficients, and $\textbf{\textit{v}}_{j, f}\in {\mathcal R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
     /// Note that $k$ is the latent dimension specified by the user.
     /// The predicted label is the sign of $\hat{y}$. If $\hat{y} > 0$, this model predicts true. Otherwise, it predicts false.
     /// For a systematic introduction to field-aware factorization machine, please see [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf)

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -67,9 +67,9 @@ namespace Microsoft.ML.Trainers
     ///
     /// ### Scoring Function
     /// Field-aware factorization machine is a scoring function which maps feature vectors from different fields to a scalar score.
-    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\mathbb{x}\in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
+    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\mathbb{x}\in {\mathcal R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
     /// The corresponding score is $\hat{y}\left(\mathbb{x}\right) = \left\langle \mathbb{w}, \mathbb{x} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \mathbb{v}_{j, {\mathcal F}(j')} , \mathbb{v}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
-    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\mathbb{w}\in{\mathbb R}^n$ stores the linear coefficients, and $\mathbb{v}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
+    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\mathbb{w}\in{\mathcal R}^n$ stores the linear coefficients, and $\mathbb{v}_{j, f}\in {\mathcal R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
     /// Note that $k$ is the latent dimension specified by the user.
     /// The predicted label is the sign of $\hat{y}$. If $\hat{y} > 0$, this model predicts true. Otherwise, it predicts false.
     /// For a systematic introduction to field-aware factorization machine, please see [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf)

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -67,9 +67,9 @@ namespace Microsoft.ML.Trainers
     ///
     /// ### Scoring Function
     /// Field-aware factorization machine is a scoring function which maps feature vectors from different fields to a scalar score.
-    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
-    /// The corresponding score is $\hat{y}\left(\textbf{\textit{x}}\right) = \left\langle \textbf{\textit{w}}, \textbf{\textit{x}} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \textbf{\textit{v}}_{j, {\mathcal F}(j')} , \textbf{\textit{v}}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
-    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\textbf{\textit{w}} \in {\mathbb R}^n$ stores the linear coefficients, and $\textbf{\textit{v}}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
+    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\textbf{ {x}} \in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
+    /// The corresponding score is $\hat{y}\left(\textbf{ {x}}\right) = \left\langle \textbf{ {w}}, \textbf{ {x}} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \textbf{ {v}}_{j, {\mathcal F}(j')} , \textbf{ {v}}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
+    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\textbf{ {w}} \in {\mathbb R}^n$ stores the linear coefficients, and $\textbf{ {v}}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
     /// Note that $k$ is the latent dimension specified by the user.
     /// The predicted label is the sign of $\hat{y}$. If $\hat{y} > 0$, this model predicts true. Otherwise, it predicts false.
     /// For a systematic introduction to field-aware factorization machine, please see [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf)

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -67,9 +67,9 @@ namespace Microsoft.ML.Trainers
     ///
     /// ### Scoring Function
     /// Field-aware factorization machine is a scoring function which maps feature vectors from different fields to a scalar score.
-    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\boldsymbol{x}\in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
-    /// The corresponding score is $\hat{y}\left(\boldsymbol{x}\right) = \left\langle \boldsymbol{w}, \boldsymbol{x} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \boldsymbol{v}_{j, {\mathcal F}(j')} , \boldsymbol{v}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
-    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\boldsymbol{w}\in{\mathbb R}^n$ stores the linear coefficients, and $\boldsymbol{v}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
+    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\mathbb{x}\in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
+    /// The corresponding score is $\hat{y}\left(\mathbb{x}\right) = \left\langle \mathbb{w}, \mathbb{x} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \mathbb{v}_{j, {\mathcal F}(j')} , \mathbb{v}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
+    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\mathbb{w}\in{\mathbb R}^n$ stores the linear coefficients, and $\mathbb{v}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
     /// Note that $k$ is the latent dimension specified by the user.
     /// The predicted label is the sign of $\hat{y}$. If $\hat{y} > 0$, this model predicts true. Otherwise, it predicts false.
     /// For a systematic introduction to field-aware factorization machine, please see [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf)

--- a/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/FactorizationMachine/FactorizationMachineTrainer.cs
@@ -67,9 +67,9 @@ namespace Microsoft.ML.Trainers
     ///
     /// ### Scoring Function
     /// Field-aware factorization machine is a scoring function which maps feature vectors from different fields to a scalar score.
-    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
+    /// Assume that all $m$ feature columns are concatenated into a long feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$ and ${\mathcal F}(j)$ denotes the $j$-th feature's field indentifier.
     /// The corresponding score is $\hat{y}\left(\textbf{\textit{x}}\right) = \left\langle \textbf{\textit{w}}, \textbf{\textit{x}} \right\rangle + \sum_{j = 1}^n \sum_{j' = j + 1}^n \left\langle \textbf{\textit{v}}_{j, {\mathcal F}(j')} , \textbf{\textit{v}}_{j', {\mathcal F}(j)} \right\rangle x_j x_{j'}$,
-    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\textbf{\textit{w}} \in {\mathcal R}^n$ stores the linear coefficients, and $\textbf{\textit{v}}_{j, f}\in {\mathcal R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
+    /// where $\left\langle \cdot, \cdot \right\rangle$ is the inner product operator, $\textbf{\textit{w}} \in {\mathbb R}^n$ stores the linear coefficients, and $\textbf{\textit{v}}_{j, f}\in {\mathbb R}^k$ is the $j$-th feature's representation in the $f$-th field's latent space.
     /// Note that $k$ is the latent dimension specified by the user.
     /// The predicted label is the sign of $\hat{y}$. If $\hat{y} > 0$, this model predicts true. Otherwise, it predicts false.
     /// For a systematic introduction to field-aware factorization machine, please see [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf)

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Trainers
     /// | Required NuGet in addition to Microsoft.ML | None |
     ///
     /// ### Scoring Function
-    /// Linear logistic regression is a variant of linear model. It maps feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$ to a scalar via $\hat{y}\left( \textbf{\textit{x}} \right) = \textbf{\textit{w}}^T  \textbf{\textit{x}} + b = \sum_{j=1}^n w_j x_j + b$,
+    /// Linear logistic regression is a variant of linear model. It maps feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left( \textbf{\textit{x}} \right) = \textbf{\textit{w}}^T  \textbf{\textit{x}} + b = \sum_{j=1}^n w_j x_j + b$,
     /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\textbf{\textit{w}}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
     /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left( \textbf{\textit{x}} \right)}}$.
     ///

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
@@ -46,9 +46,9 @@ namespace Microsoft.ML.Trainers
     /// | Required NuGet in addition to Microsoft.ML | None |
     ///
     /// ### Scoring Function
-    /// Linear logistic regression is a variant of linear model. It maps feature vector $\mathbb{x} \in {\mathcal R}^n$ to a scalar via $\hat{y}\left(\mathbb{x}\right) = \mathbb{w}^T  \mathbb{x} + b = \sum_{j=1}^n w_j x_j + b$,
-    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\mathbb{w}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
-    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left(\mathbb{x}\right)}}$.
+    /// Linear logistic regression is a variant of linear model. It maps feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$ to a scalar via $\hat{y}\left( \textbf{\textit{x}} \right) = \textbf{\textit{w}}^T  \textbf{\textit{x}} + b = \sum_{j=1}^n w_j x_j + b$,
+    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\textbf{\textit{w}}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
+    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left( \textbf{\textit{x}} \right)}}$.
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -61,9 +61,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \mathbb{w} ||_1$, and L2-norm (ridge), $|| \mathbb{w} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{\textit{w}} ||_1$, and L2-norm (ridge), $|| \textbf{\textit{w}} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\mathbb{w}$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{\textit{w}}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
@@ -46,9 +46,9 @@ namespace Microsoft.ML.Trainers
     /// | Required NuGet in addition to Microsoft.ML | None |
     ///
     /// ### Scoring Function
-    /// Linear logistic regression is a variant of linear model. It maps feature vector $\boldsymbol{x} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left(\boldsymbol{x}\right) = \boldsymbol{w}^T  \boldsymbol{x} + b = \sum_{j=1}^n w_j x_j + b$,
-    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\boldsymbol{w}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
-    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left(\boldsymbol{x}\right)}}$.
+    /// Linear logistic regression is a variant of linear model. It maps feature vector $\mathbb{x} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left(\mathbb{x}\right) = \mathbb{w}^T  \mathbb{x} + b = \sum_{j=1}^n w_j x_j + b$,
+    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\mathbb{w}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
+    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left(\mathbb{x}\right)}}$.
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -61,9 +61,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \boldsymbol{w} ||_1$, and L2-norm (ridge), $|| \boldsymbol{w} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \mathbb{w} ||_1$, and L2-norm (ridge), $|| \mathbb{w} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\boldsymbol{w}$.
+    /// Using L1-norm can increase sparsity of the trained $\mathbb{w}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
@@ -46,9 +46,9 @@ namespace Microsoft.ML.Trainers
     /// | Required NuGet in addition to Microsoft.ML | None |
     ///
     /// ### Scoring Function
-    /// Linear logistic regression is a variant of linear model. It maps feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left( \textbf{\textit{x}} \right) = \textbf{\textit{w}}^T  \textbf{\textit{x}} + b = \sum_{j=1}^n w_j x_j + b$,
-    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\textbf{\textit{w}}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
-    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left( \textbf{\textit{x}} \right)}}$.
+    /// Linear logistic regression is a variant of linear model. It maps feature vector $\textbf{ {x}} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left( \textbf{ {x}} \right) = \textbf{ {w}}^T  \textbf{ {x}} + b = \sum_{j=1}^n w_j x_j + b$,
+    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\textbf{ {w}}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
+    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left( \textbf{ {x}} \right)}}$.
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -61,9 +61,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{\textit{w}} ||_1$, and L2-norm (ridge), $|| \textbf{\textit{w}} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{ {w}} ||_1$, and L2-norm (ridge), $|| \textbf{ {w}} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\textbf{\textit{w}}$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{ {w}}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
@@ -46,9 +46,9 @@ namespace Microsoft.ML.Trainers
     /// | Required NuGet in addition to Microsoft.ML | None |
     ///
     /// ### Scoring Function
-    /// Linear logistic regression is a variant of linear model. It maps feature vector $\textbf{ {x}} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left( \textbf{ {x}} \right) = \textbf{ {w}}^T  \textbf{ {x}} + b = \sum_{j=1}^n w_j x_j + b$,
-    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\textbf{ {w}}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
-    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left( \textbf{ {x}} \right)}}$.
+    /// Linear logistic regression is a variant of linear model. It maps feature vector $\textbf{x} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left( \textbf{x} \right) = \textbf{w}^T  \textbf{x} + b = \sum_{j=1}^n w_j x_j + b$,
+    /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\textbf{w}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
+    /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left( \textbf{x} \right)}}$.
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -61,9 +61,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{ {w}} ||_1$, and L2-norm (ridge), $|| \textbf{ {w}} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{w} ||_1$, and L2-norm (ridge), $|| \textbf{w} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\textbf{ {w}}$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{w}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/LogisticRegression.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Trainers
     /// | Required NuGet in addition to Microsoft.ML | None |
     ///
     /// ### Scoring Function
-    /// Linear logistic regression is a variant of linear model. It maps feature vector $\mathbb{x} \in {\mathbb R}^n$ to a scalar via $\hat{y}\left(\mathbb{x}\right) = \mathbb{w}^T  \mathbb{x} + b = \sum_{j=1}^n w_j x_j + b$,
+    /// Linear logistic regression is a variant of linear model. It maps feature vector $\mathbb{x} \in {\mathcal R}^n$ to a scalar via $\hat{y}\left(\mathbb{x}\right) = \mathbb{w}^T  \mathbb{x} + b = \sum_{j=1}^n w_j x_j + b$,
     /// where the $x_j$ is the $j$-th feature's value, the $j$-th element of $\mathbb{w}$ is the $j$-th feature's coefficient, and $b$ is a learnable bias.
     /// The corresponding probability of getting a true label is $\frac{1}{1 + e^{\hat{y}\left(\mathbb{x}\right)}}$.
     ///

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -64,8 +64,8 @@ namespace Microsoft.ML.Trainers
     /// See Section 1 in [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/maxent_dual.pdf) for a detailed introduction.
     ///
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score is $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
     /// The probability of $\textbf{\textit{x}}$ belonging to class $c$ is defined by $\tilde{P}(c | \textbf{\textit{x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
     /// Let $P(c, \textbf{\textit{x}})$ denote the join probability of seeing $c$ and $\textbf{\textit{x}}$.
     /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \textbf{\textit{x}}) \log \tilde{P}(c | \textbf{\textit{x}}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -64,11 +64,11 @@ namespace Microsoft.ML.Trainers
     /// See Section 1 in [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/maxent_dual.pdf) for a detailed introduction.
     ///
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
-    /// The probability of $\textbf{\textit{x}}$ belonging to class $c$ is defined by $\tilde{P}(c | \textbf{\textit{x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
-    /// Let $P(c, \textbf{\textit{x}})$ denote the join probability of seeing $c$ and $\textbf{\textit{x}}$.
-    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \textbf{\textit{x}}) \log \tilde{P}(c | \textbf{\textit{x}}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
+    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
+    /// The probability of $\textbf{ {x}}$ belonging to class $c$ is defined by $\tilde{P}(c | \textbf{ {x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
+    /// Let $P(c, \textbf{ {x}})$ denote the join probability of seeing $c$ and $\textbf{ {x}}$.
+    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \textbf{ {x}}) \log \tilde{P}(c | \textbf{ {x}}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -81,9 +81,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{\textit{w}} ||_1$, and L2-norm (ridge), $|| \textbf{\textit{w}} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{ {w}} ||_1$, and L2-norm (ridge), $|| \textbf{ {w}} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\textbf{\textit{w}}$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{ {w}}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no reource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -64,11 +64,11 @@ namespace Microsoft.ML.Trainers
     /// See Section 1 in [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/maxent_dual.pdf) for a detailed introduction.
     ///
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score is $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
-    /// The probability of $\mathbb{x}$ belonging to class $c$ is defined by $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
-    /// Let $P(c, \mathbb{x})$ denote the join probability of seeing $c$ and $\mathbb{x}$.
-    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \mathbb{x}) \log \tilde{P}(c|\mathbb{x}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
+    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score is $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// The probability of $\textbf{\textit{x}}$ belonging to class $c$ is defined by $\tilde{P}(c | \textbf{\textit{x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
+    /// Let $P(c, \textbf{\textit{x}})$ denote the join probability of seeing $c$ and $\textbf{\textit{x}}$.
+    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \textbf{\textit{x}}) \log \tilde{P}(c | \textbf{\textit{x}}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -81,9 +81,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \mathbb{w} ||_1$, and L2-norm (ridge), $|| \mathbb{w} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{\textit{w}} ||_1$, and L2-norm (ridge), $|| \textbf{\textit{w}} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\mathbb{w}$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{\textit{w}}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no reource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -64,8 +64,8 @@ namespace Microsoft.ML.Trainers
     /// See Section 1 in [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/maxent_dual.pdf) for a detailed introduction.
     ///
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score is $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
     /// The probability of $\mathbb{x}$ belonging to class $c$ is defined by $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
     /// Let $P(c, \mathbb{x})$ denote the join probability of seeing $c$ and $\mathbb{x}$.
     /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \mathbb{x}) \log \tilde{P}(c|\mathbb{x}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -64,11 +64,11 @@ namespace Microsoft.ML.Trainers
     /// See Section 1 in [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/maxent_dual.pdf) for a detailed introduction.
     ///
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\boldsymbol{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\boldsymbol{x} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \boldsymbol{w}_c^T \boldsymbol{x} + b_c$.
-    /// The probability of $\boldsymbol{x}$ belonging to class $c$ is defined by $\tilde{P}(c|\boldsymbol{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
-    /// Let $P(c, \boldsymbol{x})$ denote the join probability of seeing $c$ and $\boldsymbol{x}$.
-    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \boldsymbol{x}) \log \tilde{P}(c|\boldsymbol{x}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
+    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// The probability of $\mathbb{x}$ belonging to class $c$ is defined by $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
+    /// Let $P(c, \mathbb{x})$ denote the join probability of seeing $c$ and $\mathbb{x}$.
+    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \mathbb{x}) \log \tilde{P}(c|\mathbb{x}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -81,9 +81,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \boldsymbol{w} ||_1$, and L2-norm (ridge), $|| \boldsymbol{w} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \mathbb{w} ||_1$, and L2-norm (ridge), $|| \mathbb{w} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\boldsymbol{w}$.
+    /// Using L1-norm can increase sparsity of the trained $\mathbb{w}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no reource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/LogisticRegression/MulticlassLogisticRegression.cs
@@ -64,11 +64,11 @@ namespace Microsoft.ML.Trainers
     /// See Section 1 in [this paper](https://www.csie.ntu.edu.tw/~cjlin/papers/maxent_dual.pdf) for a detailed introduction.
     ///
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
-    /// The probability of $\textbf{ {x}}$ belonging to class $c$ is defined by $\tilde{P}(c | \textbf{ {x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
-    /// Let $P(c, \textbf{ {x}})$ denote the join probability of seeing $c$ and $\textbf{ {x}}$.
-    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \textbf{ {x}}) \log \tilde{P}(c | \textbf{ {x}}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
+    /// Maximum entropy model assigns the $c$-th class a coefficient vector $\textbf{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{x} \in {\mathbb R}^n$, the $c$-th class's score is $\hat{y}^c = \textbf{w}_c^T \textbf{x} + b_c$.
+    /// The probability of $\textbf{x}$ belonging to class $c$ is defined by $\tilde{P}(c | \textbf{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$.
+    /// Let $P(c, \textbf{x})$ denote the join probability of seeing $c$ and $\textbf{x}$.
+    /// The loss function minimized by this trainer is $-\sum_{c = 1}^m P(c, \textbf{x}) \log \tilde{P}(c | \textbf{x}) $, which is the negative [log-likelihood function](https://en.wikipedia.org/wiki/Likelihood_function#Log-likelihood).
     ///
     /// ### Training Algorithm Details
     /// The optimization technique implemented is based on [the limited memory Broyden-Fletcher-Goldfarb-Shanno method (L-BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS).
@@ -81,9 +81,9 @@ namespace Microsoft.ML.Trainers
     /// Regularization works by adding the penalty that is associated with coefficient values to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{ {w}} ||_1$, and L2-norm (ridge), $|| \textbf{ {w}} ||_2^2$ regularizations.
+    /// This learner supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{w} ||_1$, and L2-norm (ridge), $|| \textbf{w} ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\textbf{ {w}}$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{w}$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no reource will be spent on those bad features when making prediction.
     /// If L1-norm regularization is used, the used training algorithm would be [QWL-QN](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.68.5260).
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
@@ -49,13 +49,13 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
-    /// If $\textbf{ {x}}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{w}_c^T \textbf{x} + b_c$.
+    /// If $\textbf{x}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
     /// In contrast, a $\hat{y}^c$ much smaller than 0 means the desired label should not be $c$.
     ///
     /// If and only if the trained model is a maximum entropy classifier, you can interpret the output score vector as the predicted class probabilities because [softmax function](https://en.wikipedia.org/wiki/Softmax_function) may be applied to post-process all classes' scores.
-    /// More specifically, the probability of $\textbf{ {x}}$ belonging to class $c$ is computed by $\tilde{P}( c | \textbf{ {x}} ) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
+    /// More specifically, the probability of $\textbf{x}$ belonging to class $c$ is computed by $\tilde{P}( c | \textbf{x} ) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
     /// In other cases, the output score vector is just $[\hat{y}^1, \dots, \hat{y}^m]$.
     ///
     /// ### Training Algorithm Details
@@ -64,12 +64,12 @@ namespace Microsoft.ML.Trainers
     ///
     /// Regularization is a method that can render an ill-posed problem more tractable by imposing constraints that provide information to supplement the data and that prevents overfitting by penalizing model's magnitude usually measured by some norm functions.
     /// This can improve the generalization of the model learned by selecting the optimal complexity in the bias-variance tradeoff.
-    /// Regularization works by adding the penalty on the magnitude of $\textbf{ {w}}_c$, $c=1,\dots,m$ to the error of the hypothesis.
+    /// Regularization works by adding the penalty on the magnitude of $\textbf{w}_c$, $c=1,\dots,m$ to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{ {w}}_c ||_1$, and L2-norm (ridge), $|| \textbf{ {w}}_c ||_2^2$ regularizations.
+    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{w}_c ||_1$, and L2-norm (ridge), $|| \textbf{w}_c ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\textbf{ {w}}_c$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{w}_c$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.
     ///
@@ -510,9 +510,9 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c | \textbf{ {x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
-    /// Note that $\tilde{P}(c | \textbf{ {x}})$ is the probability of observing class $c$ when the feature vector is $\textbf{ {x}}$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c | \textbf{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \textbf{w}_c^T \textbf{x} + b_c$.
+    /// Note that $\tilde{P}(c | \textbf{x})$ is the probability of observing class $c$ when the feature vector is $\textbf{x}$.
     ///
     /// ### Training Algorithm Details
     /// See the documentation of [SdcaMulticlassTrainerBase](xref:Microsoft.ML.Trainers.SdcaMulticlassTrainerBase).
@@ -593,8 +593,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{w}_c^T \textbf{x} + b_c$.
     /// Note that the $c$-th value in the output score column is just $\hat{y}^c$.
     ///
     /// ### Training Algorithm Details

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
@@ -49,13 +49,13 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
-    /// If $\textbf{\textit{x}}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
+    /// If $\textbf{ {x}}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
     /// In contrast, a $\hat{y}^c$ much smaller than 0 means the desired label should not be $c$.
     ///
     /// If and only if the trained model is a maximum entropy classifier, you can interpret the output score vector as the predicted class probabilities because [softmax function](https://en.wikipedia.org/wiki/Softmax_function) may be applied to post-process all classes' scores.
-    /// More specifically, the probability of $\textbf{\textit{x}}$ belonging to class $c$ is computed by $\tilde{P}( c | \textbf{\textit{x}} ) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
+    /// More specifically, the probability of $\textbf{ {x}}$ belonging to class $c$ is computed by $\tilde{P}( c | \textbf{ {x}} ) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
     /// In other cases, the output score vector is just $[\hat{y}^1, \dots, \hat{y}^m]$.
     ///
     /// ### Training Algorithm Details
@@ -64,12 +64,12 @@ namespace Microsoft.ML.Trainers
     ///
     /// Regularization is a method that can render an ill-posed problem more tractable by imposing constraints that provide information to supplement the data and that prevents overfitting by penalizing model's magnitude usually measured by some norm functions.
     /// This can improve the generalization of the model learned by selecting the optimal complexity in the bias-variance tradeoff.
-    /// Regularization works by adding the penalty on the magnitude of $\textbf{\textit{w}}_c$, $c=1,\dots,m$ to the error of the hypothesis.
+    /// Regularization works by adding the penalty on the magnitude of $\textbf{ {w}}_c$, $c=1,\dots,m$ to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{\textit{w}}_c ||_1$, and L2-norm (ridge), $|| \textbf{\textit{w}}_c ||_2^2$ regularizations.
+    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{ {w}}_c ||_1$, and L2-norm (ridge), $|| \textbf{ {w}}_c ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\textbf{\textit{w}}_c$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{ {w}}_c$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.
     ///
@@ -510,9 +510,9 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c | \textbf{\textit{x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
-    /// Note that $\tilde{P}(c | \textbf{\textit{x}})$ is the probability of observing class $c$ when the feature vector is $\textbf{\textit{x}}$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c | \textbf{ {x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
+    /// Note that $\tilde{P}(c | \textbf{ {x}})$ is the probability of observing class $c$ when the feature vector is $\textbf{ {x}}$.
     ///
     /// ### Training Algorithm Details
     /// See the documentation of [SdcaMulticlassTrainerBase](xref:Microsoft.ML.Trainers.SdcaMulticlassTrainerBase).
@@ -593,8 +593,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{ {w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{ {x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{ {w}}_c^T \textbf{ {x}} + b_c$.
     /// Note that the $c$-th value in the output score column is just $\hat{y}^c$.
     ///
     /// ### Training Algorithm Details

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
@@ -49,13 +49,13 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
-    /// If $\mathbb{x}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// If $\textbf{\textit{x}}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
     /// In contrast, a $\hat{y}^c$ much smaller than 0 means the desired label should not be $c$.
     ///
     /// If and only if the trained model is a maximum entropy classifier, you can interpret the output score vector as the predicted class probabilities because [softmax function](https://en.wikipedia.org/wiki/Softmax_function) may be applied to post-process all classes' scores.
-    /// More specifically, the probability of $\mathbb{x}$ belonging to class $c$ is computed by $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
+    /// More specifically, the probability of $\textbf{\textit{x}}$ belonging to class $c$ is computed by $\tilde{P}( c | \textbf{\textit{x}} ) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
     /// In other cases, the output score vector is just $[\hat{y}^1, \dots, \hat{y}^m]$.
     ///
     /// ### Training Algorithm Details
@@ -64,12 +64,12 @@ namespace Microsoft.ML.Trainers
     ///
     /// Regularization is a method that can render an ill-posed problem more tractable by imposing constraints that provide information to supplement the data and that prevents overfitting by penalizing model's magnitude usually measured by some norm functions.
     /// This can improve the generalization of the model learned by selecting the optimal complexity in the bias-variance tradeoff.
-    /// Regularization works by adding the penalty on the magnitude of $\mathbb{w}_c$, $c=1,\dots,m$ to the error of the hypothesis.
+    /// Regularization works by adding the penalty on the magnitude of $\textbf{\textit{w}}_c$, $c=1,\dots,m$ to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \mathbb{w}_c ||_1$, and L2-norm (ridge), $|| \mathbb{w}_c ||_2^2$ regularizations.
+    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \textbf{\textit{w}}_c ||_1$, and L2-norm (ridge), $|| \textbf{\textit{w}}_c ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\mathbb{w}_c$.
+    /// Using L1-norm can increase sparsity of the trained $\textbf{\textit{w}}_c$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.
     ///
@@ -510,9 +510,9 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score would be $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
-    /// Note that $\tilde{P}(c|\mathbb{x})$ is the probability of observing class $c$ when the feature vector is $\mathbb{x}$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score would be $\tilde{P}(c | \textbf{\textit{x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// Note that $\tilde{P}(c | \textbf{\textit{x}})$ is the probability of observing class $c$ when the feature vector is $\textbf{\textit{x}}$.
     ///
     /// ### Training Algorithm Details
     /// See the documentation of [SdcaMulticlassTrainerBase](xref:Microsoft.ML.Trainers.SdcaMulticlassTrainerBase).
@@ -593,8 +593,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
     /// Note that the $c$-th value in the output score column is just $\hat{y}^c$.
     ///
     /// ### Training Algorithm Details

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
@@ -49,8 +49,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
     /// If $\mathbb{x}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
     /// In contrast, a $\hat{y}^c$ much smaller than 0 means the desired label should not be $c$.
     ///
@@ -510,8 +510,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score would be $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
     /// Note that $\tilde{P}(c|\mathbb{x})$ is the probability of observing class $c$ when the feature vector is $\mathbb{x}$.
     ///
     /// ### Training Algorithm Details
@@ -593,8 +593,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
     /// Note that the $c$-th value in the output score column is just $\hat{y}^c$.
     ///
     /// ### Training Algorithm Details

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
@@ -49,13 +49,13 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\boldsymbol{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\boldsymbol{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \boldsymbol{w}_c^T \boldsymbol{x} + b_c$.
-    /// If $\boldsymbol{x}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
+    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// If $\mathbb{x}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
     /// In contrast, a $\hat{y}^c$ much smaller than 0 means the desired label should not be $c$.
     ///
     /// If and only if the trained model is a maximum entropy classifier, you can interpret the output score vector as the predicted class probabilities because [softmax function](https://en.wikipedia.org/wiki/Softmax_function) may be applied to post-process all classes' scores.
-    /// More specifically, the probability of $\boldsymbol{x}$ belonging to class $c$ is computed by $\tilde{P}(c|\boldsymbol{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
+    /// More specifically, the probability of $\mathbb{x}$ belonging to class $c$ is computed by $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$ and store at the $c$-th element in the score vector.
     /// In other cases, the output score vector is just $[\hat{y}^1, \dots, \hat{y}^m]$.
     ///
     /// ### Training Algorithm Details
@@ -64,12 +64,12 @@ namespace Microsoft.ML.Trainers
     ///
     /// Regularization is a method that can render an ill-posed problem more tractable by imposing constraints that provide information to supplement the data and that prevents overfitting by penalizing model's magnitude usually measured by some norm functions.
     /// This can improve the generalization of the model learned by selecting the optimal complexity in the bias-variance tradeoff.
-    /// Regularization works by adding the penalty on the magnitude of $\boldsymbol{w}_c$, $c=1,\dots,m$ to the error of the hypothesis.
+    /// Regularization works by adding the penalty on the magnitude of $\mathbb{w}_c$, $c=1,\dots,m$ to the error of the hypothesis.
     /// An accurate model with extreme coefficient values would be penalized more, but a less accurate model with more conservative values would be penalized less.
     ///
-    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \boldsymbol{w}_c ||_1$, and L2-norm (ridge), $|| \boldsymbol{w}_c ||_2^2$ regularizations.
+    /// This trainer supports [elastic net regularization](https://en.wikipedia.org/wiki/Elastic_net_regularization): a linear combination of L1-norm (LASSO), $|| \mathbb{w}_c ||_1$, and L2-norm (ridge), $|| \mathbb{w}_c ||_2^2$ regularizations.
     /// L1-norm and L2-norm regularizations have different effects and uses that are complementary in certain respects.
-    /// Using L1-norm can increase sparsity of the trained $\boldsymbol{w}_c$.
+    /// Using L1-norm can increase sparsity of the trained $\mathbb{w}_c$.
     /// When working with high-dimensional data, it shrinks small weights of irrelevant features to 0 and therefore no resource will be spent on those bad features when making prediction.
     /// L2-norm regularization is preferable for data that is not sparse and it largely penalizes the existence of large weights.
     ///
@@ -510,9 +510,9 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\boldsymbol{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\boldsymbol{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c|\boldsymbol{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \boldsymbol{w}_c^T \boldsymbol{x} + b_c$.
-    /// Note that $\tilde{P}(c|\boldsymbol{x})$ is the probability of observing class $c$ when the feature vector is $\boldsymbol{x}$.
+    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c|\mathbb{x}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
+    /// Note that $\tilde{P}(c|\mathbb{x})$ is the probability of observing class $c$ when the feature vector is $\mathbb{x}$.
     ///
     /// ### Training Algorithm Details
     /// See the documentation of [SdcaMulticlassTrainerBase](xref:Microsoft.ML.Trainers.SdcaMulticlassTrainerBase).
@@ -593,8 +593,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\boldsymbol{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\boldsymbol{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \boldsymbol{w}_c^T \boldsymbol{x} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\mathbb{w}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\mathbb{x} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \mathbb{w}_c^T \mathbb{x} + b_c$.
     /// Note that the $c$-th value in the output score column is just $\hat{y}^c$.
     ///
     /// ### Training Algorithm Details

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaMulticlass.cs
@@ -49,8 +49,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
     /// If $\textbf{\textit{x}}$ belongs to class $c$, then $\hat{y}^c$ should be much larger than 0.
     /// In contrast, a $\hat{y}^c$ much smaller than 0 means the desired label should not be $c$.
     ///
@@ -510,8 +510,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score would be $\tilde{P}(c | \textbf{\textit{x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\tilde{P}(c | \textbf{\textit{x}}) = \frac{ e^{\hat{y}^c} }{ \sum_{c' = 1}^m e^{\hat{y}^{c'}} }$, where $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
     /// Note that $\tilde{P}(c | \textbf{\textit{x}})$ is the probability of observing class $c$ when the feature vector is $\textbf{\textit{x}}$.
     ///
     /// ### Training Algorithm Details
@@ -593,8 +593,8 @@ namespace Microsoft.ML.Trainers
     /// ### Scoring Function
     /// This trains a linear model to solve multiclass classification problems.
     /// Assume that the number of classes is $m$ and number of features is $n$.
-    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathcal R}^n$ and a bias $b_c \in {\mathcal R}$, for $c=1,\dots,m$.
-    /// Given a feature vector $\textbf{\textit{x}} \in {\mathcal R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
+    /// It assigns the $c$-th class a coefficient vector $\textbf{\textit{w}}_c \in {\mathbb R}^n$ and a bias $b_c \in {\mathbb R}$, for $c=1,\dots,m$.
+    /// Given a feature vector $\textbf{\textit{x}} \in {\mathbb R}^n$, the $c$-th class's score would be $\hat{y}^c = \textbf{\textit{w}}_c^T \textbf{\textit{x}} + b_c$.
     /// Note that the $c$-th value in the output score column is just $\hat{y}^c$.
     ///
     /// ### Training Algorithm Details


### PR DESCRIPTION
`boldsymbol` is ams package, which is not included in the official latex. This PR replaces `boldsymbol` with `textbf`. Hopefully, this can fix the latex rendering of my docs.

