### PR TITLE
Disable building NuGet packages other than Microsoft.Extensions.ML.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -67,7 +67,7 @@
     <Message Importance="High" Text="Building packages ..." />
 
     <ItemGroup>
-      <PkgProject Include="pkg\**\*.nupkgproj" />
+      <PkgProject Include="pkg\Microsoft.Extensions.ML\*.nupkgproj" />
     </ItemGroup>
 
     <MSBuild Projects="@(PkgProject)"

--- a/test/Microsoft.Extensions.ML.Tests/FileLoaderTests.cs
+++ b/test/Microsoft.Extensions.ML.Tests/FileLoaderTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.ML
                         () => loaderUnderTest.GetReloadToken(),
                         () => changed = true);
 
-            await File.WriteAllTextAsync("testdata.txt", "test");
+            File.WriteAllText("testdata.txt", "test");
 
             await Task.Delay(1000);
 


### PR DESCRIPTION
Note this is only for the `features/IntegrationPackage` branch.