### PR TITLE
Make Microsoft.ML.Ensemble internals visible to NimbusML DotNetBridge

### DIFF
--- a/src/Microsoft.ML.Ensemble/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ML.Ensemble/Properties/AssemblyInfo.cs
@@ -9,3 +9,4 @@ using Microsoft.ML;
 [assembly: InternalsVisibleTo("Microsoft.ML.Core.Tests" + PublicKey.TestValue)]
 [assembly: InternalsVisibleTo("RunTests" + InternalPublicKey.Value)]
 [assembly: InternalsVisibleTo("Microsoft.ML.Runtime.Scope" + InternalPublicKey.Value)]
+[assembly: InternalsVisibleTo("DotNetBridge" + InternalPublicKey.Value)]


### PR DESCRIPTION
Fixes #4055 

Required for adding Ensemble trainers to NimbusML, which is required by Azure ML.

