### PR TITLE
Load TransformerChain model file in ModelFileUtils

### DIFF
--- a/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML
     /// </summary>
     public sealed class ModelOperationsCatalog : IInternalCatalog
     {
-        private const string SchemaEntryName = "Schema";
+        internal const string SchemaEntryName = "Schema";
 
         IHostEnvironment IInternalCatalog.Environment => _env;
         private readonly IHostEnvironment _env;

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -25,6 +25,8 @@ namespace Microsoft.ML.Model
     {
         public const string DirPredictor = "Predictor";
         public const string DirDataLoaderModel = "DataLoaderModel";
+        public const string DirTransformerChain = "TransformerChain";
+        public const string SchemaEntryName = "Schema";
         // ResultsProcessor needs access to this constant.
         public const string DirTrainingInfo = "TrainingInfo";
 
@@ -64,6 +66,15 @@ namespace Microsoft.ML.Model
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(rep, nameof(rep));
             env.CheckValue(files, nameof(files));
+
+            var entry = rep.OpenEntryOrNull(SchemaEntryName);
+            if (entry != null)
+            {
+                var loader = new BinaryLoader(env, new BinaryLoader.Arguments(), entry.Stream);
+                ModelLoadContext.LoadModel<ITransformer, SignatureLoadModel>(env, out var transformerChain, rep, DirTransformerChain);
+                return transformerChain.Transform(loader);
+            }
+
             using (var ent = rep.OpenEntry(DirDataLoaderModel, ModelLoadContext.ModelStreamName))
             {
                 ILegacyDataLoader loader;

--- a/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
+++ b/src/Microsoft.ML.Data/Utilities/ModelFileUtils.cs
@@ -25,8 +25,8 @@ namespace Microsoft.ML.Model
     {
         public const string DirPredictor = "Predictor";
         public const string DirDataLoaderModel = "DataLoaderModel";
-        public const string DirTransformerChain = "TransformerChain";
-        public const string SchemaEntryName = "Schema";
+        public const string DirTransformerChain = TransformerChain.LoaderSignature;
+        public const string SchemaEntryName = ModelOperationsCatalog.SchemaEntryName;
         // ResultsProcessor needs access to this constant.
         public const string DirTrainingInfo = "TrainingInfo";
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -612,6 +612,94 @@ namespace Microsoft.ML.RunTests
             cmd.Run();
         }
 
+        [Fact]
+        public void ScoreTransformerChainModel()
+        {
+            var dataPath = GetDataPath("wikipedia-detox-250-line-data.tsv");
+            var modelPath = DeleteOutputPath("model.zip");
+
+            var mlContext = new MLContext();
+
+            var data = new TextLoader(Env,
+                    new TextLoader.Options()
+                    {
+                        AllowQuoting = true,
+                        Separator = "\t",
+                        HasHeader = true,
+                        Columns = new[]
+                        {
+                            new TextLoader.Column("Label", DataKind.Boolean, 0),
+                            new TextLoader.Column("SentimentText", DataKind.String, 1)
+                        }
+                    }).Load(dataPath);
+
+            var pipeline = mlContext.Transforms.Text.FeaturizeText("Features", "SentimentText")
+                .Append(mlContext.BinaryClassification.Trainers.AveragedPerceptron());
+
+            var model = pipeline.Fit(data);
+
+            mlContext.Model.Save(model, data.Schema, modelPath);
+
+            string inputGraph = string.Format(@"
+                {{
+                  'Inputs': {{
+                    'file': '{0}',
+                    'transform_model': '{1}'
+                  }},
+                  'Nodes': [
+                    {{
+                      'Name': 'Data.CustomTextLoader',
+                      'Inputs': {{
+                        'CustomSchema': 'col=Sentiment:I8:0 col=SentimentText:TX:1 quote+ header=+ sep=tab',
+                        'InputFile': '$file'
+                      }},
+                      'Outputs': {{
+                        'Data': '$data'
+                      }}
+                    }},
+                    {{
+                      'Name': 'Transforms.DatasetTransformScorer',
+                      'Inputs': {{
+                        'Data': '$data',
+                        'TransformModel': '$transform_model'
+                      }},
+                      'Outputs': {{
+                        'ScoredData': '$scoredVectorData'
+                      }}
+                    }},
+                    {{
+                      'Inputs': {{
+                        'Data': '$scoredVectorData'
+                      }},
+                      'Name': 'Transforms.ScoreColumnSelector',
+                      'Outputs': {{
+                        'OutputData': '$scoreColumnsOnlyData'
+                      }}
+                    }},
+                    {{
+                      'Inputs': {{
+                        'Data': '$scoreColumnsOnlyData',
+                        'PredictedLabelColumn': 'PredictedLabel'
+                      }},
+                      'Name': 'Transforms.PredictedLabelColumnOriginalValueConverter',
+                      'Outputs': {{
+                        'OutputData': '$output_data'
+                      }}
+                    }}
+                  ],
+                  'Outputs': {{
+                    'output_data': '$output_data'
+                  }}
+                }}", EscapePath(dataPath), EscapePath(modelPath));
+
+            var jsonPath = DeleteOutputPath("graph.json");
+            File.WriteAllLines(jsonPath, new[] { inputGraph });
+
+            var args = new ExecuteGraphCommand.Arguments() { GraphPath = jsonPath };
+            var cmd = new ExecuteGraphCommand(Env, args);
+            cmd.Run();
+        }
+
         //[Fact]
         //public void EntryPointArrayOfVariables()
         //{


### PR DESCRIPTION
Fixes #4109 

Related to microsoft/NimbusML#201

Enables loading TransformerChain models from entrypoints. This is needed so that models trained in ML.NET can be scored in NimbusML.

NimbusML models could be loaded and scored in ML.NET, but we never tested it the other way around.

