### PR TITLE
fix doc for the KeyToBinaryVectorMappingEstimator

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -725,10 +725,6 @@ namespace Microsoft.ML.Transforms
     /// <summary>
     /// Estimator for <see cref="KeyToVectorMappingTransformer"/>. Converts the key types back to their original vectors.
     /// </summary>
-    /// <summary>
-    /// Utilizes KeyValues <see cref="AnnotationInfo"/> of the input column, to map keys to a vector representing the original value.
-    /// Maps zero values of the <see cref="KeyDataViewType"/> are mapped to the <see langword="default"/> value of the output type.
-    /// </summary>
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[
     ///

--- a/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToVector.cs
@@ -725,6 +725,10 @@ namespace Microsoft.ML.Transforms
     /// <summary>
     /// Estimator for <see cref="KeyToVectorMappingTransformer"/>. Converts the key types back to their original vectors.
     /// </summary>
+    /// <summary>
+    /// Utilizes KeyValues <see cref="AnnotationInfo"/> of the input column, to map keys to a vector representing the original value.
+    /// Maps zero values of the <see cref="KeyDataViewType"/> are mapped to the <see langword="default"/> value of the output type.
+    /// </summary>
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[
     ///

--- a/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        ///  Convert the key types back to binary vector.
+        /// Create a <see cref="KeyToBinaryVectorMappingEstimator"/>, which converts key types to their corresponding binary representation.
         /// </summary>
         /// <param name="catalog">The categorical transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>

--- a/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Create a <see cref="KeyToBinaryVectorMappingEstimator"/>, which converts key types to their corresponding binary representation.
+        /// Create a <see cref="KeyToBinaryVectorMappingEstimator"/>, which converts key types to their corresponding binary representation of the original value.
         /// </summary>
         /// <param name="catalog">The categorical transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
@@ -38,7 +38,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        ///  [!code-csharp[MapKeyToVector](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversions/MapKeyToBinaryVector.cs)]
+        ///  [!code-csharp[MapKeyToVector](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/Conversion/MapKeyToBinaryVector.cs)]
         /// ]]></format>
         /// </example>
         public static KeyToBinaryVectorMappingEstimator MapKeyToBinaryVector(this TransformsCatalog.ConversionTransforms catalog,

--- a/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
@@ -34,9 +34,9 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The categorical transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.
-        /// The data type is a vector of <see cref="System.Single"/> representing the input value.</param>
+        /// The data type is a known-size vector of <see cref="System.Single"/> representing the input value.</param>
         /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.
-        /// This transform operates over keys.</param>
+        /// The data type is a key or a known-size vector of keys.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[

--- a/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
+++ b/src/Microsoft.ML.Transforms/ConversionsCatalog.cs
@@ -33,8 +33,10 @@ namespace Microsoft.ML
         /// Create a <see cref="KeyToBinaryVectorMappingEstimator"/>, which converts key types to their corresponding binary representation of the original value.
         /// </summary>
         /// <param name="catalog">The categorical transform's catalog.</param>
-        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
-        /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.
+        /// The data type is a vector of <see cref="System.Single"/> representing the input value.</param>
+        /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.
+        /// This transform operates over keys.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -426,8 +426,20 @@ namespace Microsoft.ML.Transforms
     }
 
     /// <summary>
-    ///  Converts the key types back to binary vectors.
+    /// Estimator for <see cref="KeyToBinaryVectorMappingTransformer"/>. Converts key types to their corresponding binary representation.
     /// </summary>
+    /// <remarks>
+    /// <format type="text/markdown"><![CDATA[
+    ///
+    /// ###  Estimator Characteristics
+    /// |  |  |
+    /// | -- | -- |
+    /// | Does this estimator need to look at the data to train its parameters? | No |
+    /// | Input column data type | [key](xref:Microsoft.Ml.Data.KeyDataViewType) |
+    /// | Output column data type | A vector of [System.Single](xref:System.Single). |
+    ///
+    /// ]]></format>
+    /// </remarks>
     public sealed class KeyToBinaryVectorMappingEstimator : TrivialEstimator<KeyToBinaryVectorMappingTransformer>
     {
         internal KeyToBinaryVectorMappingEstimator(IHostEnvironment env, params (string outputColumnName, string inputColumnName)[] columns)

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -426,7 +426,7 @@ namespace Microsoft.ML.Transforms
     }
 
     /// <summary>
-    /// Estimator for <see cref="KeyToBinaryVectorMappingTransformer"/>. Converts key types to their corresponding binary representation.
+    /// Estimator for <see cref="KeyToBinaryVectorMappingTransformer"/>. Converts key types to their corresponding binary representation of the original value.
     /// </summary>
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -28,7 +28,7 @@ using Microsoft.ML.Transforms;
 namespace Microsoft.ML.Transforms
 {
     /// <summary>
-    ///  Converts the key types back to binary vectors.
+    /// <see cref="ITransformer"/> resulting from fitting a <see cref="KeyToBinaryVectorMappingEstimator"/>.
     /// </summary>
     public sealed class KeyToBinaryVectorMappingTransformer : OneToOneTransformerBase
     {

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -440,6 +440,7 @@ namespace Microsoft.ML.Transforms
     ///
     /// ]]></format>
     /// </remarks>
+    /// <seealso cref="ConversionsCatalog.MapKeyToBinaryVector(TransformsCatalog.ConversionTransforms, string, string)"/>
     public sealed class KeyToBinaryVectorMappingEstimator : TrivialEstimator<KeyToBinaryVectorMappingTransformer>
     {
         internal KeyToBinaryVectorMappingEstimator(IHostEnvironment env, params (string outputColumnName, string inputColumnName)[] columns)

--- a/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
+++ b/src/Microsoft.ML.Transforms/KeyToVectorMapping.cs
@@ -435,8 +435,8 @@ namespace Microsoft.ML.Transforms
     /// |  |  |
     /// | -- | -- |
     /// | Does this estimator need to look at the data to train its parameters? | No |
-    /// | Input column data type | [key](xref:Microsoft.Ml.Data.KeyDataViewType) |
-    /// | Output column data type | A vector of [System.Single](xref:System.Single). |
+    /// | Input column data type | [key](xref:Microsoft.Ml.Data.KeyDataViewType) or a known-size vector of keys. |
+    /// | Output column data type | A known-size vector of [System.Single](xref:System.Single). |
     ///
     /// ]]></format>
     /// </remarks>


### PR DESCRIPTION
Fixes #3472 

- Added `Estimator Characteristics` to the `KeyToVectorMappingEstimator` class

