### PR TITLE
Fix TextLoader constructor and add exception message

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1460,8 +1460,8 @@ namespace Microsoft.ML.Data
 
             var memberInfos = (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
 
-            if (memberInfos.Length == 0 && dataSample == null)
-                throw host.ExceptParam(nameof(TInput), $"Should define at least one public, readable field or property in {nameof(TInput)} or provide a {nameof(dataSample)}.");
+            if (memberInfos.Length == 0)
+                throw host.ExceptParam(nameof(TInput), $"Should define at least one public, readable field or property in {nameof(TInput)}.");
 
             var columns = new List<Column>();
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoader.cs
@@ -1456,9 +1456,12 @@ namespace Microsoft.ML.Data
             var propertyInfos =
                 userType
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .Where(x => x.CanRead && x.CanWrite && x.GetGetMethod() != null && x.GetSetMethod() != null && x.GetIndexParameters().Length == 0);
+                .Where(x => x.CanRead && x.GetGetMethod() != null && x.GetIndexParameters().Length == 0);
 
             var memberInfos = (fieldInfos as IEnumerable<MemberInfo>).Concat(propertyInfos).ToArray();
+
+            if (memberInfos.Length == 0 && dataSample == null)
+                throw host.ExceptParam(nameof(TInput), $"Should define at least one public, readable field or property in {nameof(TInput)} or provide a {nameof(dataSample)}.");
 
             var columns = new List<Column>();
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -62,6 +62,9 @@ namespace Microsoft.ML
         /// <summary>
         /// Create a text loader <see cref="TextLoader"/> by inferencing the dataset schema from a data model type.
         /// </summary>
+        /// <typeparam name="TInput">Defines the schema of the data to be loaded. Use public fields or properties
+        /// decorated with <see cref="LoadColumnAttribute"/> (and possibly other attributes) to specify the column
+        /// names and their data types in the schema of the loaded data.</typeparam>
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="separatorChar">Column separator character. Default is '\t'</param>
         /// <param name="hasHeader">Does the file contains header?</param>

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -68,11 +68,8 @@ namespace Microsoft.ML
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="separatorChar">Column separator character. Default is '\t'</param>
         /// <param name="hasHeader">Does the file contains header?</param>
-        /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column
-        /// names and number of slots in each column. If <typeparamref name="TInput"/> does not contain any public
-        /// fields, we assume that the first column in the <paramref name="dataSample"/> is the Label column and
-        /// the second is the Features column. If there are more than two columns, the Features column is taken
-        /// to be a vector column.</param>
+        /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer information
+        /// about the columns, such as slot names.</param>
         /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
         /// and distinguish empty values from missing values. When true, consecutive separators

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -68,7 +68,11 @@ namespace Microsoft.ML
         /// <param name="catalog">The <see cref="DataOperationsCatalog"/> catalog.</param>
         /// <param name="separatorChar">Column separator character. Default is '\t'</param>
         /// <param name="hasHeader">Does the file contains header?</param>
-        /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column names and number of slots in each column.</param>
+        /// <param name="dataSample">The optional location of a data sample. The sample can be used to infer column
+        /// names and number of slots in each column. If <typeparamref name="TInput"/> does not contain any public
+        /// fields, we assume that the first column in the <paramref name="dataSample"/> is the Label column and
+        /// the second is the Features column. If there are more than two columns, the Features column is taken
+        /// to be a vector column.</param>
         /// <param name="allowQuoting">Whether the input may include quoted values,
         /// which can contain separator characters, colons,
         /// and distinguish empty values from missing values. When true, consecutive separators

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -826,6 +826,15 @@ namespace Microsoft.ML.EntryPoints.Tests
             public float SepalWidth { get; }
         }
 
+        public class IrisPublicFields
+        {
+            [LoadColumn(0)]
+            public readonly float SepalLength;
+
+            [LoadColumn(1)]
+            public float SepalWidth;
+        }
+
         public class IrisPublicProperties
         {
             [LoadColumn(0)]
@@ -846,6 +855,11 @@ namespace Microsoft.ML.EntryPoints.Tests
             var oneIrisData = mlContext.Data.CreateEnumerable<IrisPublicProperties>(dataIris, false).First();
             Assert.True(oneIrisData.SepalLength != 0 && oneIrisData.SepalWidth != 0);
 
+            // Class with read only fields.
+            dataIris = mlContext.Data.CreateTextLoader<IrisPublicFields>(separatorChar: ',').Load(dataPath);
+            oneIrisData = mlContext.Data.CreateEnumerable<IrisPublicProperties>(dataIris, false).First();
+            Assert.True(oneIrisData.SepalLength != 0 && oneIrisData.SepalWidth != 0);
+
             // Class with no fields.
             try
             {
@@ -854,7 +868,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
             catch (Exception ex)
             {
-                Assert.True(ex.Message == "Should define at least one public, readable field or property in TInput or provide a dataSample.\r\nParameter name: TInput");
+                Assert.StartsWith("Should define at least one public, readable field or property in TInput or provide a dataSample.", ex.Message);
             }
 
             // Class with no public readable fields.
@@ -865,7 +879,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
             catch (Exception ex)
             {
-                Assert.True(ex.Message == "Should define at least one public, readable field or property in TInput or provide a dataSample.\r\nParameter name: TInput");
+                Assert.StartsWith("Should define at least one public, readable field or property in TInput or provide a dataSample.", ex.Message);
             }
         }
     }

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -797,11 +797,11 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
         }
 
-        public class IrisNoFields
+        private class IrisNoFields
         {
         }
 
-        public class IrisPrivateFields
+        private class IrisPrivateFields
         {
             [LoadColumn(0)]
             private float SepalLength;
@@ -817,7 +817,7 @@ namespace Microsoft.ML.EntryPoints.Tests
                 SepalLength = sepalLength;
             }
         }
-        public class IrisPublicGetProperties
+        private class IrisPublicGetProperties
         {
             [LoadColumn(0)]
             public float SepalLength { get; }
@@ -826,8 +826,14 @@ namespace Microsoft.ML.EntryPoints.Tests
             public float SepalWidth { get; }
         }
 
-        public class IrisPublicFields
+        private class IrisPublicFields
         {
+            public IrisPublicFields(float sepalLength, float sepalWidth)
+            {
+                SepalLength = sepalLength;
+                SepalWidth = sepalWidth;
+            }
+
             [LoadColumn(0)]
             public readonly float SepalLength;
 
@@ -835,7 +841,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             public float SepalWidth;
         }
 
-        public class IrisPublicProperties
+        private class IrisPublicProperties
         {
             [LoadColumn(0)]
             public float SepalLength { get; set; }
@@ -868,7 +874,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
             catch (Exception ex)
             {
-                Assert.StartsWith("Should define at least one public, readable field or property in TInput or provide a dataSample.", ex.Message);
+                Assert.StartsWith("Should define at least one public, readable field or property in TInput.", ex.Message);
             }
 
             // Class with no public readable fields.
@@ -879,7 +885,7 @@ namespace Microsoft.ML.EntryPoints.Tests
             }
             catch (Exception ex)
             {
-                Assert.StartsWith("Should define at least one public, readable field or property in TInput or provide a dataSample.", ex.Message);
+                Assert.StartsWith("Should define at least one public, readable field or property in TInput.", ex.Message);
             }
         }
     }


### PR DESCRIPTION
Fixes #3705.

In issue #3705 it appeared that the class defining the data was required to have both get and **set** auto-properties. In `TextLoader` however, we don't use the set property, so I removed that from the conditions.

Second, I added an exception message in case no public readable property or field is found in the class defining the data and no dataSample is passed to the constructor.

I added a related test which tests the various scenarios.
 