### PR TITLE
These changes allow for ML.NET to be built from source by VS2019 

### DIFF
--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -5,13 +5,13 @@ You can build ML.NET either via the command line or by using Visual Studio.
 
 ## Required Software
 
-1. **[Visual Studio 2017](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 15.8.0 and higher.
+1. **[Visual Studio 2019 or Visual Studio 2017](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 15.8.0 and higher.
 2. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path.
 
-### Visual Studio 2017 Installation
+### Visual Studio 2019 Visual Studio 2017 Installation
 We have successfully verified the below build instructions for Visual Studio version 15.8.0 and higher. 
 
-#### Visual Studio 2017 - 'Workloads' based install
+#### Visual Studio 2019 Visual Studio 2017 - 'Workloads' based install
 
 The following are the minimum requirements:
   * .NET desktop development
@@ -19,21 +19,21 @@ The following are the minimum requirements:
     * .NET Framework 4-4.6 Development Tools
   * Desktop development with C++
     * All Required Components
-    * VC++ 2017 v141 Toolset (x86, x64)
+    * VC++ 2019 v142 Toolset (x86, x64) for Visual Studio 2019 or VC++ 2017 v141 Toolset (x86, x64) for Visual Studio 2017
     * Windows 8.1 SDK and UCRT SDK
   * .NET Core cross-platform development
     * All Required Components
 
 Note: If you have both VS 2017 and 2015 installed, you need to copy DIA SDK directory from VS 2015 installation into VS 2017 (VS installer bug).
 
-#### Visual Studio 2017 - 'Individual components' based install
+#### Visual Studio 2019 or Visual Studio 2017 - 'Individual components' based install
 
 The following are the minimum requirements:
   * C# and Visual Basic Roslyn Compilers
   * Static Analysis Tools
   * .NET Portable Library Targeting Pack
   * Visual Studio C++ Core Features
-  * VC++ 2017 v141 Toolset (x86, x64)
+  * VC++ 2019 v142 Toolset (x86, x64) for Visual Studio 2019 or VC++ 2017 v141 Toolset (x86, x64) for Visual Studio 2017
   * MSBuild
   * .NET Framework 4.6 Targeting Pack
   * Windows Universal CRT SDK
@@ -42,7 +42,7 @@ The following are the minimum requirements:
 
 In order to fetch dependencies which come through Git submodules the following command needs to be run before building: `git submodule update --init`.
 
-### Building From Visual Studio 2017
+### Building From Visual Studio 2019 or Visual Studio 2017
 
 First, set up the required tools, from a (non-admin) Command Prompt window:
 
@@ -76,5 +76,7 @@ For more details, or to test an individual project, you can navigate to the test
 ## Known Issues
 
 CMake 3.7 or higher is required for Visual Studio 2017.
+
+CMake 3.14 or higher is required for Visual Studio 2019.
 
 You need to run `build` from the root of the repo first prior to opening the solution file and building in Visual Studio.

--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -5,13 +5,13 @@ You can build ML.NET either via the command line or by using Visual Studio.
 
 ## Required Software
 
-1. **[Visual Studio 2019 or Visual Studio 2017](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 15.8.0 and higher.
+1. **[Visual Studio 2019 / Visual Studio 2017](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 15.8.0 and higher.
 2. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path.
 
-### Visual Studio 2019 Visual Studio 2017 Installation
+### Visual Studio 2019 / Visual Studio 2017 Installation
 We have successfully verified the below build instructions for Visual Studio version 15.8.0 and higher. 
 
-#### Visual Studio 2019 Visual Studio 2017 - 'Workloads' based install
+#### Visual Studio 2019 / Visual Studio 2017 - 'Workloads' based install
 
 The following are the minimum requirements:
   * .NET desktop development
@@ -26,7 +26,7 @@ The following are the minimum requirements:
 
 Note: If you have both VS 2017 and 2015 installed, you need to copy DIA SDK directory from VS 2015 installation into VS 2017 (VS installer bug).
 
-#### Visual Studio 2019 or Visual Studio 2017 - 'Individual components' based install
+#### Visual Studio 2019 / Visual Studio 2017 - 'Individual components' based install
 
 The following are the minimum requirements:
   * C# and Visual Basic Roslyn Compilers
@@ -42,7 +42,7 @@ The following are the minimum requirements:
 
 In order to fetch dependencies which come through Git submodules the following command needs to be run before building: `git submodule update --init`.
 
-### Building From Visual Studio 2019 or Visual Studio 2017
+### Building From Visual Studio 2019 / Visual Studio 2017
 
 First, set up the required tools, from a (non-admin) Command Prompt window:
 

--- a/src/Native/build.cmd
+++ b/src/Native/build.cmd
@@ -64,7 +64,7 @@ exit /b 1
 :VS2019
 :: Setup vars for VS2019
 set __PlatformToolset=v142
-set __VSVersion=15 2017
+set __VSVersion=16 2019
 if NOT "%__BuildArch%" == "arm64" (
     :: Set the environment for the native build
     call "%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -15,9 +15,6 @@ set __VSString=%2
  :: Remove quotes
 set __VSString=%__VSString:"=%
 
-:: Set the target architecture to a format cmake understands.
-if /i "%3" == "x86"     (set __VSString=%__VSString%)
-if /i "%3" == "x64"     (set __VSString=%__VSString% Win64)
 
 if defined CMakePath goto DoGen
 
@@ -27,14 +24,16 @@ for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& .\pro
 popd
 
 :DoGen
-"%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" -G "Visual Studio %__VSString%" -B. -H%1
+
+if /i "%3" == "x86"     ("%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" -G "Visual Studio %__VSString%" -B. -H%1)
+if /i "%3" == "x64"     ("%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" -G "Visual Studio %__VSString%" -A "x64" -B. -H%1)
 endlocal
 GOTO :DONE
 
 :USAGE
   echo "Usage..."
   echo "gen-buildsys-win.bat <VSVersion> <Target Architecture>"
-  echo "Specify the VSVersion to be used - VS2015 or VS2017"
+  echo "Specify the VSVersion to be used - VS2015, VS2017 or VS2019"
   echo "Specify the Target Architecture - x86, or x64."
   EXIT /B 1
 

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -11,6 +11,8 @@ if %1=="/?" GOTO :USAGE
 setlocal
 set __sourceDir=%~dp0
 
+set __ExtraCmakeParams=
+
 set __VSString=%2
  :: Remove quotes
 set __VSString=%__VSString:"=%
@@ -24,9 +26,8 @@ for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& .\pro
 popd
 
 :DoGen
-
-if /i "%3" == "x86"     ("%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" -G "Visual Studio %__VSString%" -B. -H%1)
-if /i "%3" == "x64"     ("%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" -G "Visual Studio %__VSString%" -A "x64" -B. -H%1)
+if /i "%3" == "x64"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
+"%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" -G "Visual Studio %__VSString%" %__ExtraCmakeParams% -B. -H%1
 endlocal
 GOTO :DONE
 

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -27,6 +27,7 @@ popd
 
 :DoGen
 if /i "%3" == "x64"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
+if /i "%3" == "x86"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A Win32)
 "%CMakePath%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DMKL_LIB_PATH=%MKL_LIB_PATH%" -G "Visual Studio %__VSString%" %__ExtraCmakeParams% -B. -H%1
 endlocal
 GOTO :DONE


### PR DESCRIPTION
Fixes [#3739](https://github.com/dotnet/machinelearning/issues/3739)

