### PR TITLE
[One Line Change] Fix Kmeans Options Link

### DIFF
--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -90,8 +90,7 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// Options for the <see cref="KMeansTrainer"/> as used in
-        /// <see cref="KMeansClusteringExtensions.KMeans(ClusteringCatalog.ClusteringTrainers, Options)"/>.
+        /// Options for the <see cref="KMeansTrainer"/> as used in [KMeansTrainer(Options)](xref:Microsoft.ML.KMeansClusteringExtensions.KMeans(Microsoft.ML.ClusteringCatalog.ClusteringTrainers,Microsoft.ML.Trainers.KMeansTrainer.Options)).
         /// </summary>
         public sealed class Options : UnsupervisedTrainerInputBaseWithWeight
         {

--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.ML.Trainers
 
         /// <summary>
         /// Options for the <see cref="KMeansTrainer"/> as used in
-        /// [KMeansTrainer(Options)](xref:"Microsoft.ML.KMeansClusteringExtensions.KMeans(Microsoft.ML.ClusteringCatalog.ClusteringTrainers,Microsoft.ML.Trainers.KMeansTrainer.Options)".
+        /// <see cref="KMeansClusteringExtensions.KMeans(ClusteringCatalog.ClusteringTrainers, Options)"/>.
         /// </summary>
         public sealed class Options : UnsupervisedTrainerInputBaseWithWeight
         {


### PR DESCRIPTION
Fix #3492 by replacing xref with cref in Kmean's Options. Other places have been fixed by someone.

