### PR TITLE
Changed Image classification API to accept Image as VBuffer<byte>

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningEarlyStopping.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningEarlyStopping.cs
@@ -57,18 +57,7 @@ namespace Samples.Dynamic
 
                 IDataView trainDataset = trainTestData.TrainSet;
                 IDataView testDataset = trainTestData.TestSet;
-                /*
-                var pipeline = mlContext.Model.ImageClassification(
-                    "ImagePath", "Label",
-                    // Just by changing/selecting InceptionV3 here instead of 
-                    // ResnetV2101 you can try a different architecture/pre-trained 
-                    // model. 
-                    arch: ImageClassificationEstimator.Architecture.ResnetV2101, 
-                    batchSize: 10,
-                    learningRate: 0.01f,
-                    earlyStopping: new ImageClassificationEstimator.EarlyStopping(minDelta: 0.001f, patience:20, metric:ImageClassificationEstimator.EarlyStoppingMetric.Loss),
-                    metricsCallback: (metrics) => Console.WriteLine(metrics),
-                    validationSet: testDataset);*/
+                
                 var validationSet = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
                 .Fit(testDataset)
                 .Transform(testDataset);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningEarlyStopping.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningEarlyStopping.cs
@@ -57,7 +57,7 @@ namespace Samples.Dynamic
 
                 IDataView trainDataset = trainTestData.TrainSet;
                 IDataView testDataset = trainTestData.TestSet;
-
+                /*
                 var pipeline = mlContext.Model.ImageClassification(
                     "ImagePath", "Label",
                     // Just by changing/selecting InceptionV3 here instead of 
@@ -68,7 +68,24 @@ namespace Samples.Dynamic
                     learningRate: 0.01f,
                     earlyStopping: new ImageClassificationEstimator.EarlyStopping(minDelta: 0.001f, patience:20, metric:ImageClassificationEstimator.EarlyStoppingMetric.Loss),
                     metricsCallback: (metrics) => Console.WriteLine(metrics),
-                    validationSet: testDataset);
+                    validationSet: testDataset);*/
+                var validationSet = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                .Fit(testDataset)
+                .Transform(testDataset);
+
+                var pipeline = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                    .Append(mlContext.Model.ImageClassification(
+                        "Image", "Label",
+                        // Just by changing/selecting InceptionV3 here instead of 
+                        // ResnetV2101 you can try a different architecture/pre-trained 
+                        // model. 
+                        arch: ImageClassificationEstimator.Architecture.ResnetV2101,
+                        epoch: 50,
+                        batchSize: 10,
+                        learningRate: 0.01f,
+                        metricsCallback: (metrics) => Console.WriteLine(metrics),
+                        validationSet: validationSet,
+                        disableEarlyStopping: true));
 
 
                 Console.WriteLine("*** Training the image classification model with " +

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningEarlyStopping.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningEarlyStopping.cs
@@ -80,12 +80,11 @@ namespace Samples.Dynamic
                         // ResnetV2101 you can try a different architecture/pre-trained 
                         // model. 
                         arch: ImageClassificationEstimator.Architecture.ResnetV2101,
-                        epoch: 50,
                         batchSize: 10,
                         learningRate: 0.01f,
+                        earlyStopping: new ImageClassificationEstimator.EarlyStopping(minDelta: 0.001f, patience: 20, metric: ImageClassificationEstimator.EarlyStoppingMetric.Loss),
                         metricsCallback: (metrics) => Console.WriteLine(metrics),
-                        validationSet: validationSet,
-                        disableEarlyStopping: true));
+                        validationSet: validationSet));
 
 
                 Console.WriteLine("*** Training the image classification model with " +

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
@@ -30,7 +30,6 @@ namespace Samples.Dynamic
             //Download the image set and unzip
             string finalImagesFolderName = DownloadImageSet(
                 imagesDownloadFolderPath);
-
             string fullImagesetFolderPath = Path.Combine(
                 imagesDownloadFolderPath, finalImagesFolderName);
 
@@ -57,19 +56,24 @@ namespace Samples.Dynamic
 
                 IDataView trainDataset = trainTestData.TrainSet;
                 IDataView testDataset = trainTestData.TestSet;
+                
+                var validationSet = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                    .Fit(testDataset)
+                    .Transform(testDataset);
 
-                var pipeline = mlContext.Model.ImageClassification(
-                    "ImagePath", "Label",
-                    // Just by changing/selecting InceptionV3 here instead of 
-                    // ResnetV2101 you can try a different architecture/pre-trained 
-                    // model. 
-                    arch: ImageClassificationEstimator.Architecture.ResnetV2101, 
-                    epoch: 50,
-                    batchSize: 10,
-                    learningRate: 0.01f,
-                    metricsCallback: (metrics) => Console.WriteLine(metrics),
-                    validationSet: testDataset,
-                    disableEarlyStopping: true);
+                var pipeline = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                    .Append(mlContext.Model.ImageClassification(
+                        "Image", "Label",
+                        // Just by changing/selecting InceptionV3 here instead of 
+                        // ResnetV2101 you can try a different architecture/pre-trained 
+                        // model. 
+                        arch: ImageClassificationEstimator.Architecture.ResnetV2101,
+                        epoch: 50,
+                        batchSize: 10,
+                        learningRate: 0.01f,
+                        metricsCallback: (metrics) => Console.WriteLine(metrics),
+                    	validationSet: testDataset,
+                    	disableEarlyStopping: true);
 
 
                 Console.WriteLine("*** Training the image classification model with " +
@@ -84,7 +88,7 @@ namespace Samples.Dynamic
                 watch.Stop();
                 long elapsedMs = watch.ElapsedMilliseconds;
 
-                Console.WriteLine("Training with transfer learning took: " + 
+                Console.WriteLine("Training with transfer learning took: " +
                     (elapsedMs / 1000).ToString() + " seconds");
 
                 mlContext.Model.Save(trainedModel, shuffledFullImagesDataset.Schema,
@@ -101,7 +105,7 @@ namespace Samples.Dynamic
                 loadedModel.GetOutputSchema(schema)["Label"].GetKeyValues(ref keys);
 
                 watch = System.Diagnostics.Stopwatch.StartNew();
-                TrySinglePrediction(fullImagesetFolderPath, mlContext, loadedModel, 
+                TrySinglePrediction(fullImagesetFolderPath, mlContext, loadedModel,
                     keys.DenseValues().ToArray());
 
                 watch.Stop();
@@ -129,6 +133,9 @@ namespace Samples.Dynamic
 
             IEnumerable<ImageData> testImages = LoadImagesFromDirectory(
                 imagesForPredictions, false);
+
+            byte[] imgBytes = File.ReadAllBytes(testImages.First().ImagePath);
+            VBuffer<Byte> imgData = new VBuffer<byte>(imgBytes.Length, imgBytes);
 
             ImageData imageToPredict = new ImageData
             {
@@ -166,16 +173,15 @@ namespace Samples.Dynamic
             Console.WriteLine("Predicting and Evaluation took: " +
                 (elapsed2Ms / 1000).ToString() + " seconds");
         }
-
+        
         public static IEnumerable<ImageData> LoadImagesFromDirectory(string folder,
             bool useFolderNameasLabel = true)
         {
             var files = Directory.GetFiles(folder, "*",
                 searchOption: SearchOption.AllDirectories);
-
             foreach (var file in files)
             {
-                if (Path.GetExtension(file) != ".jpg")
+                if (Path.GetExtension(file) != ".JPEG" && Path.GetExtension(file) != ".jpg")
                     continue;
 
                 var label = Path.GetFileName(file);
@@ -192,7 +198,7 @@ namespace Samples.Dynamic
                         }
                     }
                 }
-
+                
                 yield return new ImageData()
                 {
                     ImagePath = file,
@@ -305,4 +311,3 @@ namespace Samples.Dynamic
         }
     }
 }
-

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
@@ -72,8 +72,8 @@ namespace Samples.Dynamic
                         batchSize: 10,
                         learningRate: 0.01f,
                         metricsCallback: (metrics) => Console.WriteLine(metrics),
-                    	validationSet: validationSet,
-                    	disableEarlyStopping: true));
+                        validationSet: validationSet,
+                        disableEarlyStopping: true));
 
 
                 Console.WriteLine("*** Training the image classification model with " +

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
@@ -181,7 +181,7 @@ namespace Samples.Dynamic
                 searchOption: SearchOption.AllDirectories);
             foreach (var file in files)
             {
-                if (Path.GetExtension(file) != ".JPEG" && Path.GetExtension(file) != ".jpg")
+                if (Path.GetExtension(file) != ".jpg")
                     continue;
 
                 var label = Path.GetFileName(file);

--- a/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
+++ b/docs/samples/Microsoft.ML.Samples/Dynamic/ImageClassification/ResnetV2101TransferLearningTrainTestSplit.cs
@@ -72,8 +72,8 @@ namespace Samples.Dynamic
                         batchSize: 10,
                         learningRate: 0.01f,
                         metricsCallback: (metrics) => Console.WriteLine(metrics),
-                    	validationSet: testDataset,
-                    	disableEarlyStopping: true);
+                    	validationSet: validationSet,
+                    	disableEarlyStopping: true));
 
 
                 Console.WriteLine("*** Training the image classification model with " +

--- a/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
+++ b/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
     <PackageDescription>ML.NET component for Image support</PackageDescription>
   </PropertyGroup>
 

--- a/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
+++ b/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
     <PackageDescription>ML.NET component for Image support</PackageDescription>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
+++ b/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageDescription>ML.NET component for Image support</PackageDescription>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
+++ b/pkg/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.nupkgproj
@@ -9,6 +9,5 @@
   <ItemGroup>
     <ProjectReference Include="../Microsoft.ML/Microsoft.ML.nupkgproj" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
-  </ItemGroup>
-
+  </ItemGroup>  
 </Project>

--- a/src/Microsoft.ML.Dnn/ImageClassificationTransform.cs
+++ b/src/Microsoft.ML.Dnn/ImageClassificationTransform.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ML.Transforms
                 _imagePreprocessingRunner.AddOutputs(transformer._resizedImageTensorName);
             }
 
-            public Tensor ProcessImage(VBuffer<byte> imageBuffer)
+            public Tensor ProcessImage(in VBuffer<byte> imageBuffer)
             {
                 var imageTensor = EncodeByteAsString(imageBuffer);
                 var processedTensor = _imagePreprocessingRunner.AddInput(imageTensor, 0).Run()[0];

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -97,6 +97,53 @@ namespace Microsoft.ML
             env.CheckValue(columns, nameof(columns));
             return new ImageLoadingEstimator(env, imageFolder, InputOutputColumnPair.ConvertToValueTuples(columns));
         }
+        /// <summary>
+        /// Create a <see cref="ImageLoadingEstimator"/>, which loads the data from the column specified in <paramref name="inputColumnName"/>
+        /// as an image to a new column: <paramref name="outputColumnName"/>.
+        /// </summary>
+        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.
+        /// This column's data type will be <see cref="VectorDataViewType"/>.</param>
+        /// <param name="inputColumnName">Name of the column with paths to the images to load.
+        /// This estimator operates over text data.</param>
+        /// <param name="imageFolder">Folder where to look for images.</param>
+        /// <param name="useImageType">Image type flag - If true loads image as a ImageDataViewType type else loads image as VectorDataViewType. Defaults to ImageDataViewType if not specified or is true.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[LoadImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
+        /// ]]></format>
+        /// </example>
+        public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string outputColumnName, string imageFolder, bool useImageType, string inputColumnName = null)
+           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, useImageType, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
+
+        /// <summary>
+        /// Loads the images from the <see cref="ImageLoadingTransformer.ImageFolder" /> into memory.
+        /// </summary>
+        /// <remarks>
+        /// The image get loaded in memory as a <see cref="VectorDataViewType" /> of bytes.
+        /// Loading is the first step of almost every pipeline that does image processing, and further analysis on images.
+        /// The images to load need to be in the formats supported by <see cref = "VectorDataViewType" /> of bytes.
+        /// For end-to-end image processing pipelines, and scenarios in your applications, see the
+        /// <a href="https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started"> examples in the machinelearning-samples github repository.</a>
+        /// </remarks>
+        /// <param name="catalog">The transform's catalog.</param>
+        /// <param name="imageFolder">Folder where to look for images.</param>
+        /// <param name="useImageType ">Image type flag - If true loads image as a ImageDataViewType type else loads image as VectorDataViewType. Defaults to ImageDataViewType if not specified or is true.</param>
+        /// <param name="columns">Specifies the names of the input columns for the transformation, and their respective output column names.</param>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        ///  [!code-csharp[LoadImagesAsBytes](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
+        /// ]]></format>
+        /// </example>
+        [BestFriend]
+        internal static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string imageFolder, bool useImageType, params InputOutputColumnPair[] columns)
+        {
+            var env = CatalogUtils.GetEnvironment(catalog);
+            env.CheckValue(columns, nameof(columns));
+            return new ImageLoadingEstimator(env, imageFolder, useImageType, InputOutputColumnPair.ConvertToValueTuples(columns));
+        }
 
         /// <summary>
         /// Create a <see cref="ImagePixelExtractingEstimator"/>, which extracts pixels values from the data specified in column: <paramref name="inputColumnName"/>

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -69,34 +69,8 @@ namespace Microsoft.ML
         /// ]]></format>
         /// </example>
         public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName = null)
-           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
+           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, true, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
 
-        /// <summary>
-        /// Loads the images from the <see cref="ImageLoadingTransformer.ImageFolder" /> into memory.
-        /// </summary>
-        /// <remarks>
-        /// The image get loaded in memory as a <see cref="System.Drawing.Bitmap" /> type.
-        /// Loading is the first step of almost every pipeline that does image processing, and further analysis on images.
-        /// The images to load need to be in the formats supported by <see cref = "System.Drawing.Bitmap" />.
-        /// For end-to-end image processing pipelines, and scenarios in your applications, see the
-        /// <a href="https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started"> examples in the machinelearning-samples github repository.</a>
-        /// </remarks>
-        /// <param name="catalog">The transform's catalog.</param>
-        /// <param name="imageFolder">Folder where to look for images.</param>
-        /// <param name="columns">Specifies the names of the input columns for the transformation, and their respective output column names.</param>
-        /// <example>
-        /// <format type="text/markdown">
-        /// <![CDATA[
-        ///  [!code-csharp[LoadImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
-        /// ]]></format>
-        /// </example>
-        [BestFriend]
-        internal static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string imageFolder, params InputOutputColumnPair[] columns)
-        {
-            var env = CatalogUtils.GetEnvironment(catalog);
-            env.CheckValue(columns, nameof(columns));
-            return new ImageLoadingEstimator(env, imageFolder, InputOutputColumnPair.ConvertToValueTuples(columns));
-        }
         /// <summary>
         /// Create a <see cref="ImageLoadingEstimator"/>, which loads the data from the column specified in <paramref name="inputColumnName"/>
         /// as an image to a new column: <paramref name="outputColumnName"/>.
@@ -116,34 +90,6 @@ namespace Microsoft.ML
         /// </example>
         public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string outputColumnName, string imageFolder, bool useImageType, string inputColumnName = null)
            => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, useImageType, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
-
-        /// <summary>
-        /// Loads the images from the <see cref="ImageLoadingTransformer.ImageFolder" /> into memory.
-        /// </summary>
-        /// <remarks>
-        /// The image get loaded in memory as a <see cref="VectorDataViewType" /> of bytes.
-        /// Loading is the first step of almost every pipeline that does image processing, and further analysis on images.
-        /// The images to load need to be in the formats supported by <see cref = "VectorDataViewType" /> of bytes.
-        /// For end-to-end image processing pipelines, and scenarios in your applications, see the
-        /// <a href="https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started"> examples in the machinelearning-samples github repository.</a>
-        /// </remarks>
-        /// <param name="catalog">The transform's catalog.</param>
-        /// <param name="imageFolder">Folder where to look for images.</param>
-        /// <param name="useImageType ">Image type flag - If true loads image as a ImageDataViewType type else loads image as VectorDataViewType. Defaults to ImageDataViewType if not specified or is true.</param>
-        /// <param name="columns">Specifies the names of the input columns for the transformation, and their respective output column names.</param>
-        /// <example>
-        /// <format type="text/markdown">
-        /// <![CDATA[
-        ///  [!code-csharp[LoadImagesAsBytes](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
-        /// ]]></format>
-        /// </example>
-        [BestFriend]
-        internal static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string imageFolder, bool useImageType, params InputOutputColumnPair[] columns)
-        {
-            var env = CatalogUtils.GetEnvironment(catalog);
-            env.CheckValue(columns, nameof(columns));
-            return new ImageLoadingEstimator(env, imageFolder, useImageType, InputOutputColumnPair.ConvertToValueTuples(columns));
-        }
 
         /// <summary>
         /// Create a <see cref="ImagePixelExtractingEstimator"/>, which extracts pixels values from the data specified in column: <paramref name="inputColumnName"/>

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Data
             // int: id of image folder
 
             ImageFolder = ctx.LoadStringOrNull();
-           if (ctx.Header.ModelVerReadable >= 0x00010003) // do a version check
+           if (ctx.Header.ModelVerWritten >= 0x00010003) // do a version check
                 UseImageType = ctx.Reader.ReadBoolean();
             else
                 UseImageType = true; // It is an ImageDataViewType

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -320,6 +320,7 @@ namespace Microsoft.ML.Data
                     if (bytesRead != srcSpan.Length)
                         srcSpan = readBufferSpan.Slice(0, bytesRead);
                     var dstSpan = bufferSpan.Slice(totalBytesRead, bytesRead);
+                    Contract.Assert(srcSpan.Length == dstSpan.Length);
                     srcSpan.CopyTo(dstSpan);
                     totalBytesRead += bytesRead;
                 }

--- a/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
+++ b/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeInPackage>Microsoft.ML.ImageAnalytics</IncludeInPackage>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
+++ b/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
@@ -13,12 +13,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Buffers">
-      <HintPath>..\..\..\..\..\..\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.0.0-preview8-28405-07\ref\netcoreapp3.0\System.Buffers.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  
+  </ItemGroup>  
 </Project>

--- a/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
+++ b/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
     <IncludeInPackage>Microsoft.ML.ImageAnalytics</IncludeInPackage>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,5 +14,5 @@
     <ProjectReference Include="..\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
   </ItemGroup>
-
+  
 </Project>

--- a/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
+++ b/src/Microsoft.ML.ImageAnalytics/Microsoft.ML.ImageAnalytics.csproj
@@ -14,5 +14,11 @@
     <ProjectReference Include="..\Microsoft.ML.Core\Microsoft.ML.Core.csproj" />
     <ProjectReference Include="..\Microsoft.ML.Data\Microsoft.ML.Data.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Buffers">
+      <HintPath>..\..\..\..\..\..\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.0.0-preview8-28405-07\ref\netcoreapp3.0\System.Buffers.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   
 </Project>

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1330,16 +1330,24 @@ namespace Microsoft.ML.Scenarios
             IDataView testDataset = trainTestData.TestSet;
 
             int lastEpoch = 0;
-            var pipeline = mlContext.Model.ImageClassification(
-                "ImagePath", "Label",
-                arch: ImageClassificationEstimator.Architecture.ResnetV2101,
-                epoch: 100,
-                batchSize: 5,
-                learningRate: 0.01f,
-                earlyStopping: new ImageClassificationEstimator.EarlyStopping(),
-                metricsCallback: (metrics) => { Console.WriteLine(metrics); lastEpoch = metrics.Train != null ? metrics.Train.Epoch : 0; },
-                testOnTrainSet: false,
-                validationSet: testDataset);
+            var validationSet = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                    .Fit(testDataset)
+                    .Transform(testDataset);
+
+            var pipeline = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                .Append(mlContext.Model.ImageClassification(
+                    "Image", "Label",
+                    // Just by changing/selecting InceptionV3 here instead of 
+                    // ResnetV2101 you can try a different architecture/pre-trained 
+                    // model. 
+                    arch: ImageClassificationEstimator.Architecture.ResnetV2101,
+                    epoch: 50,
+                    batchSize: 10,
+                    learningRate: 0.01f,
+                    metricsCallback: (metrics) => Console.WriteLine(metrics),
+                    testOnTrainSet: false,
+                    validationSet: validationSet,
+                    disableEarlyStopping: true));
 
             var trainedModel = pipeline.Fit(trainDataset);
             mlContext.Model.Save(trainedModel, shuffledFullImagesDataset.Schema,
@@ -1411,16 +1419,24 @@ namespace Microsoft.ML.Scenarios
             IDataView testDataset = trainTestData.TestSet;
 
             int lastEpoch = 0;
-            var pipeline = mlContext.Model.ImageClassification(
-                "ImagePath", "Label",
-                arch: ImageClassificationEstimator.Architecture.ResnetV2101,
-                epoch: 100,
-                batchSize: 5,
-                learningRate: 0.01f,
-                earlyStopping: new ImageClassificationEstimator.EarlyStopping(metric: ImageClassificationEstimator.EarlyStoppingMetric.Loss),
-                metricsCallback: (metrics) => { Console.WriteLine(metrics); lastEpoch = metrics.Train != null ? metrics.Train.Epoch : 0; },
-                testOnTrainSet: false,
-                validationSet: testDataset);
+            var validationSet = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                     .Fit(testDataset)
+                     .Transform(testDataset);
+
+            var pipeline = mlContext.Transforms.LoadImages("Image", fullImagesetFolderPath, false, "ImagePath") // false indicates we want the image as a VBuffer<byte>
+                .Append(mlContext.Model.ImageClassification(
+                    "Image", "Label",
+                    // Just by changing/selecting InceptionV3 here instead of 
+                    // ResnetV2101 you can try a different architecture/pre-trained 
+                    // model. 
+                    arch: ImageClassificationEstimator.Architecture.ResnetV2101,
+                    epoch: 50,
+                    batchSize: 10,
+                    learningRate: 0.01f,
+                    metricsCallback: (metrics) => Console.WriteLine(metrics),
+                    testOnTrainSet: false,
+                    validationSet: validationSet,
+                    disableEarlyStopping: true));
 
             var trainedModel = pipeline.Fit(trainDataset);
             mlContext.Model.Save(trainedModel, shuffledFullImagesDataset.Schema,

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1258,9 +1258,9 @@ namespace Microsoft.ML.Scenarios
                     batchSize: 10,
                     learningRate: 0.01f,
                     metricsCallback: (metrics) => Console.WriteLine(metrics),
-                	testOnTrainSet: false,
+                    testOnTrainSet: false,
                     validationSet: validationSet,
-                	disableEarlyStopping: true));
+                    disableEarlyStopping: true));
 
             var trainedModel = pipeline.Fit(trainDataset);
 

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1341,13 +1341,13 @@ namespace Microsoft.ML.Scenarios
                     // ResnetV2101 you can try a different architecture/pre-trained 
                     // model. 
                     arch: ImageClassificationEstimator.Architecture.ResnetV2101,
-                    epoch: 50,
-                    batchSize: 10,
+                    epoch: 100,
+                    batchSize: 5,
                     learningRate: 0.01f,
-                    metricsCallback: (metrics) => Console.WriteLine(metrics),
+                    earlyStopping: new ImageClassificationEstimator.EarlyStopping(),
+                    metricsCallback: (metrics) => { Console.WriteLine(metrics); lastEpoch = metrics.Train != null ? metrics.Train.Epoch : 0; },
                     testOnTrainSet: false,
-                    validationSet: validationSet,
-                    disableEarlyStopping: true));
+                    validationSet: validationSet));
 
             var trainedModel = pipeline.Fit(trainDataset);
             mlContext.Model.Save(trainedModel, shuffledFullImagesDataset.Schema,
@@ -1430,13 +1430,13 @@ namespace Microsoft.ML.Scenarios
                     // ResnetV2101 you can try a different architecture/pre-trained 
                     // model. 
                     arch: ImageClassificationEstimator.Architecture.ResnetV2101,
-                    epoch: 50,
-                    batchSize: 10,
+                    epoch: 100,
+                    batchSize: 5,
                     learningRate: 0.01f,
-                    metricsCallback: (metrics) => Console.WriteLine(metrics),
+                    earlyStopping: new ImageClassificationEstimator.EarlyStopping(metric: ImageClassificationEstimator.EarlyStoppingMetric.Loss),
+                    metricsCallback: (metrics) => {Console.WriteLine(metrics); lastEpoch = metrics.Train != null ? metrics.Train.Epoch : 0;},
                     testOnTrainSet: false,
-                    validationSet: validationSet,
-                    disableEarlyStopping: true));
+                    validationSet: validationSet));
 
             var trainedModel = pipeline.Fit(trainDataset);
             mlContext.Model.Save(trainedModel, shuffledFullImagesDataset.Schema,

--- a/tools-local/Microsoft.ML.StableApi/Microsoft.ML.StableApi.csproj
+++ b/tools-local/Microsoft.ML.StableApi/Microsoft.ML.StableApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- needs to contain all frameworks which src projects wish to restore -->
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools-local/Microsoft.ML.StableApi/Microsoft.ML.StableApi.csproj
+++ b/tools-local/Microsoft.ML.StableApi/Microsoft.ML.StableApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- needs to contain all frameworks which src projects wish to restore -->
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changed Image classification API to accept Image as V Buffer<byte>. Also, added a few optimizations to re-use the buffer for performance gains.
So we can do the best job, please check:

fixes #4153

