### PR TITLE
Reformatting BinaryClassification samples to width 85

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -11,16 +11,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
@@ -32,22 +32,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,17 +96,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-		        0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -130,14 +130,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -129,11 +129,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -27,14 +27,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .AveragedPerceptron();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
             // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
@@ -129,12 +128,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -10,35 +10,44 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.AveragedPerceptron();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .AveragedPerceptron();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -48,7 +57,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -71,7 +82,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.7402 |   0.7061 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -82,13 +95,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -111,9 +128,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .AveragedPerceptron();
+                .AveragedPerceptron();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,10 +96,10 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+		        0.1f).ToArray()
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -100,6 +100,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 		        0.1f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptron.cs
@@ -105,7 +105,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -36,29 +36,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .AveragedPerceptron(options);
+                .AveragedPerceptron(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -69,7 +69,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -94,7 +94,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -107,17 +107,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -141,14 +141,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -36,29 +36,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .AveragedPerceptron(options);
+	        .AveragedPerceptron(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -69,7 +69,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -94,7 +94,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -107,16 +107,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -140,11 +140,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
@@ -111,6 +111,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.1f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
@@ -11,15 +11,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -33,23 +35,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.AveragedPerceptron(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .AveragedPerceptron(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -59,7 +68,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -82,7 +93,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.7402 |   0.7061 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -93,13 +106,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -122,9 +139,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/AveragedPerceptronWithOptions.cs
@@ -38,7 +38,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .AveragedPerceptron(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -140,12 +139,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
@@ -14,8 +14,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
             // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
@@ -23,15 +23,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 <# if (CacheData) { #>
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
@@ -39,7 +39,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 <# if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .<#=Trainer#>();
+                .<#=Trainer#>();
 
 <# } else { #>
             // Define trainer options.
@@ -47,7 +47,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .<#=Trainer#>(options);
+                .<#=Trainer#>(options);
 
 <# } #>
 
@@ -55,30 +55,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             <#=ExpectedOutputPerInstance#>
             <# string Evaluator = IsCalibrated ? "Evaluate" :
-	        "EvaluateNonCalibrated"; #>
+                "EvaluateNonCalibrated"; #>
 
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .<#=Evaluator#>(transformedTestData);
+                .<#=Evaluator#>(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,17 +99,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			<#=DataSepValue#>).ToArray()
-			
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        <#=DataSepValue#>).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -133,11 +133,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
@@ -14,24 +14,24 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 <# if (CacheData) { #>
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
@@ -39,7 +39,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 <# if (TrainerOptions == null) { #>
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .<#=Trainer#>();
+	        .<#=Trainer#>();
 
 <# } else { #>
             // Define trainer options.
@@ -47,7 +47,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.<#=Trainer#>(options);
+	        .<#=Trainer#>(options);
 
 <# } #>
 
@@ -55,30 +55,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             <#=ExpectedOutputPerInstance#>
             <# string Evaluator = IsCalibrated ? "Evaluate" :
-			    "EvaluateNonCalibrated"; #>
+	        "EvaluateNonCalibrated"; #>
 
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .<#=Evaluator#>(transformedTestData);
+	        .<#=Evaluator#>(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,16 +99,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						<#=DataSepValue#>).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			<#=DataSepValue#>).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -132,11 +132,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
@@ -13,63 +13,81 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {<#=Comments#>
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 <# if (CacheData) { #>
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 <# } #>
 
 <# if (TrainerOptions == null) { #>
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.<#=Trainer#>();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .<#=Trainer#>();
+
 <# } else { #>
             // Define trainer options.
             var options = new <#=TrainerOptions#>;
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.<#=Trainer#>(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.<#=Trainer#>(options);
+
 <# } #>
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             <#=ExpectedOutputPerInstance#>
-            <# string Evaluator = IsCalibrated ? "Evaluate" : "EvaluateNonCalibrated"; #>
+            <# string Evaluator = IsCalibrated ? "Evaluate" :
+			    "EvaluateNonCalibrated"; #>
 
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.<#=Evaluator#>(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .<#=Evaluator#>(transformedTestData);
+
             PrintMetrics(metrics);
             
             <#=ExpectedOutput#>
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -80,13 +98,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + <#=DataSepValue#>).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						<#=DataSepValue#>).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -109,9 +131,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
@@ -103,6 +103,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			<#=DataSepValue#>).ToArray()
+			
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/BinaryClassification.ttinclude
@@ -40,7 +40,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
                 .<#=Trainer#>();
-
 <# } else { #>
             // Define trainer options.
             var options = new <#=TrainerOptions#>;
@@ -48,7 +47,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
                 .<#=Trainer#>(options);
-
 <# } #>
 
             // Train the model.
@@ -132,12 +130,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/FixedPlatt.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/FixedPlatt.cs
@@ -9,26 +9,36 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils
+                .LoadFeaturizedAdultDataset(mlContext);
+
             // Leave out 10% of data for testing.
-            var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
+            var trainTestData = mlContext.Data
+                .TrainTestSplit(data, testFraction: 0.3);
 
-            // Create data training pipeline for non calibrated trainer and train Naive calibrator on top of it.
-            var pipeline = mlContext.BinaryClassification.Trainers.AveragedPerceptron();
+            // Create data training pipeline for non calibrated trainer and train
+            // Naive calibrator on top of it.
+            var pipeline = mlContext.BinaryClassification.Trainers
+                .AveragedPerceptron();
 
-            // Fit the pipeline, and get a transformer that knows how to score new data.  
+            // Fit the pipeline, and get a transformer that knows how to score new
+            // data.  
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
-            // Let's score the new data. The score will give us a numerical estimation of the chance that the particular sample 
-            // bears positive sentiment. This estimate is relative to the numbers obtained. 
+            // Let's score the new data. The score will give us a numerical
+            // estimation of the chance that the particular sample bears positive
+            // sentiment. This estimate is relative to the numbers obtained. 
             var scoredData = transformer.Transform(trainTestData.TestSet);
-            var outScores = mlContext.Data.CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
+            var outScores = mlContext.Data
+                .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
+
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
             // Score   4.18144
@@ -37,16 +47,24 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // Score  -2.554229
             // Score   5.36571
 
-            // Let's train a calibrator estimator on this scored dataset. The trained calibrator estimator produces a transformer
-            // that can transform the scored data by adding a new column names "Probability". 
-            var calibratorEstimator = mlContext.BinaryClassification.Calibrators.Platt(slope: -1f, offset: -0.05f);
+            // Let's train a calibrator estimator on this scored dataset. The
+            // trained calibrator estimator produces a transformer that can
+            // transform the scored data by adding a new column names "Probability". 
+            var calibratorEstimator = mlContext.BinaryClassification.Calibrators
+                .Platt(slope: -1f, offset: -0.05f);
+
             var calibratorTransformer = calibratorEstimator.Fit(scoredData);
 
-            // Transform the scored data with a calibrator transfomer by adding a new column names "Probability". 
-            // This column is a calibrated version of the "Score" column, meaning its values are a valid probability value in the [0, 1] interval
-            // representing the chance that the respective sample bears positive sentiment. 
+            // Transform the scored data with a calibrator transfomer by adding a
+            // new column names "Probability". This column is a calibrated version
+            // of the "Score" column, meaning its values are a valid probability
+            // value in the [0, 1] interval representing the chance that the
+            // respective sample bears positive sentiment. 
             var finalData = calibratorTransformer.Transform(scoredData);
-            var outScoresAndProbabilities = mlContext.Data.CreateEnumerable<ScoreAndProbabilityValue>(finalData, reuseRowObject: false);
+            var outScoresAndProbabilities = mlContext.Data
+                .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
+                reuseRowObject: false);
+
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
             // Score   4.18144   Probability 0.9856767
             // Score  -14.10248  Probability 7.890148E-07
@@ -61,10 +79,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 Console.WriteLine("{0, -10} {1, -10}", "Score", value.Score);
         }
 
-        private static void PrintScoreAndProbability(IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+        private static void PrintScoreAndProbability(
+            IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+
         {
             foreach (var value in values.Take(numRows))
-                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score", value.Score, "Probability", value.Probability);
+                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score", 
+                    value.Score, "Probability", value.Probability);
         }
 
         private class ScoreValue

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Isotonic.cs
@@ -9,26 +9,35 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils
+                .LoadFeaturizedAdultDataset(mlContext);
+
             // Leave out 10% of data for testing.
-            var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
+            var trainTestData = mlContext.Data
+                .TrainTestSplit(data, testFraction: 0.3);
 
-            // Create data training pipeline for non calibrated trainer and train Naive calibrator on top of it.
-            var pipeline = mlContext.BinaryClassification.Trainers.AveragedPerceptron();
+            // Create data training pipeline for non calibrated trainer and train
+            // Naive calibrator on top of it.
+            var pipeline = mlContext.BinaryClassification.Trainers
+                .AveragedPerceptron();
 
-            // Fit the pipeline, and get a transformer that knows how to score new data.  
+            // Fit the pipeline, and get a transformer that knows how to score new
+            // data.  
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
-            // Let's score the new data. The score will give us a numerical estimation of the chance that the particular sample 
-            // bears positive sentiment. This estimate is relative to the numbers obtained. 
+            // Let's score the new data. The score will give us a numerical
+            // estimation of the chance that the particular sample bears positive
+            // sentiment. This estimate is relative to the numbers obtained. 
             var scoredData = transformer.Transform(trainTestData.TestSet);
-            var outScores = mlContext.Data.CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
+            var outScores = mlContext.Data
+                .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
 
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
@@ -38,16 +47,24 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // Score  -2.554229
             // Score   5.36571
 
-            // Let's train a calibrator estimator on this scored dataset. The trained calibrator estimator produces a transformer
-            // that can transform the scored data by adding a new column names "Probability". 
-            var calibratorEstimator = mlContext.BinaryClassification.Calibrators.Isotonic();
+            // Let's train a calibrator estimator on this scored dataset. The
+            // trained calibrator estimator produces a transformer that can
+            // transform the scored data by adding a new column names "Probability". 
+            var calibratorEstimator = mlContext.BinaryClassification.Calibrators
+                .Isotonic();
+
             var calibratorTransformer = calibratorEstimator.Fit(scoredData);
 
-            // Transform the scored data with a calibrator transfomer by adding a new column names "Probability". 
-            // This column is a calibrated version of the "Score" column, meaning its values are a valid probability value in the [0, 1] interval
-            // representing the chance that the respective sample bears positive sentiment. 
+            // Transform the scored data with a calibrator transfomer by adding a
+            // new column names "Probability". This column is a calibrated version
+            // of the "Score" column, meaning its values are a valid probability
+            // value in the [0, 1] interval representing the chance that the
+            // respective sample bears positive sentiment. 
             var finalData = calibratorTransformer.Transform(scoredData);
-            var outScoresAndProbabilities = mlContext.Data.CreateEnumerable<ScoreAndProbabilityValue>(finalData, reuseRowObject: false);
+            var outScoresAndProbabilities = mlContext.Data
+                .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
+                reuseRowObject: false);
+
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
             // Score   4.18144   Probability 0.8
             // Score  -14.10248  Probability 1E-15
@@ -62,10 +79,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 Console.WriteLine("{0, -10} {1, -10}", "Score", value.Score);
         }
 
-        private static void PrintScoreAndProbability(IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+        private static void PrintScoreAndProbability(
+            IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+
         {
             foreach (var value in values.Take(numRows))
-                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score", value.Score, "Probability", value.Probability);
+                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score",
+                    value.Score, "Probability", value.Probability);
+
         }
 
         private class ScoreValue

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Naive.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Naive.cs
@@ -9,26 +9,36 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils
+                .LoadFeaturizedAdultDataset(mlContext);
+
             // Leave out 10% of data for testing.
-            var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
+            var trainTestData = mlContext.Data
+                .TrainTestSplit(data, testFraction: 0.3);
 
-            // Create data training pipeline for non calibrated trainer and train Naive calibrator on top of it.
-            var pipeline = mlContext.BinaryClassification.Trainers.AveragedPerceptron();
+            // Create data training pipeline for non calibrated trainer and train
+            // Naive calibrator on top of it.
+            var pipeline = mlContext.BinaryClassification.Trainers
+                .AveragedPerceptron();
 
-            // Fit the pipeline, and get a transformer that knows how to score new data.  
+            // Fit the pipeline, and get a transformer that knows how to score new
+            // data.  
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
-            // Let's score the new data. The score will give us a numerical estimation of the chance that the particular sample 
-            // bears positive sentiment. This estimate is relative to the numbers obtained. 
+            // Let's score the new data. The score will give us a numerical
+            // estimation of the chance that the particular sample bears positive
+            // sentiment. This estimate is relative to the numbers obtained. 
             var scoredData = transformer.Transform(trainTestData.TestSet);
-            var outScores = mlContext.Data.CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
+            var outScores = mlContext.Data
+                .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
+
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
             // Score   4.18144
@@ -37,16 +47,24 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // Score  -2.554229
             // Score   5.36571
 
-            // Let's train a calibrator estimator on this scored dataset. The trained calibrator estimator produces a transformer
-            // that can transform the scored data by adding a new column names "Probability". 
-            var calibratorEstimator = mlContext.BinaryClassification.Calibrators.Naive();
+            // Let's train a calibrator estimator on this scored dataset. The
+            // trained calibrator estimator produces a transformer that can
+            // transform the scored data by adding a new column names "Probability". 
+            var calibratorEstimator = mlContext.BinaryClassification.Calibrators
+                .Naive();
+
             var calibratorTransformer = calibratorEstimator.Fit(scoredData);
 
-            // Transform the scored data with a calibrator transfomer by adding a new column names "Probability". 
-            // This column is a calibrated version of the "Score" column, meaning its values are a valid probability value in the [0, 1] interval
-            // representing the chance that the respective sample bears positive sentiment. 
+            // Transform the scored data with a calibrator transfomer by adding a
+            // new column names "Probability". This column is a calibrated version
+            // of the "Score" column, meaning its values are a valid probability
+            // value in the [0, 1] interval representing the chance that the
+            // respective sample bears positive sentiment. 
             var finalData = calibratorTransformer.Transform(scoredData);
-            var outScoresAndProbabilities = mlContext.Data.CreateEnumerable<ScoreAndProbabilityValue>(finalData, reuseRowObject: false);
+            var outScoresAndProbabilities = mlContext.Data
+                .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
+                reuseRowObject: false);
+
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
             // Score   4.18144   Probability 0.775
             // Score  -14.10248  Probability 0.01923077
@@ -61,10 +79,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 Console.WriteLine("{0, -10} {1, -10}", "Score", value.Score);
         }
 
-        private static void PrintScoreAndProbability(IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+        private static void PrintScoreAndProbability(
+            IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+
         {
             foreach (var value in values.Take(numRows))
-                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score", value.Score, "Probability", value.Probability);
+                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score",
+                    value.Score, "Probability", value.Probability);
+
         }
 
         private class ScoreValue

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Platt.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Calibrators/Platt.cs
@@ -9,26 +9,36 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Download and featurize the dataset.
-            var data = Microsoft.ML.SamplesUtils.DatasetUtils.LoadFeaturizedAdultDataset(mlContext);
+            var data = Microsoft.ML.SamplesUtils.DatasetUtils
+                .LoadFeaturizedAdultDataset(mlContext);
+
             // Leave out 10% of data for testing.
-            var trainTestData = mlContext.Data.TrainTestSplit(data, testFraction: 0.3);
+            var trainTestData = mlContext.Data
+                .TrainTestSplit(data, testFraction: 0.3);
 
-            // Create data training pipeline for non calibrated trainer and train Naive calibrator on top of it.
-            var pipeline = mlContext.BinaryClassification.Trainers.AveragedPerceptron();
+            // Create data training pipeline for non calibrated trainer and train
+            // Naive calibrator on top of it.
+            var pipeline = mlContext.BinaryClassification.Trainers
+                .AveragedPerceptron();
 
-            // Fit the pipeline, and get a transformer that knows how to score new data.  
+            // Fit the pipeline, and get a transformer that knows how to score new
+            // data.  
             var transformer = pipeline.Fit(trainTestData.TrainSet);
             // Fit this pipeline to the training data.
-            // Let's score the new data. The score will give us a numerical estimation of the chance that the particular sample 
-            // bears positive sentiment. This estimate is relative to the numbers obtained. 
+            // Let's score the new data. The score will give us a numerical
+            // estimation of the chance that the particular sample bears positive
+            // sentiment. This estimate is relative to the numbers obtained. 
             var scoredData = transformer.Transform(trainTestData.TestSet);
-            var outScores = mlContext.Data.CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
+            var outScores = mlContext.Data
+                .CreateEnumerable<ScoreValue>(scoredData, reuseRowObject: false);
+
             PrintScore(outScores, 5);
             // Preview of scoredDataPreview.RowView
             // Score   4.18144
@@ -37,16 +47,24 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
             // Score  -2.554229
             // Score   5.36571
 
-            // Let's train a calibrator estimator on this scored dataset. The trained calibrator estimator produces a transformer
-            // that can transform the scored data by adding a new column names "Probability". 
-            var calibratorEstimator = mlContext.BinaryClassification.Calibrators.Platt();
+            // Let's train a calibrator estimator on this scored dataset. The
+            // trained calibrator estimator produces a transformer that can
+            // transform the scored data by adding a new column names "Probability". 
+            var calibratorEstimator = mlContext.BinaryClassification.Calibrators
+                .Platt();
+
             var calibratorTransformer = calibratorEstimator.Fit(scoredData);
 
-            // Transform the scored data with a calibrator transfomer by adding a new column names "Probability". 
-            // This column is a calibrated version of the "Score" column, meaning its values are a valid probability value in the [0, 1] interval
-            // representing the chance that the respective sample bears positive sentiment. 
+            // Transform the scored data with a calibrator transfomer by adding a
+            // new column names "Probability". This column is a calibrated version
+            // of the "Score" column, meaning its values are a valid probability
+            // value in the [0, 1] interval representing the chance that the
+            // respective sample bears positive sentiment. 
             var finalData = calibratorTransformer.Transform(scoredData);
-            var outScoresAndProbabilities = mlContext.Data.CreateEnumerable<ScoreAndProbabilityValue>(finalData, reuseRowObject: false);
+            var outScoresAndProbabilities = mlContext.Data
+                .CreateEnumerable<ScoreAndProbabilityValue>(finalData,
+                reuseRowObject: false);
+
             PrintScoreAndProbability(outScoresAndProbabilities, 5);
             // Score   4.18144   Probability 0.8511352
             // Score  -14.10248  Probability 0.001633563
@@ -61,10 +79,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification.Calibrators
                 Console.WriteLine("{0, -10} {1, -10}", "Score", value.Score);
         }
 
-        private static void PrintScoreAndProbability(IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+        private static void PrintScoreAndProbability(
+            IEnumerable<ScoreAndProbabilityValue> values, int numRows)
+
         {
             foreach (var value in values.Take(numRows))
-                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score", value.Score, "Probability", value.Probability);
+                Console.WriteLine("{0, -10} {1, -10} {2, -10} {3, -10}", "Score",
+                    value.Score, "Probability", value.Probability);
+
         }
 
         private class ScoreValue

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
@@ -11,51 +11,51 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .FieldAwareFactorizationMachine();
+                .FieldAwareFactorizationMachine();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -91,7 +91,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -104,17 +104,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -138,14 +138,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
@@ -35,7 +35,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .FieldAwareFactorizationMachine();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -137,12 +136,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
@@ -10,41 +10,52 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FieldAwareFactorizationMachine();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .FieldAwareFactorizationMachine();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -54,7 +65,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -77,7 +90,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.9063 |   0.8732 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -88,13 +103,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -117,9 +136,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
@@ -11,51 +11,51 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .FieldAwareFactorizationMachine();
+	        .FieldAwareFactorizationMachine();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -91,7 +91,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -104,16 +104,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -137,11 +137,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FactorizationMachine.cs
@@ -108,6 +108,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.1f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
@@ -8,49 +8,49 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastForest
     {
-       // This example requires installation of additional NuGet package for 
-       // Microsoft.ML.FastTree at
-       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .FastForest();
+                .FastForest();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,16 +99,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -132,15 +133,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
@@ -8,39 +8,49 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastForest
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+       // This example requires installation of additional NuGet package for 
+       // Microsoft.ML.FastTree at
+       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FastForest();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .FastForest();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -50,7 +60,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -73,7 +85,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6182 |   0.5416 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -84,13 +98,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -113,9 +131,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
@@ -30,7 +30,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .FastForest();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -132,12 +131,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForest.cs
@@ -14,43 +14,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .FastForest();
+	        .FastForest();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,16 +99,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -132,11 +132,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
@@ -9,22 +9,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastForestWithOptions
     {
-       // This example requires installation of additional NuGet package for 
-       // Microsoft.ML.FastTree at
-       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -40,29 +40,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .FastForest(options);
+                .FastForest(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -73,7 +73,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -98,7 +98,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -111,17 +111,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -145,15 +145,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
@@ -115,6 +115,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -40,29 +40,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .FastForest(options);
+	        .FastForest(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -73,7 +73,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -98,7 +98,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -111,16 +111,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -144,11 +144,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
@@ -42,7 +42,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .FastForest(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -144,12 +143,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastForestWithOptions.cs
@@ -9,19 +9,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastForestWithOptions
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+       // This example requires installation of additional NuGet package for 
+       // Microsoft.ML.FastTree at
+       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -36,23 +39,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FastForest(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .FastForest(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -62,7 +72,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -85,7 +97,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.7072 |   0.7806 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -96,13 +110,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -125,9 +143,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
@@ -106,6 +106,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
@@ -14,43 +14,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .FastTree();
+	        .FastTree();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -89,7 +89,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,16 +102,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -135,11 +135,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
@@ -30,7 +30,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .FastTree();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -135,12 +134,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
@@ -8,39 +8,49 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastTree
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+       // This example requires installation of additional NuGet package for 
+       // Microsoft.ML.FastTree at
+       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FastTree();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .FastTree();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -50,7 +60,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -76,7 +88,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6903 |   0.7716 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -87,13 +101,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -116,9 +134,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTree.cs
@@ -8,49 +8,49 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastTree
     {
-       // This example requires installation of additional NuGet package for 
-       // Microsoft.ML.FastTree at
-       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .FastTree();
+                .FastTree();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -89,7 +89,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -102,17 +102,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -136,15 +136,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
@@ -42,7 +42,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .FastTree(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -147,12 +146,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
@@ -118,6 +118,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
@@ -9,19 +9,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastTreeWithOptions
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+       // This example requires installation of additional NuGet package for 
+       // Microsoft.ML.FastTree at
+       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -36,23 +39,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.FastTree(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .FastTree(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -62,7 +72,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -88,7 +100,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //  Precision ||   0.6903 |   0.7716 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -99,13 +113,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -128,9 +146,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -40,29 +40,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .FastTree(options);
+	        .FastTree(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -73,7 +73,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -101,7 +101,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -114,16 +114,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -147,11 +147,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FastTreeWithOptions.cs
@@ -9,22 +9,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FastTreeWithOptions
     {
-       // This example requires installation of additional NuGet package for 
-       // Microsoft.ML.FastTree at
-       // https://www.nuget.org/packages/Microsoft.ML.FastTree/
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -40,29 +40,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .FastTree(options);
+                .FastTree(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -73,7 +73,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -101,7 +101,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -114,17 +114,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -148,15 +148,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -37,11 +37,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 .FieldAwareFactorizationMachine(
                 // Specify three feature columns!
                 new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
-            nameof(DataPoint.Field2) },
-
+                nameof(DataPoint.Field2) },
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) );
-
 
             // Train the model.
             var model = pipeline.Fit(trainingData);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -8,30 +8,40 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FieldAwareFactorizationMachine
     {
-        // This example first train a field-aware factorization to binary classification, measure the trained model's quality, and finally
+        // This example first train a field-aware factorization to binary
+		// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
             // Define the trainer.
-            // This trainer trains field-aware factorization (FFM) for binary classification. See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf
-            // for the theory behind and https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the training
-            // algorithm implemented in ML.NET.
-            var pipeline = mlContext.BinaryClassification.Trainers.FieldAwareFactorizationMachine(
+            // This trainer trains field-aware factorization (FFM)
+            //for binary classification.
+			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+			// behind and 
+			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+			// training algorithm implemented in ML.NET.
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .FieldAwareFactorizationMachine(
                 // Specify three feature columns!
-                new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+                new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
+				    nameof(DataPoint.Field2) },
+
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) );
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -40,7 +50,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var transformedTrainingData = model.Transform(trainingData);
 
             // Measure the quality of the trained model.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTrainingData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -68,14 +79,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.7878 |   0.8235 |
 
             // Create prediction function from the trained model.
-            var engine = mlContext.Model.CreatePredictionEngine<DataPoint, Result>(model);
+            var engine = mlContext.Model
+			    .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
-                Console.WriteLine($"Actual label: {dataPoint.Label}, predicted label: {result.PredictedLabel}, " +
-                    $"score of being positive class: {result.Score}, and probability of beling positive class: {result.Probability}.");
+                Console.WriteLine($"Actual label: {dataPoint.Label}, "
+				    + $"predicted label: {result.PredictedLabel}, "
+                    + $"score of being positive class: {result.Score}, "
+					+ $"and probability of beling positive class: "
+					+ $"{result.Probability}.");
             }
 
             // Expected output:
@@ -95,7 +110,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Label.
             public bool Label { get; set; }
 
-            // Features from the first field. Note that different fields can have different numbers of features.
+            // Features from the first field. Note that different fields can have
+			// different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -108,8 +124,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public float[] Field2 { get; set; }
         }
 
-        // This class defines objects produced by trained model. The trained model maps
-        // a DataPoint to a Result.
+        // This class defines objects produced by trained model. The trained model
+		// maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -123,13 +139,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // Function used to create toy data sets.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int exampleCount, int seed = 0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(
+		    int exampleCount, int seed = 0)
+
         {
             var rnd = new Random(seed);
             var data = new List<DataPoint>();
             for (int i = 0; i < exampleCount; ++i)
             {
-                // Initialize an example with a random label and an empty feature vector.
+                // Initialize an example with a random label and an empty feature
+				// vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -139,9 +158,10 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 };
 
                 // Fill feature vectors according the assigned label.
-                // Notice that features from different fields have different biases and therefore different distributions.
-                // In practices such as game recommendation, one may use one field to store features from user profile and
-                // another field to store features from game profile.
+                // Notice that features from different fields have different biases
+				// and therefore different distributions. In practices such as game
+				// recommendation, one may use one field to store features from user
+				// profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -169,14 +189,20 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // Function used to show evaluation metrics such as accuracy of predictions.
-        private static void PrintMetrics(CalibratedBinaryClassificationMetrics metrics)
+        private static void PrintMetrics(
+		    CalibratedBinaryClassificationMetrics metrics)
+
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -195,12 +195,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " + 
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -9,35 +9,36 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     public static class FieldAwareFactorizationMachine
     {
         // This example first train a field-aware factorization to binary
-		// classification, measure the trained model's quality, and finally
+	// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
             // Define the trainer.
             // This trainer trains field-aware factorization (FFM)
-            //for binary classification.
-			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-			// behind and 
-			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-			// training algorithm implemented in ML.NET.
+            // for binary classification.
+	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+	    // behind and 
+	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+	    // training algorithm implemented in ML.NET.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .FieldAwareFactorizationMachine(
+	        .FieldAwareFactorizationMachine(
+		    
                 // Specify three feature columns!
                 new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
-				    nameof(DataPoint.Field2) },
+		    nameof(DataPoint.Field2) },
 
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) );
@@ -51,7 +52,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Measure the quality of the trained model.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTrainingData);
+	        .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -80,17 +81,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Create prediction function from the trained model.
             var engine = mlContext.Model
-			    .CreatePredictionEngine<DataPoint, Result>(model);
+	        .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
                 Console.WriteLine($"Actual label: {dataPoint.Label}, "
-				    + $"predicted label: {result.PredictedLabel}, "
+		    + $"predicted label: {result.PredictedLabel}, "
                     + $"score of being positive class: {result.Score}, "
-					+ $"and probability of beling positive class: "
-					+ $"{result.Probability}.");
+		    + $"and probability of beling positive class: "
+		    + $"{result.Probability}.");
             }
 
             // Expected output:
@@ -111,7 +112,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public bool Label { get; set; }
 
             // Features from the first field. Note that different fields can have
-			// different numbers of features.
+	    // different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -125,7 +126,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // This class defines objects produced by trained model. The trained model
-		// maps a DataPoint to a Result.
+	// maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -140,7 +141,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to create toy data sets.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(
-		    int exampleCount, int seed = 0)
+	    int exampleCount, int seed = 0)
 
         {
             var rnd = new Random(seed);
@@ -148,7 +149,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             for (int i = 0; i < exampleCount; ++i)
             {
                 // Initialize an example with a random label and an empty feature
-				// vector.
+		// vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -159,9 +160,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
                 // Fill feature vectors according the assigned label.
                 // Notice that features from different fields have different biases
-				// and therefore different distributions. In practices such as game
-				// recommendation, one may use one field to store features from user
-				// profile and another field to store features from game profile.
+		// and therefore different distributions. In practices such as game
+		// recommendation, one may use one field to store features from user
+		// profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -197,11 +198,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -191,7 +191,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to show evaluation metrics such as accuracy of predictions.
         private static void PrintMetrics(
-		    CalibratedBinaryClassificationMetrics metrics)
+	    CalibratedBinaryClassificationMetrics metrics)
 
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -92,6 +92,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     + $"score of being positive class: {result.Score}, "
 		    + $"and probability of beling positive class: "
 		    + $"{result.Probability}.");
+		    
             }
 
             // Expected output:

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.cs
@@ -9,36 +9,35 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     public static class FieldAwareFactorizationMachine
     {
         // This example first train a field-aware factorization to binary
-	// classification, measure the trained model's quality, and finally
+        // classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
             // Define the trainer.
             // This trainer trains field-aware factorization (FFM)
             // for binary classification.
-	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-	    // behind and 
-	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-	    // training algorithm implemented in ML.NET.
+            // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+            // behind and 
+            // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+            // training algorithm implemented in ML.NET.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .FieldAwareFactorizationMachine(
-		    
+                .FieldAwareFactorizationMachine(
                 // Specify three feature columns!
                 new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
-		    nameof(DataPoint.Field2) },
+            nameof(DataPoint.Field2) },
 
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) );
@@ -52,7 +51,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Measure the quality of the trained model.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTrainingData);
+                .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -81,18 +80,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Create prediction function from the trained model.
             var engine = mlContext.Model
-	        .CreatePredictionEngine<DataPoint, Result>(model);
+                .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
                 Console.WriteLine($"Actual label: {dataPoint.Label}, "
-		    + $"predicted label: {result.PredictedLabel}, "
+                    + $"predicted label: {result.PredictedLabel}, "
                     + $"score of being positive class: {result.Score}, "
-		    + $"and probability of beling positive class: "
-		    + $"{result.Probability}.");
-		    
+                    + $"and probability of beling positive class: "
+                    + $"{result.Probability}.");
+
             }
 
             // Expected output:
@@ -113,7 +112,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public bool Label { get; set; }
 
             // Features from the first field. Note that different fields can have
-	    // different numbers of features.
+            // different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -127,7 +126,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // This class defines objects produced by trained model. The trained model
-	// maps a DataPoint to a Result.
+        // maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -142,7 +141,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to create toy data sets.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(
-	    int exampleCount, int seed = 0)
+            int exampleCount, int seed = 0)
 
         {
             var rnd = new Random(seed);
@@ -150,7 +149,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             for (int i = 0; i < exampleCount; ++i)
             {
                 // Initialize an example with a random label and an empty feature
-		// vector.
+                // vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -161,9 +160,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
                 // Fill feature vectors according the assigned label.
                 // Notice that features from different fields have different biases
-		// and therefore different distributions. In practices such as game
-		// recommendation, one may use one field to store features from user
-		// profile and another field to store features from game profile.
+                // and therefore different distributions. In practices such as game
+                // recommendation, one may use one field to store features from user
+                // profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -192,18 +191,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to show evaluation metrics such as accuracy of predictions.
         private static void PrintMetrics(
-	    CalibratedBinaryClassificationMetrics metrics)
+            CalibratedBinaryClassificationMetrics metrics)
 
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
@@ -3,19 +3,25 @@
 string ClassName="FieldAwareFactorizationMachine";
 string Trainer = @"FieldAwareFactorizationMachine(
                 // Specify three feature columns!
-                new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+                new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
+				    nameof(DataPoint.Field2) },
+
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) )";
 
 string OptionsInclude = null;
 
 string Comments = @"
-        // This example first train a field-aware factorization to binary classification, measure the trained model's quality, and finally
+        // This example first train a field-aware factorization to binary
+		// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.";
 
-string TrainerDescription = @"// This trainer trains field-aware factorization (FFM) for binary classification. See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf
-            // for the theory behind and https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the training
-            // algorithm implemented in ML.NET.";
+string TrainerDescription = @"// This trainer trains field-aware factorization (FFM)
+            //for binary classification.
+			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+			// behind and 
+			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+			// training algorithm implemented in ML.NET.";
 
 string TrainerOptions = null;
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
@@ -4,8 +4,7 @@ string ClassName="FieldAwareFactorizationMachine";
 string Trainer = @"FieldAwareFactorizationMachine(
                 // Specify three feature columns!
                 new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
-            nameof(DataPoint.Field2) },
-
+                nameof(DataPoint.Field2) },
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) )";
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
@@ -4,7 +4,7 @@ string ClassName="FieldAwareFactorizationMachine";
 string Trainer = @"FieldAwareFactorizationMachine(
                 // Specify three feature columns!
                 new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
-				    nameof(DataPoint.Field2) },
+		    nameof(DataPoint.Field2) },
 
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) )";
@@ -13,15 +13,15 @@ string OptionsInclude = null;
 
 string Comments = @"
         // This example first train a field-aware factorization to binary
-		// classification, measure the trained model's quality, and finally
+	// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.";
 
 string TrainerDescription = @"// This trainer trains field-aware factorization (FFM)
             //for binary classification.
-			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-			// behind and 
-			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-			// training algorithm implemented in ML.NET.";
+	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+	    // behind and 
+	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+	    // training algorithm implemented in ML.NET.";
 
 string TrainerOptions = null;
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachine.tt
@@ -4,7 +4,7 @@ string ClassName="FieldAwareFactorizationMachine";
 string Trainer = @"FieldAwareFactorizationMachine(
                 // Specify three feature columns!
                 new[] {nameof(DataPoint.Field0), nameof(DataPoint.Field1),
-		    nameof(DataPoint.Field2) },
+            nameof(DataPoint.Field2) },
 
                 // Specify binary label's column name.
                 nameof(DataPoint.Label) )";
@@ -13,15 +13,15 @@ string OptionsInclude = null;
 
 string Comments = @"
         // This example first train a field-aware factorization to binary
-	// classification, measure the trained model's quality, and finally
+        // classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.";
 
 string TrainerDescription = @"// This trainer trains field-aware factorization (FFM)
-            //for binary classification.
-	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-	    // behind and 
-	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-	    // training algorithm implemented in ML.NET.";
+            // for binary classification.
+            // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+            // behind and 
+            // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+            // training algorithm implemented in ML.NET.";
 
 string TrainerOptions = null;
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
@@ -32,7 +32,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
                 ExtraFeatureColumns = 
-            new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+                new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
 
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,
@@ -206,12 +206,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " + 
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
@@ -10,21 +10,21 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     public static class FieldAwareFactorizationMachineWithOptions
     {
         // This example first train a field-aware factorization to binary
-		// classification, measure the trained model's quality, and finally
+	// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
             // Define trainer options.
@@ -32,7 +32,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
                 ExtraFeatureColumns = 
-				    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+		    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
 
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,
@@ -45,12 +45,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Define the trainer.
             // This trainer trains field-aware factorization (FFM)
             // for binary classification.
-			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-			// behind and
-			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-			// training algorithm implemented in ML.NET.
+	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+	    // behind and
+	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+	    // training algorithm implemented in ML.NET.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .FieldAwareFactorizationMachine(options);
+	        .FieldAwareFactorizationMachine(options);
 
 
             // Train the model.
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Measure the quality of the trained model.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTrainingData);
+	        .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -90,17 +90,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Create prediction function from the trained model.
             var engine = mlContext.Model
-			    .CreatePredictionEngine<DataPoint, Result>(model);
+	        .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
                 Console.WriteLine($"Actual label: {dataPoint.Label}, "
-				    + $"predicted label: {result.PredictedLabel}, "
+		    + $"predicted label: {result.PredictedLabel}, "
                     + $"score of being positive class: {result.Score}, "
-					+ $"and probability of beling positive class: "
-					+ $"{result.Probability}.");
+		    + $"and probability of beling positive class: "
+		    + $"{result.Probability}.");
+		    
             }
 
             // Expected output:
@@ -121,7 +122,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public bool Label { get; set; }
 
             // Features from the first field. Note that different fields can have
-			// different numbers of features.
+	    // different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -135,7 +136,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // This class defines objects produced by trained model. The trained model
-		// maps a DataPoint to a Result.
+	// maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -150,7 +151,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to create toy data sets.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(
-		    int exampleCount, int seed = 0)
+	    int exampleCount, int seed = 0)
 
         {
             var rnd = new Random(seed);
@@ -158,7 +159,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             for (int i = 0; i < exampleCount; ++i)
             {
                 // Initialize an example with a random label and an empty feature
-				// vector.
+		// vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -169,9 +170,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
                 // Fill feature vectors according the assigned label.
                 // Notice that features from different fields have different biases
-				// and therefore different distributions. In practices such as game
-				// recommendation, one may use one field to store features from user
-				// profile and another field to store features from game profile.
+		// and therefore different distributions. In practices such as game
+		// recommendation, one may use one field to store features from user
+		// profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -200,18 +201,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to show evaluation metrics such as accuracy of predictions.
         private static void PrintMetrics(
-		    CalibratedBinaryClassificationMetrics metrics)
+	    CalibratedBinaryClassificationMetrics metrics)
 
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
@@ -52,7 +52,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .FieldAwareFactorizationMachine(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
@@ -9,26 +9,31 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class FieldAwareFactorizationMachineWithOptions
     {
-        // This example first train a field-aware factorization to binary classification, measure the trained model's quality, and finally
+        // This example first train a field-aware factorization to binary
+		// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
             // Define trainer options.
             var options = new FieldAwareFactorizationMachineTrainer.Options
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
-                ExtraFeatureColumns = new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+                ExtraFeatureColumns = 
+				    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,
                 LambdaLinear = 0.001f,
@@ -38,10 +43,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            // This trainer trains field-aware factorization (FFM) for binary classification. See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf
-            // for the theory behind and https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the training
-            // algorithm implemented in ML.NET.
-            var pipeline = mlContext.BinaryClassification.Trainers.FieldAwareFactorizationMachine(options);
+            // This trainer trains field-aware factorization (FFM)
+            // for binary classification.
+			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+			// behind and
+			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+			// training algorithm implemented in ML.NET.
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .FieldAwareFactorizationMachine(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -50,7 +60,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var transformedTrainingData = model.Transform(trainingData);
 
             // Measure the quality of the trained model.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTrainingData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -78,14 +89,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //  Precision ||   0.7425 |   0.8319 |
 
             // Create prediction function from the trained model.
-            var engine = mlContext.Model.CreatePredictionEngine<DataPoint, Result>(model);
+            var engine = mlContext.Model
+			    .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
-                Console.WriteLine($"Actual label: {dataPoint.Label}, predicted label: {result.PredictedLabel}, " +
-                    $"score of being positive class: {result.Score}, and probability of beling positive class: {result.Probability}.");
+                Console.WriteLine($"Actual label: {dataPoint.Label}, "
+				    + $"predicted label: {result.PredictedLabel}, "
+                    + $"score of being positive class: {result.Score}, "
+					+ $"and probability of beling positive class: "
+					+ $"{result.Probability}.");
             }
 
             // Expected output:
@@ -105,7 +120,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Label.
             public bool Label { get; set; }
 
-            // Features from the first field. Note that different fields can have different numbers of features.
+            // Features from the first field. Note that different fields can have
+			// different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -118,8 +134,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public float[] Field2 { get; set; }
         }
 
-        // This class defines objects produced by trained model. The trained model maps
-        // a DataPoint to a Result.
+        // This class defines objects produced by trained model. The trained model
+		// maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -133,13 +149,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // Function used to create toy data sets.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int exampleCount, int seed = 0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(
+		    int exampleCount, int seed = 0)
+
         {
             var rnd = new Random(seed);
             var data = new List<DataPoint>();
             for (int i = 0; i < exampleCount; ++i)
             {
-                // Initialize an example with a random label and an empty feature vector.
+                // Initialize an example with a random label and an empty feature
+				// vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -149,9 +168,10 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 };
 
                 // Fill feature vectors according the assigned label.
-                // Notice that features from different fields have different biases and therefore different distributions.
-                // In practices such as game recommendation, one may use one field to store features from user profile and
-                // another field to store features from game profile.
+                // Notice that features from different fields have different biases
+				// and therefore different distributions. In practices such as game
+				// recommendation, one may use one field to store features from user
+				// profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -179,14 +199,20 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // Function used to show evaluation metrics such as accuracy of predictions.
-        private static void PrintMetrics(CalibratedBinaryClassificationMetrics metrics)
+        private static void PrintMetrics(
+		    CalibratedBinaryClassificationMetrics metrics)
+
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.cs
@@ -10,21 +10,21 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     public static class FieldAwareFactorizationMachineWithOptions
     {
         // This example first train a field-aware factorization to binary
-	// classification, measure the trained model's quality, and finally
+        // classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
             // Define trainer options.
@@ -32,7 +32,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
                 ExtraFeatureColumns = 
-		    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+            new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
 
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,
@@ -45,12 +45,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Define the trainer.
             // This trainer trains field-aware factorization (FFM)
             // for binary classification.
-	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-	    // behind and
-	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-	    // training algorithm implemented in ML.NET.
+            // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+            // behind and
+            // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+            // training algorithm implemented in ML.NET.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .FieldAwareFactorizationMachine(options);
+                .FieldAwareFactorizationMachine(options);
 
 
             // Train the model.
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Measure the quality of the trained model.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTrainingData);
+                .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -90,18 +90,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Create prediction function from the trained model.
             var engine = mlContext.Model
-	        .CreatePredictionEngine<DataPoint, Result>(model);
+                .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
                 Console.WriteLine($"Actual label: {dataPoint.Label}, "
-		    + $"predicted label: {result.PredictedLabel}, "
+                    + $"predicted label: {result.PredictedLabel}, "
                     + $"score of being positive class: {result.Score}, "
-		    + $"and probability of beling positive class: "
-		    + $"{result.Probability}.");
-		    
+                    + $"and probability of beling positive class: "
+                    + $"{result.Probability}.");
+
             }
 
             // Expected output:
@@ -122,7 +122,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public bool Label { get; set; }
 
             // Features from the first field. Note that different fields can have
-	    // different numbers of features.
+            // different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -136,7 +136,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // This class defines objects produced by trained model. The trained model
-	// maps a DataPoint to a Result.
+        // maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -151,7 +151,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to create toy data sets.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(
-	    int exampleCount, int seed = 0)
+            int exampleCount, int seed = 0)
 
         {
             var rnd = new Random(seed);
@@ -159,7 +159,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             for (int i = 0; i < exampleCount; ++i)
             {
                 // Initialize an example with a random label and an empty feature
-		// vector.
+                // vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -170,9 +170,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
                 // Fill feature vectors according the assigned label.
                 // Notice that features from different fields have different biases
-		// and therefore different distributions. In practices such as game
-		// recommendation, one may use one field to store features from user
-		// profile and another field to store features from game profile.
+                // and therefore different distributions. In practices such as game
+                // recommendation, one may use one field to store features from user
+                // profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -201,18 +201,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to show evaluation metrics such as accuracy of predictions.
         private static void PrintMetrics(
-	    CalibratedBinaryClassificationMetrics metrics)
+            CalibratedBinaryClassificationMetrics metrics)
 
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
@@ -7,21 +7,21 @@ string OptionsInclude = @"using Microsoft.ML.Trainers;";
 
 string Comments = @"
         // This example first train a field-aware factorization to binary
-	// classification, measure the trained model's quality, and finally
+        // classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.";
 
 string TrainerDescription = @"// This trainer trains field-aware factorization (FFM)
             // for binary classification.
-	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-	    // behind and
-	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-	    // training algorithm implemented in ML.NET.";
+            // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+            // behind and
+            // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+            // training algorithm implemented in ML.NET.";
 
 string TrainerOptions = @"FieldAwareFactorizationMachineTrainer.Options
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
                 ExtraFeatureColumns = 
-		    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+            new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
 
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
@@ -7,21 +7,21 @@ string OptionsInclude = @"using Microsoft.ML.Trainers;";
 
 string Comments = @"
         // This example first train a field-aware factorization to binary
-		// classification, measure the trained model's quality, and finally
+	// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.";
 
 string TrainerDescription = @"// This trainer trains field-aware factorization (FFM)
             // for binary classification.
-			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
-			// behind and
-			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
-			// training algorithm implemented in ML.NET.";
+	    // See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+	    // behind and
+	    // https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+	    // training algorithm implemented in ML.NET.";
 
 string TrainerOptions = @"FieldAwareFactorizationMachineTrainer.Options
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
                 ExtraFeatureColumns = 
-				    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+		    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
 
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
@@ -21,7 +21,7 @@ string TrainerOptions = @"FieldAwareFactorizationMachineTrainer.Options
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
                 ExtraFeatureColumns = 
-            new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+                new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
 
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/FieldAwareFactorizationMachineWithOptions.tt
@@ -6,17 +6,23 @@ string Trainer = "FieldAwareFactorizationMachine";
 string OptionsInclude = @"using Microsoft.ML.Trainers;";
 
 string Comments = @"
-        // This example first train a field-aware factorization to binary classification, measure the trained model's quality, and finally
+        // This example first train a field-aware factorization to binary
+		// classification, measure the trained model's quality, and finally
         // use the trained model to make prediction.";
 
-string TrainerDescription = @"// This trainer trains field-aware factorization (FFM) for binary classification. See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf
-            // for the theory behind and https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the training
-            // algorithm implemented in ML.NET.";
+string TrainerDescription = @"// This trainer trains field-aware factorization (FFM)
+            // for binary classification.
+			// See https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf for the theory
+			// behind and
+			// https://github.com/wschin/fast-ffm/blob/master/fast-ffm.pdf for the
+			// training algorithm implemented in ML.NET.";
 
 string TrainerOptions = @"FieldAwareFactorizationMachineTrainer.Options
             {
                 FeatureColumnName = nameof(DataPoint.Field0),
-                ExtraFeatureColumns = new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+                ExtraFeatureColumns = 
+				    new[] { nameof(DataPoint.Field1), nameof(DataPoint.Field2) },
+
                 LabelColumnName = nameof(DataPoint.Label),
                 LambdaLatent = 0.01f,
                 LambdaLinear = 0.001f,

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Gam.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/Gam.cs
@@ -7,12 +7,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class Gam
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness.
             var mlContext = new MLContext();
             
             // Create the dataset.
@@ -27,30 +29,36 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var validSet = dataSets.TestSet;
 
             // Create a GAM trainer.
-            // Use a small number of bins for this example. The setting below means for each feature, 
-            // we divide its range into 16 discrete regions for the training process. Note that these
-            // regions are not evenly spaced, and that the final model may contain fewer bins, as
-            // neighboring bins with identical values will be combined. In general, we recommend using
-            // at least the default number of bins, as a small number of bins limits the capacity of
-            // the model.
-            var trainer = mlContext.BinaryClassification.Trainers.Gam(maximumBinCountPerFeature: 16);
+            // Use a small number of bins for this example. The setting below means
+            // for each feature, we divide its range into 16 discrete regions for
+            // the training process. Note that these regions are not evenly spaced,
+            // and that the final model may contain fewer bins, as neighboring bins
+            // with identical values will be combined. In general, we recommend
+            // using at least the default number of bins, as a small number of bins
+            // limits the capacity of the model.
+            var trainer = mlContext.BinaryClassification.Trainers
+                .Gam(maximumBinCountPerFeature: 16);
 
-            // Fit the model using both of training and validation sets. GAM can use a technique called 
-            // pruning to tune the model to the validation set after training to improve generalization.
+            // Fit the model using both of training and validation sets. GAM can use
+            // a technique called pruning to tune the model to the validation set
+            // after training to improve generalization.
             var model = trainer.Fit(trainSet, validSet);
             
             // Extract the model parameters.
             var gam = model.Model.SubModel;
 
-            // Now we can inspect the parameters of the Generalized Additive Model to understand the fit
-            // and potentially learn about our dataset.
-            // First, we will look at the bias; the bias represents the average prediction for the training data.
+            // Now we can inspect the parameters of the Generalized Additive Model
+            // to understand the fit and potentially learn about our dataset. First,
+            // we will look at the bias; the bias represents the average prediction
+            // for the training data.
             Console.WriteLine($"Average prediction: {gam.Bias:0.00}");
 
-            // Now look at the shape functions that the model has learned. Similar to a linear model, we have
-            // one response per feature, and they are independent. Unlike a linear model, this response is a 
-            // generic function instead of a line. Because we have included a bias term, each feature response 
-            // represents the deviation from the average prediction as a function of the feature value.
+            // Now look at the shape functions that the model has learned. Similar
+            // to a linear model, we have one response per feature, and they are
+            // independent. Unlike a linear model, this response is a generic
+            // function instead of a line. Because we have included a bias term,
+            // each feature response represents the deviation from the average
+            // prediction as a function of the feature value.
             for (int i = 0; i < gam.NumberOfShapeFunctions; i++)
             {
                 // Break a line.
@@ -62,11 +70,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 // Get the bin effects; these are the function values for each bin.
                 var binEffects = gam.GetBinEffects(i);
 
-                // Now, write the function to the console. The function is a set of bins, and the corresponding
-                // function values. You can think of GAMs as building a bar-chart or lookup table for each feature.
+                // Now, write the function to the console. The function is a set of
+                // bins, and the corresponding function values. You can think of
+                // GAMs as building a bar-chart or lookup table for each feature.
                 Console.WriteLine($"Feature{i}");
                 for (int j = 0; j < binUpperBounds.Count; j++)
-                    Console.WriteLine($"x < {binUpperBounds[j]:0.00} => {binEffects[j]:0.000}");
+                    Console.WriteLine(
+                        $"x < {binUpperBounds[j]:0.00} => {binEffects[j]:0.000}");
+
             }
 
             // Expected output:
@@ -91,18 +102,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //  x < 0.31 => -0.138
             //  x < ∞ => -0.188
 
-            // Let's consider this output. To score a given example, we look up the first bin where the inequality
-            // is satisfied for the feature value. We can look at the whole function to get a sense for how the
-            // model responds to the variable on a global level.
-            // The model can be seen to reconstruct the parabolic and step-wise function, shifted with respect to the average
-            // expected output over the training set. Very few bins are used to model the second feature because the GAM model
-            // discards unchanged bins to create smaller models.
-            // One last thing to notice is that these feature functions can be noisy. While we know that Feature1 should be
-            // symmetric, this is not captured in the model. This is due to noise in the data. Common practice is to use 
-            // resampling methods to estimate a confidence interval at each bin. This will help to determine if the effect is 
-            // real or just sampling noise. See for example:
-            // Tan, Caruana, Hooker, and Lou. "Distill-and-Compare: Auditing Black-Box Models Using Transparent Model 
-            // Distillation." <a href='https://arxiv.org/abs/1710.06169'>arXiv:1710.06169</a>."
+            // Let's consider this output. To score a given example, we look up the
+            // first bin where the inequality is satisfied for the feature value.
+            // We can look at the whole function to get a sense for how the model
+            // responds to the variable on a global level.The model can be seen to
+            // reconstruct the parabolic and step-wise function, shifted with
+            // respect to the average expected output over the training set.
+            // Very few bins are used to model the second feature because the GAM
+            // model discards unchanged bins to create smaller models. One last
+            // thing to notice is that these feature functions can be noisy. While
+            // we know that Feature1 should be symmetric, this is not captured in
+            // the model. This is due to noise in the data. Common practice is to
+            // use resampling methods to estimate a confidence interval at each bin.
+            // This will help to determine if the effect is real or just sampling
+            // noise. See for example: Tan, Caruana, Hooker, and Lou.
+            // "Distill-and-Compare: Auditing Black-Box Models Using Transparent
+            // Model Distillation."
+            // <a href='https://arxiv.org/abs/1710.06169'>arXiv:1710.06169</a>."
         }
 
         private class Data
@@ -114,13 +130,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         /// <summary>
-        /// Creates a dataset, an IEnumerable of Data objects, for a GAM sample. Feature1 is a parabola centered around 0,
-        /// while Feature2 is a simple piecewise function.
+        /// Creates a dataset, an IEnumerable of Data objects, for a GAM sample.
+        /// Feature1 is a parabola centered around 0, while Feature2 is a simple
+        /// piecewise function.
         /// </summary>
         /// <param name="numExamples">The number of examples to generate.</param>
-        /// <param name="seed">The seed for the random number generator used to produce data.</param>
+        /// <param name="seed">The seed for the random number generator used to
+        /// produce data.</param>
         /// <returns></returns>
-        private static IEnumerable<Data> GenerateData(int numExamples = 25000, int seed = 1)
+        private static IEnumerable<Data> GenerateData(int numExamples = 25000,
+            int seed = 1)
+
         {
             var rng = new Random(seed);
             float centeredFloat() => (float)(rng.NextDouble() - 0.5);
@@ -131,7 +151,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = new float[2] { centeredFloat(), centeredFloat() }
                 };
                 // Compute the label from the shape functions and add noise.
-                data.Label = Sigmoid(Parabola(data.Features[0]) + SimplePiecewise(data.Features[1]) + centeredFloat()) > 0.5;
+                data.Label = Sigmoid(Parabola(data.Features[0])
+                    + SimplePiecewise(data.Features[1]) + centeredFloat()) > 0.5;
 
                 yield return data;
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/GamWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/GamWithOptions.cs
@@ -158,8 +158,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = new float[2] { centeredFloat(), centeredFloat() }
                 };
                 // Compute the label from the shape functions and add noise.
-                data.Label = Sigmoid(Parabola(data.Features[0])
-                    + SimplePiecewise(data.Features[1]) + centeredFloat()) > 0.5;
+                data.Label = Sigmoid(Parabola(data.Features[0]) +
+                    SimplePiecewise(data.Features[1]) + centeredFloat()) > 0.5;
 
                 yield return data;
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/GamWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/GamWithOptions.cs
@@ -8,12 +8,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class GamWithOptions
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.FastTree/">Microsoft.ML.FastTree</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness.
             var mlContext = new MLContext();
 
             // Create the dataset.
@@ -28,14 +30,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var validSet = dataSets.TestSet;
 
             // Create a GAM trainer.
-            // Use a small number of bins for this example. The setting below means for each feature, 
-            // we divide its range into 16 discrete regions for the training process. Note that these
-            // regions are not evenly spaced, and that the final model may contain fewer bins, as
-            // neighboring bins with identical values will be combined. In general, we recommend using
-            // at least the default number of bins, as a small number of bins limits the capacity of
-            // the model.
-            // Also, set the learning rate to half the default to slow down the gradient descent, and
-            // double the number of iterations to compensate.
+            // Use a small number of bins for this example. The setting below means
+            // for each feature, we divide its range into 16 discrete regions for
+            // the training process. Note that these regions are not evenly spaced,
+            // and that the final model may contain fewer bins, as neighboring bins
+            // with identical values will be combined. In general, we recommend
+            // using at least the default number of bins, as a small number of bins
+            // limits the capacity of the model. Also, set the learning rate to half
+            // the default to slow down the gradient descent, and double the number
+            // of iterations to compensate.
             var trainer = mlContext.BinaryClassification.Trainers.Gam(
                 new GamBinaryTrainer.Options {
                     NumberOfIterations = 19000,
@@ -43,22 +46,26 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     LearningRate = 0.001
                 });
 
-            // Fit the model using both of training and validation sets. GAM can use a technique called 
-            // pruning to tune the model to the validation set after training to improve generalization.
+            // Fit the model using both of training and validation sets. GAM can use
+            // a technique called pruning to tune the model to the validation set
+            // after training to improve generalization.
             var model = trainer.Fit(trainSet, validSet);
 
             // Extract the model parameters.
             var gam = model.Model.SubModel;
 
-            // Now we can inspect the parameters of the Generalized Additive Model to understand the fit
-            // and potentially learn about our dataset.
-            // First, we will look at the bias; the bias represents the average prediction for the training data.
+            // Now we can inspect the parameters of the Generalized Additive Model
+            // to understand the fit and potentially learn about our dataset. First,
+            // we will look at the bias; the bias represents the average prediction
+            // for the training data.
             Console.WriteLine($"Average prediction: {gam.Bias:0.00}");
 
-            // Now look at the shape functions that the model has learned. Similar to a linear model, we have
-            // one response per feature, and they are independent. Unlike a linear model, this response is a 
-            // generic function instead of a line. Because we have included a bias term, each feature response 
-            // represents the deviation from the average prediction as a function of the feature value.
+            // Now look at the shape functions that the model has learned. Similar
+            // to a linear model, we have one response per feature, and they are
+            // independent. Unlike a linear model, this response is a generic
+            // function instead of a line. Because we have included a bias term,
+            // each feature response represents the deviation from the average
+            // prediction as a function of the feature value.
             for (int i = 0; i < gam.NumberOfShapeFunctions; i++)
             {
                 // Break a line.
@@ -70,11 +77,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 // Get the bin effects; these are the function values for each bin.
                 var binEffects = gam.GetBinEffects(i);
 
-                // Now, write the function to the console. The function is a set of bins, and the corresponding
-                // function values. You can think of GAMs as building a bar-chart or lookup table for each feature.
+                // Now, write the function to the console. The function is a set of
+                // bins, and the corresponding function values. You can think of
+                // GAMs as building a bar-chart or lookup table for each feature.
                 Console.WriteLine($"Feature{i}");
                 for (int j = 0; j < binUpperBounds.Count; j++)
-                    Console.WriteLine($"x < {binUpperBounds[j]:0.00} => {binEffects[j]:0.000}");
+                    Console.WriteLine(
+                        $"x < {binUpperBounds[j]:0.00} => {binEffects[j]:0.000}");
             }
 
             // Expected output:
@@ -99,18 +108,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //  x < 0.31 => -0.138
             //  x < ∞ => -0.188
 
-            // Let's consider this output. To score a given example, we look up the first bin where the inequality
-            // is satisfied for the feature value. We can look at the whole function to get a sense for how the
-            // model responds to the variable on a global level.
-            // The model can be seen to reconstruct the parabolic and step-wise function, shifted with respect to the average
-            // expected output over the training set. Very few bins are used to model the second feature because the GAM model
-            // discards unchanged bins to create smaller models.
-            // One last thing to notice is that these feature functions can be noisy. While we know that Feature1 should be
-            // symmetric, this is not captured in the model. This is due to noise in the data. Common practice is to use 
-            // resampling methods to estimate a confidence interval at each bin. This will help to determine if the effect is 
-            // real or just sampling noise. See for example:
-            // Tan, Caruana, Hooker, and Lou. "Distill-and-Compare: Auditing Black-Box Models Using Transparent Model 
-            // Distillation." <a href='https://arxiv.org/abs/1710.06169'>arXiv:1710.06169</a>."
+            // Let's consider this output. To score a given example, we look up the
+            // first bin where the inequality is satisfied for the feature value.
+            // We can look at the whole function to get a sense for how the model
+            // responds to the variable on a global level. The model can be seen to
+            // reconstruct the parabolic and step-wise function, shifted with
+            // respect to the average expected output over the training set. Very
+            // few bins are used to model the second feature because the GAM model
+            // discards unchanged bins to create smaller models.One last thing to
+            // notice is that these feature functions can be noisy. While we know
+            // that Feature1 should be symmetric, this is not captured in the model.
+            // This is due to noise in the data. Common practice is to use
+            // resampling methods to estimate a confidence interval at each bin.
+            // This will help to determine if the effect is real or just sampling
+            // noise. See for example: Tan, Caruana, Hooker, and Lou.
+            // "Distill-and-Compare: Auditing Black-Box Models Using Transparent
+            // Model Distillation."
+            // <a href='https://arxiv.org/abs/1710.06169'>arXiv:1710.06169</a>."
         }
 
         private class Data
@@ -122,13 +136,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         /// <summary>
-        /// Creates a dataset, an IEnumerable of Data objects, for a GAM sample. Feature1 is a parabola centered around 0,
-        /// while Feature2 is a simple piecewise function.
+        /// Creates a dataset, an IEnumerable of Data objects, for a GAM sample.
+        /// Feature1 is a parabola centered around 0, while Feature2 is a simple
+        /// piecewise function.
         /// </summary>
         /// <param name="numExamples">The number of examples to generate.</param>
-        /// <param name="seed">The seed for the random number generator used to produce data.</param>
+        /// <param name="seed">The seed for the random number generator used to
+        /// produce data.</param>
         /// <returns></returns>
-        private static IEnumerable<Data> GenerateData(int numExamples = 25000, int seed = 1)
+        private static IEnumerable<Data> GenerateData(int numExamples = 25000,
+            int seed = 1)
+
         {
             var rng = new Random(seed);
             float centeredFloat() => (float)(rng.NextDouble() - 0.5);
@@ -140,7 +158,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = new float[2] { centeredFloat(), centeredFloat() }
                 };
                 // Compute the label from the shape functions and add noise.
-                data.Label = Sigmoid(Parabola(data.Features[0]) + SimplePiecewise(data.Features[1]) + centeredFloat()) > 0.5;
+                data.Label = Sigmoid(Parabola(data.Features[0])
+                    + SimplePiecewise(data.Features[1]) + centeredFloat()) > 0.5;
 
                 yield return data;
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
@@ -10,35 +10,44 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.LbfgsLogisticRegression();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .LbfgsLogisticRegression();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -48,7 +57,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -74,7 +85,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.8583 |   0.8972 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -85,13 +98,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -114,9 +131,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .LbfgsLogisticRegression();
+	        .LbfgsLogisticRegression();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,16 +99,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -132,11 +132,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
@@ -103,6 +103,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.1f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
@@ -27,7 +27,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .LbfgsLogisticRegression();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -132,12 +131,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegression.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .LbfgsLogisticRegression();
+                .LbfgsLogisticRegression();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,17 +99,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -133,14 +133,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -11,15 +11,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -31,23 +33,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.LbfgsLogisticRegression(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.LbfgsLogisticRegression(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -57,7 +66,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -83,7 +94,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.8571 |   0.8902 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -94,13 +107,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -123,9 +140,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,29 +34,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.LbfgsLogisticRegression(options);
+                .LbfgsLogisticRegression(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -108,16 +108,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -141,11 +141,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -36,7 +36,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .LbfgsLogisticRegression(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -141,12 +140,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -112,6 +112,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.1f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LbfgsLogisticRegressionWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -41,22 +41,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -108,17 +108,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -142,14 +142,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
@@ -103,6 +103,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
@@ -14,43 +14,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .LightGbm();
+            .LightGbm();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,17 +99,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -133,14 +133,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
@@ -28,8 +28,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-            .LightGbm();
-
+                .LightGbm();
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -37,7 +36,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Create testing data. Use different random seed to make it different
             // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
@@ -132,12 +131,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
@@ -14,43 +14,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .LightGbm();
+	        .LightGbm();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,10 +99,10 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
@@ -132,11 +132,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.cs
@@ -8,39 +8,49 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class LightGbm
     {
-        // This example requires installation of additional nuget package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.LightGbm/">Microsoft.ML.LightGbm</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.LightGbm();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .LightGbm();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -50,7 +60,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -73,7 +85,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.7531 |   0.7860 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -84,13 +98,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -113,9 +131,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbm.tt
@@ -10,8 +10,9 @@ string LabelThreshold = "0.5f";
 string DataSepValue = "0.03f";
 string OptionsInclude = "";
 string Comments= @"
-        // This example requires installation of additional nuget package
-        // <a href=""https://www.nuget.org/packages/Microsoft.ML.LightGbm/"">Microsoft.ML.LightGbm</a>.";
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: True, Prediction: True

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -39,29 +39,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .LightGbm(options);
+                .LightGbm(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -72,7 +72,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -97,7 +97,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -110,17 +110,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -144,14 +144,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -39,29 +39,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.LightGbm(options);
+	        .LightGbm(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -72,7 +72,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -97,7 +97,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -110,16 +110,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -143,11 +143,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
@@ -9,19 +9,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class LightGbmWithOptions
     {
-        // This example requires installation of additional nuget package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.LightGbm/">Microsoft.ML.LightGbm</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -35,23 +38,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.LightGbm(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.LightGbm(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -61,7 +71,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -84,7 +96,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6563 |   0.7131 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -95,13 +109,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -124,9 +142,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
@@ -114,6 +114,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.cs
@@ -41,7 +41,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .LightGbm(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -143,12 +142,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LightGbmWithOptions.tt
@@ -9,8 +9,9 @@ string LabelThreshold = "0.5f";
 string DataSepValue = "0.03f";
 string OptionsInclude = "using Microsoft.ML.Trainers.LightGbm;";
 string Comments= @"
-        // This example requires installation of additional nuget package
-        // <a href=""https://www.nuget.org/packages/Microsoft.ML.LightGbm/"">Microsoft.ML.LightGbm</a>.";
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
 
 string TrainerOptions = @"LightGbmBinaryTrainer.Options
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
@@ -10,35 +10,44 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.LinearSvm();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .LinearSvm();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -48,7 +57,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -71,7 +82,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6624 |   0.8387 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -82,13 +95,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -111,9 +128,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
@@ -100,6 +100,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.1f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
@@ -27,7 +27,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .LinearSvm();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -129,12 +128,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .LinearSvm();
+                .LinearSvm();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,17 +96,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -130,14 +130,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvm.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .LinearSvm();
+	        .LinearSvm();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,16 +96,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -129,11 +129,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
@@ -36,7 +36,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .LinearSvm(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -138,12 +137,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
@@ -109,6 +109,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.1f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
@@ -11,15 +11,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -31,23 +33,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.LinearSvm(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.LinearSvm(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -57,7 +66,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -80,7 +91,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.8044 |   0.9127 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -91,13 +104,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -120,9 +137,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,29 +34,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .LinearSvm(options);
+                .LinearSvm(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -92,7 +92,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -105,17 +105,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -139,14 +139,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/LinearSvmWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,29 +34,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.LinearSvm(options);
+	        .LinearSvm(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -92,7 +92,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -105,10 +105,10 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
                 };
             }
         }
@@ -138,11 +138,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
@@ -14,23 +14,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
 <# if (TrainerOptions == null) { #>
             // Define the trainer.
             <#=TrainerDescription#>
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .<#=Trainer#>;
+                .<#=Trainer#>;
 
 <# } else { #>
             // Define trainer options.
@@ -39,7 +39,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Define the trainer.
             <#=TrainerDescription#>
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .<#=Trainer#>(options);
+                .<#=Trainer#>(options);
 
 <# } #>
 
@@ -51,7 +51,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Measure the quality of the trained model.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTrainingData);
+                .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -60,17 +60,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Create prediction function from the trained model.
             var engine = mlContext.Model
-	        .CreatePredictionEngine<DataPoint, Result>(model);
+                .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
                 Console.WriteLine($"Actual label: {dataPoint.Label}, "
-		    + $"predicted label: {result.PredictedLabel}, "
+                    + $"predicted label: {result.PredictedLabel}, "
                     + $"score of being positive class: {result.Score}, "
-		    + $"and probability of beling positive class: "
-		    + $"{result.Probability}.");
+                    + $"and probability of beling positive class: "
+                    + $"{result.Probability}.");
+
             }
 
             <#=ExpectedOutputPerInstance#>
@@ -86,7 +87,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public bool Label { get; set; }
 
             // Features from the first field. Note that different fields can have
-	    // different numbers of features.
+            // different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -100,7 +101,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // This class defines objects produced by trained model. The trained model
-	// maps a DataPoint to a Result.
+        // maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -115,7 +116,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to create toy data sets.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(
-	    int exampleCount, int seed = 0)
+            int exampleCount, int seed = 0)
 
         {
             var rnd = new Random(seed);
@@ -123,7 +124,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             for (int i = 0; i < exampleCount; ++i)
             {
                 // Initialize an example with a random label and an empty feature
-		// vector.
+                // vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -134,9 +135,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
                 // Fill feature vectors according the assigned label.
                 // Notice that features from different fields have different biases
-		// and therefore different distributions. In practices such as game
-		// recommendation, one may use one field to store features from user
-		// profile and another field to store features from game profile.
+                // and therefore different distributions. In practices such as game
+                // recommendation, one may use one field to store features from user
+                // profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -165,18 +166,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to show evaluation metrics such as accuracy of predictions.
         private static void PrintMetrics(
-	    CalibratedBinaryClassificationMetrics metrics)
+            CalibratedBinaryClassificationMetrics metrics)
 
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
@@ -31,7 +31,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             <#=TrainerDescription#>
             var pipeline = mlContext.BinaryClassification.Trainers
                 .<#=Trainer#>;
-
 <# } else { #>
             // Define trainer options.
             var options = new <#=TrainerOptions#>;
@@ -40,7 +39,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             <#=TrainerDescription#>
             var pipeline = mlContext.BinaryClassification.Trainers
                 .<#=Trainer#>(options);
-
 <# } #>
 
             // Train the model.

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
@@ -170,12 +170,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " + 
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
@@ -14,23 +14,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
 <# if (TrainerOptions == null) { #>
             // Define the trainer.
             <#=TrainerDescription#>
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .<#=Trainer#>;
+	        .<#=Trainer#>;
 
 <# } else { #>
             // Define trainer options.
@@ -39,7 +39,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Define the trainer.
             <#=TrainerDescription#>
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .<#=Trainer#>(options);
+	        .<#=Trainer#>(options);
 
 <# } #>
 
@@ -51,7 +51,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Measure the quality of the trained model.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTrainingData);
+	        .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -60,17 +60,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Create prediction function from the trained model.
             var engine = mlContext.Model
-			    .CreatePredictionEngine<DataPoint, Result>(model);
+	        .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
                 Console.WriteLine($"Actual label: {dataPoint.Label}, "
-				    + $"predicted label: {result.PredictedLabel}, "
+		    + $"predicted label: {result.PredictedLabel}, "
                     + $"score of being positive class: {result.Score}, "
-					+ $"and probability of beling positive class: "
-					+ $"{result.Probability}.");
+		    + $"and probability of beling positive class: "
+		    + $"{result.Probability}.");
             }
 
             <#=ExpectedOutputPerInstance#>
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public bool Label { get; set; }
 
             // Features from the first field. Note that different fields can have
-			// different numbers of features.
+	    // different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -100,7 +100,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // This class defines objects produced by trained model. The trained model
-		// maps a DataPoint to a Result.
+	// maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -115,7 +115,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to create toy data sets.
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(
-		    int exampleCount, int seed = 0)
+	    int exampleCount, int seed = 0)
 
         {
             var rnd = new Random(seed);
@@ -123,7 +123,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             for (int i = 0; i < exampleCount; ++i)
             {
                 // Initialize an example with a random label and an empty feature
-				// vector.
+		// vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -134,9 +134,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
                 // Fill feature vectors according the assigned label.
                 // Notice that features from different fields have different biases
-				// and therefore different distributions. In practices such as game
-				// recommendation, one may use one field to store features from user
-				// profile and another field to store features from game profile.
+		// and therefore different distributions. In practices such as game
+		// recommendation, one may use one field to store features from user
+		// profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -165,18 +165,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
         // Function used to show evaluation metrics such as accuracy of predictions.
         private static void PrintMetrics(
-		    CalibratedBinaryClassificationMetrics metrics)
+	    CalibratedBinaryClassificationMetrics metrics)
 
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/MultipleFeatureColumnsBinaryClassification.ttinclude
@@ -13,28 +13,34 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {<#=Comments#>
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             IEnumerable<DataPoint> data = GenerateRandomDataPoints(500);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(data);
 
 <# if (TrainerOptions == null) { #>
             // Define the trainer.
             <#=TrainerDescription#>
-            var pipeline = mlContext.BinaryClassification.Trainers.<#=Trainer#>;
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .<#=Trainer#>;
+
 <# } else { #>
             // Define trainer options.
             var options = new <#=TrainerOptions#>;
 
             // Define the trainer.
             <#=TrainerDescription#>
-            var pipeline = mlContext.BinaryClassification.Trainers.<#=Trainer#>(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .<#=Trainer#>(options);
+
 <# } #>
 
             // Train the model.
@@ -44,7 +50,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var transformedTrainingData = model.Transform(trainingData);
 
             // Measure the quality of the trained model.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTrainingData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTrainingData);
 
             // Show the quality metrics.
             PrintMetrics(metrics);
@@ -52,14 +59,18 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             <#=ExpectedOutput#>
 
             // Create prediction function from the trained model.
-            var engine = mlContext.Model.CreatePredictionEngine<DataPoint, Result>(model);
+            var engine = mlContext.Model
+			    .CreatePredictionEngine<DataPoint, Result>(model);
 
             // Make some predictions.
             foreach(var dataPoint in data.Take(5))
             {
                 var result = engine.Predict(dataPoint);
-                Console.WriteLine($"Actual label: {dataPoint.Label}, predicted label: {result.PredictedLabel}, " +
-                    $"score of being positive class: {result.Score}, and probability of beling positive class: {result.Probability}.");
+                Console.WriteLine($"Actual label: {dataPoint.Label}, "
+				    + $"predicted label: {result.PredictedLabel}, "
+                    + $"score of being positive class: {result.Score}, "
+					+ $"and probability of beling positive class: "
+					+ $"{result.Probability}.");
             }
 
             <#=ExpectedOutputPerInstance#>
@@ -74,7 +85,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Label.
             public bool Label { get; set; }
 
-            // Features from the first field. Note that different fields can have different numbers of features.
+            // Features from the first field. Note that different fields can have
+			// different numbers of features.
             [VectorType(featureLength)]
             public float[] Field0 { get; set; }
 
@@ -87,8 +99,8 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             public float[] Field2 { get; set; }
         }
 
-        // This class defines objects produced by trained model. The trained model maps
-        // a DataPoint to a Result.
+        // This class defines objects produced by trained model. The trained model
+		// maps a DataPoint to a Result.
         public class Result
         {
             // Label.
@@ -102,13 +114,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // Function used to create toy data sets.
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int exampleCount, int seed = 0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(
+		    int exampleCount, int seed = 0)
+
         {
             var rnd = new Random(seed);
             var data = new List<DataPoint>();
             for (int i = 0; i < exampleCount; ++i)
             {
-                // Initialize an example with a random label and an empty feature vector.
+                // Initialize an example with a random label and an empty feature
+				// vector.
                 var sample = new DataPoint()
                 {
                     Label = rnd.Next() % 2 == 0,
@@ -118,9 +133,10 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 };
 
                 // Fill feature vectors according the assigned label.
-                // Notice that features from different fields have different biases and therefore different distributions.
-                // In practices such as game recommendation, one may use one field to store features from user profile and
-                // another field to store features from game profile.
+                // Notice that features from different fields have different biases
+				// and therefore different distributions. In practices such as game
+				// recommendation, one may use one field to store features from user
+				// profile and another field to store features from game profile.
                 for (int j = 0; j < featureLength; ++j)
                 {
                     var value0 = (float)rnd.NextDouble();
@@ -148,14 +164,20 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         // Function used to show evaluation metrics such as accuracy of predictions.
-        private static void PrintMetrics(CalibratedBinaryClassificationMetrics metrics)
+        private static void PrintMetrics(
+		    CalibratedBinaryClassificationMetrics metrics)
+
         {
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}");
             Console.WriteLine($"Log Loss: {metrics.LogLoss:F2}");
             Console.WriteLine($"Log Loss Reduction: {metrics.LogLossReduction:F2}");

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PermutationFeatureImportance.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PermutationFeatureImportance.cs
@@ -9,8 +9,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
+            // Create a new context for ML.NET operations. It can be used for
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness.
             var mlContext = new MLContext(seed:1);
 
             // Create sample data.
@@ -19,12 +20,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Load the sample data as an IDataView.
             var data = mlContext.Data.LoadFromEnumerable(samples);
 
-            // Define a training pipeline that concatenates features into a vector, normalizes them, and then
-            // trains a linear model.
-            var featureColumns = new string[] { nameof(Data.Feature1), nameof(Data.Feature2) };
-            var pipeline = mlContext.Transforms.Concatenate("Features", featureColumns)
-                    .Append(mlContext.Transforms.NormalizeMinMax("Features"))
-                    .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression());
+            // Define a training pipeline that concatenates features into a vector,
+            // normalizes them, and then trains a linear model.
+            var featureColumns =
+                new string[] { nameof(Data.Feature1), nameof(Data.Feature2) };
+            var pipeline = mlContext.Transforms
+                .Concatenate("Features", featureColumns)
+                .Append(mlContext.Transforms.NormalizeMinMax("Features"))
+                .Append(mlContext.BinaryClassification.Trainers
+                .SdcaLogisticRegression());
 
             // Fit the pipeline to the data.
             var model = pipeline.Fit(data);
@@ -35,17 +39,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Extract the predictor.
             var linearPredictor = model.LastTransformer;
 
-            // Compute the permutation metrics for the linear model using the normalized data.
-            var permutationMetrics = mlContext.BinaryClassification.PermutationFeatureImportance(
-                linearPredictor, transformedData, permutationCount: 30);
+            // Compute the permutation metrics for the linear model using the
+            // normalized data.
+            var permutationMetrics = mlContext.BinaryClassification
+                .PermutationFeatureImportance(linearPredictor, transformedData,
+                permutationCount: 30);
 
-            // Now let's look at which features are most important to the model overall.
-            // Get the feature indices sorted by their impact on AUC.
-            var sortedIndices = permutationMetrics.Select((metrics, index) => new { index, metrics.AreaUnderRocCurve})
-                .OrderByDescending(feature => Math.Abs(feature.AreaUnderRocCurve.Mean))
+            // Now let's look at which features are most important to the model
+            // overall. Get the feature indices sorted by their impact on AUC.
+            var sortedIndices = permutationMetrics
+                .Select((metrics, index) => new { index, metrics.AreaUnderRocCurve})
+                .OrderByDescending(
+                feature => Math.Abs(feature.AreaUnderRocCurve.Mean))
                 .Select(feature => feature.index);
 
-            Console.WriteLine("Feature\tModel Weight\tChange in AUC\t95% Confidence in the Mean Change in AUC");
+            Console.WriteLine("Feature\tModel Weight\tChange in AUC"
+                + "\t95% Confidence in the Mean Change in AUC");
             var auc = permutationMetrics.Select(x => x.AreaUnderRocCurve).ToArray();
             foreach (int i in sortedIndices)
             {
@@ -76,10 +85,14 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         /// linear combination of the features.
         /// </summary>
         /// <param name="nExamples">The number of examples.</param>
-        /// <param name="bias">The bias, or offset, in the calculation of the label.</param>
-        /// <param name="weight1">The weight to multiply the first feature with to compute the label.</param>
-        /// <param name="weight2">The weight to multiply the second feature with to compute the label.</param>
-        /// <param name="seed">The seed for generating feature values and label noise.</param>
+        /// <param name="bias">The bias, or offset, in the calculation of the label.
+        /// </param>
+        /// <param name="weight1">The weight to multiply the first feature with to
+        /// compute the label.</param>
+        /// <param name="weight2">The weight to multiply the second feature with to
+        /// compute the label.</param>
+        /// <param name="seed">The seed for generating feature values and label
+        /// noise.</param>
         /// <returns>An enumerable of Data objects.</returns>
         private static IEnumerable<Data> GenerateData(int nExamples = 10000,
             double bias = 0, double weight1 = 1, double weight2 = 2, int seed = 1)
@@ -94,7 +107,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 };
 
                 // Create a noisy label.
-                var value = (float)(bias + weight1 * data.Feature1 + weight2 * data.Feature2 + rng.NextDouble() - 0.5);
+                var value = (float)(bias + weight1 * data.Feature1 + weight2 * 
+                    data.Feature2 + rng.NextDouble() - 0.5);
+
                 data.Label = Sigmoid(value) > 0.5;
                 yield return data;
             }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .Prior();
+                .Prior();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,17 +96,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.3f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.3f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -130,14 +130,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
@@ -27,7 +27,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .Prior();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -129,12 +128,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .Prior();
+	        .Prior();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,16 +96,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.3f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.3f).ToArray()
+			    
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -129,11 +130,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/PriorTrainer.cs
@@ -10,35 +10,44 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.Prior();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .Prior();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -48,7 +57,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -71,7 +82,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6840 |   0.0000 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -82,13 +95,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.3f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.3f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -111,9 +128,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
@@ -11,51 +11,51 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .SdcaLogisticRegression();
+	        .SdcaLogisticRegression();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -91,7 +91,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -104,16 +104,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -137,11 +137,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
@@ -108,6 +108,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
@@ -10,41 +10,52 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .SdcaLogisticRegression();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -54,7 +65,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -77,7 +90,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6210 |   0.6667 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -88,13 +103,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -117,9 +136,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
@@ -11,51 +11,51 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SdcaLogisticRegression();
+                .SdcaLogisticRegression();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -91,7 +91,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -104,17 +104,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -138,14 +138,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegression.cs
@@ -35,7 +35,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SdcaLogisticRegression();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -137,12 +136,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
@@ -12,23 +12,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
@@ -45,29 +45,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.SdcaLogisticRegression(options);
+	        .SdcaLogisticRegression(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -78,7 +78,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -103,7 +103,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -116,16 +116,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -149,11 +149,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
@@ -11,20 +11,24 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
@@ -40,23 +44,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.SdcaLogisticRegression(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -66,7 +77,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -89,7 +102,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.5957 |   0.6726 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -100,13 +115,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -129,9 +148,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
@@ -120,6 +120,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
@@ -47,7 +47,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SdcaLogisticRegression(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -149,12 +148,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaLogisticRegressionWithOptions.cs
@@ -12,23 +12,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
@@ -45,29 +45,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SdcaLogisticRegression(options);
+                .SdcaLogisticRegression(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -78,7 +78,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -103,7 +103,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -116,17 +116,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -150,14 +150,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
@@ -107,6 +107,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Features = Enumerable.Repeat(label, 50)
 		        .Select(x => x ? randomFloat() : randomFloat() +
 			0.03f).ToArray()
+			    
                 };
             }
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
@@ -10,41 +10,52 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SdcaNonCalibrated();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .SdcaNonCalibrated();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -54,7 +65,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -76,7 +89,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6185 |   0.6653 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -87,13 +102,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -116,9 +135,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
@@ -11,51 +11,51 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SdcaNonCalibrated();
+                .SdcaNonCalibrated();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -90,7 +90,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -103,17 +103,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -137,14 +137,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
@@ -11,51 +11,51 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .SdcaNonCalibrated();
+	        .SdcaNonCalibrated();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: True
@@ -66,7 +66,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -90,7 +90,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -103,16 +103,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -136,11 +136,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibrated.cs
@@ -35,7 +35,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SdcaNonCalibrated();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -136,12 +135,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
@@ -12,23 +12,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-			// data set from a file and accesses it many times, it can be slow due
-			// to expensive featurization and disk operations. When the considered
-			// data can fit into memory, a solution is to cache the data in memory.
-			// Caching is especially helpful when working with iterative algorithms 
+	    // data set from a file and accesses it many times, it can be slow due
+	    // to expensive featurization and disk operations. When the considered
+	    // data can fit into memory, a solution is to cache the data in memory.
+	    // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
@@ -47,29 +47,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.SdcaNonCalibrated(options);
+	        .SdcaNonCalibrated(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -105,7 +105,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -118,10 +118,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
+			    
                 };
             }
         }
@@ -151,11 +152,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
@@ -11,20 +11,24 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
-            // ML.NET doesn't cache data set by default. Therefore, if one reads a data set from a file and accesses it many times,
-            // it can be slow due to expensive featurization and disk operations. When the considered data can fit into memory,
-            // a solution is to cache the data in memory. Caching is especially helpful when working with iterative algorithms 
+            // ML.NET doesn't cache data set by default. Therefore, if one reads a
+			// data set from a file and accesses it many times, it can be slow due
+			// to expensive featurization and disk operations. When the considered
+			// data can fit into memory, a solution is to cache the data in memory.
+			// Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
@@ -42,23 +46,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SdcaNonCalibrated(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.SdcaNonCalibrated(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -68,7 +79,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -91,7 +104,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.5705 |   0.6809 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -102,13 +117,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -131,9 +150,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
@@ -12,23 +12,23 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // ML.NET doesn't cache data set by default. Therefore, if one reads a
-	    // data set from a file and accesses it many times, it can be slow due
-	    // to expensive featurization and disk operations. When the considered
-	    // data can fit into memory, a solution is to cache the data in memory.
-	    // Caching is especially helpful when working with iterative algorithms 
+            // data set from a file and accesses it many times, it can be slow due
+            // to expensive featurization and disk operations. When the considered
+            // data can fit into memory, a solution is to cache the data in memory.
+            // Caching is especially helpful when working with iterative algorithms 
             // which needs many data passes.
             trainingData = mlContext.Data.Cache(trainingData);
 
@@ -47,29 +47,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SdcaNonCalibrated(options);
+                .SdcaNonCalibrated(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -80,7 +80,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -105,7 +105,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -118,17 +118,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -152,14 +152,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SdcaNonCalibratedWithOptions.cs
@@ -49,7 +49,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SdcaNonCalibrated(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -151,12 +150,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
@@ -10,35 +10,44 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SgdCalibrated();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .SgdCalibrated();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -48,7 +57,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -71,7 +82,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6417 |   0.5763 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -82,13 +95,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -111,9 +128,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
@@ -27,7 +27,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SgdCalibrated();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -129,12 +128,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
@@ -11,42 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SgdCalibrated();
 
+
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -57,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -82,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -95,17 +96,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -129,14 +130,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibrated.cs
@@ -11,43 +11,42 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .SgdCalibrated();
-
+                .SgdCalibrated();
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -58,7 +57,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +82,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,16 +95,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
+			    
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -129,11 +129,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -37,29 +37,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SgdCalibrated(options);
+                .SgdCalibrated(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -70,7 +70,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -108,17 +108,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -142,14 +142,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
@@ -11,15 +11,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,23 +36,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SgdCalibrated(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.SgdCalibrated(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -60,7 +69,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -83,7 +94,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.5412 |   0.6625 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -94,13 +107,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -123,9 +140,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
@@ -39,7 +39,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SgdCalibrated(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -141,12 +140,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdCalibratedWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -37,29 +37,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.SgdCalibrated(options);
+	        .SgdCalibrated(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -70,7 +70,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -108,16 +108,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
+			    
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -141,11 +142,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .SgdNonCalibrated();
+	        .SgdNonCalibrated();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,16 +96,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
+			    
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -129,11 +130,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
@@ -11,43 +11,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SgdNonCalibrated();
+            .SgdNonCalibrated();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -58,7 +58,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -83,7 +83,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -96,17 +96,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -130,14 +130,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
@@ -25,8 +25,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-            .SgdNonCalibrated();
-
+                .SgdNonCalibrated();
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -34,7 +33,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Create testing data. Use different random seed to make it different
             // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
@@ -129,12 +128,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibrated.cs
@@ -10,35 +10,44 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SgdNonCalibrated();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .SgdNonCalibrated();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -48,7 +57,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -71,7 +82,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.6441 |   0.5759 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -82,13 +95,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -111,9 +128,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
+            // exception tracking and logging, as a catalog of available operations
             // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,29 +34,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SgdNonCalibrated(options);
+            .SgdNonCalibrated(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .EvaluateNonCalibrated(transformedTestData);
+                .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -92,7 +92,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -105,17 +105,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.03f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.03f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -139,14 +139,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
@@ -34,8 +34,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-            .SgdNonCalibrated(options);
-
+                .SgdNonCalibrated(options);
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
@@ -43,7 +42,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             // Create testing data. Use different random seed to make it different
             // from training data.
             var testData = mlContext.Data
-            .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
@@ -138,12 +137,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
@@ -12,16 +12,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -34,29 +34,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.SgdNonCalibrated(options);
+	        .SgdNonCalibrated(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -67,7 +67,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .EvaluateNonCalibrated(transformedTestData);
+	        .EvaluateNonCalibrated(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -92,7 +92,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -105,16 +105,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.03f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.03f).ToArray()
+			    
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -138,11 +139,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SgdNonCalibratedWithOptions.cs
@@ -11,15 +11,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
     {
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -31,23 +33,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SgdNonCalibrated(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.SgdNonCalibrated(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -57,7 +66,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.EvaluateNonCalibrated(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .EvaluateNonCalibrated(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -80,7 +91,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.5373 |   0.5878 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -91,13 +104,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.03f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.03f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -120,9 +137,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
@@ -14,43 +14,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
-	    // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SymbolicSgdLogisticRegression();
+                .SymbolicSgdLogisticRegression();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,17 +99,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -133,14 +133,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
@@ -30,7 +30,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SymbolicSgdLogisticRegression();
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -132,12 +131,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
@@ -8,39 +8,49 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class SymbolicSgdLogisticRegression
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.Mkl.Components/">Microsoft.ML.Mkl.Components</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SymbolicSgdLogisticRegression();
+            var pipeline = mlContext.BinaryClassification.Trainers
+			    .SymbolicSgdLogisticRegression();
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -50,7 +60,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: True
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -73,7 +85,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.8235 |   0.8397 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -84,13 +98,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -113,9 +131,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.cs
@@ -14,43 +14,43 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+	    // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-			    .SymbolicSgdLogisticRegression();
+	        .SymbolicSgdLogisticRegression();
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -61,7 +61,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -86,7 +86,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -99,16 +99,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
+			    
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -132,11 +133,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegression.tt
@@ -10,8 +10,9 @@ string LabelThreshold = "0.5f";
 string DataSepValue = "0.1f";
 string OptionsInclude = "";
 string Comments = @"
-        // This example requires installation of additional NuGet package
-        // <a href=""https://www.nuget.org/packages/Microsoft.ML.Mkl.Components/"">Microsoft.ML.Mkl.Components</a>.";
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
 
 string ExpectedOutputPerInstance = @"// Expected output:
             //   Label: True, Prediction: False

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
@@ -39,7 +39,6 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             var pipeline = mlContext.BinaryClassification.Trainers
                 .SymbolicSgdLogisticRegression(options);
 
-
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
@@ -141,12 +140,12 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-                ;
+            Console.WriteLine($"Negative Precision: " + 
+                $"{metrics.NegativePrecision:F2}");
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-                ;
+            Console.WriteLine($"Positive Precision: " +
+                $"{metrics.PositivePrecision:F2}");
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
@@ -9,19 +9,22 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 {
     public static class SymbolicSgdLogisticRegressionWithOptions
     {
-        // This example requires installation of additional NuGet package
-        // <a href="https://www.nuget.org/packages/Microsoft.ML.Mkl.Components/">Microsoft.ML.Mkl.Components</a>.
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/
         public static void Example()
         {
-            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
-            // as a catalog of available operations and as the source of randomness.
-            // Setting the seed to a fixed number in this example to make outputs deterministic.
+            // Create a new context for ML.NET operations. It can be used for
+			// exception tracking and logging, as a catalog of available operations
+			// and as the source of randomness. Setting the seed to a fixed number
+			// in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
-            // Convert the list of data points to an IDataView object, which is consumable by ML.NET API.
+            // Convert the list of data points to an IDataView object, which is
+			// consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -33,23 +36,30 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             };
 
             // Define the trainer.
-            var pipeline = mlContext.BinaryClassification.Trainers.SymbolicSgdLogisticRegression(options);
+            var pipeline = mlContext.BinaryClassification.Trainers
+				.SymbolicSgdLogisticRegression(options);
+
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
-            // Create testing data. Use different random seed to make it different from training data.
-            var testData = mlContext.Data.LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+            // Create testing data. Use different random seed to make it different
+			// from training data.
+            var testData = mlContext.Data
+			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
-            var predictions = mlContext.Data.CreateEnumerable<Prediction>(transformedTestData, reuseRowObject: false).ToList();
+            var predictions = mlContext.Data
+			    .CreateEnumerable<Prediction>(transformedTestData,
+				reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
-                Console.WriteLine($"Label: {p.Label}, Prediction: {p.PredictedLabel}");
+                Console.WriteLine($"Label: {p.Label}, " 
+				    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -59,7 +69,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Label: False, Prediction: False
             
             // Evaluate the overall metrics.
-            var metrics = mlContext.BinaryClassification.Evaluate(transformedTestData);
+            var metrics = mlContext.BinaryClassification
+			    .Evaluate(transformedTestData);
+
             PrintMetrics(metrics);
             
             // Expected output:
@@ -82,7 +94,9 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             //   Precision ||   0.7964 |   0.6847 |
         }
 
-        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count, int seed=0)
+        private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
+		    int seed=0)
+
         {
             var random = new Random(seed);
             float randomFloat() => (float)random.NextDouble();
@@ -93,13 +107,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                 {
                     Label = label,
                     // Create random features that are correlated with the label.
-                    // For data points with false label, the feature values are slightly increased by adding a constant.
-                    Features = Enumerable.Repeat(label, 50).Select(x => x ? randomFloat() : randomFloat() + 0.1f).ToArray()
+                    // For data points with false label, the feature values are
+					// slightly increased by adding a constant.
+                    Features = Enumerable.Repeat(label, 50)
+					    .Select(x => x ? randomFloat() : randomFloat() +
+						0.1f).ToArray()
                 };
             }
         }
 
-        // Example with label and 50 feature values. A data set is a collection of such examples.
+        // Example with label and 50 feature values. A data set is a collection of
+		// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -122,9 +140,13 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"Accuracy: {metrics.Accuracy:F2}");
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
-            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}");
+            Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
-            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}");
+            Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
+			    ;
+
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-	    // exception tracking and logging, as a catalog of available operations
+            // exception tracking and logging, as a catalog of available operations
             // and as the source of randomness. Setting the seed to a fixed number
-	    // in this example to make outputs deterministic.
+            // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-	    // consumable by ML.NET API.
+            // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -37,29 +37,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-	        .SymbolicSgdLogisticRegression(options);
+                .SymbolicSgdLogisticRegression(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-	    // from training data.
+            // from training data.
             var testData = mlContext.Data
-	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+                .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-	        .CreateEnumerable<Prediction>(transformedTestData,
-		reuseRowObject: false).ToList();
+                .CreateEnumerable<Prediction>(transformedTestData,
+                reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-		    + $"Prediction: {p.PredictedLabel}");
+                    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -70,7 +70,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-	        .Evaluate(transformedTestData);
+                .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-	    int seed=0)
+            int seed=0)
 
         {
             var random = new Random(seed);
@@ -108,17 +108,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-		    // slightly increased by adding a constant.
+                    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-		        .Select(x => x ? randomFloat() : randomFloat() +
-			0.1f).ToArray()
-			    
+                        .Select(x => x ? randomFloat() : randomFloat() +
+                        0.1f).ToArray()
+            
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-	// such examples.
+        // such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -142,14 +142,15 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-	        ;
+                ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());
         }
     }
 }
+

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.cs
@@ -15,16 +15,16 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         public static void Example()
         {
             // Create a new context for ML.NET operations. It can be used for
-			// exception tracking and logging, as a catalog of available operations
-			// and as the source of randomness. Setting the seed to a fixed number
-			// in this example to make outputs deterministic.
+	    // exception tracking and logging, as a catalog of available operations
+            // and as the source of randomness. Setting the seed to a fixed number
+	    // in this example to make outputs deterministic.
             var mlContext = new MLContext(seed: 0);
 
             // Create a list of training data points.
             var dataPoints = GenerateRandomDataPoints(1000);
 
             // Convert the list of data points to an IDataView object, which is
-			// consumable by ML.NET API.
+	    // consumable by ML.NET API.
             var trainingData = mlContext.Data.LoadFromEnumerable(dataPoints);
 
             // Define trainer options.
@@ -37,29 +37,29 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
 
             // Define the trainer.
             var pipeline = mlContext.BinaryClassification.Trainers
-				.SymbolicSgdLogisticRegression(options);
+	        .SymbolicSgdLogisticRegression(options);
 
 
             // Train the model.
             var model = pipeline.Fit(trainingData);
 
             // Create testing data. Use different random seed to make it different
-			// from training data.
+	    // from training data.
             var testData = mlContext.Data
-			    .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
+	        .LoadFromEnumerable(GenerateRandomDataPoints(500, seed:123));
 
             // Run the model on test data set.
             var transformedTestData = model.Transform(testData);
 
             // Convert IDataView object to a list.
             var predictions = mlContext.Data
-			    .CreateEnumerable<Prediction>(transformedTestData,
-				reuseRowObject: false).ToList();
+	        .CreateEnumerable<Prediction>(transformedTestData,
+		reuseRowObject: false).ToList();
 
             // Print 5 predictions.
             foreach (var p in predictions.Take(5))
                 Console.WriteLine($"Label: {p.Label}, " 
-				    + $"Prediction: {p.PredictedLabel}");
+		    + $"Prediction: {p.PredictedLabel}");
 
             // Expected output:
             //   Label: True, Prediction: False
@@ -70,7 +70,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             
             // Evaluate the overall metrics.
             var metrics = mlContext.BinaryClassification
-			    .Evaluate(transformedTestData);
+	        .Evaluate(transformedTestData);
 
             PrintMetrics(metrics);
             
@@ -95,7 +95,7 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
         }
 
         private static IEnumerable<DataPoint> GenerateRandomDataPoints(int count,
-		    int seed=0)
+	    int seed=0)
 
         {
             var random = new Random(seed);
@@ -108,16 +108,17 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
                     Label = label,
                     // Create random features that are correlated with the label.
                     // For data points with false label, the feature values are
-					// slightly increased by adding a constant.
+		    // slightly increased by adding a constant.
                     Features = Enumerable.Repeat(label, 50)
-					    .Select(x => x ? randomFloat() : randomFloat() +
-						0.1f).ToArray()
+		        .Select(x => x ? randomFloat() : randomFloat() +
+			0.1f).ToArray()
+			    
                 };
             }
         }
 
         // Example with label and 50 feature values. A data set is a collection of
-		// such examples.
+	// such examples.
         private class DataPoint
         {
             public bool Label { get; set; }
@@ -141,11 +142,11 @@ namespace Samples.Dynamic.Trainers.BinaryClassification
             Console.WriteLine($"AUC: {metrics.AreaUnderRocCurve:F2}");
             Console.WriteLine($"F1 Score: {metrics.F1Score:F2}");
             Console.WriteLine($"Negative Precision: {metrics.NegativePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Negative Recall: {metrics.NegativeRecall:F2}");
             Console.WriteLine($"Positive Precision: {metrics.PositivePrecision:F2}")
-			    ;
+	        ;
 
             Console.WriteLine($"Positive Recall: {metrics.PositiveRecall:F2}\n");
             Console.WriteLine(metrics.ConfusionMatrix.GetFormattedConfusionTable());

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.tt
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/SymbolicSgdLogisticRegressionWithOptions.tt
@@ -9,8 +9,9 @@ string LabelThreshold = "0.5f";
 string DataSepValue = "0.1f";
 string OptionsInclude = "using Microsoft.ML.Trainers;";
 string Comments = @"
-        // This example requires installation of additional NuGet package
-        // <a href=""https://www.nuget.org/packages/Microsoft.ML.Mkl.Components/"">Microsoft.ML.Mkl.Components</a>.";
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
 
 string TrainerOptions = @"SymbolicSgdLogisticRegressionBinaryTrainer.Options()
             {

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/TreeSamplesTemplate.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/TreeSamplesTemplate.ttinclude
@@ -4,6 +4,7 @@ string LabelThreshold = "0.5f";
 string DataSepValue = "0.03f";
 string OptionsInclude = "using Microsoft.ML.Trainers.FastTree;";
 string Comments= @"
-        // This example requires installation of additional NuGet package
-        // <a href=""https://www.nuget.org/packages/Microsoft.ML.FastTree/"">Microsoft.ML.FastTree</a>.";
+       // This example requires installation of additional NuGet package for 
+       // Microsoft.ML.FastTree at
+       // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/TreeSamplesTemplate.ttinclude
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/BinaryClassification/TreeSamplesTemplate.ttinclude
@@ -4,7 +4,7 @@ string LabelThreshold = "0.5f";
 string DataSepValue = "0.03f";
 string OptionsInclude = "using Microsoft.ML.Trainers.FastTree;";
 string Comments= @"
-       // This example requires installation of additional NuGet package for 
-       // Microsoft.ML.FastTree at
-       // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
+        // This example requires installation of additional NuGet package for 
+        // Microsoft.ML.FastTree at
+        // https://www.nuget.org/packages/Microsoft.ML.FastTree/";
 #>

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using Samples.Dynamic;
 
 namespace Microsoft.ML.Samples
 {
@@ -9,13 +10,12 @@ namespace Microsoft.ML.Samples
 
         internal static void RunAll()
         {
-            // Samples counter.
             int samples = 0;
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-
-                if (sample != null)
+                
+                
                 {
                     Console.WriteLine(type.Name);
                     sample.Invoke(null, null);

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using Samples.Dynamic;
 
 namespace Microsoft.ML.Samples
 {
@@ -10,6 +9,7 @@ namespace Microsoft.ML.Samples
 
         internal static void RunAll()
         {
+            // Samples counter.
             int samples = 0;
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Reflection;
 using Samples.Dynamic;
-using Samples.Dynamic.Trainers.BinaryClassification;
 
 namespace Microsoft.ML.Samples
 {

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using Samples.Dynamic;
+using Samples.Dynamic.Trainers.BinaryClassification;
 
 namespace Microsoft.ML.Samples
 {
@@ -14,8 +15,10 @@ namespace Microsoft.ML.Samples
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+                String[] test = {"PairwiseCoupling", "PermutationFeatureImportance", "SdcaMaximumEntropy",
+                "SdcaMaximumEntropyWithOptions", "SdcaNonCalibrated", "SdcaNonCalibratedWithOptions"};
+                if (sample != null && Array.IndexOf(test, type.Name) > -1)//type.Name.Equals("ConvertType"))
 
-                if (sample != null)
                 {
                     Console.WriteLine(type.Name);
                     sample.Invoke(null, null);

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -14,8 +14,8 @@ namespace Microsoft.ML.Samples
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-                
-                
+
+                if (sample != null)
                 {
                     Console.WriteLine(type.Name);
                     sample.Invoke(null, null);

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -15,10 +15,8 @@ namespace Microsoft.ML.Samples
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-                String[] test = {"PairwiseCoupling", "PermutationFeatureImportance", "SdcaMaximumEntropy",
-                "SdcaMaximumEntropyWithOptions", "SdcaNonCalibrated", "SdcaNonCalibratedWithOptions"};
-                if (sample != null && Array.IndexOf(test, type.Name) > -1)//type.Name.Equals("ConvertType"))
 
+                if (sample != null)
                 {
                     Console.WriteLine(type.Name);
                     sample.Invoke(null, null);


### PR DESCRIPTION
Guidelines followed:
-85 characters per line
-Use 4 spaces for indentation
-Dot and open parentheses stay on same line as function
-If not a preexisting line under line that we break, add an extra line after it
-Don't indent comments
-Don't break a comment if it represents output
-Don't break links
-If applicable, break right before $
-Keep math op together

Fix for issue #3478
