### PR TITLE
[AutoML] Change the conflicting alias for the command line option

### DIFF
--- a/src/mlnet/Commands/CommandDefinitions.cs
+++ b/src/mlnet/Commands/CommandDefinitions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.CLI.Commands
                 new Argument<DirectoryInfo>(defaultValue: new DirectoryInfo(".")));
 
             Option HasHeader() =>
-                new Option(new List<string>() { "--has-header", "-h" }, "Specify true/false depending if the dataset file(s) have a header row.",
+                new Option(new List<string>() { "--has-header", "-H" }, "Specify true/false depending if the dataset file(s) have a header row.",
                 new Argument<bool>(defaultValue: true));
 
             Option Cache() =>


### PR DESCRIPTION
looks like -h is already taken by command line api's "help" option. So changing header alias to -H instead of -h.