### PR TITLE
Add load names to Platt calibrator

### DIFF
--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -25,7 +25,7 @@ using Newtonsoft.Json.Linq;
 [assembly: LoadableClass(PlattCalibratorTrainer.Summary, typeof(PlattCalibratorTrainer), null, typeof(SignatureCalibrator),
     PlattCalibratorTrainer.UserName,
     PlattCalibratorTrainer.LoadName,
-    "SigmoidCalibration")]
+    "SigmoidCalibration", "Platt", "Sigmoid")]
 
 [assembly: LoadableClass(FixedPlattCalibratorTrainer.Summary, typeof(FixedPlattCalibratorTrainer), typeof(FixedPlattCalibratorTrainer.Arguments), typeof(SignatureCalibrator),
     FixedPlattCalibratorTrainer.UserName,

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -30,7 +30,7 @@ using Newtonsoft.Json.Linq;
 [assembly: LoadableClass(FixedPlattCalibratorTrainer.Summary, typeof(FixedPlattCalibratorTrainer), typeof(FixedPlattCalibratorTrainer.Arguments), typeof(SignatureCalibrator),
     FixedPlattCalibratorTrainer.UserName,
     FixedPlattCalibratorTrainer.LoadName,
-    "FixedSigmoidCalibration")]
+    "FixedSigmoidCalibration", "FixedPlatt")]
 
 [assembly: LoadableClass(PavCalibratorTrainer.Summary, typeof(PavCalibratorTrainer), null, typeof(SignatureCalibrator),
     PavCalibratorTrainer.UserName,

--- a/test/Microsoft.ML.Predictor.Tests/CmdLine/CmdLineReverseTest.cs
+++ b/test/Microsoft.ML.Predictor.Tests/CmdLine/CmdLineReverseTest.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using Microsoft.ML.Calibrators;
 using Microsoft.ML.CommandLine;
+using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
+using Microsoft.ML.TestFramework;
 using Xunit;
 
 namespace Microsoft.ML.RunTests
@@ -73,6 +76,26 @@ namespace Microsoft.ML.RunTests
             Assert.Equal(innerArg3, testArg);
         }
 
+        [Fact]
+        [TestCategory("Cmd Parsing")]
+        public void NewTest()
+        {
+            var ml = new MLContext();
+            ml.AddStandardComponents();
+            var classes = Utils.MarshalInvoke(ml.ComponentCatalog.FindLoadableClasses<int>, typeof(SignatureCalibrator));
+            foreach (var cls in classes)
+            {
+                var factory = CmdParser.CreateComponentFactory(typeof(IComponentFactory<ICalibratorTrainer>), typeof(SignatureCalibrator), cls.LoadNames[0]);
+                var calibrator = ((IComponentFactory<ICalibratorTrainer>)factory).CreateComponent(ml);
+            }
+            var components = ml.ComponentCatalog.GetAllComponents(typeof(ICalibratorTrainerFactory));
+            foreach (var component in components)
+            {
+                var factory = CmdParser.CreateComponentFactory(typeof(IComponentFactory<ICalibratorTrainer>), typeof(SignatureCalibrator), component.Aliases[0]);
+                var calibrator = ((IComponentFactory<ICalibratorTrainer>)factory).CreateComponent(ml);
+            }
+        }
+    
         private delegate void SignatureSimpleComponent();
 
         private class SimpleArg


### PR DESCRIPTION
The load names of the `PlattCalibratorTrainerFactory` need to match those of the `LoadableClassAttribute`.
