### PR TITLE
[AutoML] Bump ML.NET package version to 1.2.0 in AutoML API and CLI; and AutoML package versions to 0.14.0

### DIFF
--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' != 'true'">
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>4</MinorVersion>
+    <MinorVersion>14</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseLabel>preview</PreReleaseLabel>
   </PropertyGroup>

--- a/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
+++ b/src/Microsoft.ML.AutoML/Microsoft.ML.AutoML.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MlDotNetPackageVersion>1.0.0</MlDotNetPackageVersion>
+    <MlDotNetPackageVersion>1.2.0</MlDotNetPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mlnet/Templates/Console/ModelProject.cs
+++ b/src/mlnet/Templates/Console/ModelProject.cs
@@ -27,15 +27,15 @@ namespace Microsoft.ML.CLI.Templates.Console
         {
             this.Write("<Project Sdk=\"Microsoft.NET.Sdk\">\r\n\r\n  <PropertyGroup>\r\n    <TargetFramework>netc" +
                     "oreapp2.1</TargetFramework>\r\n  </PropertyGroup>\r\n  <ItemGroup>\r\n    <PackageRefe" +
-                    "rence Include=\"Microsoft.ML\" Version=\"1.0.0\" />\r\n");
+                    "rence Include=\"Microsoft.ML\" Version=\"1.2.0\" />\r\n");
  if (IncludeLightGBMPackage) { 
-            this.Write("    <PackageReference Include=\"Microsoft.ML.LightGBM\" Version=\"1.0.0\" />\r\n");
+            this.Write("    <PackageReference Include=\"Microsoft.ML.LightGBM\" Version=\"1.2.0\" />\r\n");
 }
  if (IncludeMklComponentsPackage){ 
-            this.Write("    <PackageReference Include=\"Microsoft.ML.Mkl.Components\" Version=\"1.0.0\" />\r\n");
+            this.Write("    <PackageReference Include=\"Microsoft.ML.Mkl.Components\" Version=\"1.2.0\" />\r\n");
 }
  if (IncludeFastTreePackage){ 
-            this.Write("    <PackageReference Include=\"Microsoft.ML.FastTree\" Version=\"1.0.0\" />\r\n");
+            this.Write("    <PackageReference Include=\"Microsoft.ML.FastTree\" Version=\"1.2.0\" />\r\n");
 }
             this.Write("  </ItemGroup>\r\n\r\n  <ItemGroup>\r\n    <None Update=\"MLModel.zip\">\r\n      <CopyToOu" +
                     "tputDirectory>PreserveNewest</CopyToOutputDirectory>\r\n    </None>\r\n  </ItemGroup" +

--- a/src/mlnet/Templates/Console/ModelProject.tt
+++ b/src/mlnet/Templates/Console/ModelProject.tt
@@ -9,15 +9,15 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML" Version="1.2.0" />
 <# if (IncludeLightGBMPackage) { #>
-    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.2.0" />
 <#}#>
 <# if (IncludeMklComponentsPackage){ #>
-    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.2.0" />
 <#}#>
 <# if (IncludeFastTreePackage){ #>
-    <PackageReference Include="Microsoft.ML.FastTree" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML.FastTree" Version="1.2.0" />
 <#}#>
   </ItemGroup>
 

--- a/src/mlnet/Templates/Console/PredictProject.cs
+++ b/src/mlnet/Templates/Console/PredictProject.cs
@@ -28,16 +28,16 @@ namespace Microsoft.ML.CLI.Templates.Console
         {
             this.Write("<Project Sdk=\"Microsoft.NET.Sdk\">\r\n\r\n  <PropertyGroup>\r\n    <OutputType>Exe</Outp" +
                     "utType>\r\n    <TargetFramework>netcoreapp2.1</TargetFramework>\r\n  </PropertyGroup" +
-                    ">\r\n  <ItemGroup>\r\n    <PackageReference Include=\"Microsoft.ML\" Version=\"1.0.0\" /" +
+                    ">\r\n  <ItemGroup>\r\n    <PackageReference Include=\"Microsoft.ML\" Version=\"1.2.0\" /" +
                     ">\r\n");
  if (IncludeLightGBMPackage){ 
-            this.Write("    <PackageReference Include=\"Microsoft.ML.LightGBM\" Version=\"1.0.0\" />\r\n");
+            this.Write("    <PackageReference Include=\"Microsoft.ML.LightGBM\" Version=\"1.2.0\" />\r\n");
 }
  if (IncludeMklComponentsPackage){ 
-            this.Write("    <PackageReference Include=\"Microsoft.ML.Mkl.Components\" Version=\"1.0.0\" />\r\n");
+            this.Write("    <PackageReference Include=\"Microsoft.ML.Mkl.Components\" Version=\"1.2.0\" />\r\n");
 }
  if (IncludeFastTreePackage){ 
-            this.Write("    <PackageReference Include=\"Microsoft.ML.FastTree\" Version=\"1.0.0\" />\r\n");
+            this.Write("    <PackageReference Include=\"Microsoft.ML.FastTree\" Version=\"1.2.0\" />\r\n");
 }
             this.Write("  </ItemGroup>\r\n  <ItemGroup>\r\n    <ProjectReference Include=\"..\\");
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));

--- a/src/mlnet/Templates/Console/PredictProject.tt
+++ b/src/mlnet/Templates/Console/PredictProject.tt
@@ -11,15 +11,15 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML" Version="1.2.0" />
 <# if (IncludeLightGBMPackage){ #>
-    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.2.0" />
 <#}#>
 <# if (IncludeMklComponentsPackage){ #>
-    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.2.0" />
 <#}#>
 <# if (IncludeFastTreePackage){ #>
-    <PackageReference Include="Microsoft.ML.FastTree" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML.FastTree" Version="1.2.0" />
 <#}#>
   </ItemGroup>
   <ItemGroup>

--- a/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppProjectFileContentTest.approved.txt
+++ b/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ConsoleAppProjectFileContentTest.approved.txt
@@ -5,9 +5,9 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.0.0" />
-    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.0.0" />
-    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TestNamespace.Model\TestNamespace.Model.csproj" />

--- a/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ModelProjectFileContentTest.approved.txt
+++ b/test/mlnet.Tests/ApprovalTests/ConsoleCodeGeneratorTests.ModelProjectFileContentTest.approved.txt
@@ -4,10 +4,10 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.0.0" />
-    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.0.0" />
-    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.0.0" />
-    <PackageReference Include="Microsoft.ML.FastTree" Version="1.0.0" />
+    <PackageReference Include="Microsoft.ML" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.LightGBM" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.FastTree" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes https://github.com/dotnet/machinelearning/issues/3959 and closes https://github.com/dotnet/machinelearning/issues/3960:
Bump ML.NET package version to latest 1.2.0 in AutoML API and CLI (including the generated C# code); bump AutoML package versions to 0.14.0 to be consistent with ML.NET preview version