### PR TITLE
Change default EvaluationMetric for LightGbm trainers to conform to d…

### DIFF
--- a/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Logloss;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
 
             static Options()
             {

--- a/src/Microsoft.ML.LightGbm/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmMulticlassTrainer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Error;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
 
             static Options()
             {

--- a/src/Microsoft.ML.LightGbm/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmRankingTrainer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.NormalizedDiscountedCumulativeGain;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
 
             static Options()
             {

--- a/src/Microsoft.ML.LightGbm/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmRegressionTrainer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.RootMeanSquaredError;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
 
             static Options()
             {

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -11297,7 +11297,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "Logloss"
+          "Default": "Default"
         },
         {
           "Name": "MaximumBinCountPerFeature",
@@ -11782,7 +11782,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "Error"
+          "Default": "Default"
         },
         {
           "Name": "MaximumBinCountPerFeature",
@@ -12279,7 +12279,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "NormalizedDiscountedCumulativeGain"
+          "Default": "Default"
         },
         {
           "Name": "MaximumBinCountPerFeature",
@@ -12737,7 +12737,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "RootMeanSquaredError"
+          "Default": "Default"
         },
         {
           "Name": "MaximumBinCountPerFeature",

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMReg-CV-generatedRegressionDataset-out.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMReg-CV-generatedRegressionDataset-out.txt
@@ -35,10 +35,10 @@ Virtual memory usage(MB): %Number%
 [1] 'Loading data for LightGBM' started.
 [1] 'Loading data for LightGBM' finished in %Time%.
 [2] 'Training with LightGBM' started.
-[2] (%Time%)	Iteration: 50	Training-rmse: 6.09160118577349
+[2] (%Time%)	Iteration: 50	Training-: 37.107605006517
 [2] 'Training with LightGBM' finished in %Time%.
 [3] 'Loading data for LightGBM #2' started.
 [3] 'Loading data for LightGBM #2' finished in %Time%.
 [4] 'Training with LightGBM #2' started.
-[4] (%Time%)	Iteration: 50	Training-rmse: 5.26343689176522
+[4] (%Time%)	Iteration: 50	Training-: 27.7037679135951
 [4] 'Training with LightGBM #2' finished in %Time%.

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMReg-TrainTest-generatedRegressionDataset-out.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMReg-TrainTest-generatedRegressionDataset-out.txt
@@ -26,7 +26,7 @@ Virtual memory usage(MB): %Number%
 [1] 'Loading data for LightGBM' started.
 [1] 'Loading data for LightGBM' finished in %Time%.
 [2] 'Training with LightGBM' started.
-[2] (%Time%)	Iteration: 50	Training-rmse: 5.10533343749577
+[2] (%Time%)	Iteration: 50	Training-: 26.0644295080124
 [2] 'Training with LightGBM' finished in %Time%.
 [3] 'Saving model' started.
 [3] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-CV-generatedRegressionDataset.RMSE-rp.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-CV-generatedRegressionDataset.RMSE-rp.txt
@@ -1,4 +1,4 @@
 LightGBMR
-L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-26.59978	1393.326	37.32081	1393.326	0.923402	50	0.2	20	10	+	1	LightGBMR	%Data%		%Output%	99	0	0	maml.exe CV tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} threads=- dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% seed=1	/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
+L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/em	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
+26.59978	1393.326	37.32081	1393.326	0.923402	RootMeanSquaredError	50	0.2	20	10	+	1	LightGBMR	%Data%		%Output%	99	0	0	maml.exe CV tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} threads=- dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% seed=1	/em:RootMeanSquaredError;/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
 

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-TrainTest-generatedRegressionDataset.RMSE-rp.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-TrainTest-generatedRegressionDataset.RMSE-rp.txt
@@ -1,4 +1,4 @@
 LightGBMR
-L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-3.428896	25.23601	5.023546	25.23601	0.998616	50	0.2	20	10	+	1	LightGBMR	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% out=%Output% seed=1	/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
+L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/em	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
+3.428896	25.23601	5.023546	25.23601	0.998616	RootMeanSquaredError	50	0.2	20	10	+	1	LightGBMR	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% out=%Output% seed=1	/em:RootMeanSquaredError;/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
 


### PR DESCRIPTION
…efault metric in standalone LightGbm

Fixes #3822 

In ML.NET, the default `EvaluationMetric` for LightGbm is set to `EvaluateMetricType.Error` for multiclass, `EvaluationMetricType.LogLoss` for binary, and so on. This leads to inconsistent behavior from the user's perspective: If a user specified `EvaluationMetric = EvaluateMetricType.Default`, the parameter passed to LightGbm would be the empty string "", which is the LightGbm default and means that the metric is selected based on the objective. However, if they do not specify `EvaluationMetric` at all, the parameter passed to LightGbm would be Error for multiclass, LogLoss for binary, and so on. 

We should make the experience for LightGbm in ML.NET consistent with what a user of standalone LightGbm experiences, and not expect them to dig through LightGbm docs and ML.NET docs to find this out.

This PR makes the user experience consistent with standalone LightGbm by by changing the default `EvaluationMetric` in ML.NET to `EvaluationMetricType.Default`.

[LightGbm metric parameters docs](https://lightgbm.readthedocs.io/en/latest/Parameters.html#metric-parameters)