### PR TITLE
Stop LightGbm Warning for Default Metric Input [Issue #3965 Fix]

### DIFF
--- a/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmBinaryTrainer.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Logloss;
 
             static Options()
             {

--- a/src/Microsoft.ML.LightGbm/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmMulticlassTrainer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Error;
 
             static Options()
             {

--- a/src/Microsoft.ML.LightGbm/LightGbmRankingTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmRankingTrainer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.NormalizedDiscountedCumulativeGain;
 
             static Options()
             {

--- a/src/Microsoft.ML.LightGbm/LightGbmRegressionTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmRegressionTrainer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Trainers.LightGbm
             [Argument(ArgumentType.AtMostOnce,
                 HelpText = "Evaluation metrics.",
                 ShortName = "em")]
-            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.Default;
+            public EvaluateMetricType EvaluationMetric = EvaluateMetricType.RootMeanSquaredError;
 
             static Options()
             {

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -11535,7 +11535,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "Default"
+          "Default": "Logloss"
         },
         {
           "Name": "MaximumBinCountPerFeature",
@@ -12032,7 +12032,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "Default"
+          "Default": "Error"
         },
         {
           "Name": "MaximumBinCountPerFeature",
@@ -12529,7 +12529,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "Default"
+          "Default": "NormalizedDiscountedCumulativeGain"
         },
         {
           "Name": "MaximumBinCountPerFeature",
@@ -12987,7 +12987,7 @@
           "Required": false,
           "SortOrder": 150.0,
           "IsNullable": false,
-          "Default": "Default"
+          "Default": "RootMeanSquaredError"
         },
         {
           "Name": "MaximumBinCountPerFeature",

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMReg-CV-generatedRegressionDataset-out.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMReg-CV-generatedRegressionDataset-out.txt
@@ -35,10 +35,10 @@ Virtual memory usage(MB): %Number%
 [1] 'Loading data for LightGBM' started.
 [1] 'Loading data for LightGBM' finished in %Time%.
 [2] 'Training with LightGBM' started.
-[2] (%Time%)	Iteration: 50	Training-: 37.107605006517
+[2] (%Time%)	Iteration: 50	Training-rmse: 6.09160118577349
 [2] 'Training with LightGBM' finished in %Time%.
 [3] 'Loading data for LightGBM #2' started.
 [3] 'Loading data for LightGBM #2' finished in %Time%.
 [4] 'Training with LightGBM #2' started.
-[4] (%Time%)	Iteration: 50	Training-: 27.7037679135951
+[4] (%Time%)	Iteration: 50	Training-rmse: 5.26343689176522
 [4] 'Training with LightGBM #2' finished in %Time%.

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMReg-TrainTest-generatedRegressionDataset-out.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMReg-TrainTest-generatedRegressionDataset-out.txt
@@ -26,7 +26,7 @@ Virtual memory usage(MB): %Number%
 [1] 'Loading data for LightGBM' started.
 [1] 'Loading data for LightGBM' finished in %Time%.
 [2] 'Training with LightGBM' started.
-[2] (%Time%)	Iteration: 50	Training-: 26.0644295080124
+[2] (%Time%)	Iteration: 50	Training-rmse: 5.10533343749577
 [2] 'Training with LightGBM' finished in %Time%.
 [3] 'Saving model' started.
 [3] 'Saving model' finished in %Time%.

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-CV-generatedRegressionDataset.RMSE-rp.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-CV-generatedRegressionDataset.RMSE-rp.txt
@@ -1,4 +1,4 @@
 LightGBMR
-L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/em	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-26.59978	1393.326	37.32081	1393.326	0.923402	RootMeanSquaredError	50	0.2	20	10	+	1	LightGBMR	%Data%		%Output%	99	0	0	maml.exe CV tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} threads=- dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% seed=1	/em:RootMeanSquaredError;/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
+L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
+26.59978	1393.326	37.32081	1393.326	0.923402	50	0.2	20	10	+	1	LightGBMR	%Data%		%Output%	99	0	0	maml.exe CV tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} threads=- dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% seed=1	/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
 

--- a/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-TrainTest-generatedRegressionDataset.RMSE-rp.txt
+++ b/test/BaselineOutput/Common/LightGBMR/LightGBMRegRmse-TrainTest-generatedRegressionDataset.RMSE-rp.txt
@@ -1,4 +1,4 @@
 LightGBMR
-L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/em	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
-3.428896	25.23601	5.023546	25.23601	0.998616	RootMeanSquaredError	50	0.2	20	10	+	1	LightGBMR	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% out=%Output% seed=1	/em:RootMeanSquaredError;/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
+L1(avg)	L2(avg)	RMS(avg)	Loss-fn(avg)	R Squared	/iter	/lr	/nl	/mil	/v	/nt	Learner Name	Train Dataset	Test Dataset	Results File	Run Time	Physical Memory	Virtual Memory	Command Line	Settings	
+3.428896	25.23601	5.023546	25.23601	0.998616	50	0.2	20	10	+	1	LightGBMR	%Data%	%Data%	%Output%	99	0	0	maml.exe TrainTest test=%Data% tr=LightGBMR{nt=1 iter=50 em=RootMeanSquaredError v=+ lr=0.2 mil=10 nl=20} dout=%Output% loader=Text{col=Label:R4:11 col=Features:R4:0-10 sep=; header+} data=%Data% out=%Output% seed=1	/iter:50;/lr:0.2;/nl:20;/mil:10;/v:+;/nt:1	
 


### PR DESCRIPTION
Issue #3965 reported that a warning, "LightGBM] [Warning] Unknown parameter metric=" is produced when the default metric is used. This warning came after this [commit](https://github.com/dotnet/machinelearning/pull/3859) which aimed to provide a consistent user experience from an ML.NET implementation of LightGbm with standalone LightGbm. If a user were to set `EvaluationMetric = EvaluateMetricType.Default`, they might expect that this would set the EvaluationMetric to "" and assigned the metric based on the objective as shown in the LightGbm docs. When the correction was made, this warning began to appear when the metric parameter was set to "". which was also being produced in LightGbm alone. The only way to prevent this error would be to not assign a parameter to the metric at all.

This warning has not appeared in previous versions of ML.NET and can be prevent by assigning the correct metric based on the objective as was previously done.

To prevent this warning, the changes from this [commit](https://github.com/dotnet/machinelearning/pull/3859) were reverted.