### PR TITLE
Improve error message for non-vector input to TensorFlowTransform

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -740,8 +740,8 @@ namespace Microsoft.ML.Transforms
                         throw Host.Except("Variable length input columns not supported");
 
                     _isInputVector[i] = type is VectorDataViewType;
-                    if (!_isInputVector[i]) // Temporary pending fix of issue #1542. In its current state, the below code would fail anyway with a naked exception if this check was not here.
-                        throw Host.Except("Non-vector columns not supported");
+                    if (!_isInputVector[i])
+                        throw Host.Except("Non-vector columns are not supported and should be loaded as vector columns of size 1");
                     vecType = (VectorDataViewType)type;
                     var expectedType = TensorFlowUtils.Tf2MlNetType(_parent.TFInputTypes[i]);
                     if (type.GetItemType() != expectedType)


### PR DESCRIPTION
Closes #1542 

The behavior is expected. TensorFlow treats all inputs as tensors. A scalar input should simply be loaded as a uni-dimensional tensor.

This PR improves the error message for the existing check for non-vector inputs to make this clear and closes the issue.
