### PR TITLE
Revert "Publish nugets to temporary myget feed (#3400)"

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -182,7 +182,7 @@ phases:
     _SignType: real
     _UseEsrpSigning: true
     _TeamName: DotNetCore
-    _NuGetFeedUrl: https://www.myget.org/F/shmoradi-mlnet2/api/v2/package
+    _NuGetFeedUrl: https://dotnet.myget.org/F/dotnet-core/api/v2/package
     _SymwebSymbolServerPath: https://microsoft.artifacts.visualstudio.com/DefaultCollection
     _MsdlSymbolServerPath: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
   queue:
@@ -236,12 +236,12 @@ phases:
       nuGetFeedType: internal 
       feedPublish: MachineLearning
       
-  - task: MSBuild@1
-    displayName: Publish Packages to MyGet Feed
-    inputs:
-      solution: build/publish.proj
-      msbuildArguments: /t:PublishPackages /p:NuGetFeedUrl=$(_NuGetFeedUrl) /p:NuGetApiKey=$(myget-shmoradi-mlnet2-api-key)
-      msbuildVersion: 15.0
+  # - task: MSBuild@1
+  #   displayName: Publish Packages to MyGet Feed
+  #   inputs:
+  #     solution: build/publish.proj
+  #     msbuildArguments: /t:PublishPackages /p:NuGetFeedUrl=$(_NuGetFeedUrl) /p:NuGetApiKey=$(dotnet-myget-org-api-key)
+  #     msbuildVersion: 15.0
 
   - task: MSBuild@1
     displayName: Publish Symbols to SymWeb Symbol Server


### PR DESCRIPTION
This reverts commit 0a90bbb49da69765c2ff870078fdabfb20783a58.

shmoradi myget feed is downgraded to 200MB of space after a month and needs to be replaced with a permanent solution. It was created as a workaround before //build. Disabling it for now to prevent the failure in publishing step.