### PR TITLE
Add the correct name to the InitializationAlgorithm enum

### DIFF
--- a/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
+++ b/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs
@@ -88,7 +88,8 @@ namespace Microsoft.ML.Trainers
         {
             KMeansPlusPlus = 0,
             Random = 1,
-            KMeansYinyang = 2
+            KMeansYinyang = 2,
+            KMeansBarBar = 2
         }
 
         [BestFriend]
@@ -115,7 +116,7 @@ namespace Microsoft.ML.Trainers
             /// Cluster initialization algorithm.
             /// </summary>
             [Argument(ArgumentType.AtMostOnce, HelpText = "Cluster initialization algorithm", ShortName = "init")]
-            public InitializationAlgorithm InitializationAlgorithm = InitializationAlgorithm.KMeansYinyang;
+            public InitializationAlgorithm InitializationAlgorithm = InitializationAlgorithm.KMeansBarBar;
 
             /// <summary>
             /// Tolerance parameter for trainer convergence. Low = slower, more accurate.


### PR DESCRIPTION
The name Yinyang actually refers to the implementation of the algorithm itself, not the initialization of the clusters. The algorithm for cluster initialization either random, kmeans++ or kmeans||
(see the links in the trainer documentation [here](https://github.com/dotnet/machinelearning/blob/master/src/Microsoft.ML.KMeansClustering/KMeansPlusPlusTrainer.cs#L48-L57)).