### PR TITLE
Sample of using LoadFromEnumerable with a SchemaDefinition

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
@@ -1,8 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.Data;
@@ -11,7 +7,11 @@ namespace Samples.Dynamic
 {
     public static class LoadFromEnumerable
     {
-        // A simple case of creating IDataView from IEnumerable.
+        // Creating IDataView from IEnumerable, and setting the size of the vector at runtime. 
+        // When the data model is defined through types, setting the size of the vector is done through the VectorType 
+        // annotation. When the size of the data is not known at compile time, the Schema can be directly modified at runtime
+        // and the size of the vector set there. 
+        // This is important, because most of the ML.NET trainers require the Features vector to be of known size. 
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
@@ -45,7 +45,8 @@ namespace Samples.Dynamic
                new DataPoint{ Features = new float[]{ 1.6f, 3.5f, 4.5f } },
             };
 
-            // The feature dimension retrievable at runtime.
+            // The feature dimension (typically this will be the Count of the array of the features vector
+            // known at runtime).
             int featureDimension = 3;
             var definedSchema = SchemaDefinition.Create(typeof(DataPoint));
             featureColumn = definedSchema["Features"].ColumnType as VectorDataViewType;
@@ -54,7 +55,7 @@ namespace Samples.Dynamic
             // Preview
             //
             // Is the size of the Features column known? False.
-            //Size: 0.
+            // Size: 0.
 
             // Set the column type to be a known-size vector.
             var vectorItemType = ((VectorDataViewType)definedSchema[0].ColumnType).ItemType;

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
@@ -61,7 +61,7 @@ namespace Samples.Dynamic
             var vectorItemType = ((VectorDataViewType)definedSchema[0].ColumnType).ItemType;
             definedSchema[0].ColumnType = new VectorDataViewType(vectorItemType, featureDimension);
 
-            // Read the data into an IDataView with the schema supplied in
+            // Read the data into an IDataView with the modified schema supplied in
             IDataView data2 = mlContext.Data.LoadFromEnumerable(enumerableUnknownSize, definedSchema);
 
             featureColumn = data2.Schema["Features"].Type as VectorDataViewType;

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.ML;
 using Microsoft.ML.Data;

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+
+namespace Samples.Dynamic
+{
+    public static class LoadFromEnumerable
+    {
+        // A simple case of creating IDataView from IEnumerable.
+        public static void Example()
+        {
+            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // as a catalog of available operations and as the source of randomness.
+            var mlContext = new MLContext();
+
+            // Get a small dataset as an IEnumerable.
+            IEnumerable<DataPointVector> enumerableKnownSize = new DataPointVector[]
+            {
+               new DataPointVector{ Features = new float[]{ 1.2f, 3.4f, 4.5f, 3.2f, 7,5f } },
+               new DataPointVector{ Features = new float[]{ 4.2f, 3.4f, 14.65f, 3.2f, 3,5f } },
+               new DataPointVector{ Features = new float[]{ 1.6f, 3.5f, 4.5f, 6.2f, 3,5f } },
+            };
+
+            // Load dataset into an IDataView. 
+            IDataView data = mlContext.Data.LoadFromEnumerable(enumerableKnownSize);
+            var featureColumn = data.Schema["Features"].Type as VectorDataViewType;
+            // Inspecting the schema
+            Console.WriteLine($"Is the size of the Features column known: {featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
+
+            // Preview
+            //
+            // Is the size of the Features column known? True.
+            // Size: 5.
+
+            // If the size of the vector is unknown at compile time, it can be set at runtime.
+            IEnumerable<DataPoint> enumerableUnknownSize = new DataPoint[]
+            {
+               new DataPoint{ Features = new float[]{ 1.2f, 3.4f, 4.5f } },
+               new DataPoint{ Features = new float[]{ 4.2f, 3.4f, 1.6f } },
+               new DataPoint{ Features = new float[]{ 1.6f, 3.5f, 4.5f } },
+            };
+
+            // The feature dimension retrievable at runtime.
+            int featureDimension = 3;
+            var definedSchema = SchemaDefinition.Create(typeof(DataPoint));
+            featureColumn = definedSchema["Features"].ColumnType as VectorDataViewType;
+            Console.WriteLine($"Is the size of the Features column known: {featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
+
+            // Preview
+            //
+            // Is the size of the Features column known? False.
+            //Size: 0.
+
+            // Set the column type to be a known-size vector.
+            var vectorItemType = ((VectorDataViewType)definedSchema[0].ColumnType).ItemType;
+            definedSchema[0].ColumnType = new VectorDataViewType(vectorItemType, featureDimension);
+
+            // Read the data into an IDataView with the schema supplied in
+            IDataView data2 = mlContext.Data.LoadFromEnumerable(enumerableUnknownSize, definedSchema);
+
+            featureColumn = data2.Schema["Features"].Type as VectorDataViewType;
+            // Inspecting the schema
+            Console.WriteLine($"Is the size of the Features column known: {featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
+
+            // Preview
+            //
+            // Is the size of the Features column known? True. 
+            // Size: 3.
+        }
+    }
+
+    public class DataPoint
+    {
+        public float[] Features { get; set; }
+    }
+
+    public class DataPointVector
+    {
+        [VectorType(5)]
+        public float[] Features { get; set; }
+    }
+}

--- a/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/DataOperationsCatalog.cs
@@ -70,7 +70,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[LoadFromEnumerable](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs)]
+        /// [!code-csharp[LoadFromEnumerable](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs)]
         /// ]]>
         /// </format>
         /// </example>


### PR DESCRIPTION
I have seen a few asks for how to bypass having to define the size of the vector in the data models. 
Adding an example for it. 

