### PR TITLE
Fix SoftMax precision by utilizing double in the internal calculations

### DIFF
--- a/build/ci/phase-template.yml
+++ b/build/ci/phase-template.yml
@@ -34,7 +34,7 @@ phases:
       ${{ insert }}: ${{ parameters.queue }}
     steps:
     - ${{ if eq(parameters.queue.name, 'Hosted macOS') }}:
-      - script: brew update && brew install libomp && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)
       displayName: Build

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -48,7 +48,7 @@ phases:
     demands:
     - agent.os -equals Darwin
   steps:
-  - script: brew update && brew install libomp && brew link libomp --force
+  - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link libomp --force
     displayName: Install build dependencies
   # Only build native assets to avoid conflicts.
   - script: ./build.sh -buildNative -$(BuildConfig) -skipRIDAgnosticAssets

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -43,12 +43,12 @@ macOS 10.12 (Sierra) or higher is needed to build dotnet/machinelearning.
 
 On macOS a few components are needed which are not provided by a default developer setup:
 * cmake 3.10.3
-* libomp
+* libomp 7
 * libgdiplus
 * gettext
 * All the requirements necessary to run .NET Core 2.0 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore2x).
 
 One way of obtaining CMake and other required libraries is via [Homebrew](https://brew.sh):
 ```sh
-$ brew install cmake libomp mono-libgdiplus gettext && brew link gettext --force
+$ brew install cmake https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb mono-libgdiplus gettext && brew link gettext --force
 ```

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -740,15 +740,17 @@ namespace Microsoft.ML.Trainers
 
             private void NormalizeSoftmax(float[] scores, int count)
             {
-                float sum = 0;
+                double sum = 0;
+                var score = new double[count];
+
                 for (int i = 0; i < count; i++)
                 {
-                    scores[i] = (float)Math.Exp(scores[i]);
-                    sum += scores[i];
+                    score[i] = Math.Exp(scores[i]);
+                    sum += score[i];
                 }
 
                 for (int i = 0; i < count; i++)
-                    scores[i] = scores[i] / sum;
+                    scores[i] = (float)(score[i] / sum);
             }
 
             public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)


### PR DESCRIPTION
Fixes #3648 

Uses `double` when calculating softmax exponent scores and only cast to `float` at the final step returning the probabilities.

cc: @rauhs 