### PR TITLE
Add DateTime to DateTime standard conversion.

### DIFF
--- a/src/Microsoft.ML.Data/Data/Conversion.cs
+++ b/src/Microsoft.ML.Data/Data/Conversion.cs
@@ -231,6 +231,7 @@ namespace Microsoft.ML.Data.Conversion
             AddStd<DT, I8>(Convert);
             AddStd<DT, R4>(Convert);
             AddStd<DT, R8>(Convert);
+            AddStd<DT, DT>(Convert);
             AddAux<DT, SB>(Convert);
 
             AddStd<DZ, I8>(Convert);
@@ -1673,5 +1674,9 @@ namespace Microsoft.ML.Data.Conversion
         public void Convert(in BL src, ref R8 dst) => dst = System.Convert.ToDouble(src);
         public void Convert(in BL src, ref BL dst) => dst = src;
         #endregion FromBL
+
+        #region ToDT
+        public void Convert(in DT src, ref DT dst) => dst = src;
+        #endregion ToDT
     }
 }

--- a/test/Microsoft.ML.Core.Tests/UnitTests/DataTypes.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/DataTypes.cs
@@ -228,6 +228,26 @@ namespace Microsoft.ML.RunTests
             Assert.Equal(default, dst);
         }
 
+        [Fact]
+        public void DTToDT()
+        {
+            bool identity;
+            var dtToDT = Conversions.Instance.GetStandardConversion<DateTime, DateTime>(
+                DateTimeDataViewType.Instance, DateTimeDataViewType.Instance, out identity);
+
+            Assert.NotNull(dtToDT);
+
+            DateTime dt = new DateTime(2017, 03, 05);
+            DateTime result = default;
+
+            dtToDT(in dt, ref result);
+
+            Assert.True(identity);
+            Assert.Equal(dt, result);
+            Assert.Equal(3, dt.Month);
+            Assert.Equal(dt.Kind, result.Kind);
+        }
+
         private static ValueMapper<TSrc, TDst> GetMapper<TSrc, TDst>(DataViewType dstType)
         {
             Assert.True(typeof(TDst) == dstType.RawType);


### PR DESCRIPTION
This fixes an error which is caused by a missing DateTime to DateTime conversion when outputting DateTime columns in NimbusML. NimbusML calls in to `RowCursorUtils.GetGetterAsCore` (indirectly) which tries to find a conversion from DateTime to DateTime and fails with the following error:

```console
Error: *** System.InvalidOperationException: 'No standard conversion from 'DateTime' to 'DateTime'
```
