### PR TITLE
Sanitize OutputName using dots to handle spaces in namespaces and project files

### DIFF
--- a/src/Microsoft.ML.CodeGen/CodeGenerator/CSharp/CodeGenerator.cs
+++ b/src/Microsoft.ML.CodeGen/CodeGenerator/CSharp/CodeGenerator.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.CodeGenerator.CSharp
             SetRequiredNugetPackages(trainerNodes, ref includeLightGbmPackage, ref includeMklComponentsPackage, ref includeFastTreeePackage);
 
             // Get Namespace
-            var namespaceValue = Utils.Normalize(_settings.OutputName);
+            var namespaceValue = _settings.OutputName;
             var labelType = _columnInferenceResult.TextLoaderOptions.Columns.Where(t => t.Name == _settings.LabelName).First().DataKind;
             Type labelTypeCsharp = Utils.GetCSharpType(labelType);
 

--- a/src/mlnet/CodeGenerator/CodeGenerationHelper.cs
+++ b/src/mlnet/CodeGenerator/CodeGenerationHelper.cs
@@ -300,7 +300,8 @@ namespace Microsoft.ML.CLI.CodeGenerator
             #endregion
 
             // Save the model
-            var modelprojectDir = Path.Combine(_settings.OutputPath.FullName, $"{_settings.Name}.Model");
+            var sanitizedName = Utils.Sanitize(_settings.Name, '.');
+            var modelprojectDir = Path.Combine(_settings.OutputPath.FullName, $"{sanitizedName}.Model");
             var modelPath = new FileInfo(Path.Combine(modelprojectDir, "MLModel.zip"));
 
             try
@@ -350,7 +351,7 @@ namespace Microsoft.ML.CLI.CodeGenerator
                     TrainDataset = _settings.Dataset.FullName,
                     MlTask = _taskKind,
                     TestDataset = _settings.TestDataset?.FullName,
-                    OutputName = _settings.Name,
+                    OutputName = Utils.Sanitize(_settings.Name, '.'),
                     OutputBaseDir = _settings.OutputPath.FullName,
                     LabelName = labelName,
                     ModelPath = modelPath.FullName

--- a/src/mlnet/Utilities/Utils.cs
+++ b/src/mlnet/Utilities/Utils.cs
@@ -44,9 +44,9 @@ namespace Microsoft.ML.CLI.Utilities
                 mlContext.Model.Save(model, modelInputSchema, fs);
         }
 
-        internal static string Sanitize(string name)
+        internal static string Sanitize(string name, char replacement = '_')
         {
-            return string.Join("", name.Select(x => Char.IsLetterOrDigit(x) ? x : '_'));
+            return string.Join("", name.Select(x => Char.IsLetterOrDigit(x) ? x : replacement));
         }
 
         internal static TaskKind GetTaskKind(string mlTask)

--- a/test/mlnet.Tests/UtilsTests.cs
+++ b/test/mlnet.Tests/UtilsTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.ML.CLI.Utilities;
+
+namespace mlnet.Tests
+{
+    [TestClass]
+    public class UtilsTests
+    {
+
+        [DataTestMethod]
+        [DataRow("NameWithoutSpaces", '_', "NameWithoutSpaces")]
+        [DataRow("Name With Spaces", '.', "Name.With.Spaces")]
+        [DataRow("학습유형들에", '_', "학습유형들에")]
+        public void SanitizeTest(string input, char replacement, string expected)
+        {
+            Assert.AreEqual(Utils.Sanitize(input, replacement), expected);
+        }
+
+    }
+}


### PR DESCRIPTION
This fixes the issue with generating namespaces and project files with spaces in them.
Fixes #3792.

The `Utils.Sanitize` method now takes an extra (optional) parameter, `replacement`, which is the char to replace non letters/digits with. Default value: `_`.  
I thought it's better and easier to sanitize the `OutputName` in the settings directly, since it's used in all the places that needs to be changed (namespaces, project files).

In order to try it, I used the same command/dataset from the issue, the output is:
- Analyzing Categorical Data
  - Analyzing.Categorical.Data.ConsoleApp
    - Analyzing.Categorical.Data.ConsoleApp.csproj
    - ModelBuilder.cs
    - Program.cs
  - Analyzing.Categorical.Data.Model
    - Analyzing.Categorical.Data.Model.csproj
    - DataModels
      - ConsumeModel.cs
      - ModelInput.cs
      - ModelOutput.cs
    - MLModel.zip
  - logs
  - Analyzing.Categorical.Data.sln

And the base namespace is `Analyzing.Categorical.Data`.

---
We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

