### PR TITLE
[AutoML] Produce AutoML NuGet package in build pipeline

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -68,7 +68,7 @@
     <Message Importance="High" Text="Building packages ..." />
 
     <ItemGroup>
-      <PkgProject Include="pkg\Microsoft.ML.AutoML\Microsoft.ML.AutoML.symbols.nupkgproj" />
+      <PkgProject Include="pkg\Microsoft.ML.AutoML\*.nupkgproj" />
       <PkgProject Include="pkg\mlnet\*.nupkgproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Produce AutoML NuGet package in build pipeline

Currently, only the `mlnet` and _symbols_ `Microsoft.ML.AutoML` are produced. We need to also produce the NuGet for `Microsoft.ML.AutoML`.

This reverts the change from https://github.com/dotnet/machinelearning/pull/3656.