### PR TITLE
Add FixZero for LogMeanVariance normalizer

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeLogMeanVarianceFixZero.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeLogMeanVarianceFixZero.cs
@@ -26,10 +26,10 @@ namespace Samples.Dynamic
             var data = mlContext.Data.LoadFromEnumerable(samples);
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
             // Uses Cumulative distribution function as output.
-            var normalize = mlContext.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: true);
+            var normalize = mlContext.Transforms.NormalizeLogMeanVariance("Features", true, useCdf: true);
 
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
-            var normalizeNoCdf = mlContext.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: false);
+            var normalizeNoCdf = mlContext.Transforms.NormalizeLogMeanVariance("Features", true, useCdf: false);
 
             // Now we can transform the data and look at the output to confirm the behavior of the estimator.
             // This operation doesn't actually evaluate data until we read the data below.
@@ -58,19 +58,19 @@ namespace Samples.Dynamic
             // Let's get transformation parameters. Since we work with only one column we need to pass 0 as parameter for GetNormalizerModelParameters.
             // If we have multiple columns transformations we need to pass index of InputOutputColumnPair.
             var transformParams = normalizeTransform.GetNormalizerModelParameters(0) as CdfNormalizerModelParameters<ImmutableArray<float>>;
-            Console.WriteLine("The 1-index value in resulting array would be produce by:");
+            Console.WriteLine("The values in the column with index 1 in the resulting array would be produced by:");
             Console.WriteLine($"y = 0.5* (1 + ERF((Math.Log(x)- {transformParams.Mean[1]}) / ({transformParams.StandardDeviation[1]} * sqrt(2)))");
 
             // ERF is https://en.wikipedia.org/wiki/Error_function.
             // Expected output:
-            // The 1 - index value in resulting array would be produce by:
+            // The values in the column with index 1 in the resulting array would be produced by:
             // y = 0.5 * (1 + ERF((Math.Log(x) - 0.3465736) / (0.3465736 * sqrt(2)))
             var noCdfParams = normalizeNoCdfTransform.GetNormalizerModelParameters(0) as AffineNormalizerModelParameters<ImmutableArray<float>>;
             var offset = noCdfParams.Offset.Length == 0 ? 0 : noCdfParams.Offset[1];
             var scale = noCdfParams.Scale[1];
-            Console.WriteLine($"The 1-index value in resulting array would be produce by: y = (x - ({offset})) * {scale}");
+            Console.WriteLine($"The values in the column with index 1 in the resulting array would be produced by: y = (x - ({offset})) * {scale}");
             // Expected output:
-            // The 1-index value in resulting array would be produce by: y = (x - (0)) * 2.040279
+            // The values in the column with index 1 in the resulting array would be produced by: y = (x - (0)) * 2.040279
         }
 
         private class DataPoint

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeLogMeanVarianceFixZero.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeLogMeanVarianceFixZero.cs
@@ -8,7 +8,7 @@ using static Microsoft.ML.Transforms.NormalizingTransformer;
 
 namespace Samples.Dynamic
 {
-    public class NormalizeLogMeanVariance
+    public class NormalizeLogMeanVarianceFixZero
     {
         public static void Example()
         {
@@ -26,10 +26,10 @@ namespace Samples.Dynamic
             var data = mlContext.Data.LoadFromEnumerable(samples);
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
             // Uses Cumulative distribution function as output.
-            var normalize = mlContext.Transforms.NormalizeLogMeanVariance("Features", useCdf: true);
+            var normalize = mlContext.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: true);
 
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
-            var normalizeNoCdf = mlContext.Transforms.NormalizeLogMeanVariance("Features", useCdf: false);
+            var normalizeNoCdf = mlContext.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: false);
 
             // Now we can transform the data and look at the output to confirm the behavior of the estimator.
             // This operation doesn't actually evaluate data until we read the data below.
@@ -50,10 +50,10 @@ namespace Samples.Dynamic
             foreach (var row in columnFixZero)
                 Console.WriteLine(string.Join(", ", row.Select(x => x.ToString("f4"))));
             // Expected output:
-            //  1.8854, 1.8854, 5.2970, 0.0000, 7670682000000000000000000000000000000.0000
-            //  4.7708, 4.7708, 3.0925, 0.0000, -7670682000000000000000000000000000000.0000
-            // -1.0000,-1.0000, 0.8879, 0.0000, -1.0000
-            // -3.8854,-3.8854,-3.5213, 0.0000, -0.9775
+            //  2.0403, 2.0403, 4.0001, 0.0000, 5423991000000000000000000000000000000.0000
+            //  4.0806, 4.0806, 2.6667, 0.0000,-5423991000000000000000000000000000000.0000
+            //  0.0000, 0.0000, 1.3334, 0.0000, 0.0000
+            // -2.0403,-2.0403,-1.3334, 0.0000, 0.0159
 
             // Let's get transformation parameters. Since we work with only one column we need to pass 0 as parameter for GetNormalizerModelParameters.
             // If we have multiple columns transformations we need to pass index of InputOutputColumnPair.
@@ -63,14 +63,14 @@ namespace Samples.Dynamic
 
             // ERF is https://en.wikipedia.org/wiki/Error_function.
             // Expected output:
-            //  The 1-index value in resulting array would be produce by:
-            //  y = 0.5 * (1 + ERF((Math.Log(x) - 0.3465736) / (0.3465736 * sqrt(2)))
+            // The 1 - index value in resulting array would be produce by:
+            // y = 0.5 * (1 + ERF((Math.Log(x) - 0.3465736) / (0.3465736 * sqrt(2)))
             var noCdfParams = normalizeNoCdfTransform.GetNormalizerModelParameters(0) as AffineNormalizerModelParameters<ImmutableArray<float>>;
             var offset = noCdfParams.Offset.Length == 0 ? 0 : noCdfParams.Offset[1];
             var scale = noCdfParams.Scale[1];
             Console.WriteLine($"The 1-index value in resulting array would be produce by: y = (x - ({offset})) * {scale}");
             // Expected output:
-            // The 1-index value in resulting array would be produce by: y = (x - (0.3465736)) * 2.88539
+            // The 1-index value in resulting array would be produce by: y = (x - (0)) * 2.040279
         }
 
         private class DataPoint

--- a/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
+++ b/src/Microsoft.ML.Data/Transforms/NormalizeColumnSng.cs
@@ -1557,7 +1557,7 @@ namespace Microsoft.ML.Transforms
                 {
                     var lim = column.MaximumExampleCount;
                     host.CheckUserArg(lim > 1, nameof(column.MaximumExampleCount), "Must be greater than 1");
-                    return new MeanVarOneColumnFunctionBuilder(host, lim, false, getter, true, column.UseCdf);
+                    return new MeanVarOneColumnFunctionBuilder(host, lim, column.EnsureZeroUntouched, getter, true, column.UseCdf);
                 }
 
                 protected override bool ProcessValue(in TFloat origVal)
@@ -1633,7 +1633,7 @@ namespace Microsoft.ML.Transforms
                     var lim = column.MaximumExampleCount;
                     host.CheckUserArg(lim > 1, nameof(column.MaximumExampleCount), "Must be greater than 1");
                     var cv = srcType.Size;
-                    return new MeanVarVecColumnFunctionBuilder(host, cv, lim, false, getter, true, column.UseCdf);
+                    return new MeanVarVecColumnFunctionBuilder(host, cv, lim, column.EnsureZeroUntouched, getter, true, column.UseCdf);
                 }
 
                 protected override bool ProcessValue(in VBuffer<TFloat> buffer)

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -183,13 +183,13 @@ namespace Microsoft.ML.Transforms
         }
 
         [BestFriend]
-        internal sealed class LogMeanVarianceColumnOptions : ColumnOptionsBase
+        internal sealed class LogMeanVarianceColumnOptions : ControlZeroColumnOptionsBase
         {
             public readonly bool UseCdf;
 
             public LogMeanVarianceColumnOptions(string outputColumnName, string inputColumnName = null,
-                long maximumExampleCount = Defaults.MaximumExampleCount, bool useCdf = Defaults.LogMeanVarCdf)
-                : base(outputColumnName, inputColumnName ?? outputColumnName, maximumExampleCount)
+                long maximumExampleCount = Defaults.MaximumExampleCount, bool useCdf = Defaults.LogMeanVarCdf, bool fixZero = Defaults.EnsureZeroUntouched)
+                : base(outputColumnName, inputColumnName ?? outputColumnName, maximumExampleCount, fixZero)
             {
                 UseCdf = useCdf;
             }

--- a/src/Microsoft.ML.Data/Transforms/Normalizer.cs
+++ b/src/Microsoft.ML.Data/Transforms/Normalizer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Transforms
     /// The resulting NormalizingEstimator will normalize the data in one of the following ways based upon how it was created:
     /// * Min Max - A linear rescale that is based upon the minimum and maximum values for each row.
     /// * Mean Variance - Rescale each row to unit variance and, optionally, zero mean.
-    /// * Log Mean Variance - Rescale each row to unit variance based on a log scale.
+    /// * Log Mean Variance - Rescale each row to unit variance, optionally, zero mean based on computations in log scale.
     /// * Binning - Bucketizes the data in each row and performs a linear rescale based on the calculated bins.
     /// * Supervised Binning - Bucketize the data in each row and performas a linear rescale based on the calculated bins. The bin calculation is based on correlation of the Label column.
     ///
@@ -53,6 +53,13 @@ namespace Microsoft.ML.Transforms
     /// When fixZero is set, the normalized interval is $[-1,1]$ with the distribution of the normalized values depending on the normalization mode, but the behavior is different.
     /// With Min Max, the distribution depends on how far away the number is from 0, resulting in the number with the largest distance being mapped to 1 if its a positive number
     /// or -1 if its a negative number. The distance from 0 will affect the distribution with a majority of numbers that are closer together normalizing towards 0.
+    ///
+    /// The equation for the output $y$ of applying both Mean Variance and Log Mean Variance on input $x$ without
+    /// using the CDF option is: $y = (x - \text{offset}) \text{scale}$. Where offset and scale are computed during training.
+    ///
+    /// Using the CDF option it is: $y = 0.5 * (1 + \text{ERF}((x - \text{mean}) / (\text{standard deviation} * sqrt(2)))$.
+    /// Where ERF is the [Error Function](https://en.wikipedia.org/wiki/Error_function) used to approximate the CDF of a random variable assumed to
+    /// normally distributed. The mean and standard deviation are computing during training.
     ///
     /// To create this estimator use one of the following:
     /// * [NormalizeMinMax](xref:Microsoft.ML.NormalizationCatalog.NormalizeMinMax(Microsoft.ML.TransformsCatalog, System.String, System.String, System.Int64, System.Boolean))

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -165,9 +165,9 @@ namespace Microsoft.ML
         /// Create a <see cref="NormalizingEstimator"/>, which normalizes based on the computed mean and variance of the logarithm of the data.
         /// </summary>
         /// <param name="catalog">The transform catalog</param>
-        /// <param name="fixZero">TODO</param>
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.
         ///                                The data type on this column is the same as the input column.</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.
         ///                               The data type on this column should be <see cref="System.Single"/>, <see cref="System.Double"/> or a known-sized vector of those types.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
@@ -180,8 +180,9 @@ namespace Microsoft.ML
         /// </format>
         /// </example>
         public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog,
+            string outputColumnName,
             bool fixZero,
-            string outputColumnName, string inputColumnName = null,
+            string inputColumnName = null,
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
             bool useCdf = NormalizingEstimator.Defaults.LogMeanVarCdf)
         {
@@ -196,7 +197,7 @@ namespace Microsoft.ML
         /// <param name="columns">The pairs of input and output columns.
         ///             The input columns must be of data type <see cref="System.Single"/>, <see cref="System.Double"/> or a known-sized vector of those types.
         ///             The data type for the output column will be the same as the associated input column.</param>
-        /// <param name="fixZero">TODO</param>
+        /// <param name="fixZero">Whether to map zero to zero, preserving sparsity.</param>
         /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
         /// <param name="useCdf">Whether to use CDF as the output.</param>
         public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog, InputOutputColumnPair[] columns,

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -141,7 +141,7 @@ namespace Microsoft.ML
             long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
             bool useCdf = NormalizingEstimator.Defaults.LogMeanVarCdf)
         {
-            var columnOptions = new NormalizingEstimator.LogMeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, useCdf);
+            var columnOptions = new NormalizingEstimator.LogMeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, useCdf, false);
             return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
         }
 
@@ -159,7 +159,53 @@ namespace Microsoft.ML
             bool useCdf = NormalizingEstimator.Defaults.LogMeanVarCdf) =>
             new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog),
                 columns.Select(column =>
-                    new NormalizingEstimator.LogMeanVarianceColumnOptions(column.OutputColumnName, column.InputColumnName, maximumExampleCount, useCdf)).ToArray());
+                    new NormalizingEstimator.LogMeanVarianceColumnOptions(column.OutputColumnName, column.InputColumnName, maximumExampleCount, useCdf, false)).ToArray());
+
+        /// <summary>
+        /// Create a <see cref="NormalizingEstimator"/>, which normalizes based on the computed mean and variance of the logarithm of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="fixZero">TODO</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.
+        ///                                The data type on this column is the same as the input column.</param>
+        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.
+        ///                               The data type on this column should be <see cref="System.Single"/>, <see cref="System.Double"/> or a known-sized vector of those types.</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="useCdf">Whether to use CDF as the output.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!code-csharp[NormalizeLogMeanVariance](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeLogMeanVariance.cs)]
+        /// ]]>
+        /// </format>
+        /// </example>
+        public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog,
+            bool fixZero,
+            string outputColumnName, string inputColumnName = null,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool useCdf = NormalizingEstimator.Defaults.LogMeanVarCdf)
+        {
+            var columnOptions = new NormalizingEstimator.LogMeanVarianceColumnOptions(outputColumnName, inputColumnName, maximumExampleCount, useCdf, fixZero);
+            return new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog), columnOptions);
+        }
+
+        /// <summary>
+        /// Create a <see cref="NormalizingEstimator"/>, which normalizes based on the computed mean and variance of the logarithm of the data.
+        /// </summary>
+        /// <param name="catalog">The transform catalog</param>
+        /// <param name="columns">The pairs of input and output columns.
+        ///             The input columns must be of data type <see cref="System.Single"/>, <see cref="System.Double"/> or a known-sized vector of those types.
+        ///             The data type for the output column will be the same as the associated input column.</param>
+        /// <param name="fixZero">TODO</param>
+        /// <param name="maximumExampleCount">Maximum number of examples used to train the normalizer.</param>
+        /// <param name="useCdf">Whether to use CDF as the output.</param>
+        public static NormalizingEstimator NormalizeLogMeanVariance(this TransformsCatalog catalog, InputOutputColumnPair[] columns,
+            bool fixZero,
+            long maximumExampleCount = NormalizingEstimator.Defaults.MaximumExampleCount,
+            bool useCdf = NormalizingEstimator.Defaults.LogMeanVarCdf) =>
+            new NormalizingEstimator(CatalogUtils.GetEnvironment(catalog),
+                columns.Select(column =>
+                    new NormalizingEstimator.LogMeanVarianceColumnOptions(column.OutputColumnName, column.InputColumnName, maximumExampleCount, useCdf, fixZero)).ToArray());
 
         /// <summary>
         /// Create a <see cref="NormalizingEstimator"/>, which normalizes by assigning the data into bins with equal density.

--- a/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
+++ b/src/Microsoft.ML.Transforms/NormalizerCatalog.cs
@@ -175,7 +175,7 @@ namespace Microsoft.ML
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
-        /// [!code-csharp[NormalizeLogMeanVariance](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeLogMeanVariance.cs)]
+        /// [!code-csharp[NormalizeLogMeanVariance](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/NormalizeLogMeanVarianceFixZero.cs)]
         /// ]]>
         /// </format>
         /// </example>

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.ML;
@@ -17,6 +18,7 @@ using Microsoft.ML.Tools;
 using Microsoft.ML.Transforms;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.ML.Transforms.NormalizingTransformer;
 
 namespace Microsoft.ML.Tests.Transformers
 {
@@ -492,8 +494,8 @@ namespace Microsoft.ML.Tests.Transformers
             // Normalizer Extensions
             var est1 = ML.Transforms.NormalizeMinMax("float4", "float4");
             var est2 = ML.Transforms.NormalizeMeanVariance("float4", "float4");
-            var est3 = ML.Transforms.NormalizeLogMeanVariance("float4", "float4"); 
-            var est4 = ML.Transforms.NormalizeBinning("float4", "float4"); 
+            var est3 = ML.Transforms.NormalizeLogMeanVariance("float4", "float4");
+            var est4 = ML.Transforms.NormalizeBinning("float4", "float4");
             var est5 = ML.Transforms.NormalizeSupervisedBinning("float4", "float4");
 
             // Normalizer Extensions (Experimental)
@@ -503,7 +505,7 @@ namespace Microsoft.ML.Tests.Transformers
             var est9 = ML.Transforms.NormalizeBinning("float4", "float4");
             var est10 = ML.Transforms.NormalizeSupervisedBinning("float4", "float4");
 
-            // Fit and Transpose 
+            // Fit and Transpose
             var data1 = est1.Fit(data).Transform(data);
             var data2 = est2.Fit(data).Transform(data);
             var data3 = est3.Fit(data).Transform(data);
@@ -781,6 +783,60 @@ namespace Microsoft.ML.Tests.Transformers
                 var result = ModelFileUtils.LoadTransforms(Env, dataView, fs);
                 Assert.Equal(3, result.Schema.Count);
             }
+        }
+
+        private sealed class DataPoint
+        {
+            [VectorType(5)]
+            public float[] Features { get; set; }
+        }
+
+        [Fact]
+        void TestNormalizeLogMeanVarianceFixZero()
+        {
+            var samples = new List<DataPoint>()
+            {
+                new DataPoint(){ Features = new float[5] { 1, 1, 3, 0, float.MaxValue } },
+                new DataPoint(){ Features = new float[5] { 2, 2, 2, 0, float.MinValue } },
+                new DataPoint(){ Features = new float[5] { 0, 0, 1, 0.5f, 0} },
+                new DataPoint(){ Features = new float[5] {-1,-1,-1, 1, 1} }
+            };
+            // Convert training data to IDataView, the general data type used in ML.NET.
+            var data = ML.Data.LoadFromEnumerable(samples);
+            // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
+            // Uses Cumulative distribution function as output.
+            var normalize = ML.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: true);
+
+            // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
+            var normalizeNoCdf = ML.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: false);
+
+            // Now we can transform the data and look at the output to confirm the behavior of the estimator.
+            var normalizeTransform = normalize.Fit(data);
+            var transformedData = normalizeTransform.Transform(data);
+            var normalizeNoCdfTransform = normalizeNoCdf.Fit(data);
+            var noCdfData = normalizeNoCdfTransform.Transform(data);
+
+            var transformParams = normalizeTransform.GetNormalizerModelParameters(0) as CdfNormalizerModelParameters<ImmutableArray<float>>;
+            var noCdfParams = normalizeNoCdfTransform.GetNormalizerModelParameters(0) as AffineNormalizerModelParameters<ImmutableArray<float>>;
+
+            for (int i = 0; i < 5; i++)
+            {
+                // Standard deviation and offset should not be zero for the given data even when FixZero is set to true.
+                Assert.NotEqual(0f, transformParams.Mean[i]);
+                Assert.NotEqual(0f, transformParams.StandardDeviation[i]);
+
+                // Offset should be zero when FixZero is set to true but not the scale (on this data).
+                Assert.Empty(noCdfParams.Offset);
+                Assert.NotEqual(0f, noCdfParams.Scale[i]);
+            }
+
+            var transformedDataArray = ML.Data.CreateEnumerable<DataPoint>(noCdfData, false).ToImmutableArray();
+            // Without the Cdf and fixing zero, any 0 should stay 0.
+            Assert.Equal(0f, transformedDataArray[0].Features[3]);
+            Assert.Equal(0f, transformedDataArray[1].Features[3]);
+            Assert.Equal(0f, transformedDataArray[2].Features[0]);
+            Assert.Equal(0f, transformedDataArray[2].Features[1]);
+            Assert.Equal(0f, transformedDataArray[2].Features[4]);
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
+++ b/test/Microsoft.ML.Tests/Transformers/NormalizerTests.cs
@@ -810,10 +810,10 @@ namespace Microsoft.ML.Tests.Transformers
             var data = ML.Data.LoadFromEnumerable(samples);
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
             // Uses Cumulative distribution function as output.
-            var normalize = ML.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: true);
+            var normalize = ML.Transforms.NormalizeLogMeanVariance("Features", true, useCdf: true);
 
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
-            var normalizeNoCdf = ML.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: false);
+            var normalizeNoCdf = ML.Transforms.NormalizeLogMeanVariance("Features", true, useCdf: false);
 
             // Now we can transform the data and look at the output to confirm the behavior of the estimator.
             var normalizeTransform = normalize.Fit(data);
@@ -851,10 +851,10 @@ namespace Microsoft.ML.Tests.Transformers
             var data = ML.Data.LoadFromEnumerable(samples);
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
             // Uses Cumulative distribution function as output.
-            var normalize = ML.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: true);
+            var normalize = ML.Transforms.NormalizeLogMeanVariance("Features", true, useCdf: true);
 
             // NormalizeLogMeanVariance normalizes the data based on the computed mean and variance of the logarithm of the data.
-            var normalizeNoCdf = ML.Transforms.NormalizeLogMeanVariance(true, "Features", useCdf: false);
+            var normalizeNoCdf = ML.Transforms.NormalizeLogMeanVariance("Features", true, useCdf: false);
 
             // Now we can transform the data and look at the output to confirm the behavior of the estimator.
             var normalizeTransform = normalize.Fit(data);


### PR DESCRIPTION
Fixes #2798.

This PR introduces the `FixZero` argument to the `LogMeanVariance` normalizer, a relative tests and a sample.

It's still in WIP because I would like to make a breaking change instead of creating an overload with required parameter `FixZero`. As soon as the change is accepted and I set up the API Compat tool to accept the breaking change, I should be able to remove the overloads to the `MLContext` extensions.
