### PR TITLE
OneVersusAllModelParameters Strongly Typed

### DIFF
--- a/src/Microsoft.ML.Core/Prediction/IPredictor.cs
+++ b/src/Microsoft.ML.Core/Prediction/IPredictor.cs
@@ -12,8 +12,7 @@ namespace Microsoft.ML
     /// <see cref="ITrainer"/> and <see cref="IPredictor"/> it is still useful, but for things based on
     /// the <see cref="IEstimator{TTransformer}"/> idiom, it is inappropriate.
     /// </summary>
-    [BestFriend]
-    internal enum PredictionKind
+    public enum PredictionKind
     {
         Unknown = 0,
         Custom = 1,
@@ -34,8 +33,7 @@ namespace Microsoft.ML
     /// <summary>
     /// Weakly typed version of IPredictor.
     /// </summary>
-    [BestFriend]
-    internal interface IPredictor
+    public interface IPredictor
     {
         /// <summary>
         /// Return the type of prediction task.
@@ -47,8 +45,7 @@ namespace Microsoft.ML
     /// A predictor the produces values of the indicated type.
     /// REVIEW: Determine whether this is just a temporary shim or long term solution.
     /// </summary>
-    [BestFriend]
-    internal interface IPredictorProducing<out TResult> : IPredictor
+    public interface IPredictorProducing<out TResult> : IPredictor
     {
     }
 

--- a/src/Microsoft.ML.Core/Prediction/IPredictor.cs
+++ b/src/Microsoft.ML.Core/Prediction/IPredictor.cs
@@ -33,7 +33,8 @@ namespace Microsoft.ML
     /// <summary>
     /// Weakly typed version of IPredictor.
     /// </summary>
-    public interface IPredictor
+    [BestFriend]
+    internal interface IPredictor
     {
         /// <summary>
         /// Return the type of prediction task.
@@ -45,7 +46,8 @@ namespace Microsoft.ML
     /// A predictor the produces values of the indicated type.
     /// REVIEW: Determine whether this is just a temporary shim or long term solution.
     /// </summary>
-    public interface IPredictorProducing<out TResult> : IPredictor
+    [BestFriend]
+    internal interface IPredictorProducing<out TResult> : IPredictor
     {
     }
 

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -989,9 +989,7 @@ namespace Microsoft.ML.Calibrators
 
             var predWithFeatureScores = predictor as IPredictorWithFeatureWeights<float>;
             if (predWithFeatureScores != null && predictor is IParameterMixer<float> && cali is IParameterMixer)
-            {
                 return new ParameterMixingCalibratedModelParameters<TSubPredictor, TCalibrator>(env, predictor, cali);
-            }
 
             if (predictor is IValueMapper)
                 return new ValueMapperCalibratedModelParameters<TSubPredictor, TCalibrator>(env, predictor, cali);

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -879,10 +879,12 @@ namespace Microsoft.ML.Calibrators
             return CreateCalibratedPredictor(env, (IPredictorProducing<float>)predictor, trainedCalibrator);
         }
 
-        public static CalibratedModelParametersBase<T, ICalibrator> GetCalibratedPredictor<T>(IHostEnvironment env, IChannel ch, ICalibratorTrainer caliTrainer,
-            T predictor, RoleMappedData data, int maxRows = _maxCalibrationExamples) where T: class
+        public static CalibratedModelParametersBase<TSubPredictor, TCalibrator> GetCalibratedPredictor<TSubPredictor, TCalibrator>(IHostEnvironment env, IChannel ch, ICalibratorTrainer caliTrainer,
+            TSubPredictor predictor, RoleMappedData data, int maxRows = _maxCalibrationExamples)
+            where TSubPredictor : class
+            where TCalibrator : class, ICalibrator
         {
-            var trainedCalibrator = TrainCalibrator(env, ch, caliTrainer, (IPredictorProducing<float>)predictor, data, maxRows);
+            var trainedCalibrator = TrainCalibrator(env, ch, caliTrainer, (IPredictorProducing<float>)predictor, data, maxRows) as TCalibrator;
             var cp = CreateCalibratedPredictor(env, predictor, trainedCalibrator);
             return cp;
         }
@@ -990,6 +992,7 @@ namespace Microsoft.ML.Calibrators
             if (predWithFeatureScores != null && predictor is IParameterMixer<float> && cali is IParameterMixer)
             {
                 var s = typeof(TSubPredictor);
+                var d = typeof(TCalibrator);
                 var pm = new ParameterMixingCalibratedModelParameters<TSubPredictor, TCalibrator>(env, predictor, cali);
                 return pm;
             }

--- a/src/Microsoft.ML.Data/Prediction/Calibrator.cs
+++ b/src/Microsoft.ML.Data/Prediction/Calibrator.cs
@@ -881,10 +881,10 @@ namespace Microsoft.ML.Calibrators
 
         public static CalibratedModelParametersBase<TSubPredictor, TCalibrator> GetCalibratedPredictor<TSubPredictor, TCalibrator>(IHostEnvironment env, IChannel ch, ICalibratorTrainer caliTrainer,
             TSubPredictor predictor, RoleMappedData data, int maxRows = _maxCalibrationExamples)
-            where TSubPredictor : class, IPredictorProducing<float>
+            where TSubPredictor : class
             where TCalibrator : class, ICalibrator
         {
-            var trainedCalibrator = TrainCalibrator(env, ch, caliTrainer, predictor, data, maxRows) as TCalibrator;
+            var trainedCalibrator = TrainCalibrator(env, ch, caliTrainer, (IPredictor)predictor, data, maxRows) as TCalibrator;
             return (CalibratedModelParametersBase<TSubPredictor, TCalibrator>)CreateCalibratedPredictor(env, predictor, trainedCalibrator);
         }
 
@@ -972,12 +972,12 @@ namespace Microsoft.ML.Calibrators
         }
 
         public static IPredictorProducing<float> CreateCalibratedPredictor<TSubPredictor, TCalibrator>(IHostEnvironment env, TSubPredictor predictor, TCalibrator cali)
-        where TSubPredictor : class, IPredictorProducing<float>
+        where TSubPredictor : class
         where TCalibrator : class, ICalibrator
         {
             Contracts.Assert(predictor != null);
             if (cali == null)
-                return predictor;
+                return (IPredictorProducing<float>)predictor;
 
             for (; ; )
             {

--- a/src/Microsoft.ML.EntryPoints/ModelOperations.cs
+++ b/src/Microsoft.ML.EntryPoints/ModelOperations.cs
@@ -155,7 +155,7 @@ namespace Microsoft.ML.EntryPoints
                 return new PredictorModelOutput
                 {
                     PredictorModel = new PredictorModelImpl(env, data, input.TrainingData,
-                    OneVersusAllModelParameters.Create(host, input.UseProbabilities,
+                    OneVersusAllModelParametersBuilder.Create(host, input.UseProbabilities,
                             input.ModelArray.Select(p => p.Predictor as IPredictorProducing<float>).ToArray()))
                 };
             }

--- a/src/Microsoft.ML.LightGbm/LightGbmMulticlassTrainer.cs
+++ b/src/Microsoft.ML.LightGbm/LightGbmMulticlassTrainer.cs
@@ -198,9 +198,9 @@ namespace Microsoft.ML.Trainers.LightGbm
             }
             string obj = (string)GetGbmParameters()["objective"];
             if (obj == "multiclass")
-                return OneVersusAllModelParameters.Create(Host, OneVersusAllModelParameters.OutputFormula.Softmax, predictors);
+                return OneVersusAllModelParametersBuilder.Create(Host, OneVersusAllModelParameters.OutputFormula.Softmax, predictors);
             else
-                return OneVersusAllModelParameters.Create(Host, predictors);
+                return OneVersusAllModelParametersBuilder.Create(Host, predictors);
         }
 
         private protected override void CheckDataValid(IChannel ch, RoleMappedData data)

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -37,6 +37,150 @@ namespace Microsoft.ML.Trainers
     using TDistPredictor = IDistPredictorProducing<float, float>;
     using TScalarPredictor = IPredictorProducing<float>;
     using TScalarTrainer = ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>>;
+
+    public abstract class OneVersusAllTrainerBase<T> : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParameters<T>>, OneVersusAllModelParameters<T>> where T : class
+    {
+        internal const string LoadNameValue = "OVA";
+        internal const string UserNameValue = "One-vs-All";
+        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
+            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
+            + "and choosing the prediction with the highest confidence score.";
+
+        private readonly Options _options;
+
+        /// <summary>
+        /// Options passed to <see cref="OneVersusAllTrainerBase{T}"/>
+        /// </summary>
+        internal sealed class Options : OptionsBase
+        {
+            /// <summary>
+            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
+            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
+            public bool UseProbabilities = true;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="Options"/>.
+        /// </summary>
+        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
+        /// <param name="options">The legacy <see cref="Options"/></param>
+        internal OneVersusAllTrainerBase(IHostEnvironment env, Options options)
+            : base(env, options, LoadNameValue)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="OneVersusAllTrainerBase{T}"/>.
+        /// </summary>
+        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
+        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
+        /// <param name="labelColumnName">The name of the label colum.</param>
+        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
+        /// /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
+        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
+        internal OneVersusAllTrainerBase(IHostEnvironment env,
+            TScalarTrainer binaryEstimator,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool imputeMissingLabelsAsNegative = false,
+            ICalibratorTrainer calibrator = null,
+            int maximumCalibrationExampleCount = 1000000000,
+            bool useProbabilities = true)
+         : base(env,
+               new Options
+               {
+                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative,
+                   MaxCalibrationExamples = maximumCalibrationExampleCount,
+               },
+               LoadNameValue, labelColumnName, binaryEstimator, calibrator)
+        {
+            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
+            _options = (Options)Args;
+            _options.UseProbabilities = useProbabilities;
+        }
+
+        private protected override OneVersusAllModelParameters<T> TrainCore(IChannel ch, RoleMappedData data, int count)
+        {
+            // Train one-vs-all models.
+            var predictors = new T[count];
+            for (int i = 0; i < predictors.Length; i++)
+            {
+                ch.Info($"Training learner {i}");
+                predictors[i] = (T)TrainOne(ch, Trainer, data, i).Model;
+            }
+            return OneVersusAllModelParameters<T>.Create(Host, _options.UseProbabilities, predictors);
+        }
+
+        private ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOne(IChannel ch, TScalarTrainer trainer, RoleMappedData data, int cls)
+        {
+            var view = MapLabels(data, cls);
+
+            string trainerLabel = data.Schema.Label.Value.Name;
+
+            // REVIEW: In principle we could support validation sets and the like via the train context, but
+            // this is currently unsupported.
+            var transformer = trainer.Fit(view);
+
+            return TrainOneHelper(ch, _options.UseProbabilities, view, trainerLabel, transformer);
+        }
+
+        private protected abstract ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
+            bool useProbabilities, IDataView view, string trainerLabel,
+            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer);
+
+        private IDataView MapLabels(RoleMappedData data, int cls)
+        {
+            var label = data.Schema.Label.Value;
+            Host.Assert(!label.IsHidden);
+            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
+
+            if (label.Type.GetKeyCount() > 0)
+            {
+                // Key values are 1-based.
+                uint key = (uint)(cls + 1);
+                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
+            }
+
+            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainer: {label.Type.RawType}");
+        }
+
+        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model.</summary>
+        /// <param name="input">The input data.</param>
+        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model./></returns>
+        public override MulticlassPredictionTransformer<OneVersusAllModelParameters<T>> Fit(IDataView input)
+        {
+            var roles = new KeyValuePair<CR, string>[1];
+            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
+            var td = new RoleMappedData(input, roles);
+
+            td.CheckMulticlassLabel(out var numClasses);
+
+            var predictors = new T[numClasses];
+            string featureColumn = null;
+
+            using (var ch = Host.Start("Fitting"))
+            {
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    ch.Info($"Training learner {i}");
+
+                    if (i == 0)
+                    {
+                        var transformer = TrainOne(ch, Trainer, td, i);
+                        featureColumn = transformer.FeatureColumnName;
+                    }
+                    predictors[i] = (T)TrainOne(ch, Trainer, td, i).Model;
+
+                }
+            }
+
+            return new MulticlassPredictionTransformer<OneVersusAllModelParameters<T>>(Host, OneVersusAllModelParameters<T>.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
+        }
+    }
+
     /// <summary>
     /// The <see cref="IEstimator{TTransformer}"/> for training a one-versus-all multi-class classifier that uses the specified binary classifier.
     /// </summary>
@@ -82,38 +226,16 @@ namespace Microsoft.ML.Trainers
     /// </format>
     /// </remarks>
     /// <seealso cref="StandardTrainersCatalog.OneVersusAll{TModel}(MulticlassClassificationCatalog.MulticlassClassificationTrainers, ITrainerEstimator{BinaryPredictionTransformer{TModel}, TModel}, string, bool, IEstimator{ISingleFeaturePredictionTransformer{ICalibrator}}, int, bool)" />
-    public sealed class OneVersusAllTrainer : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParameters>, OneVersusAllModelParameters>
+    public sealed class OneVersusAllTrainer : OneVersusAllTrainerBase<TScalarPredictor>
     {
-        internal const string LoadNameValue = "OVA";
-        internal const string UserNameValue = "One-vs-All";
-        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
-            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
-            + "and choosing the prediction with the highest confidence score.";
-
-        private readonly Options _options;
-
         /// <summary>
-        /// Options passed to <see cref="OneVersusAllTrainer"/>
-        /// </summary>
-        internal sealed class Options : OptionsBase
-        {
-            /// <summary>
-            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
-            /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
-            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
-            public bool UseProbabilities = true;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="OneVersusAllTrainer"/> trainer supplying a <see cref="Options"/>.
+        /// Constructs a <see cref="OneVersusAllTrainer"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
         /// </summary>
         /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
-        /// <param name="options">The legacy <see cref="Options"/></param>
+        /// <param name="options">The legacy <see cref="OneVersusAllTrainerBase{T}.Options"/></param>
         internal OneVersusAllTrainer(IHostEnvironment env, Options options)
-            : base(env, options, LoadNameValue)
+            : base(env, options)
         {
-            _options = options;
         }
 
         /// <summary>
@@ -121,10 +243,10 @@ namespace Microsoft.ML.Trainers
         /// </summary>
         /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
-        /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
+        /// /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
         /// <param name="labelColumnName">The name of the label colum.</param>
         /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
-        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
+        /// /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
         internal OneVersusAllTrainer(IHostEnvironment env,
             TScalarTrainer binaryEstimator,
@@ -133,42 +255,15 @@ namespace Microsoft.ML.Trainers
             ICalibratorTrainer calibrator = null,
             int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
-         : base(env,
-               new Options
-               {
-                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative,
-                   MaxCalibrationExamples = maximumCalibrationExampleCount,
-               },
-               LoadNameValue, labelColumnName, binaryEstimator, calibrator)
+         : base(env, binaryEstimator, labelColumnName, imputeMissingLabelsAsNegative, calibrator, maximumCalibrationExampleCount, useProbabilities)
         {
-            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
-            _options = (Options)Args;
-            _options.UseProbabilities = useProbabilities;
         }
 
-        private protected override OneVersusAllModelParameters TrainCore(IChannel ch, RoleMappedData data, int count)
+        private protected override ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
+            bool useProbabilities, IDataView view, string trainerLabel,
+            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer)
         {
-            // Train one-vs-all models.
-            var predictors = new TScalarPredictor[count];
-            for (int i = 0; i < predictors.Length; i++)
-            {
-                ch.Info($"Training learner {i}");
-                predictors[i] = TrainOne(ch, Trainer, data, i).Model;
-            }
-            return OneVersusAllModelParameters.Create(Host, _options.UseProbabilities, predictors);
-        }
-
-        private ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOne(IChannel ch, TScalarTrainer trainer, RoleMappedData data, int cls)
-        {
-            var view = MapLabels(data, cls);
-
-            string trainerLabel = data.Schema.Label.Value.Name;
-
-            // REVIEW: In principle we could support validation sets and the like via the train context, but
-            // this is currently unsupported.
-            var transformer = trainer.Fit(view);
-
-            if (_options.UseProbabilities)
+            if (useProbabilities)
             {
                 var calibratedModel = transformer.Model as TDistPredictor;
 
@@ -185,793 +280,20 @@ namespace Microsoft.ML.Trainers
 
             return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
         }
-
-        private IDataView MapLabels(RoleMappedData data, int cls)
-        {
-            var label = data.Schema.Label.Value;
-            Host.Assert(!label.IsHidden);
-            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
-
-            if (label.Type.GetKeyCount() > 0)
-            {
-                // Key values are 1-based.
-                uint key = (uint)(cls + 1);
-                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
-            }
-
-            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainer: {label.Type.RawType}");
-        }
-
-        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model.</summary>
-        /// <param name="input">The input data.</param>
-        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model./></returns>
-        public override MulticlassPredictionTransformer<OneVersusAllModelParameters> Fit(IDataView input)
-        {
-            var roles = new KeyValuePair<CR, string>[1];
-            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
-            var td = new RoleMappedData(input, roles);
-
-            td.CheckMulticlassLabel(out var numClasses);
-
-            var predictors = new TScalarPredictor[numClasses];
-            string featureColumn = null;
-
-            using (var ch = Host.Start("Fitting"))
-            {
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    ch.Info($"Training learner {i}");
-
-                    if (i == 0)
-                    {
-                        var transformer = TrainOne(ch, Trainer, td, i);
-                        featureColumn = transformer.FeatureColumnName;
-                    }
-
-                    predictors[i] = TrainOne(ch, Trainer, td, i).Model;
-                }
-            }
-
-            return new MulticlassPredictionTransformer<OneVersusAllModelParameters>(Host, OneVersusAllModelParameters.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
-        }
     }
 
-    /// <summary>
-    /// Model parameters for <see cref="OneVersusAllTrainer"/>.
-    /// </summary>
-    public sealed class OneVersusAllModelParameters :
-        ModelParametersBase<VBuffer<float>>,
-        IValueMapper,
-        ICanSaveInSourceCode,
-        ICanSaveInTextFormat,
-        ISingleCanSavePfa
+    public sealed class OneVersusAllTrainerTyped<TSubPredictor, TCalibrator> : OneVersusAllTrainerBase<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>
+        where TSubPredictor: class, IPredictorProducing<float>
+        where TCalibrator: class, ICalibrator
     {
-        internal const string LoaderSignature = "OVAExec";
-        internal const string RegistrationName = "OVAPredictor";
-
-        private static VersionInfo GetVersionInfo()
-        {
-            return new VersionInfo(
-                modelSignature: "TLC OVA ",
-                verWrittenCur: 0x00010001, // Initial
-                verReadableCur: 0x00010001,
-                verWeCanReadBack: 0x00010001,
-                loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(OneVersusAllModelParameters).Assembly.FullName);
-        }
-
-        private const string SubPredictorFmt = "SubPredictor_{0:000}";
-
-        private readonly ImplBase _impl;
-
         /// <summary>
-        /// Retrieves the model parameters.
-        /// </summary>
-        internal ImmutableArray<object> SubModelParameters => _impl.Predictors.Cast<object>().ToImmutableArray();
-
-        /// <summary>
-        /// The type of the prediction task.
-        /// </summary>
-        private protected override PredictionKind PredictionKind => PredictionKind.MulticlassClassification;
-
-        /// <summary>
-        /// Function applied to output of predictors. Assume that we have n predictors (one per class) and for the i-th predictor,
-        /// y_i is its raw output and p_i is its probability output. Note that not all predictors are able to produce probability output.
-        /// <para>
-        /// <see cref="Raw"/>: output the result of predictors without post-processing. Output is [y_1, ..., y_n].
-        /// <see cref="ProbabilityNormalization"/>: fetch probability output of each class probability from provided predictors and make sure the sume of class probabilities is one.
-        /// Output is [p_1 / (p_1 + ... + p_n), ..., p_n / (p_1 + ... + p_n)].
-        /// <see cref="Softmax"/>: Generate probability by feeding raw outputs to softmax function. Output is [z_1, ..., z_n], where z_i is exp(y_i) / (exp(y_1) + ... + exp(y_n)).
-        /// </para>
-        /// </summary>
-        [BestFriend]
-        internal enum OutputFormula { Raw = 0, ProbabilityNormalization = 1, Softmax = 2 };
-
-        private DataViewType DistType { get; }
-
-        bool ICanSavePfa.CanSavePfa => _impl.CanSavePfa;
-
-        [BestFriend]
-        internal static OneVersusAllModelParameters Create(IHost host, OutputFormula outputFormula, TScalarPredictor[] predictors)
-        {
-            ImplBase impl;
-
-            using (var ch = host.Start("Creating OVA predictor"))
-            {
-                if (outputFormula == OutputFormula.Softmax)
-                {
-                    impl = new ImplSoftmax(predictors);
-                    return new OneVersusAllModelParameters(host, impl);
-                }
-
-                // Caller of this function asks for probability output. We check if input predictor can produce probability.
-                // If that predictor can't produce probability, ivmd will be null.
-                IValueMapperDist ivmd = null;
-                if (outputFormula == OutputFormula.ProbabilityNormalization &&
-                    ((ivmd = predictors[0] as IValueMapperDist) == null ||
-                        ivmd.OutputType != NumberDataViewType.Single ||
-                        ivmd.DistType != NumberDataViewType.Single))
-                {
-                    ch.Warning($"{nameof(OneVersusAllTrainer.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainer.Options.PredictorType)} that can't produce probabilities.");
-                    ivmd = null;
-                }
-
-                // If ivmd is null, either the user didn't ask for probability or the provided predictors can't produce probability.
-                if (ivmd != null)
-                {
-                    var dists = new IValueMapperDist[predictors.Length];
-                    for (int i = 0; i < predictors.Length; ++i)
-                        dists[i] = (IValueMapperDist)predictors[i];
-                    impl = new ImplDist(dists);
-                }
-                else
-                    impl = new ImplRaw(predictors);
-            }
-
-            return new OneVersusAllModelParameters(host, impl);
-        }
-
-        [BestFriend]
-        internal static OneVersusAllModelParameters Create(IHost host, bool useProbability, TScalarPredictor[] predictors)
-        {
-            var outputFormula = useProbability ? OutputFormula.ProbabilityNormalization : OutputFormula.Raw;
-
-            return Create(host, outputFormula, predictors);
-        }
-
-        /// <summary>
-        /// Create a <see cref="OneVersusAllModelParameters"/> from an array of predictors.
-        /// </summary>
-        [BestFriend]
-        internal static OneVersusAllModelParameters Create(IHost host, TScalarPredictor[] predictors)
-        {
-            Contracts.CheckValue(host, nameof(host));
-            host.CheckNonEmpty(predictors, nameof(predictors));
-            return Create(host, OutputFormula.ProbabilityNormalization, predictors);
-        }
-
-        private OneVersusAllModelParameters(IHostEnvironment env, ImplBase impl)
-                : base(env, RegistrationName)
-        {
-            Host.AssertValue(impl, nameof(impl));
-            Host.Assert(Utils.Size(impl.Predictors) > 0);
-
-            _impl = impl;
-            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
-        }
-
-        private OneVersusAllModelParameters(IHostEnvironment env, ModelLoadContext ctx)
-                : base(env, RegistrationName, ctx)
-        {
-            // *** Binary format ***
-            // bool: useDist
-            // int: predictor count
-            bool useDist = ctx.Reader.ReadBoolByte();
-            int len = ctx.Reader.ReadInt32();
-            Host.CheckDecode(len > 0);
-
-            if (useDist)
-            {
-                var predictors = new IValueMapperDist[len];
-                LoadPredictors(Host, predictors, ctx);
-                _impl = new ImplDist(predictors);
-            }
-            else
-            {
-                var predictors = new TScalarPredictor[len];
-                LoadPredictors(Host, predictors, ctx);
-                _impl = new ImplRaw(predictors);
-            }
-
-            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
-        }
-
-        private static OneVersusAllModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
-        {
-            Contracts.CheckValue(env, nameof(env));
-            env.CheckValue(ctx, nameof(ctx));
-            ctx.CheckAtModel(GetVersionInfo());
-            return new OneVersusAllModelParameters(env, ctx);
-        }
-
-        private static void LoadPredictors<TPredictor>(IHostEnvironment env, TPredictor[] predictors, ModelLoadContext ctx)
-            where TPredictor : class
-        {
-            for (int i = 0; i < predictors.Length; i++)
-                ctx.LoadModel<TPredictor, SignatureLoadModel>(env, out predictors[i], string.Format(SubPredictorFmt, i));
-        }
-
-        private protected override void SaveCore(ModelSaveContext ctx)
-        {
-            base.SaveCore(ctx);
-            ctx.SetVersionInfo(GetVersionInfo());
-
-            var preds = _impl.Predictors;
-
-            // *** Binary format ***
-            // bool: useDist
-            // int: predictor count
-            ctx.Writer.WriteBoolByte(_impl is ImplDist);
-            ctx.Writer.Write(preds.Length);
-
-            // Save other streams.
-            for (int i = 0; i < preds.Length; i++)
-                ctx.SaveModel(preds[i], string.Format(SubPredictorFmt, i));
-        }
-
-        JToken ISingleCanSavePfa.SaveAsPfa(BoundPfaContext ctx, JToken input)
-        {
-            Host.CheckValue(ctx, nameof(ctx));
-            Host.CheckValue(input, nameof(input));
-            return _impl.SaveAsPfa(ctx, input);
-        }
-
-        DataViewType IValueMapper.InputType
-        {
-            get { return _impl.InputType; }
-        }
-
-        DataViewType IValueMapper.OutputType
-        {
-            get { return DistType; }
-        }
-        ValueMapper<TIn, TOut> IValueMapper.GetMapper<TIn, TOut>()
-        {
-            Host.Check(typeof(TIn) == typeof(VBuffer<float>));
-            Host.Check(typeof(TOut) == typeof(VBuffer<float>));
-
-            return (ValueMapper<TIn, TOut>)(Delegate)_impl.GetMapper();
-        }
-
-        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
-        {
-            Host.CheckValue(writer, nameof(writer));
-            Host.CheckValue(schema, nameof(schema));
-
-            var preds = _impl.Predictors;
-            writer.WriteLine("double[] outputs = new double[{0}];", preds.Length);
-
-            for (int i = 0; i < preds.Length; i++)
-            {
-                var saveInSourceCode = preds[i] as ICanSaveInSourceCode;
-                Host.Check(saveInSourceCode != null, "Saving in code is not supported.");
-
-                writer.WriteLine("{");
-                saveInSourceCode.SaveAsCode(writer, schema);
-                writer.WriteLine("outputs[{0}] = output;", i);
-                writer.WriteLine("}");
-            }
-        }
-
-        void ICanSaveInTextFormat.SaveAsText(TextWriter writer, RoleMappedSchema schema)
-        {
-            Host.CheckValue(writer, nameof(writer));
-            Host.CheckValue(schema, nameof(schema));
-
-            var preds = _impl.Predictors;
-
-            for (int i = 0; i < preds.Length; i++)
-            {
-                var saveInText = preds[i] as ICanSaveInTextFormat;
-                Host.Check(saveInText != null, "Saving in text is not supported.");
-
-                writer.WriteLine("#region: class-{0} classifier", i);
-                saveInText.SaveAsText(writer, schema);
-
-                writer.WriteLine("#endregion: class-{0} classifier", i);
-                writer.WriteLine();
-            }
-        }
-
-        private abstract class ImplBase : ISingleCanSavePfa
-        {
-            public abstract DataViewType InputType { get; }
-            public abstract IValueMapper[] Predictors { get; }
-            public abstract bool CanSavePfa { get; }
-            public abstract ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper();
-            public abstract JToken SaveAsPfa(BoundPfaContext ctx, JToken input);
-
-            protected bool IsValid(IValueMapper mapper, ref VectorDataViewType inputType)
-            {
-                Contracts.AssertValueOrNull(mapper);
-                Contracts.AssertValueOrNull(inputType);
-
-                if (mapper == null)
-                    return false;
-                if (mapper.OutputType != NumberDataViewType.Single)
-                    return false;
-                if (!(mapper.InputType is VectorDataViewType mapperVectorType) || mapperVectorType.ItemType != NumberDataViewType.Single)
-                    return false;
-                if (inputType == null)
-                    inputType = mapperVectorType;
-                else if (inputType.Size != mapperVectorType.Size)
-                {
-                    if (inputType.Size == 0)
-                        inputType = mapperVectorType;
-                    else if (mapperVectorType.Size != 0)
-                        return false;
-                }
-                return true;
-            }
-        }
-
-        private sealed class ImplRaw : ImplBase
-        {
-            public override DataViewType InputType { get; }
-            public override IValueMapper[] Predictors { get; }
-            public override bool CanSavePfa { get; }
-
-            internal ImplRaw(TScalarPredictor[] predictors)
-            {
-                Contracts.CheckNonEmpty(predictors, nameof(predictors));
-
-                Predictors = new IValueMapper[predictors.Length];
-                VectorDataViewType inputType = null;
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    var vm = predictors[i] as IValueMapper;
-                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
-                    Predictors[i] = vm;
-                }
-                CanSavePfa = Predictors.All(m => (m as ISingleCanSavePfa)?.CanSavePfa == true);
-                Contracts.AssertValue(inputType);
-                InputType = inputType;
-            }
-
-            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
-            {
-                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
-                for (int i = 0; i < Predictors.Length; i++)
-                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
-
-                var buffer = new float[maps.Length];
-                return
-                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
-                    {
-                        int inputSize = InputType.GetVectorSize();
-                        if (inputSize > 0)
-                            Contracts.Check(src.Length == inputSize);
-
-                        var tmp = src;
-                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
-
-                        var editor = VBufferEditor.Create(ref dst, maps.Length);
-                        buffer.CopyTo(editor.Values);
-                        dst = editor.Commit();
-                    };
-            }
-
-            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
-            {
-                Contracts.CheckValue(ctx, nameof(ctx));
-                Contracts.CheckValue(input, nameof(input));
-                Contracts.Assert(CanSavePfa);
-
-                JArray rootObjects = new JArray();
-                for (int i = 0; i < Predictors.Length; ++i)
-                {
-                    var pred = (ISingleCanSavePfa)Predictors[i];
-                    Contracts.Assert(pred.CanSavePfa);
-                    rootObjects.Add(ctx.DeclareVar(null, pred.SaveAsPfa(ctx, input)));
-                }
-                JObject jobj = null;
-                return jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
-            }
-        }
-
-        private sealed class ImplDist : ImplBase
-        {
-            private readonly IValueMapperDist[] _mappers;
-            public override DataViewType InputType { get; }
-            public override IValueMapper[] Predictors => _mappers;
-            public override bool CanSavePfa { get; }
-
-            internal ImplDist(IValueMapperDist[] predictors)
-            {
-                Contracts.Check(Utils.Size(predictors) > 0);
-
-                _mappers = new IValueMapperDist[predictors.Length];
-                VectorDataViewType inputType = null;
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    var vm = predictors[i];
-                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
-                    _mappers[i] = vm;
-                }
-                CanSavePfa = Predictors.All(m => (m as IDistCanSavePfa)?.CanSavePfa == true);
-                Contracts.AssertValue(inputType);
-                InputType = inputType;
-            }
-
-            private bool IsValid(IValueMapperDist mapper, ref VectorDataViewType inputType)
-            {
-                return base.IsValid(mapper, ref inputType) && mapper.DistType == NumberDataViewType.Single;
-            }
-
-            /// <summary>
-            /// Each predictor produces a probability of a class. All classes' probabilities are normalized so that
-            /// their sum is one.
-            /// </summary>
-            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
-            {
-                var maps = new ValueMapper<VBuffer<float>, float, float>[Predictors.Length];
-                for (int i = 0; i < Predictors.Length; i++)
-                    maps[i] = _mappers[i].GetMapper<VBuffer<float>, float, float>();
-
-                var buffer = new float[maps.Length];
-                return
-                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
-                    {
-                        int inputSize = InputType.GetVectorSize();
-                        if (inputSize > 0)
-                            Contracts.Check(src.Length == inputSize);
-
-                        var tmp = src;
-                        Parallel.For(0, maps.Length,
-                            i =>
-                            {
-                                float score = 0;
-                                // buffer[i] is the probability of the i-th class.
-                                // score is the raw prediction score.
-                                maps[i](in tmp, ref score, ref buffer[i]);
-                            });
-
-                        // buffer[i] is the probability of the i-th class.
-                        // score is the raw prediction score.
-                        NormalizeSumToOne(buffer, maps.Length);
-
-                        var editor = VBufferEditor.Create(ref dst, maps.Length);
-                        buffer.CopyTo(editor.Values);
-                        dst = editor.Commit();
-                    };
-            }
-
-            private void NormalizeSumToOne(float[] output, int count)
-            {
-                // Clamp to zero and normalize.
-                Double sum = 0;
-                for (int i = 0; i < count; i++)
-                {
-                    var value = output[i];
-                    if (float.IsNaN(value))
-                        continue;
-
-                    if (value >= 0)
-                        sum += value;
-                    else
-                        output[i] = 0;
-                }
-
-                if (sum > 0)
-                {
-                    for (int i = 0; i < count; i++)
-                        output[i] = (float)(output[i] / sum);
-                }
-            }
-
-            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
-            {
-                Contracts.CheckValue(ctx, nameof(ctx));
-                Contracts.CheckValue(input, nameof(input));
-                Contracts.Assert(CanSavePfa);
-
-                JArray rootObjects = new JArray();
-                for (int i = 0; i < Predictors.Length; ++i)
-                {
-                    var pred = (IDistCanSavePfa)Predictors[i];
-                    Contracts.Assert(pred.CanSavePfa);
-                    pred.SaveAsPfa(ctx, input, null, out JToken scoreToken, null, out JToken probToken);
-                    rootObjects.Add(probToken);
-                }
-                JObject jobj = null;
-                var rootResult = jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
-                var resultVar = ctx.DeclareVar(null, rootResult);
-                var factorVar = ctx.DeclareVar(null, PfaUtils.Call("/", 1.0, PfaUtils.Call("a.sum", resultVar)));
-                return PfaUtils.Call("la.scale", resultVar, factorVar);
-            }
-        }
-
-        private sealed class ImplSoftmax : ImplBase
-        {
-            public override DataViewType InputType { get; }
-            public override IValueMapper[] Predictors { get; }
-            public override bool CanSavePfa { get; }
-
-            internal ImplSoftmax(TScalarPredictor[] predictors)
-            {
-                Contracts.CheckNonEmpty(predictors, nameof(predictors));
-
-                Predictors = new IValueMapper[predictors.Length];
-                VectorDataViewType inputType = null;
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    var vm = predictors[i] as IValueMapper;
-                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
-                    Predictors[i] = vm;
-                }
-                CanSavePfa = false;
-                Contracts.AssertValue(inputType);
-                InputType = inputType;
-            }
-
-            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
-            {
-                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
-                for (int i = 0; i < Predictors.Length; i++)
-                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
-
-                var buffer = new float[maps.Length];
-                return
-                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
-                    {
-                        int inputSize = InputType.GetVectorSize();
-                        if (inputSize > 0)
-                            Contracts.Check(src.Length == inputSize);
-
-                        var tmp = src;
-                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
-                        NormalizeSoftmax(buffer, maps.Length);
-
-                        var editor = VBufferEditor.Create(ref dst, maps.Length);
-                        buffer.CopyTo(editor.Values);
-                        dst = editor.Commit();
-                    };
-            }
-
-            private void NormalizeSoftmax(float[] scores, int count)
-            {
-                double sum = 0;
-                var score = new double[count];
-
-                for (int i = 0; i < count; i++)
-                {
-                    score[i] = Math.Exp(scores[i]);
-                    sum += score[i];
-                }
-
-                for (int i = 0; i < count; i++)
-                    scores[i] = (float)(score[i] / sum);
-            }
-
-            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
-            {
-                throw new NotImplementedException("Softmax's PFA exporter is not implemented yet.");
-            }
-        }
-    }
-
-    public sealed class OneVersusAllTrainerTypedT<TSubPredictor, TCalibrator> : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>, OneVersusAllModelParametersTyped<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>> where TSubPredictor : class where TCalibrator: class, ICalibrator
-    {
-        internal const string LoadNameValue = "OVA";
-        internal const string UserNameValue = "One-vs-All";
-        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
-            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
-            + "and choosing the prediction with the highest confidence score.";
-
-        private readonly Options _options;
-        /// <summary>
-        /// Options passed to <see cref="OneVersusAllTrainerTyped{T}"/>
-        /// </summary>
-        internal sealed class Options : OptionsBase
-        {
-            /// <summary>
-            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
-            /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
-            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
-            public bool UseProbabilities = true;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="OneVersusAllTrainerTyped{T}"/> trainer supplying a <see cref="Options"/>.
+        /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
         /// </summary>
         /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
-        /// <param name="options">The legacy <see cref="Options"/></param>
-        internal OneVersusAllTrainerTypedT(IHostEnvironment env, Options options)
-            : base(env, options, LoadNameValue)
-        {
-            _options = options;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="OneVersusAllTrainerTyped{T}"/>.
-        /// </summary>
-        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
-        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
-        /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
-        /// <param name="labelColumnName">The name of the label colum.</param>
-        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
-        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
-        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        internal OneVersusAllTrainerTypedT(IHostEnvironment env,
-            TScalarTrainer binaryEstimator,
-            string labelColumnName = DefaultColumnNames.Label,
-            bool imputeMissingLabelsAsNegative = false,
-            ICalibratorTrainer calibrator = null,
-            int maximumCalibrationExampleCount = 1000000000,
-            bool useProbabilities = true)
-         : base(env,
-               new Options
-               {
-                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative,
-                   MaxCalibrationExamples = maximumCalibrationExampleCount,
-               },
-               LoadNameValue, labelColumnName, binaryEstimator, calibrator)
-        {
-            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
-            _options = (Options)Args;
-            _options.UseProbabilities = useProbabilities;
-        }
-
-        private protected override OneVersusAllModelParametersTyped<CalibratedModelParametersBase<TSubPredictor, TCalibrator>> TrainCore(IChannel ch, RoleMappedData data, int count)
-        {
-            // Train one-vs-all models.
-            var predictors = new CalibratedModelParametersBase<TSubPredictor, TCalibrator>[count];
-            for (int i = 0; i < predictors.Length; i++)
-            {
-                ch.Info($"Training learner {i}");
-                predictors[i] = (CalibratedModelParametersBase<TSubPredictor, TCalibrator>)TrainOne(ch, Trainer, data, i).Model;
-            }
-            return OneVersusAllModelParametersTyped<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>.Create(Host, _options.UseProbabilities, predictors);
-        }
-
-        private dynamic TrainOne(IChannel ch, dynamic trainer, RoleMappedData data, int cls)
-        {
-            /*var view = MapLabels(data, cls);
-
-            string trainerLabel = data.Schema.Label.Value.Name;
-
-            // REVIEW: In principle we could support validation sets and the like via the train context, but
-            // this is currently unsupported.
-            var transformer = trainer.Fit(view);
-
-            if (_options.UseProbabilities)
-            {
-                var calibratedModel = transformer.Model as TDistPredictor;
-
-                // If probabilities are requested and the Predictor is not calibrated or if it doesn't implement the right interface then throw.
-                Host.Check(calibratedModel != null, "Predictor is either not calibrated or does not implement the expected interface");
-
-                // REVIEW: restoring the RoleMappedData, as much as we can.
-                // not having the weight column on the data passed to the TrainCalibrator should be addressed.
-                var trainedData = new RoleMappedData(view, label: trainerLabel, feature: transformer.FeatureColumnName);
-
-                return new BinaryPredictionTransformer<TScalarPredictor>(Host, calibratedModel, trainedData.Data.Schema, transformer.FeatureColumnName);
-            }
-
-            return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);*/
-
-            var view = MapLabels(data, cls);
-
-            string trainerLabel = data.Schema.Label.Value.Name;
-
-            // REVIEW: In principle we could support validation sets and the like via the train context, but
-            // this is currently unsupported.
-            var transformer = trainer.Fit(view);
-
-            if (_options.UseProbabilities)
-            {
-                var calibratedModel = transformer.Model as TDistPredictor;
-
-                var s = transformer.Model.GetType();
-
-                // REVIEW: restoring the RoleMappedData, as much as we can.
-                // not having the weight column on the data passed to the TrainCalibrator should be addressed.
-                var trainedData = new RoleMappedData(view, label: trainerLabel, feature: transformer.FeatureColumnName);
-
-                if (calibratedModel == null)
-                    calibratedModel = CalibratorUtils.GetCalibratedPredictor<TSubPredictor, TCalibrator>(Host, ch, Calibrator, transformer.Model, trainedData, Args.MaxCalibrationExamples) as TDistPredictor;
-
-                Host.Check(calibratedModel != null, "Calibrated predictor does not implement the expected interface");
-                return new BinaryPredictionTransformer<TScalarPredictor>(Host, calibratedModel, trainedData.Data.Schema, transformer.FeatureColumnName);
-            }
-
-            return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
-        }
-
-        private IDataView MapLabels(RoleMappedData data, int cls)
-        {
-            var label = data.Schema.Label.Value;
-            Host.Assert(!label.IsHidden);
-            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
-
-            if (label.Type.GetKeyCount() > 0)
-            {
-                // Key values are 1-based.
-                uint key = (uint)(cls + 1);
-                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
-            }
-
-            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainerTyped: {label.Type.RawType}");
-        }
-
-        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParametersTyped}"/> model.</summary>
-        /// <param name="input">The input data.</param>
-        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParametersTyped}"/> model./></returns>
-        public override MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>> Fit(IDataView input)
-        {
-            var roles = new KeyValuePair<CR, string>[1];
-            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
-            var td = new RoleMappedData(input, roles);
-
-            td.CheckMulticlassLabel(out var numClasses);
-
-            var predictors = new CalibratedModelParametersBase<TSubPredictor, TCalibrator>[numClasses];
-            string featureColumn = null;
-
-            using (var ch = Host.Start("Fitting"))
-            {
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    ch.Info($"Training learner {i}");
-
-                    if (i == 0)
-                    {
-                        var transformer = TrainOne(ch, Trainer, td, i);
-                        featureColumn = transformer.FeatureColumnName;
-                    }
-                    var model = TrainOne(ch, Trainer, td, i).Model;
-                    var m = model as CalibratedModelParametersBase<TSubPredictor, TCalibrator>;
-                    predictors[i] = model as CalibratedModelParametersBase<TSubPredictor, TCalibrator>;
-
-                }
-            }
-
-            return new MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>(Host, OneVersusAllModelParametersTyped<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
-        }
-    }
-
-    public sealed class OneVersusAllTrainerTyped<T> : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<T>>, OneVersusAllModelParametersTyped<T>> where T : class
-    {
-        internal const string LoadNameValue = "OVA";
-        internal const string UserNameValue = "One-vs-All";
-        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
-            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
-            + "and choosing the prediction with the highest confidence score.";
-
-        private readonly Options _options;
-        /// <summary>
-        /// Options passed to <see cref="OneVersusAllTrainerTyped{T}"/>
-        /// </summary>
-        internal sealed class Options : OptionsBase
-        {
-            /// <summary>
-            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
-            /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
-            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
-            public bool UseProbabilities = true;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="OneVersusAllTrainerTyped{T}"/> trainer supplying a <see cref="Options"/>.
-        /// </summary>
-        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
-        /// <param name="options">The legacy <see cref="Options"/></param>
+        /// <param name="options">The legacy <see cref="OneVersusAllTrainerBase{T}.Options"/></param>
         internal OneVersusAllTrainerTyped(IHostEnvironment env, Options options)
-            : base(env, options, LoadNameValue)
+            : base(env, options)
         {
-            _options = options;
         }
 
         /// <summary>
@@ -991,42 +313,71 @@ namespace Microsoft.ML.Trainers
             ICalibratorTrainer calibrator = null,
             int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
-         : base(env,
-               new Options
-               {
-                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative,
-                   MaxCalibrationExamples = maximumCalibrationExampleCount,
-               },
-               LoadNameValue, labelColumnName, binaryEstimator, calibrator)
+         : base(env, binaryEstimator, labelColumnName, imputeMissingLabelsAsNegative, calibrator, maximumCalibrationExampleCount, useProbabilities)
         {
-            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
-            _options = (Options)Args;
-            _options.UseProbabilities = useProbabilities;
         }
 
-        private protected override OneVersusAllModelParametersTyped<T> TrainCore(IChannel ch, RoleMappedData data, int count)
+        private protected override ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
+            bool useProbabilities, IDataView view, string trainerLabel,
+            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer)
         {
-            // Train one-vs-all models.
-            var predictors = new T[count];
-            for (int i = 0; i < predictors.Length; i++)
+            if (useProbabilities)
             {
-                ch.Info($"Training learner {i}");
-                predictors[i] = (T)TrainOne(ch, Trainer, data, i).Model;
+                var calibratedModel = transformer.Model as TDistPredictor;
+
+                // REVIEW: restoring the RoleMappedData, as much as we can.
+                // not having the weight column on the data passed to the TrainCalibrator should be addressed.
+                var trainedData = new RoleMappedData(view, label: trainerLabel, feature: transformer.FeatureColumnName);
+
+                if (calibratedModel == null)
+                    calibratedModel = CalibratorUtils.GetCalibratedPredictor<TSubPredictor, TCalibrator>(Host, ch, Calibrator, (TSubPredictor)transformer.Model, trainedData, Args.MaxCalibrationExamples) as TDistPredictor;
+
+                Host.Check(calibratedModel != null, "Calibrated predictor does not implement the expected interface");
+                return new BinaryPredictionTransformer<TScalarPredictor>(Host, calibratedModel, trainedData.Data.Schema, transformer.FeatureColumnName);
             }
-            return OneVersusAllModelParametersTyped<T>.Create(Host, _options.UseProbabilities, predictors);
+
+            return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
+        }
+    }
+
+    public sealed class OneVersusAllTrainerTyped<T> : OneVersusAllTrainerBase<T> where T: class
+    {
+        /// <summary>
+        /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
+        /// </summary>
+        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
+        /// <param name="options">The legacy <see cref="OneVersusAllTrainerBase{T}.Options"/></param>
+        internal OneVersusAllTrainerTyped(IHostEnvironment env, Options options)
+            : base(env, options)
+        {
         }
 
-        private dynamic TrainOne(IChannel ch, dynamic trainer, RoleMappedData data, int cls)
+        /// <summary>
+        /// Initializes a new instance of <see cref="OneVersusAllTrainerTyped{T}"/>.
+        /// </summary>
+        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
+        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
+        /// <param name="labelColumnName">The name of the label colum.</param>
+        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
+        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
+        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
+        internal OneVersusAllTrainerTyped(IHostEnvironment env,
+            TScalarTrainer binaryEstimator,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool imputeMissingLabelsAsNegative = false,
+            ICalibratorTrainer calibrator = null,
+            int maximumCalibrationExampleCount = 1000000000,
+            bool useProbabilities = true)
+         : base(env, binaryEstimator, labelColumnName, imputeMissingLabelsAsNegative, calibrator, maximumCalibrationExampleCount, useProbabilities)
         {
-            /*var view = MapLabels(data, cls);
+        }
 
-            string trainerLabel = data.Schema.Label.Value.Name;
-
-            // REVIEW: In principle we could support validation sets and the like via the train context, but
-            // this is currently unsupported.
-            var transformer = trainer.Fit(view);
-
-            if (_options.UseProbabilities)
+        private protected override ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
+            bool useProbabilities, IDataView view, string trainerLabel,
+            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer)
+        {
+            if (useProbabilities)
             {
                 var calibratedModel = transformer.Model as TDistPredictor;
 
@@ -1040,92 +391,14 @@ namespace Microsoft.ML.Trainers
                 return new BinaryPredictionTransformer<TScalarPredictor>(Host, calibratedModel, trainedData.Data.Schema, transformer.FeatureColumnName);
             }
 
-            return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);*/
-
-            var view = MapLabels(data, cls);
-
-            string trainerLabel = data.Schema.Label.Value.Name;
-
-            // REVIEW: In principle we could support validation sets and the like via the train context, but
-            // this is currently unsupported.
-            var transformer = trainer.Fit(view);
-
-            if (_options.UseProbabilities)
-            {
-                var calibratedModel = transformer.Model as TDistPredictor;
-
-                var s = transformer.Model.GetType();
-
-                // REVIEW: restoring the RoleMappedData, as much as we can.
-                // not having the weight column on the data passed to the TrainCalibrator should be addressed.
-                var trainedData = new RoleMappedData(view, label: trainerLabel, feature: transformer.FeatureColumnName);
-
-                if (calibratedModel == null)
-                    calibratedModel = CalibratorUtils.GetCalibratedPredictor<LinearBinaryModelParameters, PlattCalibrator>(Host, ch, Calibrator, transformer.Model, trainedData, Args.MaxCalibrationExamples) as TDistPredictor;
-
-                Host.Check(calibratedModel != null, "Calibrated predictor does not implement the expected interface");
-                return new BinaryPredictionTransformer<TScalarPredictor>(Host, calibratedModel, trainedData.Data.Schema, transformer.FeatureColumnName);
-            }
-
             return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
-        }
-
-        private IDataView MapLabels(RoleMappedData data, int cls)
-        {
-            var label = data.Schema.Label.Value;
-            Host.Assert(!label.IsHidden);
-            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
-
-            if (label.Type.GetKeyCount() > 0)
-            {
-                // Key values are 1-based.
-                uint key = (uint)(cls + 1);
-                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
-            }
-
-            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainerTyped: {label.Type.RawType}");
-        }
-
-        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParametersTyped}"/> model.</summary>
-        /// <param name="input">The input data.</param>
-        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParametersTyped}"/> model./></returns>
-        public override MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<T>> Fit(IDataView input)
-        {
-            var roles = new KeyValuePair<CR, string>[1];
-            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
-            var td = new RoleMappedData(input, roles);
-
-            td.CheckMulticlassLabel(out var numClasses);
-
-            var predictors = new T[numClasses];
-            string featureColumn = null;
-
-            using (var ch = Host.Start("Fitting"))
-            {
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    ch.Info($"Training learner {i}");
-
-                    if (i == 0)
-                    {
-                        var transformer = TrainOne(ch, Trainer, td, i);
-                        featureColumn = transformer.FeatureColumnName;
-                    }
-                    var model = TrainOne(ch, Trainer, td, i).Model;
-                    var m = model as T;
-                    predictors[i] = model as T;
-
-                }
-            }
-
-            return new MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<T>>(Host, OneVersusAllModelParametersTyped<T>.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
         }
     }
 
     /// <summary>
-    /// Model parameters for <see cref="OneVersusAllTrainerTyped{T}"/>.
+    /// Model parameters for <see cref="OneVersusAllTrainerBase{T}"/>.
     /// </summary>
-    public sealed class OneVersusAllModelParametersTyped<T> :
+    public class OneVersusAllModelParameters<T> :
         ModelParametersBase<VBuffer<float>>,
         IValueMapper,
         ICanSaveInSourceCode,
@@ -1136,7 +409,7 @@ namespace Microsoft.ML.Trainers
         internal const string LoaderSignature = "OVAExec";
         internal const string RegistrationName = "OVAPredictor";
 
-        private static VersionInfo GetVersionInfo()
+        private protected static VersionInfo GetVersionInfo()
         {
             return new VersionInfo(
                 modelSignature: "TLC OVA ",
@@ -1144,7 +417,7 @@ namespace Microsoft.ML.Trainers
                 verReadableCur: 0x00010001,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(OneVersusAllModelParametersTyped<T>).Assembly.FullName);
+                loaderAssemblyName: typeof(OneVersusAllModelParameters<T>).Assembly.FullName);
         }
 
         private const string SubPredictorFmt = "SubPredictor_{0:000}";
@@ -1179,7 +452,7 @@ namespace Microsoft.ML.Trainers
         bool ICanSavePfa.CanSavePfa => _impl.CanSavePfa;
 
         [BestFriend]
-        internal static OneVersusAllModelParametersTyped<T> Create(IHost host, OutputFormula outputFormula, T[] predictors)
+        internal static OneVersusAllModelParameters<T> Create(IHost host, OutputFormula outputFormula, T[] predictors)
         {
             ImplBase impl;
 
@@ -1188,7 +461,7 @@ namespace Microsoft.ML.Trainers
                 if (outputFormula == OutputFormula.Softmax)
                 {
                     impl = new ImplSoftmax(predictors);
-                    return new OneVersusAllModelParametersTyped<T>(host, impl);
+                    return new OneVersusAllModelParameters<T>(host, impl);
                 }
 
                 // Caller of this function asks for probability output. We check if input predictor can produce probability.
@@ -1199,7 +472,7 @@ namespace Microsoft.ML.Trainers
                         ivmd.OutputType != NumberDataViewType.Single ||
                         ivmd.DistType != NumberDataViewType.Single))
                 {
-                    ch.Warning($"{nameof(OneVersusAllTrainerTyped<T>.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainerTyped<T>.Options.PredictorType)} that can't produce probabilities.");
+                    ch.Warning($"{nameof(OneVersusAllTrainerBase<T>.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainerBase<T>.Options.PredictorType)} that can't produce probabilities.");
                     ivmd = null;
                 }
 
@@ -1212,11 +485,11 @@ namespace Microsoft.ML.Trainers
                     impl = new ImplRaw(predictors);
             }
 
-            return new OneVersusAllModelParametersTyped<T>(host, impl);
+            return new OneVersusAllModelParameters<T>(host, impl);
         }
 
         [BestFriend]
-        internal static OneVersusAllModelParametersTyped<T> Create(IHost host, bool useProbability, T[] predictors)
+        internal static OneVersusAllModelParameters<T> Create(IHost host, bool useProbability, T[] predictors)
         {
             var outputFormula = useProbability ? OutputFormula.ProbabilityNormalization : OutputFormula.Raw;
 
@@ -1224,17 +497,17 @@ namespace Microsoft.ML.Trainers
         }
 
         /// <summary>
-        /// Create a <see cref="OneVersusAllModelParametersTyped{T}"/> from an array of predictors.
+        /// Create a <see cref="OneVersusAllModelParameters{T}"/> from an array of predictors.
         /// </summary>
         [BestFriend]
-        internal static OneVersusAllModelParametersTyped<T> Create(IHost host, T[] predictors)
+        internal static OneVersusAllModelParameters<T> Create(IHost host, T[] predictors)
         {
             Contracts.CheckValue(host, nameof(host));
             host.CheckNonEmpty(predictors, nameof(predictors));
             return Create(host, OutputFormula.ProbabilityNormalization, predictors);
         }
 
-        private OneVersusAllModelParametersTyped(IHostEnvironment env, ImplBase impl)
+        private protected OneVersusAllModelParameters(IHostEnvironment env, ImplBase impl)
                 : base(env, RegistrationName)
         {
             Host.AssertValue(impl, nameof(impl));
@@ -1244,7 +517,7 @@ namespace Microsoft.ML.Trainers
             DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
         }
 
-        private OneVersusAllModelParametersTyped(IHostEnvironment env, ModelLoadContext ctx)
+        private protected OneVersusAllModelParameters(IHostEnvironment env, ModelLoadContext ctx)
                 : base(env, RegistrationName, ctx)
         {
             // *** Binary format ***
@@ -1270,12 +543,12 @@ namespace Microsoft.ML.Trainers
             DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
         }
 
-        private static OneVersusAllModelParametersTyped<T> Create(IHostEnvironment env, ModelLoadContext ctx)
+        private static OneVersusAllModelParameters<T> Create(IHostEnvironment env, ModelLoadContext ctx)
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(ctx, nameof(ctx));
             ctx.CheckAtModel(GetVersionInfo());
-            return new OneVersusAllModelParametersTyped<T>(env, ctx);
+            return new OneVersusAllModelParameters<T>(env, ctx);
         }
 
         private static void LoadPredictors<TPredictor>(IHostEnvironment env, TPredictor[] predictors, ModelLoadContext ctx)
@@ -1367,7 +640,7 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        private abstract class ImplBase : ISingleCanSavePfa
+        private protected abstract class ImplBase : ISingleCanSavePfa
         {
             public abstract DataViewType InputType { get; }
             public abstract IValueMapper[] Predictors { get; }
@@ -1399,7 +672,7 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        private sealed class ImplRaw : ImplBase
+        private protected sealed class ImplRaw : ImplBase
         {
             public override DataViewType InputType { get; }
             public override IValueMapper[] Predictors { get; }
@@ -1463,7 +736,7 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        private sealed class ImplDist : ImplBase
+        private protected sealed class ImplDist : ImplBase
         {
             private readonly IValueMapperDist[] _mappers;
             public override DataViewType InputType { get; }
@@ -1575,7 +848,7 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        private sealed class ImplSoftmax : ImplBase
+        private protected sealed class ImplSoftmax : ImplBase
         {
             public override DataViewType InputType { get; }
             public override IValueMapper[] Predictors { get; }
@@ -1641,6 +914,79 @@ namespace Microsoft.ML.Trainers
             {
                 throw new NotImplementedException("Softmax's PFA exporter is not implemented yet.");
             }
+        }
+    }
+
+    /// <summary>
+    /// Model parameters for <see cref="OneVersusAllTrainer"/>.
+    /// </summary>
+    public sealed class OneVersusAllModelParameters :
+            OneVersusAllModelParameters<TScalarPredictor>
+    {
+        private OneVersusAllModelParameters(IHostEnvironment env, ImplBase impl)
+                : base(env, impl)
+        {
+        }
+
+        private OneVersusAllModelParameters(IHostEnvironment env, ModelLoadContext ctx)
+                : base(env, ctx)
+        {
+        }
+
+        /// <summary>
+        /// Create a <see cref="OneVersusAllModelParameters{T}"/> from an array of predictors.
+        /// </summary>
+        [BestFriend]
+        internal static new OneVersusAllModelParameters Create(IHost host, TScalarPredictor[] predictors)
+        {
+            Contracts.CheckValue(host, nameof(host));
+            host.CheckNonEmpty(predictors, nameof(predictors));
+            return Create(host, OutputFormula.ProbabilityNormalization, predictors);
+        }
+
+        [BestFriend]
+        internal static new OneVersusAllModelParameters Create(IHost host, OutputFormula outputFormula, TScalarPredictor[] predictors)
+        {
+            ImplBase impl;
+
+            using (var ch = host.Start("Creating OVA predictor"))
+            {
+                if (outputFormula == OutputFormula.Softmax)
+                {
+                    impl = new ImplSoftmax(predictors);
+                    return new OneVersusAllModelParameters(host, impl);
+                }
+
+                // Caller of this function asks for probability output. We check if input predictor can produce probability.
+                // If that predictor can't produce probability, ivmd will be null.
+                IValueMapperDist ivmd = null;
+                if (outputFormula == OutputFormula.ProbabilityNormalization &&
+                    ((ivmd = predictors[0] as IValueMapperDist) == null ||
+                        ivmd.OutputType != NumberDataViewType.Single ||
+                        ivmd.DistType != NumberDataViewType.Single))
+                {
+                    ch.Warning($"{nameof(OneVersusAllTrainer.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainer.Options.PredictorType)} that can't produce probabilities.");
+                    ivmd = null;
+                }
+
+                // If ivmd is null, either the user didn't ask for probability or the provided predictors can't produce probability.
+                if (ivmd != null)
+                {
+                    impl = new ImplDist(predictors);
+                }
+                else
+                    impl = new ImplRaw(predictors);
+            }
+
+            return new OneVersusAllModelParameters(host, impl);
+        }
+
+        private static OneVersusAllModelParameters Create(IHostEnvironment env, ModelLoadContext ctx)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            env.CheckValue(ctx, nameof(ctx));
+            ctx.CheckAtModel(GetVersionInfo());
+            return new OneVersusAllModelParameters(env, ctx);
         }
     }
 }

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -1028,7 +1028,7 @@ namespace Microsoft.ML.Trainers
         /// <summary>
         /// Retrieves the model parameters.
         /// </summary>
-        internal ImmutableArray<T> SubModelParameters => Impl.Predictors.Cast<T>().ToImmutableArray();
+        public ImmutableArray<T> SubModelParameters => Impl.Predictors.Cast<T>().ToImmutableArray();
     }
 
     /// <summary>
@@ -1050,6 +1050,6 @@ namespace Microsoft.ML.Trainers
         /// <summary>
         /// Retrieves the model parameters.
         /// </summary>
-        internal ImmutableArray<object> SubModelParameters => Impl.Predictors.Cast<object>().ToImmutableArray();
+        public ImmutableArray<object> SubModelParameters => Impl.Predictors.Cast<object>().ToImmutableArray();
     }
 }

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -470,7 +470,8 @@ namespace Microsoft.ML.Trainers
     /// <summary>
     /// Class that holds the static create methods for the <see cref="OneVersusAllModelParameters"/> classes.
     /// </summary>
-    public class OneVersusAllModelParametersBuilder {
+    [BestFriend]
+    internal static class OneVersusAllModelParametersBuilder {
         [BestFriend]
         internal static OneVersusAllModelParameters<T> Create<T>(IHost host, OneVersusAllModelParametersBase<T>.OutputFormula outputFormula, T[] predictors) where T : class
         {

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -237,7 +237,7 @@ namespace Microsoft.ML.Trainers
     }
 
     /// <summary>
-    /// Implementation of the <see cref="OneVersusAllTrainerBase{T}"/> where T is a <see cref="OneVersusAllModelParameters"/>
+    /// Implementation of the <see cref="OneVersusAllTrainer{T}"/> where T is a <see cref="OneVersusAllModelParameters"/>
     /// to maintain api compatability.
     /// </summary>
     public sealed class OneVersusAllTrainer : OneVersusAllTrainerBase<OneVersusAllModelParameters>
@@ -319,8 +319,8 @@ namespace Microsoft.ML.Trainers
     /// </summary>
     /// <typeparam name="TSubPredictor"></typeparam>
     /// <typeparam name="TCalibrator"></typeparam>
-    public sealed class OneVersusAllTrainer<TSubPredictor, TCalibrator> : OneVersusAllTrainerBase<OneVersusAllModelParametersBase<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>
-        where TSubPredictor : class, IPredictorProducing<float>
+    public sealed class OneVersusAllTrainer<TSubPredictor, TCalibrator> : OneVersusAllTrainerBase<OneVersusAllModelParameters<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>
+        where TSubPredictor : class
         where TCalibrator : class, ICalibrator
     {
         /// <summary>
@@ -375,12 +375,12 @@ namespace Microsoft.ML.Trainers
 
             return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
         }
-        private protected override MulticlassPredictionTransformer<OneVersusAllModelParametersBase<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>> FitHelper(IHost host, bool useProbabilities, TScalarPredictor[] predictors, DataViewSchema schema, string featureColumn, string labelColumnName)
+        private protected override MulticlassPredictionTransformer<OneVersusAllModelParameters<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>> FitHelper(IHost host, bool useProbabilities, TScalarPredictor[] predictors, DataViewSchema schema, string featureColumn, string labelColumnName)
         {
-            return new MulticlassPredictionTransformer<OneVersusAllModelParametersBase<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>(Host, OneVersusAllModelParametersBuilder.Create(Host, useProbabilities, predictors.Cast<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>().ToArray()), schema, featureColumn, LabelColumn.Name);
+            return new MulticlassPredictionTransformer<OneVersusAllModelParameters<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>(Host, OneVersusAllModelParametersBuilder.Create(Host, useProbabilities, predictors.Cast<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>().ToArray()), schema, featureColumn, LabelColumn.Name);
         }
 
-        private protected override OneVersusAllModelParametersBase<CalibratedModelParametersBase<TSubPredictor, TCalibrator>> TrainCore(IChannel ch, RoleMappedData data, int count)
+        private protected override OneVersusAllModelParameters<CalibratedModelParametersBase<TSubPredictor, TCalibrator>> TrainCore(IChannel ch, RoleMappedData data, int count)
         {
             // Train one-vs-all models.
             var predictors = new CalibratedModelParametersBase<TSubPredictor, TCalibrator>[count];
@@ -399,7 +399,7 @@ namespace Microsoft.ML.Trainers
     /// This cannot be used to turn a non calibrated binary classification estimator into its calibrated version. If that is required, use <see cref="OneVersusAllTrainer{TSubPredictor, TCalibrator}"/> instead.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public sealed class OneVersusAllTrainer<T> : OneVersusAllTrainerBase<OneVersusAllModelParametersBase<T>> where T : class
+    public sealed class OneVersusAllTrainer<T> : OneVersusAllTrainerBase<OneVersusAllModelParameters<T>> where T : class
     {
         /// <summary>
         /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
@@ -449,12 +449,12 @@ namespace Microsoft.ML.Trainers
             return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
         }
 
-        private protected override MulticlassPredictionTransformer<OneVersusAllModelParametersBase<T>> FitHelper(IHost host, bool useProbabilities, TScalarPredictor[] predictors, DataViewSchema schema, string featureColumn, string labelColumnName)
+        private protected override MulticlassPredictionTransformer<OneVersusAllModelParameters<T>> FitHelper(IHost host, bool useProbabilities, TScalarPredictor[] predictors, DataViewSchema schema, string featureColumn, string labelColumnName)
         {
-            return new MulticlassPredictionTransformer<OneVersusAllModelParametersBase<T>>(Host, OneVersusAllModelParametersBuilder.Create<T>(Host, useProbabilities, predictors.Cast<T>().ToArray()), schema, featureColumn, LabelColumn.Name);
+            return new MulticlassPredictionTransformer<OneVersusAllModelParameters<T>>(Host, OneVersusAllModelParametersBuilder.Create<T>(Host, useProbabilities, predictors.Cast<T>().ToArray()), schema, featureColumn, LabelColumn.Name);
         }
 
-        private protected override OneVersusAllModelParametersBase<T> TrainCore(IChannel ch, RoleMappedData data, int count)
+        private protected override OneVersusAllModelParameters<T> TrainCore(IChannel ch, RoleMappedData data, int count)
         {
             // Train one-vs-all models.
             var predictors = new T[count];
@@ -473,7 +473,7 @@ namespace Microsoft.ML.Trainers
     [BestFriend]
     internal static class OneVersusAllModelParametersBuilder {
         [BestFriend]
-        internal static OneVersusAllModelParameters<T> Create<T>(IHost host, OneVersusAllModelParametersBase<T>.OutputFormula outputFormula, T[] predictors) where T : class
+        internal static OneVersusAllModelParameters<T> Create<T>(IHost host, OneVersusAllModelParameters<T>.OutputFormula outputFormula, T[] predictors) where T : class
         {
             return new OneVersusAllModelParameters<T>(host, outputFormula, predictors);
         }
@@ -481,7 +481,7 @@ namespace Microsoft.ML.Trainers
         [BestFriend]
         internal static OneVersusAllModelParameters<T> Create<T>(IHost host, bool useProbability, T[] predictors) where T : class
         {
-            var outputFormula = useProbability ? OneVersusAllModelParametersBase<T>.OutputFormula.ProbabilityNormalization : OneVersusAllModelParametersBase<T>.OutputFormula.Raw;
+            var outputFormula = useProbability ? OneVersusAllModelParameters<T>.OutputFormula.ProbabilityNormalization : OneVersusAllModelParameters<T>.OutputFormula.Raw;
 
             return Create(host, outputFormula, predictors);
         }
@@ -527,18 +527,17 @@ namespace Microsoft.ML.Trainers
     /// <summary>
     /// Base model parameters for <see cref="OneVersusAllTrainer"/>.
     /// </summary>
-    public abstract class OneVersusAllModelParametersBase<T> :
+    public abstract class OneVersusAllModelParametersBase :
         ModelParametersBase<VBuffer<float>>,
         IValueMapper,
         ICanSaveInSourceCode,
         ICanSaveInTextFormat,
         ISingleCanSavePfa
-        where T : class
     {
         internal const string LoaderSignature = "OVAExec";
         internal const string RegistrationName = "OVAPredictor";
 
-        private protected static VersionInfo GetVersionInfo()
+        private static VersionInfo GetVersionInfo()
         {
             return new VersionInfo(
                 modelSignature: "TLC OVA ",
@@ -546,17 +545,12 @@ namespace Microsoft.ML.Trainers
                 verReadableCur: 0x00010001,
                 verWeCanReadBack: 0x00010001,
                 loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(OneVersusAllModelParametersBase<T>).Assembly.FullName);
+                loaderAssemblyName: typeof(OneVersusAllModelParameters).Assembly.FullName);
         }
 
         private const string SubPredictorFmt = "SubPredictor_{0:000}";
 
-        private readonly ImplBase _impl;
-
-        /// <summary>
-        /// Retrieves the model parameters.
-        /// </summary>
-        internal ImmutableArray<T> SubModelParameters => _impl.Predictors.Cast<T>().ToImmutableArray();
+        private protected readonly ImplBase Impl;
 
         /// <summary>
         /// The type of the prediction task.
@@ -578,16 +572,16 @@ namespace Microsoft.ML.Trainers
 
         private DataViewType DistType { get; }
 
-        bool ICanSavePfa.CanSavePfa => _impl.CanSavePfa;
+        bool ICanSavePfa.CanSavePfa => Impl.CanSavePfa;
 
-        internal OneVersusAllModelParametersBase(IHostEnvironment env, OutputFormula outputFormula, T[] predictors)
+        internal OneVersusAllModelParametersBase(IHostEnvironment env, OutputFormula outputFormula, TScalarPredictor[] predictors)
                 : base(env, RegistrationName)
         {
             using (var ch = env.Start("Creating OVA predictor"))
             {
                 if (outputFormula == OutputFormula.Softmax)
                 {
-                    _impl = new ImplSoftmax(predictors);
+                    Impl = new ImplSoftmax(predictors);
                 }
 
                 // Caller of this function asks for probability output. We check if input predictor can produce probability.
@@ -600,24 +594,27 @@ namespace Microsoft.ML.Trainers
                         ivmd.OutputType != NumberDataViewType.Single ||
                         ivmd.DistType != NumberDataViewType.Single))
                     {
-                        ch.Warning($"{nameof(OneVersusAllTrainerBase<T>.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainerBase<T>.Options.PredictorType)} that can't produce probabilities.");
+                        ch.Warning($"{nameof(OneVersusAllTrainer.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainer.Options.PredictorType)} that can't produce probabilities.");
                         ivmd = null;
                     }
 
                     // If ivmd is null, either the user didn't ask for probability or the provided predictors can't produce probability.
                     if (ivmd != null)
                     {
-                        _impl = new ImplDist(predictors);
+                        var dists = new IValueMapperDist[predictors.Length];
+                        for (int i = 0; i < predictors.Length; ++i)
+                            dists[i] = (IValueMapperDist)predictors[i];
+                        Impl = new ImplDist(dists);
                     }
                     else
-                        _impl = new ImplRaw(predictors);
+                        Impl = new ImplRaw(predictors);
                 }
             }
 
-            Host.AssertValue(_impl, nameof(_impl));
-            Host.Assert(Utils.Size(_impl.Predictors) > 0);
+            Host.AssertValue(Impl, nameof(Impl));
+            Host.Assert(Utils.Size(Impl.Predictors) > 0);
 
-            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
+            DistType = new VectorDataViewType(NumberDataViewType.Single, Impl.Predictors.Length);
         }
 
         private protected OneVersusAllModelParametersBase(IHostEnvironment env, ModelLoadContext ctx)
@@ -632,18 +629,18 @@ namespace Microsoft.ML.Trainers
 
             if (useDist)
             {
-                var predictors = new T[len];
+                var predictors = new IValueMapperDist[len];
                 LoadPredictors(Host, predictors, ctx);
-                _impl = new ImplDist(predictors);
+                Impl = new ImplDist(predictors);
             }
             else
             {
-                var predictors = new T[len];
+                var predictors = new TScalarPredictor[len];
                 LoadPredictors(Host, predictors, ctx);
-                _impl = new ImplRaw(predictors);
+                Impl = new ImplRaw(predictors);
             }
 
-            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
+            DistType = new VectorDataViewType(NumberDataViewType.Single, Impl.Predictors.Length);
         }
 
         private static void LoadPredictors<TPredictor>(IHostEnvironment env, TPredictor[] predictors, ModelLoadContext ctx)
@@ -658,12 +655,12 @@ namespace Microsoft.ML.Trainers
             base.SaveCore(ctx);
             ctx.SetVersionInfo(GetVersionInfo());
 
-            var preds = _impl.Predictors;
+            var preds = Impl.Predictors;
 
             // *** Binary format ***
             // bool: useDist
             // int: predictor count
-            ctx.Writer.WriteBoolByte(_impl is ImplDist);
+            ctx.Writer.WriteBoolByte(Impl is ImplDist);
             ctx.Writer.Write(preds.Length);
 
             // Save other streams.
@@ -675,12 +672,12 @@ namespace Microsoft.ML.Trainers
         {
             Host.CheckValue(ctx, nameof(ctx));
             Host.CheckValue(input, nameof(input));
-            return _impl.SaveAsPfa(ctx, input);
+            return Impl.SaveAsPfa(ctx, input);
         }
 
         DataViewType IValueMapper.InputType
         {
-            get { return _impl.InputType; }
+            get { return Impl.InputType; }
         }
 
         DataViewType IValueMapper.OutputType
@@ -692,7 +689,7 @@ namespace Microsoft.ML.Trainers
             Host.Check(typeof(TIn) == typeof(VBuffer<float>));
             Host.Check(typeof(TOut) == typeof(VBuffer<float>));
 
-            return (ValueMapper<TIn, TOut>)(Delegate)_impl.GetMapper();
+            return (ValueMapper<TIn, TOut>)(Delegate)Impl.GetMapper();
         }
 
         void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
@@ -700,7 +697,7 @@ namespace Microsoft.ML.Trainers
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
 
-            var preds = _impl.Predictors;
+            var preds = Impl.Predictors;
             writer.WriteLine("double[] outputs = new double[{0}];", preds.Length);
 
             for (int i = 0; i < preds.Length; i++)
@@ -720,7 +717,7 @@ namespace Microsoft.ML.Trainers
             Host.CheckValue(writer, nameof(writer));
             Host.CheckValue(schema, nameof(schema));
 
-            var preds = _impl.Predictors;
+            var preds = Impl.Predictors;
 
             for (int i = 0; i < preds.Length; i++)
             {
@@ -767,13 +764,13 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        private protected sealed class ImplRaw : ImplBase
+        private sealed class ImplRaw : ImplBase
         {
             public override DataViewType InputType { get; }
             public override IValueMapper[] Predictors { get; }
             public override bool CanSavePfa { get; }
 
-            internal ImplRaw(T[] predictors)
+            internal ImplRaw(TScalarPredictor[] predictors)
             {
                 Contracts.CheckNonEmpty(predictors, nameof(predictors));
 
@@ -831,14 +828,14 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        private protected sealed class ImplDist : ImplBase
+        private sealed class ImplDist : ImplBase
         {
             private readonly IValueMapperDist[] _mappers;
             public override DataViewType InputType { get; }
             public override IValueMapper[] Predictors => _mappers;
             public override bool CanSavePfa { get; }
 
-            internal ImplDist(T[] predictors)
+            internal ImplDist(IValueMapperDist[] predictors)
             {
                 Contracts.Check(Utils.Size(predictors) > 0);
 
@@ -846,7 +843,7 @@ namespace Microsoft.ML.Trainers
                 VectorDataViewType inputType = null;
                 for (int i = 0; i < predictors.Length; i++)
                 {
-                    var vm = predictors[i] as IValueMapperDist;
+                    var vm = predictors[i];
                     Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
                     _mappers[i] = vm;
                 }
@@ -943,13 +940,13 @@ namespace Microsoft.ML.Trainers
             }
         }
 
-        private protected sealed class ImplSoftmax : ImplBase
+        private sealed class ImplSoftmax : ImplBase
         {
             public override DataViewType InputType { get; }
             public override IValueMapper[] Predictors { get; }
             public override bool CanSavePfa { get; }
 
-            internal ImplSoftmax(T[] predictors)
+            internal ImplSoftmax(TScalarPredictor[] predictors)
             {
                 Contracts.CheckNonEmpty(predictors, nameof(predictors));
 
@@ -1016,10 +1013,10 @@ namespace Microsoft.ML.Trainers
     /// Model parameters for typed versions of <see cref="OneVersusAllTrainer"/>.
     /// </summary>
     public sealed class OneVersusAllModelParameters<T> :
-        OneVersusAllModelParametersBase<T> where T : class
+        OneVersusAllModelParametersBase where T : class
     {
         internal OneVersusAllModelParameters(IHostEnvironment env, OutputFormula outputFormula, T[] predictors)
-                : base(env, outputFormula, predictors)
+                : base(env, outputFormula, predictors.Cast<IPredictorProducing<float>>().ToArray())
         {
         }
 
@@ -1027,13 +1024,18 @@ namespace Microsoft.ML.Trainers
              : base(env, ctx)
         {
         }
+
+        /// <summary>
+        /// Retrieves the model parameters.
+        /// </summary>
+        internal ImmutableArray<T> SubModelParameters => Impl.Predictors.Cast<T>().ToImmutableArray();
     }
 
     /// <summary>
     /// Model parameters for <see cref="OneVersusAllTrainer"/>.
     /// </summary>
     public sealed class OneVersusAllModelParameters :
-            OneVersusAllModelParametersBase<TScalarPredictor>
+            OneVersusAllModelParametersBase
     {
         internal OneVersusAllModelParameters(IHostEnvironment env, OutputFormula outputFormula, TScalarPredictor[] predictors)
                 : base(env, outputFormula, predictors)
@@ -1044,5 +1046,10 @@ namespace Microsoft.ML.Trainers
                 : base(env, ctx)
         {
         }
+
+        /// <summary>
+        /// Retrieves the model parameters.
+        /// </summary>
+        internal ImmutableArray<object> SubModelParameters => Impl.Predictors.Cast<object>().ToImmutableArray();
     }
 }

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -798,20 +798,25 @@ namespace Microsoft.ML.Trainers
         /// </summary>
         /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
         /// <param name="labelColumnName">The name of the label colum.</param>
         /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
+        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
         internal OneVersusAllTrainerTyped(IHostEnvironment env,
             TScalarTrainer binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
+            ICalibratorTrainer calibrator = null,
+            int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
          : base(env,
                new Options
                {
-                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative
+                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative,
+                   MaxCalibrationExamples = maximumCalibrationExampleCount,
                },
-               LoadNameValue, labelColumnName, binaryEstimator)
+               LoadNameValue, labelColumnName, binaryEstimator, calibrator)
         {
             Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
             _options = (Options)Args;

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -357,19 +357,15 @@ namespace Microsoft.ML.Trainers
         /// </summary>
         /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
-        /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
         /// <param name="labelColumnName">The name of the label colum.</param>
         /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
-        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
         internal OneVersusAllTrainerTyped(IHostEnvironment env,
             TScalarTrainer binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
-            ICalibratorTrainer calibrator = null,
-            int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
-         : base(env, binaryEstimator, labelColumnName, imputeMissingLabelsAsNegative, calibrator, maximumCalibrationExampleCount, useProbabilities)
+         : base(env: env, binaryEstimator: binaryEstimator, labelColumnName: labelColumnName, imputeMissingLabelsAsNegative: imputeMissingLabelsAsNegative, useProbabilities: useProbabilities)
         {
         }
 

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -37,6 +37,667 @@ namespace Microsoft.ML.Trainers
     using TDistPredictor = IDistPredictorProducing<float, float>;
     using TScalarPredictor = IPredictorProducing<float>;
     using TScalarTrainer = ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>>;
+
+    public abstract class OneVersusAllTrainerBase<T> : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParameters<T>>, OneVersusAllModelParameters<T>> where T : class
+    {
+        internal const string LoadNameValue = "OVA";
+        internal const string UserNameValue = "One-vs-All";
+        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
+            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
+            + "and choosing the prediction with the highest confidence score.";
+
+        private readonly Options _options;
+
+        /// <summary>
+        /// Options passed to <see cref="OneVersusAllTrainerBase{T}"/>
+        /// </summary>
+        internal sealed class Options : OptionsBase
+        {
+            /// <summary>
+            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
+            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
+            public bool UseProbabilities = true;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="Options"/>.
+        /// </summary>
+        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
+        /// <param name="options">The legacy <see cref="Options"/></param>
+        internal OneVersusAllTrainerBase(IHostEnvironment env, Options options)
+            : base(env, options, LoadNameValue)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="OneVersusAllTrainerBase{T}"/>.
+        /// </summary>
+        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
+        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="labelColumnName">The name of the label colum.</param>
+        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
+        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
+        internal OneVersusAllTrainerBase(IHostEnvironment env,
+            TScalarTrainer binaryEstimator,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool imputeMissingLabelsAsNegative = false,
+            bool useProbabilities = true)
+         : base(env,
+               new Options
+               {
+                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative
+               },
+               LoadNameValue, labelColumnName, binaryEstimator)
+        {
+            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
+            _options = (Options)Args;
+            _options.UseProbabilities = useProbabilities;
+        }
+
+        private protected override OneVersusAllModelParameters<T> TrainCore(IChannel ch, RoleMappedData data, int count)
+        {
+            // Train one-vs-all models.
+            var predictors = new T[count];
+            for (int i = 0; i < predictors.Length; i++)
+            {
+                ch.Info($"Training learner {i}");
+                predictors[i] = (T)TrainOne(ch, Trainer, data, i).Model;
+            }
+            return OneVersusAllModelParameters<T>.Create(Host, _options.UseProbabilities, predictors);
+        }
+
+        private ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOne(IChannel ch, TScalarTrainer trainer, RoleMappedData data, int cls)
+        {
+            var view = MapLabels(data, cls);
+
+            string trainerLabel = data.Schema.Label.Value.Name;
+
+            // REVIEW: In principle we could support validation sets and the like via the train context, but
+            // this is currently unsupported.
+            var transformer = trainer.Fit(view);
+
+            return TrainOneHelper(ch, _options.UseProbabilities, view, trainerLabel, transformer);
+        }
+
+        private protected abstract ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
+            bool useProbabilities, IDataView view, string trainerLabel,
+            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer);
+
+        private IDataView MapLabels(RoleMappedData data, int cls)
+        {
+            var label = data.Schema.Label.Value;
+            Host.Assert(!label.IsHidden);
+            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
+
+            if (label.Type.GetKeyCount() > 0)
+            {
+                // Key values are 1-based.
+                uint key = (uint)(cls + 1);
+                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
+            }
+
+            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainer: {label.Type.RawType}");
+        }
+
+        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model.</summary>
+        /// <param name="input">The input data.</param>
+        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model./></returns>
+        public override MulticlassPredictionTransformer<OneVersusAllModelParameters<T>> Fit(IDataView input)
+        {
+            var roles = new KeyValuePair<CR, string>[1];
+            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
+            var td = new RoleMappedData(input, roles);
+
+            td.CheckMulticlassLabel(out var numClasses);
+
+            var predictors = new T[numClasses];
+            string featureColumn = null;
+
+            using (var ch = Host.Start("Fitting"))
+            {
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    ch.Info($"Training learner {i}");
+
+                    if (i == 0)
+                    {
+                        var transformer = TrainOne(ch, Trainer, td, i);
+                        featureColumn = transformer.FeatureColumnName;
+                    }
+                    predictors[i] = (T)TrainOne(ch, Trainer, td, i).Model;
+
+                }
+            }
+
+            return new MulticlassPredictionTransformer<OneVersusAllModelParameters<T>>(Host, OneVersusAllModelParameters<T>.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
+        }
+    }
+
+    /// <summary>
+    /// Model parameters for <see cref="OneVersusAllTrainerBase{T}"/>.
+    /// </summary>
+    public sealed class OneVersusAllModelParameters<T> :
+        ModelParametersBase<VBuffer<float>>,
+        IValueMapper,
+        ICanSaveInSourceCode,
+        ICanSaveInTextFormat,
+        ISingleCanSavePfa
+        where T : class
+    {
+        internal const string LoaderSignature = "OVAExec";
+        internal const string RegistrationName = "OVAPredictor";
+
+        private static VersionInfo GetVersionInfo()
+        {
+            return new VersionInfo(
+                modelSignature: "TLC OVA ",
+                verWrittenCur: 0x00010001, // Initial
+                verReadableCur: 0x00010001,
+                verWeCanReadBack: 0x00010001,
+                loaderSignature: LoaderSignature,
+                loaderAssemblyName: typeof(OneVersusAllModelParameters<T>).Assembly.FullName);
+        }
+
+        private const string SubPredictorFmt = "SubPredictor_{0:000}";
+
+        private readonly ImplBase _impl;
+
+        /// <summary>
+        /// Retrieves the model parameters.
+        /// </summary>
+        internal ImmutableArray<T> SubModelParameters => _impl.Predictors.Cast<T>().ToImmutableArray();
+
+        /// <summary>
+        /// The type of the prediction task.
+        /// </summary>
+        private protected override PredictionKind PredictionKind => PredictionKind.MulticlassClassification;
+
+        /// <summary>
+        /// Function applied to output of predictors. Assume that we have n predictors (one per class) and for the i-th predictor,
+        /// y_i is its raw output and p_i is its probability output. Note that not all predictors are able to produce probability output.
+        /// <para>
+        /// <see cref="Raw"/>: output the result of predictors without post-processing. Output is [y_1, ..., y_n].
+        /// <see cref="ProbabilityNormalization"/>: fetch probability output of each class probability from provided predictors and make sure the sume of class probabilities is one.
+        /// Output is [p_1 / (p_1 + ... + p_n), ..., p_n / (p_1 + ... + p_n)].
+        /// <see cref="Softmax"/>: Generate probability by feeding raw outputs to softmax function. Output is [z_1, ..., z_n], where z_i is exp(y_i) / (exp(y_1) + ... + exp(y_n)).
+        /// </para>
+        /// </summary>
+        [BestFriend]
+        internal enum OutputFormula { Raw = 0, ProbabilityNormalization = 1, Softmax = 2 };
+
+        private DataViewType DistType { get; }
+
+        bool ICanSavePfa.CanSavePfa => _impl.CanSavePfa;
+
+        [BestFriend]
+        internal static OneVersusAllModelParameters<T> Create(IHost host, OutputFormula outputFormula, T[] predictors)
+        {
+            ImplBase impl;
+
+            using (var ch = host.Start("Creating OVA predictor"))
+            {
+                if (outputFormula == OutputFormula.Softmax)
+                {
+                    impl = new ImplSoftmax(predictors);
+                    return new OneVersusAllModelParameters<T>(host, impl);
+                }
+
+                // Caller of this function asks for probability output. We check if input predictor can produce probability.
+                // If that predictor can't produce probability, ivmd will be null.
+                IValueMapperDist ivmd = null;
+                if (outputFormula == OutputFormula.ProbabilityNormalization &&
+                    ((ivmd = predictors[0] as IValueMapperDist) == null ||
+                        ivmd.OutputType != NumberDataViewType.Single ||
+                        ivmd.DistType != NumberDataViewType.Single))
+                {
+                    ch.Warning($"{nameof(OneVersusAllTrainerBase<T>.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainerBase<T>.Options.PredictorType)} that can't produce probabilities.");
+                    ivmd = null;
+                }
+
+                // If ivmd is null, either the user didn't ask for probability or the provided predictors can't produce probability.
+                if (ivmd != null)
+                {
+                    impl = new ImplDist(predictors);
+                }
+                else
+                    impl = new ImplRaw(predictors);
+            }
+
+            return new OneVersusAllModelParameters<T>(host, impl);
+        }
+
+        [BestFriend]
+        internal static OneVersusAllModelParameters<T> Create(IHost host, bool useProbability, T[] predictors)
+        {
+            var outputFormula = useProbability ? OutputFormula.ProbabilityNormalization : OutputFormula.Raw;
+
+            return Create(host, outputFormula, predictors);
+        }
+
+        /// <summary>
+        /// Create a <see cref="OneVersusAllModelParameters{T}"/> from an array of predictors.
+        /// </summary>
+        [BestFriend]
+        internal static OneVersusAllModelParameters<T> Create(IHost host, T[] predictors)
+        {
+            Contracts.CheckValue(host, nameof(host));
+            host.CheckNonEmpty(predictors, nameof(predictors));
+            return Create(host, OutputFormula.ProbabilityNormalization, predictors);
+        }
+
+        private OneVersusAllModelParameters(IHostEnvironment env, ImplBase impl)
+                : base(env, RegistrationName)
+        {
+            Host.AssertValue(impl, nameof(impl));
+            Host.Assert(Utils.Size(impl.Predictors) > 0);
+
+            _impl = impl;
+            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
+        }
+
+        private OneVersusAllModelParameters(IHostEnvironment env, ModelLoadContext ctx)
+                : base(env, RegistrationName, ctx)
+        {
+            // *** Binary format ***
+            // bool: useDist
+            // int: predictor count
+            bool useDist = ctx.Reader.ReadBoolByte();
+            int len = ctx.Reader.ReadInt32();
+            Host.CheckDecode(len > 0);
+
+            if (useDist)
+            {
+                var predictors = new T[len];
+                LoadPredictors(Host, predictors, ctx);
+                _impl = new ImplDist(predictors);
+            }
+            else
+            {
+                var predictors = new T[len];
+                LoadPredictors(Host, predictors, ctx);
+                _impl = new ImplRaw(predictors);
+            }
+
+            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
+        }
+
+        private static OneVersusAllModelParameters<T> Create(IHostEnvironment env, ModelLoadContext ctx)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            env.CheckValue(ctx, nameof(ctx));
+            ctx.CheckAtModel(GetVersionInfo());
+            return new OneVersusAllModelParameters<T>(env, ctx);
+        }
+
+        private static void LoadPredictors<TPredictor>(IHostEnvironment env, TPredictor[] predictors, ModelLoadContext ctx)
+            where TPredictor : class
+        {
+            for (int i = 0; i < predictors.Length; i++)
+                ctx.LoadModel<TPredictor, SignatureLoadModel>(env, out predictors[i], string.Format(SubPredictorFmt, i));
+        }
+
+        private protected override void SaveCore(ModelSaveContext ctx)
+        {
+            base.SaveCore(ctx);
+            ctx.SetVersionInfo(GetVersionInfo());
+
+            var preds = _impl.Predictors;
+
+            // *** Binary format ***
+            // bool: useDist
+            // int: predictor count
+            ctx.Writer.WriteBoolByte(_impl is ImplDist);
+            ctx.Writer.Write(preds.Length);
+
+            // Save other streams.
+            for (int i = 0; i < preds.Length; i++)
+                ctx.SaveModel(preds[i], string.Format(SubPredictorFmt, i));
+        }
+
+        JToken ISingleCanSavePfa.SaveAsPfa(BoundPfaContext ctx, JToken input)
+        {
+            Host.CheckValue(ctx, nameof(ctx));
+            Host.CheckValue(input, nameof(input));
+            return _impl.SaveAsPfa(ctx, input);
+        }
+
+        DataViewType IValueMapper.InputType
+        {
+            get { return _impl.InputType; }
+        }
+
+        DataViewType IValueMapper.OutputType
+        {
+            get { return DistType; }
+        }
+        ValueMapper<TIn, TOut> IValueMapper.GetMapper<TIn, TOut>()
+        {
+            Host.Check(typeof(TIn) == typeof(VBuffer<float>));
+            Host.Check(typeof(TOut) == typeof(VBuffer<float>));
+
+            return (ValueMapper<TIn, TOut>)(Delegate)_impl.GetMapper();
+        }
+
+        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
+        {
+            Host.CheckValue(writer, nameof(writer));
+            Host.CheckValue(schema, nameof(schema));
+
+            var preds = _impl.Predictors;
+            writer.WriteLine("double[] outputs = new double[{0}];", preds.Length);
+
+            for (int i = 0; i < preds.Length; i++)
+            {
+                var saveInSourceCode = preds[i] as ICanSaveInSourceCode;
+                Host.Check(saveInSourceCode != null, "Saving in code is not supported.");
+
+                writer.WriteLine("{");
+                saveInSourceCode.SaveAsCode(writer, schema);
+                writer.WriteLine("outputs[{0}] = output;", i);
+                writer.WriteLine("}");
+            }
+        }
+
+        void ICanSaveInTextFormat.SaveAsText(TextWriter writer, RoleMappedSchema schema)
+        {
+            Host.CheckValue(writer, nameof(writer));
+            Host.CheckValue(schema, nameof(schema));
+
+            var preds = _impl.Predictors;
+
+            for (int i = 0; i < preds.Length; i++)
+            {
+                var saveInText = preds[i] as ICanSaveInTextFormat;
+                Host.Check(saveInText != null, "Saving in text is not supported.");
+
+                writer.WriteLine("#region: class-{0} classifier", i);
+                saveInText.SaveAsText(writer, schema);
+
+                writer.WriteLine("#endregion: class-{0} classifier", i);
+                writer.WriteLine();
+            }
+        }
+
+        private abstract class ImplBase : ISingleCanSavePfa
+        {
+            public abstract DataViewType InputType { get; }
+            public abstract IValueMapper[] Predictors { get; }
+            public abstract bool CanSavePfa { get; }
+            public abstract ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper();
+            public abstract JToken SaveAsPfa(BoundPfaContext ctx, JToken input);
+
+            protected bool IsValid(IValueMapper mapper, ref VectorDataViewType inputType)
+            {
+                Contracts.AssertValueOrNull(mapper);
+                Contracts.AssertValueOrNull(inputType);
+
+                if (mapper == null)
+                    return false;
+                if (mapper.OutputType != NumberDataViewType.Single)
+                    return false;
+                if (!(mapper.InputType is VectorDataViewType mapperVectorType) || mapperVectorType.ItemType != NumberDataViewType.Single)
+                    return false;
+                if (inputType == null)
+                    inputType = mapperVectorType;
+                else if (inputType.Size != mapperVectorType.Size)
+                {
+                    if (inputType.Size == 0)
+                        inputType = mapperVectorType;
+                    else if (mapperVectorType.Size != 0)
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        private sealed class ImplRaw : ImplBase
+        {
+            public override DataViewType InputType { get; }
+            public override IValueMapper[] Predictors { get; }
+            public override bool CanSavePfa { get; }
+
+            internal ImplRaw(T[] predictors)
+            {
+                Contracts.CheckNonEmpty(predictors, nameof(predictors));
+
+                Predictors = new IValueMapper[predictors.Length];
+                VectorDataViewType inputType = null;
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    var vm = predictors[i] as IValueMapper;
+                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
+                    Predictors[i] = vm;
+                }
+                CanSavePfa = Predictors.All(m => (m as ISingleCanSavePfa)?.CanSavePfa == true);
+                Contracts.AssertValue(inputType);
+                InputType = inputType;
+            }
+
+            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
+            {
+                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
+                for (int i = 0; i < Predictors.Length; i++)
+                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
+
+                var buffer = new float[maps.Length];
+                return
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
+                    {
+                        int inputSize = InputType.GetVectorSize();
+                        if (inputSize > 0)
+                            Contracts.Check(src.Length == inputSize);
+
+                        var tmp = src;
+                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
+
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
+                    };
+            }
+
+            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
+            {
+                Contracts.CheckValue(ctx, nameof(ctx));
+                Contracts.CheckValue(input, nameof(input));
+                Contracts.Assert(CanSavePfa);
+
+                JArray rootObjects = new JArray();
+                for (int i = 0; i < Predictors.Length; ++i)
+                {
+                    var pred = (ISingleCanSavePfa)Predictors[i];
+                    Contracts.Assert(pred.CanSavePfa);
+                    rootObjects.Add(ctx.DeclareVar(null, pred.SaveAsPfa(ctx, input)));
+                }
+                JObject jobj = null;
+                return jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
+            }
+        }
+
+        private sealed class ImplDist : ImplBase
+        {
+            private readonly IValueMapperDist[] _mappers;
+            public override DataViewType InputType { get; }
+            public override IValueMapper[] Predictors => _mappers;
+            public override bool CanSavePfa { get; }
+
+            internal ImplDist(T[] predictors)
+            {
+                Contracts.Check(Utils.Size(predictors) > 0);
+
+                _mappers = new IValueMapperDist[predictors.Length];
+                VectorDataViewType inputType = null;
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    var vm = predictors[i] as IValueMapperDist;
+                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
+                    _mappers[i] = vm;
+                }
+                CanSavePfa = Predictors.All(m => (m as IDistCanSavePfa)?.CanSavePfa == true);
+                Contracts.AssertValue(inputType);
+                InputType = inputType;
+            }
+
+            private bool IsValid(IValueMapperDist mapper, ref VectorDataViewType inputType)
+            {
+                return base.IsValid(mapper, ref inputType) && mapper.DistType == NumberDataViewType.Single;
+            }
+
+            /// <summary>
+            /// Each predictor produces a probability of a class. All classes' probabilities are normalized so that
+            /// their sum is one.
+            /// </summary>
+            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
+            {
+                var maps = new ValueMapper<VBuffer<float>, float, float>[Predictors.Length];
+                for (int i = 0; i < Predictors.Length; i++)
+                    maps[i] = _mappers[i].GetMapper<VBuffer<float>, float, float>();
+
+                var buffer = new float[maps.Length];
+                return
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
+                    {
+                        int inputSize = InputType.GetVectorSize();
+                        if (inputSize > 0)
+                            Contracts.Check(src.Length == inputSize);
+
+                        var tmp = src;
+                        Parallel.For(0, maps.Length,
+                            i =>
+                            {
+                                float score = 0;
+                                // buffer[i] is the probability of the i-th class.
+                                // score is the raw prediction score.
+                                maps[i](in tmp, ref score, ref buffer[i]);
+                            });
+
+                        // buffer[i] is the probability of the i-th class.
+                        // score is the raw prediction score.
+                        NormalizeSumToOne(buffer, maps.Length);
+
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
+                    };
+            }
+
+            private void NormalizeSumToOne(float[] output, int count)
+            {
+                // Clamp to zero and normalize.
+                Double sum = 0;
+                for (int i = 0; i < count; i++)
+                {
+                    var value = output[i];
+                    if (float.IsNaN(value))
+                        continue;
+
+                    if (value >= 0)
+                        sum += value;
+                    else
+                        output[i] = 0;
+                }
+
+                if (sum > 0)
+                {
+                    for (int i = 0; i < count; i++)
+                        output[i] = (float)(output[i] / sum);
+                }
+            }
+
+            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
+            {
+                Contracts.CheckValue(ctx, nameof(ctx));
+                Contracts.CheckValue(input, nameof(input));
+                Contracts.Assert(CanSavePfa);
+
+                JArray rootObjects = new JArray();
+                for (int i = 0; i < Predictors.Length; ++i)
+                {
+                    var pred = (IDistCanSavePfa)Predictors[i];
+                    Contracts.Assert(pred.CanSavePfa);
+                    pred.SaveAsPfa(ctx, input, null, out JToken scoreToken, null, out JToken probToken);
+                    rootObjects.Add(probToken);
+                }
+                JObject jobj = null;
+                var rootResult = jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
+                var resultVar = ctx.DeclareVar(null, rootResult);
+                var factorVar = ctx.DeclareVar(null, PfaUtils.Call("/", 1.0, PfaUtils.Call("a.sum", resultVar)));
+                return PfaUtils.Call("la.scale", resultVar, factorVar);
+            }
+        }
+
+        private sealed class ImplSoftmax : ImplBase
+        {
+            public override DataViewType InputType { get; }
+            public override IValueMapper[] Predictors { get; }
+            public override bool CanSavePfa { get; }
+
+            internal ImplSoftmax(T[] predictors)
+            {
+                Contracts.CheckNonEmpty(predictors, nameof(predictors));
+
+                Predictors = new IValueMapper[predictors.Length];
+                VectorDataViewType inputType = null;
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    var vm = predictors[i] as IValueMapper;
+                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
+                    Predictors[i] = vm;
+                }
+                CanSavePfa = false;
+                Contracts.AssertValue(inputType);
+                InputType = inputType;
+            }
+
+            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
+            {
+                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
+                for (int i = 0; i < Predictors.Length; i++)
+                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
+
+                var buffer = new float[maps.Length];
+                return
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
+                    {
+                        int inputSize = InputType.GetVectorSize();
+                        if (inputSize > 0)
+                            Contracts.Check(src.Length == inputSize);
+
+                        var tmp = src;
+                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
+                        NormalizeSoftmax(buffer, maps.Length);
+
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
+                    };
+            }
+
+            private void NormalizeSoftmax(float[] scores, int count)
+            {
+                double sum = 0;
+                var score = new double[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    score[i] = Math.Exp(scores[i]);
+                    sum += score[i];
+                }
+
+                for (int i = 0; i < count; i++)
+                    scores[i] = (float)(score[i] / sum);
+            }
+
+            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
+            {
+                throw new NotImplementedException("Softmax's PFA exporter is not implemented yet.");
+            }
+        }
+    }
+
     /// <summary>
     /// The <see cref="IEstimator{TTransformer}"/> for training a one-versus-all multi-class classifier that uses the specified binary classifier.
     /// </summary>
@@ -82,93 +743,19 @@ namespace Microsoft.ML.Trainers
     /// </format>
     /// </remarks>
     /// <seealso cref="StandardTrainersCatalog.OneVersusAll{TModel}(MulticlassClassificationCatalog.MulticlassClassificationTrainers, ITrainerEstimator{BinaryPredictionTransformer{TModel}, TModel}, string, bool, IEstimator{ISingleFeaturePredictionTransformer{ICalibrator}}, int, bool)" />
-    public sealed class OneVersusAllTrainer : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParameters>, OneVersusAllModelParameters>
+    public sealed class OneVersusAllTrainer : OneVersusAllTrainerBase<TScalarPredictor>
     {
-        internal const string LoadNameValue = "OVA";
-        internal const string UserNameValue = "One-vs-All";
-        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
-            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
-            + "and choosing the prediction with the highest confidence score.";
+        //internal const string LoadNameValue = "OVA";
+        //internal const string UserNameValue = "One-vs-All";
+        //internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
+        //    + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
+        //    + "and choosing the prediction with the highest confidence score.";
 
-        private readonly Options _options;
-
-        /// <summary>
-        /// Options passed to <see cref="OneVersusAllTrainer"/>
-        /// </summary>
-        internal sealed class Options : OptionsBase
+        private protected override ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
+            bool useProbabilities, IDataView view, string trainerLabel,
+            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer)
         {
-            /// <summary>
-            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
-            /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
-            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
-            public bool UseProbabilities = true;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="OneVersusAllTrainer"/> trainer supplying a <see cref="Options"/>.
-        /// </summary>
-        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
-        /// <param name="options">The legacy <see cref="Options"/></param>
-        internal OneVersusAllTrainer(IHostEnvironment env, Options options)
-            : base(env, options, LoadNameValue)
-        {
-            _options = options;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="OneVersusAllTrainer"/>.
-        /// </summary>
-        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
-        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
-        /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
-        /// <param name="labelColumnName">The name of the label colum.</param>
-        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
-        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
-        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        internal OneVersusAllTrainer(IHostEnvironment env,
-            TScalarTrainer binaryEstimator,
-            string labelColumnName = DefaultColumnNames.Label,
-            bool imputeMissingLabelsAsNegative = false,
-            ICalibratorTrainer calibrator = null,
-            int maximumCalibrationExampleCount = 1000000000,
-            bool useProbabilities = true)
-         : base(env,
-               new Options
-               {
-                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative,
-                   MaxCalibrationExamples = maximumCalibrationExampleCount,
-               },
-               LoadNameValue, labelColumnName, binaryEstimator, calibrator)
-        {
-            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
-            _options = (Options)Args;
-            _options.UseProbabilities = useProbabilities;
-        }
-
-        private protected override OneVersusAllModelParameters TrainCore(IChannel ch, RoleMappedData data, int count)
-        {
-            // Train one-vs-all models.
-            var predictors = new TScalarPredictor[count];
-            for (int i = 0; i < predictors.Length; i++)
-            {
-                ch.Info($"Training learner {i}");
-                predictors[i] = TrainOne(ch, Trainer, data, i).Model;
-            }
-            return OneVersusAllModelParameters.Create(Host, _options.UseProbabilities, predictors);
-        }
-
-        private ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOne(IChannel ch, TScalarTrainer trainer, RoleMappedData data, int cls)
-        {
-            var view = MapLabels(data, cls);
-
-            string trainerLabel = data.Schema.Label.Value.Name;
-
-            // REVIEW: In principle we could support validation sets and the like via the train context, but
-            // this is currently unsupported.
-            var transformer = trainer.Fit(view);
-
-            if (_options.UseProbabilities)
+            if (useProbabilities)
             {
                 var calibratedModel = transformer.Model as TDistPredictor;
 
@@ -184,55 +771,6 @@ namespace Microsoft.ML.Trainers
             }
 
             return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
-        }
-
-        private IDataView MapLabels(RoleMappedData data, int cls)
-        {
-            var label = data.Schema.Label.Value;
-            Host.Assert(!label.IsHidden);
-            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
-
-            if (label.Type.GetKeyCount() > 0)
-            {
-                // Key values are 1-based.
-                uint key = (uint)(cls + 1);
-                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
-            }
-
-            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainer: {label.Type.RawType}");
-        }
-
-        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model.</summary>
-        /// <param name="input">The input data.</param>
-        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model./></returns>
-        public override MulticlassPredictionTransformer<OneVersusAllModelParameters> Fit(IDataView input)
-        {
-            var roles = new KeyValuePair<CR, string>[1];
-            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
-            var td = new RoleMappedData(input, roles);
-
-            td.CheckMulticlassLabel(out var numClasses);
-
-            var predictors = new TScalarPredictor[numClasses];
-            string featureColumn = null;
-
-            using (var ch = Host.Start("Fitting"))
-            {
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    ch.Info($"Training learner {i}");
-
-                    if (i == 0)
-                    {
-                        var transformer = TrainOne(ch, Trainer, td, i);
-                        featureColumn = transformer.FeatureColumnName;
-                    }
-
-                    predictors[i] = TrainOne(ch, Trainer, td, i).Model;
-                }
-            }
-
-            return new MulticlassPredictionTransformer<OneVersusAllModelParameters>(Host, OneVersusAllModelParameters.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
         }
     }
 

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -37,667 +37,6 @@ namespace Microsoft.ML.Trainers
     using TDistPredictor = IDistPredictorProducing<float, float>;
     using TScalarPredictor = IPredictorProducing<float>;
     using TScalarTrainer = ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>>;
-
-    public abstract class OneVersusAllTrainerBase<T> : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParameters<T>>, OneVersusAllModelParameters<T>> where T : class
-    {
-        internal const string LoadNameValue = "OVA";
-        internal const string UserNameValue = "One-vs-All";
-        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
-            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
-            + "and choosing the prediction with the highest confidence score.";
-
-        private readonly Options _options;
-
-        /// <summary>
-        /// Options passed to <see cref="OneVersusAllTrainerBase{T}"/>
-        /// </summary>
-        internal sealed class Options : OptionsBase
-        {
-            /// <summary>
-            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
-            /// </summary>
-            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
-            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
-            public bool UseProbabilities = true;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="Options"/>.
-        /// </summary>
-        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
-        /// <param name="options">The legacy <see cref="Options"/></param>
-        internal OneVersusAllTrainerBase(IHostEnvironment env, Options options)
-            : base(env, options, LoadNameValue)
-        {
-            _options = options;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="OneVersusAllTrainerBase{T}"/>.
-        /// </summary>
-        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
-        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
-        /// <param name="labelColumnName">The name of the label colum.</param>
-        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
-        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        internal OneVersusAllTrainerBase(IHostEnvironment env,
-            TScalarTrainer binaryEstimator,
-            string labelColumnName = DefaultColumnNames.Label,
-            bool imputeMissingLabelsAsNegative = false,
-            bool useProbabilities = true)
-         : base(env,
-               new Options
-               {
-                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative
-               },
-               LoadNameValue, labelColumnName, binaryEstimator)
-        {
-            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
-            _options = (Options)Args;
-            _options.UseProbabilities = useProbabilities;
-        }
-
-        private protected override OneVersusAllModelParameters<T> TrainCore(IChannel ch, RoleMappedData data, int count)
-        {
-            // Train one-vs-all models.
-            var predictors = new T[count];
-            for (int i = 0; i < predictors.Length; i++)
-            {
-                ch.Info($"Training learner {i}");
-                predictors[i] = (T)TrainOne(ch, Trainer, data, i).Model;
-            }
-            return OneVersusAllModelParameters<T>.Create(Host, _options.UseProbabilities, predictors);
-        }
-
-        private ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOne(IChannel ch, TScalarTrainer trainer, RoleMappedData data, int cls)
-        {
-            var view = MapLabels(data, cls);
-
-            string trainerLabel = data.Schema.Label.Value.Name;
-
-            // REVIEW: In principle we could support validation sets and the like via the train context, but
-            // this is currently unsupported.
-            var transformer = trainer.Fit(view);
-
-            return TrainOneHelper(ch, _options.UseProbabilities, view, trainerLabel, transformer);
-        }
-
-        private protected abstract ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
-            bool useProbabilities, IDataView view, string trainerLabel,
-            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer);
-
-        private IDataView MapLabels(RoleMappedData data, int cls)
-        {
-            var label = data.Schema.Label.Value;
-            Host.Assert(!label.IsHidden);
-            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
-
-            if (label.Type.GetKeyCount() > 0)
-            {
-                // Key values are 1-based.
-                uint key = (uint)(cls + 1);
-                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
-            }
-
-            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainer: {label.Type.RawType}");
-        }
-
-        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model.</summary>
-        /// <param name="input">The input data.</param>
-        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model./></returns>
-        public override MulticlassPredictionTransformer<OneVersusAllModelParameters<T>> Fit(IDataView input)
-        {
-            var roles = new KeyValuePair<CR, string>[1];
-            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
-            var td = new RoleMappedData(input, roles);
-
-            td.CheckMulticlassLabel(out var numClasses);
-
-            var predictors = new T[numClasses];
-            string featureColumn = null;
-
-            using (var ch = Host.Start("Fitting"))
-            {
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    ch.Info($"Training learner {i}");
-
-                    if (i == 0)
-                    {
-                        var transformer = TrainOne(ch, Trainer, td, i);
-                        featureColumn = transformer.FeatureColumnName;
-                    }
-                    predictors[i] = (T)TrainOne(ch, Trainer, td, i).Model;
-
-                }
-            }
-
-            return new MulticlassPredictionTransformer<OneVersusAllModelParameters<T>>(Host, OneVersusAllModelParameters<T>.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
-        }
-    }
-
-    /// <summary>
-    /// Model parameters for <see cref="OneVersusAllTrainerBase{T}"/>.
-    /// </summary>
-    public sealed class OneVersusAllModelParameters<T> :
-        ModelParametersBase<VBuffer<float>>,
-        IValueMapper,
-        ICanSaveInSourceCode,
-        ICanSaveInTextFormat,
-        ISingleCanSavePfa
-        where T : class
-    {
-        internal const string LoaderSignature = "OVAExec";
-        internal const string RegistrationName = "OVAPredictor";
-
-        private static VersionInfo GetVersionInfo()
-        {
-            return new VersionInfo(
-                modelSignature: "TLC OVA ",
-                verWrittenCur: 0x00010001, // Initial
-                verReadableCur: 0x00010001,
-                verWeCanReadBack: 0x00010001,
-                loaderSignature: LoaderSignature,
-                loaderAssemblyName: typeof(OneVersusAllModelParameters<T>).Assembly.FullName);
-        }
-
-        private const string SubPredictorFmt = "SubPredictor_{0:000}";
-
-        private readonly ImplBase _impl;
-
-        /// <summary>
-        /// Retrieves the model parameters.
-        /// </summary>
-        internal ImmutableArray<T> SubModelParameters => _impl.Predictors.Cast<T>().ToImmutableArray();
-
-        /// <summary>
-        /// The type of the prediction task.
-        /// </summary>
-        private protected override PredictionKind PredictionKind => PredictionKind.MulticlassClassification;
-
-        /// <summary>
-        /// Function applied to output of predictors. Assume that we have n predictors (one per class) and for the i-th predictor,
-        /// y_i is its raw output and p_i is its probability output. Note that not all predictors are able to produce probability output.
-        /// <para>
-        /// <see cref="Raw"/>: output the result of predictors without post-processing. Output is [y_1, ..., y_n].
-        /// <see cref="ProbabilityNormalization"/>: fetch probability output of each class probability from provided predictors and make sure the sume of class probabilities is one.
-        /// Output is [p_1 / (p_1 + ... + p_n), ..., p_n / (p_1 + ... + p_n)].
-        /// <see cref="Softmax"/>: Generate probability by feeding raw outputs to softmax function. Output is [z_1, ..., z_n], where z_i is exp(y_i) / (exp(y_1) + ... + exp(y_n)).
-        /// </para>
-        /// </summary>
-        [BestFriend]
-        internal enum OutputFormula { Raw = 0, ProbabilityNormalization = 1, Softmax = 2 };
-
-        private DataViewType DistType { get; }
-
-        bool ICanSavePfa.CanSavePfa => _impl.CanSavePfa;
-
-        [BestFriend]
-        internal static OneVersusAllModelParameters<T> Create(IHost host, OutputFormula outputFormula, T[] predictors)
-        {
-            ImplBase impl;
-
-            using (var ch = host.Start("Creating OVA predictor"))
-            {
-                if (outputFormula == OutputFormula.Softmax)
-                {
-                    impl = new ImplSoftmax(predictors);
-                    return new OneVersusAllModelParameters<T>(host, impl);
-                }
-
-                // Caller of this function asks for probability output. We check if input predictor can produce probability.
-                // If that predictor can't produce probability, ivmd will be null.
-                IValueMapperDist ivmd = null;
-                if (outputFormula == OutputFormula.ProbabilityNormalization &&
-                    ((ivmd = predictors[0] as IValueMapperDist) == null ||
-                        ivmd.OutputType != NumberDataViewType.Single ||
-                        ivmd.DistType != NumberDataViewType.Single))
-                {
-                    ch.Warning($"{nameof(OneVersusAllTrainerBase<T>.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainerBase<T>.Options.PredictorType)} that can't produce probabilities.");
-                    ivmd = null;
-                }
-
-                // If ivmd is null, either the user didn't ask for probability or the provided predictors can't produce probability.
-                if (ivmd != null)
-                {
-                    impl = new ImplDist(predictors);
-                }
-                else
-                    impl = new ImplRaw(predictors);
-            }
-
-            return new OneVersusAllModelParameters<T>(host, impl);
-        }
-
-        [BestFriend]
-        internal static OneVersusAllModelParameters<T> Create(IHost host, bool useProbability, T[] predictors)
-        {
-            var outputFormula = useProbability ? OutputFormula.ProbabilityNormalization : OutputFormula.Raw;
-
-            return Create(host, outputFormula, predictors);
-        }
-
-        /// <summary>
-        /// Create a <see cref="OneVersusAllModelParameters{T}"/> from an array of predictors.
-        /// </summary>
-        [BestFriend]
-        internal static OneVersusAllModelParameters<T> Create(IHost host, T[] predictors)
-        {
-            Contracts.CheckValue(host, nameof(host));
-            host.CheckNonEmpty(predictors, nameof(predictors));
-            return Create(host, OutputFormula.ProbabilityNormalization, predictors);
-        }
-
-        private OneVersusAllModelParameters(IHostEnvironment env, ImplBase impl)
-                : base(env, RegistrationName)
-        {
-            Host.AssertValue(impl, nameof(impl));
-            Host.Assert(Utils.Size(impl.Predictors) > 0);
-
-            _impl = impl;
-            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
-        }
-
-        private OneVersusAllModelParameters(IHostEnvironment env, ModelLoadContext ctx)
-                : base(env, RegistrationName, ctx)
-        {
-            // *** Binary format ***
-            // bool: useDist
-            // int: predictor count
-            bool useDist = ctx.Reader.ReadBoolByte();
-            int len = ctx.Reader.ReadInt32();
-            Host.CheckDecode(len > 0);
-
-            if (useDist)
-            {
-                var predictors = new T[len];
-                LoadPredictors(Host, predictors, ctx);
-                _impl = new ImplDist(predictors);
-            }
-            else
-            {
-                var predictors = new T[len];
-                LoadPredictors(Host, predictors, ctx);
-                _impl = new ImplRaw(predictors);
-            }
-
-            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
-        }
-
-        private static OneVersusAllModelParameters<T> Create(IHostEnvironment env, ModelLoadContext ctx)
-        {
-            Contracts.CheckValue(env, nameof(env));
-            env.CheckValue(ctx, nameof(ctx));
-            ctx.CheckAtModel(GetVersionInfo());
-            return new OneVersusAllModelParameters<T>(env, ctx);
-        }
-
-        private static void LoadPredictors<TPredictor>(IHostEnvironment env, TPredictor[] predictors, ModelLoadContext ctx)
-            where TPredictor : class
-        {
-            for (int i = 0; i < predictors.Length; i++)
-                ctx.LoadModel<TPredictor, SignatureLoadModel>(env, out predictors[i], string.Format(SubPredictorFmt, i));
-        }
-
-        private protected override void SaveCore(ModelSaveContext ctx)
-        {
-            base.SaveCore(ctx);
-            ctx.SetVersionInfo(GetVersionInfo());
-
-            var preds = _impl.Predictors;
-
-            // *** Binary format ***
-            // bool: useDist
-            // int: predictor count
-            ctx.Writer.WriteBoolByte(_impl is ImplDist);
-            ctx.Writer.Write(preds.Length);
-
-            // Save other streams.
-            for (int i = 0; i < preds.Length; i++)
-                ctx.SaveModel(preds[i], string.Format(SubPredictorFmt, i));
-        }
-
-        JToken ISingleCanSavePfa.SaveAsPfa(BoundPfaContext ctx, JToken input)
-        {
-            Host.CheckValue(ctx, nameof(ctx));
-            Host.CheckValue(input, nameof(input));
-            return _impl.SaveAsPfa(ctx, input);
-        }
-
-        DataViewType IValueMapper.InputType
-        {
-            get { return _impl.InputType; }
-        }
-
-        DataViewType IValueMapper.OutputType
-        {
-            get { return DistType; }
-        }
-        ValueMapper<TIn, TOut> IValueMapper.GetMapper<TIn, TOut>()
-        {
-            Host.Check(typeof(TIn) == typeof(VBuffer<float>));
-            Host.Check(typeof(TOut) == typeof(VBuffer<float>));
-
-            return (ValueMapper<TIn, TOut>)(Delegate)_impl.GetMapper();
-        }
-
-        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
-        {
-            Host.CheckValue(writer, nameof(writer));
-            Host.CheckValue(schema, nameof(schema));
-
-            var preds = _impl.Predictors;
-            writer.WriteLine("double[] outputs = new double[{0}];", preds.Length);
-
-            for (int i = 0; i < preds.Length; i++)
-            {
-                var saveInSourceCode = preds[i] as ICanSaveInSourceCode;
-                Host.Check(saveInSourceCode != null, "Saving in code is not supported.");
-
-                writer.WriteLine("{");
-                saveInSourceCode.SaveAsCode(writer, schema);
-                writer.WriteLine("outputs[{0}] = output;", i);
-                writer.WriteLine("}");
-            }
-        }
-
-        void ICanSaveInTextFormat.SaveAsText(TextWriter writer, RoleMappedSchema schema)
-        {
-            Host.CheckValue(writer, nameof(writer));
-            Host.CheckValue(schema, nameof(schema));
-
-            var preds = _impl.Predictors;
-
-            for (int i = 0; i < preds.Length; i++)
-            {
-                var saveInText = preds[i] as ICanSaveInTextFormat;
-                Host.Check(saveInText != null, "Saving in text is not supported.");
-
-                writer.WriteLine("#region: class-{0} classifier", i);
-                saveInText.SaveAsText(writer, schema);
-
-                writer.WriteLine("#endregion: class-{0} classifier", i);
-                writer.WriteLine();
-            }
-        }
-
-        private abstract class ImplBase : ISingleCanSavePfa
-        {
-            public abstract DataViewType InputType { get; }
-            public abstract IValueMapper[] Predictors { get; }
-            public abstract bool CanSavePfa { get; }
-            public abstract ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper();
-            public abstract JToken SaveAsPfa(BoundPfaContext ctx, JToken input);
-
-            protected bool IsValid(IValueMapper mapper, ref VectorDataViewType inputType)
-            {
-                Contracts.AssertValueOrNull(mapper);
-                Contracts.AssertValueOrNull(inputType);
-
-                if (mapper == null)
-                    return false;
-                if (mapper.OutputType != NumberDataViewType.Single)
-                    return false;
-                if (!(mapper.InputType is VectorDataViewType mapperVectorType) || mapperVectorType.ItemType != NumberDataViewType.Single)
-                    return false;
-                if (inputType == null)
-                    inputType = mapperVectorType;
-                else if (inputType.Size != mapperVectorType.Size)
-                {
-                    if (inputType.Size == 0)
-                        inputType = mapperVectorType;
-                    else if (mapperVectorType.Size != 0)
-                        return false;
-                }
-                return true;
-            }
-        }
-
-        private sealed class ImplRaw : ImplBase
-        {
-            public override DataViewType InputType { get; }
-            public override IValueMapper[] Predictors { get; }
-            public override bool CanSavePfa { get; }
-
-            internal ImplRaw(T[] predictors)
-            {
-                Contracts.CheckNonEmpty(predictors, nameof(predictors));
-
-                Predictors = new IValueMapper[predictors.Length];
-                VectorDataViewType inputType = null;
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    var vm = predictors[i] as IValueMapper;
-                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
-                    Predictors[i] = vm;
-                }
-                CanSavePfa = Predictors.All(m => (m as ISingleCanSavePfa)?.CanSavePfa == true);
-                Contracts.AssertValue(inputType);
-                InputType = inputType;
-            }
-
-            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
-            {
-                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
-                for (int i = 0; i < Predictors.Length; i++)
-                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
-
-                var buffer = new float[maps.Length];
-                return
-                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
-                    {
-                        int inputSize = InputType.GetVectorSize();
-                        if (inputSize > 0)
-                            Contracts.Check(src.Length == inputSize);
-
-                        var tmp = src;
-                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
-
-                        var editor = VBufferEditor.Create(ref dst, maps.Length);
-                        buffer.CopyTo(editor.Values);
-                        dst = editor.Commit();
-                    };
-            }
-
-            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
-            {
-                Contracts.CheckValue(ctx, nameof(ctx));
-                Contracts.CheckValue(input, nameof(input));
-                Contracts.Assert(CanSavePfa);
-
-                JArray rootObjects = new JArray();
-                for (int i = 0; i < Predictors.Length; ++i)
-                {
-                    var pred = (ISingleCanSavePfa)Predictors[i];
-                    Contracts.Assert(pred.CanSavePfa);
-                    rootObjects.Add(ctx.DeclareVar(null, pred.SaveAsPfa(ctx, input)));
-                }
-                JObject jobj = null;
-                return jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
-            }
-        }
-
-        private sealed class ImplDist : ImplBase
-        {
-            private readonly IValueMapperDist[] _mappers;
-            public override DataViewType InputType { get; }
-            public override IValueMapper[] Predictors => _mappers;
-            public override bool CanSavePfa { get; }
-
-            internal ImplDist(T[] predictors)
-            {
-                Contracts.Check(Utils.Size(predictors) > 0);
-
-                _mappers = new IValueMapperDist[predictors.Length];
-                VectorDataViewType inputType = null;
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    var vm = predictors[i] as IValueMapperDist;
-                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
-                    _mappers[i] = vm;
-                }
-                CanSavePfa = Predictors.All(m => (m as IDistCanSavePfa)?.CanSavePfa == true);
-                Contracts.AssertValue(inputType);
-                InputType = inputType;
-            }
-
-            private bool IsValid(IValueMapperDist mapper, ref VectorDataViewType inputType)
-            {
-                return base.IsValid(mapper, ref inputType) && mapper.DistType == NumberDataViewType.Single;
-            }
-
-            /// <summary>
-            /// Each predictor produces a probability of a class. All classes' probabilities are normalized so that
-            /// their sum is one.
-            /// </summary>
-            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
-            {
-                var maps = new ValueMapper<VBuffer<float>, float, float>[Predictors.Length];
-                for (int i = 0; i < Predictors.Length; i++)
-                    maps[i] = _mappers[i].GetMapper<VBuffer<float>, float, float>();
-
-                var buffer = new float[maps.Length];
-                return
-                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
-                    {
-                        int inputSize = InputType.GetVectorSize();
-                        if (inputSize > 0)
-                            Contracts.Check(src.Length == inputSize);
-
-                        var tmp = src;
-                        Parallel.For(0, maps.Length,
-                            i =>
-                            {
-                                float score = 0;
-                                // buffer[i] is the probability of the i-th class.
-                                // score is the raw prediction score.
-                                maps[i](in tmp, ref score, ref buffer[i]);
-                            });
-
-                        // buffer[i] is the probability of the i-th class.
-                        // score is the raw prediction score.
-                        NormalizeSumToOne(buffer, maps.Length);
-
-                        var editor = VBufferEditor.Create(ref dst, maps.Length);
-                        buffer.CopyTo(editor.Values);
-                        dst = editor.Commit();
-                    };
-            }
-
-            private void NormalizeSumToOne(float[] output, int count)
-            {
-                // Clamp to zero and normalize.
-                Double sum = 0;
-                for (int i = 0; i < count; i++)
-                {
-                    var value = output[i];
-                    if (float.IsNaN(value))
-                        continue;
-
-                    if (value >= 0)
-                        sum += value;
-                    else
-                        output[i] = 0;
-                }
-
-                if (sum > 0)
-                {
-                    for (int i = 0; i < count; i++)
-                        output[i] = (float)(output[i] / sum);
-                }
-            }
-
-            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
-            {
-                Contracts.CheckValue(ctx, nameof(ctx));
-                Contracts.CheckValue(input, nameof(input));
-                Contracts.Assert(CanSavePfa);
-
-                JArray rootObjects = new JArray();
-                for (int i = 0; i < Predictors.Length; ++i)
-                {
-                    var pred = (IDistCanSavePfa)Predictors[i];
-                    Contracts.Assert(pred.CanSavePfa);
-                    pred.SaveAsPfa(ctx, input, null, out JToken scoreToken, null, out JToken probToken);
-                    rootObjects.Add(probToken);
-                }
-                JObject jobj = null;
-                var rootResult = jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
-                var resultVar = ctx.DeclareVar(null, rootResult);
-                var factorVar = ctx.DeclareVar(null, PfaUtils.Call("/", 1.0, PfaUtils.Call("a.sum", resultVar)));
-                return PfaUtils.Call("la.scale", resultVar, factorVar);
-            }
-        }
-
-        private sealed class ImplSoftmax : ImplBase
-        {
-            public override DataViewType InputType { get; }
-            public override IValueMapper[] Predictors { get; }
-            public override bool CanSavePfa { get; }
-
-            internal ImplSoftmax(T[] predictors)
-            {
-                Contracts.CheckNonEmpty(predictors, nameof(predictors));
-
-                Predictors = new IValueMapper[predictors.Length];
-                VectorDataViewType inputType = null;
-                for (int i = 0; i < predictors.Length; i++)
-                {
-                    var vm = predictors[i] as IValueMapper;
-                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
-                    Predictors[i] = vm;
-                }
-                CanSavePfa = false;
-                Contracts.AssertValue(inputType);
-                InputType = inputType;
-            }
-
-            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
-            {
-                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
-                for (int i = 0; i < Predictors.Length; i++)
-                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
-
-                var buffer = new float[maps.Length];
-                return
-                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
-                    {
-                        int inputSize = InputType.GetVectorSize();
-                        if (inputSize > 0)
-                            Contracts.Check(src.Length == inputSize);
-
-                        var tmp = src;
-                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
-                        NormalizeSoftmax(buffer, maps.Length);
-
-                        var editor = VBufferEditor.Create(ref dst, maps.Length);
-                        buffer.CopyTo(editor.Values);
-                        dst = editor.Commit();
-                    };
-            }
-
-            private void NormalizeSoftmax(float[] scores, int count)
-            {
-                double sum = 0;
-                var score = new double[count];
-
-                for (int i = 0; i < count; i++)
-                {
-                    score[i] = Math.Exp(scores[i]);
-                    sum += score[i];
-                }
-
-                for (int i = 0; i < count; i++)
-                    scores[i] = (float)(score[i] / sum);
-            }
-
-            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
-            {
-                throw new NotImplementedException("Softmax's PFA exporter is not implemented yet.");
-            }
-        }
-    }
-
     /// <summary>
     /// The <see cref="IEstimator{TTransformer}"/> for training a one-versus-all multi-class classifier that uses the specified binary classifier.
     /// </summary>
@@ -743,47 +82,93 @@ namespace Microsoft.ML.Trainers
     /// </format>
     /// </remarks>
     /// <seealso cref="StandardTrainersCatalog.OneVersusAll{TModel}(MulticlassClassificationCatalog.MulticlassClassificationTrainers, ITrainerEstimator{BinaryPredictionTransformer{TModel}, TModel}, string, bool, IEstimator{ISingleFeaturePredictionTransformer{ICalibrator}}, int, bool)" />
-    public sealed class OneVersusAllTrainer : OneVersusAllTrainerBase<TScalarPredictor>
+    public sealed class OneVersusAllTrainer : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParameters>, OneVersusAllModelParameters>
     {
-        //internal const string LoadNameValue = "OVA";
-        //internal const string UserNameValue = "One-vs-All";
-        //internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
-        //    + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
-        //    + "and choosing the prediction with the highest confidence score.";
+        internal const string LoadNameValue = "OVA";
+        internal const string UserNameValue = "One-vs-All";
+        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
+            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
+            + "and choosing the prediction with the highest confidence score.";
+
+        private readonly Options _options;
 
         /// <summary>
-        /// Constructs a <see cref="OneVersusAllTrainer"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
+        /// Options passed to <see cref="OneVersusAllTrainer"/>
+        /// </summary>
+        internal sealed class Options : OptionsBase
+        {
+            /// <summary>
+            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
+            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
+            public bool UseProbabilities = true;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="OneVersusAllTrainer"/> trainer supplying a <see cref="Options"/>.
         /// </summary>
         /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
-        /// <param name="options">The legacy <see cref="OneVersusAllTrainerBase{T}.Options"/></param>
+        /// <param name="options">The legacy <see cref="Options"/></param>
         internal OneVersusAllTrainer(IHostEnvironment env, Options options)
             : base(env, options, LoadNameValue)
         {
+            _options = options;
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="OneVersusAllTrainerBase{T}"/>.
+        /// Initializes a new instance of <see cref="OneVersusAllTrainer"/>.
         /// </summary>
         /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="calibrator">The calibrator. If a calibrator is not provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
         /// <param name="labelColumnName">The name of the label colum.</param>
         /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
+        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        internal OneVersusAllTrainerBase(IHostEnvironment env,
+        internal OneVersusAllTrainer(IHostEnvironment env,
             TScalarTrainer binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
+            ICalibratorTrainer calibrator = null,
+            int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
          : base(env,
-               binaryEstimator, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities)
+               new Options
+               {
+                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative,
+                   MaxCalibrationExamples = maximumCalibrationExampleCount,
+               },
+               LoadNameValue, labelColumnName, binaryEstimator, calibrator)
         {
+            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
+            _options = (Options)Args;
+            _options.UseProbabilities = useProbabilities;
         }
 
-        private protected override ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
-            bool useProbabilities, IDataView view, string trainerLabel,
-            ISingleFeaturePredictionTransformer<TScalarPredictor> transformer)
+        private protected override OneVersusAllModelParameters TrainCore(IChannel ch, RoleMappedData data, int count)
         {
-            if (useProbabilities)
+            // Train one-vs-all models.
+            var predictors = new TScalarPredictor[count];
+            for (int i = 0; i < predictors.Length; i++)
+            {
+                ch.Info($"Training learner {i}");
+                predictors[i] = TrainOne(ch, Trainer, data, i).Model;
+            }
+            return OneVersusAllModelParameters.Create(Host, _options.UseProbabilities, predictors);
+        }
+
+        private ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOne(IChannel ch, TScalarTrainer trainer, RoleMappedData data, int cls)
+        {
+            var view = MapLabels(data, cls);
+
+            string trainerLabel = data.Schema.Label.Value.Name;
+
+            // REVIEW: In principle we could support validation sets and the like via the train context, but
+            // this is currently unsupported.
+            var transformer = trainer.Fit(view);
+
+            if (_options.UseProbabilities)
             {
                 var calibratedModel = transformer.Model as TDistPredictor;
 
@@ -799,6 +184,55 @@ namespace Microsoft.ML.Trainers
             }
 
             return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
+        }
+
+        private IDataView MapLabels(RoleMappedData data, int cls)
+        {
+            var label = data.Schema.Label.Value;
+            Host.Assert(!label.IsHidden);
+            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
+
+            if (label.Type.GetKeyCount() > 0)
+            {
+                // Key values are 1-based.
+                uint key = (uint)(cls + 1);
+                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
+            }
+
+            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainer: {label.Type.RawType}");
+        }
+
+        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model.</summary>
+        /// <param name="input">The input data.</param>
+        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParameters}"/> model./></returns>
+        public override MulticlassPredictionTransformer<OneVersusAllModelParameters> Fit(IDataView input)
+        {
+            var roles = new KeyValuePair<CR, string>[1];
+            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
+            var td = new RoleMappedData(input, roles);
+
+            td.CheckMulticlassLabel(out var numClasses);
+
+            var predictors = new TScalarPredictor[numClasses];
+            string featureColumn = null;
+
+            using (var ch = Host.Start("Fitting"))
+            {
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    ch.Info($"Training learner {i}");
+
+                    if (i == 0)
+                    {
+                        var transformer = TrainOne(ch, Trainer, td, i);
+                        featureColumn = transformer.FeatureColumnName;
+                    }
+
+                    predictors[i] = TrainOne(ch, Trainer, td, i).Model;
+                }
+            }
+
+            return new MulticlassPredictionTransformer<OneVersusAllModelParameters>(Host, OneVersusAllModelParameters.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
         }
     }
 
@@ -1264,6 +698,676 @@ namespace Microsoft.ML.Trainers
             public override bool CanSavePfa { get; }
 
             internal ImplSoftmax(TScalarPredictor[] predictors)
+            {
+                Contracts.CheckNonEmpty(predictors, nameof(predictors));
+
+                Predictors = new IValueMapper[predictors.Length];
+                VectorDataViewType inputType = null;
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    var vm = predictors[i] as IValueMapper;
+                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
+                    Predictors[i] = vm;
+                }
+                CanSavePfa = false;
+                Contracts.AssertValue(inputType);
+                InputType = inputType;
+            }
+
+            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
+            {
+                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
+                for (int i = 0; i < Predictors.Length; i++)
+                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
+
+                var buffer = new float[maps.Length];
+                return
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
+                    {
+                        int inputSize = InputType.GetVectorSize();
+                        if (inputSize > 0)
+                            Contracts.Check(src.Length == inputSize);
+
+                        var tmp = src;
+                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
+                        NormalizeSoftmax(buffer, maps.Length);
+
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
+                    };
+            }
+
+            private void NormalizeSoftmax(float[] scores, int count)
+            {
+                double sum = 0;
+                var score = new double[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    score[i] = Math.Exp(scores[i]);
+                    sum += score[i];
+                }
+
+                for (int i = 0; i < count; i++)
+                    scores[i] = (float)(score[i] / sum);
+            }
+
+            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
+            {
+                throw new NotImplementedException("Softmax's PFA exporter is not implemented yet.");
+            }
+        }
+    }
+
+    public sealed class OneVersusAllTrainerTyped<T> : MetaMulticlassTrainer<MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<T>>, OneVersusAllModelParametersTyped<T>> where T : class
+    {
+        internal const string LoadNameValue = "OVA";
+        internal const string UserNameValue = "One-vs-All";
+        internal const string Summary = "In this strategy, a binary classification algorithm is used to train one classifier for each class, "
+            + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
+            + "and choosing the prediction with the highest confidence score.";
+
+        private readonly Options _options;
+
+        /// <summary>
+        /// Options passed to <see cref="OneVersusAllTrainerTyped{T}"/>
+        /// </summary>
+        internal sealed class Options : OptionsBase
+        {
+            /// <summary>
+            /// Whether to use probabilities (vs. raw outputs) to identify top-score category.
+            /// </summary>
+            [Argument(ArgumentType.AtMostOnce, HelpText = "Use probability or margins to determine max", ShortName = "useprob")]
+            [TGUI(Label = "Use Probability", Description = "Use probabilities (vs. raw outputs) to identify top-score category")]
+            public bool UseProbabilities = true;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="OneVersusAllTrainerTyped{T}"/> trainer supplying a <see cref="Options"/>.
+        /// </summary>
+        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
+        /// <param name="options">The legacy <see cref="Options"/></param>
+        internal OneVersusAllTrainerTyped(IHostEnvironment env, Options options)
+            : base(env, options, LoadNameValue)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="OneVersusAllTrainerTyped{T}"/>.
+        /// </summary>
+        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
+        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="labelColumnName">The name of the label colum.</param>
+        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
+        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
+        internal OneVersusAllTrainerTyped(IHostEnvironment env,
+            TScalarTrainer binaryEstimator,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool imputeMissingLabelsAsNegative = false,
+            bool useProbabilities = true)
+         : base(env,
+               new Options
+               {
+                   ImputeMissingLabelsAsNegative = imputeMissingLabelsAsNegative
+               },
+               LoadNameValue, labelColumnName, binaryEstimator)
+        {
+            Host.CheckValue(labelColumnName, nameof(labelColumnName), "Label column should not be null.");
+            _options = (Options)Args;
+            _options.UseProbabilities = useProbabilities;
+        }
+
+        private protected override OneVersusAllModelParametersTyped<T> TrainCore(IChannel ch, RoleMappedData data, int count)
+        {
+            // Train one-vs-all models.
+            var predictors = new T[count];
+            for (int i = 0; i < predictors.Length; i++)
+            {
+                ch.Info($"Training learner {i}");
+                predictors[i] = (T)TrainOne(ch, Trainer, data, i).Model;
+            }
+            return OneVersusAllModelParametersTyped<T>.Create(Host, _options.UseProbabilities, predictors);
+        }
+
+        private ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOne(IChannel ch, TScalarTrainer trainer, RoleMappedData data, int cls)
+        {
+            var view = MapLabels(data, cls);
+
+            string trainerLabel = data.Schema.Label.Value.Name;
+
+            // REVIEW: In principle we could support validation sets and the like via the train context, but
+            // this is currently unsupported.
+            var transformer = trainer.Fit(view);
+
+            if (_options.UseProbabilities)
+            {
+                var calibratedModel = transformer.Model as TDistPredictor;
+
+                // If probabilities are requested and the Predictor is not calibrated or if it doesn't implement the right interface then throw.
+                Host.Check(calibratedModel != null, "Predictor is either not calibrated or does not implement the expected interface");
+
+                // REVIEW: restoring the RoleMappedData, as much as we can.
+                // not having the weight column on the data passed to the TrainCalibrator should be addressed.
+                var trainedData = new RoleMappedData(view, label: trainerLabel, feature: transformer.FeatureColumnName);
+
+                return new BinaryPredictionTransformer<TScalarPredictor>(Host, calibratedModel, trainedData.Data.Schema, transformer.FeatureColumnName);
+            }
+
+            return new BinaryPredictionTransformer<TScalarPredictor>(Host, transformer.Model, view.Schema, transformer.FeatureColumnName);
+        }
+
+        private IDataView MapLabels(RoleMappedData data, int cls)
+        {
+            var label = data.Schema.Label.Value;
+            Host.Assert(!label.IsHidden);
+            Host.Assert(label.Type.GetKeyCount() > 0 || label.Type == NumberDataViewType.Single || label.Type == NumberDataViewType.Double);
+
+            if (label.Type.GetKeyCount() > 0)
+            {
+                // Key values are 1-based.
+                uint key = (uint)(cls + 1);
+                return MapLabelsCore(NumberDataViewType.UInt32, (in uint val) => key == val, data);
+            }
+
+            throw Host.ExceptNotSupp($"Label column type is not supported by OneVersusAllTrainerTyped: {label.Type.RawType}");
+        }
+
+        /// <summary> Trains a <see cref="MulticlassPredictionTransformer{OneVersusAllModelParametersTyped}"/> model.</summary>
+        /// <param name="input">The input data.</param>
+        /// <returns>A <see cref="MulticlassPredictionTransformer{OneVersusAllModelParametersTyped}"/> model./></returns>
+        public override MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<T>> Fit(IDataView input)
+        {
+            var roles = new KeyValuePair<CR, string>[1];
+            roles[0] = new KeyValuePair<CR, string>(new CR(DefaultColumnNames.Label), LabelColumn.Name);
+            var td = new RoleMappedData(input, roles);
+
+            td.CheckMulticlassLabel(out var numClasses);
+
+            var predictors = new T[numClasses];
+            string featureColumn = null;
+
+            using (var ch = Host.Start("Fitting"))
+            {
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    ch.Info($"Training learner {i}");
+
+                    if (i == 0)
+                    {
+                        var transformer = TrainOne(ch, Trainer, td, i);
+                        featureColumn = transformer.FeatureColumnName;
+                    }
+                    predictors[i] = (T)TrainOne(ch, Trainer, td, i).Model;
+
+                }
+            }
+
+            return new MulticlassPredictionTransformer<OneVersusAllModelParametersTyped<T>>(Host, OneVersusAllModelParametersTyped<T>.Create(Host, _options.UseProbabilities, predictors), input.Schema, featureColumn, LabelColumn.Name);
+        }
+    }
+
+    /// <summary>
+    /// Model parameters for <see cref="OneVersusAllTrainerTyped{T}"/>.
+    /// </summary>
+    public sealed class OneVersusAllModelParametersTyped<T> :
+        ModelParametersBase<VBuffer<float>>,
+        IValueMapper,
+        ICanSaveInSourceCode,
+        ICanSaveInTextFormat,
+        ISingleCanSavePfa
+        where T : class
+    {
+        internal const string LoaderSignature = "OVAExec";
+        internal const string RegistrationName = "OVAPredictor";
+
+        private static VersionInfo GetVersionInfo()
+        {
+            return new VersionInfo(
+                modelSignature: "TLC OVA ",
+                verWrittenCur: 0x00010001, // Initial
+                verReadableCur: 0x00010001,
+                verWeCanReadBack: 0x00010001,
+                loaderSignature: LoaderSignature,
+                loaderAssemblyName: typeof(OneVersusAllModelParametersTyped<T>).Assembly.FullName);
+        }
+
+        private const string SubPredictorFmt = "SubPredictor_{0:000}";
+
+        private readonly ImplBase _impl;
+
+        /// <summary>
+        /// Retrieves the model parameters.
+        /// </summary>
+        internal ImmutableArray<T> SubModelParameters => _impl.Predictors.Cast<T>().ToImmutableArray();
+
+        /// <summary>
+        /// The type of the prediction task.
+        /// </summary>
+        private protected override PredictionKind PredictionKind => PredictionKind.MulticlassClassification;
+
+        /// <summary>
+        /// Function applied to output of predictors. Assume that we have n predictors (one per class) and for the i-th predictor,
+        /// y_i is its raw output and p_i is its probability output. Note that not all predictors are able to produce probability output.
+        /// <para>
+        /// <see cref="Raw"/>: output the result of predictors without post-processing. Output is [y_1, ..., y_n].
+        /// <see cref="ProbabilityNormalization"/>: fetch probability output of each class probability from provided predictors and make sure the sume of class probabilities is one.
+        /// Output is [p_1 / (p_1 + ... + p_n), ..., p_n / (p_1 + ... + p_n)].
+        /// <see cref="Softmax"/>: Generate probability by feeding raw outputs to softmax function. Output is [z_1, ..., z_n], where z_i is exp(y_i) / (exp(y_1) + ... + exp(y_n)).
+        /// </para>
+        /// </summary>
+        [BestFriend]
+        internal enum OutputFormula { Raw = 0, ProbabilityNormalization = 1, Softmax = 2 };
+
+        private DataViewType DistType { get; }
+
+        bool ICanSavePfa.CanSavePfa => _impl.CanSavePfa;
+
+        [BestFriend]
+        internal static OneVersusAllModelParametersTyped<T> Create(IHost host, OutputFormula outputFormula, T[] predictors)
+        {
+            ImplBase impl;
+
+            using (var ch = host.Start("Creating OVA predictor"))
+            {
+                if (outputFormula == OutputFormula.Softmax)
+                {
+                    impl = new ImplSoftmax(predictors);
+                    return new OneVersusAllModelParametersTyped<T>(host, impl);
+                }
+
+                // Caller of this function asks for probability output. We check if input predictor can produce probability.
+                // If that predictor can't produce probability, ivmd will be null.
+                IValueMapperDist ivmd = null;
+                if (outputFormula == OutputFormula.ProbabilityNormalization &&
+                    ((ivmd = predictors[0] as IValueMapperDist) == null ||
+                        ivmd.OutputType != NumberDataViewType.Single ||
+                        ivmd.DistType != NumberDataViewType.Single))
+                {
+                    ch.Warning($"{nameof(OneVersusAllTrainerTyped<T>.Options.UseProbabilities)} specified with {nameof(OneVersusAllTrainerTyped<T>.Options.PredictorType)} that can't produce probabilities.");
+                    ivmd = null;
+                }
+
+                // If ivmd is null, either the user didn't ask for probability or the provided predictors can't produce probability.
+                if (ivmd != null)
+                {
+                    impl = new ImplDist(predictors);
+                }
+                else
+                    impl = new ImplRaw(predictors);
+            }
+
+            return new OneVersusAllModelParametersTyped<T>(host, impl);
+        }
+
+        [BestFriend]
+        internal static OneVersusAllModelParametersTyped<T> Create(IHost host, bool useProbability, T[] predictors)
+        {
+            var outputFormula = useProbability ? OutputFormula.ProbabilityNormalization : OutputFormula.Raw;
+
+            return Create(host, outputFormula, predictors);
+        }
+
+        /// <summary>
+        /// Create a <see cref="OneVersusAllModelParametersTyped{T}"/> from an array of predictors.
+        /// </summary>
+        [BestFriend]
+        internal static OneVersusAllModelParametersTyped<T> Create(IHost host, T[] predictors)
+        {
+            Contracts.CheckValue(host, nameof(host));
+            host.CheckNonEmpty(predictors, nameof(predictors));
+            return Create(host, OutputFormula.ProbabilityNormalization, predictors);
+        }
+
+        private OneVersusAllModelParametersTyped(IHostEnvironment env, ImplBase impl)
+                : base(env, RegistrationName)
+        {
+            Host.AssertValue(impl, nameof(impl));
+            Host.Assert(Utils.Size(impl.Predictors) > 0);
+
+            _impl = impl;
+            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
+        }
+
+        private OneVersusAllModelParametersTyped(IHostEnvironment env, ModelLoadContext ctx)
+                : base(env, RegistrationName, ctx)
+        {
+            // *** Binary format ***
+            // bool: useDist
+            // int: predictor count
+            bool useDist = ctx.Reader.ReadBoolByte();
+            int len = ctx.Reader.ReadInt32();
+            Host.CheckDecode(len > 0);
+
+            if (useDist)
+            {
+                var predictors = new T[len];
+                LoadPredictors(Host, predictors, ctx);
+                _impl = new ImplDist(predictors);
+            }
+            else
+            {
+                var predictors = new T[len];
+                LoadPredictors(Host, predictors, ctx);
+                _impl = new ImplRaw(predictors);
+            }
+
+            DistType = new VectorDataViewType(NumberDataViewType.Single, _impl.Predictors.Length);
+        }
+
+        private static OneVersusAllModelParametersTyped<T> Create(IHostEnvironment env, ModelLoadContext ctx)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            env.CheckValue(ctx, nameof(ctx));
+            ctx.CheckAtModel(GetVersionInfo());
+            return new OneVersusAllModelParametersTyped<T>(env, ctx);
+        }
+
+        private static void LoadPredictors<TPredictor>(IHostEnvironment env, TPredictor[] predictors, ModelLoadContext ctx)
+            where TPredictor : class
+        {
+            for (int i = 0; i < predictors.Length; i++)
+                ctx.LoadModel<TPredictor, SignatureLoadModel>(env, out predictors[i], string.Format(SubPredictorFmt, i));
+        }
+
+        private protected override void SaveCore(ModelSaveContext ctx)
+        {
+            base.SaveCore(ctx);
+            ctx.SetVersionInfo(GetVersionInfo());
+
+            var preds = _impl.Predictors;
+
+            // *** Binary format ***
+            // bool: useDist
+            // int: predictor count
+            ctx.Writer.WriteBoolByte(_impl is ImplDist);
+            ctx.Writer.Write(preds.Length);
+
+            // Save other streams.
+            for (int i = 0; i < preds.Length; i++)
+                ctx.SaveModel(preds[i], string.Format(SubPredictorFmt, i));
+        }
+
+        JToken ISingleCanSavePfa.SaveAsPfa(BoundPfaContext ctx, JToken input)
+        {
+            Host.CheckValue(ctx, nameof(ctx));
+            Host.CheckValue(input, nameof(input));
+            return _impl.SaveAsPfa(ctx, input);
+        }
+
+        DataViewType IValueMapper.InputType
+        {
+            get { return _impl.InputType; }
+        }
+
+        DataViewType IValueMapper.OutputType
+        {
+            get { return DistType; }
+        }
+        ValueMapper<TIn, TOut> IValueMapper.GetMapper<TIn, TOut>()
+        {
+            Host.Check(typeof(TIn) == typeof(VBuffer<float>));
+            Host.Check(typeof(TOut) == typeof(VBuffer<float>));
+
+            return (ValueMapper<TIn, TOut>)(Delegate)_impl.GetMapper();
+        }
+
+        void ICanSaveInSourceCode.SaveAsCode(TextWriter writer, RoleMappedSchema schema)
+        {
+            Host.CheckValue(writer, nameof(writer));
+            Host.CheckValue(schema, nameof(schema));
+
+            var preds = _impl.Predictors;
+            writer.WriteLine("double[] outputs = new double[{0}];", preds.Length);
+
+            for (int i = 0; i < preds.Length; i++)
+            {
+                var saveInSourceCode = preds[i] as ICanSaveInSourceCode;
+                Host.Check(saveInSourceCode != null, "Saving in code is not supported.");
+
+                writer.WriteLine("{");
+                saveInSourceCode.SaveAsCode(writer, schema);
+                writer.WriteLine("outputs[{0}] = output;", i);
+                writer.WriteLine("}");
+            }
+        }
+
+        void ICanSaveInTextFormat.SaveAsText(TextWriter writer, RoleMappedSchema schema)
+        {
+            Host.CheckValue(writer, nameof(writer));
+            Host.CheckValue(schema, nameof(schema));
+
+            var preds = _impl.Predictors;
+
+            for (int i = 0; i < preds.Length; i++)
+            {
+                var saveInText = preds[i] as ICanSaveInTextFormat;
+                Host.Check(saveInText != null, "Saving in text is not supported.");
+
+                writer.WriteLine("#region: class-{0} classifier", i);
+                saveInText.SaveAsText(writer, schema);
+
+                writer.WriteLine("#endregion: class-{0} classifier", i);
+                writer.WriteLine();
+            }
+        }
+
+        private abstract class ImplBase : ISingleCanSavePfa
+        {
+            public abstract DataViewType InputType { get; }
+            public abstract IValueMapper[] Predictors { get; }
+            public abstract bool CanSavePfa { get; }
+            public abstract ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper();
+            public abstract JToken SaveAsPfa(BoundPfaContext ctx, JToken input);
+
+            protected bool IsValid(IValueMapper mapper, ref VectorDataViewType inputType)
+            {
+                Contracts.AssertValueOrNull(mapper);
+                Contracts.AssertValueOrNull(inputType);
+
+                if (mapper == null)
+                    return false;
+                if (mapper.OutputType != NumberDataViewType.Single)
+                    return false;
+                if (!(mapper.InputType is VectorDataViewType mapperVectorType) || mapperVectorType.ItemType != NumberDataViewType.Single)
+                    return false;
+                if (inputType == null)
+                    inputType = mapperVectorType;
+                else if (inputType.Size != mapperVectorType.Size)
+                {
+                    if (inputType.Size == 0)
+                        inputType = mapperVectorType;
+                    else if (mapperVectorType.Size != 0)
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        private sealed class ImplRaw : ImplBase
+        {
+            public override DataViewType InputType { get; }
+            public override IValueMapper[] Predictors { get; }
+            public override bool CanSavePfa { get; }
+
+            internal ImplRaw(T[] predictors)
+            {
+                Contracts.CheckNonEmpty(predictors, nameof(predictors));
+
+                Predictors = new IValueMapper[predictors.Length];
+                VectorDataViewType inputType = null;
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    var vm = predictors[i] as IValueMapper;
+                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
+                    Predictors[i] = vm;
+                }
+                CanSavePfa = Predictors.All(m => (m as ISingleCanSavePfa)?.CanSavePfa == true);
+                Contracts.AssertValue(inputType);
+                InputType = inputType;
+            }
+
+            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
+            {
+                var maps = new ValueMapper<VBuffer<float>, float>[Predictors.Length];
+                for (int i = 0; i < Predictors.Length; i++)
+                    maps[i] = Predictors[i].GetMapper<VBuffer<float>, float>();
+
+                var buffer = new float[maps.Length];
+                return
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
+                    {
+                        int inputSize = InputType.GetVectorSize();
+                        if (inputSize > 0)
+                            Contracts.Check(src.Length == inputSize);
+
+                        var tmp = src;
+                        Parallel.For(0, maps.Length, i => maps[i](in tmp, ref buffer[i]));
+
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
+                    };
+            }
+
+            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
+            {
+                Contracts.CheckValue(ctx, nameof(ctx));
+                Contracts.CheckValue(input, nameof(input));
+                Contracts.Assert(CanSavePfa);
+
+                JArray rootObjects = new JArray();
+                for (int i = 0; i < Predictors.Length; ++i)
+                {
+                    var pred = (ISingleCanSavePfa)Predictors[i];
+                    Contracts.Assert(pred.CanSavePfa);
+                    rootObjects.Add(ctx.DeclareVar(null, pred.SaveAsPfa(ctx, input)));
+                }
+                JObject jobj = null;
+                return jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
+            }
+        }
+
+        private sealed class ImplDist : ImplBase
+        {
+            private readonly IValueMapperDist[] _mappers;
+            public override DataViewType InputType { get; }
+            public override IValueMapper[] Predictors => _mappers;
+            public override bool CanSavePfa { get; }
+
+            internal ImplDist(T[] predictors)
+            {
+                Contracts.Check(Utils.Size(predictors) > 0);
+
+                _mappers = new IValueMapperDist[predictors.Length];
+                VectorDataViewType inputType = null;
+                for (int i = 0; i < predictors.Length; i++)
+                {
+                    var vm = predictors[i] as IValueMapperDist;
+                    Contracts.Check(IsValid(vm, ref inputType), "Predictor doesn't implement the expected interface");
+                    _mappers[i] = vm;
+                }
+                CanSavePfa = Predictors.All(m => (m as IDistCanSavePfa)?.CanSavePfa == true);
+                Contracts.AssertValue(inputType);
+                InputType = inputType;
+            }
+
+            private bool IsValid(IValueMapperDist mapper, ref VectorDataViewType inputType)
+            {
+                return base.IsValid(mapper, ref inputType) && mapper.DistType == NumberDataViewType.Single;
+            }
+
+            /// <summary>
+            /// Each predictor produces a probability of a class. All classes' probabilities are normalized so that
+            /// their sum is one.
+            /// </summary>
+            public override ValueMapper<VBuffer<float>, VBuffer<float>> GetMapper()
+            {
+                var maps = new ValueMapper<VBuffer<float>, float, float>[Predictors.Length];
+                for (int i = 0; i < Predictors.Length; i++)
+                    maps[i] = _mappers[i].GetMapper<VBuffer<float>, float, float>();
+
+                var buffer = new float[maps.Length];
+                return
+                    (in VBuffer<float> src, ref VBuffer<float> dst) =>
+                    {
+                        int inputSize = InputType.GetVectorSize();
+                        if (inputSize > 0)
+                            Contracts.Check(src.Length == inputSize);
+
+                        var tmp = src;
+                        Parallel.For(0, maps.Length,
+                            i =>
+                            {
+                                float score = 0;
+                                // buffer[i] is the probability of the i-th class.
+                                // score is the raw prediction score.
+                                maps[i](in tmp, ref score, ref buffer[i]);
+                            });
+
+                        // buffer[i] is the probability of the i-th class.
+                        // score is the raw prediction score.
+                        NormalizeSumToOne(buffer, maps.Length);
+
+                        var editor = VBufferEditor.Create(ref dst, maps.Length);
+                        buffer.CopyTo(editor.Values);
+                        dst = editor.Commit();
+                    };
+            }
+
+            private void NormalizeSumToOne(float[] output, int count)
+            {
+                // Clamp to zero and normalize.
+                Double sum = 0;
+                for (int i = 0; i < count; i++)
+                {
+                    var value = output[i];
+                    if (float.IsNaN(value))
+                        continue;
+
+                    if (value >= 0)
+                        sum += value;
+                    else
+                        output[i] = 0;
+                }
+
+                if (sum > 0)
+                {
+                    for (int i = 0; i < count; i++)
+                        output[i] = (float)(output[i] / sum);
+                }
+            }
+
+            public override JToken SaveAsPfa(BoundPfaContext ctx, JToken input)
+            {
+                Contracts.CheckValue(ctx, nameof(ctx));
+                Contracts.CheckValue(input, nameof(input));
+                Contracts.Assert(CanSavePfa);
+
+                JArray rootObjects = new JArray();
+                for (int i = 0; i < Predictors.Length; ++i)
+                {
+                    var pred = (IDistCanSavePfa)Predictors[i];
+                    Contracts.Assert(pred.CanSavePfa);
+                    pred.SaveAsPfa(ctx, input, null, out JToken scoreToken, null, out JToken probToken);
+                    rootObjects.Add(probToken);
+                }
+                JObject jobj = null;
+                var rootResult = jobj.AddReturn("type", PfaUtils.Type.Array(PfaUtils.Type.Double)).AddReturn("new", rootObjects);
+                var resultVar = ctx.DeclareVar(null, rootResult);
+                var factorVar = ctx.DeclareVar(null, PfaUtils.Call("/", 1.0, PfaUtils.Call("a.sum", resultVar)));
+                return PfaUtils.Call("la.scale", resultVar, factorVar);
+            }
+        }
+
+        private sealed class ImplSoftmax : ImplBase
+        {
+            public override DataViewType InputType { get; }
+            public override IValueMapper[] Predictors { get; }
+            public override bool CanSavePfa { get; }
+
+            internal ImplSoftmax(T[] predictors)
             {
                 Contracts.CheckNonEmpty(predictors, nameof(predictors));
 

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -751,6 +751,34 @@ namespace Microsoft.ML.Trainers
         //    + "which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers, "
         //    + "and choosing the prediction with the highest confidence score.";
 
+        /// <summary>
+        /// Constructs a <see cref="OneVersusAllTrainer"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
+        /// </summary>
+        /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
+        /// <param name="options">The legacy <see cref="OneVersusAllTrainerBase{T}.Options"/></param>
+        internal OneVersusAllTrainer(IHostEnvironment env, Options options)
+            : base(env, options, LoadNameValue)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="OneVersusAllTrainerBase{T}"/>.
+        /// </summary>
+        /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
+        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="labelColumnName">The name of the label colum.</param>
+        /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
+        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
+        internal OneVersusAllTrainerBase(IHostEnvironment env,
+            TScalarTrainer binaryEstimator,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool imputeMissingLabelsAsNegative = false,
+            bool useProbabilities = true)
+         : base(env,
+               binaryEstimator, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities)
+        {
+        }
+
         private protected override ISingleFeaturePredictionTransformer<TScalarPredictor> TrainOneHelper(IChannel ch,
             bool useProbabilities, IDataView view, string trainerLabel,
             ISingleFeaturePredictionTransformer<TScalarPredictor> transformer)

--- a/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/MulticlassClassification/OneVersusAllTrainer.cs
@@ -319,22 +319,22 @@ namespace Microsoft.ML.Trainers
     /// </summary>
     /// <typeparam name="TSubPredictor"></typeparam>
     /// <typeparam name="TCalibrator"></typeparam>
-    public sealed class OneVersusAllTrainerTyped<TSubPredictor, TCalibrator> : OneVersusAllTrainerBase<OneVersusAllModelParametersBase<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>
+    public sealed class OneVersusAllTrainer<TSubPredictor, TCalibrator> : OneVersusAllTrainerBase<OneVersusAllModelParametersBase<CalibratedModelParametersBase<TSubPredictor, TCalibrator>>>
         where TSubPredictor : class, IPredictorProducing<float>
         where TCalibrator : class, ICalibrator
     {
         /// <summary>
-        /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
+        /// Constructs a <see cref="OneVersusAllTrainer{TSubPredictor, TCalibrator}"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
         /// </summary>
         /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
         /// <param name="options">The legacy <see cref="OneVersusAllTrainerBase{T}.Options"/></param>
-        internal OneVersusAllTrainerTyped(IHostEnvironment env, Options options)
+        internal OneVersusAllTrainer(IHostEnvironment env, Options options)
             : base(env, options)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="OneVersusAllTrainerTyped{T}"/>.
+        /// Initializes a new instance of <see cref="OneVersusAllTrainer{TSubPredictor, TCalibrator}"/>.
         /// </summary>
         /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
@@ -343,7 +343,7 @@ namespace Microsoft.ML.Trainers
         /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
         /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        internal OneVersusAllTrainerTyped(IHostEnvironment env,
+        internal OneVersusAllTrainer(IHostEnvironment env,
             TScalarTrainer binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
@@ -396,30 +396,30 @@ namespace Microsoft.ML.Trainers
     /// <summary>
     /// Strongly typed implementation of the <see cref="OneVersusAllTrainerBase{T}"/> where T is a <see cref="OneVersusAllModelParameters{T}"/>.  T can either be
     /// a calibrated binary estimator of type <see cref="CalibratedModelParametersBase{TSubPredictor, TCalibrator}"/>, or a non calibrated binary estimary.
-    /// This cannot be used to turn a non calibrated binary classification estimator into its calibrated version. If that is required, use <see cref="OneVersusAllTrainerTyped{TSubPredictor, TCalibrator}"/> instead.
+    /// This cannot be used to turn a non calibrated binary classification estimator into its calibrated version. If that is required, use <see cref="OneVersusAllTrainer{TSubPredictor, TCalibrator}"/> instead.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public sealed class OneVersusAllTrainerTyped<T> : OneVersusAllTrainerBase<OneVersusAllModelParametersBase<T>> where T : class
+    public sealed class OneVersusAllTrainer<T> : OneVersusAllTrainerBase<OneVersusAllModelParametersBase<T>> where T : class
     {
         /// <summary>
         /// Constructs a <see cref="OneVersusAllTrainerBase{T}"/> trainer supplying a <see cref="OneVersusAllTrainerBase{T}.Options"/>.
         /// </summary>
         /// <param name="env">The private <see cref="IHostEnvironment"/> for this estimator.</param>
         /// <param name="options">The legacy <see cref="OneVersusAllTrainerBase{T}.Options"/></param>
-        internal OneVersusAllTrainerTyped(IHostEnvironment env, Options options)
+        internal OneVersusAllTrainer(IHostEnvironment env, Options options)
             : base(env, options)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="OneVersusAllTrainerTyped{T}"/>.
+        /// Initializes a new instance of <see cref="OneVersusAllTrainer{T}"/>.
         /// </summary>
         /// <param name="env">The <see cref="IHostEnvironment"/> instance.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
         /// <param name="labelColumnName">The name of the label colum.</param>
         /// <param name="imputeMissingLabelsAsNegative">If true will treat missing labels as negative labels.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        internal OneVersusAllTrainerTyped(IHostEnvironment env,
+        internal OneVersusAllTrainer(IHostEnvironment env,
             TScalarTrainer binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -725,7 +725,8 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Create a <see cref="OneVersusAllTrainer"/>, which predicts a multiclass target using one-versus-all strategy with
-        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
+        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>. If you want to retrieve strongly typed model parameters,
+        /// use either the <see cref="OneVersusAllUnCalibratedToCalibrated{TModelIn, TCalibrator}"/> or <see cref="OneVersusAllTyped{TModel}"/> methods instead.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -768,7 +769,8 @@ namespace Microsoft.ML
         /// Create a <see cref="OneVersusAllTrainer{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>. This method works with binary classifiers that
         /// are either already calibrated, or non calibrated ones you don't want calibrated. If you need to have your classifier calibrated, use the
-        /// <see cref="OneVersusAllUnCalibratedToCalibrated{TModelIn, TCalibrator}"/> method instead.
+        /// <see cref="OneVersusAllUnCalibratedToCalibrated{TModelIn, TCalibrator}"/> method instead. If you want to retrieve strongly typed model parameters,
+        /// you must use either this method or <see cref="OneVersusAllUnCalibratedToCalibrated{TModelIn, TCalibrator}"/> method.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -808,7 +810,8 @@ namespace Microsoft.ML
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.This method works with binary classifiers that
         /// are not calibrated and need to be calibrated before use. Due to the type of estimator changing (from uncalibrated to calibrated), you must manually
         /// specify both the type of the model and the type of the calibrator. If your classifier is already calibrated or it does not need to be, use the
-        /// <see cref="OneVersusAllTyped{TModel}"/> method instead.
+        /// <see cref="OneVersusAllTyped{TModel}"/> method instead. If you want to retrieve strongly typed model parameters, you must either use this method or
+        /// <see cref="OneVersusAllTyped{TModel}"/> method.
         /// </summary>
         /// <remarks>
         /// <para>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -758,6 +758,7 @@ namespace Microsoft.ML
             where TModel : class
         {
             Contracts.CheckValue(catalog, nameof(catalog));
+            var s = typeof(TModel);
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -839,7 +839,7 @@ namespace Microsoft.ML
             IEstimator<ISingleFeaturePredictionTransformer<ICalibrator>> calibrator = null,
             int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
-            where TModelIn : class, IPredictorProducing<float>
+            where TModelIn : class
             where TCalibrator : class, ICalibrator
         {
             Contracts.CheckValue(catalog, nameof(catalog));

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -766,7 +766,9 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Create a <see cref="OneVersusAllTrainerTyped{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
-        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
+        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>. This method works with binary classifiers that
+        /// are either already calibrated, or non calibrated ones you don't want calibrated. If you need to have your classifier calibrated, use the
+        /// <see cref="OneVersusAllUnCalibratedToCalibrated{TModelIn, TCalibrator}"/> method instead.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -803,7 +805,9 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Create a <see cref="OneVersusAllTrainerTyped{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
-        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
+        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.This method works with binary classifiers that
+        /// are not calibrated and need to be calibrated before use. If your classifier is already calibrated or it does not need to be, use the
+        /// <see cref="OneVersusAllTyped{TModel}"/> method instead.
         /// </summary>
         /// <remarks>
         /// <para>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -765,6 +765,80 @@ namespace Microsoft.ML
         }
 
         /// <summary>
+        /// Create a <see cref="OneVersusAllTrainer"/>, which predicts a multiclass target using one-versus-all strategy with
+        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In one-versus-all strategy, a binary classification algorithm is used to train one classifier for each class,
+        /// which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers,
+        /// and choosing the prediction with the highest confidence score.
+        /// </para>
+        /// </remarks>
+        /// <param name="catalog">The multiclass classification catalog trainer object.</param>
+        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="labelColumnName">The name of the label column.</param>
+        /// <param name="imputeMissingLabelsAsNegative">Whether to treat missing labels as having negative labels, instead of keeping them missing.</param>
+        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
+        /// <typeparam name="TModel">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
+        /// ]]></format>
+        /// </example>
+        public static OneVersusAllTrainerTyped<TModel> OneVersusAllStronglyTyped<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+            ITrainerEstimator<BinaryPredictionTransformer<TModel>, TModel> binaryEstimator,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool imputeMissingLabelsAsNegative = false,
+            bool useProbabilities = true)
+            where TModel : class
+        {
+            Contracts.CheckValue(catalog, nameof(catalog));
+            var env = CatalogUtils.GetEnvironment(catalog);
+            if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
+                throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
+            return new OneVersusAllTrainerTyped<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
+        }
+
+        /// <summary>
+        /// Create a <see cref="OneVersusAllTrainer"/>, which predicts a multiclass target using one-versus-all strategy with
+        /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In one-versus-all strategy, a binary classification algorithm is used to train one classifier for each class,
+        /// which distinguishes that class from all other classes. Prediction is then performed by running these binary classifiers,
+        /// and choosing the prediction with the highest confidence score.
+        /// </para>
+        /// </remarks>
+        /// <param name="catalog">The multiclass classification catalog trainer object.</param>
+        /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="labelColumnName">The name of the label column.</param>
+        /// <param name="imputeMissingLabelsAsNegative">Whether to treat missing labels as having negative labels, instead of keeping them missing.</param>
+        /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
+        /// <typeparam name="TModel">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
+        /// ]]></format>
+        /// </example>
+        public static OneVersusAllTrainerTyped<TModel> OneVersusAllStronglyTypedNoChange<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+            IPredictorProducing<float> binaryEstimator,
+            string labelColumnName = DefaultColumnNames.Label,
+            bool imputeMissingLabelsAsNegative = false,
+            bool useProbabilities = true)
+            where TModel : class
+        {
+            Contracts.CheckValue(catalog, nameof(catalog));
+            var env = CatalogUtils.GetEnvironment(catalog);
+            if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
+                throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
+            return new OneVersusAllTrainerTyped<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
+        }
+
+        /// <summary>
         /// Create a <see cref="PairwiseCouplingTrainer"/>, which predicts a multiclass target using pairwise coupling strategy with
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
         /// </summary>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -804,9 +804,10 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Create a <see cref="OneVersusAllTrainerTyped{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
+        /// Create a <see cref="OneVersusAllTrainerTyped{TModelIn, TCalibrator}"/>, which predicts a multiclass target using one-versus-all strategy with
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.This method works with binary classifiers that
-        /// are not calibrated and need to be calibrated before use. If your classifier is already calibrated or it does not need to be, use the
+        /// are not calibrated and need to be calibrated before use. Due to the type of estimator changing (from uncalibrated to calibrated), you must manually
+        /// specify both the type of the model and the type of the calibrator. If your classifier is already calibrated or it does not need to be, use the
         /// <see cref="OneVersusAllTyped{TModel}"/> method instead.
         /// </summary>
         /// <remarks>
@@ -823,8 +824,8 @@ namespace Microsoft.ML
         /// <param name="imputeMissingLabelsAsNegative">Whether to treat missing labels as having negative labels, instead of keeping them missing.</param>
         /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        /// <typeparam name="TModelIn">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
-        /// <typeparam name="TCalibrator">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
+        /// <typeparam name="TModelIn">The type of the model. This type parameter cannot be inferred and must be specified manually. It is usually a <see cref="LinearBinaryModelParameters"/>.</typeparam>
+        /// <typeparam name="TCalibrator">The calibrator for the model. This type parameter cannot be inferred automatically and must be specified manually and must be of type <see cref="ICalibrator"/>.</typeparam>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -787,18 +787,21 @@ namespace Microsoft.ML
         ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
         /// ]]></format>
         /// </example>
-        public static OneVersusAllTrainerTyped<TModel> OneVersusAllStronglyTyped<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+        public static OneVersusAllTrainerTyped<TModel> OneVersusAll<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
             ITrainerEstimator<BinaryPredictionTransformer<TModel>, TModel> binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
+            IEstimator<ISingleFeaturePredictionTransformer<ICalibrator>> calibrator = null,
+            int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
             where TModel : class
         {
-            Contracts.CheckValue(catalog, nameof(catalog));
-            var env = CatalogUtils.GetEnvironment(catalog);
-            if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
-                throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new OneVersusAllTrainerTyped<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
+            return OneVersusAllStronglyTyped<TModel, TModel>(
+                catalog,
+            binaryEstimator,
+            DefaultColumnNames.Label,
+            false,
+            true);
         }
 
         /// <summary>
@@ -817,25 +820,27 @@ namespace Microsoft.ML
         /// <param name="labelColumnName">The name of the label column.</param>
         /// <param name="imputeMissingLabelsAsNegative">Whether to treat missing labels as having negative labels, instead of keeping them missing.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
-        /// <typeparam name="TModel">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
+        /// <typeparam name="TModelIn">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
+        /// <typeparam name="TModelOut">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
         ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
         /// ]]></format>
         /// </example>
-        public static OneVersusAllTrainerTyped<TModel> OneVersusAllStronglyTypedNoChange<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
-            IPredictorProducing<float> binaryEstimator,
+        public static OneVersusAllTrainerTyped<TModelOut> OneVersusAllStronglyTyped<TModelIn, TModelOut>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+            ITrainerEstimator<BinaryPredictionTransformer<TModelIn>, TModelIn> binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
             bool useProbabilities = true)
-            where TModel : class
+            where TModelIn : class
+            where TModelOut : class
         {
             Contracts.CheckValue(catalog, nameof(catalog));
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new OneVersusAllTrainerTyped<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
+            return new OneVersusAllTrainerTyped<TModelOut>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -827,7 +827,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
         /// ]]></format>
         /// </example>
-        public static OneVersusAllTrainerTyped<TModelIn, TCalibrator> OneVersusAllUnCalibratedToCalibratedTyped<TModelIn, TCalibrator>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+        public static OneVersusAllTrainerTyped<TModelIn, TCalibrator> OneVersusAllUnCalibratedToCalibrated<TModelIn, TCalibrator>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
             ITrainerEstimator<BinaryPredictionTransformer<TModelIn>, TModelIn> binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -765,7 +765,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Create a <see cref="OneVersusAllTrainer"/>, which predicts a multiclass target using one-versus-all strategy with
+        /// Create a <see cref="OneVersusAllTrainerTyped{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
         /// </summary>
         /// <remarks>
@@ -787,25 +787,23 @@ namespace Microsoft.ML
         ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
         /// ]]></format>
         /// </example>
-        public static OneVersusAllTrainerTyped<TModel> OneVersusAll<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+        public static OneVersusAllTrainerTyped<TModel> OneVersusAllTyped<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
             ITrainerEstimator<BinaryPredictionTransformer<TModel>, TModel> binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
-            IEstimator<ISingleFeaturePredictionTransformer<ICalibrator>> calibrator = null,
-            int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
             where TModel : class
         {
-            return OneVersusAllStronglyTyped<TModel, TModel>(
-                catalog,
-            binaryEstimator,
-            DefaultColumnNames.Label,
-            false,
-            true);
+            return OneVersusAllTyped<TModel, TModel>(
+                catalog: catalog,
+                binaryEstimator: binaryEstimator,
+                labelColumnName: labelColumnName,
+                imputeMissingLabelsAsNegative: imputeMissingLabelsAsNegative,
+                useProbabilities: useProbabilities);
         }
 
         /// <summary>
-        /// Create a <see cref="OneVersusAllTrainer"/>, which predicts a multiclass target using one-versus-all strategy with
+        /// Create a <see cref="OneVersusAllTrainerTyped{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.
         /// </summary>
         /// <remarks>
@@ -817,8 +815,10 @@ namespace Microsoft.ML
         /// </remarks>
         /// <param name="catalog">The multiclass classification catalog trainer object.</param>
         /// <param name="binaryEstimator">An instance of a binary <see cref="ITrainerEstimator{TTransformer, TPredictor}"/> used as the base trainer.</param>
+        /// <param name="calibrator">The calibrator. If a calibrator is not explicitly provided, it will default to <see cref="PlattCalibratorTrainer"/></param>
         /// <param name="labelColumnName">The name of the label column.</param>
         /// <param name="imputeMissingLabelsAsNegative">Whether to treat missing labels as having negative labels, instead of keeping them missing.</param>
+        /// <param name="maximumCalibrationExampleCount">Number of instances to train the calibrator.</param>
         /// <param name="useProbabilities">Use probabilities (vs. raw outputs) to identify top-score category.</param>
         /// <typeparam name="TModelIn">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
         /// <typeparam name="TModelOut">The type of the model. This type parameter will usually be inferred automatically from <paramref name="binaryEstimator"/>.</typeparam>
@@ -828,10 +828,12 @@ namespace Microsoft.ML
         ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
         /// ]]></format>
         /// </example>
-        public static OneVersusAllTrainerTyped<TModelOut> OneVersusAllStronglyTyped<TModelIn, TModelOut>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+        public static OneVersusAllTrainerTyped<TModelOut> OneVersusAllTyped<TModelIn, TModelOut>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
             ITrainerEstimator<BinaryPredictionTransformer<TModelIn>, TModelIn> binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
+            IEstimator<ISingleFeaturePredictionTransformer<ICalibrator>> calibrator = null,
+            int maximumCalibrationExampleCount = 1000000000,
             bool useProbabilities = true)
             where TModelIn : class
             where TModelOut : class
@@ -840,7 +842,7 @@ namespace Microsoft.ML
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new OneVersusAllTrainerTyped<TModelOut>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
+            return new OneVersusAllTrainerTyped<TModelOut>(env, est, labelColumnName, imputeMissingLabelsAsNegative, GetCalibratorTrainerOrThrow(env, calibrator), maximumCalibrationExampleCount, useProbabilities);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -799,7 +799,7 @@ namespace Microsoft.ML
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new OneVersusAllTrainerTyped<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, null, 10000, useProbabilities);
+            return new OneVersusAllTrainerTyped<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -765,7 +765,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Create a <see cref="OneVersusAllTrainerTyped{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
+        /// Create a <see cref="OneVersusAllTrainer{TModelOut}"/>, which predicts a multiclass target using one-versus-all strategy with
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>. This method works with binary classifiers that
         /// are either already calibrated, or non calibrated ones you don't want calibrated. If you need to have your classifier calibrated, use the
         /// <see cref="OneVersusAllUnCalibratedToCalibrated{TModelIn, TCalibrator}"/> method instead.
@@ -789,7 +789,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
         /// ]]></format>
         /// </example>
-        public static OneVersusAllTrainerTyped<TModel> OneVersusAllTyped<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+        public static OneVersusAllTrainer<TModel> OneVersusAllTyped<TModel>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
             ITrainerEstimator<BinaryPredictionTransformer<TModel>, TModel> binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
@@ -800,11 +800,11 @@ namespace Microsoft.ML
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new OneVersusAllTrainerTyped<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
+            return new OneVersusAllTrainer<TModel>(env, est, labelColumnName, imputeMissingLabelsAsNegative, useProbabilities);
         }
 
         /// <summary>
-        /// Create a <see cref="OneVersusAllTrainerTyped{TModelIn, TCalibrator}"/>, which predicts a multiclass target using one-versus-all strategy with
+        /// Create a <see cref="OneVersusAllTrainer{TModelIn, TCalibrator}"/>, which predicts a multiclass target using one-versus-all strategy with
         /// the binary classification estimator specified by <paramref name="binaryEstimator"/>.This method works with binary classifiers that
         /// are not calibrated and need to be calibrated before use. Due to the type of estimator changing (from uncalibrated to calibrated), you must manually
         /// specify both the type of the model and the type of the calibrator. If your classifier is already calibrated or it does not need to be, use the
@@ -832,7 +832,7 @@ namespace Microsoft.ML
         ///  [!code-csharp[OneVersusAll](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/MulticlassClassification/OneVersusAll.cs)]
         /// ]]></format>
         /// </example>
-        public static OneVersusAllTrainerTyped<TModelIn, TCalibrator> OneVersusAllUnCalibratedToCalibrated<TModelIn, TCalibrator>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
+        public static OneVersusAllTrainer<TModelIn, TCalibrator> OneVersusAllUnCalibratedToCalibrated<TModelIn, TCalibrator>(this MulticlassClassificationCatalog.MulticlassClassificationTrainers catalog,
             ITrainerEstimator<BinaryPredictionTransformer<TModelIn>, TModelIn> binaryEstimator,
             string labelColumnName = DefaultColumnNames.Label,
             bool imputeMissingLabelsAsNegative = false,
@@ -846,7 +846,7 @@ namespace Microsoft.ML
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");
-            return new OneVersusAllTrainerTyped<TModelIn, TCalibrator>(env, est, labelColumnName, imputeMissingLabelsAsNegative, GetCalibratorTrainerOrThrow(env, calibrator), maximumCalibrationExampleCount, useProbabilities);
+            return new OneVersusAllTrainer<TModelIn, TCalibrator>(env, est, labelColumnName, imputeMissingLabelsAsNegative, GetCalibratorTrainerOrThrow(env, calibrator), maximumCalibrationExampleCount, useProbabilities);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
+++ b/src/Microsoft.ML.StandardTrainers/StandardTrainersCatalog.cs
@@ -758,7 +758,6 @@ namespace Microsoft.ML
             where TModel : class
         {
             Contracts.CheckValue(catalog, nameof(catalog));
-            var s = typeof(TModel);
             var env = CatalogUtils.GetEnvironment(catalog);
             if (!(binaryEstimator is ITrainerEstimator<ISingleFeaturePredictionTransformer<IPredictorProducing<float>>, IPredictorProducing<float>> est))
                 throw env.ExceptParam(nameof(binaryEstimator), "Trainer estimator does not appear to produce the right kind of model.");

--- a/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
@@ -53,7 +53,6 @@ namespace Microsoft.ML.Scenarios
 
             Assert.Equal(metrics.MicroAccuracy, metricsTyped.MicroAccuracy);
         }
-                //.Append(ML.MulticlassClassification.Trainers.OneVersusAllUnCalibratedToCalibratedTyped<LinearBinaryModelParameters, PlattCalibrator>(sdcaTrainer))
 
         [Fact]
         public void OvaAveragedPerceptron()

--- a/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
@@ -215,6 +215,9 @@ namespace Microsoft.ML.Scenarios
                             new TextLoader.Column("Features", DataKind.Single, new [] { new TextLoader.Range(1, 4) }),
                         }
             });
+
+            // REVIEW: readerTyped and dataTyped aren't used anywhere in this test, but if I take them out
+            // the test will fail. It seems to me that something is changing state somewhere, maybe in the cache?
             var readerTyped = new TextLoader(mlContextTyped, new TextLoader.Options()
             {
                 Columns = new[]

--- a/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Reflection.Metadata;
+using Microsoft.ML.Calibrators;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.FastTree;
@@ -35,14 +37,24 @@ namespace Microsoft.ML.Scenarios
             // Pipeline
             var logReg = mlContext.BinaryClassification.Trainers.LbfgsLogisticRegression();
             var pipeline = mlContext.MulticlassClassification.Trainers.OneVersusAll(logReg, useProbabilities: false);
+            var pipelineTyped = mlContext.MulticlassClassification.Trainers.OneVersusAllTyped(logReg, useProbabilities: false);
 
             var model = pipeline.Fit(data);
             var predictions = model.Transform(data);
 
+            var modelTyped = pipelineTyped.Fit(data);
+            var predictionsTyped = modelTyped.Transform(data);
+
             // Metrics
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
             Assert.True(metrics.MicroAccuracy > 0.94);
+
+            var metricsTyped = mlContext.MulticlassClassification.Evaluate(predictionsTyped);
+            Assert.True(metricsTyped.MicroAccuracy > 0.94);
+
+            Assert.Equal(metrics.MicroAccuracy, metricsTyped.MicroAccuracy);
         }
+                //.Append(ML.MulticlassClassification.Trainers.OneVersusAllUnCalibratedToCalibratedTyped<LinearBinaryModelParameters, PlattCalibrator>(sdcaTrainer))
 
         [Fact]
         public void OvaAveragedPerceptron()
@@ -69,15 +81,73 @@ namespace Microsoft.ML.Scenarios
             // Pipeline
             var ap = mlContext.BinaryClassification.Trainers.AveragedPerceptron(
                     new AveragedPerceptronTrainer.Options { Shuffle = true });
+            var apTyped = mlContext.BinaryClassification.Trainers.AveragedPerceptron(
+                    new AveragedPerceptronTrainer.Options { Shuffle = true });
 
             var pipeline = mlContext.MulticlassClassification.Trainers.OneVersusAll(ap, useProbabilities: false);
+            var pipelineTyped = mlContext.MulticlassClassification.Trainers.OneVersusAllTyped(apTyped, useProbabilities: false);
 
             var model = pipeline.Fit(data);
             var predictions = model.Transform(data);
 
+            var modelTyped = pipelineTyped.Fit(data);
+            var predictionsTyped = modelTyped.Transform(data);
+
             // Metrics
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
             Assert.True(metrics.MicroAccuracy > 0.66);
+
+            var metricsTyped = mlContext.MulticlassClassification.Evaluate(predictionsTyped);
+            Assert.True(metricsTyped.MicroAccuracy > 0.66);
+
+            Assert.Equal(metrics.MicroAccuracy, metricsTyped.MicroAccuracy);
+        }
+
+        [Fact]
+        public void OvaCalibratedAveragedPerceptron()
+        {
+            string dataPath = GetDataPath("iris.txt");
+
+            // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
+            // as a catalog of available operations and as the source of randomness.
+            var mlContext = new MLContext(seed: 1);
+            var reader = new TextLoader(mlContext, new TextLoader.Options()
+            {
+                Columns = new[]
+                        {
+                            new TextLoader.Column("Label", DataKind.Single, 0),
+                            new TextLoader.Column("Features", DataKind.Single, new [] { new TextLoader.Range(1, 4) }),
+                        }
+            });
+
+            // Data
+            var textData = reader.Load(GetDataPath(dataPath));
+            var data = mlContext.Data.Cache(mlContext.Transforms.Conversion.MapValueToKey("Label")
+                .Fit(textData).Transform(textData));
+
+            // Pipeline
+            var ap = mlContext.BinaryClassification.Trainers.AveragedPerceptron(
+                    new AveragedPerceptronTrainer.Options { Shuffle = true });
+            var apTyped = mlContext.BinaryClassification.Trainers.AveragedPerceptron(
+                    new AveragedPerceptronTrainer.Options { Shuffle = true });
+
+            var pipeline = mlContext.MulticlassClassification.Trainers.OneVersusAll(ap);
+            var pipelineTyped = mlContext.MulticlassClassification.Trainers.OneVersusAllUnCalibratedToCalibratedTyped<LinearBinaryModelParameters, PlattCalibrator>(apTyped);
+
+            var model = pipeline.Fit(data);
+            var predictions = model.Transform(data);
+
+            var modelTyped = pipelineTyped.Fit(data);
+            var predictionsTyped = modelTyped.Transform(data);
+
+            // Metrics
+            var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
+            Assert.True(metrics.MicroAccuracy > 0.95);
+
+            var metricsTyped = mlContext.MulticlassClassification.Evaluate(predictionsTyped);
+            Assert.True(metricsTyped.MicroAccuracy > 0.95);
+
+            Assert.Equal(metrics.MicroAccuracy, metricsTyped.MicroAccuracy);
         }
 
         [Fact]
@@ -107,12 +177,24 @@ namespace Microsoft.ML.Scenarios
                 mlContext.BinaryClassification.Trainers.FastTree(new FastTreeBinaryTrainer.Options { NumberOfThreads = 1 }),
                 useProbabilities: false);
 
+            var pipelineTyped = mlContext.MulticlassClassification.Trainers.OneVersusAllTyped(
+                mlContext.BinaryClassification.Trainers.FastTree(new FastTreeBinaryTrainer.Options { NumberOfThreads = 1 }),
+                useProbabilities: false);
+
             var model = pipeline.Fit(data);
             var predictions = model.Transform(data);
+
+            var modelTyped = pipelineTyped.Fit(data);
+            var predictionsTyped = modelTyped.Transform(data);
 
             // Metrics
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
             Assert.True(metrics.MicroAccuracy > 0.99);
+
+            var metricsTyped = mlContext.MulticlassClassification.Evaluate(predictionsTyped);
+            Assert.True(metricsTyped.MicroAccuracy > 0.99);
+
+            Assert.Equal(metrics.MicroAccuracy, metricsTyped.MicroAccuracy);
         }
 
         [Fact]
@@ -123,7 +205,17 @@ namespace Microsoft.ML.Scenarios
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext(seed: 1);
+            var mlContextTyped = new MLContext(seed: 1);
+
             var reader = new TextLoader(mlContext, new TextLoader.Options()
+            {
+                Columns = new[]
+                        {
+                            new TextLoader.Column("Label", DataKind.Single, 0),
+                            new TextLoader.Column("Features", DataKind.Single, new [] { new TextLoader.Range(1, 4) }),
+                        }
+            });
+            var readerTyped = new TextLoader(mlContextTyped, new TextLoader.Options()
             {
                 Columns = new[]
                         {
@@ -133,20 +225,35 @@ namespace Microsoft.ML.Scenarios
             });
             // Data
             var textData = reader.Load(GetDataPath(dataPath));
+            var textDataTyped = reader.Load(GetDataPath(dataPath));
             var data = mlContext.Data.Cache(mlContext.Transforms.Conversion.MapValueToKey("Label")
                 .Fit(textData).Transform(textData));
+            var dataTyped = mlContextTyped.Data.Cache(mlContextTyped.Transforms.Conversion.MapValueToKey("Label")
+                .Fit(textDataTyped).Transform(textDataTyped));
 
             // Pipeline
             var pipeline = mlContext.MulticlassClassification.Trainers.OneVersusAll(
                 mlContext.BinaryClassification.Trainers.LinearSvm(new LinearSvmTrainer.Options { NumberOfIterations = 100 }),
                 useProbabilities: false);
 
+            var pipelineTyped = mlContextTyped.MulticlassClassification.Trainers.OneVersusAllTyped(
+                mlContextTyped.BinaryClassification.Trainers.LinearSvm(new LinearSvmTrainer.Options { NumberOfIterations = 100 }),
+                useProbabilities: false);
+
             var model = pipeline.Fit(data);
             var predictions = model.Transform(data);
+
+            var modelTyped = pipelineTyped.Fit(dataTyped);
+            var predictionsTyped = modelTyped.Transform(dataTyped);
 
             // Metrics
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
             Assert.True(metrics.MicroAccuracy > 0.83);
+
+            var metricsTyped = mlContextTyped.MulticlassClassification.Evaluate(predictionsTyped);
+            Assert.True(metricsTyped.MicroAccuracy > 0.83);
+
+            Assert.Equal(metrics.MicroAccuracy, metricsTyped.MicroAccuracy);
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection.Metadata;
 using Microsoft.ML.Calibrators;
 using Microsoft.ML.Data;
 using Microsoft.ML.Trainers;

--- a/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/OvaTest.cs
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Scenarios
                     new AveragedPerceptronTrainer.Options { Shuffle = true });
 
             var pipeline = mlContext.MulticlassClassification.Trainers.OneVersusAll(ap);
-            var pipelineTyped = mlContext.MulticlassClassification.Trainers.OneVersusAllUnCalibratedToCalibratedTyped<LinearBinaryModelParameters, PlattCalibrator>(apTyped);
+            var pipelineTyped = mlContext.MulticlassClassification.Trainers.OneVersusAllUnCalibratedToCalibrated<LinearBinaryModelParameters, PlattCalibrator>(apTyped);
 
             var model = pipeline.Fit(data);
             var predictions = model.Transform(data);
@@ -225,11 +225,10 @@ namespace Microsoft.ML.Scenarios
             });
             // Data
             var textData = reader.Load(GetDataPath(dataPath));
-            var textDataTyped = reader.Load(GetDataPath(dataPath));
             var data = mlContext.Data.Cache(mlContext.Transforms.Conversion.MapValueToKey("Label")
                 .Fit(textData).Transform(textData));
             var dataTyped = mlContextTyped.Data.Cache(mlContextTyped.Transforms.Conversion.MapValueToKey("Label")
-                .Fit(textDataTyped).Transform(textDataTyped));
+                .Fit(textData).Transform(textData));
 
             // Pipeline
             var pipeline = mlContext.MulticlassClassification.Trainers.OneVersusAll(
@@ -243,15 +242,15 @@ namespace Microsoft.ML.Scenarios
             var model = pipeline.Fit(data);
             var predictions = model.Transform(data);
 
-            var modelTyped = pipelineTyped.Fit(dataTyped);
-            var predictionsTyped = modelTyped.Transform(dataTyped);
+            var modelTyped = pipelineTyped.Fit(data);
+            var predictionsTyped = modelTyped.Transform(data);
 
             // Metrics
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
-            Assert.True(metrics.MicroAccuracy > 0.83);
+            Assert.True(metrics.MicroAccuracy > 0.95);
 
             var metricsTyped = mlContextTyped.MulticlassClassification.Evaluate(predictionsTyped);
-            Assert.True(metricsTyped.MicroAccuracy > 0.83);
+            Assert.True(metricsTyped.MicroAccuracy > 0.95);
 
             Assert.Equal(metrics.MicroAccuracy, metricsTyped.MicroAccuracy);
         }

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -110,20 +110,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                     NumberOfThreads = 1,
                 });
 
-            var sdca = ML.BinaryClassification.Trainers.SgdCalibrated(
-                new SgdCalibratedTrainer.Options
-                {
-                    LabelColumnName = "Label",
-                    FeatureColumnName = "Vars",
-                    Shuffle = true,
-                    NumberOfThreads = 1,
-                });
-
             var pipeline = new ColumnConcatenatingEstimator(Env, "Vars", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(Env, "Label"), TransformerScope.TrainTest)
-                .Append(ML.MulticlassClassification.Trainers.OneVersusAllUnCalibratedToCalibratedTyped<LinearBinaryModelParameters, PlattCalibrator>(sdcaTrainer))
-                
-                //.Append(ML.MulticlassClassification.Trainers.OneVersusAllTyped(sdca))
                 .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));
 
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -53,23 +53,6 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         }
 
         /// <summary>
-        /// OVA strongly typed un-calibrated
-        /// </summary>
-        [Fact]
-        public void OVATypedUncalibrated()
-        {
-            var (pipeline, data) = GetMulticlassPipeline();
-            var sdcaTrainer = ML.BinaryClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1 });
-
-            pipeline = pipeline.Append(ML.MulticlassClassification.Trainers.OneVersusAllTyped(sdcaTrainer, useProbabilities: false))
-                    .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));
-
-            TestEstimatorCore(pipeline, data);
-            Done();
-        }
-
-        /// <summary>
         /// Pairwise Coupling trainer
         /// </summary>
         [Fact]
@@ -112,6 +95,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var pipeline = new ColumnConcatenatingEstimator(Env, "Vars", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(Env, "Label"), TransformerScope.TrainTest)
+                .Append(ML.MulticlassClassification.Trainers.OneVersusAll(sdcaTrainer))
                 .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));
 
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var pipeline = new ColumnConcatenatingEstimator(Env, "Vars", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(Env, "Label"), TransformerScope.TrainTest)
-                .Append(ML.MulticlassClassification.Trainers.OneVersusAllTyped<LinearBinaryModelParameters, CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>(sdcaTrainer))
+                .Append(ML.MulticlassClassification.Trainers.OneVersusAllUnCalibratedToCalibratedTyped<LinearBinaryModelParameters, PlattCalibrator>(sdcaTrainer))
                 
                 //.Append(ML.MulticlassClassification.Trainers.OneVersusAllTyped(sdca))
                 .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var pipeline = new ColumnConcatenatingEstimator(Env, "Vars", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(Env, "Label"), TransformerScope.TrainTest)
-                .Append(ML.MulticlassClassification.Trainers.OneVersusAll(sdcaTrainer))
+                .Append(ML.MulticlassClassification.Trainers.OneVersusAllStronglyTyped<SdcaLogisticRegressionBinaryTrainer, CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>(sdcaTrainer))
                 .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));
 
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -95,7 +95,8 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             var pipeline = new ColumnConcatenatingEstimator(Env, "Vars", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(Env, "Label"), TransformerScope.TrainTest)
-                .Append(ML.MulticlassClassification.Trainers.OneVersusAllStronglyTyped<SdcaLogisticRegressionBinaryTrainer, CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>(sdcaTrainer))
+                //.Append(ML.MulticlassClassification.Trainers.OneVersusAllTyped<SdcaLogisticRegressionBinaryTrainer, CalibratedModelParametersBase<LinearBinaryModelParameters, PlattCalibrator>>(sdcaTrainer))
+                .Append(ML.MulticlassClassification.Trainers.OneVersusAllTyped(sdcaTrainer, useProbabilities: false))
                 .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));
 
             var model = pipeline.Fit(data);


### PR DESCRIPTION
Fixes #2467

We used to remove all Type information when we constructed our `OneVersusAllModelParameters`. This prevented the users from access the inner model without run-time casting.

This PR makes the `OneVersusAllModelParameters` strongly typed, and adds a strongly typed version of the `OneVersusAllTrainer` as it uses the `OneVersusAllModelParameters`. This change is no longer a breaking change to the current public api. 
