### PR TITLE
[AutoML] Increment AutoML build version to 0.15.0 for preview.

### DIFF
--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -22,13 +22,13 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' == 'true'">
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseLabel>preview</PreReleaseLabel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' != 'true'">
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>14</MinorVersion>
+    <MinorVersion>15</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseLabel>preview</PreReleaseLabel>
   </PropertyGroup>


### PR DESCRIPTION
Increment build version to 1.3.0 for release and 0.15.0 for preview. Note there are no release AutoML components at this time.

This is to keep in sync w/ the ML.NET versions -- ref: https://github.com/dotnet/machinelearning/pull/3956