### PR TITLE
Adds missing license headers.

### DIFF
--- a/src/Microsoft.ML.FastTree/Utils/BufferPoolManager.cs
+++ b/src/Microsoft.ML.FastTree/Utils/BufferPoolManager.cs
@@ -1,8 +1,6 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BufferPoolManager.cs" company="Microsoft Corporation">
-//     Copyright (C) All Rights Reserved
-// </copyright>
-// -----------------------------------------------------------------------
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.ML.TensorFlow/TensorFlow/TensorGeneric.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorFlow/TensorGeneric.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Microsoft.ML.TensorFlow/TensorFlow/TensorGeneric.tt
+++ b/src/Microsoft.ML.TensorFlow/TensorFlow/TensorGeneric.tt
@@ -5,11 +5,14 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ import namespace="System.Runtime.InteropServices" #>
-<#@ output extension=".cs" #>// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+<#@ output extension=".cs" #>
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;
+using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.Transforms.TensorFlow
 {


### PR DESCRIPTION
In addition to #3645, I wrote a small C# program to open every ".cs" file in src directory and read the first non-null/empty line and compare it against "// Licensed to the .NET Foundation under one or more agreements." and found few more places where license was missing. 

```csharp
public static class Program
    {
        public static void Main(string[] args) => RunAll(@"E:\machinelearning\src");

        internal static void RunAll(string sDir)
        {
           foreach (string d in Directory.GetDirectories(sDir))
            {
                foreach (string f in Directory.GetFiles(d))
                {
                    if (Path.GetExtension(f) == ".cs" || Path.GetExtension(f) == ".tt")
                    {
                        using (var fileStream = File.OpenRead(f))
                        using (var streamReader = new StreamReader(fileStream, Encoding.UTF8, true))
                        {
                            string line;
                            while ((line = streamReader.ReadLine()) != null)
                            {
                                if(String.IsNullOrEmpty(line))
                                    continue;

                                if (line !=
                                    @"// Licensed to the .NET Foundation under one or more agreements.")
                                {
                                    Console.WriteLine(f + " : " + line);
                                }

                                break;

                            }
                        }
                    }
                }
                RunAll(d);
            }
        }
    }
```