### PR TITLE
Modify ImageClassification API to use a workspace for saving data

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
@@ -561,5 +561,11 @@ namespace Microsoft.ML.TensorFlow
             }
 
         }
+        internal static string GetTemporaryDirectory()
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDirectory);
+            return tempDirectory;
+        }
     }
 }

--- a/test/Microsoft.ML.Benchmarks/ImageClassificationBench.cs
+++ b/test/Microsoft.ML.Benchmarks/ImageClassificationBench.cs
@@ -20,7 +20,6 @@ namespace Microsoft.ML.Benchmarks
     [Config(typeof(TrainConfig))]
     public class ImageClassificationBench
     {
-        private string assetsPath;
         private MLContext mlContext;
         private IDataView trainDataset;
         private IDataView testDataset;
@@ -36,7 +35,7 @@ namespace Microsoft.ML.Benchmarks
              * level up to prevent issues with saving data.
              */
             string assetsRelativePath = @"../../../../assets";
-            assetsPath = GetAbsolutePath(assetsRelativePath);
+            string assetsPath = GetAbsolutePath(assetsRelativePath);
 
             var outputMlNetModelFilePath = Path.Combine(assetsPath, "outputs",
                 "imageClassifier.zip");
@@ -87,8 +86,7 @@ namespace Microsoft.ML.Benchmarks
                 BatchSize = 10,
                 LearningRate = 0.01f,
                 EarlyStoppingCriteria = new ImageClassificationTrainer.EarlyStopping(minDelta: 0.001f, patience: 20, metric: ImageClassificationTrainer.EarlyStoppingMetric.Loss),
-                ValidationSet = testDataset,
-                ModelSavePath = assetsPath
+                ValidationSet = testDataset
             };
             var pipeline = mlContext.MulticlassClassification.Trainers.ImageClassification(options)
             .Append(mlContext.Transforms.Conversion.MapKeyToValue(

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1493,11 +1493,12 @@ namespace Microsoft.ML.Scenarios
                 // Using Exponential Decay for learning rate scheduling
                 // You can also try other types of Learning rate scheduling methods
                 // available in LearningRateScheduler.cs  
-                LearningRateScheduler = learningRateScheduler
+                LearningRateScheduler = learningRateScheduler,
+                WorkspacePath = GetTemporaryDirectory()
             };
 
             var pipeline = mlContext.Transforms.LoadRawImageBytes("Image", fullImagesetFolderPath, "ImagePath")
-                .Append(mlContext.MulticlassClassification.Trainers.ImageClassification(options))
+                    .Append(mlContext.MulticlassClassification.Trainers.ImageClassification(options))
                 .Append(mlContext.Transforms.Conversion.MapKeyToValue(
                         outputColumnName: "PredictedLabel",
                         inputColumnName: "PredictedLabel"));
@@ -1577,6 +1578,11 @@ namespace Microsoft.ML.Scenarios
             Assert.Equal("roses", predictionSecond.PredictedLabel);
             Assert.True(Array.IndexOf(labels, predictionFirst.PredictedLabel) > -1);
             Assert.True(Array.IndexOf(labels, predictionSecond.PredictedLabel) > -1);
+
+            Assert.True(File.Exists(Path.Combine(options.WorkspacePath, options.TrainSetBottleneckCachedValuesFileName)));
+            Assert.True(File.Exists(Path.Combine(options.WorkspacePath, options.ValidationSetBottleneckCachedValuesFileName)));
+            Assert.True(File.Exists(Path.Combine(options.WorkspacePath, ImageClassificationTrainer.ModelFileName[options.Arch])));
+            Directory.Delete(options.WorkspacePath, true);
         }
 
         [TensorFlowFact]
@@ -1952,5 +1958,11 @@ namespace Microsoft.ML.Scenarios
             public string PredictedLabel;
         }
 
+        private static string GetTemporaryDirectory()
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDirectory);
+            return tempDirectory;
+        }
     }
 }


### PR DESCRIPTION
Originally this API saved data to the same directory as the DLL, this
could cause issues if the DLL was in a read only path. Instead moving to
default to a temporary workspace path which can be defined in the
options by the user. This will allow all the data to be saved in one
path.
