### PR TITLE
Reformatting ModelOperations and DataOperations samples to width 85

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/BootstrapSample.cs
@@ -7,8 +7,9 @@ namespace Samples.Dynamic
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations 
+            // and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -23,20 +24,27 @@ namespace Samples.Dynamic
 
             var data = mlContext.Data.LoadFromEnumerable(rawData);
 
-            // Now take a bootstrap sample of this dataset to create a new dataset. The bootstrap is a resampling technique that
-            // creates a training set of the same size by picking with replacement from the original dataset. With the bootstrap, 
-            // we expect that the resampled dataset will have about 63% of the rows of the original dataset (i.e. 1-e^-1), with some
-            // rows represented more than once.
-            // BootstrapSample is a streaming implementation of the boostrap that enables sampling from a dataset too large to hold in memory.
-            // To enable streaming, BootstrapSample approximates the bootstrap by sampling each row according to a Poisson(1) distribution.
-            // Note that this streaming approximation treats each row independently, thus the resampled dataset is not guaranteed to be the 
-            // same length as the input dataset.
-            // Let's take a look at the behavior of the BootstrapSample by examining a few draws:
+            // Now take a bootstrap sample of this dataset to create a new dataset. 
+            // The bootstrap is a resampling technique that creates a training set
+            // of the same size by picking with replacement from the original
+            // dataset. With the bootstrap, we expect that the resampled dataset
+            // will have about 63% of the rows of the original dataset
+            // (i.e. 1-e^-1), with some rows represented more than once.
+            // BootstrapSample is a streaming implementation of the boostrap that
+            // enables sampling from a dataset too large to hold in memory. To
+            // enable streaming, BootstrapSample approximates the bootstrap by 
+            // sampling each row according to a Poisson(1) distribution. Note that
+            // this streaming approximation treats each row independently, thus the
+            // resampled dataset is not guaranteed to be the same length as the 
+            // input dataset. Let's take a look at the behavior of the
+            // BootstrapSample by examining a few draws:
             for (int i = 0; i < 3; i++)
             {
                 var resample = mlContext.Data.BootstrapSample(data, seed: i);
 
-                var enumerable = mlContext.Data.CreateEnumerable<DataPoint>(resample, reuseRowObject: false);
+                var enumerable = mlContext.Data
+                    .CreateEnumerable<DataPoint>(resample, reuseRowObject: false);
+
                 Console.WriteLine($"Label\tFeature");
                 foreach (var row in enumerable)
                 {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
@@ -8,56 +8,78 @@ namespace Samples.Dynamic
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for except
+            // ion tracking and logging, as a catalog of available operations and as
+            // the source of randomness.
             var mlContext = new MLContext();
 
             var data = DatasetUtils.LoadHousingRegressionDataset(mlContext);
 
             // Time how long it takes to page through the records if we don't cache.
-            (int lines, double columnAverage, double elapsedSeconds) = TimeToScanIDataView(mlContext, data);
-            Console.WriteLine($"Lines={lines}, averageOfColumn0={columnAverage:0.00} and took {elapsedSeconds} seconds.");
+            (int lines, double columnAverage, double elapsedSeconds) =
+                TimeToScanIDataView(mlContext, data);
+
+            Console.WriteLine($"Lines={lines}," +
+                $"averageOfColumn0={columnAverage:0.00}and took {elapsedSeconds}" +
+                $"seconds.");
             // Expected output (time is approximate):
             // Lines=506, averageOfColumn0=564.17 and took 0.314 seconds.
 
             // Now create a cached view of the data.
             var cachedData = mlContext.Data.Cache(data);
 
-            // Time how long it takes to page through the records the first time they're accessed after a cache is applied.
-            // This iteration will be longer than subsequent calls, as the dataset is being accessed and stored for later.
-            // Note that this operation may be relatively quick, as the system may have cached the file.
-            (lines, columnAverage, elapsedSeconds) = TimeToScanIDataView(mlContext, cachedData);
-            Console.WriteLine($"Lines={lines}, averageOfColumn0={columnAverage:0.00} and took {elapsedSeconds} seconds.");
+            // Time how long it takes to page through the records the first time
+            // they're accessed after a cache is applied. This iteration will be
+            // longer than subsequent calls, as the dataset is being accessed and
+            // stored for later. Note that this operation may be relatively quick,
+            // as the system may have cached the file.
+            (lines, columnAverage, elapsedSeconds) = TimeToScanIDataView(mlContext,
+                cachedData);
+
+            Console.WriteLine($"Lines={lines}," +
+                $"averageOfColumn0={columnAverage:0.00} and took {elapsedSeconds}" +
+                $"seconds.");
             // Expected output (time is approximate):
             // Lines=506, averageOfColumn0=564.17 and took 0.056 seconds.
 
-            // Time how long it takes to page through the records now that the data is cached. After the first iteration that caches the IDataView,
-            // future iterations, like this one, are faster because they are pulling from data cached in memory.
-            (lines, columnAverage, elapsedSeconds) = TimeToScanIDataView(mlContext, cachedData);
-            Console.WriteLine($"Lines={lines}, averageOfColumn0={columnAverage:0.00} and took {elapsedSeconds} seconds.");
+            // Time how long it takes to page through the records now that the data
+            // is cached. After the first iteration that caches the IDataView,
+            // future iterations, like this one, are faster because they are pulling
+            // from data cached in memory.
+            (lines, columnAverage, elapsedSeconds) = TimeToScanIDataView(mlContext,
+                cachedData);
+
+            Console.WriteLine(
+                $"Lines={lines}, averageOfColumn0={columnAverage:0.00} and took " +
+                $"{elapsedSeconds} seconds.");
             // Expected output (time is approximate):
             // Lines=506, averageOfColumn0=564.17 and took 0.006 seconds.
         }
 
-        private static (int lines, double columnAverage, double elapsedSeconds) TimeToScanIDataView(MLContext mlContext, IDataView data)
+        private static (int lines, double columnAverage, double elapsedSeconds)
+            TimeToScanIDataView(MLContext mlContext, IDataView data)
         {
             int lines = 0;
             double columnAverage = 0.0;
-            var enumerable = mlContext.Data.CreateEnumerable<HousingRegression>(data, reuseRowObject: true);
+            var enumerable = mlContext.Data
+                .CreateEnumerable<HousingRegression>(data, reuseRowObject: true);
+
             var watch = System.Diagnostics.Stopwatch.StartNew();
             foreach (var row in enumerable)
             {
                 lines++;
-                columnAverage += row.MedianHomeValue + row.CrimesPerCapita + row.PercentResidental + row.PercentNonRetail + row.CharlesRiver 
-                    + row.NitricOxides + row.RoomsPerDwelling + row.PercentPre40s + row.EmploymentDistance 
-                    + row.HighwayDistance + row.TaxRate + row.TeacherRatio;
+                columnAverage += row.MedianHomeValue + row.CrimesPerCapita +
+                    row.PercentResidental + row.PercentNonRetail + row.CharlesRiver
+                    + row.NitricOxides + row.RoomsPerDwelling + row.PercentPre40s +
+                    row.EmploymentDistance + row.HighwayDistance + row.TaxRate +
+                    row.TeacherRatio;
             }
             watch.Stop();
             columnAverage /= lines;
             var elapsed = watch.Elapsed;
 
             return (lines, columnAverage, elapsed.Seconds);
-        }       
+        }
 
         /// <summary>
         /// A class to hold the raw housing regression rows.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/Cache.cs
@@ -20,7 +20,7 @@ namespace Samples.Dynamic
                 TimeToScanIDataView(mlContext, data);
 
             Console.WriteLine($"Lines={lines}," +
-                $"averageOfColumn0={columnAverage:0.00}and took {elapsedSeconds}" +
+                $"averageOfColumn0={columnAverage:0.00} and took {elapsedSeconds}" +
                 $"seconds.");
             // Expected output (time is approximate):
             // Lines=506, averageOfColumn0=564.17 and took 0.314 seconds.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/CrossValidationSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/CrossValidationSplit.cs
@@ -17,16 +17,28 @@ namespace Samples.Dynamic
             // Generate some data points.
             var examples = GenerateRandomDataPoints(10);
 
-            // Convert the examples list to an IDataView object, which is consumable by ML.NET API.
+            // Convert the examples list to an IDataView object, which is consumable
+            // by ML.NET API.
             var dataview = mlContext.Data.LoadFromEnumerable(examples);
 
-            // Cross validation splits your data randomly into set of "folds", and creates groups of Train and Test sets,
-            // where for each group, one fold is the Test and the rest of the folds the Train.
-            // So below, we specify Group column as the column containing the sampling keys.
-            // If we pass that column to cross validation it would be used to break data into certain chunks.
-            var folds = mlContext.Data.CrossValidationSplit(dataview, numberOfFolds: 3, samplingKeyColumnName: "Group");
-            var trainSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[0].TrainSet, reuseRowObject: false);
-            var testSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[0].TestSet, reuseRowObject: false);
+            // Cross validation splits your data randomly into set of "folds", and
+            // creates groups of Train and Test sets, where for each group, one fold
+            // is the Test and the rest of the folds the Train. So below, we specify
+            // Group column as the column containing the sampling keys. If we pass
+            // that column to cross validation it would be used to break data into
+            // certain chunks.
+            var folds = mlContext.Data
+                .CrossValidationSplit(dataview, numberOfFolds:3,
+                samplingKeyColumnName: "Group");
+
+            var trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[0].TrainSet,
+                reuseRowObject: false);
+
+            var testSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[0].TestSet,
+                reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
 
             // The data in the Train split.
@@ -43,8 +55,14 @@ namespace Samples.Dynamic
             // [Group, 0], [Features, 0.9060271]
             // [Group, 0], [Features, 0.2737045]
 
-            trainSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[1].TrainSet, reuseRowObject: false);
-            testSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[1].TestSet, reuseRowObject: false);
+            trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[1].TrainSet,
+                reuseRowObject: false);
+
+            testSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[1].TestSet,
+                reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
             // The data in the Train split.
             // [Group, 0], [Features, 0.7262433]
@@ -60,8 +78,14 @@ namespace Samples.Dynamic
             // [Group, 1], [Features, 0.2060332]
             // [Group, 1], [Features, 0.4421779]
 
-            trainSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[2].TrainSet, reuseRowObject: false);
-            testSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[2].TestSet, reuseRowObject: false);
+            trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[2].TrainSet,
+                reuseRowObject: false);
+
+            testSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[2].TestSet,
+                reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
             // The data in the Train split.
             // [Group, 0], [Features, 0.7262433]
@@ -79,8 +103,14 @@ namespace Samples.Dynamic
 
             // Example of a split without specifying a sampling key column.
             folds = mlContext.Data.CrossValidationSplit(dataview, numberOfFolds: 3);
-            trainSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[0].TrainSet, reuseRowObject: false);
-            testSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[0].TestSet, reuseRowObject: false);
+            trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[0].TrainSet,
+                reuseRowObject: false);
+
+            testSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[0].TestSet,
+                reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
             // The data in the Train split.
             // [Group, 0], [Features, 0.7262433]
@@ -96,8 +126,14 @@ namespace Samples.Dynamic
             // [Group, 2], [Features, 0.5588848]
             // [Group, 0], [Features, 0.9060271]
 
-            trainSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[1].TrainSet, reuseRowObject: false);
-            testSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[1].TestSet, reuseRowObject: false);
+            trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[1].TrainSet,
+                reuseRowObject: false);
+
+            testSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[1].TestSet,
+                reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
             // The data in the Train split.
             // [Group, 2], [Features, 0.7680227]
@@ -113,8 +149,13 @@ namespace Samples.Dynamic
             // [Group, 2], [Features, 0.9775497]
             // [Group, 0], [Features, 0.2737045]
 
-            trainSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[2].TrainSet, reuseRowObject: false);
-            testSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[2].TestSet, reuseRowObject: false);
+            trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(folds[2].TrainSet,
+                reuseRowObject: false);
+
+            testSet = mlContext.Data.CreateEnumerable<DataPoint>(folds[2].TestSet, 
+                reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
             // The data in the Train split.
             // [Group, 0], [Features, 0.7262433]
@@ -131,7 +172,9 @@ namespace Samples.Dynamic
             // [Group, 1], [Features, 0.4421779]
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, 
+            int seed = 0)
+
         {
             var random = new Random(seed);
             for (int i = 0; i < count; i++)
@@ -146,7 +189,8 @@ namespace Samples.Dynamic
             }
         }
 
-        // Example with features and group column. A data set is a collection of such examples.
+        // Example with features and group column. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public float Group { get; set; }
@@ -155,7 +199,9 @@ namespace Samples.Dynamic
         }
 
         // print helper
-        private static void PrintPreviewRows(IEnumerable<DataPoint> trainSet, IEnumerable<DataPoint> testSet)
+        private static void PrintPreviewRows(IEnumerable<DataPoint> trainSet, 
+            IEnumerable<DataPoint> testSet)
+
         {
 
             Console.WriteLine($"The data in the Train split.");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -6,31 +6,41 @@ namespace Samples.Dynamic
 {
     public static class DataViewEnumerable
     {
-        // A simple case of creating IDataView from IEnumerable.
+        // A simple case of creating IDataView from
+        //IEnumerable.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // Create a new context for ML.NET operations. It can be used for
+		    // exception tracking and logging,
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
-            IEnumerable<SampleTemperatureData> enumerableOfData = GetSampleTemperatureData(5);
+            IEnumerable<SampleTemperatureData> enumerableOfData =
+			    GetSampleTemperatureData(5);
 
             // Load dataset into an IDataView. 
             IDataView data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
-            // We can now examine the records in the IDataView. We first create an enumerable of rows in the IDataView.
-            var rowEnumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(data, reuseRowObject: true);
+            // We can now examine the records in the IDataView. We first create an
+			// enumerable of rows in the IDataView.
+            var rowEnumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(data,
+				reuseRowObject: true);
 
-            // SampleTemperatureDataWithLatitude has the definition of a Latitude column of type float. 
-            // We can use the parameter ignoreMissingColumns to true to ignore any missing columns in the IDataView.
-            // The produced enumerable will have the Latitude field set to the default for the data type, in this case 0. 
-            var rowEnumerableIgnoreMissing = mlContext.Data.CreateEnumerable<SampleTemperatureDataWithLatitude>(data,
-                reuseRowObject: true, ignoreMissingColumns: true);
+            // SampleTemperatureDataWithLatitude has the definition of a Latitude
+			// column of type float. We can use the parameter ignoreMissingColumns
+			// to true to ignore any missing columns in the IDataView. The produced
+			// enumerable will have the Latitude field set to the default for the
+			// data type, in this case 0. 
+            var rowEnumerableIgnoreMissing = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureDataWithLatitude>(data, 
+				reuseRowObject: true, ignoreMissingColumns: true);
 
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in rowEnumerable)
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine(
+					$"{row.Date.ToString("d")}\t{row.Temperature}");
 
             // Expected output:
             //  Date    Temperature
@@ -42,7 +52,8 @@ namespace Samples.Dynamic
 
             Console.WriteLine($"Date\tTemperature\tLatitude");
             foreach (var row in rowEnumerableIgnoreMissing)
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}\t{row.Latitude}");
+                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}" 
+				    + $"\t{row.Latitude}");
 
             // Expected output:
             //  Date    Temperature     Latitude
@@ -71,7 +82,9 @@ namespace Samples.Dynamic
         /// </summary>
         /// <param name="exampleCount">The number of examples to return.</param>
         /// <returns>An enumerable of <see cref="SampleTemperatureData"/>.</returns>
-        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(int exampleCount)
+        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(
+		    int exampleCount)
+
         {
             var rng = new Random(1234321);
             var date = new DateTime(2012, 1, 1);
@@ -81,7 +94,9 @@ namespace Samples.Dynamic
             {
                 date = date.AddDays(1);
                 temperature += rng.Next(-5, 5);
-                yield return new SampleTemperatureData { Date = date, Temperature = temperature };
+                yield return new SampleTemperatureData { Date = date, Temperature = 
+				    temperature };
+
             }
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -23,7 +23,7 @@ namespace Samples.Dynamic
             IDataView data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
             // We can now examine the records in the IDataView. We first create an
-			// enumerable of rows in the IDataView.
+	    // enumerable of rows in the IDataView.
             var rowEnumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(data,
 				reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.cs
@@ -11,7 +11,7 @@ namespace Samples.Dynamic
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-		    // exception tracking and logging,
+            // exception tracking and logging,
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();
 
@@ -29,10 +29,10 @@ namespace Samples.Dynamic
 				reuseRowObject: true);
 
             // SampleTemperatureDataWithLatitude has the definition of a Latitude
-			// column of type float. We can use the parameter ignoreMissingColumns
-			// to true to ignore any missing columns in the IDataView. The produced
-			// enumerable will have the Latitude field set to the default for the
-			// data type, in this case 0. 
+	    // column of type float. We can use the parameter ignoreMissingColumns
+	    // to true to ignore any missing columns in the IDataView. The produced
+	    // enumerable will have the Latitude field set to the default for the
+	    // data type, in this case 0. 
             var rowEnumerableIgnoreMissing = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureDataWithLatitude>(data, 
 				reuseRowObject: true, ignoreMissingColumns: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.tt
@@ -3,29 +3,39 @@
 string NameSpace = "Samples.Dynamic";
 string ClassName="DataViewEnumerable";
 string AddExtraClass = "true";
-string ExampleShortDoc = @"// A simple case of creating IDataView from IEnumerable.";
-string Example = @"// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+string ExampleShortDoc = @"// A simple case of creating IDataView from
+        //IEnumerable.";
+string Example = @"// Create a new context for ML.NET operations. It can be used for
+		    // exception tracking and logging,
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
-            IEnumerable<SampleTemperatureData> enumerableOfData = GetSampleTemperatureData(5);
+            IEnumerable<SampleTemperatureData> enumerableOfData =
+			    GetSampleTemperatureData(5);
 
             // Load dataset into an IDataView. 
             IDataView data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
-            // We can now examine the records in the IDataView. We first create an enumerable of rows in the IDataView.
-            var rowEnumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(data, reuseRowObject: true);
+            // We can now examine the records in the IDataView. We first create an
+			// enumerable of rows in the IDataView.
+            var rowEnumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(data,
+				reuseRowObject: true);
 
-            // SampleTemperatureDataWithLatitude has the definition of a Latitude column of type float. 
-            // We can use the parameter ignoreMissingColumns to true to ignore any missing columns in the IDataView.
-            // The produced enumerable will have the Latitude field set to the default for the data type, in this case 0. 
-            var rowEnumerableIgnoreMissing = mlContext.Data.CreateEnumerable<SampleTemperatureDataWithLatitude>(data,
-                reuseRowObject: true, ignoreMissingColumns: true);
+            // SampleTemperatureDataWithLatitude has the definition of a Latitude
+			// column of type float. We can use the parameter ignoreMissingColumns
+			// to true to ignore any missing columns in the IDataView. The produced
+			// enumerable will have the Latitude field set to the default for the
+			// data type, in this case 0. 
+            var rowEnumerableIgnoreMissing = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureDataWithLatitude>(data, 
+				reuseRowObject: true, ignoreMissingColumns: true);
 
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in rowEnumerable)
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine(
+					$""{row.Date.ToString(""d"")}\t{row.Temperature}"");
 
             // Expected output:
             //  Date    Temperature
@@ -37,7 +47,8 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
 
             Console.WriteLine($""Date\tTemperature\tLatitude"");
             foreach (var row in rowEnumerableIgnoreMissing)
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}\t{row.Latitude}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"" 
+				    + $""\t{row.Latitude}"");
 
             // Expected output:
             //  Date    Temperature     Latitude

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.tt
@@ -18,7 +18,7 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             IDataView data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
             // We can now examine the records in the IDataView. We first create an
-			// enumerable of rows in the IDataView.
+            // enumerable of rows in the IDataView.
             var rowEnumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(data,
 				reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/DataViewEnumerable.tt
@@ -24,10 +24,10 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
 				reuseRowObject: true);
 
             // SampleTemperatureDataWithLatitude has the definition of a Latitude
-			// column of type float. We can use the parameter ignoreMissingColumns
-			// to true to ignore any missing columns in the IDataView. The produced
-			// enumerable will have the Latitude field set to the default for the
-			// data type, in this case 0. 
+            // column of type float. We can use the parameter ignoreMissingColumns
+            // to true to ignore any missing columns in the IDataView. The produced
+	    // enumerable will have the Latitude field set to the default for the
+            // data type, in this case 0. 
             var rowEnumerableIgnoreMissing = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureDataWithLatitude>(data, 
 				reuseRowObject: true, ignoreMissingColumns: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
@@ -6,11 +6,13 @@ namespace Samples.Dynamic
 {
     public static class FilterRowsByColumn
     {
-        // // Sample class showing how to filter out some rows in IDataView.
+        // // Sample class showing how to filter out some rows in
+        // IDataView.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available
+			// operations and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -21,7 +23,9 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine(
+				    $"{row.Date.ToString("d")}\t{row.Temperature}");
+
             }
             Console.WriteLine();
             // Expected output:
@@ -37,15 +41,24 @@ namespace Samples.Dynamic
             //  1/10/2012       30
             //  1/11/2012       29
 
-            // Filter the data by the values of the temperature. The lower bound is inclusive, the upper exclusive.
-            var filteredData = mlContext.Data.FilterRowsByColumn(data, columnName: "Temperature", lowerBound: 34, upperBound: 37);
+            // Filter the data by the values of the temperature. The lower bound is
+			// inclusive, the upper exclusive.
+            var filteredData = mlContext.Data
+			    .FilterRowsByColumn(data, columnName: "Temperature",
+				lowerBound: 34, upperBound: 37);
 
-            // Look at the filtered data and observe that values outside [34,37) have been dropped.
-            var enumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(filteredData, reuseRowObject: true);
+            // Look at the filtered data and observe that values outside [34,37)
+			// have been dropped.
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(filteredData,
+			    reuseRowObject: true);
+
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine(
+				    $"{row.Date.ToString("d")}\t{row.Temperature}");
+
             }
 
             // Expected output:
@@ -69,7 +82,9 @@ namespace Samples.Dynamic
         /// </summary>
         /// <param name="exampleCount">The number of examples to return.</param>
         /// <returns>An enumerable of <see cref="SampleTemperatureData"/>.</returns>
-        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(int exampleCount)
+        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(
+		    int exampleCount)
+
         {
             var rng = new Random(1234321);
             var date = new DateTime(2012, 1, 1);
@@ -79,7 +94,9 @@ namespace Samples.Dynamic
             {
                 date = date.AddDays(1);
                 temperature += rng.Next(-5, 5);
-                yield return new SampleTemperatureData { Date = date, Temperature = temperature };
+                yield return new SampleTemperatureData { Date = date, Temperature = 
+				    temperature };
+
             }
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
@@ -42,13 +42,13 @@ namespace Samples.Dynamic
             //  1/11/2012       29
 
             // Filter the data by the values of the temperature. The lower bound is
-			// inclusive, the upper exclusive.
+	    // inclusive, the upper exclusive.
             var filteredData = mlContext.Data
 			    .FilterRowsByColumn(data, columnName: "Temperature",
 				lowerBound: 34, upperBound: 37);
 
             // Look at the filtered data and observe that values outside [34,37)
-			// have been dropped.
+	    // have been dropped.
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(filteredData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
@@ -23,8 +23,7 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine(
-				    $"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
 
             }
             Console.WriteLine();
@@ -45,7 +44,7 @@ namespace Samples.Dynamic
 	    // inclusive, the upper exclusive.
             var filteredData = mlContext.Data
 			    .FilterRowsByColumn(data, columnName: "Temperature",
-				lowerBound: 34, upperBound: 37);
+			    lowerBound: 34, upperBound: 37);
 
             // Look at the filtered data and observe that values outside [34,37)
 	    // have been dropped.
@@ -56,8 +55,7 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {
-                Console.WriteLine(
-				    $"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
 
             }
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
@@ -12,7 +12,7 @@ namespace Samples.Dynamic
         {
             // Create a new context for ML.NET operations. It can be used for
             // exception tracking and logging, as a catalog of available
-			// operations and as the source of randomness.
+	    // operations and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.cs
@@ -23,7 +23,8 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine(
+		    $"{row.Date.ToString("d")}\t{row.Temperature}");
 
             }
             Console.WriteLine();
@@ -55,7 +56,8 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine(
+		    $"{row.Date.ToString("d")}\t{row.Temperature}");
 
             }
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
@@ -3,9 +3,11 @@
 string NameSpace = "Samples.Dynamic";
 string ClassName="FilterRowsByColumn";
 string AddExtraClass = null;
-string ExampleShortDoc = @"// // Sample class showing how to filter out some rows in IDataView.";
-string Example = @"// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+string ExampleShortDoc = @"// // Sample class showing how to filter out some rows in
+        // IDataView.";
+string Example = @"// Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available
+			// operations and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -16,7 +18,9 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine(
+				    $""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+
             }
             Console.WriteLine();
             // Expected output:
@@ -32,15 +36,24 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             //  1/10/2012       30
             //  1/11/2012       29
 
-            // Filter the data by the values of the temperature. The lower bound is inclusive, the upper exclusive.
-            var filteredData = mlContext.Data.FilterRowsByColumn(data, columnName: ""Temperature"", lowerBound: 34, upperBound: 37);
+            // Filter the data by the values of the temperature. The lower bound is
+			// inclusive, the upper exclusive.
+            var filteredData = mlContext.Data
+			    .FilterRowsByColumn(data, columnName: ""Temperature"",
+				lowerBound: 34, upperBound: 37);
 
-            // Look at the filtered data and observe that values outside [34,37) have been dropped.
-            var enumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(filteredData, reuseRowObject: true);
+            // Look at the filtered data and observe that values outside [34,37)
+			// have been dropped.
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(filteredData,
+			    reuseRowObject: true);
+
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine(
+				    $""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+
             }
 
             // Expected output:

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
@@ -7,7 +7,7 @@ string ExampleShortDoc = @"// // Sample class showing how to filter out some row
         // IDataView.";
 string Example = @"// Create a new context for ML.NET operations. It can be used for
             // exception tracking and logging, as a catalog of available
-			// operations and as the source of randomness.
+            // operations and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -37,13 +37,13 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             //  1/11/2012       29
 
             // Filter the data by the values of the temperature. The lower bound is
-			// inclusive, the upper exclusive.
+	    // inclusive, the upper exclusive.
             var filteredData = mlContext.Data
 			    .FilterRowsByColumn(data, columnName: ""Temperature"",
 				lowerBound: 34, upperBound: 37);
 
             // Look at the filtered data and observe that values outside [34,37)
-			// have been dropped.
+	    // have been dropped.
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(filteredData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
@@ -50,7 +50,8 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine(
+		    $""{row.Date.ToString(""d"")}\t{row.Temperature}"");
 
             }
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByColumn.tt
@@ -18,8 +18,7 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine(
-				    $""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
 
             }
             Console.WriteLine();
@@ -51,8 +50,7 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerable)
             {
-                Console.WriteLine(
-				    $""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
 
             }
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByKeyColumnFraction.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByKeyColumnFraction.cs
@@ -11,7 +11,8 @@ namespace Samples.Dynamic
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();
 
@@ -36,7 +37,9 @@ namespace Samples.Dynamic
             var transformedData = pipeline.Fit(data).Transform(data);
 
             // Before we apply a filter, examine all the records in the dataset.
-            var enumerable = mlContext.Data.CreateEnumerable<DataPoint>(transformedData, reuseRowObject: true);
+            var enumerable = mlContext.Data
+                .CreateEnumerable<DataPoint>(transformedData, reuseRowObject: true);
+
             Console.WriteLine($"Age");
             foreach (var row in enumerable)
             {
@@ -56,12 +59,20 @@ namespace Samples.Dynamic
 
             // Now filter down to half the keys, choosing the lower half of values. 
             // For the keys we have the sorted values: 1 1 2 2 2 3 4 4.
-            // Projected in the [0, 1[ interval as per: (key - 0.5)/(Count of Keys) the values of the keys for our data would be:
+            // Projected in the [0, 1[ interval as per: (key - 0.5)/(Count of Keys)
+            // the values of the keys for our data would be:
             // 0.125 0.125 0.375 0.375 0.375 0.625 0.875 0.875
-            // so the keys resulting from filtering in the [0, 0.5 [ interval are the ones with normalized values 0.125 and 0.375, respectively keys 
+            // so the keys resulting from filtering in the [0, 0.5 [ interval are
+            // the ones with normalized values 0.125 and 0.375, respectively keys 
             // with values 1 and 2.
-            var filteredHalfData = mlContext.Data.FilterRowsByKeyColumnFraction(transformedData, columnName: "Age", lowerBound: 0, upperBound: 0.5);
-            var filteredHalfEnumerable = mlContext.Data.CreateEnumerable<DataPoint>(filteredHalfData, reuseRowObject: true);
+            var filteredHalfData = mlContext.Data
+                .FilterRowsByKeyColumnFraction(transformedData, columnName: "Age",
+                lowerBound: 0, upperBound: 0.5);
+
+            var filteredHalfEnumerable = mlContext.Data
+                .CreateEnumerable<DataPoint>(filteredHalfData,
+                reuseRowObject: true);
+
             Console.WriteLine($"Age");
             foreach (var row in filteredHalfEnumerable)
             {
@@ -76,12 +87,21 @@ namespace Samples.Dynamic
             //  2
             //  1
 
-            // As mentioned above, the normalized keys are: 0.125 0.125 0.375 0.375 0.375 0.625 0.875 0.875
-            // so the keys resulting from filtering in the [0.3, 0.6 [ interval are the ones with normalized value 0.375, respectively key 
-            // with value = 2.
-            var filteredMiddleData = mlContext.Data.FilterRowsByKeyColumnFraction(transformedData, columnName: "Age", lowerBound: 0.3, upperBound: 0.6);
-            // Look at the data and observe that values above 2 have been filtered out
-            var filteredMiddleEnumerable = mlContext.Data.CreateEnumerable<DataPoint>(filteredMiddleData, reuseRowObject: true);
+            // As mentioned above, the normalized keys are:
+            // 0.125 0.125 0.375 0.375 0.375 0.625 0.875 0.875
+            // so the keys resulting from filtering in the [0.3, 0.6 [ interval are
+            // the ones with normalized value 0.375, respectively key with
+            // value = 2.
+            var filteredMiddleData = mlContext.Data
+                .FilterRowsByKeyColumnFraction(transformedData, columnName: "Age",
+                lowerBound: 0.3, upperBound: 0.6);
+
+            // Look at the data and observe that values above 2 have been filtered
+            // out
+            var filteredMiddleEnumerable = mlContext.Data
+                .CreateEnumerable<DataPoint>(filteredMiddleData, 
+                reuseRowObject: true);
+
             Console.WriteLine($"Age");
             foreach (var row in filteredMiddleEnumerable)
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByMissingValues.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/FilterRowsByMissingValues.cs
@@ -12,32 +12,40 @@ namespace Samples.Dynamic
         /// </summary>
         public static void Example()
         {
-            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
-            // as well as the source of randomness.
+            // Create a new ML context, for ML.NET operations. It can be used for
+            // exception tracking and logging, as well as the source of randomness.
             var mlContext = new MLContext();
 
             // Create a small dataset as an IEnumerable.
             var samples = new List<DataPoint>()
             {
-                new DataPoint(){ Feature1 = 21, Feature2 = new [] { 1, 2, float.NaN} },
+                new DataPoint(){ Feature1 = 21, Feature2 = new [] { 1, 2, float.NaN}
+                    },
+
                 new DataPoint(){ Feature1 = 40, Feature2 = new [] { 1f, 2f, 3f}  },
-                new DataPoint(){ Feature1 = float.NaN, Feature2 = new [] { 1, 2, float.NaN}  }
+                new DataPoint(){ Feature1 = float.NaN, Feature2 = new [] { 1, 2,
+                    float.NaN}  }
+
             };
 
             // Convert training data to IDataView.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
             // Filter out any row with an NaN values in either column
-            var filteredData = mlContext.Data.FilterRowsByMissingValues(data, new[] { "Feature1", "Feature2" });
+            var filteredData = mlContext.Data
+                .FilterRowsByMissingValues(data, new[] { "Feature1", "Feature2" });
 
-            // Take a look at the resulting dataset and note that rows with NaNs are filtered out.
-            // Only the second data point is left
-            var enumerable = mlContext.Data.CreateEnumerable<DataPoint>(filteredData, reuseRowObject: true);
+            // Take a look at the resulting dataset and note that rows with NaNs are
+            // filtered out. Only the second data point is left
+            var enumerable = mlContext.Data
+                .CreateEnumerable<DataPoint>(filteredData, reuseRowObject: true);
+
             Console.WriteLine($"Feature1   Feature2");
 
             foreach (var row in enumerable)
             {
-                Console.WriteLine($"{row.Feature1}\t({string.Join(", ", row.Feature2)})");
+                Console.WriteLine($"{row.Feature1}" +
+                    $"\t({string.Join(", ", row.Feature2)})");
             }
 
             // Feature1     Feature2

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/LoadFromEnumerable.cs
@@ -7,37 +7,48 @@ namespace Samples.Dynamic
 {
     public static class LoadFromEnumerable
     {
-        // Creating IDataView from IEnumerable, and setting the size of the vector at runtime. 
-        // When the data model is defined through types, setting the size of the vector is done through the VectorType 
-        // annotation. When the size of the data is not known at compile time, the Schema can be directly modified at runtime
-        // and the size of the vector set there. 
-        // This is important, because most of the ML.NET trainers require the Features vector to be of known size. 
+        // Creating IDataView from IEnumerable, and setting the size of the vector
+        // at runtime. When the data model is defined through types, setting the
+        // size of the vector is done through the VectorType annotation. When the
+        // size of the data is not known at compile time, the Schema can be directly
+        // modified at runtime and the size of the vector set there. This is
+        // important, because most of the ML.NET trainers require the Features
+        // vector to be of known size. 
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
             IEnumerable<DataPointVector> enumerableKnownSize = new DataPointVector[]
             {
-               new DataPointVector{ Features = new float[]{ 1.2f, 3.4f, 4.5f, 3.2f, 7,5f } },
-               new DataPointVector{ Features = new float[]{ 4.2f, 3.4f, 14.65f, 3.2f, 3,5f } },
-               new DataPointVector{ Features = new float[]{ 1.6f, 3.5f, 4.5f, 6.2f, 3,5f } },
+               new DataPointVector{ Features = new float[]{ 1.2f, 3.4f, 4.5f, 3.2f,
+                   7,5f } },
+
+               new DataPointVector{ Features = new float[]{ 4.2f, 3.4f, 14.65f,
+                   3.2f, 3,5f } },
+
+               new DataPointVector{ Features = new float[]{ 1.6f, 3.5f, 4.5f, 6.2f,
+                   3,5f } },
+
             };
 
             // Load dataset into an IDataView. 
             IDataView data = mlContext.Data.LoadFromEnumerable(enumerableKnownSize);
             var featureColumn = data.Schema["Features"].Type as VectorDataViewType;
             // Inspecting the schema
-            Console.WriteLine($"Is the size of the Features column known: {featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
+            Console.WriteLine($"Is the size of the Features column known: " +
+                $"{featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
 
             // Preview
             //
             // Is the size of the Features column known? True.
             // Size: 5.
 
-            // If the size of the vector is unknown at compile time, it can be set at runtime.
+            // If the size of the vector is unknown at compile time, it can be set 
+            // at runtime.
             IEnumerable<DataPoint> enumerableUnknownSize = new DataPoint[]
             {
                new DataPoint{ Features = new float[]{ 1.2f, 3.4f, 4.5f } },
@@ -45,12 +56,15 @@ namespace Samples.Dynamic
                new DataPoint{ Features = new float[]{ 1.6f, 3.5f, 4.5f } },
             };
 
-            // The feature dimension (typically this will be the Count of the array of the features vector
-            // known at runtime).
+            // The feature dimension (typically this will be the Count of the array 
+            // of the features vector known at runtime).
             int featureDimension = 3;
             var definedSchema = SchemaDefinition.Create(typeof(DataPoint));
-            featureColumn = definedSchema["Features"].ColumnType as VectorDataViewType;
-            Console.WriteLine($"Is the size of the Features column known: {featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
+            featureColumn = definedSchema["Features"]
+                .ColumnType as VectorDataViewType;
+
+            Console.WriteLine($"Is the size of the Features column known: " +
+                $"{featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
 
             // Preview
             //
@@ -58,15 +72,19 @@ namespace Samples.Dynamic
             // Size: 0.
 
             // Set the column type to be a known-size vector.
-            var vectorItemType = ((VectorDataViewType)definedSchema[0].ColumnType).ItemType;
-            definedSchema[0].ColumnType = new VectorDataViewType(vectorItemType, featureDimension);
+            var vectorItemType = ((VectorDataViewType)definedSchema[0].ColumnType)
+                .ItemType;
+            definedSchema[0].ColumnType = new VectorDataViewType(vectorItemType,
+                featureDimension);
 
             // Read the data into an IDataView with the modified schema supplied in
-            IDataView data2 = mlContext.Data.LoadFromEnumerable(enumerableUnknownSize, definedSchema);
+            IDataView data2 = mlContext.Data
+                .LoadFromEnumerable(enumerableUnknownSize, definedSchema);
 
             featureColumn = data2.Schema["Features"].Type as VectorDataViewType;
             // Inspecting the schema
-            Console.WriteLine($"Is the size of the Features column known: {featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
+            Console.WriteLine($"Is the size of the Features column known: " +
+                $"{featureColumn.IsKnownSize}.\nSize: {featureColumn.Size}");
 
             // Preview
             //

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SaveAndLoadFromBinary.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SaveAndLoadFromBinary.cs
@@ -9,9 +9,10 @@ namespace Samples.Dynamic
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
@@ -24,18 +25,22 @@ namespace Samples.Dynamic
                 new DataPoint(){ Label = 1, Features = 9},
             };
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             IDataView data = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // Create a FileStream object and write the IDataView to it as a binary IDV file. 
+            // Create a FileStream object and write the IDataView to it as a binary
+            // IDV file. 
             using (FileStream stream = new FileStream("data.idv", FileMode.Create))
                 mlContext.Data.SaveAsBinary(data, stream);
 
             // Create an IDataView object by loading the binary IDV file.
             IDataView loadedData = mlContext.Data.LoadFromBinary("data.idv");
 
-            // Inspect the data that is loaded from the previously saved binary file.
-            var loadedDataEnumerable = mlContext.Data.CreateEnumerable<DataPoint>(loadedData, reuseRowObject: false);
+            // Inspect the data that is loaded from the previously saved binary file
+            var loadedDataEnumerable = mlContext.Data
+                .CreateEnumerable<DataPoint>(loadedData, reuseRowObject: false);
+
             foreach (DataPoint row in loadedDataEnumerable)
                 Console.WriteLine($"{row.Label}, {row.Features}");
 
@@ -47,7 +52,8 @@ namespace Samples.Dynamic
             // 1, 9
         }
 
-        // Example with label and feature values. A data set is a collection of such examples.
+        // Example with label and feature values. A data set is a collection of such
+        // examples.
         private class DataPoint
         {
             public float Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SaveAndLoadFromText.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SaveAndLoadFromText.cs
@@ -9,9 +9,10 @@ namespace Samples.Dynamic
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
@@ -24,10 +25,12 @@ namespace Samples.Dynamic
                 new DataPoint(){ Label = 1, Features = 9},
             };
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             IDataView data = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // Create a FileStream object and write the IDataView to it as a text file.
+            // Create a FileStream object and write the IDataView to it as a text
+            // file.
             using (FileStream stream = new FileStream("data.tsv", FileMode.Create))
                 mlContext.Data.SaveAsText(data, stream);
 
@@ -35,7 +38,9 @@ namespace Samples.Dynamic
             IDataView loadedData = mlContext.Data.LoadFromTextFile("data.tsv");
 
             // Inspect the data that is loaded from the previously saved text file.
-            var loadedDataEnumerable = mlContext.Data.CreateEnumerable<DataPoint>(loadedData, reuseRowObject: false);
+            var loadedDataEnumerable = mlContext.Data
+                .CreateEnumerable<DataPoint>(loadedData, reuseRowObject: false);
+
             foreach (DataPoint row in loadedDataEnumerable)
                 Console.WriteLine($"{row.Label}, {row.Features}");
 
@@ -47,7 +52,8 @@ namespace Samples.Dynamic
             // 1, 9
         }
 
-        // Example with label and feature values. A data set is a collection of such examples.
+        // Example with label and feature values. A data set is a collection of such
+        // examples.
         private class DataPoint
         {
             public float Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
@@ -6,11 +6,13 @@ namespace Samples.Dynamic
 {
     public static class ShuffleRows
     {
-        // Sample class showing how to shuffle rows in IDataView.
+        // Sample class showing how to shuffle rows in 
+        //IDataView.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -21,7 +23,8 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}" +
+				    $"\t{row.Temperature}");
             }
             Console.WriteLine();
             // Expected output:
@@ -35,12 +38,17 @@ namespace Samples.Dynamic
             // Shuffle the dataset.
             var shuffledData = mlContext.Data.ShuffleRows(data, seed: 123);
 
-            // Look at the shuffled data and observe that the rows are in a randomized order.
-            var enumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(shuffledData, reuseRowObject: true);
+            // Look at the shuffled data and observe that the rows are in a
+			// randomized order.
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(shuffledData,
+			    reuseRowObject: true);
+
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}" +
+				$"\t{row.Temperature}");
             }
             // Expected output:
             //  Date    Temperature
@@ -62,7 +70,9 @@ namespace Samples.Dynamic
         /// </summary>
         /// <param name="exampleCount">The number of examples to return.</param>
         /// <returns>An enumerable of <see cref="SampleTemperatureData"/>.</returns>
-        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(int exampleCount)
+        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(
+		    int exampleCount)
+
         {
             var rng = new Random(1234321);
             var date = new DateTime(2012, 1, 1);
@@ -72,7 +82,9 @@ namespace Samples.Dynamic
             {
                 date = date.AddDays(1);
                 temperature += rng.Next(-5, 5);
-                yield return new SampleTemperatureData { Date = date, Temperature = temperature };
+                yield return new SampleTemperatureData { Date = date, Temperature = 
+				    temperature };
+
             }
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
@@ -39,7 +39,7 @@ namespace Samples.Dynamic
             var shuffledData = mlContext.Data.ShuffleRows(data, seed: 123);
 
             // Look at the shuffled data and observe that the rows are in a
-			// randomized order.
+	    // randomized order.
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(shuffledData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
@@ -7,7 +7,7 @@ namespace Samples.Dynamic
     public static class ShuffleRows
     {
         // Sample class showing how to shuffle rows in 
-        //IDataView.
+        // IDataView.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.cs
@@ -12,7 +12,7 @@ namespace Samples.Dynamic
         {
             // Create a new context for ML.NET operations. It can be used for
             // exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness.
+	    // and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.tt
@@ -3,9 +3,11 @@
 string NameSpace = "Samples.Dynamic";
 string ClassName="ShuffleRows";
 string AddExtraClass = null;
-string ExampleShortDoc = @"// Sample class showing how to shuffle rows in IDataView.";
-string Example = @"// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+string ExampleShortDoc = @"// Sample class showing how to shuffle rows in 
+        //IDataView.";
+string Example = @"// Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -16,7 +18,8 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}"" +
+				    $""\t{row.Temperature}"");
             }
             Console.WriteLine();
             // Expected output:
@@ -30,12 +33,17 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             // Shuffle the dataset.
             var shuffledData = mlContext.Data.ShuffleRows(data, seed: 123);
 
-            // Look at the shuffled data and observe that the rows are in a randomized order.
-            var enumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(shuffledData, reuseRowObject: true);
+            // Look at the shuffled data and observe that the rows are in a
+			// randomized order.
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(shuffledData,
+			    reuseRowObject: true);
+
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}"" +
+				$""\t{row.Temperature}"");
             }
             // Expected output:
             //  Date    Temperature

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.tt
@@ -7,7 +7,7 @@ string ExampleShortDoc = @"// Sample class showing how to shuffle rows in
         //IDataView.";
 string Example = @"// Create a new context for ML.NET operations. It can be used for
             // exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness.
+	    // and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -34,7 +34,7 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             var shuffledData = mlContext.Data.ShuffleRows(data, seed: 123);
 
             // Look at the shuffled data and observe that the rows are in a
-			// randomized order.
+	    // randomized order.
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(shuffledData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/ShuffleRows.tt
@@ -4,7 +4,7 @@ string NameSpace = "Samples.Dynamic";
 string ClassName="ShuffleRows";
 string AddExtraClass = null;
 string ExampleShortDoc = @"// Sample class showing how to shuffle rows in 
-        //IDataView.";
+        // IDataView.";
 string Example = @"// Create a new context for ML.NET operations. It can be used for
             // exception tracking and logging, as a catalog of available operations
 	    // and as the source of randomness.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
@@ -9,8 +9,9 @@ namespace Samples.Dynamic
         // Sample class showing how to skip rows in IDataView.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -21,7 +22,8 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}" +
+				$"\t{row.Temperature}");
             }
             Console.WriteLine();
             // Expected output:
@@ -40,12 +42,17 @@ namespace Samples.Dynamic
             // Skip the first 5 rows in the dataset
             var filteredData = mlContext.Data.SkipRows(data, 5);
 
-            // Look at the filtered data and observe that the first 5 rows have been dropped
-            var enumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(filteredData, reuseRowObject: true);
+            // Look at the filtered data and observe that the first 5 rows have been
+			// dropped
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(filteredData,
+			    reuseRowObject: true);
+
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}" +
+				    $"\t{row.Temperature}");
             }
             // Expected output:
             //  Date    Temperature
@@ -67,7 +74,9 @@ namespace Samples.Dynamic
         /// </summary>
         /// <param name="exampleCount">The number of examples to return.</param>
         /// <returns>An enumerable of <see cref="SampleTemperatureData"/>.</returns>
-        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(int exampleCount)
+        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(
+		    int exampleCount)
+
         {
             var rng = new Random(1234321);
             var date = new DateTime(2012, 1, 1);
@@ -77,7 +86,9 @@ namespace Samples.Dynamic
             {
                 date = date.AddDays(1);
                 temperature += rng.Next(-5, 5);
-                yield return new SampleTemperatureData { Date = date, Temperature = temperature };
+                yield return new SampleTemperatureData { Date = date, Temperature = 
+				    temperature };
+
             }
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
@@ -43,7 +43,7 @@ namespace Samples.Dynamic
             var filteredData = mlContext.Data.SkipRows(data, 5);
 
             // Look at the filtered data and observe that the first 5 rows have been
-			// dropped
+	    // dropped
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(filteredData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.cs
@@ -11,7 +11,7 @@ namespace Samples.Dynamic
         {
             // Create a new context for ML.NET operations. It can be used for
             // exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness.
+	    // and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.tt
@@ -4,8 +4,9 @@ string NameSpace = "Samples.Dynamic";
 string ClassName="SkipRows";
 string AddExtraClass = null;
 string ExampleShortDoc = @"// Sample class showing how to skip rows in IDataView.";
-string Example = @"// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+string Example = @"// Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
@@ -16,7 +17,8 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}"" +
+				$""\t{row.Temperature}"");
             }
             Console.WriteLine();
             // Expected output:
@@ -35,12 +37,17 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             // Skip the first 5 rows in the dataset
             var filteredData = mlContext.Data.SkipRows(data, 5);
 
-            // Look at the filtered data and observe that the first 5 rows have been dropped
-            var enumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(filteredData, reuseRowObject: true);
+            // Look at the filtered data and observe that the first 5 rows have been
+			// dropped
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(filteredData,
+			    reuseRowObject: true);
+
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}"" +
+				    $""\t{row.Temperature}"");
             }
             // Expected output:
             //  Date    Temperature

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.tt
@@ -6,7 +6,7 @@ string AddExtraClass = null;
 string ExampleShortDoc = @"// Sample class showing how to skip rows in IDataView.";
 string Example = @"// Create a new context for ML.NET operations. It can be used for
             // exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness.
+	    // and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/SkipRows.tt
@@ -38,7 +38,7 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             var filteredData = mlContext.Data.SkipRows(data, 5);
 
             // Look at the filtered data and observe that the first 5 rows have been
-			// dropped
+	    // dropped
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(filteredData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
@@ -6,10 +6,12 @@ namespace Samples.Dynamic
 {
     public static class TakeRows
     {
-        // Sample class showing how to take some rows from the beginning of IDataView.
+        // Sample class showing how to take some rows from the
+        // beginning of IDataView.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // Create a new context for ML.NET operations. It can be used for
+            //exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();
 
@@ -21,7 +23,8 @@ namespace Samples.Dynamic
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}" +
+				    $"\t{row.Temperature}");
             }
             Console.WriteLine();
             // Expected output:
@@ -40,12 +43,17 @@ namespace Samples.Dynamic
             // Take the first 5 rows in the dataset
             var filteredData = mlContext.Data.TakeRows(data, 5);
 
-            // Look at the filtered data and observe that only the first 5 rows are in the resulting dataset.
-            var enumerable = mlContext.Data.CreateEnumerable<SampleTemperatureData>(filteredData, reuseRowObject: true);
+            // Look at the filtered data and observe that only the first 5 rows are
+			// in the resulting dataset.
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(filteredData,
+			    reuseRowObject: true);
+
             Console.WriteLine($"Date\tTemperature");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($"{row.Date.ToString("d")}\t{row.Temperature}");
+                Console.WriteLine($"{row.Date.ToString("d")}" +
+				    $"\t{row.Temperature}");
             }
             // Expected output:
             //  Date    Temperature
@@ -67,7 +75,9 @@ namespace Samples.Dynamic
         /// </summary>
         /// <param name="exampleCount">The number of examples to return.</param>
         /// <returns>An enumerable of <see cref="SampleTemperatureData"/>.</returns>
-        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(int exampleCount)
+        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(
+		    int exampleCount)
+
         {
             var rng = new Random(1234321);
             var date = new DateTime(2012, 1, 1);
@@ -77,7 +87,9 @@ namespace Samples.Dynamic
             {
                 date = date.AddDays(1);
                 temperature += rng.Next(-5, 5);
-                yield return new SampleTemperatureData { Date = date, Temperature = temperature };
+                yield return new SampleTemperatureData { Date = date, Temperature = 
+				    temperature };
+
             }
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.cs
@@ -44,7 +44,7 @@ namespace Samples.Dynamic
             var filteredData = mlContext.Data.TakeRows(data, 5);
 
             // Look at the filtered data and observe that only the first 5 rows are
-			// in the resulting dataset.
+	    // in the resulting dataset.
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(filteredData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.tt
@@ -3,20 +3,23 @@
 string NameSpace = "Samples.Dynamic";
 string ClassName="TakeRows";
 string AddExtraClass = null;
-string ExampleShortDoc = @"// Sample class showing how to take some rows from the beginning of IDataView.";
-string Example = @"// Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+string ExampleShortDoc = @"// Sample class showing how to take some rows from the
+        // beginning of IDataView.";
+string Example = @"// Create a new context for ML.NET operations. It can be used for
+            //exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();
 
             // Get a small dataset as an IEnumerable.
-            var enumerableOfData = Microsoft.ML.SamplesUtils.DatasetUtils.GetSampleTemperatureData(10);
+            var enumerableOfData = GetSampleTemperatureData(10);
             var data = mlContext.Data.LoadFromEnumerable(enumerableOfData);
 
             // Before we apply a filter, examine all the records in the dataset.
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerableOfData)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}"" +
+				    $""\t{row.Temperature}"");
             }
             Console.WriteLine();
             // Expected output:
@@ -35,12 +38,17 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             // Take the first 5 rows in the dataset
             var filteredData = mlContext.Data.TakeRows(data, 5);
 
-            // Look at the filtered data and observe that only the first 5 rows are in the resulting dataset.
-            var enumerable = mlContext.Data.CreateEnumerable<Microsoft.ML.SamplesUtils.DatasetUtils.SampleTemperatureData>(filteredData, reuseRowObject: true);
+            // Look at the filtered data and observe that only the first 5 rows are
+			// in the resulting dataset.
+            var enumerable = mlContext.Data
+			    .CreateEnumerable<SampleTemperatureData>(filteredData,
+			    reuseRowObject: true);
+
             Console.WriteLine($""Date\tTemperature"");
             foreach (var row in enumerable)
             {
-                Console.WriteLine($""{row.Date.ToString(""d"")}\t{row.Temperature}"");
+                Console.WriteLine($""{row.Date.ToString(""d"")}"" +
+				    $""\t{row.Temperature}"");
             }
             // Expected output:
             //  Date    Temperature

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TakeRows.tt
@@ -39,7 +39,7 @@ string Example = @"// Create a new context for ML.NET operations. It can be used
             var filteredData = mlContext.Data.TakeRows(data, 5);
 
             // Look at the filtered data and observe that only the first 5 rows are
-			// in the resulting dataset.
+	    // in the resulting dataset.
             var enumerable = mlContext.Data
 			    .CreateEnumerable<SampleTemperatureData>(filteredData,
 			    reuseRowObject: true);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TemperatureAndLatitude.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TemperatureAndLatitude.ttinclude
@@ -32,7 +32,9 @@ namespace <#=NameSpace#>
         /// </summary>
         /// <param name="exampleCount">The number of examples to return.</param>
         /// <returns>An enumerable of <see cref="SampleTemperatureData"/>.</returns>
-        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(int exampleCount)
+        private static IEnumerable<SampleTemperatureData> GetSampleTemperatureData(
+		    int exampleCount)
+
         {
             var rng = new Random(1234321);
             var date = new DateTime(2012, 1, 1);
@@ -42,7 +44,9 @@ namespace <#=NameSpace#>
             {
                 date = date.AddDays(1);
                 temperature += rng.Next(-5, 5);
-                yield return new SampleTemperatureData { Date = date, Temperature = temperature };
+                yield return new SampleTemperatureData { Date = date,
+				    Temperature = temperature };
+
             }
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TrainTestSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/DataOperations/TrainTestSplit.cs
@@ -17,16 +17,26 @@ namespace Samples.Dynamic
             // Generate some data points.
             var examples = GenerateRandomDataPoints(10);
 
-            // Convert the examples list to an IDataView object, which is consumable by ML.NET API.
+            // Convert the examples list to an IDataView object, which is consumable
+            // by ML.NET API.
             var dataview = mlContext.Data.LoadFromEnumerable(examples);
 
-            // Leave out 10% of the dataset for testing.For some types of problems, for example for ranking or anomaly detection,
-            // we must ensure that the split leaves the rows with the same value in a particular column, in one of the splits. 
-            // So below, we specify Group column as the column containing the sampling keys.
-            // Notice how keeping the rows with the same value in the Group column overrides the testFraction definition. 
-            var split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.1, samplingKeyColumnName: "Group");
-            var trainSet = mlContext.Data.CreateEnumerable<DataPoint>(split.TrainSet, reuseRowObject: false);
-            var testSet = mlContext.Data.CreateEnumerable<DataPoint>(split.TestSet, reuseRowObject: false);
+            // Leave out 10% of the dataset for testing.For some types of problems,
+            // for example for ranking or anomaly detection, we must ensure that the
+            // split leaves the rows with the same value in a particular column, in
+            // one of the splits. So below, we specify Group column as the column
+            // containing the sampling keys. Notice how keeping the rows with the
+            // same value in the Group column overrides the testFraction definition. 
+            var split = mlContext.Data
+                .TrainTestSplit(dataview, testFraction: 0.1,
+                samplingKeyColumnName: "Group");
+
+            var trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(split.TrainSet, reuseRowObject: false);
+
+            var testSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(split.TestSet,reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
 
             //  The data in the Train split.
@@ -45,8 +55,12 @@ namespace Samples.Dynamic
 
             // Example of a split without specifying a sampling key column.
             split = mlContext.Data.TrainTestSplit(dataview, testFraction: 0.2);
-            trainSet = mlContext.Data.CreateEnumerable<DataPoint>(split.TrainSet, reuseRowObject: false);
-            testSet = mlContext.Data.CreateEnumerable<DataPoint>(split.TestSet, reuseRowObject: false);
+            trainSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(split.TrainSet,reuseRowObject: false);
+
+            testSet = mlContext.Data
+                .CreateEnumerable<DataPoint>(split.TestSet,reuseRowObject: false);
+
             PrintPreviewRows(trainSet, testSet);
 
             // The data in the Train split.
@@ -65,7 +79,9 @@ namespace Samples.Dynamic
 
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             for (int i = 0; i < count; i++)
@@ -80,7 +96,8 @@ namespace Samples.Dynamic
             }
         }
 
-        // Example with label and group column. A data set is a collection of such examples.
+        // Example with label and group column. A data set is a collection of such
+        // examples.
         private class DataPoint
         {
             public float Group { get; set; }
@@ -89,7 +106,9 @@ namespace Samples.Dynamic
         }
 
         // print helper
-        private static void PrintPreviewRows(IEnumerable<DataPoint> trainSet, IEnumerable<DataPoint> testSet)
+        private static void PrintPreviewRows(IEnumerable<DataPoint> trainSet,
+            IEnumerable<DataPoint> testSet)
+
         {
 
             Console.WriteLine($"The data in the Train split.");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModel.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModel.cs
@@ -25,8 +25,8 @@ namespace Samples.Dynamic.ModelOperations
             var outputColumnName = nameof(Transformation.Key);
 
             // Transform.
-            ITransformer model = mlContext.Transforms.Conversion.MapValueToKey(
-                outputColumnName, inputColumnName).Fit(dataView);
+            ITransformer model = mlContext.Transforms.Conversion
+                .MapValueToKey(outputColumnName, inputColumnName).Fit(dataView);
 
             // Save model.
             mlContext.Model.Save(model, dataView.Schema, "model.zip");
@@ -36,8 +36,8 @@ namespace Samples.Dynamic.ModelOperations
                 model = mlContext.Model.Load(file, out DataViewSchema schema);
 
             // Create a prediction engine from the model for feeding new data.
-            var engine = mlContext.Model.CreatePredictionEngine<Data,
-                Transformation>(model);
+            var engine = mlContext.Model
+                .CreatePredictionEngine<Data, Transformation>(model);
 
             var transformation = engine.Predict(new Data() { Value = "abc" });
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModel.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModel.cs
@@ -9,8 +9,8 @@ namespace Samples.Dynamic.ModelOperations
     {
         public static void Example()
         {
-            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
-            // as well as the source of randomness.
+            // Create a new ML context, for ML.NET operations. It can be used for
+            // exception tracking and logging, as well as the source of randomness.
             var mlContext = new MLContext();
 
             // Generate sample data.
@@ -25,7 +25,8 @@ namespace Samples.Dynamic.ModelOperations
             var outputColumnName = nameof(Transformation.Key);
 
             // Transform.
-            ITransformer model = mlContext.Transforms.Conversion.MapValueToKey(outputColumnName, inputColumnName).Fit(dataView);
+            ITransformer model = mlContext.Transforms.Conversion.MapValueToKey(
+                outputColumnName, inputColumnName).Fit(dataView);
 
             // Save model.
             mlContext.Model.Save(model, dataView.Schema, "model.zip");
@@ -35,11 +36,15 @@ namespace Samples.Dynamic.ModelOperations
                 model = mlContext.Model.Load(file, out DataViewSchema schema);
 
             // Create a prediction engine from the model for feeding new data.
-            var engine = mlContext.Model.CreatePredictionEngine<Data, Transformation>(model);
+            var engine = mlContext.Model.CreatePredictionEngine<Data,
+                Transformation>(model);
+
             var transformation = engine.Predict(new Data() { Value = "abc" });
 
             // Print transformation to console.
-            Console.WriteLine("Value: {0}\t Key:{1}", transformation.Value, transformation.Key);
+            Console.WriteLine("Value: {0}\t Key:{1}", transformation.Value,
+                transformation.Key);
+
             // Value: abc       Key:1
 
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModelFile.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModelFile.cs
@@ -9,8 +9,8 @@ namespace Samples.Dynamic.ModelOperations
     {
         public static void Example()
         {
-            // Create a new ML context, for ML.NET operations. It can be used for exception tracking and logging, 
-            // as well as the source of randomness.
+            // Create a new ML context, for ML.NET operations. It can be used for
+            // exception tracking and logging, as well as the source of randomness.
             var mlContext = new MLContext();
 
             // Generate sample data.
@@ -25,7 +25,8 @@ namespace Samples.Dynamic.ModelOperations
             var outputColumnName = nameof(Transformation.Key);
 
             // Transform.
-            ITransformer model = mlContext.Transforms.Conversion.MapValueToKey(outputColumnName, inputColumnName).Fit(dataView);
+            ITransformer model = mlContext.Transforms.Conversion.MapValueToKey(
+                outputColumnName, inputColumnName).Fit(dataView);
 
             // Save model.
             mlContext.Model.Save(model, dataView.Schema, "model.zip");
@@ -34,11 +35,15 @@ namespace Samples.Dynamic.ModelOperations
             model = mlContext.Model.Load("model.zip", out DataViewSchema schema);
 
             // Create a prediction engine from the model for feeding new data.
-            var engine = mlContext.Model.CreatePredictionEngine<Data, Transformation>(model);
+            var engine = mlContext.Model.CreatePredictionEngine<Data,
+                Transformation>(model);
+
             var transformation = engine.Predict(new Data() { Value = "abc" });
 
             // Print transformation to console.
-            Console.WriteLine("Value: {0}\t Key:{1}", transformation.Value, transformation.Key);
+            Console.WriteLine("Value: {0}\t Key:{1}", transformation.Value,
+                transformation.Key);
+
             // Value: abc       Key:1
 
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModelFile.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ModelOperations/SaveLoadModelFile.cs
@@ -25,8 +25,8 @@ namespace Samples.Dynamic.ModelOperations
             var outputColumnName = nameof(Transformation.Key);
 
             // Transform.
-            ITransformer model = mlContext.Transforms.Conversion.MapValueToKey(
-                outputColumnName, inputColumnName).Fit(dataView);
+            ITransformer model = mlContext.Transforms.Conversion
+                .MapValueToKey(outputColumnName, inputColumnName).Fit(dataView);
 
             // Save model.
             mlContext.Model.Save(model, dataView.Schema, "model.zip");
@@ -35,8 +35,8 @@ namespace Samples.Dynamic.ModelOperations
             model = mlContext.Model.Load("model.zip", out DataViewSchema schema);
 
             // Create a prediction engine from the model for feeding new data.
-            var engine = mlContext.Model.CreatePredictionEngine<Data,
-                Transformation>(model);
+            var engine = mlContext.Model
+                .CreatePredictionEngine<Data, Transformation>(model);
 
             var transformation = engine.Predict(new Data() { Value = "abc" });
 

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -9,6 +9,7 @@ namespace Microsoft.ML.Samples
 
         internal static void RunAll()
         {
+            // Samples counter.
             int samples = 0;
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -9,7 +9,6 @@ namespace Microsoft.ML.Samples
 
         internal static void RunAll()
         {
-            // Samples counter.
             int samples = 0;
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {


### PR DESCRIPTION
Guidelines followed:
-85 characters per line
-Use 4 spaces for indentation
-Dot and open parentheses stay on same line as function
-If not a preexisting line under line that we break, add an extra line after it
-Don't indent comments
-Don't break a comment if it represents output
-Don't break links
-If applicable, break right before $
-Keep math op together

Fix for issue #3478 