### PR TITLE
Adding the CommonPackage.props file to FastTree.

### DIFF
--- a/pkg/Microsoft.ML.FastTree/Microsoft.ML.FastTree.nupkgproj
+++ b/pkg/Microsoft.ML.FastTree/Microsoft.ML.FastTree.nupkgproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="../Microsoft.ML/Microsoft.ML.nupkgproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\common\CommonPackage.props" Pack="true" PackagePath="build\netstandard2.0\$(MSBuildProjectName).props" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The FastTree NuGet package is currently broken on .NET Framework when using packages.config because we are not copying the native files to the output folder.

Fix #3626
