### PR TITLE
Update official build and CI to run on macOS 10.13.

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
     pool:
-      name: Hosted macOS
+      name: Hosted macOS High Sierra
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -32,7 +32,7 @@ jobs:
       container: ${{ parameters.container }}
 
     steps:
-    - ${{ if eq(parameters.pool.name, 'Hosted macOS') }}:
+    - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
       - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -44,9 +44,7 @@ phases:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
   queue:
-    name: DotNetCore-Build
-    demands:
-    - agent.os -equals Darwin
+    name: Hosted macOS High Sierra
   steps:
   - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link libomp --force
     displayName: Install build dependencies

--- a/docs/building/netcoreapp3.0-instructions.md
+++ b/docs/building/netcoreapp3.0-instructions.md
@@ -1,11 +1,9 @@
-In order to build ML.NET for .NET Core 3.0, you need to do a few manual steps.
+ML.NET now builds for .NET Core 3.0 by default. However to run tests on .NET Core 3.0, you need to do a few manual steps.
 
-1. Delete the local `.\Tools\` folder from the root of the repo, to ensure you download the new version of the .NET Core SDK.
-2. Run `.\build.cmd -- /p:Configuration=Release-netcoreapp3_0` or `.\build.cmd -Release-netcoreapp3_0` from the root of the repo.
-3. If you want to build the NuGet packages, `.\build.cmd -buildPackages` after step 2.
+1. Run `.\build.cmd -- /p:Configuration=Release-netcoreapp3_0` or `.\build.cmd -Release-netcoreapp3_0` from the root of the repo.
+2. If you want to build the NuGet packages, `.\build.cmd -buildPackages` after step 2.
 
 If you are using Visual Studio, you will need to do the following:
 
-1. Install the above .NET Core 3.0 SDK into %Program Files%. Or extract it to a directory and put that directory at the front of your %PATH%, so it is the first `dotnet.exe` on the PATH.
-2. In the Configuration Manager, switch the current configuration to `Debug-netcoreapp3_0` or `Release-netcoreapp3_0`.
-3. Build and test as usual.
+1. In the Configuration Manager, switch the current configuration to `Debug-netcoreapp3_0` or `Release-netcoreapp3_0`.
+2. Build and test as usual.

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -28,7 +28,7 @@ The following components are needed:
 * libunwind8
 * libomp-dev
 * curl
-* All the requirements necessary to run .NET Core 2.0 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu52 for ubuntu 14.x, libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x). For more information on prerequisites in different linux distributions click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
+* All the requirements necessary to run .NET Core 3.0 applications: libssl1.0.0 (1.0.2 for Debian 9) and libicu5x (libicu52 for ubuntu 14.x, libicu55 for ubuntu 16.x, and libicu57 for ubuntu 17.x). For more information on prerequisites in different linux distributions click [here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore30).
 
 For example, for Ubuntu 16.x:
 
@@ -41,14 +41,14 @@ sudo apt-get install libomp-dev
 
 ### macOS
 
-macOS 10.12 (Sierra) or higher is needed to build dotnet/machinelearning.
+macOS 10.13 (High Sierra) or higher is needed to build dotnet/machinelearning. We are using a .NET Core 3.0 SDK to build, which supports 10.13 or higher.
 
 On macOS a few components are needed which are not provided by a default developer setup:
 * cmake 3.10.3
 * libomp 7
 * libgdiplus
 * gettext
-* All the requirements necessary to run .NET Core 2.0 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore2x).
+* All the requirements necessary to run .NET Core 3.0 applications. To view macOS prerequisites click [here](https://docs.microsoft.com/en-us/dotnet/core/macos-prerequisites?tabs=netcore30).
 
 One way of obtaining CMake and other required libraries is via [Homebrew](https://brew.sh):
 ```sh

--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -5,13 +5,13 @@ You can build ML.NET either via the command line or by using Visual Studio.
 
 ## Required Software
 
-1. **[Visual Studio 2019 / Visual Studio 2017](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 15.8.0 and higher.
+1. **[Visual Studio 2019 Update 3 Preview](https://visualstudio.microsoft.com/vs/preview/) (Community, Professional, Enterprise)** The Community version is completely free. The below build instructions were verified for VS 16.3 Preview 3.
 2. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path.
 
-### Visual Studio 2019 / Visual Studio 2017 Installation
-We have successfully verified the below build instructions for Visual Studio version 15.8.0 and higher. 
+### Visual Studio 2019 Installation
+We have successfully verified the below build instructions for Visual Studio version 16.3 and higher. 
 
-#### Visual Studio 2019 / Visual Studio 2017 - 'Workloads' based install
+#### Visual Studio 2019 - 'Workloads' based install
 
 The following are the minimum requirements:
   * .NET desktop development
@@ -19,21 +19,19 @@ The following are the minimum requirements:
     * .NET Framework 4-4.6 Development Tools
   * Desktop development with C++
     * All Required Components
-    * VC++ 2019 v142 Toolset (x86, x64) for Visual Studio 2019 or VC++ 2017 v141 Toolset (x86, x64) for Visual Studio 2017
+    * VC++ 2019 v142 Toolset (x86, x64)
     * Windows 8.1 SDK and UCRT SDK
   * .NET Core cross-platform development
     * All Required Components
 
-Note: If you have both VS 2017 and 2015 installed, you need to copy DIA SDK directory from VS 2015 installation into VS 2017 (VS installer bug).
-
-#### Visual Studio 2019 / Visual Studio 2017 - 'Individual components' based install
+#### Visual Studio 2019 - 'Individual components' based install
 
 The following are the minimum requirements:
   * C# and Visual Basic Roslyn Compilers
   * Static Analysis Tools
   * .NET Portable Library Targeting Pack
   * Visual Studio C++ Core Features
-  * VC++ 2019 v142 Toolset (x86, x64) for Visual Studio 2019 or VC++ 2017 v141 Toolset (x86, x64) for Visual Studio 2017
+  * VC++ 2019 v142 Toolset (x86, x64)
   * MSBuild
   * .NET Framework 4.6 Targeting Pack
   * Windows Universal CRT SDK
@@ -42,7 +40,7 @@ The following are the minimum requirements:
 
 In order to fetch dependencies which come through Git submodules the following command needs to be run before building: `git submodule update --init`.
 
-### Building From Visual Studio 2019 / Visual Studio 2017
+### Building From Visual Studio 2019
 
 First, set up the required tools, from a (non-admin) Command Prompt window:
 
@@ -52,7 +50,7 @@ After successfully running the command, the project can be built directly from t
 
 ### Building From the Command Line
 
-You can use the Developer Command Prompt, Powershell or work in any regular cmd. The Developer Command Prompt will have a name like "Developer Command Prompt for VS 2017" or similar in your start menu. 
+You can use the Developer Command Prompt, Powershell or work in any regular cmd. The Developer Command Prompt will have a name like "Developer Command Prompt for VS 2019" or similar in your start menu. 
 
 From a (non-admin) Command Prompt window:
 
@@ -74,8 +72,6 @@ From the root, run `build.cmd` and then `build.cmd -runTests`.
 For more details, or to test an individual project, you can navigate to the test project directory and then use `dotnet test`
 
 ## Known Issues
-
-CMake 3.7 or higher is required for Visual Studio 2017.
 
 CMake 3.14 or higher is required for Visual Studio 2019.
 


### PR DESCRIPTION
The official build is currently broken because it uses macOS 10.12, which is not supported with .NET Core 3.0. I also updated the CI to run on macOS 10.13, since that is supported and our tests are currently running on 10.14.

Also update the building instructions to reflect the new requirement to build for .NET Core 3.0.

Since we are building for .NET Core 3.0, we now require VS 2019 Update 3, which is in preview right now. It can be downloaded from https://visualstudio.microsoft.com/vs/preview/.