### PR TITLE
Added omp requirement to build on Linux on README

### DIFF
--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -26,6 +26,7 @@ The following components are needed:
 * clang-3.9
 * cmake 2.8.12
 * libunwind8
+* libomp-dev
 * curl
 * All the requirements necessary to run .NET Core 2.0 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu52 for ubuntu 14.x, libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x). For more information on prerequisites in different linux distributions click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
 
@@ -35,6 +36,7 @@ For example, for Ubuntu 16.x:
 sudo apt-get update
 sudo apt-get install git clang-3.9 cmake libunwind8 curl
 sudo apt-get install libssl1.0.0 libicu55
+sudo apt-get install libomp-dev
 ```
 
 ### macOS


### PR DESCRIPTION
Fixes #3740.

Adds requirement and sample command to build on Linux.

