### PR TITLE
Fixes #3207. Prevent usage of KeyType without parameter.

### DIFF
--- a/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
+++ b/src/Microsoft.ML.Data/Data/SchemaDefinition.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Data
         /// </remarks>
         public KeyTypeAttribute()
         {
-
+            throw Contracts.ExceptNotSupp("Using KeyType without the Count parameter is not supported");
         }
 
         /// <summary>


### PR DESCRIPTION
Added an exception to the parameterless constructor for KeyType because it doesn't make sense to use it without a parameter

When KeyType is called without a constructor, the Count member remains uninitialized and when that remains null, it is set to uint.MaxValue which fails the overflow check. 

Since the value that a particular KeyType takes on represents an index into a 1 based vector, it cannot be set to zero by zero by default. It always needs to have a valid max value and that needs to be determined by the use case. Therefore, the best approach is to prevents its usage without the parameter. 

There seems to be a different but related doc bug that this fix does not address:

The documentation for [KeyTypeAttribute](https://docs.microsoft.com/en-us/dotnet/api/microsoft.ml.data.keytypeattribute?view=ml-dotnet) says it can be used with uint and ulong.  However, during mapping there is an overflow check performed and an exception is thrown if the value is greater than int.MaxValue - 1. 

That means, we don't actually support the full range of uint and ulong. 

@codemzs / @artidoro Any thoughts on whether we should fix the docs or remove the overflow check?


- [X] There's a descriptive title that will make sense to other developers some time from now. 
- [X] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [X] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

fixes #3207
