### PR TITLE
Fix Time Series XML Doc

### DIFF
--- a/docs/api-reference/io-time-series-change-point.md
+++ b/docs/api-reference/io-time-series-change-point.md
@@ -1,7 +1,10 @@
 ### Input and Output Columns
-There is only one input column and its type is <xref:System.Single>.
-This estimator adds the following output columns:
+There is only one input column and produces a column typed to a 4-element vector.
+The output vector sequentially contains alert level (non-zero value means a change point), score, p-value, and martingale value.
 
-| Output Column Name | Column Type | Description|
-| -- | -- | -- |
-| `Prediction` | 4-element vector of <xref:System.Double> | It sequentially contains alert level (non-zero value means a change point), score, p-value, and martingale value. |
+###  Estimator Characteristics 
+|  |  | 
+| -- | -- | 
+| Does this estimator need to look at the data to train its parameters? | No | 
+| Input column data type | Vector of <xref:System.Single> | 
+| Output column data type | 4-element vector of <xref:System.Double> |

--- a/docs/api-reference/io-time-series-spike.md
+++ b/docs/api-reference/io-time-series-spike.md
@@ -1,7 +1,10 @@
 ### Input and Output Columns
-There is only one input column and its type is <xref:System.Single>.
-This estimator adds the following output columns:
+There is only one input column and produces a column typed to a 3-element vector.
+The output vector sequentially contains alert level (non-zero value means a change point), score, and p-value.
 
-| Output Column Name | Column Type | Description|
-| -- | -- | -- |
-| `Prediction` | 3-element vector of <xref:System.Double> | It sequentially contains alert level (non-zero value means a change point), score, and p-value. |
+###  Estimator Characteristics 
+|  |  | 
+| -- | -- | 
+| Does this estimator need to look at the data to train its parameters? | No | 
+| Input column data type | Vector of <xref:System.Single> | 
+| Output column data type | 3-element vector of <xref:System.Double> |

--- a/docs/api-reference/time-series-pvalue.md
+++ b/docs/api-reference/time-series-pvalue.md
@@ -1,0 +1,12 @@
+### Anomaly Scorer
+Once the raw score at a timestamp is computed, it is fed to the anomaly scorer component to calculate the final anomaly score at that timestamp.
+
+#### Spike detection based on p-value
+The p-value score indicates the p-value of the current computed raw score according to a distribution of raw scores.
+Here, the distribution is estimated based on the most recent raw score values up to certain depth back in the history.
+More specifically, this distribution is estimated using [kernel density estimation](https://en.wikipedia.org/wiki/Kernel_density_estimation)
+with the Gaussian [kernels](https://en.wikipedia.org/wiki/Kernel_(statistics)#In_non-parametric_statistics) of adaptive bandwidth.
+The p-value score is always in $[0, 1]$, and the lower its value, the more likely the current point is an outlier (also known as a spike).
+If the p-value score exceeds $1 - \frac{\text{confidence}}{100}$, the associated timestamp may get a non-zero alert value in spike detection, which means a spike point is detected.
+Note that $\text{confidence}$ is defined in the signatures of [DetectIidSpike](xref:Microsoft.ML.TimeSeriesCatalog.DetectIidSpike(Microsoft.ML.TransformsCatalog,System.String,System.String,System.Int32,System.Int32,Microsoft.ML.Transforms.TimeSeries.AnomalySide))
+and [DetectSpikeBySsa](xref:Microsoft.ML.TimeSeriesCatalog.DetectSpikeBySsa(Microsoft.ML.TransformsCatalog,System.String,System.String,System.Int32,System.Int32,System.Int32,System.Int32,Microsoft.ML.Transforms.TimeSeries.AnomalySide,Microsoft.ML.Transforms.TimeSeries.ErrorFunction)).

--- a/docs/api-reference/time-series-scorer.md
+++ b/docs/api-reference/time-series-scorer.md
@@ -2,15 +2,12 @@
 Once the raw score at a timestamp is computed, it is fed to the anomaly scorer component to calculate the final anomaly score at that timestamp.
 There are two statistics involved in this scorer, p-value and martingale score.
 
-#### Spike detection based on p-value
+#### P-value score
 The p-value score indicates the p-value of the current computed raw score according to a distribution of raw scores.
 Here, the distribution is estimated based on the most recent raw score values up to certain depth back in the history.
 More specifically, this distribution is estimated using [kernel density estimation](https://en.wikipedia.org/wiki/Kernel_density_estimation)
 with the Gaussian [kernels](https://en.wikipedia.org/wiki/Kernel_(statistics)#In_non-parametric_statistics) of adaptive bandwidth.
 The p-value score is always in $[0, 1]$, and the lower its value, the more likely the current point is an outlier (also known as a spike).
-If the p-value score exceeds $1 - \frac{\text{confidence}}{100}$, the associated timestamp may get a non-zero alert value in spike detection, which means a spike point is detected.
-Note that $\text{confidence}$ is defined in the signatures of [DetectChangePointBySsa](xref:Microsoft.ML.TimeSeriesCatalog.DetectChangePointBySsa(Microsoft.ML.TransformsCatalog,System.String,System.String,System.Int32,System.Int32,System.Int32,System.Int32,Microsoft.ML.Transforms.TimeSeries.ErrorFunction,Microsoft.ML.Transforms.TimeSeries.MartingaleType,System.Double))
-and [DetectIidChangePoint](xref:Microsoft.ML.TimeSeriesCatalog.DetectIidChangePoint(Microsoft.ML.TransformsCatalog,System.String,System.String,System.Int32,System.Int32,Microsoft.ML.Transforms.TimeSeries.MartingaleType,System.Double)).
 
 
 #### Change point detection based on martingale score

--- a/src/Microsoft.ML.TimeSeries/IidChangePointDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/IidChangePointDetector.cs
@@ -26,7 +26,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 namespace Microsoft.ML.Transforms.TimeSeries
 {
     /// <summary>
-    /// <see cref="ITransformer"/> produced by fitting the <see cref="IDataView"/> to an <see cref="IidChangePointEstimator" />.
+    /// <see cref="ITransformer"/> resulting from fitting a <see cref="IidChangePointEstimator"/>.
     /// </summary>
     public sealed class IidChangePointDetector : IidAnomalyDetectionBaseWrapper, IStatefulTransformer
     {
@@ -191,7 +191,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     }
 
     /// <summary>
-    /// The <see cref="IEstimator{TTransformer}"/> to detect a signal change on an
+    /// Detect a signal change on an
     /// <a href="https://en.wikipedia.org/wiki/Independent_and_identically_distributed_random_variables"> independent identically distributed (i.i.d.)</a>
     /// time series based on adaptive kernel density estimation and martingales.
     /// </summary>

--- a/src/Microsoft.ML.TimeSeries/IidSpikeDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/IidSpikeDetector.cs
@@ -25,7 +25,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 namespace Microsoft.ML.Transforms.TimeSeries
 {
     /// <summary>
-    /// <see cref="ITransformer"/> produced by fitting the <see cref="IDataView"/> to an <see cref="IidSpikeEstimator" />.
+    /// <see cref="ITransformer"/> resulting from fitting a <see cref="IidSpikeEstimator"/>.
     /// </summary>
     public sealed class IidSpikeDetector : IidAnomalyDetectionBaseWrapper, IStatefulTransformer
     {
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     }
 
     /// <summary>
-    /// The <see cref="IEstimator{TTransformer}"/> to detect a signal spike on an
+    /// Detect a signal spike on an
     /// <a href="https://en.wikipedia.org/wiki/Independent_and_identically_distributed_random_variables"> independent identically distributed (i.i.d.)</a>
     /// time series based on adaptive kernel density estimation.
     /// </summary>
@@ -185,7 +185,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     ///
     /// [!include[io](~/../docs/samples/docs/api-reference/time-series-iid.md)]
     ///
-    /// [!include[io](~/../docs/samples/docs/api-reference/time-series-scorer.md)]
+    /// [!include[io](~/../docs/samples/docs/api-reference/time-series-pvalue.md)]
     /// ]]>
     /// </format>
     /// </remarks>

--- a/src/Microsoft.ML.TimeSeries/SsaChangePointDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaChangePointDetector.cs
@@ -26,7 +26,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 namespace Microsoft.ML.Transforms.TimeSeries
 {
     /// <summary>
-    /// <see cref="ITransformer"/> produced by fitting the <see cref="IDataView"/> to an <see cref="SsaChangePointEstimator" />.
+    /// <see cref="ITransformer"/> resulting from fitting a <see cref="SsaChangePointEstimator"/>.
     /// </summary>
     public sealed class SsaChangePointDetector : SsaAnomalyDetectionBaseWrapper, IStatefulTransformer
     {
@@ -200,7 +200,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     }
 
     /// <summary>
-    /// The <see cref="IEstimator{TTransformer}"/> to predict change points in time series using Singular Spectrum Analysis.
+    /// Detect change points in time series using Singular Spectrum Analysis.
     /// </summary>
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[

--- a/src/Microsoft.ML.TimeSeries/SsaSpikeDetector.cs
+++ b/src/Microsoft.ML.TimeSeries/SsaSpikeDetector.cs
@@ -25,7 +25,7 @@ using Microsoft.ML.Transforms.TimeSeries;
 namespace Microsoft.ML.Transforms.TimeSeries
 {
     /// <summary>
-    /// <see cref="ITransformer"/> produced by fitting the <see cref="IDataView"/> to an <see cref="SsaSpikeEstimator" />.
+    /// <see cref="ITransformer"/> resulting from fitting a <see cref="SsaSpikeEstimator"/>.
     /// </summary>
     public sealed class SsaSpikeDetector : SsaAnomalyDetectionBaseWrapper, IStatefulTransformer
     {
@@ -181,7 +181,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     }
 
     /// <summary>
-    /// The <see cref="IEstimator{TTransformer}"/> to predict spikes in time series using Singular Spectrum Analysis.
+    /// Detect spikes in time series using Singular Spectrum Analysis.
     /// </summary>
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Transforms.TimeSeries
     ///
     /// [!include[io](~/../docs/samples/docs/api-reference/time-series-ssa.md)]
     ///
-    /// [!include[io](~/../docs/samples/docs/api-reference/time-series-scorer.md)]
+    /// [!include[io](~/../docs/samples/docs/api-reference/time-series-pvalue.md)]
     /// ]]>
     /// </format>
     /// </remarks>


### PR DESCRIPTION
Fix #3517 by

1.  Change Trainer Template to Transformer Template
2.  Decompose scoring paragraph into two files so that Spike Detection and Change Point Detection can reference files independently.
3.  Some minor polishment.

