### PR TITLE
Issue 4120, add reasonable exception when user try to use OnnxSequenceType attribute without specify sequence type

### DIFF
--- a/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
@@ -57,7 +57,8 @@ namespace Microsoft.ML.Transforms.Onnx
         private Type _elemType;
 
         // Comment out default constructor
-        // Use default contructor will left the _elemType field empty and cause exception in methods using _elemType
+        // Use default constructor will left the _elemType field empty and cause exception in methods using _elemType
+        // Comment out default constructor will give user compile error when user try to use [OnnxSequenceType] attribute directly without specify sequence type
         //public OnnxSequenceTypeAttribute()
         //{
         //}

--- a/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
@@ -56,12 +56,13 @@ namespace Microsoft.ML.Transforms.Onnx
     {
         private Type _elemType;
 
-        // Comment out default constructor
-        // Use default constructor will left the _elemType field empty and cause exception in methods using _elemType
-        // Comment out default constructor will give user compile error when user try to use [OnnxSequenceType] attribute directly without specify sequence type
-        //public OnnxSequenceTypeAttribute()
-        //{
-        //}
+        // Make default constructor obsolete.
+        // Use default constructor will left the _elemType field empty and cause exception in methods using _elemType.
+        // User will receive compile error when try to use [OnnxSequenceType] attribute directly without specify sequence type
+        [Obsolete("Please specify sequence type when use OnnxSequenceType Attribute", true)]
+        public OnnxSequenceTypeAttribute()
+        {
+        }
 
         /// <summary>
         /// Create a <paramref name="elemType"/>-sequence type.

--- a/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
@@ -94,6 +94,12 @@ namespace Microsoft.ML.Transforms.Onnx
         /// </summary>
         public override void Register()
         {
+            // this happens when use OnnxSequenceType attribute without specify sequence type
+            if (_elemType == null)
+            {
+                throw new Exception("Please specify sequence type when use OnnxSequenceType Attribute.");
+            }
+
             var enumerableType = typeof(IEnumerable<>);
             var type = enumerableType.MakeGenericType(_elemType);
             DataViewTypeManager.Register(new OnnxSequenceType(_elemType), type, this);

--- a/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
@@ -56,12 +56,11 @@ namespace Microsoft.ML.Transforms.Onnx
     {
         private Type _elemType;
 
-        /// <summary>
-        /// Create a sequence type.
-        /// </summary>
-        public OnnxSequenceTypeAttribute()
-        {
-        }
+        // Comment out default constructor
+        // Use default contructor will left the _elemType field empty and cause exception in methods using _elemType
+        //public OnnxSequenceTypeAttribute()
+        //{
+        //}
 
         /// <summary>
         /// Create a <paramref name="elemType"/>-sequence type.
@@ -94,10 +93,6 @@ namespace Microsoft.ML.Transforms.Onnx
         /// </summary>
         public override void Register()
         {
-            // this happens when use OnnxSequenceType attribute without specify sequence type
-            if (_elemType == null)
-                throw new InvalidOperationException("Please specify sequence type when use OnnxSequenceType Attribute.");
-
             var enumerableType = typeof(IEnumerable<>);
             var type = enumerableType.MakeGenericType(_elemType);
             DataViewTypeManager.Register(new OnnxSequenceType(_elemType), type, this);

--- a/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxSequenceType.cs
@@ -96,9 +96,7 @@ namespace Microsoft.ML.Transforms.Onnx
         {
             // this happens when use OnnxSequenceType attribute without specify sequence type
             if (_elemType == null)
-            {
-                throw new Exception("Please specify sequence type when use OnnxSequenceType Attribute.");
-            }
+                throw new InvalidOperationException("Please specify sequence type when use OnnxSequenceType Attribute.");
 
             var enumerableType = typeof(IEnumerable<>);
             var type = enumerableType.MakeGenericType(_elemType);

--- a/test/Microsoft.ML.Tests/OnnxSequenceTypeTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxSequenceTypeTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using Microsoft.ML.Data;
@@ -13,7 +14,7 @@ using Xunit.Abstractions;
 using System.Linq;
 using System.IO;
 using Microsoft.ML.TestFramework.Attributes;
-using System;
+
 
 namespace Microsoft.ML.Tests
 {
@@ -83,7 +84,7 @@ namespace Microsoft.ML.Tests
 
         }
 
-        private static PredictionEngine<FloatInput, ProblematicOutputObj> CreatePredictorWithPronlematicOutputObj()
+        private static PredictionEngine<FloatInput, ProblematicOutputObj> CreatePredictorWithProblematicOutputObj()
         {
             var onnxModelFilePath = Path.Combine(Directory.GetCurrentDirectory(), "zipmap", "TestZipMapString.onnx");
 
@@ -95,7 +96,7 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxSequenceTypeWithouSpecifySequenceTypeTest()
         {
-            Exception ex = Assert.Throws<Exception>(() => CreatePredictorWithPronlematicOutputObj());
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => CreatePredictorWithProblematicOutputObj());
             Assert.Equal("Please specify sequence type when use OnnxSequenceType Attribute.", ex.Message);
         }
     }

--- a/test/Microsoft.ML.Tests/OnnxSequenceTypeTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxSequenceTypeTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Tests
 
         }
 
-        private static PredictionEngine<FloatInput, ProblematicOutputObj> CreatePredictor()
+        private static PredictionEngine<FloatInput, ProblematicOutputObj> CreatePredictorWithPronlematicOutputObj()
         {
             var onnxModelFilePath = Path.Combine(Directory.GetCurrentDirectory(), "zipmap", "TestZipMapString.onnx");
 
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxSequenceTypeWithouSpecifySequenceTypeTest()
         {
-            Exception ex = Assert.Throws<Exception>(() => CreatePredictor());
+            Exception ex = Assert.Throws<Exception>(() => CreatePredictorWithPronlematicOutputObj());
             Assert.Equal("Please specify sequence type when use OnnxSequenceType Attribute.", ex.Message);
         }
     }

--- a/test/Microsoft.ML.Tests/OnnxSequenceTypeWithAttributesTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxSequenceTypeWithAttributesTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Tests
             var onnx_out = output.Output.FirstOrDefault();
             Assert.True(onnx_out.Count == 3, "Output missing data.");
             var keys = new List<string>(onnx_out.Keys);
-            for (var i = 0; i < onnx_out.Count; ++i)
+            for(var i =0; i < onnx_out.Count; ++i)
             {
                 Assert.Equal(onnx_out[keys[i]], input.Input[i]);
             }


### PR DESCRIPTION
Fixes #4120 

The issue is: when user use OnnxSequenceType attribute directly without specify sequence type like [OnnxSequenceType], user will hit run time exception when try to use it.

The ideal way to fix this issue is to remove the default constructor of OnnxSequenceTypeAttribute and user will get compiler error when he/she try to use [OnnxSequenceType]. 
But this can be a break change in Public API. After discuss with @eerhardt and @ericstj , we decide to obsolete the default constructor for now. Then we will remove the default constructor in next major release.



