### PR TITLE
Renaming CI legs

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -22,7 +22,7 @@ phases:
         _includeBenchmarkData: false
       Release_Build:
         _configuration: Release-Intrinsics
-        _config_short: R
+        _config_short: RI
         _includeBenchmarkData: true
     queue:
       name: Hosted Ubuntu 1604

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -13,31 +13,15 @@ resources:
 phases:
 - template: /build/ci/phase-template.yml
   parameters:
-    name: core30
-    buildScript: build.cmd
-    customMatrixes:
-      Build_Debug_Intrinsics:
-        _configuration: Debug-Intrinsics
-        _config_short: DI
-        _includeBenchmarkData: false
-      Build_Release_Intrinsics:
-        _configuration: Release-Intrinsics
-        _config_short: RI
-        _includeBenchmarkData: true
-    queue:
-      name: Hosted VS2017
-
-- template: /build/ci/phase-template.yml
-  parameters:
-    name: Centos
+    name: Centos_x64_Netcoreapp30
     buildScript: ./build.sh
     customMatrixes:
-      Build_Debug_Intrinsics:
+      Debug_Build:
         _configuration: Debug-Intrinsics
         _config_short: DI
         _includeBenchmarkData: false
-      Build_Release:
-        _configuration: Release
+      Release_Build:
+        _configuration: Release-Intrinsics
         _config_short: R
         _includeBenchmarkData: true
     queue:
@@ -46,38 +30,52 @@ phases:
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Ubuntu
+    name: Ubuntu_x64_Netcoreapp21
     buildScript: ./build.sh
-    customMatrixes:
-      Build_Debug:
-        _configuration: Debug
-        _config_short: D
-        _includeBenchmarkData: false
-      Build_Release_Intrinsics:
-        _configuration: Release-Intrinsics
-        _config_short: RI
-        _includeBenchmarkData: true
     queue:
       name: Hosted Ubuntu 1604
       container: UbuntuContainer
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: MacOS
+    name: MacOS_x64_Netcoreapp21
     buildScript: ./build.sh
     queue:
       name: Hosted macOS
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Windows_NetFx
+    name: Windows_x64_Netcoreapp30
     buildScript: build.cmd
     customMatrixes:
-      Build_Debug_netfx:
+      Debug_Build:
+        _configuration: Debug-Intrinsics
+        _config_short: DI
+        _includeBenchmarkData: false
+      Release_Build:
+        _configuration: Release-Intrinsics
+        _config_short: RI
+        _includeBenchmarkData: true
+    queue:
+      name: Hosted VS2017
+
+- template: /build/ci/phase-template.yml
+  parameters:
+    name: Windows_x64_Netcoreapp21
+    buildScript: build.cmd
+    queue:
+      name: Hosted VS2017
+
+- template: /build/ci/phase-template.yml
+  parameters:
+    name: Windows_x64_Netfx
+    buildScript: build.cmd
+    customMatrixes:
+      Debug_Build:
         _configuration: Debug-netfx
         _config_short: DFX
         _includeBenchmarkData: false
-      Build_Release_netfx:
+      Release_Build:
         _configuration: Release-netfx
         _config_short: RFX
         _includeBenchmarkData: false
@@ -86,14 +84,7 @@ phases:
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Windows_x64
-    buildScript: build.cmd
-    queue:
-      name: Hosted VS2017
-
-- template: /build/ci/phase-template.yml
-  parameters:
-    name: Windows_x86
+    name: Windows_x86_Netcoreapp21
     architecture: x86
     buildScript: build.cmd
     queue:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -13,7 +13,7 @@ resources:
 phases:
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Centos_x64_Netcoreapp30
+    name: Centos_x64_NetCoreApp30
     buildScript: ./build.sh
     customMatrixes:
       Debug_Build:
@@ -30,7 +30,7 @@ phases:
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Ubuntu_x64_Netcoreapp21
+    name: Ubuntu_x64_NetCoreApp21
     buildScript: ./build.sh
     queue:
       name: Hosted Ubuntu 1604
@@ -38,14 +38,14 @@ phases:
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: MacOS_x64_Netcoreapp21
+    name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
     queue:
       name: Hosted macOS
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Windows_x64_Netcoreapp30
+    name: Windows_x64_NetCoreApp30
     buildScript: build.cmd
     customMatrixes:
       Debug_Build:
@@ -61,14 +61,14 @@ phases:
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Windows_x64_Netcoreapp21
+    name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
     queue:
       name: Hosted VS2017
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Windows_x64_Netfx
+    name: Windows_x64_NetFx461
     buildScript: build.cmd
     customMatrixes:
       Debug_Build:
@@ -84,7 +84,7 @@ phases:
 
 - template: /build/ci/phase-template.yml
   parameters:
-    name: Windows_x86_Netcoreapp21
+    name: Windows_x86_NetCoreApp21
     architecture: x86
     buildScript: build.cmd
     queue:

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -33,7 +33,7 @@ phases:
           ${{ insert }}: ${{ parameters.customMatrixes }}
       ${{ insert }}: ${{ parameters.queue }}
     steps:
-    - ${{ if eq(parameters.name, 'MacOS') }}:
+    - ${{ if eq(parameters.queue.name, 'Hosted macOS') }}:
       - script: brew update && brew install libomp && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)

--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -21,11 +21,11 @@ phases:
       parallel: 99
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:
-          Build_Debug:
+          Debug_Build:
             _configuration: Debug
             _config_short: D
             _includeBenchmarkData: false
-          Build_Release:
+          Release_Build:
             _configuration: Release
             _config_short: R
             _includeBenchmarkData: true


### PR DESCRIPTION
The previous pr was alwayus using the mac machines with missing dependencies so just creating a new pr to avoid those failures.


@eerhardt is it fine to run centos just with netcoreapp3.0 and ubuntu with netcoreapp2.1 ?