### PR TITLE
fixes #3992,  when inputColumnNames is not provided, it is set to new[] { outputColumnName }. and part of #3994(making SlotDroppingTransfomer exposed as public)

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/SlotsDroppingTransformer.cs
@@ -260,7 +260,7 @@ namespace Microsoft.ML.Transforms
         /// <param name="inputColumnName">Name of column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="min">Specifies the lower bound of the range of slots to be dropped. The lower bound is inclusive. </param>
         /// <param name="max">Specifies the upper bound of the range of slots to be dropped. The upper bound is exclusive.</param>
-        internal SlotsDroppingTransformer(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int min = default, int? max = null)
+        public SlotsDroppingTransformer(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int min = default, int? max = null)
             : this(env, new ColumnOptions(outputColumnName, inputColumnName, (min, max)))
         {
         }
@@ -270,7 +270,7 @@ namespace Microsoft.ML.Transforms
         /// </summary>
         /// <param name="env">The environment to use.</param>
         /// <param name="columns">Specifies the ranges of slots to drop for each column pair.</param>
-        internal SlotsDroppingTransformer(IHostEnvironment env, params ColumnOptions[] columns)
+        public SlotsDroppingTransformer(IHostEnvironment env, params ColumnOptions[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(RegistrationName), GetColumnPairs(columns))
         {
             Host.AssertNonEmpty(ColumnPairs);

--- a/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
+++ b/src/Microsoft.ML.Transforms/Text/TextCatalog.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML
             TextFeaturizingEstimator.Options options,
             params string[] inputColumnNames)
             => new TextFeaturizingEstimator(Contracts.CheckRef(catalog, nameof(catalog)).GetEnvironment(),
-                outputColumnName, inputColumnNames, options);
+                outputColumnName, inputColumnNames == null ? new[] { outputColumnName } : inputColumnNames, options);
 
         /// <summary>
         /// Create a <see cref="TokenizingByCharactersEstimator"/>, which tokenizes by splitting text into sequences of characters


### PR DESCRIPTION
fixes #3992 and part of #3994(making SlotDroppingTransfomer exposed as public)

We are excited to review your PR.

So we can do the best job, please check:

- [ ] There's a descriptive title that will make sense to other developers some time from now. 
- [ ] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [ ] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [ ] You have included any necessary tests in the same PR.

