### PR TITLE
Delete build files before packaging and increase build timeout

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -65,8 +65,7 @@ jobs:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
     pool:
-      name: NetCorePublic-Pool
-      queue: buildpool.windows.10.amd64.vs2017.open
+      name: Hosted VS2017
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -82,8 +81,7 @@ jobs:
         _config_short: RFX
         _includeBenchmarkData: false
     pool:
-      name: NetCorePublic-Pool
-      queue: buildpool.windows.10.amd64.vs2017.open
+      name: Hosted VS2017
 
 - template: /build/ci/job-template.yml
   parameters:
@@ -91,5 +89,4 @@ jobs:
     architecture: x86
     buildScript: build.cmd
     pool:
-      name: NetCorePublic-Pool
-      queue: buildpool.windows.10.amd64.vs2017.open
+      name: Hosted VS2017

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
   - job: ${{ parameters.name }}
     ${{ if eq(parameters.codeCoverage, 'false') }}:
-      timeoutInMinutes: 40
+      timeoutInMinutes: 60
     ${{ if eq(parameters.codeCoverage, 'true') }}:
       timeoutInMinutes: 60
     strategy:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -77,5 +77,35 @@ jobs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         artifactName: ${{ parameters.name }} $(_config_short)
         artifactType: container
+    - ${{ if eq(parameters.buildScript, 'build.cmd') }}:
+      - powershell: |
+                  $taskListOutput = & TaskList /FI "IMAGENAME eq dotnet.exe" | Out-String
+                  if ($taskListOutput.Contains("dotnet.exe"))
+                  {
+                      Write-Output "Killing dotnet.exe processes..."
+                      & taskkill /IM dotnet.exe /F
+                  }
+
+                  if (Test-Path .\packages\)
+                  {
+                      Write-Output "Removing nuget cache dir..."
+                      Remove-Item -Force -Recurse .\packages\
+                  }
+
+                  if (Test-Path .\test\data\external\)
+                  {
+                      Write-Output "Removing external test data..."
+                      Remove-Item -Force -Recurse .\test\data\external\
+                  }
+
+                  mkdir .\tmp\
+                  Move-Item .\bin\obj\packages .\tmp\
+                  Write-Output "Removing bin dir..."
+                  Remove-Item -Force -Recurse .\bin\
+                  mkdir .\bin\obj\
+                  Move-Item .\tmp\packages\ .\bin\obj\
+                  Remove-Item -Force -Recurse .\tmp\
+                  Write-Output "Done cleaning up binary folder..."
+        displayName: Clean up test data
     - script: ${{ parameters.buildScript }} -buildPackages
       displayName: Build Packages


### PR DESCRIPTION
This reverts commit c922529e669d1c4dcb4d2bf8157a579b10a60cee and deletes build files before packaging to get rid of out of memory error. It also increases the build timeout to 60 minutes.
