### PR TITLE
[AutoML] Cross validation fixes; validate empty training / validation input data

### DIFF
--- a/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
+++ b/src/Microsoft.ML.AutoML/API/ExperimentBase.cs
@@ -162,9 +162,7 @@ namespace Microsoft.ML.AutoML
         {
             if (validationData == null)
             {
-                var splitResult = SplitUtil.TrainValidateSplit(Context, trainData, columnInformation?.SamplingKeyColumnName);
-                trainData = splitResult.trainData;
-                validationData = splitResult.validationData;
+                return Execute(trainData, columnInformation, preFeaturizer, progressHandler);
             }
             return ExecuteTrainValidate(trainData, columnInformation, validationData, preFeaturizer, progressHandler);
         }

--- a/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
@@ -10,28 +10,37 @@ namespace Microsoft.ML.AutoML
 {
     internal static class SplitUtil
     {
-        private const string CrossValEmptyFoldErrorMsg = @"Cross validation split has 0 rows. Perhaps " +
-            "try increasing number of rows provided in training data, or lowering specified number of " +
-            "cross validation folds.";
-
         public static (IDataView[] trainDatasets, IDataView[] validationDatasets) CrossValSplit(MLContext context, 
             IDataView trainData, uint numFolds, string samplingKeyColumn)
         {
             var originalColumnNames = trainData.Schema.Select(c => c.Name);
             var splits = context.Data.CrossValidationSplit(trainData, (int)numFolds, samplingKeyColumnName: samplingKeyColumn);
-            var trainDatasets = new IDataView[numFolds];
-            var validationDatasets = new IDataView[numFolds];
-            for (var i = 0; i < numFolds; i++)
+            var trainDatasets = new List<IDataView>();
+            var validationDatasets = new List<IDataView>();
+            
+            foreach (var split in splits)
             {
-                var split = splits[i];
-                trainDatasets[i] = DropAllColumnsExcept(context, split.TrainSet, originalColumnNames);
-                validationDatasets[i] = DropAllColumnsExcept(context, split.TestSet, originalColumnNames);
-                if (DatasetDimensionsUtil.IsDataViewEmpty(trainDatasets[i]) || DatasetDimensionsUtil.IsDataViewEmpty(validationDatasets[i]))
+                if (DatasetDimensionsUtil.IsDataViewEmpty(split.TrainSet) ||
+                    DatasetDimensionsUtil.IsDataViewEmpty(split.TestSet))
                 {
-                    throw new InvalidOperationException(CrossValEmptyFoldErrorMsg);
+                    continue;
                 }
+
+                var trainDataset = DropAllColumnsExcept(context, split.TrainSet, originalColumnNames);
+                var validationDataset = DropAllColumnsExcept(context, split.TestSet, originalColumnNames);
+
+                trainDatasets.Add(trainDataset);
+                validationDatasets.Add(validationDataset);
             }
-            return (trainDatasets, validationDatasets);
+
+            if (!trainDatasets.Any())
+            {
+                throw new InvalidOperationException("All cross validation folds have empty train or test data. Perhaps " +
+                    "try increasing the number of rows provided in training data, or lowering specified number of " +
+                    "cross validation folds.");
+            }
+
+            return (trainDatasets.ToArray(), validationDatasets.ToArray());
         }
 
         /// <summary>

--- a/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
@@ -35,8 +35,8 @@ namespace Microsoft.ML.AutoML
 
             if (!trainDatasets.Any())
             {
-                throw new InvalidOperationException("All cross validation folds have empty train or test data. Perhaps " +
-                    "try increasing the number of rows provided in training data, or lowering specified number of " +
+                throw new InvalidOperationException("All cross validation folds have empty train or test data. " +
+                    "Try increasing the number of rows provided in training data, or lowering specified number of " +
                     "cross validation folds.");
             }
 

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -61,6 +61,11 @@ namespace Microsoft.ML.AutoML
                 throw new ArgumentNullException(nameof(trainData), "Training data cannot be null");
             }
 
+            if (DatasetDimensionsUtil.IsDataViewEmpty(trainData))
+            {
+                throw new ArgumentException("Training data has 0 rows", nameof(trainData));
+            }
+
             foreach (var column in trainData.Schema)
             {
                 if (column.Name == DefaultColumnNames.Features && column.Type.GetItemType() != NumberDataViewType.Single)
@@ -162,6 +167,11 @@ namespace Microsoft.ML.AutoML
             if (validationData == null)
             {
                 return;
+            }
+
+            if (DatasetDimensionsUtil.IsDataViewEmpty(validationData))
+            {
+                throw new ArgumentException("Validation data has 0 rows", nameof(validationData));
             }
 
             const string schemaMismatchError = "Training data and validation data schemas do not match.";

--- a/test/Microsoft.ML.AutoML.Tests/SplitUtilTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/SplitUtilTests.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using Microsoft.ML.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.ML.AutoML.Test
+{
+    [TestClass]
+    public class SplitUtilTests
+    {
+        /// <summary>
+        /// When there's only one row of data, assert that
+        /// attempted cross validation throws (all splits should have empty
+        /// train or test set).
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void CrossValSplitThrowsWhenNotEnoughData()
+        {
+            var mlContext = new MLContext();
+            var dataViewBuilder = new ArrayDataViewBuilder(mlContext);
+            dataViewBuilder.AddColumn("Number", NumberDataViewType.Single, 0f);
+            dataViewBuilder.AddColumn("Label", NumberDataViewType.Single, 0f);
+            var dataView = dataViewBuilder.GetDataView();
+            SplitUtil.CrossValSplit(mlContext, dataView, 10, null);
+        }
+
+        /// <summary>
+        /// When there are few rows of data, assert that
+        /// cross validation succeeds, but # of splits is less than 10
+        /// (splits with empty train or test sets should not be returned from this API).
+        /// </summary>
+        [TestMethod]
+        public void CrossValSplitSmallDataView()
+        {
+            var mlContext = new MLContext(seed: 0);
+            var dataViewBuilder = new ArrayDataViewBuilder(mlContext);
+            dataViewBuilder.AddColumn("Number", NumberDataViewType.Single, new float[9]);
+            dataViewBuilder.AddColumn("Label", NumberDataViewType.Single, new float[9]);
+            var dataView = dataViewBuilder.GetDataView();
+            const int requestedNumSplits = 10;
+            var splits = SplitUtil.CrossValSplit(mlContext, dataView, requestedNumSplits, null);
+            Assert.IsTrue(splits.trainDatasets.Any());
+            Assert.IsTrue(splits.trainDatasets.Count() < requestedNumSplits);
+            Assert.AreEqual(splits.trainDatasets.Count(), splits.validationDatasets.Count());
+        }
+
+        /// <summary>
+        /// Assert that with many rows of data, cross validation produces the requested
+        /// # of splits.
+        /// </summary>
+        [TestMethod]
+        public void CrossValSplitLargeDataView()
+        {
+            var mlContext = new MLContext(seed: 0);
+            var dataViewBuilder = new ArrayDataViewBuilder(mlContext);
+            dataViewBuilder.AddColumn("Number", NumberDataViewType.Single, new float[10000]);
+            dataViewBuilder.AddColumn("Label", NumberDataViewType.Single, new float[10000]);
+            var dataView = dataViewBuilder.GetDataView();
+            const int requestedNumSplits = 10;
+            var splits = SplitUtil.CrossValSplit(mlContext, dataView, requestedNumSplits, null);
+            Assert.IsTrue(splits.trainDatasets.Any());
+            Assert.AreEqual(requestedNumSplits, splits.trainDatasets.Count());
+            Assert.AreEqual(requestedNumSplits, splits.validationDatasets.Count());
+        }
+    }
+}


### PR DESCRIPTION
Updates --
- In the AutoML API -- when calling the `Execute` method signature that contains both training & validation data, if validation data is null, route to the `Execute` method that doesn't contain validation data / that splits the data in a train/test or cross-val manner depending on the # of rows.
- Don't crash if some cross val splits have empty train/test data. As long as not all splits have empty train or test data, proceed only using splits w/ non-empty train & test sets. Explicitly throw an exception if all splits either have empty train or test sets.
- Validate input training & validation data (if explicitly provided) are not empty