### PR TITLE
[AutoML] Fix Internationalization bug in generated project. 

### DIFF
--- a/src/mlnet/CodeGenerator/CSharp/TrainerGeneratorBase.cs
+++ b/src/mlnet/CodeGenerator/CSharp/TrainerGeneratorBase.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.ML.AutoML;
@@ -12,7 +13,6 @@ namespace Microsoft.ML.CLI.CodeGenerator.CSharp
 {
     /// <summary>
     /// Supports generation of code for trainers (Binary,Multi,Regression)
-    /// Ova is an exception though. Need to figure out how to tackle that.
     /// </summary>
     internal abstract class TrainerGeneratorBase : ITrainerGenerator
     {
@@ -61,17 +61,27 @@ namespace Microsoft.ML.CLI.CodeGenerator.CSharp
                 if (type == typeof(bool))
                 {
                     //True to true
-                    value = ((bool)kv.Value).ToString().ToLowerInvariant();
+                    value = ((bool)kv.Value).ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
                 }
                 if (type == typeof(float))
                 {
                     //0.0 to 0.0f
-                    value = ((float)kv.Value).ToString() + "f";
+                    value = ((float)kv.Value).ToString(CultureInfo.InvariantCulture) + "f";
                 }
 
-                if (type == typeof(int) || type == typeof(double) || type == typeof(long))
+                if (type == typeof(int))
                 {
-                    value = (kv.Value).ToString();
+                    value = ((int)kv.Value).ToString(CultureInfo.InvariantCulture);
+                }
+
+                if (type == typeof(double))
+                {
+                    value = ((double)kv.Value).ToString(CultureInfo.InvariantCulture);
+                }
+
+                if (type == typeof(long))
+                {
+                    value = ((long)kv.Value).ToString(CultureInfo.InvariantCulture);
                 }
 
                 if (type == typeof(string))

--- a/test/mlnet.Tests/TrainerGeneratorTests.cs
+++ b/test/mlnet.Tests/TrainerGeneratorTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 using Microsoft.ML;
 using Microsoft.ML.AutoML;
 using Microsoft.ML.CLI.CodeGenerator.CSharp;
@@ -6,12 +8,34 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace mlnet.Tests
 {
-    /****************************
-     * TODO : Add all trainer tests :
-     * **************************/
     [TestClass]
     public class TrainerGeneratorTests
     {
+        [TestMethod]
+        public void CultureInvariantTest()
+        {
+
+            var context = new MLContext();
+
+            var elementProperties = new Dictionary<string, object>()
+            {
+                {"LearningRate", 0.1f },
+                {"NumberOfLeaves", 1 },
+            };
+            PipelineNode node = new PipelineNode("LightGbmBinary", PipelineNodeType.Trainer, default(string[]), default(string), elementProperties);
+            Pipeline pipeline = new Pipeline(new PipelineNode[] { node });
+
+            //Set culture to deutsch.
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+            CodeGenerator codeGenerator = new CodeGenerator(pipeline, null, null);
+            var actual = codeGenerator.GenerateTrainerAndUsings();
+            string expectedTrainerString = "LightGbm(learningRate:0.1f,numberOfLeaves:1,labelColumnName:\"Label\",featureColumnName:\"Features\")";
+            Assert.AreEqual(expectedTrainerString, actual.Item1);
+            Assert.IsNull(actual.Item2);
+
+        }
+
         [TestMethod]
         public void LightGbmBinaryBasicTest()
         {


### PR DESCRIPTION
Looks like in Deutsch culture the floats are causing compilation errors in generated project because of the strings that generated floats are culture specific. Need to make them culture invariant.

Example : 1.1 -> 1,1 (deutsch)
closes #3677 