### PR TITLE
[AutoML] Reset the culture info back to its original value in the test case.

### DIFF
--- a/test/mlnet.Tests/TrainerGeneratorTests.cs
+++ b/test/mlnet.Tests/TrainerGeneratorTests.cs
@@ -26,10 +26,13 @@ namespace mlnet.Tests
             Pipeline pipeline = new Pipeline(new PipelineNode[] { node });
 
             //Set culture to deutsch.
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
 
             CodeGenerator codeGenerator = new CodeGenerator(pipeline, null, null);
             var actual = codeGenerator.GenerateTrainerAndUsings();
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
             string expectedTrainerString = "LightGbm(learningRate:0.1f,numberOfLeaves:1,labelColumnName:\"Label\",featureColumnName:\"Features\")";
             Assert.AreEqual(expectedTrainerString, actual.Item1);
             Assert.IsNull(actual.Item2);


### PR DESCRIPTION
Reset the culture info back to its original value in the test case so that if the thread is reused else we do not have any side effects. Just to be safe.
