### PR TITLE
For binary classification, discard cross validation splits where there is not at least one true & one false label in the validation set

### DIFF
--- a/src/Microsoft.ML.AutoML/DatasetDimensions/DatasetDimensionsUtil.cs
+++ b/src/Microsoft.ML.AutoML/DatasetDimensions/DatasetDimensionsUtil.cs
@@ -81,5 +81,30 @@ namespace Microsoft.ML.AutoML
         {
             return CountRows(data, 1) == 0;
         }
+
+        /// <summary>
+        /// Compute the cardinality of each column. Stop computing when <paramref name="maxCardinality"/> unique
+        /// elements have been found.
+        /// </summary>
+        public static int ComputeCardinality<T>(IDataView data, DataViewSchema.Column column, int maxCardinality)
+        {
+            var seen = new HashSet<T>();
+            using (var cursor = data.GetRowCursor(new[] { column }))
+            {
+                var getter = cursor.GetGetter<T>(column);
+                while (cursor.MoveNext())
+                {
+                    var value = default(T);
+                    getter(ref value);
+                    seen.Add(value);
+
+                    if (seen.Count == maxCardinality)
+                    {
+                        return maxCardinality;
+                    }
+                }
+            }
+            return seen.Count;
+        }
     }
 }

--- a/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.AutoML
             for (var i = 0; i < trainDatasets.Count(); i++)
             {
                 var validationDataset = validationDatasets.ElementAt(i);
-                var labelColumn = validationDataset.Schema.First(c => c.Name == labelColumnName);
+                var labelColumn = validationDataset.Schema.First(c => !c.IsHidden && c.Name == labelColumnName);
                 if (DatasetDimensionsUtil.ComputeCardinality<bool>(validationDataset, labelColumn, 2) < 2)
                 {
                     continue;

--- a/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/SplitUtil.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ML.AutoML
             {
                 // Discard splits where either train or test set is empty
                 if (DatasetDimensionsUtil.IsDataViewEmpty(split.TrainSet) ||
-                DatasetDimensionsUtil.IsDataViewEmpty(split.TestSet))
+                    DatasetDimensionsUtil.IsDataViewEmpty(split.TestSet))
                 {
                     continue;
                 }


### PR DESCRIPTION
For binary classification, discard cross validation splits where there is not at least one true & one false label in the validation set. Otherwise, scoring the dataset crashes because AUC cannot be computed like in https://github.com/dotnet/machinelearning/issues/3800