### PR TITLE
Improve column purpose detection for sparse text datasets

### DIFF
--- a/src/Microsoft.ML.AutoML/ColumnInference/PurposeInference.cs
+++ b/src/Microsoft.ML.AutoML/ColumnInference/PurposeInference.cs
@@ -123,15 +123,19 @@ namespace Microsoft.ML.AutoML
                         var data = column.GetColumnData();
 
                         long sumLength = 0;
-                        int sumSpaces = 0;
+                        long sumSpaces = 0;
+                        long numMissing = 0;
                         var seen = new HashSet<string>();
-                        int imagePathCount = 0;
+                        long imagePathCount = 0;
                         foreach (var span in data)
                         {
                             sumLength += span.Length;
-                            seen.Add(span.ToString());
                             string spanStr = span.ToString();
+                            seen.Add(spanStr);
                             sumSpaces += spanStr.Count(x => x == ' ');
+
+                            if (string.IsNullOrEmpty(spanStr))
+                                numMissing += 1;
 
                             foreach (var ext in commonImageExtensions)
                             {
@@ -145,9 +149,9 @@ namespace Microsoft.ML.AutoML
 
                         if (imagePathCount < data.Count - 1)
                         {
-                            Double avgLength = 1.0 * sumLength / data.Count;
-                            Double cardinalityRatio = 1.0 * seen.Count / data.Count;
-                            Double avgSpaces = 1.0 * sumSpaces / data.Count;
+                            Double avgLength = 1.0 * sumLength / Math.Max(data.Count - numMissing, 1);
+                            Double cardinalityRatio = 1.0 * seen.Count / Math.Max(data.Count - numMissing, 1);
+                            Double avgSpaces = 1.0 * sumSpaces / Math.Max(data.Count - numMissing, 1);
                             if (cardinalityRatio < 0.7)
                                 column.SuggestedPurpose = ColumnPurpose.CategoricalFeature;
                             // (note: the columns.Count() == 1 condition below, in case a dataset has only


### PR DESCRIPTION
Fixes #3879 by not counting empty text values when calculating the column statistics.

Background from #3879:
> AutoML does poorly on a few text datasets. For example, a text dataset we benchmark on has an accuracy of 0.60 vs. an expected accuracy of 0.85. 
> 
> This is caused by us detecting the text columns columns as **categorical** instead of **free text**. For the this dataset, this is due to the text column being 84% blank (a sparsely filled out column). 
> 
> **To fix:** 
> We need to detect the column purpose only on the set (non-blank) values.
> 
> Recommend subtracting the blank values from `data.Count`:
> https://github.com/dotnet/machinelearning/blob/227da9d7db2ce80b073cc64bfd067b04e6189de1/src/Microsoft.ML.AutoML/ColumnInference/PurposeInference.cs#L148-L158
> 
> Currently `avgLength`, `cardinalityRatio`, `avgSpaces` are artificially lower due to the missing values.
