### PR TITLE
Adding code generation logic to skip generating properties for ignored columns

### DIFF
--- a/src/Microsoft.ML.CodeGen/CodeGenerator/CSharp/CodeGenerator.cs
+++ b/src/Microsoft.ML.CodeGen/CodeGenerator/CSharp/CodeGenerator.cs
@@ -218,6 +218,10 @@ namespace Microsoft.ML.CodeGenerator.CSharp
             IList<string> result = new List<string>();
             foreach (var column in _columnInferenceResult.TextLoaderOptions.Columns)
             {
+                if (this.columnInferenceResult.ColumnInformation.IgnoredColumnNames.Contains(column.Name))
+                {
+                    continue;
+                }
                 StringBuilder sb = new StringBuilder();
                 int range = (column.Source[0].Max - column.Source[0].Min).Value;
                 bool isArray = range > 0;

--- a/src/Microsoft.ML.CodeGen/CodeGenerator/CSharp/CodeGenerator.cs
+++ b/src/Microsoft.ML.CodeGen/CodeGenerator/CSharp/CodeGenerator.cs
@@ -218,7 +218,7 @@ namespace Microsoft.ML.CodeGenerator.CSharp
             IList<string> result = new List<string>();
             foreach (var column in _columnInferenceResult.TextLoaderOptions.Columns)
             {
-                if (this.columnInferenceResult.ColumnInformation.IgnoredColumnNames.Contains(column.Name))
+                if (IsColumnIgnored(column.Name))
                 {
                     continue;
                 }
@@ -315,7 +315,7 @@ namespace Microsoft.ML.CodeGenerator.CSharp
         private string GeneratePredictProgramCSFileContent(string namespaceValue)
         {
             var columns = _columnInferenceResult.TextLoaderOptions.Columns;
-            var featuresList = columns.Where((str) => str.Name != _settings.LabelName).Select((str) => str.Name).ToList();
+            var featuresList = columns.Where((str) => str.Name != _settings.LabelName && !IsColumnIgnored(str.Name)).Select((str) => str.Name).ToList();
             PredictProgram predictProgram = new PredictProgram()
             {
                 TaskType = _settings.MlTask.ToString(),
@@ -362,6 +362,9 @@ namespace Microsoft.ML.CodeGenerator.CSharp
 
             return modelBuilder.TransformText();
         }
+
+        private bool IsColumnIgnored(string columnName) => _columnInferenceResult.ColumnInformation.IgnoredColumnNames.Contains(columnName);
+
         #endregion
     }
 }

--- a/test/mlnet.Tests/CodeGenTests.cs
+++ b/test/mlnet.Tests/CodeGenTests.cs
@@ -116,6 +116,72 @@ namespace mlnet.Tests
         }
 
         [TestMethod]
+        public void ClassLabelGenerationIgnoredColumns()
+        {
+            var columns = new TextLoader.Column[]
+            {
+                new TextLoader.Column(){ Name = DefaultColumnNames.Item, Source = new TextLoader.Range[]{new TextLoader.Range(0) }, DataKind = DataKind.String },
+            };
+
+            var result = new ColumnInferenceResults()
+            {
+                TextLoaderOptions = new TextLoader.Options()
+                {
+                    Columns = columns,
+                    AllowQuoting = false,
+                    AllowSparse = false,
+                    Separators = new[] { ',' },
+                    HasHeader = true,
+                    TrimWhitespace = true
+                },
+                ColumnInformation = new ColumnInformation()
+            };
+            result.ColumnInformation.IgnoredColumnNames.Add(DefaultColumnNames.Item);
+
+            CodeGenerator codeGenerator = new CodeGenerator(null, result, null);
+            var actual = codeGenerator.GenerateClassLabels();
+
+            Assert.AreEqual(0, actual.Count);
+        }
+
+        [TestMethod]
+        public void ClassLabelGenerationIgnoredAndFeatureColumns()
+        {
+            var columns = new TextLoader.Column[]
+            {
+                new TextLoader.Column(){ Name = DefaultColumnNames.Item, Source = new TextLoader.Range[]{new TextLoader.Range(0) }, DataKind = DataKind.String },
+                new TextLoader.Column(){ Name = DefaultColumnNames.Label, Source = new TextLoader.Range[]{new TextLoader.Range(0) }, DataKind = DataKind.Boolean },
+            };
+
+            var result = new ColumnInferenceResults()
+            {
+                TextLoaderOptions = new TextLoader.Options()
+                {
+                    Columns = columns,
+                    AllowQuoting = false,
+                    AllowSparse = false,
+                    Separators = new[] { ',' },
+                    HasHeader = true,
+                    TrimWhitespace = true
+                },
+                ColumnInformation = new ColumnInformation()
+            };
+            result.ColumnInformation.IgnoredColumnNames.Add(DefaultColumnNames.Item);
+
+            CodeGenerator codeGenerator = new CodeGenerator(null, result, null);
+            var actual = codeGenerator.GenerateClassLabels();
+
+            var expected1 = "[ColumnName(\"Label\"), LoadColumn(0)]";
+            var expected2 = "public bool Label{get; set;}";
+            var expected3 = "\r\n";
+            Assert.AreEqual(3, actual.Count);
+            Assert.AreEqual(expected1, actual[0]);
+            Assert.AreEqual(expected2, actual[1]);
+            Assert.AreEqual(expected3, actual[2]);
+
+        }
+
+        [TestMethod]
         public void TrainerComplexParameterTest()
         {
             var context = new MLContext();


### PR DESCRIPTION
Adding code generation logic to skip generating properties for ignored columns in the Input Model. Ignored columns are specified by the code gen caller in the `ColumnInferenceResults.ColumnInformation` that is passed to the CodeGenerator.

- Adding unit tests to verify that ignored columns do not generate properties.

**Note - I also verified that this change works as expected with a fully generated project.

We are excited to review your PR.

So we can do the best job, please check:

- [x] There's a descriptive title that will make sense to other developers some time from now. 
- [x] There's associated issues. All PR's should have issue(s) associated - unless a trivial self-evident change such as fixing a typo. You can use the format `Fixes #nnnn` in your description to cause GitHub to automatically close the issue(s) when your PR is merged.
- [x] Your change description explains what the change does, why you chose your approach, and anything else that reviewers should know.
- [x] You have included any necessary tests in the same PR.

Fixes https://github.com/dotnet/machinelearning/issues/4224