### PR TITLE
Fixes #4405 About publishing nugets to public feed

### DIFF
--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -174,13 +174,13 @@ phases:
   variables:
     BuildConfig: Release
     OfficialBuildId: $(BUILD.BUILDNUMBER)
-    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DOTNET_CLI_TELEMETRY_OUTPUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     DOTNET_MULTILEVEL_LOOKUP: 0
     _SignType: real
     _UseEsrpSigning: true
     _TeamName: DotNetCore
-    _NuGetFeedUrl: https://dotnet.myget.org/F/dotnet-core/api/v2/package
+    _AzureDevopsFeedUrl: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json
     _SymwebSymbolServerPath: https://microsoft.artifacts.visualstudio.com/DefaultCollection
     _MsdlSymbolServerPath: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
   queue:
@@ -226,20 +226,19 @@ phases:
       msbuildVersion: 15.0
     continueOnError: false
 
-  - task: NuGetCommand@2 
-    displayName: Publish Packages to VSTS Feed 
-    inputs:
-      command: push 
-      packagesToPush: $(Build.SourcesDirectory)/bin/packages/**/*.nupkg;!$(Build.SourcesDirectory)/bin/packages/**/*.symbols.nupkg 
-      nuGetFeedType: internal 
-      feedPublish: MachineLearning
-      
   # - task: MSBuild@1
   #   displayName: Publish Packages to MyGet Feed
   #   inputs:
   #     solution: build/publish.proj
   #     msbuildArguments: /t:PublishPackages /p:NuGetFeedUrl=$(_NuGetFeedUrl) /p:NuGetApiKey=$(dotnet-myget-org-api-key)
   #     msbuildVersion: 15.0
+
+  - task: NuGetAuthenticate@0
+    inputs:
+      nuGetServiceConnections: machinelearning-dnceng-public-feed # To allow publishing to a feed of another organization
+
+  - script: Tools\dotnetcli\dotnet msbuild build\publish.proj /t:PublishPackages /p:NuGetFeedUrl=$(_AzureDevopsFeedUrl) /p:NuGetApiKey=AzureArtifacts
+    displayName: Publish Packages to AzureDevOps Feed
 
   - task: MSBuild@1
     displayName: Publish Symbols to SymWeb Symbol Server

--- a/build/vsts-ci.yml
+++ b/build/vsts-ci.yml
@@ -256,6 +256,14 @@ phases:
       msbuildVersion: 15.0
     continueOnError: true
 
+  - task: NuGetCommand@2 
+    displayName: Publish Packages to private VSTS Feed 
+    inputs:
+      command: push 
+      packagesToPush: $(Build.SourcesDirectory)/bin/packages/**/*.nupkg;!$(Build.SourcesDirectory)/bin/packages/**/*.symbols.nupkg 
+      nuGetFeedType: internal 
+      feedPublish: MachineLearning
+
   # Terminate all dotnet build processes.
   - script: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet.exe build-server shutdown
     displayName: Dotnet Server Shutdown


### PR DESCRIPTION
Fixes #4405 about publishing nugets to this public feed:
https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=MachineLearning

This will be executed by the AzureDevOps build pipeline whenever a new commit is added to the master branch of this repo. Notice that sometimes there are some problems on the side of Azure DevOps, and it might fail when executing the programs in the pipeline that should lead to publishing the nugets; the solution is to rerun the build manually.

Worked this out following @safern instructions.