### PR TITLE
Update Api Compat after 1.2 release

### DIFF
--- a/src/Microsoft.ML.OnnxTransformer/Microsoft.ML.OnnxTransformer.csproj
+++ b/src/Microsoft.ML.OnnxTransformer/Microsoft.ML.OnnxTransformer.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeInPackage>Microsoft.ML.OnnxTransformer</IncludeInPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.TensorFlow/Microsoft.ML.TensorFlow.csproj
+++ b/src/Microsoft.ML.TensorFlow/Microsoft.ML.TensorFlow.csproj
@@ -5,7 +5,6 @@
     <IncludeInPackage>Microsoft.ML.TensorFlow</IncludeInPackage>
     <DefineConstants>CORECLR</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.TimeSeries/Microsoft.ML.TimeSeries.csproj
+++ b/src/Microsoft.ML.TimeSeries/Microsoft.ML.TimeSeries.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeInPackage>Microsoft.ML.TimeSeries</IncludeInPackage>
-    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools-local/Microsoft.ML.StableApi/Microsoft.ML.StableApi.csproj
+++ b/tools-local/Microsoft.ML.StableApi/Microsoft.ML.StableApi.csproj
@@ -7,13 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ML.DataView" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ML.CpuMath" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ML.FastTree" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ML.LightGbm" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.1.0" />
-    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.1.0" />
+    <PackageReference Include="Microsoft.ML" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.CpuMath" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.DataView" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.FastTree" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.LightGbm" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.OnnxTransformer" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.TensorFlow" Version="1.2.0" />
+    <PackageReference Include="Microsoft.ML.TimeSeries" Version="1.2.0" />
   </ItemGroup>
 
   <!-- The purpose of this target is to return a path from a referenced


### PR DESCRIPTION
Fixes #3980 

I update the package version number for the stable projects and I activate the API Compat tool for Onnx, TimeSeries and TensorFlow packages which became stable in the last release.  
