### PR TITLE
Modified the project to support running of TensorFlow on GPU on Windows.

### DIFF
--- a/Microsoft.ML.sln
+++ b/Microsoft.ML.sln
@@ -276,6 +276,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.ML.AutoML", "Micr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ML.AutoML.Samples", "docs\samples\Microsoft.ML.AutoML.Samples\Microsoft.ML.AutoML.Samples.csproj", "{A6924919-9E37-4023-8B7F-E85C8E3CC9B3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ML.Samples.GPU", "docs\samples\Microsoft.ML.Samples.GPU\Microsoft.ML.Samples.GPU.csproj", "{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1611,6 +1613,30 @@ Global
 		{A6924919-9E37-4023-8B7F-E85C8E3CC9B3}.Release-netfx|Any CPU.ActiveCfg = Release-netfx|Any CPU
 		{A6924919-9E37-4023-8B7F-E85C8E3CC9B3}.Release-netfx|Any CPU.Build.0 = Release-netfx|Any CPU
 		{A6924919-9E37-4023-8B7F-E85C8E3CC9B3}.Release-netfx|x64.ActiveCfg = Release-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netcoreapp3_0|Any CPU.ActiveCfg = Debug-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netcoreapp3_0|Any CPU.Build.0 = Debug-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netcoreapp3_0|x64.ActiveCfg = Debug-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netcoreapp3_0|x64.Build.0 = Debug-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netfx|Any CPU.ActiveCfg = Debug-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netfx|Any CPU.Build.0 = Debug-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netfx|x64.ActiveCfg = Debug-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Debug-netfx|x64.Build.0 = Debug-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release|x64.Build.0 = Release|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netcoreapp3_0|Any CPU.ActiveCfg = Release-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netcoreapp3_0|Any CPU.Build.0 = Release-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netcoreapp3_0|x64.ActiveCfg = Release-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netcoreapp3_0|x64.Build.0 = Release-netcoreapp3_0|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netfx|Any CPU.ActiveCfg = Release-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netfx|Any CPU.Build.0 = Release-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netfx|x64.ActiveCfg = Release-netfx|Any CPU
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD}.Release-netfx|x64.Build.0 = Release-netfx|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1697,6 +1723,7 @@ Global
 		{E48285BF-F49A-4EA3-AED0-1BDDBF77EB80} = {09EADF06-BE25-4228-AB53-95AE3E15B530}
 		{F5D11F71-2D61-4AE9-99D7-0F0B54649B15} = {D3D38B03-B557-484D-8348-8BADEE4DF592}
 		{A6924919-9E37-4023-8B7F-E85C8E3CC9B3} = {DA452A53-2E94-4433-B08C-041EDEC729E6}
+		{3C8F910B-7F23-4D25-B521-6D5AC9570ADD} = {DA452A53-2E94-4433-B08C-041EDEC729E6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {41165AF1-35BB-4832-A189-73060F82B01D}

--- a/docs/api-reference/tensorflow-usage.md
+++ b/docs/api-reference/tensorflow-usage.md
@@ -1,0 +1,36 @@
+## Using TensorFlow based APIs
+In order to run any TensorFlow based ML.Net APIs you must first add a NuGet dependency 
+on the TensorFlow redist library. There are currently two versions you can use. One which is 
+compiled for GPU support, and one which has CPU support only.
+
+### CPU only
+CPU based TensorFlow is currently supported on:
+* Linux
+* MacOS
+* Windows
+
+To get TensorFlow working on the CPU only all that is to take a NuGet dependency on
+SciSharp.TensorFlow.Redist v1.14.0
+
+### GPU support
+GPU based TensorFlow is currently supported on:
+* Windows
+
+#### Prerequisites
+You must have at least one CUDA compatible GPU, for a list of compatible GPUs see
+[Nvidia's Guide](https://developer.nvidia.com/cuda-gpus).
+
+Install [CUDA v10.0](https://developer.nvidia.com/cuda-10.0-download-archive) and [CUDNN v7.6.4](https://developer.nvidia.com/rdp/cudnn-download)
+following [Nvidia's Install guide](https://docs.nvidia.com/cuda/cuda-quick-start-guide/index.html).
+
+#### Usage
+To use TensorFlow with GPU support take a NuGet dependency on the following package depending on your OS:
+
+Windows -> SciSharp.TensorFlow.Redist-Windows-GPU
+
+No code modification should be necessary to leverage the GPU for TensorFlow operations.
+
+#### Troubleshooting
+If you are not able to use your GPU after adding the GPU based TensorFlow NuGet,
+make sure that there is only a dependency on the GPU based version. If you have
+a dependency on both NuGets, the CPU based TensorFlow will run instead.

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -1,0 +1,63 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <SignAssembly>false</SignAssembly>
+    <!--This ensures that we can never make the mistake of adding this as a friend assembly. Please don't remove.-->
+    <PublicSign>false</PublicSign>
+    <RootNamespace>Samples</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Microsoft.ML.Samples\Program.cs" Link="Program.cs" />
+    <Compile Include="..\Microsoft.ML.Samples\Dynamic\ImageClassification\*.cs">
+      <Link>Dynamic\ImageClassification\%(FileName)</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.ML.Samples\Dynamic\TensorFlow\*.cs">
+      <Link>Dynamic\TensorFlow\%(FileName)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.ML.Dnn\Microsoft.ML.Dnn.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.ML.TensorFlow\Microsoft.ML.TensorFlow.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.ML.SamplesUtils\Microsoft.ML.SamplesUtils.csproj" />
+
+    <NativeAssemblyReference Include="CpuMathNative" />
+    <NativeAssemblyReference Include="FastTreeNative" />
+    <NativeAssemblyReference Include="MatrixFactorizationNative" />
+    <NativeAssemblyReference Include="LdaNative" />
+    <NativeAssemblyReference Include="SymSgdNative" />
+    <NativeAssemblyReference Include="MklProxyNative" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist-Windows-GPU" Version="1.14.0" />
+  </ItemGroup>
+
+    <ItemGroup>
+    <Content Include="$(ObjDir)DnnImageModels\ResNet18Onnx\ResNet18.onnx">
+      <Link>DnnImageModels\ResNet18Onnx\ResNet18.onnx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+    <ItemGroup>
+    <Content Include="$(ObjDir)DnnImageModels\ResNetPrepOnnx\ResNetPreprocess.onnx">
+      <Link>DnnImageModels\ResNetPrepOnnx\ResNetPreprocess.onnx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Dynamic\" />
+    </ItemGroup>
+
+</Project>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
-    <PackageReference Include="SciSharp.TensorFlow.Redist-Windows-GPU" Version="1.14.0" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist-Windows-GPU" Version="$(TensorFlowVersion)" />
   </ItemGroup>
 
     <ItemGroup>

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -947,7 +947,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="$(TensorFlowVersion)" />
   </ItemGroup>
 
     <ItemGroup>

--- a/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
+++ b/docs/samples/Microsoft.ML.Samples/Microsoft.ML.Samples.csproj
@@ -70,7 +70,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>LbfgsLogisticRegressionWithOptions.tt</DependentUpon>
     </None>
-    <PackageReference Include="Microsoft.ML.TensorFlow.Redist" Version="0.10.0" />
 
   </ItemGroup>
 
@@ -948,6 +947,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
   </ItemGroup>
 
     <ItemGroup>

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -11,8 +11,6 @@ namespace Microsoft.ML.Samples
         internal static void RunAll()
         {
             int samples = 0;
-
-
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -11,6 +11,8 @@ namespace Microsoft.ML.Samples
         internal static void RunAll()
         {
             int samples = 0;
+
+
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);

--- a/src/Microsoft.ML.Dnn/DnnCatalog.cs
+++ b/src/Microsoft.ML.Dnn/DnnCatalog.cs
@@ -20,6 +20,12 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Retrain the dnn model on new data.
+        /// usage of this API requires additional NuGet dependencies on TensorFlow redist, see linked document for more information.
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!include[io](~/../docs/samples/docs/api-reference/tensorflow-usage.md)]
+        /// ]]>
+        /// </format>
         /// </summary>
         /// <param name="catalog"></param>
         /// <param name="inputColumnNames"> The names of the model inputs.</param>
@@ -79,6 +85,12 @@ namespace Microsoft.ML
 
         /// <summary>
         /// Performs image classification using transfer learning.
+        /// usage of this API requires additional NuGet dependencies on TensorFlow redist, see linked document for more information.
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!include[io](~/../docs/samples/docs/api-reference/tensorflow-usage.md)]
+        /// ]]>
+        /// </format>
         /// </summary>
         /// <param name="catalog"></param>
         /// <param name="featuresColumnName">The name of the input features column.</param>

--- a/src/Microsoft.ML.Dnn/Microsoft.ML.Dnn.csproj
+++ b/src/Microsoft.ML.Dnn/Microsoft.ML.Dnn.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControl)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindows)" />
     <PackageReference Include="TensorFlow.NET" Version="$(TensorflowDotNETVersion)" />

--- a/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowCatalog.cs
@@ -14,6 +14,12 @@ namespace Microsoft.ML
         /// <summary>
         /// Load TensorFlow model into memory. This is the convenience method that allows the model to be loaded once and subsequently use it for querying schema and creation of
         /// <see cref="TensorFlowEstimator"/> using <see cref="TensorFlowModel.ScoreTensorFlowModel(string, string, bool)"/>.
+        /// usage of this API requires additional NuGet dependencies on TensorFlow redist, see linked document for more information.
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// [!include[io](~/../docs/samples/docs/api-reference/tensorflow-usage.md)]
+        /// ]]>
+        /// </format>
         /// </summary>
         /// <param name="catalog">The transform's catalog.</param>
         /// <param name="modelLocation">Location of the TensorFlow model.</param>

--- a/test/Microsoft.ML.Core.Tests/Microsoft.ML.Core.Tests.csproj
+++ b/test/Microsoft.ML.Core.Tests/Microsoft.ML.Core.Tests.csproj
@@ -25,7 +25,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.TestModels" Version="$(MicrosoftMLTestModelsPackageVersion)" />
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="$(TensorFlowVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.ML.Core.Tests/Microsoft.ML.Core.Tests.csproj
+++ b/test/Microsoft.ML.Core.Tests/Microsoft.ML.Core.Tests.csproj
@@ -25,6 +25,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.TestModels" Version="$(MicrosoftMLTestModelsPackageVersion)" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,7 +34,7 @@
     <NativeAssemblyReference Include="FastTreeNative" />
     <NativeAssemblyReference Include="LdaNative" />
     <NativeAssemblyReference Include="MklImports" />
-    <NativeAssemblyReference Condition="'$(OS)' == 'Windows_NT'" Include="libiomp5md"/>
+    <NativeAssemblyReference Condition="'$(OS)' == 'Windows_NT'" Include="libiomp5md" />
   </ItemGroup>
 
   <!-- TensorFlow is 64-bit only -->

--- a/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
+++ b/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
     <PackageReference Include="Microsoft.ML.TestDatabases" Version="$(MicrosoftMLTestDatabasesPackageVersion)" />
     <PackageReference Include="Microsoft.ML.TestModels" Version="$(MicrosoftMLTestModelsPackageVersion)" />
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="$(TensorFlowVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
+++ b/test/Microsoft.ML.Tests/Microsoft.ML.Tests.csproj
@@ -52,6 +52,7 @@
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
     <PackageReference Include="Microsoft.ML.TestDatabases" Version="$(MicrosoftMLTestDatabasesPackageVersion)" />
     <PackageReference Include="Microsoft.ML.TestModels" Version="$(MicrosoftMLTestModelsPackageVersion)" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed all dependencies of TensorFlow redist from the source projects,
and instead added the dependency to the Sample project.
Created separate sample project for GPU examples since gpu tensorflow requires cuda,
which may not be available on all machines, so it needs to be a separate
project.
Added documentation for setup as there is now some setup requirements to use this API.

In testing on the large flowers data set I was able to see a large improvement in speed, from taking ~720 seconds to train to taking ~156 seconds. 

Fixes #4269

Addresses part of the issue in #86 

