### PR TITLE
Reformatting MulticlassClassification samples to width 85

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -32,7 +32,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LbfgsMaximumEntropy());
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -111,7 +111,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -11,49 +11,49 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-                        .MapValueToKey(nameof(DataPoint.Label))
+					    .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply LbfgsMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .LbfgsMaximumEntropy());
+					    .LbfgsMaximumEntropy());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,16 +64,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //  Micro Accuracy: 0.91
             //  Macro Accuracy: 0.91
             //  Log Loss: 0.24
             //  Log Loss Reduction: 0.79
-
+            
             //  Confusion table
             //            ||========================
             //  PREDICTED ||     0 |     1 |     2 | Recall
@@ -88,7 +88,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,16 +102,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -11,34 +11,34 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-		        .MapValueToKey(nameof(DataPoint.Label))
+                .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply LbfgsMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-	                .LbfgsMaximumEntropy());
+                    .LbfgsMaximumEntropy());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
                 .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -48,12 +48,12 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
                 .CreateEnumerable<Prediction>(transformedTestData,
-	        reuseRowObject: false).ToList();
+            reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-	            $"Prediction: {p.PredictedLabel}");
+                $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -88,7 +88,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, 
-	    int seed=0)
+        int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,9 +102,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-	                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -27,11 +27,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
+		        .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply LbfgsMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .LbfgsMaximumEntropy());
+	                .LbfgsMaximumEntropy());
 
 
             // Train the model.
@@ -40,20 +40,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+	        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+	            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -87,8 +87,8 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, 
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,9 +102,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+	                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -11,34 +11,33 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-
-                    // Apply LbfgsMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
-                    .LbfgsMaximumEntropy());
+            // Apply LbfgsMaximumEntropy multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
+                .LbfgsMaximumEntropy());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
                 .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -48,12 +47,12 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
                 .CreateEnumerable<Prediction>(transformedTestData,
-            reuseRowObject: false).ToList();
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-                $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -87,8 +86,8 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, 
-        int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,9 +101,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                    .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -141,3 +140,4 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -10,39 +10,50 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+                        .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply LbfgsMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.LbfgsMaximumEntropy());
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .LbfgsMaximumEntropy());
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -52,15 +63,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //  Micro Accuracy: 0.91
             //  Macro Accuracy: 0.91
             //  Log Loss: 0.24
             //  Log Loss Reduction: 0.79
-            
+
             //  Confusion table
             //            ||========================
             //  PREDICTED ||     0 |     1 |     2 | Recall
@@ -72,8 +85,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //  Precision ||0.9308 |0.9593 |0.8580 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -85,13 +101,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -114,7 +134,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -25,10 +25,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-            // Apply LbfgsMaximumEntropy multiclass trainer.
+                // Apply LbfgsMaximumEntropy multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LbfgsMaximumEntropy());
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.cs
@@ -38,7 +38,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropy.tt
@@ -8,7 +8,8 @@ string TrainerOptions = null;
 string OptionsInclude = "";
 string Comments = "";
 bool CacheData = false;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -34,9 +34,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply LbfgsMaximumEntropy multiclass trainer.
+                // Apply LbfgsMaximumEntropy multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LbfgsMaximumEntropy(options));
             

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,18 +34,18 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-	            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LbfgsMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-	                .LbfgsMaximumEntropy(options));
-			
+                    .LbfgsMaximumEntropy(options));
+            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
                 .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -55,7 +55,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
                 .CreateEnumerable<Prediction>(transformedTestData,
-	        reuseRowObject: false).ToList();
+            reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
@@ -109,9 +109,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -12,55 +12,55 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
             var options = new LbfgsMaximumEntropyMulticlassTrainer.Options
-            {
-                HistorySize = 50,
-                L1Regularization = 0.1f,
-                NumberOfThreads = 1
-            };
+                        {
+                            HistorySize = 50,
+                            L1Regularization = 0.1f,
+                            NumberOfThreads = 1
+                        };
 
             // Define the trainer.
-            var pipeline =
-                    // Convert the string labels into key types.
+            var pipeline = 
+			        // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LbfgsMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .LbfgsMaximumEntropy(options));
-
+					    .LbfgsMaximumEntropy(options));
+			
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -71,10 +71,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -109,16 +109,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -142,7 +142,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,18 +34,18 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-                // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply LbfgsMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
-                    .LbfgsMaximumEntropy(options));
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply LbfgsMaximumEntropy multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
+                .LbfgsMaximumEntropy(options));
             
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
                 .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -55,7 +55,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
                 .CreateEnumerable<Prediction>(transformedTestData,
-            reuseRowObject: false).ToList();
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
@@ -109,9 +109,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -148,3 +148,4 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -11,48 +11,56 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
             var options = new LbfgsMaximumEntropyMulticlassTrainer.Options
-                        {
-                            HistorySize = 50,
-                            L1Regularization = 0.1f,
-                            NumberOfThreads = 1
-                        };
+            {
+                HistorySize = 50,
+                L1Regularization = 0.1f,
+                NumberOfThreads = 1
+            };
 
             // Define the trainer.
-            var pipeline = 
-			        // Convert the string labels into key types.
+            var pipeline =
+                    // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LbfgsMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.LbfgsMaximumEntropy(options));
-			
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .LbfgsMaximumEntropy(options));
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -62,9 +70,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
@@ -82,8 +92,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9304 |0.9593 |0.8529 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -95,13 +108,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -124,7 +141,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -39,7 +39,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 // Apply LbfgsMaximumEntropy multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LbfgsMaximumEntropy(options));
-            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -34,11 +34,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-			        // Convert the string labels into key types.
+	            // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LbfgsMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .LbfgsMaximumEntropy(options));
+	                .LbfgsMaximumEntropy(options));
 			
 
             // Train the model.
@@ -47,20 +47,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+	        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -71,7 +71,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -109,9 +109,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -142,7 +142,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -45,7 +45,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -118,7 +118,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LbfgsMaximumEntropyWithOptions.tt
@@ -12,7 +12,9 @@ string TrainerOptions = @"LbfgsMaximumEntropyMulticlassTrainer.Options
 
 string OptionsInclude = "using Microsoft.ML.Trainers;";
 string Comments = "";
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
+
 bool CacheData = false;
 
 string ExpectedOutputPerInstance = @"// Expected output:

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -28,10 +28,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-            // Apply LightGbm multiclass trainer.
+                // Apply LightGbm multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LightGbm());
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -8,43 +8,55 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 {
     public static class LightGbm
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+                        .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply LightGbm multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.LightGbm());
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .LightGbm());
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -54,15 +66,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.99
             //   Macro Accuracy: 0.99
             //   Log Loss: 0.05
             //   Log Loss Reduction: 0.95
-                 
+
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -74,8 +88,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9936 |1.0000 |0.9701 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -87,13 +104,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -116,7 +137,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -14,36 +14,35 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-
-                    // Apply LightGbm multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
-            .LightGbm());
+            // Apply LightGbm multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
+                .LightGbm());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
@@ -51,12 +50,12 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
                 .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -67,7 +66,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -91,7 +90,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-        int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -105,16 +104,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-    // such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -138,9 +137,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -35,7 +35,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LightGbm());
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -14,36 +14,36 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-		        .MapValueToKey(nameof(DataPoint.Label))
+                .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply LightGbm multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-			.LightGbm());
+            .LightGbm());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
@@ -51,12 +51,12 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
                 .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -91,7 +91,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+        int seed=0)
 
         {
             var random = new Random(seed);
@@ -105,16 +105,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-	// such examples.
+    // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -138,7 +138,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -105,7 +105,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -30,11 +30,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
+		        .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply LightGbm multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .LightGbm());
+			.LightGbm());
 
 
             // Train the model.
@@ -43,20 +43,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -91,7 +91,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -107,7 +107,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -138,7 +138,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -14,49 +14,49 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-                        .MapValueToKey(nameof(DataPoint.Label))
+					    .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply LightGbm multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .LightGbm());
+					    .LightGbm());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -67,16 +67,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.99
             //   Macro Accuracy: 0.99
             //   Log Loss: 0.05
             //   Log Loss Reduction: 0.95
-
+                 
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -91,7 +91,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -105,16 +105,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -138,7 +138,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.cs
@@ -14,16 +14,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -41,7 +41,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -114,7 +114,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbm.tt
@@ -7,10 +7,13 @@ string TrainerOptions = null;
 
 string OptionsInclude = "";
 string Comments = @"
-        // This example requires installation of additional NuGet package
-        // <a href=""https://www.nuget.org/packages/Microsoft.ML.FastTree/"">Microsoft.ML.FastTree</a>.";
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
+
 bool CacheData = false;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -39,9 +39,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply LightGbm multiclass trainer.
+                // Apply LightGbm multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LightGbm(options));
             

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -44,7 +44,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 // Apply LightGbm multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .LightGbm(options));
-            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -39,10 +39,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-                // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply LightGbm multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply LightGbm multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
                 .LightGbm(options));
             
 
@@ -50,22 +50,22 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -76,7 +76,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -100,7 +100,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-        int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -114,9 +114,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -147,9 +147,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -39,7 +39,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-			        // Convert the string labels into key types.
+	            // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LightGbm multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
@@ -114,7 +114,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -9,54 +9,63 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 {
     public static class LightGbmWithOptions
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
             var options = new LightGbmMulticlassTrainer.Options
-                        {
-                            Booster = new DartBooster.Options()
-                            {
-                                TreeDropFraction = 0.15,
-                                XgboostDartMode = false
-                            }
-                        };
+            {
+                Booster = new DartBooster.Options()
+                {
+                    TreeDropFraction = 0.15,
+                    XgboostDartMode = false
+                }
+            };
 
             // Define the trainer.
-            var pipeline = 
-			        // Convert the string labels into key types.
+            var pipeline =
+                    // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LightGbm multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.LightGbm(options));
-			
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .LightGbm(options));
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -66,15 +75,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.98
             //   Macro Accuracy: 0.98
             //   Log Loss: 0.07
             //   Log Loss Reduction: 0.94
-                 
+
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -86,8 +97,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9936 |1.0000 |0.9419 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -99,13 +113,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -128,7 +146,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -15,57 +15,57 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
             var options = new LightGbmMulticlassTrainer.Options
-            {
-                Booster = new DartBooster.Options()
-                {
-                    TreeDropFraction = 0.15,
-                    XgboostDartMode = false
-                }
-            };
+                        {
+                            Booster = new DartBooster.Options()
+                            {
+                                TreeDropFraction = 0.15,
+                                XgboostDartMode = false
+                            }
+                        };
 
             // Define the trainer.
-            var pipeline =
-                    // Convert the string labels into key types.
+            var pipeline = 
+			        // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LightGbm multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .LightGbm(options));
-
+					    .LightGbm(options));
+			
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -76,16 +76,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.98
             //   Macro Accuracy: 0.98
             //   Log Loss: 0.07
             //   Log Loss Reduction: 0.94
-
+                 
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -100,7 +100,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -114,16 +114,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -147,7 +147,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -39,33 +39,33 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-	            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LightGbm multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .LightGbm(options));
-			
+                .LightGbm(options));
+            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -76,7 +76,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -100,7 +100,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+        int seed=0)
 
         {
             var random = new Random(seed);
@@ -114,9 +114,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -147,7 +147,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -43,7 +43,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply LightGbm multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .LightGbm(options));
+		        .LightGbm(options));
 			
 
             // Train the model.
@@ -52,20 +52,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -76,7 +76,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -100,7 +100,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -116,7 +116,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -147,7 +147,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -50,7 +50,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -123,7 +123,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LightGbmWithOptions.tt
@@ -14,11 +14,13 @@ string TrainerOptions = @"LightGbmMulticlassTrainer.Options
 
 string OptionsInclude = "using Microsoft.ML.Trainers.LightGbm;";
 string Comments = @"
-        // This example requires installation of additional NuGet package
-        // <a href=""https://www.nuget.org/packages/Microsoft.ML.FastTree/"">Microsoft.ML.FastTree</a>.";
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
 
 bool CacheData = false;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LogLossPerClass.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LogLossPerClass.cs
@@ -10,42 +10,50 @@ namespace Samples.Dynamic
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+                        .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply a multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers.LightGbm());
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
 
             // Find the original label values.
             VBuffer<uint> keys = default;
             transformedTestData.Schema["PredictedLabel"].GetKeyValues(ref keys);
             var originalLabels = keys.DenseValues().ToArray();
             for (var i = 0; i < originalLabels.Length; i++)
-                Console.WriteLine($"LogLoss for label {originalLabels[i]}: {metrics.PerClassLogLoss[i]:F4}");
+                Console.WriteLine($"LogLoss for label " +
+                    $"{originalLabels[i]}: {metrics.PerClassLogLoss[i]:F4}");
 
             // Expected output:
             //   LogLoss for label 7: 0.2578
@@ -60,7 +68,9 @@ namespace Samples.Dynamic
         }
 
         // Generates data points with random features and labels 1 to 9.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -72,13 +82,17 @@ namespace Samples.Dynamic
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LogLossPerClass.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LogLossPerClass.cs
@@ -25,13 +25,12 @@ namespace Samples.Dynamic
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
-                        .MapValueToKey(nameof(DataPoint.Label))
-
-                    // Apply a multiclass trainer.
-                        .Append(mlContext.MulticlassClassification.Trainers
-                        .LightGbm());
+                // Convert the string labels into key types.
+                mlContext.Transforms.Conversion
+                .MapValueToKey(nameof(DataPoint.Label))
+                // Apply a multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
+                .LightGbm());
 
             // Train the model.
             var model = pipeline.Fit(trainingData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LogLossPerClass.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/LogLossPerClass.cs
@@ -30,7 +30,8 @@ namespace Samples.Dynamic
                         .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply a multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.LightGbm());
+                        .Append(mlContext.MulticlassClassification.Trainers
+                        .LightGbm());
 
             // Train the model.
             var model = pipeline.Fit(trainingData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -14,16 +14,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 <# if (CacheData) { #>
 
@@ -42,7 +42,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply <#=MetaTrainer#> multiclass meta trainer on top of
-					// binary trainer.
+		    // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
 					    .<#=MetaTrainer#>(
 						<#=Trainer#>()));
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-			        // Convert the string labels into key types.
+                    // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply <#=Trainer#> multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
@@ -76,7 +76,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -120,7 +120,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -129,7 +129,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -14,26 +14,26 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 <# if (CacheData) { #>
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
-	    // which needs many data passes.
-	    trainingData = mlContext.Data.Cache(trainingData);
+        // data set from a file and accesses it many times, it can be slow due
+        // to expensive featurization and disk operations. When the considered
+        // data can fit into memory, a solution is to cache the data in memory.
+        // Caching is especially helpful when working with iterative algorithms 
+        // which needs many data passes.
+        trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
 
 <# if (MetaTrainer != null) { #>
@@ -42,21 +42,21 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply <#=MetaTrainer#> multiclass meta trainer on top of
-		    // binary trainer.
+            // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .<#=MetaTrainer#>(
-			<#=Trainer#>()));
+                .<#=MetaTrainer#>(
+            <#=Trainer#>()));
 
 <# } else if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-		        .MapValueToKey(nameof(DataPoint.Label))
+                .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply <#=Trainer#> multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .<#=Trainer#>());
+                .<#=Trainer#>());
 
 <# } else { #>
             // Define trainer options.
@@ -68,36 +68,36 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply <#=Trainer#> multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .<#=Trainer#>(options));
-			
+                .<#=Trainer#>(options));
+            
 <# } #>
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             <#=ExpectedOutputPerInstance#>
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -120,7 +120,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
                         .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -129,7 +129,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-	// such examples.
+    // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -153,7 +153,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -28,11 +28,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 <# if (CacheData) { #>
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
+	    // which needs many data passes.
 			trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -39,10 +39,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 <# if (MetaTrainer != null) { #>
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply <#=MetaTrainer#> multiclass meta trainer on top of
-            // binary trainer.
+                // Apply <#=MetaTrainer#> multiclass meta trainer on top of
+                // binary trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .<#=MetaTrainer#>(
                 <#=Trainer#>()));
@@ -50,10 +50,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 <# } else if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-            // Apply <#=Trainer#> multiclass trainer.
+                // Apply <#=Trainer#> multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .<#=Trainer#>());
 
@@ -63,9 +63,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply <#=Trainer#> multiclass trainer.
+                // Apply <#=Trainer#> multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .<#=Trainer#>(options));
             

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -13,21 +13,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {<#=Comments#>
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 <# if (CacheData) { #>
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-			// it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-			// a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
 			// which needs many data passes.
 			trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
@@ -37,15 +41,23 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply <#=MetaTrainer#> multiclass meta trainer on top of binary trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.<#=MetaTrainer#>(<#=Trainer#>()));
+                    // Apply <#=MetaTrainer#> multiclass meta trainer on top of
+					// binary trainer.
+                    .Append(mlContext.MulticlassClassification.Trainers
+					    .<#=MetaTrainer#>(
+						<#=Trainer#>()));
+
 <# } else if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+					    .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply <#=Trainer#> multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.<#=Trainer#>());
+                    .Append(mlContext.MulticlassClassification.Trainers
+					    .<#=Trainer#>());
+
 <# } else { #>
             // Define trainer options.
             var options = new <#=TrainerOptions#>;
@@ -55,37 +67,47 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 			        // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply <#=Trainer#> multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.<#=Trainer#>(options));
+                    .Append(mlContext.MulticlassClassification.Trainers
+					    .<#=Trainer#>(options));
 			
 <# } #>
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             <#=ExpectedOutputPerInstance#>
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             <#=ExpectedOutput#>
         }
 
         <#=DataGenerationComments#>
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -97,13 +119,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+					// constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -126,7 +152,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -46,7 +46,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .Append(mlContext.MulticlassClassification.Trainers
                 .<#=MetaTrainer#>(
                 <#=Trainer#>()));
-
 <# } else if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline =
@@ -56,7 +55,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 // Apply <#=Trainer#> multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .<#=Trainer#>());
-
 <# } else { #>
             // Define trainer options.
             var options = new <#=TrainerOptions#>;
@@ -68,7 +66,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 // Apply <#=Trainer#> multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .<#=Trainer#>(options));
-            
 <# } #>
 
             // Train the model.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -33,7 +33,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 	    // data can fit into memory, a solution is to cache the data in memory.
 	    // Caching is especially helpful when working with iterative algorithms 
 	    // which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+	    trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
 
 <# if (MetaTrainer != null) { #>
@@ -44,19 +44,19 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Apply <#=MetaTrainer#> multiclass meta trainer on top of
 		    // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .<#=MetaTrainer#>(
-						<#=Trainer#>()));
+		        .<#=MetaTrainer#>(
+			<#=Trainer#>()));
 
 <# } else if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
+		        .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply <#=Trainer#> multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .<#=Trainer#>());
+		        .<#=Trainer#>());
 
 <# } else { #>
             // Define trainer options.
@@ -68,7 +68,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply <#=Trainer#> multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .<#=Trainer#>(options));
+		        .<#=Trainer#>(options));
 			
 <# } #>
 
@@ -78,26 +78,26 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             <#=ExpectedOutputPerInstance#>
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -106,7 +106,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
         <#=DataGenerationComments#>
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -122,7 +122,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -153,7 +153,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/MulticlassClassification.ttinclude
@@ -14,48 +14,47 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 <# if (CacheData) { #>
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-        // data set from a file and accesses it many times, it can be slow due
-        // to expensive featurization and disk operations. When the considered
-        // data can fit into memory, a solution is to cache the data in memory.
-        // Caching is especially helpful when working with iterative algorithms 
-        // which needs many data passes.
-        trainingData = mlContext.Data.Cache(trainingData);
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
 
 <# if (MetaTrainer != null) { #>
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply <#=MetaTrainer#> multiclass meta trainer on top of
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply <#=MetaTrainer#> multiclass meta trainer on top of
             // binary trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+                .Append(mlContext.MulticlassClassification.Trainers
                 .<#=MetaTrainer#>(
-            <#=Trainer#>()));
+                <#=Trainer#>()));
 
 <# } else if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-
-                    // Apply <#=Trainer#> multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+            // Apply <#=Trainer#> multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
                 .<#=Trainer#>());
 
 <# } else { #>
@@ -64,10 +63,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply <#=Trainer#> multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply <#=Trainer#> multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
                 .<#=Trainer#>(options));
             
 <# } #>
@@ -76,28 +75,28 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             <#=ExpectedOutputPerInstance#>
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -120,7 +119,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
                         .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -129,7 +128,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-    // such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -153,7 +152,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -10,56 +10,56 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         // Naive Bayes classifier is based on Bayes' theorem. 
         // It assumes independence among the presence of features in a class even
-        // though they may be dependent on each other. It is  a multi-class trainer
-        // that accepts binary feature values of type float, i.e., feature values
-        // are either true or false. Specifically a feature value greater than zero
-        // is treated as true, zero or less is treated as false.
+		// though they may be dependent on each other. It is  a multi-class trainer
+		// that accepts binary feature values of type float, i.e., feature values
+		// are either true or false. Specifically a feature value greater than zero
+		// is treated as true, zero or less is treated as false.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-                        .MapValueToKey(nameof(DataPoint.Label))
+					    .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply NaiveBayes multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .NaiveBayes());
+					    .NaiveBayes());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -70,16 +70,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.88
             //   Macro Accuracy: 0.88
             //   Log Loss: 34.54
             //   Log Loss Reduction: -30.47
-
+                 
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -91,12 +91,12 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9467 |0.8735 |0.8061 |
         }
 
-
+        
         // Generates random uniform doubles in [-0.5, 0.5) range with labels
-        // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
-        // zero or less are treated as false.
+		// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+		// zero or less are treated as false.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -110,16 +110,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -143,7 +143,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -31,10 +31,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-            // Apply NaiveBayes multiclass trainer.
+                // Apply NaiveBayes multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .NaiveBayes());
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -10,56 +10,56 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         // Naive Bayes classifier is based on Bayes' theorem. 
         // It assumes independence among the presence of features in a class even
-	// though they may be dependent on each other. It is  a multi-class trainer
-	// that accepts binary feature values of type float, i.e., feature values
-	// are either true or false. Specifically a feature value greater than zero
-	// is treated as true, zero or less is treated as false.
+        // though they may be dependent on each other. It is  a multi-class trainer
+    // that accepts binary feature values of type float, i.e., feature values
+    // are either true or false. Specifically a feature value greater than zero
+    // is treated as true, zero or less is treated as false.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-		        .MapValueToKey(nameof(DataPoint.Label))
+                .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply NaiveBayes multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .NaiveBayes());
+                .NaiveBayes());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -70,7 +70,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -93,10 +93,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
         
         // Generates random uniform doubles in [-0.5, 0.5) range with labels
-	// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
-	// zero or less are treated as false.
+    // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+    // zero or less are treated as false.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -110,16 +110,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-	// such examples.
+    // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -143,9 +143,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -10,23 +10,23 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         // Naive Bayes classifier is based on Bayes' theorem. 
         // It assumes independence among the presence of features in a class even
-		// though they may be dependent on each other. It is  a multi-class trainer
-		// that accepts binary feature values of type float, i.e., feature values
-		// are either true or false. Specifically a feature value greater than zero
-		// is treated as true, zero or less is treated as false.
+	// though they may be dependent on each other. It is  a multi-class trainer
+	// that accepts binary feature values of type float, i.e., feature values
+	// are either true or false. Specifically a feature value greater than zero
+	// is treated as true, zero or less is treated as false.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -44,7 +44,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -93,8 +93,8 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
         
         // Generates random uniform doubles in [-0.5, 0.5) range with labels
-		// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
-		// zero or less are treated as false.
+	// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+	// zero or less are treated as false.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
 		    int seed=0)
 
@@ -110,7 +110,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -119,7 +119,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -38,7 +38,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .Append(mlContext.MulticlassClassification.Trainers
                 .NaiveBayes());
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -11,32 +11,31 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Naive Bayes classifier is based on Bayes' theorem. 
         // It assumes independence among the presence of features in a class even
         // though they may be dependent on each other. It is  a multi-class trainer
-    // that accepts binary feature values of type float, i.e., feature values
-    // are either true or false. Specifically a feature value greater than zero
-    // is treated as true, zero or less is treated as false.
+        // that accepts binary feature values of type float, i.e., feature values
+        // are either true or false. Specifically a feature value greater than zero
+        // is treated as true, zero or less is treated as false.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-
-                    // Apply NaiveBayes multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+            // Apply NaiveBayes multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
                 .NaiveBayes());
 
 
@@ -44,22 +43,22 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -70,7 +69,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -93,8 +92,8 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
         
         // Generates random uniform doubles in [-0.5, 0.5) range with labels
-    // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
-    // zero or less are treated as false.
+        // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+        // zero or less are treated as false.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
             int seed=0)
 
@@ -110,7 +109,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
                         .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -119,7 +118,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-    // such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -143,7 +142,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -33,11 +33,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
+		        .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply NaiveBayes multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .NaiveBayes());
+                        .NaiveBayes());
 
 
             // Train the model.
@@ -46,20 +46,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -70,7 +70,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -96,7 +96,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 	// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
 	// zero or less are treated as false.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -112,7 +112,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -143,7 +143,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.cs
@@ -9,44 +9,57 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     public static class NaiveBayes
     {
         // Naive Bayes classifier is based on Bayes' theorem. 
-        // It assumes independence among the presence of features in a class even though they may be dependent on each other.
-        // It is  a multi-class trainer that accepts binary feature values of type float, i.e., feature values are either true or false.
-        // Specifically a feature value greater than zero is treated as true, zero or less is treated as false.
+        // It assumes independence among the presence of features in a class even
+        // though they may be dependent on each other. It is  a multi-class trainer
+        // that accepts binary feature values of type float, i.e., feature values
+        // are either true or false. Specifically a feature value greater than zero
+        // is treated as true, zero or less is treated as false.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+                        .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply NaiveBayes multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.NaiveBayes());
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .NaiveBayes());
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -56,15 +69,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.88
             //   Macro Accuracy: 0.88
             //   Log Loss: 34.54
             //   Log Loss Reduction: -30.47
-                 
+
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -76,10 +91,13 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9467 |0.8735 |0.8061 |
         }
 
-        
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        // For NaiveBayes values greater than zero are treated as true, zero or less are treated as false.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+
+        // Generates random uniform doubles in [-0.5, 0.5) range with labels
+        // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+        // zero or less are treated as false.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -91,13 +109,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -120,7 +142,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
@@ -11,14 +11,14 @@ string Comments= @"
         // Naive Bayes classifier is based on Bayes' theorem. 
         // It assumes independence among the presence of features in a class even
         // though they may be dependent on each other. It is  a multi-class trainer
-	// that accepts binary feature values of type float, i.e., feature values
-	// are either true or false. Specifically a feature value greater than zero
-	// is treated as true, zero or less is treated as false.";
+    // that accepts binary feature values of type float, i.e., feature values
+    // are either true or false. Specifically a feature value greater than zero
+    // is treated as true, zero or less is treated as false.";
 
 string DataGenerationComments= @"
         // Generates random uniform doubles in [-0.5, 0.5) range with labels
-	// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
-	// zero or less are treated as false.";
+    // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+    // zero or less are treated as false.";
 
 string ExpectedOutputPerInstance= @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
@@ -10,15 +10,15 @@ string OptionsInclude = "";
 string Comments= @"
         // Naive Bayes classifier is based on Bayes' theorem. 
         // It assumes independence among the presence of features in a class even
-		// though they may be dependent on each other. It is  a multi-class trainer
-		// that accepts binary feature values of type float, i.e., feature values
-		// are either true or false. Specifically a feature value greater than zero
-		// is treated as true, zero or less is treated as false.";
+        // though they may be dependent on each other. It is  a multi-class trainer
+	// that accepts binary feature values of type float, i.e., feature values
+	// are either true or false. Specifically a feature value greater than zero
+	// is treated as true, zero or less is treated as false.";
 
 string DataGenerationComments= @"
         // Generates random uniform doubles in [-0.5, 0.5) range with labels
-		// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
-		// zero or less are treated as false.";
+	// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+	// zero or less are treated as false.";
 
 string ExpectedOutputPerInstance= @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
@@ -11,14 +11,14 @@ string Comments= @"
         // Naive Bayes classifier is based on Bayes' theorem. 
         // It assumes independence among the presence of features in a class even
         // though they may be dependent on each other. It is  a multi-class trainer
-    // that accepts binary feature values of type float, i.e., feature values
-    // are either true or false. Specifically a feature value greater than zero
-    // is treated as true, zero or less is treated as false.";
+        // that accepts binary feature values of type float, i.e., feature values
+        // are either true or false. Specifically a feature value greater than zero
+        // is treated as true, zero or less is treated as false.";
 
 string DataGenerationComments= @"
         // Generates random uniform doubles in [-0.5, 0.5) range with labels
-    // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
-    // zero or less are treated as false.";
+        // 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+        // zero or less are treated as false.";
 
 string ExpectedOutputPerInstance= @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/NaiveBayes.tt
@@ -9,13 +9,16 @@ bool CacheData = false;
 string OptionsInclude = "";
 string Comments= @"
         // Naive Bayes classifier is based on Bayes' theorem. 
-        // It assumes independence among the presence of features in a class even though they may be dependent on each other.
-        // It is  a multi-class trainer that accepts binary feature values of type float, i.e., feature values are either true or false.
-        // Specifically a feature value greater than zero is treated as true, zero or less is treated as false.";
+        // It assumes independence among the presence of features in a class even
+		// though they may be dependent on each other. It is  a multi-class trainer
+		// that accepts binary feature values of type float, i.e., feature values
+		// are either true or false. Specifically a feature value greater than zero
+		// is treated as true, zero or less is treated as false.";
 
 string DataGenerationComments= @"
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        // For NaiveBayes values greater than zero are treated as true, zero or less are treated as false.";
+        // Generates random uniform doubles in [-0.5, 0.5) range with labels
+		// 1, 2 or 3. For NaiveBayes values greater than zero are treated as true,
+		// zero or less are treated as false.";
 
 string ExpectedOutputPerInstance= @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -33,7 +33,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .OneVersusAll(
                 mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -28,7 +28,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply OneVersusAll multiclass meta trainer on top of
-					// binary trainer.
+		    // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
 					    .OneVersusAll(
 						mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
@@ -38,7 +38,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -102,7 +102,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -111,7 +111,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -28,32 +28,32 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply OneVersusAll multiclass meta trainer on top of
-                    // binary trainer.
+					// binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .OneVersusAll(
-                        mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+					    .OneVersusAll(
+						mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,16 +64,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.90
             //   Macro Accuracy: 0.90
             //   Log Loss: 0.36
             //   Log Loss Reduction: 0.68
-
+            
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -88,7 +88,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,16 +102,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -30,8 +30,8 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Apply OneVersusAll multiclass meta trainer on top of
 		    // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .OneVersusAll(
-						mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+	                .OneVersusAll(
+			mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
@@ -40,20 +40,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -88,7 +88,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -25,10 +25,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply OneVersusAll multiclass meta trainer on top of
-            // binary trainer.
+                // Apply OneVersusAll multiclass meta trainer on top of
+                // binary trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .OneVersusAll(
                 mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -28,32 +28,32 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply OneVersusAll multiclass meta trainer on top of
-		    // binary trainer.
+            // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-	                .OneVersusAll(
-			mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+                .OneVersusAll(
+            mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -88,7 +88,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,16 +102,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+    // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -135,9 +135,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -11,49 +11,49 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply OneVersusAll multiclass meta trainer on top of
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply OneVersusAll multiclass meta trainer on top of
             // binary trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+                .Append(mlContext.MulticlassClassification.Trainers
                 .OneVersusAll(
-            mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+                mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -102,7 +102,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
                         .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -111,7 +111,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-    // such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs
@@ -10,39 +10,50 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply OneVersusAll multiclass meta trainer on top of binary trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.OneVersusAll(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+                    // Apply OneVersusAll multiclass meta trainer on top of
+                    // binary trainer.
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .OneVersusAll(
+                        mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -52,15 +63,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 2
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.90
             //   Macro Accuracy: 0.90
             //   Log Loss: 0.36
             //   Log Loss Reduction: 0.68
-            
+
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
@@ -72,8 +85,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.8994 |0.9180 |0.8851 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -85,13 +101,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -114,7 +134,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.tt
@@ -7,7 +7,8 @@ string TrainerOptions = null;
 
 string OptionsInclude = "";
 string Comments= "";
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
 
 bool CacheData = false;
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -25,10 +25,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply PairwiseCoupling multiclass meta trainer on top of
-            // binary trainer.
+                // Apply PairwiseCoupling multiclass meta trainer on top of
+                // binary trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .PairwiseCoupling(
                 mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -38,7 +38,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -102,7 +102,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -111,7 +111,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -28,32 +28,32 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply PairwiseCoupling multiclass meta trainer on top of
-		    // binary trainer.
+            // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .PairwiseCoupling(
-			mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+                .PairwiseCoupling(
+            mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-	        reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+            reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -102,9 +102,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -28,10 +28,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply PairwiseCoupling multiclass meta trainer on top of
-					// binary trainer.
+		    // binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .PairwiseCoupling(
-						mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+		        .PairwiseCoupling(
+			mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
@@ -40,20 +40,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+	        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -88,7 +88,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -33,7 +33,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .PairwiseCoupling(
                 mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -28,32 +28,32 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply PairwiseCoupling multiclass meta trainer on top of
-                    // binary trainer.
+					// binary trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .PairwiseCoupling(
-                        mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+					    .PairwiseCoupling(
+						mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,10 +64,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.90
             //   Macro Accuracy: 0.90
@@ -88,7 +88,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,16 +102,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -135,7 +135,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -10,39 +10,50 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply PairwiseCoupling multiclass meta trainer on top of binary trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.PairwiseCoupling(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+                    // Apply PairwiseCoupling multiclass meta trainer on top of
+                    // binary trainer.
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .PairwiseCoupling(
+                        mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -52,9 +63,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 2
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.90
             //   Macro Accuracy: 0.90
@@ -72,8 +85,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9091 |0.9171 |0.8636 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -85,13 +101,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -114,7 +134,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.cs
@@ -11,49 +11,49 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply PairwiseCoupling multiclass meta trainer on top of
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply PairwiseCoupling multiclass meta trainer on top of
             // binary trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+                .Append(mlContext.MulticlassClassification.Trainers
                 .PairwiseCoupling(
-            mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
+                mlContext.BinaryClassification.Trainers.SdcaLogisticRegression()));
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-            reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -64,7 +64,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -102,9 +102,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -135,9 +135,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PairwiseCoupling.tt
@@ -7,7 +7,9 @@ string TrainerOptions = null;
 
 string OptionsInclude = "";
 string Comments= "";
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
+
 bool CacheData = false;
 
 string ExpectedOutputPerInstance= @"// Expected output:

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PermutationFeatureImportance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PermutationFeatureImportance.cs
@@ -9,9 +9,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            var mlContext = new MLContext(seed:1);
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness.
+            var mlContext = new MLContext(seed: 1);
 
             // Create sample data.
             var samples = GenerateData();
@@ -19,13 +20,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Load the sample data as an IDataView.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
-            // Define a training pipeline that concatenates features into a vector, normalizes them, and then
-            // trains a linear model.
-            var featureColumns = new string[] { nameof(Data.Feature1), nameof(Data.Feature2) };
-            var pipeline = mlContext.Transforms.Concatenate("Features", featureColumns)
+            // Define a training pipeline that concatenates features into a vector,
+            // normalizes them, and then trains a linear model.
+            var featureColumns =
+                new string[] { nameof(Data.Feature1), nameof(Data.Feature2) };
+
+            var pipeline = mlContext.Transforms
+                    .Concatenate("Features", featureColumns)
                     .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
                     .Append(mlContext.Transforms.NormalizeMinMax("Features"))
-                    .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy());
+                    .Append(mlContext.MulticlassClassification.Trainers
+                    .SdcaMaximumEntropy());
 
             // Fit the pipeline to the data.
             var model = pipeline.Fit(data);
@@ -36,18 +41,26 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Extract the predictor.
             var linearPredictor = model.LastTransformer;
 
-            // Compute the permutation metrics for the linear model using the normalized data.
-            var permutationMetrics = mlContext.MulticlassClassification.PermutationFeatureImportance(
-                linearPredictor, transformedData, permutationCount: 30);
+            // Compute the permutation metrics for the linear model using the
+            // normalized data.
+            var permutationMetrics = mlContext.MulticlassClassification
+                .PermutationFeatureImportance(linearPredictor, transformedData,
+                permutationCount: 30);
 
-            // Now let's look at which features are most important to the model overall.
-            // Get the feature indices sorted by their impact on microaccuracy.
-            var sortedIndices = permutationMetrics.Select((metrics, index) => new { index, metrics.MicroAccuracy})
+            // Now let's look at which features are most important to the model
+            // overall. Get the feature indices sorted by their impact on
+            // microaccuracy.
+            var sortedIndices = permutationMetrics
+                .Select((metrics, index) => new { index, metrics.MicroAccuracy })
                 .OrderByDescending(feature => Math.Abs(feature.MicroAccuracy.Mean))
                 .Select(feature => feature.index);
 
-            Console.WriteLine("Feature\tChange in MicroAccuracy\t95% Confidence in the Mean Change in MicroAccuracy");
-            var microAccuracy = permutationMetrics.Select(x => x.MicroAccuracy).ToArray();
+            Console.WriteLine("Feature\tChange in MicroAccuracy\t95% Confidence in "
+                + "the Mean Change in MicroAccuracy");
+
+            var microAccuracy = permutationMetrics.Select(x => x.MicroAccuracy)
+                .ToArray();
+
             foreach (int i in sortedIndices)
             {
                 Console.WriteLine("{0}\t{1:G4}\t{2:G4}",
@@ -76,10 +89,14 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         /// linear combination of the features.
         /// </summary>
         /// <param name="nExamples">The number of examples.</param>
-        /// <param name="bias">The bias, or offset, in the calculation of the label.</param>
-        /// <param name="weight1">The weight to multiply the first feature with to compute the label.</param>
-        /// <param name="weight2">The weight to multiply the second feature with to compute the label.</param>
-        /// <param name="seed">The seed for generating feature values and label noise.</param>
+        /// <param name="bias">The bias, or offset, in the calculation of the
+        /// label.</param>
+        /// <param name="weight1">The weight to multiply the first feature with to
+        /// compute the label.</param>
+        /// <param name="weight2">The weight to multiply the second feature with to
+        /// compute the label.</param>
+        /// <param name="seed">The seed for generating feature values and label
+        /// noise.</param>
         /// <returns>An enumerable of Data objects.</returns>
         private static IEnumerable<Data> GenerateData(int nExamples = 10000,
             double bias = 0, double weight1 = 1, double weight2 = 2, int seed = 1)
@@ -95,7 +112,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 };
 
                 // Create a noisy label.
-                var value = (float)(bias + weight1 * data.Feature1 + weight2 * data.Feature2 + rng.NextDouble() - 0.5);
+                var value = (float)
+                    (bias + weight1 * data.Feature1 + weight2 * data.Feature2 +
+                    rng.NextDouble() - 0.5);
+
                 if (value < max / 3)
                     data.Label = 0;
                 else if (value < 2 * max / 3)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PermutationFeatureImportance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/PermutationFeatureImportance.cs
@@ -26,11 +26,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 new string[] { nameof(Data.Feature1), nameof(Data.Feature2) };
 
             var pipeline = mlContext.Transforms
-                    .Concatenate("Features", featureColumns)
-                    .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
-                    .Append(mlContext.Transforms.NormalizeMinMax("Features"))
-                    .Append(mlContext.MulticlassClassification.Trainers
-                    .SdcaMaximumEntropy());
+                .Concatenate("Features", featureColumns)
+                .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
+                .Append(mlContext.Transforms.NormalizeMinMax("Features"))
+                .Append(mlContext.MulticlassClassification.Trainers
+                .SdcaMaximumEntropy());
 
             // Fit the pipeline to the data.
             var model = pipeline.Fit(data);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -11,34 +11,33 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-        // data set from a file and accesses it many times, it can be slow due
-        // to expensive featurization and disk operations. When the considered
-        // data can fit into memory, a solution is to cache the data in memory.
-        // Caching is especially helpful when working with iterative algorithms 
-        // which needs many data passes.
-        trainingData = mlContext.Data.Cache(trainingData);
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-
-                    // Apply SdcaMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+            // Apply SdcaMaximumEntropy multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaMaximumEntropy());
 
 
@@ -46,22 +45,22 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-            reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-                $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -72,7 +71,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +94,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-        int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -109,16 +108,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-    // such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -142,9 +141,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -40,7 +40,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaMaximumEntropy());
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -35,11 +35,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-		    .MapValueToKey(nameof(DataPoint.Label))
+		        .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		    .SdcaMaximumEntropy());
+		        .SdcaMaximumEntropy());
 
 
             // Train the model.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -11,57 +11,57 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
-	    // which needs many data passes.
-	    trainingData = mlContext.Data.Cache(trainingData);
+        // data set from a file and accesses it many times, it can be slow due
+        // to expensive featurization and disk operations. When the considered
+        // data can fit into memory, a solution is to cache the data in memory.
+        // Caching is especially helpful when working with iterative algorithms 
+        // which needs many data passes.
+        trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-		        .MapValueToKey(nameof(DataPoint.Label))
+                .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .SdcaMaximumEntropy());
+                .SdcaMaximumEntropy());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-	        reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+            reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-	            $"Prediction: {p.PredictedLabel}");
+                $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -72,7 +72,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+        int seed=0)
 
         {
             var random = new Random(seed);
@@ -109,16 +109,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-	// such examples.
+    // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -142,7 +142,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -33,10 +33,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-            // Apply SdcaMaximumEntropy multiclass trainer.
+                // Apply SdcaMaximumEntropy multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaMaximumEntropy());
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -29,17 +29,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 	    // data can fit into memory, a solution is to cache the data in memory.
 	    // Caching is especially helpful when working with iterative algorithms 
 	    // which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+	    trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
+		    .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .SdcaMaximumEntropy());
+		    .SdcaMaximumEntropy());
 
 
             // Train the model.
@@ -48,20 +48,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+	        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+	            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -72,7 +72,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -111,7 +111,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -142,7 +142,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -10,45 +10,58 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-			// it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-			// a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+                        .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply SdcaMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy());
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .SdcaMaximumEntropy());
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -58,9 +71,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
@@ -77,8 +92,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9130 |0.9538 |0.8494 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -90,13 +108,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -119,7 +141,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -11,57 +11,57 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-            // data set from a file and accesses it many times, it can be slow due
-            // to expensive featurization and disk operations. When the considered
-            // data can fit into memory, a solution is to cache the data in memory.
-            // Caching is especially helpful when working with iterative algorithms 
-            // which needs many data passes.
-            trainingData = mlContext.Data.Cache(trainingData);
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
+			// which needs many data passes.
+			trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-                        .MapValueToKey(nameof(DataPoint.Label))
+					    .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .SdcaMaximumEntropy());
+					    .SdcaMaximumEntropy());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -72,10 +72,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -109,16 +109,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -142,7 +142,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.cs
@@ -11,24 +11,24 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
+	    // which needs many data passes.
 			trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
@@ -46,7 +46,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -109,7 +109,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -118,7 +118,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropy.tt
@@ -8,7 +8,8 @@ string TrainerOptions = null;
 string OptionsInclude = "";
 string Comments = "";
 bool CacheData = true;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)" 
+    + "\n        // range with labels 1, 2 or 3.";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -11,22 +11,26 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-			// it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-			// a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaMaximumEntropyMulticlassTrainer.Options
@@ -38,28 +42,34 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             };
 
             // Define the trainer.
-            var pipeline = 
-			        // Convert the string labels into key types.
+            var pipeline =
+                    // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(options));
-			
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .SdcaMaximumEntropy(options));
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -69,9 +79,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.92
             //   Macro Accuracy: 0.92
@@ -89,8 +101,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9363 |0.9647 |0.8497 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -102,13 +117,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -131,7 +150,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -43,9 +43,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply SdcaMaximumEntropy multiclass trainer.
+                // Apply SdcaMaximumEntropy multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaMaximumEntropy(options));
             

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -12,25 +12,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-        // data set from a file and accesses it many times, it can be slow due
-        // to expensive featurization and disk operations. When the considered
-        // data can fit into memory, a solution is to cache the data in memory.
-        // Caching is especially helpful when working with iterative algorithms 
-        // which needs many data passes.
-        trainingData = mlContext.Data.Cache(trainingData);
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaMaximumEntropyMulticlassTrainer.Options
@@ -43,33 +43,33 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-                // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply SdcaMaximumEntropy multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
-                    .SdcaMaximumEntropy(options));
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply SdcaMaximumEntropy multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
+                .SdcaMaximumEntropy(options));
             
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-        int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -118,16 +118,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-    // such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -151,9 +151,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -12,25 +12,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
-	    // which needs many data passes.
-	    trainingData = mlContext.Data.Cache(trainingData);
+        // data set from a file and accesses it many times, it can be slow due
+        // to expensive featurization and disk operations. When the considered
+        // data can fit into memory, a solution is to cache the data in memory.
+        // Caching is especially helpful when working with iterative algorithms 
+        // which needs many data passes.
+        trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaMaximumEntropyMulticlassTrainer.Options
@@ -43,33 +43,33 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-	            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-	                .SdcaMaximumEntropy(options));
-			
+                    .SdcaMaximumEntropy(options));
+            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+        int seed=0)
 
         {
             var random = new Random(seed);
@@ -118,16 +118,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-	// such examples.
+    // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -151,7 +151,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -30,7 +30,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 	    // data can fit into memory, a solution is to cache the data in memory.
 	    // Caching is especially helpful when working with iterative algorithms 
 	    // which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+	    trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaMaximumEntropyMulticlassTrainer.Options
@@ -47,7 +47,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .SdcaMaximumEntropy(options));
+	                .SdcaMaximumEntropy(options));
 			
 
             // Train the model.
@@ -56,20 +56,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -120,7 +120,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -151,7 +151,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -12,24 +12,24 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
+	    // which needs many data passes.
 			trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
@@ -43,7 +43,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-			        // Convert the string labels into key types.
+	            // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
@@ -54,7 +54,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -118,7 +118,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -127,7 +127,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -12,25 +12,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-            // exception tracking and logging, as a catalog of available operations
-            // and as the source of randomness. Setting the seed to a fixed number
-            // in this example to make outputs deterministic.
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-            // consumable by ML.NET API.
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-            // data set from a file and accesses it many times, it can be slow due
-            // to expensive featurization and disk operations. When the considered
-            // data can fit into memory, a solution is to cache the data in memory.
-            // Caching is especially helpful when working with iterative algorithms 
-            // which needs many data passes.
-            trainingData = mlContext.Data.Cache(trainingData);
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
+			// which needs many data passes.
+			trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaMaximumEntropyMulticlassTrainer.Options
@@ -42,34 +42,34 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             };
 
             // Define the trainer.
-            var pipeline =
-                    // Convert the string labels into key types.
+            var pipeline = 
+			        // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaMaximumEntropy multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-                        .SdcaMaximumEntropy(options));
-
+					    .SdcaMaximumEntropy(options));
+			
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-            // from training data.
+			// from training data.
             var testData = mlContext.Data
-                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-                .CreateEnumerable<Prediction>(transformedTestData,
-                reuseRowObject: false).ToList();
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " +
-                    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -80,10 +80,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-                .Evaluate(transformedTestData);
+			    .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
-
+            
             // Expected output:
             //   Micro Accuracy: 0.92
             //   Macro Accuracy: 0.92
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-            int seed = 0)
+		    int seed=0)
 
         {
             var random = new Random(seed);
@@ -118,16 +118,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-                    // constant multiple of label.
+					// constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-        // such examples.
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -151,7 +151,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.cs
@@ -48,7 +48,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 // Apply SdcaMaximumEntropy multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaMaximumEntropy(options));
-            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaMaximumEntropyWithOptions.tt
@@ -14,7 +14,8 @@ string TrainerOptions = @"SdcaMaximumEntropyMulticlassTrainer.Options
 string OptionsInclude = "using Microsoft.ML.Trainers;";
 string Comments = "";
 bool CacheData = true;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)" 
+    + "\n        // range with labels 1, 2 or 3.";
 
 
 string ExpectedOutputPerInstance = @"// Expected output:

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -35,11 +35,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var pipeline =
                     // Convert the string labels into key types.
                     mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
+                        .MapValueToKey(nameof(DataPoint.Label))
 
                     // Apply SdcaNonCalibrated multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .SdcaNonCalibrated());
+		        .SdcaNonCalibrated());
 
 
             // Train the model.
@@ -48,20 +48,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-			    reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -72,7 +72,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -96,7 +96,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -112,7 +112,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -143,7 +143,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -10,58 +10,45 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // as a catalog of available operations and as the source of randomness.
+            // Setting the seed to a fixed number in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
+            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
+            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
-
+                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
                     // Apply SdcaNonCalibrated multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
-					    .SdcaNonCalibrated());
-
+                    .Append(mlContext.MulticlassClassification.Trainers.SdcaNonCalibrated());
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different
-			// from training data.
-            var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different from training data.
+            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -71,11 +58,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
-
+            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
@@ -93,11 +78,8 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9304 |0.9538 |0.8521 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5)
-        // range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
-
+        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -109,17 +91,13 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a
-					// constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
-
+                    // The feature values are slightly increased by adding a constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+        // Example with label and 20 feature values. A data set is a collection of such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -142,9 +120,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
-
+            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -29,7 +29,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 	    // data can fit into memory, a solution is to cache the data in memory.
 	    // Caching is especially helpful when working with iterative algorithms 
 	    // which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+	    trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -11,25 +11,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
-	    // which needs many data passes.
-	    trainingData = mlContext.Data.Cache(trainingData);
+        // data set from a file and accesses it many times, it can be slow due
+        // to expensive featurization and disk operations. When the considered
+        // data can fit into memory, a solution is to cache the data in memory.
+        // Caching is especially helpful when working with iterative algorithms 
+        // which needs many data passes.
+        trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
@@ -39,29 +39,29 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
                     // Apply SdcaNonCalibrated multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .SdcaNonCalibrated());
+                .SdcaNonCalibrated());
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -72,7 +72,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -96,7 +96,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+        int seed=0)
 
         {
             var random = new Random(seed);
@@ -110,9 +110,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -143,7 +143,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -56,7 +56,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
 			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+			    reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -10,45 +10,58 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-			// it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-			// a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
 			// which needs many data passes.
 			trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+					    .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply SdcaNonCalibrated multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.SdcaNonCalibrated());
+                    .Append(mlContext.MulticlassClassification.Trainers
+					    .SdcaNonCalibrated());
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -58,7 +71,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -78,8 +93,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9304 |0.9538 |0.8521 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -91,13 +109,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+					// constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -120,7 +142,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -10,45 +10,58 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
-            // which needs many data passes.
-            trainingData = mlContext.Data.Cache(trainingData);
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
+			// which needs many data passes.
+			trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
                     // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey(nameof(DataPoint.Label))
+                    mlContext.Transforms.Conversion
+					    .MapValueToKey(nameof(DataPoint.Label))
+
                     // Apply SdcaNonCalibrated multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.SdcaNonCalibrated());
+                    .Append(mlContext.MulticlassClassification.Trainers
+					    .SdcaNonCalibrated());
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " + 
+				    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -58,9 +71,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
-            PrintMetrics(metrics);
+            var metrics = mlContext.MulticlassClassification
+			    .Evaluate(transformedTestData);
 
+            PrintMetrics(metrics);
+            
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
@@ -78,8 +93,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9304 |0.9538 |0.8521 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed = 0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -91,13 +109,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+					// constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -120,7 +142,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -11,24 +11,24 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
+	    // which needs many data passes.
 			trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
@@ -46,7 +46,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -110,7 +110,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -119,7 +119,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -11,34 +11,33 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-        // data set from a file and accesses it many times, it can be slow due
-        // to expensive featurization and disk operations. When the considered
-        // data can fit into memory, a solution is to cache the data in memory.
-        // Caching is especially helpful when working with iterative algorithms 
-        // which needs many data passes.
-        trainingData = mlContext.Data.Cache(trainingData);
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
-                        .MapValueToKey(nameof(DataPoint.Label))
-
-                    // Apply SdcaNonCalibrated multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion
+                .MapValueToKey(nameof(DataPoint.Label))
+            // Apply SdcaNonCalibrated multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaNonCalibrated());
 
 
@@ -46,22 +45,22 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -72,7 +71,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -96,7 +95,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-        int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -110,9 +109,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-                .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -143,9 +142,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -33,10 +33,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline =
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion
                 .MapValueToKey(nameof(DataPoint.Label))
-            // Apply SdcaNonCalibrated multiclass trainer.
+                // Apply SdcaNonCalibrated multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaNonCalibrated());
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.cs
@@ -40,7 +40,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaNonCalibrated());
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.tt
@@ -8,7 +8,8 @@ string TrainerOptions = null;
 string OptionsInclude = "";
 string Comments = "";
 bool CacheData = true;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibrated.tt
@@ -8,8 +8,7 @@ string TrainerOptions = null;
 string OptionsInclude = "";
 string Comments = "";
 bool CacheData = true;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
-    + "\n        // range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -12,25 +12,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+        // exception tracking and logging, as a catalog of available operations
+        // and as the source of randomness. Setting the seed to a fixed number
+        // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+        // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
-	    // which needs many data passes.
-	    trainingData = mlContext.Data.Cache(trainingData);
+        // data set from a file and accesses it many times, it can be slow due
+        // to expensive featurization and disk operations. When the considered
+        // data can fit into memory, a solution is to cache the data in memory.
+        // Caching is especially helpful when working with iterative algorithms 
+        // which needs many data passes.
+        trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaNonCalibratedMulticlassTrainer.Options
@@ -43,33 +43,33 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-	            // Convert the string labels into key types.
+                    // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaNonCalibrated multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-		        .SdcaNonCalibrated(options));
-			
+                .SdcaNonCalibrated(options));
+            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+        // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+            .CreateEnumerable<Prediction>(transformedTestData,
+        reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-		    $"Prediction: {p.PredictedLabel}");
+            $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-	        .Evaluate(transformedTestData);
+            .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -118,16 +118,16 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-		    // constant multiple of label.
+            // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-		        .Select(x => randomFloat() + label * 0.2f).ToArray()
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-	// such examples.
+    // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -151,9 +151,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -12,25 +12,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
+	    // which needs many data passes.
+	    trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaNonCalibratedMulticlassTrainer.Options
@@ -43,7 +43,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-			        // Convert the string labels into key types.
+	            // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaNonCalibrated multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
@@ -54,7 +54,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
 			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
@@ -118,7 +118,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-					// constant multiple of label.
+		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
 					    .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -127,7 +127,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public uint Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -48,7 +48,6 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 // Apply SdcaNonCalibrated multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaNonCalibrated(options));
-            
 
             // Train the model.
             var model = pipeline.Fit(trainingData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -47,7 +47,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaNonCalibrated multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .SdcaNonCalibrated(options));
+		        .SdcaNonCalibrated(options));
 			
 
             // Train the model.
@@ -56,20 +56,20 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Create testing data. Use different random seed to make it different
 	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-				    $"Prediction: {p.PredictedLabel}");
+		    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -104,7 +104,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         // Generates random uniform doubles in [-0.5, 0.5)
         // range with labels 1, 2 or 3.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -120,7 +120,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     // The feature values are slightly increased by adding a
 		    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
-					    .Select(x => randomFloat() + label * 0.2f).ToArray()
+		        .Select(x => randomFloat() + label * 0.2f).ToArray()
 
                 };
             }
@@ -151,7 +151,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-			    $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+	        $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
+using Microsoft.ML.Trainers;
 
 namespace Samples.Dynamic.Trainers.MulticlassClassification
 {
-    public static class SdcaNonCalibrated
+    public static class SdcaNonCalibratedWithOptions
     {
         public static void Example()
         {
@@ -31,16 +32,23 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 			// which needs many data passes.
 			trainingData = mlContext.Data.Cache(trainingData);
 
-            // Define the trainer.
-            var pipeline =
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion
-					    .MapValueToKey(nameof(DataPoint.Label))
+            // Define trainer options.
+            var options = new SdcaNonCalibratedMulticlassTrainer.Options
+            {
+                Loss = new HingeLoss(),
+                L1Regularization = 0.1f,
+                BiasLearningRate = 0.01f,
+                NumberOfThreads = 1
+            };
 
+            // Define the trainer.
+            var pipeline = 
+			        // Convert the string labels into key types.
+                    mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaNonCalibrated multiclass trainer.
                     .Append(mlContext.MulticlassClassification.Trainers
-					    .SdcaNonCalibrated());
-
+					    .SdcaNonCalibrated(options));
+			
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -79,18 +87,18 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
-            //   Log Loss: 0.57
-            //   Log Loss Reduction: 0.48
+            //   Log Loss: 0.22
+            //   Log Loss Reduction: 0.80
 
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
             //   TRUTH     ||========================
-            //           0 ||   147 |     0 |    13 | 0.9188
-            //           1 ||     0 |   165 |    12 | 0.9322
-            //           2 ||    11 |     8 |   144 | 0.8834
+            //           0 ||   145 |     0 |    15 | 0.9063
+            //           1 ||     0 |   164 |    13 | 0.9266
+            //           2 ||    12 |     7 |   144 | 0.8834
             //             ||========================
-            //   Precision ||0.9304 |0.9538 |0.8521 |
+            //   Precision ||0.9236 |0.9591 |0.8372 |
         }
 
         // Generates random uniform doubles in [-0.5, 0.5)

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -43,9 +43,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-            // Convert the string labels into key types.
+                // Convert the string labels into key types.
                 mlContext.Transforms.Conversion.MapValueToKey("Label")
-            // Apply SdcaNonCalibrated multiclass trainer.
+                // Apply SdcaNonCalibrated multiclass trainer.
                 .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaNonCalibrated(options));
             

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -12,25 +12,25 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-        // exception tracking and logging, as a catalog of available operations
-        // and as the source of randomness. Setting the seed to a fixed number
-        // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-        // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-        // data set from a file and accesses it many times, it can be slow due
-        // to expensive featurization and disk operations. When the considered
-        // data can fit into memory, a solution is to cache the data in memory.
-        // Caching is especially helpful when working with iterative algorithms 
-        // which needs many data passes.
-        trainingData = mlContext.Data.Cache(trainingData);
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaNonCalibratedMulticlassTrainer.Options
@@ -43,10 +43,10 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Define the trainer.
             var pipeline = 
-                    // Convert the string labels into key types.
-                    mlContext.Transforms.Conversion.MapValueToKey("Label")
-                    // Apply SdcaNonCalibrated multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers
+            // Convert the string labels into key types.
+                mlContext.Transforms.Conversion.MapValueToKey("Label")
+            // Apply SdcaNonCalibrated multiclass trainer.
+                .Append(mlContext.MulticlassClassification.Trainers
                 .SdcaNonCalibrated(options));
             
 
@@ -54,22 +54,22 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-        // from training data.
+            // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-            .CreateEnumerable<Prediction>(transformedTestData,
-        reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " + 
-            $"Prediction: {p.PredictedLabel}");
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
 
             // Evaluate the overall metrics
             var metrics = mlContext.MulticlassClassification
-            .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -118,7 +118,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
                     // The feature values are slightly increased by adding a
-            // constant multiple of label.
+                    // constant multiple of label.
                     Features = Enumerable.Repeat(label, 20)
                         .Select(x => randomFloat() + label * 0.2f).ToArray()
 
@@ -127,7 +127,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
         }
 
         // Example with label and 20 feature values. A data set is a collection of
-    // such examples.
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -151,7 +151,7 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine(
-            $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
 
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.cs
@@ -11,22 +11,26 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-			// it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-			// a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
-			// which needs many data passes.
-			trainingData = mlContext.Data.Cache(trainingData);
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
+            // which needs many data passes.
+            trainingData = mlContext.Data.Cache(trainingData);
 
             // Define trainer options.
             var options = new SdcaNonCalibratedMulticlassTrainer.Options
@@ -38,28 +42,34 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             };
 
             // Define the trainer.
-            var pipeline = 
-			        // Convert the string labels into key types.
+            var pipeline =
+                    // Convert the string labels into key types.
                     mlContext.Transforms.Conversion.MapValueToKey("Label")
                     // Apply SdcaNonCalibrated multiclass trainer.
-                    .Append(mlContext.MulticlassClassification.Trainers.SdcaNonCalibrated(options));
-			
+                    .Append(mlContext.MulticlassClassification.Trainers
+                        .SdcaNonCalibrated(options));
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
+            // Create testing data. Use different random seed to make it different
+            // from training data.
+            var testData = mlContext.Data
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed: 123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Look at 5 predictions
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " +
+                    $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: 1, Prediction: 1
@@ -69,9 +79,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Label: 3, Prediction: 3
 
             // Evaluate the overall metrics
-            var metrics = mlContext.MulticlassClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.MulticlassClassification
+                .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
-            
+
             // Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
@@ -89,8 +101,11 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             //   Precision ||0.9236 |0.9591 |0.8372 |
         }
 
-        // Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        // Generates random uniform doubles in [-0.5, 0.5)
+        // range with labels 1, 2 or 3.
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+            int seed = 0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)(random.NextDouble() - 0.5);
@@ -102,13 +117,17 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
                 {
                     Label = (uint)label,
                     // Create random features that are correlated with the label.
-                    // The feature values are slightly increased by adding a constant multiple of label.
-                    Features = Enumerable.Repeat(label, 20).Select(x => randomFloat() + label * 0.2f).ToArray()
+                    // The feature values are slightly increased by adding a
+                    // constant multiple of label.
+                    Features = Enumerable.Repeat(label, 20)
+                        .Select(x => randomFloat() + label * 0.2f).ToArray()
+
                 };
             }
         }
 
-        // Example with label and 20 feature values. A data set is a collection of such examples.
+        // Example with label and 20 feature values. A data set is a collection of
+        // such examples.
         private class DataPoint
         {
             public uint Label { get; set; }
@@ -131,7 +150,9 @@ namespace Samples.Dynamic.Trainers.MulticlassClassification
             Console.WriteLine($"Micro Accuracy: {metrics.MicroAccuracy:F2}");
             Console.WriteLine($"Macro Accuracy: {metrics.MacroAccuracy:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
-            Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+            Console.WriteLine(
+                $"Log Loss Reduction: {metrics.LogLossReduction:F2}\n");
+
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.tt
@@ -1,20 +1,15 @@
 ﻿<#@ include file="MulticlassClassification.ttinclude"#>
 <#+
-string ClassName = "SdcaNonCalibratedWithOptions";
+string ClassName = "SdcaNonCalibrated";
 string Trainer = "SdcaNonCalibrated";
 string MetaTrainer = null;
-string TrainerOptions = @"SdcaNonCalibratedMulticlassTrainer.Options
-            {
-                Loss = new HingeLoss(),
-                L1Regularization = 0.1f,
-                BiasLearningRate = 0.01f,
-                NumberOfThreads = 1
-            }";
+string TrainerOptions = null;
 
-string OptionsInclude = "using Microsoft.ML.Trainers;";
+string OptionsInclude = "";
 string Comments = "";
 bool CacheData = true;
-string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5) range with labels 1, 2 or 3.";
+string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
+    + "\n        // range with labels 1, 2 or 3.";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: 1, Prediction: 1
@@ -26,16 +21,16 @@ string ExpectedOutputPerInstance = @"// Expected output:
 string ExpectedOutput = @"// Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
-            //   Log Loss: 0.22
-            //   Log Loss Reduction: 0.80
+            //   Log Loss: 0.57
+            //   Log Loss Reduction: 0.48
 
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
             //   TRUTH     ||========================
-            //           0 ||   145 |     0 |    15 | 0.9063
-            //           1 ||     0 |   164 |    13 | 0.9266
-            //           2 ||    12 |     7 |   144 | 0.8834
+            //           0 ||   147 |     0 |    13 | 0.9188
+            //           1 ||     0 |   165 |    12 | 0.9322
+            //           2 ||    11 |     8 |   144 | 0.8834
             //             ||========================
-            //   Precision ||0.9236 |0.9591 |0.8372 |";
+            //   Precision ||0.9304 |0.9538 |0.8521 |";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/SdcaNonCalibratedWithOptions.tt
@@ -1,11 +1,17 @@
 ﻿<#@ include file="MulticlassClassification.ttinclude"#>
 <#+
-string ClassName = "SdcaNonCalibrated";
+string ClassName = "SdcaNonCalibratedWithOptions";
 string Trainer = "SdcaNonCalibrated";
 string MetaTrainer = null;
-string TrainerOptions = null;
+string TrainerOptions = @"SdcaNonCalibratedMulticlassTrainer.Options
+            {
+                Loss = new HingeLoss(),
+                L1Regularization = 0.1f,
+                BiasLearningRate = 0.01f,
+                NumberOfThreads = 1
+            }";
 
-string OptionsInclude = "";
+string OptionsInclude = "using Microsoft.ML.Trainers;";
 string Comments = "";
 bool CacheData = true;
 string DataGenerationComments= "// Generates random uniform doubles in [-0.5, 0.5)"
@@ -21,16 +27,16 @@ string ExpectedOutputPerInstance = @"// Expected output:
 string ExpectedOutput = @"// Expected output:
             //   Micro Accuracy: 0.91
             //   Macro Accuracy: 0.91
-            //   Log Loss: 0.57
-            //   Log Loss Reduction: 0.48
+            //   Log Loss: 0.22
+            //   Log Loss Reduction: 0.80
 
             //   Confusion table
             //             ||========================
             //   PREDICTED ||     0 |     1 |     2 | Recall
             //   TRUTH     ||========================
-            //           0 ||   147 |     0 |    13 | 0.9188
-            //           1 ||     0 |   165 |    12 | 0.9322
-            //           2 ||    11 |     8 |   144 | 0.8834
+            //           0 ||   145 |     0 |    15 | 0.9063
+            //           1 ||     0 |   164 |    13 | 0.9266
+            //           2 ||    12 |     7 |   144 | 0.8834
             //             ||========================
-            //   Precision ||0.9304 |0.9538 |0.8521 |";
+            //   Precision ||0.9236 |0.9591 |0.8372 |";
 #>


### PR DESCRIPTION
Guidelines followed:
-85 characters per line
-Use 4 spaces for indentation
-Dot and open parentheses stay on same line as function
-If not a preexisting line under line that we break, add an extra line after it
-Don't indent comments
-Don't break a comment if it represents output
-Don't break links
-If applicable, break right before $
-Keep math op together

Fix for issue #3478
*There are a couple exceptions to the 85 char. limit that have been approved by Natalie