### PR TITLE
Move windows build machines to NetCorePublic-Pool.

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -66,6 +66,7 @@ jobs:
     buildScript: build.cmd
     pool:
       name: NetCorePublic-Pool
+      queue: buildpool.windows.10.amd64.vs2017.open
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -82,6 +83,7 @@ jobs:
         _includeBenchmarkData: false
     pool:
       name: NetCorePublic-Pool
+      queue: buildpool.windows.10.amd64.vs2017.open
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -65,7 +65,7 @@ jobs:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
     pool:
-      name: Hosted VS2017
+      name: NetCorePublic-Pool
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -81,7 +81,7 @@ jobs:
         _config_short: RFX
         _includeBenchmarkData: false
     pool:
-      name: Hosted VS2017
+      name: NetCorePublic-Pool
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -89,4 +89,4 @@ jobs:
     architecture: x86
     buildScript: build.cmd
     pool:
-      name: Hosted VS2017
+      name: NetCorePublic-Pool

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -92,3 +92,4 @@ jobs:
     buildScript: build.cmd
     pool:
       name: NetCorePublic-Pool
+      queue: buildpool.windows.10.amd64.vs2017.open


### PR DESCRIPTION
Builds seem to be failing because it runs out of disk space.