### PR TITLE
Fix memory leak in TensorflowTransform

### DIFF
--- a/src/Microsoft.ML.Dnn/DnnUtils.cs
+++ b/src/Microsoft.ML.Dnn/DnnUtils.cs
@@ -399,6 +399,11 @@ namespace Microsoft.ML.Transforms.Dnn
                 return this;
             }
 
+            public List<Tensor> GetInputValues()
+            {
+                return _inputValues;
+            }
+
             public Runner AddOutputs(string output)
             {
                 _outputs.Add(ParseOutput(output));

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -645,10 +645,12 @@ namespace Microsoft.ML.Transforms
                     Runner runner = new Runner(_parent.Session);
 
                     // Feed inputs to the graph.
+                    List<Tensor> inputTensors = new List<Tensor>();
                     for (int i = 0; i < _parent.Inputs.Length; i++)
                     {
                         var tensor = srcTensorGetters[i].GetTensor();
                         runner.AddInput(_parent.Inputs[i], tensor);
+                        inputTensors.Add(tensor);
                     }
 
                     // Add outputs.
@@ -657,6 +659,11 @@ namespace Microsoft.ML.Transforms
 
                     // Execute the graph.
                     var tensors = runner.Run();
+
+                    foreach (Tensor inputTensor in inputTensors)
+                    {
+                        inputTensor.Dispose();
+                    }
 
                     Contracts.Assert(tensors.Length > 0);
 

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -463,6 +463,11 @@ namespace Microsoft.ML.Transforms
                 {
                     Session.close(); // invoked Dispose()
                 }
+
+                if (Session != null && Session.graph != IntPtr.Zero)
+                {
+                    Session.graph.Dispose();
+                }
             }
             finally
             {

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -650,12 +650,10 @@ namespace Microsoft.ML.Transforms
                     Runner runner = new Runner(_parent.Session);
 
                     // Feed inputs to the graph.
-                    List<Tensor> inputTensors = new List<Tensor>();
-                    for (int i = 0; i < _parent.Inputs.Length; i++)
+                     for (int i = 0; i < _parent.Inputs.Length; i++)
                     {
                         var tensor = srcTensorGetters[i].GetTensor();
                         runner.AddInput(_parent.Inputs[i], tensor);
-                        inputTensors.Add(tensor);
                     }
 
                     // Add outputs.
@@ -665,6 +663,7 @@ namespace Microsoft.ML.Transforms
                     // Execute the graph.
                     var tensors = runner.Run();
 
+                    List<Tensor> inputTensors = runner.GetInputValues();
                     foreach (Tensor inputTensor in inputTensors)
                     {
                         inputTensor.Dispose();


### PR DESCRIPTION
This PR fixes two memory leaks:
1. After executing the graph, input tensor are not being freed
2. When running multiple pipelines (sessions), graphs are not being freed.

This fixes #4134
