### PR TITLE
Indicating in which package transforms belong.

### DIFF
--- a/src/Microsoft.ML.OnnxTransformer/DnnImageFeaturizerTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/DnnImageFeaturizerTransform.cs
@@ -55,6 +55,7 @@ namespace Microsoft.ML.Transforms.Onnx
     /// | Does this estimator need to look at the data to train its parameters? | No |
     /// | Input column data type | Vector of <xref:System.Single> |
     /// | Output column data type | Vector of <xref:System.Single>, the size of the vector depends on the pre-trained DNN |
+    /// | Required NuGet in addition to Microsoft.ML | Microsoft.ML.OnnxTransformer |
     ///
     /// ]]>
     /// </format>

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -44,6 +44,7 @@ namespace Microsoft.ML.Transforms.Onnx
     /// | Does this estimator need to look at the data to train its parameters? | No |
     /// | Input column data type | Known-sized vector of <xref:System.Single> or <xref:System.Double> types. |
     /// | Output column data type | The same data type as the input column |
+    /// | Required NuGet in addition to Microsoft.ML | Microsoft.ML.OnnxTransformer |
     ///
     /// Supports inferencing of models in ONNX 1.2 and 1.3 format (opset 7, 8 and 9), using the
     /// [Microsoft.ML.OnnxRuntime](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime/) library.
@@ -57,7 +58,7 @@ namespace Microsoft.ML.Transforms.Onnx
     /// Refer to [ONNX](http://onnx.ai) for more information.
     ///
     /// To create this estimator use the following:
-    /// [ApplyOnnxModel](xref:Microsoft.ML.OnnxCatalog.ApplyOnnxModel*)
+    /// [ApplyModel](xref:Microsoft.ML.OnnxCatalog.ApplyOnnxModel*)
     /// ]]>
     /// </format>
     /// </remarks>

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Transforms.Onnx
     /// Refer to [ONNX](http://onnx.ai) for more information.
     ///
     /// To create this estimator use the following:
-    /// [ApplyModel](xref:Microsoft.ML.OnnxCatalog.ApplyOnnxModel*)
+    /// [ApplyOnnxModel](xref:Microsoft.ML.OnnxCatalog.ApplyOnnxModel*)
     /// ]]>
     /// </format>
     /// </remarks>


### PR DESCRIPTION
Towards #3481. The Onnx package transforms were lacking this information. 