### PR TITLE
Added support for running TF based models on GPU in Linux

### DIFF
--- a/docs/api-reference/tensorflow-usage.md
+++ b/docs/api-reference/tensorflow-usage.md
@@ -15,6 +15,8 @@ SciSharp.TensorFlow.Redist v1.14.0
 ### GPU support
 GPU based TensorFlow is currently supported on:
 * Windows
+* Linux
+As of now TensorFlow does not support running on GPUs for MacOS, so we cannot support this currently.
 
 #### Prerequisites
 You must have at least one CUDA compatible GPU, for a list of compatible GPUs see
@@ -26,7 +28,8 @@ following [Nvidia's Install guide](https://docs.nvidia.com/cuda/cuda-quick-start
 #### Usage
 To use TensorFlow with GPU support take a NuGet dependency on the following package depending on your OS:
 
-Windows -> SciSharp.TensorFlow.Redist-Windows-GPU
+* Windows -> SciSharp.TensorFlow.Redist-Windows-GPU
+* Linux -> SciSharp.TensorFlow.Redist-Linux-GPU
 
 No code modification should be necessary to leverage the GPU for TensorFlow operations.
 

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
     <PackageReference Include="SciSharp.TensorFlow.Redist-Windows-GPU" Version="$(TensorFlowVersion)" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist-Linux-GPU" Version="$(TensorFlowVersion)" />
   </ItemGroup>
 
     <ItemGroup>

--- a/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
+++ b/docs/samples/Microsoft.ML.Samples.GPU/Microsoft.ML.Samples.GPU.csproj
@@ -39,7 +39,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.Onnx.TestModels" Version="$(MicrosoftMLOnnxTestModelsVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT'">
     <PackageReference Include="SciSharp.TensorFlow.Redist-Windows-GPU" Version="$(TensorFlowVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(OS)' == 'Unix'">
     <PackageReference Include="SciSharp.TensorFlow.Redist-Linux-GPU" Version="$(TensorFlowVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Modified the GPU samples to take a dependency on both the linux and
windows TF GPU redist.

Modified the readme content to explain how to use on linux.

Tested on Ubuntu 18.04 with GTX1070, was able to run on the GPU without any issue.

