### PR TITLE
Fix AutoML's reference to LightGbm

### DIFF
--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -19,9 +19,11 @@
       Microsoft.ML.TensorFlow;
       Microsoft.ML.OnnxTransformer;
     </StableProjects>
-    <IsStableProject Condition="'$(MSBuildProjectName.Contains(.symbols))' == 'false'">$(StableProjects.Contains($(MSBuildProjectName)))</IsStableProject>
-    <IsStableProject Condition="'$(MSBuildProjectName.Contains(.symbols))' == 'true'">$(StableProjects.Contains($(MSBuildProjectName.Substring(0, $(MSBuildProjectName.IndexOf(.symbols))))))</IsStableProject>
+    <_NormalizedStableProjectName Condition="'$(MSBuildProjectName.Contains(.symbols))' == 'true'">$(MSBuildProjectName.Substring(0, $(MSBuildProjectName.IndexOf(.symbols))))</_NormalizedStableProjectName>
+    <_NormalizedStableProjectName Condition="'$(_NormalizedStableProjectName)' == ''">$(MSBuildProjectName)</_NormalizedStableProjectName>
+
     <IsStableProject Condition="'$(UseStableVersionForNativeAssets)' == 'true'">true</IsStableProject>
+    <IsStableProject Condition="'$(StableProjects.IndexOf($(_NormalizedStableProjectName), StringComparison.OrdinalIgnoreCase))' != '-1'">true</IsStableProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsStableProject)' == 'true'">
     <MajorVersion>1</MajorVersion>

--- a/pkg/Microsoft.ML.AutoML/Microsoft.ML.AutoML.nupkgproj
+++ b/pkg/Microsoft.ML.AutoML/Microsoft.ML.AutoML.nupkgproj
@@ -7,7 +7,7 @@
   
   <ItemGroup>
     <ProjectReference Include="../Microsoft.ML/Microsoft.ML.nupkgproj" />
-    <ProjectReference Include="../Microsoft.ML.LightGBM/Microsoft.ML.LightGBM.nupkgproj" />
+    <ProjectReference Include="../Microsoft.ML.LightGbm/Microsoft.ML.LightGbm.nupkgproj" />
     <ProjectReference Include="../Microsoft.ML.Mkl.Components/Microsoft.ML.Mkl.Components.nupkgproj" />
     <ProjectReference Include="../Microsoft.ML.Recommender/Microsoft.ML.Recommender.nupkgproj" />
   </ItemGroup>


### PR DESCRIPTION
AutoML has a reference to LightGbm, however it is getting the wrong version number in the dependency. Instead of `1.4.0-preview...`, it is getting `0.16.0-preview...`. This is because the casing in the reference is incorrect.

Since the casing is incorrect, when evaluating the LightGbm project as a reference, its name no longer matches the casing in the `StableProjects` list, so it no longer thinks it is stable, and gets the unstable version.

The fix is to fix the casing, and use case-insensitve checks when evaluating IsStableProject.

Fix #4354