### PR TITLE
Updating the DatabaseLoader to not force vector for single element columns

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoader.cs
@@ -333,7 +333,14 @@ namespace Microsoft.ML.Data
             internal static Range FromTextLoaderRange(TextLoader.Range range)
             {
                 Contracts.Assert(range.Max.HasValue);
-                return new Range(range.Min, range.Max.Value);
+                if ((range.Max.Value == range.Min) && !range.ForceVector)
+                {
+                    return new Range(range.Min);
+                }
+                else
+                {
+                    return new Range(range.Min, range.Max.Value);
+                }
             }
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoader.cs
@@ -333,14 +333,10 @@ namespace Microsoft.ML.Data
             internal static Range FromTextLoaderRange(TextLoader.Range range)
             {
                 Contracts.Assert(range.Max.HasValue);
-                if ((range.Max.Value == range.Min) && !range.ForceVector)
-                {
-                    return new Range(range.Min);
-                }
-                else
-                {
-                    return new Range(range.Min, range.Max.Value);
-                }
+
+                var dbRange = new Range(range.Min, range.Max.Value);
+                dbRange.ForceVector = range.ForceVector;
+                return dbRange;
             }
         }
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
@@ -768,7 +768,7 @@ namespace Microsoft.ML.Data
 
                 if (seg.Name is null)
                 {
-                    Contracts.Check(seg.Min == seg.Lim);
+                    Contracts.Check(seg.Lim == (seg.Min + 1));
                     return seg.Min;
                 }
                 else

--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -299,6 +299,7 @@ namespace Microsoft.ML.Tests
 
         public class IrisVectorData
         {
+            [LoadColumn(0)]
             public int Label;
 
             [LoadColumn(1, 2)]
@@ -312,6 +313,7 @@ namespace Microsoft.ML.Tests
 
         public class IrisVectorDataWithLoadColumnName
         {
+            [LoadColumnName("Label")]
             public int Label;
 
             [LoadColumnName("SepalLength", "SepalWidth")]


### PR DESCRIPTION
This resolves https://github.com/dotnet/machinelearning-samples/issues/722