### PR TITLE
Add try catch block to skip bad(failing to read) images

### DIFF
--- a/src/Microsoft.ML.Dnn/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Dnn/ImageClassificationTrainer.cs
@@ -716,7 +716,7 @@ namespace Microsoft.ML.Dnn
                     if (e.HResult == -2146233088 && e.Message.Contains("Expected image (JPEG, PNG, or GIF), got unknown format"))
                         return null;
                     else
-                        throw (e);
+                        throw;
                 }
             }
         }

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1792,22 +1792,22 @@ namespace Microsoft.ML.Scenarios
             IDataView trainDataset = trainTestData.TrainSet;
             IDataView testDataset = trainTestData.TestSet;
 
-            var options = new ImageClassificationEstimator.Options()
+            var options = new ImageClassificationTrainer.Options()
             {
-                FeaturesColumnName = "Image",
+                FeatureColumnName = "Image",
                 LabelColumnName = "Label",
                 // Just by changing/selecting InceptionV3/MobilenetV2 here instead of 
                 // ResnetV2101 you can try a different architecture/
                 // pre-trained model. 
-                Arch = ImageClassificationEstimator.Architecture.ResnetV2101,
+                Arch = ImageClassificationTrainer.Architecture.ResnetV2101,
                 Epoch = 5,
                 BatchSize = 32,
                 LearningRate = 0.0001f,
                 ValidationSet = testDataset,
-                DisableEarlyStopping = true
+                EarlyStoppingCriteria = null
             };
 
-            var pipeline = mlContext.Model.ImageClassification(options);
+            var pipeline = mlContext.MulticlassClassification.Trainers.ImageClassification(options);
 
             var trainedModel = pipeline.Fit(trainDataset);
             mlContext.Model.Save(trainedModel, shuffledFullImagesDataset.Schema,

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1780,8 +1780,7 @@ namespace Microsoft.ML.Scenarios
 
             shuffledFullImagesDataset = mlContext.Transforms.Conversion
                 .MapValueToKey("Label")
-                .Append(mlContext.Transforms.LoadImages("Image",
-                                fullImagesetFolderPath, false, "ImagePath"))
+                .Append(mlContext.Transforms.LoadRawImageBytes("Image", fullImagesetFolderPath, "ImagePath"))
                 .Fit(shuffledFullImagesDataset)
                 .Transform(shuffledFullImagesDataset);
 
@@ -1823,8 +1822,8 @@ namespace Microsoft.ML.Scenarios
 
             // Assert accuracy was returned meaning training completed
             // by skipping bad images.
-            Assert.InRange(metrics.MicroAccuracy, 0.1, 1);
-            Assert.InRange(metrics.MacroAccuracy, 0.1, 1);
+            Assert.InRange(metrics.MicroAccuracy, 0.3, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.3, 1);
         }
 
         public static IEnumerable<ImageData> LoadImagesFromDirectory(string folder,

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1754,6 +1754,79 @@ namespace Microsoft.ML.Scenarios
             Assert.InRange(lastEpoch, 1, 49);
         }
 
+        [TensorFlowFact]
+        public void TensorFlowImageClassificationBadImages()
+        {
+            string assetsRelativePath = @"assets";
+            string assetsPath = GetAbsolutePath(assetsRelativePath);
+            string imagesDownloadFolderPath = Path.Combine(assetsPath, "inputs",
+                "images");
+
+            //Download the image set and unzip
+            string finalImagesFolderName = DownloadBadImageSet(
+                imagesDownloadFolderPath);
+
+            string fullImagesetFolderPath = Path.Combine(
+                imagesDownloadFolderPath, finalImagesFolderName);
+
+            MLContext mlContext = new MLContext(seed: 1);
+
+            //Load all the original images info
+            IEnumerable<ImageData> images = LoadImagesFromDirectory(
+                folder: fullImagesetFolderPath, useFolderNameAsLabel: true);
+
+            IDataView shuffledFullImagesDataset = mlContext.Data.ShuffleRows(
+                mlContext.Data.LoadFromEnumerable(images), seed: 1);
+
+            shuffledFullImagesDataset = mlContext.Transforms.Conversion
+                .MapValueToKey("Label")
+                .Append(mlContext.Transforms.LoadImages("Image",
+                                fullImagesetFolderPath, false, "ImagePath"))
+                .Fit(shuffledFullImagesDataset)
+                .Transform(shuffledFullImagesDataset);
+
+            // Split the data 90:10 into train and test sets, train and evaluate.
+            TrainTestData trainTestData = mlContext.Data.TrainTestSplit(
+                shuffledFullImagesDataset, testFraction: 0.1, seed: 1);
+
+            IDataView trainDataset = trainTestData.TrainSet;
+            IDataView testDataset = trainTestData.TestSet;
+
+            var options = new ImageClassificationEstimator.Options()
+            {
+                FeaturesColumnName = "Image",
+                LabelColumnName = "Label",
+                // Just by changing/selecting InceptionV3/MobilenetV2 here instead of 
+                // ResnetV2101 you can try a different architecture/
+                // pre-trained model. 
+                Arch = ImageClassificationEstimator.Architecture.ResnetV2101,
+                Epoch = 5,
+                BatchSize = 32,
+                LearningRate = 0.0001f,
+                ValidationSet = testDataset,
+                DisableEarlyStopping = true
+            };
+
+            var pipeline = mlContext.Model.ImageClassification(options);
+
+            var trainedModel = pipeline.Fit(trainDataset);
+            mlContext.Model.Save(trainedModel, shuffledFullImagesDataset.Schema,
+                "model.zip");
+
+            ITransformer loadedModel;
+            DataViewSchema schema;
+            using (var file = File.OpenRead("model.zip"))
+                loadedModel = mlContext.Model.Load(file, out schema);
+
+            IDataView predictions = trainedModel.Transform(testDataset);
+            var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
+
+            // Assert accuracy was returned meaning training completed
+            // by skipping bad images.
+            Assert.InRange(metrics.MicroAccuracy, 0.1, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.1, 1);
+        }
+
         public static IEnumerable<ImageData> LoadImagesFromDirectory(string folder,
             bool useFolderNameAsLabel = true)
         {
@@ -1795,6 +1868,18 @@ namespace Microsoft.ML.Scenarios
                 $"/flower_images/flower_photos_tiny_set_for_unit_tests.zip?st=2019" +
                 $"-08-29T00%3A07%3A21Z&se=2030-08-30T00%3A07%3A00Z&sp=rl&sv=2018" +
                 $"-03-28&sr=f&sig=N8HbLziTcT61kstprNLmn%2BDC0JoMrNwo6yRWb3hLLag%3D";
+
+            Download(url, imagesDownloadFolder, fileName);
+            UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);
+
+            return Path.GetFileNameWithoutExtension(fileName);
+        }
+
+        public static string DownloadBadImageSet(string imagesDownloadFolder)
+        {
+            string fileName = "CatsVsDogs_tiny_for_unit_tests.zip";
+            string url = $"https://tlcresources.blob.core.windows.net/datasets/" +
+                $"CatsVsDogs_tiny_for_unit_tests.zip"; 
 
             Download(url, imagesDownloadFolder, fileName);
             UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);


### PR DESCRIPTION
Fixes #4348
While computing the bottleneck values, if an image errors out and throws TensorflowException, this change skips the particular image and continues training.

