### PR TITLE
Rename LabelColumn to LabelColumnName for MutualInformationSelector

### DIFF
--- a/src/Microsoft.ML.Transforms/FeatureSelectionCatalog.cs
+++ b/src/Microsoft.ML.Transforms/FeatureSelectionCatalog.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML
         /// </example>
         public static MutualInformationFeatureSelectingEstimator SelectFeaturesBasedOnMutualInformation(this TransformsCatalog.FeatureSelectionTransforms catalog,
             string outputColumnName, string inputColumnName = null,
-            string labelColumnName = MutualInfoSelectDefaults.LabelColumn,
+            string labelColumnName = MutualInfoSelectDefaults.LabelColumnName,
             int slotsInOutput = MutualInfoSelectDefaults.SlotsInOutput,
             int numberOfBins = MutualInfoSelectDefaults.NumBins)
             => new MutualInformationFeatureSelectingEstimator(CatalogUtils.GetEnvironment(catalog), outputColumnName, inputColumnName, labelColumnName, slotsInOutput, numberOfBins);
@@ -58,7 +58,7 @@ namespace Microsoft.ML
         /// </example>
         public static MutualInformationFeatureSelectingEstimator SelectFeaturesBasedOnMutualInformation(this TransformsCatalog.FeatureSelectionTransforms catalog,
             InputOutputColumnPair[] columns,
-            string labelColumnName = MutualInfoSelectDefaults.LabelColumn,
+            string labelColumnName = MutualInfoSelectDefaults.LabelColumnName,
             int slotsInOutput = MutualInfoSelectDefaults.SlotsInOutput,
             int numberOfBins = MutualInfoSelectDefaults.NumBins)
         {

--- a/test/BaselineOutput/Common/EntryPoints/core_manifest.json
+++ b/test/BaselineOutput/Common/EntryPoints/core_manifest.json
@@ -18485,7 +18485,7 @@
           "IsNullable": false
         },
         {
-          "Name": "LabelColumn",
+          "Name": "LabelColumnName",
           "Type": "String",
           "Desc": "Column to use for labels",
           "Aliases": [


### PR DESCRIPTION
To follow existing practice and match all other transforms need to rename LabelColumn to LabelColumnName. Currently in NimbusML parsing logic needs to handle LabelColumn for MI, while for rest of transformers form manifest its LabelColumnName