### PR TITLE
Fix to the official build (API Compat tool)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,8 +24,7 @@
 <!-- API Compat -->
   <PropertyGroup>
     <RunApiCompat Condition="'$(RunApiCompat)' == ''">$(IsStableProject)</RunApiCompat>
-    <ToolHostCmd Condition="'$(OS)' != 'Windows_NT'">$(ToolsDir)dotnetcli/dotnet</ToolHostCmd>
-
+    <ToolHostCmd>$(ToolsDir)dotnetcli/dotnet</ToolHostCmd>
 
     <!-- only validate that the current implementation is compatible
          with the old one, not vice-versa (since latest may have new


### PR DESCRIPTION
PR #3623 breaks the official build because the .Net Core 2.1 runtime is not found.
We have it locally in the tools directory, so a solution is to make it point to that local installation of the runtime. 

Fixes #3666.

