### PR TITLE
Move from phases to jobs and use bring your own cloud pool

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -10,11 +10,12 @@ resources:
   - container: UbuntuContainer
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-mlnet-207e097-20190312152303
 
-phases:
-- template: /build/ci/phase-template.yml
+jobs:
+- template: /build/ci/job-template.yml
   parameters:
     name: Centos_x64_NetCoreApp30
     buildScript: ./build.sh
+    container: CentosContainer
     customMatrixes:
       Debug_Build:
         _configuration: Debug-Intrinsics
@@ -24,26 +25,25 @@ phases:
         _configuration: Release-Intrinsics
         _config_short: RI
         _includeBenchmarkData: true
-    queue:
+    pool:
       name: Hosted Ubuntu 1604
-      container: CentosContainer
 
-- template: /build/ci/phase-template.yml
+- template: /build/ci/job-template.yml
   parameters:
     name: Ubuntu_x64_NetCoreApp21
     buildScript: ./build.sh
-    queue:
+    container: UbuntuContainer
+    pool:
       name: Hosted Ubuntu 1604
-      container: UbuntuContainer
 
-- template: /build/ci/phase-template.yml
+- template: /build/ci/job-template.yml
   parameters:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
-    queue:
+    pool:
       name: Hosted macOS
 
-- template: /build/ci/phase-template.yml
+- template: /build/ci/job-template.yml
   parameters:
     name: Windows_x64_NetCoreApp30
     buildScript: build.cmd
@@ -56,17 +56,18 @@ phases:
         _configuration: Release-Intrinsics
         _config_short: RI
         _includeBenchmarkData: true
-    queue:
-      name: Hosted VS2017
+    pool:
+      name: NetCorePublic-Pool
+      queue: buildpool.windows.10.amd64.vs2017
 
-- template: /build/ci/phase-template.yml
+- template: /build/ci/job-template.yml
   parameters:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
-    queue:
+    pool:
       name: Hosted VS2017
 
-- template: /build/ci/phase-template.yml
+- template: /build/ci/job-template.yml
   parameters:
     name: Windows_x64_NetFx461
     buildScript: build.cmd
@@ -79,13 +80,13 @@ phases:
         _configuration: Release-netfx
         _config_short: RFX
         _includeBenchmarkData: false
-    queue:
+    pool:
       name: Hosted VS2017
 
-- template: /build/ci/phase-template.yml
+- template: /build/ci/job-template.yml
   parameters:
     name: Windows_x86_NetCoreApp21
     architecture: x86
     buildScript: build.cmd
-    queue:
+    pool:
       name: Hosted VS2017

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -58,7 +58,7 @@ jobs:
         _includeBenchmarkData: true
     pool:
       name: NetCorePublic-Pool
-      queue: buildpool.windows.10.amd64.vs2017
+      queue: buildpool.windows.10.amd64.vs2017.open
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -2,23 +2,18 @@ parameters:
   name: ''
   architecture: x64
   buildScript: ''
-  queue: {}
+  pool: {}
   customMatrixes: ''
   codeCoverage: false
+  container: ''
 
-phases:
-  - phase: ${{ parameters.name }}
-    variables:
-      _buildScript: ${{ parameters.buildScript }}
-      _phaseName: ${{ parameters.name }}
-      _arch: ${{ parameters.architecture }}
-      _codeCoverage: ${{ parameters.codeCoverage }}
-    queue:
-      ${{ if eq(variables._codeCoverage, 'false') }}:
-        timeoutInMinutes: 30
-      ${{ if eq(variables._codeCoverage, 'true') }}:
-        timeoutInMinutes: 60
-      parallel: 99
+jobs:
+  - job: ${{ parameters.name }}
+    ${{ if eq(parameters.codeCoverage, 'false') }}:
+      timeoutInMinutes: 30
+    ${{ if eq(parameters.codeCoverage, 'true') }}:
+      timeoutInMinutes: 60
+    strategy:
       matrix:
         ${{ if eq(parameters.customMatrixes, '') }}:
           Debug_Build:
@@ -31,20 +26,24 @@ phases:
             _includeBenchmarkData: true
         ${{ if ne(parameters.customMatrixes, '') }}:
           ${{ insert }}: ${{ parameters.customMatrixes }}
-      ${{ insert }}: ${{ parameters.queue }}
+    
+    pool: ${{ parameters.pool }}
+    ${{ if ne(parameters.container, '') }}:
+      container: ${{ parameters.container }}
+
     steps:
-    - ${{ if eq(parameters.queue.name, 'Hosted macOS') }}:
+    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
       - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
-    - script: $(_buildScript) -$(_configuration) -buildArch=$(_arch)
+    - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}
       displayName: Build
-    - script: $(_buildScript) -- /t:DownloadExternalTestFiles /p:IncludeBenchmarkData=$(_includeBenchmarkData)
+    - script: ${{ parameters.buildScript }} -- /t:DownloadExternalTestFiles /p:IncludeBenchmarkData=$(_includeBenchmarkData)
       displayName: Download Benchmark Data
-    - script: $(_buildScript) -$(_configuration) -runtests -coverage=$(_codeCoverage)
+    - script: ${{ parameters.buildScript }} -$(_configuration) -runtests -coverage=${{ parameters.codeCoverage }}
       displayName: Run Tests.
     - script: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet msbuild build/Codecoverage.proj /p:CodeCovToken=$(CODECOV_TOKEN)
       displayName: Upload coverage to codecov.io
-      condition: and(succeeded(), eq(variables._codeCoverage, 'true'))
+      condition: and(succeeded(), eq(${{ parameters.codeCoverage }}, True))
     - task: PublishTestResults@2
       displayName: Publish Test Results
       condition: succeededOrFailed()
@@ -52,7 +51,7 @@ phases:
         testRunner: 'vSTest'
         searchFolder: '$(System.DefaultWorkingDirectory)/bin'
         testResultsFiles: '**/*.trx'
-        testRunTitle: Machinelearning_Tests_$(_phaseName)_$(_configuration)_$(Build.BuildNumber)
+        testRunTitle: Machinelearning_Tests_${{ parameters.name }}_$(_configuration)_$(Build.BuildNumber)
         configuration: $(_configuration)
         mergeTestResults: true
     - task: CopyFiles@2
@@ -78,5 +77,5 @@ phases:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         artifactName: ${{ parameters.name }} $(_config_short)
         artifactType: container
-    - script: $(_buildScript) -buildPackages
+    - script: ${{ parameters.buildScript }} -buildPackages
       displayName: Build Packages

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
   - job: ${{ parameters.name }}
     ${{ if eq(parameters.codeCoverage, 'false') }}:
-      timeoutInMinutes: 30
+      timeoutInMinutes: 40
     ${{ if eq(parameters.codeCoverage, 'true') }}:
       timeoutInMinutes: 60
     strategy:

--- a/build/codecoverage-ci.yml
+++ b/build/codecoverage-ci.yml
@@ -3,7 +3,7 @@
 ################################################################################
 
 phases:
-- template: /build/ci/phase-template.yml
+- template: /build/ci/job-template.yml
   parameters:
     name: Windows_x64
     buildScript: build.cmd

--- a/test/Microsoft.ML.Tests/FeatureContributionTests.cs
+++ b/test/Microsoft.ML.Tests/FeatureContributionTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestLogisticRegressionBinary()
         {
-            TestFeatureContribution(ML.BinaryClassification.Trainers.LbfgsLogisticRegression(), GetSparseDataset(TaskType.BinaryClassification, 100), "LogisticRegressionBinary");
+            TestFeatureContribution(ML.BinaryClassification.Trainers.LbfgsLogisticRegression(), GetSparseDataset(TaskType.BinaryClassification, 100), "LogisticRegressionBinary", 3);
         }
 
         [Fact]


### PR DESCRIPTION
This is needed to unblock: https://github.com/dotnet/machinelearning/pull/3881

Basically the hosted azure devops machines have limited hard drive (25gb) and since tests are executed on the build machine it is running out of space. BYOC pools have 512 gb so that will unblock this scenario.

However I do think, machinelearning repo should move to run tests on helix in the long term.

**Note:** *this is easier to review if omitting whitespaces from the diff*

cc: @codemzs @wschin 
