### PR TITLE
TensorFlow fixes

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorFlowModel.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlowModel.cs
@@ -52,14 +52,14 @@ namespace Microsoft.ML.Transforms
         /// <summary>
         /// Scores a dataset using a pre-trained <a href="https://www.tensorflow.org/">TensorFlow</a> model.
         /// </summary>
-        /// <param name="inputColumnName"> The name of the model input.</param>
-        /// <param name="outputColumnName">The name of the requested model output.</param>
+        /// <param name="inputColumnName"> The name of the model input. The data type is a vector of <see cref="System.Single"/>.</param>
+        /// <param name="outputColumnName">The name of the requested model output. The data type is a vector of <see cref="System.Single"/></param>
         /// <param name="addBatchDimensionInput">Add a batch dimension to the input e.g. input = [224, 224, 3] => [-1, 224, 224, 3].
         /// This parameter is used to deal with models that have unknown shape but the internal operators in the model require data to have batch dimension as well.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[ScoreTensorFlowModel](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs)]
+        /// [!code-csharp[ScoreTensorFlowModel](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/ImageClassification.cs)]
         /// ]]>
         /// </format>
         /// </example>

--- a/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
@@ -17,6 +17,13 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelLocation">Location of the TensorFlow model.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[LoadTensorFlowModel](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/TensorFlow/TextClassification.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
         public static TensorFlowModel LoadTensorFlowModel(this ModelOperationsCatalog catalog, string modelLocation)
             => TensorFlowUtils.LoadTensorFlowModel(CatalogUtils.GetEnvironment(catalog), modelLocation);
     }

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -995,7 +995,7 @@ namespace Microsoft.ML.Transforms
                 _srcgetter(ref _vBuffer);
 
                 // _denseData.Length can be greater than _vBuffer.Length sometime after
-                // Utils.EnsureSize is exectued. Use _vBuffer.Length to access the elements in _denseData.
+                // Utils.EnsureSize is executed. Use _vBuffer.Length to access the elements in _denseData.
                 // This is done to reduce memory allocation every time tensor is created.
                 Utils.EnsureSize(ref _denseData, _vBuffer.Length, keepOld: false);
                 _vBuffer.CopyTo(_denseData);

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -32,7 +32,9 @@ using Microsoft.ML.Transforms.TensorFlow;
 
 namespace Microsoft.ML.Transforms
 {
-    /// <include file='doc.xml' path='doc/members/member[@name="TensorflowTransformer"]/*' />
+    /// <summary>
+    /// <see cref="ITransformer" /> for the <see cref="TensorFlowEstimator"/>.
+    /// </summary>
     public sealed class TensorFlowTransformer : RowToRowTransformerBase
     {
         private readonly string _savedModelPath;
@@ -1017,9 +1019,7 @@ namespace Microsoft.ML.Transforms
         }
     }
 
-    /// <summary>
-    /// Estimator for the <see cref="TensorFlowTransformer"/>.
-    /// </summary>
+    /// <include file='doc.xml' path='doc/members/member[@name="TensorflowTransformer"]/*' />
     public sealed class TensorFlowEstimator : IEstimator<TensorFlowTransformer>
     {
         /// <summary>


### PR DESCRIPTION
Closing #3481 by rearranging where the explanation lives for the TensorFlow transfomer/estimator, and fixing the links. 

