### PR TITLE
PCA Anomaly Detection Threshold

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSample.cs
@@ -19,12 +19,12 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
             // Training data.
             var samples = new List<DataPoint>()
             {
-                new DataPoint(){ Features = new float[3] {1, 0, 0} },
                 new DataPoint(){ Features = new float[3] {0, 2, 1} },
-                new DataPoint(){ Features = new float[3] {1, 2, 3} },
-                new DataPoint(){ Features = new float[3] {0, 1, 0} },
                 new DataPoint(){ Features = new float[3] {0, 2, 1} },
-                new DataPoint(){ Features = new float[3] {-100, 50, -100} }
+                new DataPoint(){ Features = new float[3] {0, 2, 1} },
+                new DataPoint(){ Features = new float[3] {0, 1, 2} },
+                new DataPoint(){ Features = new float[3] {0, 2, 1} },
+                new DataPoint(){ Features = new float[3] {2, 0, 0} }
             };
 
             // Convert the List<DataPoint> to IDataView, a consumble format to
@@ -57,23 +57,23 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
                 var featuresInText = string.Join(',', samples[i].Features);
 
                 if (result.PredictedLabel)
-                    // The i-th sample is predicted as an inlier.
-                    Console.WriteLine("The {0}-th example with features [{1}]" +
-                        "is an inlier with a score of being inlier {2}", i,
+                    // The i-th sample is predicted as an outlier.
+                    Console.WriteLine("The {0}-th example with features [{1}] is " +
+                        "an outlier with a score of being inlier {2}", i,
                             featuresInText, result.Score);
                 else
-                    // The i-th sample is predicted as an outlier.
-                    Console.WriteLine("The {0}-th example with features [{1}] is" +
-                        "an outlier with a score of being inlier {2}", i,
+                    // The i-th sample is predicted as an inlier.
+                    Console.WriteLine("The {0}-th example with features [{1}] is " +
+                        "an inlier with a score of being inlier {2}", i,
                         featuresInText, result.Score);
             }
             // Lines printed out should be
-            //   The 0 - th example with features[1, 0, 0] is an inlier with a score of being inlier 0.7453707
-            //   The 1 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 2 - th example with features[1, 2, 3] is an inlier with a score of being inlier 0.8450122
-            //   The 3 - th example with features[0, 1, 0] is an inlier with a score of being inlier 0.9428905
-            //   The 4 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 5 - th example with features[-100, 50, -100] is an outlier with a score of being inlier 0
+            // The 0 - th example with features[0, 2, 1] is an inlier with a score of being outlier 0.1101028
+            // The 1 - th example with features[0, 2, 1] is an inlier with a score of being outlier 0.1101028
+            // The 2 - th example with features[0, 2, 1] is an inlier with a score of being outlier 0.1101028
+            // The 3 - th example with features[0, 1, 2] is an outlier with a score of being outlier 0.5082728
+            // The 4 - th example with features[0, 2, 1] is an inlier with a score of being outlier 0.1101028
+            // The 5 - th example with features[2, 0, 0] is an outlier with a score of being outlier 1
         }
 
         // Example with 3 feature values. A training data set is a collection of
@@ -87,9 +87,9 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
         // Class used to capture prediction of DataPoint.
         private class Result
         {
-            // Outlier gets false while inlier has true.
+            // Outlier gets true while inlier has false.
             public bool PredictedLabel { get; set; }
-            // Outlier gets smaller score.
+            // Inlier gets smaller score. Score is between 0 and 1.
             public float Score { get; set; }
         }
     }

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/Trainers/AnomalyDetection/RandomizedPcaSampleWithOptions.cs
@@ -19,12 +19,14 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
             // Training data.
             var samples = new List<DataPoint>()
             {
-                new DataPoint(){ Features = new float[3] {1, 0, 0} },
                 new DataPoint(){ Features = new float[3] {0, 2, 1} },
-                new DataPoint(){ Features = new float[3] {1, 2, 3} },
-                new DataPoint(){ Features = new float[3] {0, 1, 0} },
+                new DataPoint(){ Features = new float[3] {0, 2, 3} },
+                new DataPoint(){ Features = new float[3] {0, 2, 4} },
                 new DataPoint(){ Features = new float[3] {0, 2, 1} },
-                new DataPoint(){ Features = new float[3] {-100, 50, -100} }
+                new DataPoint(){ Features = new float[3] {0, 2, 2} },
+                new DataPoint(){ Features = new float[3] {0, 2, 3} },
+                new DataPoint(){ Features = new float[3] {0, 2, 4} },
+                new DataPoint(){ Features = new float[3] {1, 0, 0} }
             };
 
             // Convert the List<DataPoint> to IDataView, a consumble format to
@@ -63,23 +65,25 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
                 var featuresInText = string.Join(',', samples[i].Features);
 
                 if (result.PredictedLabel)
-                    // The i-th sample is predicted as an inlier.
-                    Console.WriteLine("The {0}-th example with features [{1}] is" +
-                        "an inlier with a score of being inlier {2}", i, 
-                        featuresInText, result.Score);
-                else
                     // The i-th sample is predicted as an outlier.
                     Console.WriteLine("The {0}-th example with features [{1}] is" +
-                        "an outlier with a score of being inlier {2}",
+                        "an outlier with a score of being outlier {2}", i,
+                        featuresInText, result.Score);
+                else
+                    // The i-th sample is predicted as an inlier.
+                    Console.WriteLine("The {0}-th example with features [{1}] is" +
+                        "an inlier with a score of being outlier {2}",
                         i, featuresInText, result.Score);
             }
             // Lines printed out should be
-            //   The 0 - th example with features[1, 0, 0] is an inlier with a score of being inlier 0.7453707
-            //   The 1 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 2 - th example with features[1, 2, 3] is an inlier with a score of being inlier 0.8450122
-            //   The 3 - th example with features[0, 1, 0] is an inlier with a score of being inlier 0.9428905
-            //   The 4 - th example with features[0, 2, 1] is an inlier with a score of being inlier 0.9999999
-            //   The 5 - th example with features[-100, 50, -100] is an outlier with a score of being inlier 0
+            // The 0 - th example with features[0, 2, 1] isan inlier with a score of being outlier 0.2264826
+            // The 1 - th example with features[0, 2, 3] isan inlier with a score of being outlier 0.1739471
+            // The 2 - th example with features[0, 2, 4] isan inlier with a score of being outlier 0.05711612
+            // The 3 - th example with features[0, 2, 1] isan inlier with a score of being outlier 0.2264826
+            // The 4 - th example with features[0, 2, 2] isan inlier with a score of being outlier 0.3868995
+            // The 5 - th example with features[0, 2, 3] isan inlier with a score of being outlier 0.1739471
+            // The 6 - th example with features[0, 2, 4] isan inlier with a score of being outlier 0.05711612
+            // The 7 - th example with features[1, 0, 0] isan outlier with a score of being outlier 0.6260795
         }
 
         // Example with 3 feature values. A training data set is a collection of
@@ -93,9 +97,9 @@ namespace Samples.Dynamic.Trainers.AnomalyDetection
         // Class used to capture prediction of DataPoint.
         private class Result
         {
-            // Outlier gets false while inlier has true.
+            // Outlier gets true while inlier has false.
             public bool PredictedLabel { get; set; }
-            // Outlier gets smaller score.
+            // Inlier gets smaller score. Score is between 0 and 1.
             public float Score { get; set; }
         }
     }

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -267,7 +267,7 @@ namespace Microsoft.ML.Data
 
         [BestFriend]
         internal AnomalyPredictionTransformer(IHostEnvironment env, TModel model, DataViewSchema inputSchema, string featureColumn,
-            float threshold = 0f, string thresholdColumn = DefaultColumnNames.Score)
+            float threshold = 0.5f, string thresholdColumn = DefaultColumnNames.Score)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(AnomalyPredictionTransformer<TModel>)), model, inputSchema, featureColumn)
         {
             Host.CheckNonEmpty(thresholdColumn, nameof(thresholdColumn));

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -703,6 +703,22 @@ namespace Microsoft.ML
             var eval = new AnomalyDetectionEvaluator(Environment, args);
             return eval.Evaluate(data, labelColumnName, scoreColumnName, predictedLabelColumnName);
         }
+
+        /// <summary>
+        /// Creates a new <see cref="AnomalyPredictionTransformer{TModel}"/> with the specified <paramref name="threshold"/>.
+        /// If the provided <paramref name="threshold"/> is the same as the <paramref name="model"/> threshold it simply returns <paramref name="model"/>.
+        /// </summary>
+        /// <typeparam name="TModel"></typeparam>
+        /// <param name="model">A trained <see cref="AnomalyPredictionTransformer{TModel}"/>.</param>
+        /// <param name="threshold">The new threshold value that will be used to determine the label of a data point
+        /// based on the predicted score by the model.</param>
+        public AnomalyPredictionTransformer<TModel> ChangeModelThreshold<TModel>(AnomalyPredictionTransformer<TModel> model, float threshold)
+            where TModel : class
+        {
+            if (model.Threshold == threshold)
+                return model;
+            return new AnomalyPredictionTransformer<TModel>(Environment, model.Model, model.TrainSchema, model.FeatureColumnName, threshold, model.ThresholdColumn);
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.ML.Data/TrainCatalog.cs
+++ b/src/Microsoft.ML.Data/TrainCatalog.cs
@@ -707,8 +707,8 @@ namespace Microsoft.ML
         /// <summary>
         /// Creates a new <see cref="AnomalyPredictionTransformer{TModel}"/> with the specified <paramref name="threshold"/>.
         /// If the provided <paramref name="threshold"/> is the same as the <paramref name="model"/> threshold it simply returns <paramref name="model"/>.
+        /// Note that by default the threshold is 0.5 and valid scores range from 0 to 1.
         /// </summary>
-        /// <typeparam name="TModel"></typeparam>
         /// <param name="model">A trained <see cref="AnomalyPredictionTransformer{TModel}"/>.</param>
         /// <param name="threshold">The new threshold value that will be used to determine the label of a data point
         /// based on the predicted score by the model.</param>

--- a/src/Microsoft.ML.PCA/PCACatalog.cs
+++ b/src/Microsoft.ML.PCA/PCACatalog.cs
@@ -54,6 +54,10 @@ namespace Microsoft.ML
         /// <param name="oversampling">Oversampling parameter for randomized PCA training.</param>
         /// <param name="ensureZeroMean">If enabled, data is centered to be zero mean.</param>
         /// <param name="seed">The seed for random number generation.</param>
+        /// <remarks>
+        /// By default the threshold used to determine the label of a data point based on the predicted score is 0.5. A data point with predicted
+        /// score higher than 0.5 is considered an outlier. Use <see cref="AnomalyDetectionCatalog.ChangeModelThreshold"/> to change this threshold.
+        /// </remarks>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -78,6 +82,10 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="catalog">The anomaly detection catalog trainer object.</param>
         /// <param name="options">Advanced options to the algorithm.</param>
+        /// <remarks>
+        /// By default the threshold used to determine the label of a data point based on the predicted score is 0.5. A data point with predicted
+        /// score higher than 0.5 is considered an outlier. Use <see cref="AnomalyDetectionCatalog.ChangeModelThreshold"/> to change this threshold.
+        /// </remarks>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[

--- a/src/Microsoft.ML.PCA/PCACatalog.cs
+++ b/src/Microsoft.ML.PCA/PCACatalog.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML
         /// <param name="ensureZeroMean">If enabled, data is centered to be zero mean.</param>
         /// <param name="seed">The seed for random number generation.</param>
         /// <remarks>
-        /// By default the threshold used to determine the label of a data point based on the predicted score is 0.5. A data point with predicted
+        /// By default the threshold used to determine the label of a data point based on the predicted score is 0.5. Scores range from 0 to 1. A data point with predicted
         /// score higher than 0.5 is considered an outlier. Use <see cref="AnomalyDetectionCatalog.ChangeModelThreshold"/> to change this threshold.
         /// </remarks>
         /// <example>
@@ -83,7 +83,7 @@ namespace Microsoft.ML
         /// <param name="catalog">The anomaly detection catalog trainer object.</param>
         /// <param name="options">Advanced options to the algorithm.</param>
         /// <remarks>
-        /// By default the threshold used to determine the label of a data point based on the predicted score is 0.5. A data point with predicted
+        /// By default the threshold used to determine the label of a data point based on the predicted score is 0.5. Scores range from 0 to 1. A data point with predicted
         /// score higher than 0.5 is considered an outlier. Use <see cref="AnomalyDetectionCatalog.ChangeModelThreshold"/> to change this threshold.
         /// </remarks>
         /// <example>


### PR DESCRIPTION
Fixes #3990 

In this PR I change the default threshold for PCA anomaly detection to 0.5 (see the issue for discussion on what that means).

I also add a method to change the threshold from MlContext in the same spirit as the BinaryClassification ChangeThreshold method.

I update the samples and add a test for the new method.