### PR TITLE
Adding InternalsVisibleTo to a couple of projects

### DIFF
--- a/src/Microsoft.ML.StandardTrainers/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.StandardTrainers/Properties/AssemblyInfo.cs
@@ -14,4 +14,5 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "RunTestsMore" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Internal.MetaLinearLearner" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "ParameterMixer" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Runtime.SequencePrediction" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Runtime.Sar" + InternalPublicKey.Value)]

--- a/src/Microsoft.ML.Transforms/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.Transforms/Properties/AssemblyInfo.cs
@@ -18,5 +18,6 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.TimeSeries" + PublicKey.Value)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.Tests" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo(assemblyName: "Microsoft.ML.TestFramework" + PublicKey.TestValue)]
+[assembly: InternalsVisibleTo(assemblyName: "TMSNlearnPrediction" + InternalPublicKey.Value)]
 
 [assembly: WantsToBeBestFriends]


### PR DESCRIPTION
Fixes #3715 

- Added `Microsoft.ML.Runtime.SequencePrediction` to `Microsoft.ML.StandardTrainers`
- Added `TMSNlearnPrediction` to `Microsoft.ML.Transforms`

