### PR TITLE
Fixed typo of word "defined"

### DIFF
--- a/src/Microsoft.ML.Data/Evaluators/AucAggregator.cs
+++ b/src/Microsoft.ML.Data/Evaluators/AucAggregator.cs
@@ -112,8 +112,8 @@ namespace Microsoft.ML.Data
                 }
 
                 Contracts.Check(PosSample != null && NegSample != null, "Must call Finish() before computing AUC");
-                Contracts.CheckParam(PosSample.Any(), nameof(PosSample), "AUC is not definied when there is no positive class in the data");
-                Contracts.CheckParam(NegSample.Any(), nameof(NegSample), "AUC is not definied when there is no negative class in the data");
+                Contracts.CheckParam(PosSample.Any(), nameof(PosSample), "AUC is not defined when there is no positive class in the data");
+                Contracts.CheckParam(NegSample.Any(), nameof(NegSample), "AUC is not defined when there is no negative class in the data");
                 return ComputeWeightedAucCore(out unweighted);
             }
 


### PR DESCRIPTION
Updated AucAggregator.cs ComputeWeightedAuc method to fix spelling issue of "defined" in message text.

We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

