### PR TITLE
[AutoML] Cleaner way to exit the main()

### DIFF
--- a/src/mlnet/CodeGenerator/CodeGenerationHelper.cs
+++ b/src/mlnet/CodeGenerator/CodeGenerationHelper.cs
@@ -138,6 +138,8 @@ namespace Microsoft.ML.CLI.CodeGenerator
                                 logger.Log(LogLevel.Error, Strings.UnsupportedMlTask);
                                 break;
                         }
+
+                        t.IsBackground = true;
                         t.Start();
 
                         pbar.CompletedHandle.WaitOne(wait);
@@ -187,6 +189,8 @@ namespace Microsoft.ML.CLI.CodeGenerator
                             logger.Log(LogLevel.Error, Strings.UnsupportedMlTask);
                             break;
                     }
+
+                    t.IsBackground = true;
                     t.Start();
                     Thread.Sleep(wait);
                     context.Log -= ConsumeAutoMLSDKLog;

--- a/src/mlnet/Program.cs
+++ b/src/mlnet/Program.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.CLI
     class Program
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
             var telemetry = new MlTelemetry();
             int exitCode = 1;
@@ -101,7 +101,7 @@ namespace Microsoft.ML.CLI
             }
 
             parser.InvokeAsync(parseResult).Wait();
-            Environment.Exit(exitCode);
+            return exitCode;
         }
     }
 }


### PR DESCRIPTION
We could just return the exit code from main()
Instead of Environment.Exit(exitcode)

The reason it wasn't working before was the fact that we were spawning foreground threads.

It seems to be the standard.
https://github.com/dotnet/cli/blob/21cda4adb6d88d240978e24fcfeb3ebe73f5fdd7/src/dotnet/Program.cs#L30-L83
