### PR TITLE
Fix nuget dependency for Dnn

### DIFF
--- a/pkg/Microsoft.ML.Dnn/Microsoft.ML.Dnn.nupkgproj
+++ b/pkg/Microsoft.ML.Dnn/Microsoft.ML.Dnn.nupkgproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControl)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindows)" />
     <PackageReference Include="TensorFlow.NET" Version="$(TensorflowDotNETVersion)" />


### PR DESCRIPTION
With change to allow users to support GPU, need to remove the dependency
on TF redist from nuget. It will now be up to the user to add a
dependency on the correct nuget, such that they can choose to use either
the GPU or the CPU.

fixes #4325