### PR TITLE
Cleanup: makes Recommendation sample easier to use

### DIFF
--- a/docs/samples/Microsoft.ML.AutoML.Samples/DataStructures/Movie.cs
+++ b/docs/samples/Microsoft.ML.AutoML.Samples/DataStructures/Movie.cs
@@ -8,13 +8,19 @@ namespace Microsoft.ML.AutoML.Samples.DataStructures
 {
     public class Movie
     {
-        [LoadColumn(0)]
-        public string UserId;
+        [ColumnName("userId"), LoadColumn(0)]
+        public float UserId { get; set; }
 
-        [LoadColumn(1)]
-        public string MovieId;
 
-        [LoadColumn(2)]
-        public float Rating;
+        [ColumnName("movieId"), LoadColumn(1)]
+        public float MovieId { get; set; }
+
+
+        [ColumnName("rating"), LoadColumn(2)]
+        public float Rating { get; set; }
+
+
+        [ColumnName("timestamp"), LoadColumn(3)]
+        public float Timestamp { get; set; }
     }
 }

--- a/docs/samples/Microsoft.ML.AutoML.Samples/RecommendationExperiment.cs
+++ b/docs/samples/Microsoft.ML.AutoML.Samples/RecommendationExperiment.cs
@@ -12,13 +12,14 @@ namespace Microsoft.ML.AutoML.Samples
 {
     public static class RecommendationExperiment
     {
-        private static string TrainDataPath = "<Path to your train dataset goes here>";
-        private static string TestDataPath = "<Path to your test dataset goes here>";
+        private static string PathToMachineLearningSamplesRepo = "<Path to machinelearning-samples repo goes here>"; // https://github.com/dotnet/machinelearning-samples/
+        private static string TrainDataPath = Path.Combine(PathToMachineLearningSamplesRepo, @"samples\csharp\getting-started\MatrixFactorization_MovieRecommendation\Data\recommendation-ratings-train.csv");
+        private static string TestDataPath = Path.Combine(PathToMachineLearningSamplesRepo, @"samples\csharp\getting-started\MatrixFactorization_MovieRecommendation\Data\recommendation-ratings-test.csv");
         private static string ModelPath = @"<Desired model output directory goes here>\Model.zip";
-        private static string LabelColumnName = "Rating";
-        private static string UserColumnName = "UserId";
-        private static string ItemColumnName = "MovieId";
-        private static uint ExperimentTime = 60;
+        private static string LabelColumnName = "rating";
+        private static string UserColumnName = "userId";
+        private static string ItemColumnName = "movieId";
+        private static uint ExperimentTime = 540;
 
         public static void Run()
         {
@@ -30,15 +31,17 @@ namespace Microsoft.ML.AutoML.Samples
 
             // STEP 2: Run AutoML experiment
             Console.WriteLine($"Running AutoML recommendation experiment for {ExperimentTime} seconds...");
+            var columnInformation = new ColumnInformation()
+            {
+                LabelColumnName = LabelColumnName,
+                UserIdColumnName = UserColumnName,
+                ItemIdColumnName = ItemColumnName
+            };
+            columnInformation.IgnoredColumnNames.Add("timestamp");
             ExperimentResult<RegressionMetrics> experimentResult = mlContext.Auto()
                 .CreateRecommendationExperiment(new RecommendationExperimentSettings() { MaxExperimentTimeInSeconds = ExperimentTime })
                 .Execute(trainDataView, testDataView,
-                    new ColumnInformation()
-                    {
-                        LabelColumnName = LabelColumnName,
-                        UserIdColumnName = UserColumnName,
-                        ItemIdColumnName = ItemColumnName
-                    });
+                    columnInformation);
 
             // STEP 3: Print metric from best model
             RunDetail<RegressionMetrics> bestRun = experimentResult.BestRun;
@@ -62,8 +65,8 @@ namespace Microsoft.ML.AutoML.Samples
             // STEP 8: Initialize a new test, and get the prediction
             var testMovie = new Movie
             {
-                UserId = "1",
-                MovieId = "1097",
+                UserId = 1,
+                MovieId = 1097,
             };
             var prediction = predictionEngine.Predict(testMovie);
             Console.WriteLine($"Predicted rating for: {prediction.Rating}");
@@ -71,8 +74,8 @@ namespace Microsoft.ML.AutoML.Samples
             // Only predict for existing users
             testMovie = new Movie
             {
-                UserId = "612", // new user
-                MovieId = "2940"
+                UserId = 612, // new user
+                MovieId = 2940
             };
             prediction = predictionEngine.Predict(testMovie);
             Console.WriteLine($"Expected Rating NaN for unknown user, Predicted: {prediction.Rating}");

--- a/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.Recommendation_GenerateConsoleAppProjectContents_VerifyModelBuilder.approved.txt
+++ b/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.Recommendation_GenerateConsoleAppProjectContents_VerifyModelBuilder.approved.txt
@@ -59,7 +59,7 @@ namespace TestNamespace.ConsoleApp
             var dataProcessPipeline = mlContext.Transforms.Concatenate("Out", new[] { "In" });
 
             // Set the training algorithm 
-            var trainer = mlContext.Recommendation().Trainers.MatrixFactorization(labelColumnName: "Label", matrixColumnIndexColumnName: "userId", matrixRowIndexColumnName: "movieId");
+            var trainer = mlContext.Recommendation().Trainers.MatrixFactorization(labelColumnName: "rating", matrixColumnIndexColumnName: "userId", matrixRowIndexColumnName: "movieId");
             var trainingPipeline = dataProcessPipeline.Append(trainer);
 
             return trainingPipeline;
@@ -80,7 +80,7 @@ namespace TestNamespace.ConsoleApp
             // Evaluate the model and show accuracy stats
             Console.WriteLine("===== Evaluating Model's accuracy with Test data =====");
             IDataView predictions = mlModel.Transform(testDataView);
-            var metrics = mlContext.Recommendation().Evaluate(predictions, "Label", "Score");
+            var metrics = mlContext.Recommendation().Evaluate(predictions, "rating", "Score");
             PrintRegressionMetrics(metrics);
         }
 

--- a/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.Recommendation_GenerateConsoleAppProjectContents_VerifyPredictProgram.approved.txt
+++ b/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.Recommendation_GenerateConsoleAppProjectContents_VerifyPredictProgram.approved.txt
@@ -25,10 +25,11 @@ namespace TestNamespace.ConsoleApp
             // Make a single prediction on the sample data and print results
             ModelOutput predictionResult = ConsumeModel.Predict(sampleData);
 
-            Console.WriteLine("Using model to make single prediction -- Comparing actual Label with predicted Label from sample data...\n\n");
+            Console.WriteLine("Using model to make single prediction -- Comparing actual Rating with predicted Rating from sample data...\n\n");
             Console.WriteLine($"userId: {sampleData.UserId}");
             Console.WriteLine($"movieId: {sampleData.MovieId}");
-            Console.WriteLine($"\n\nActual Label: {sampleData.Label} \nPredicted Label: {predictionResult.Score}\n\n");
+            Console.WriteLine($"timestamp: {sampleData.Timestamp}");
+            Console.WriteLine($"\n\nActual Rating: {sampleData.Rating} \nPredicted Rating: {predictionResult.Score}\n\n");
             Console.WriteLine("=============== End of process, hit any key to finish ===============");
             Console.ReadKey();
         }

--- a/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.Recommendation_GenerateModelProjectContents_VerifyModelInput.approved.txt
+++ b/test/Microsoft.ML.CodeGenerator.Tests/ApprovalTests/ConsoleCodeGeneratorTests.Recommendation_GenerateModelProjectContents_VerifyModelInput.approved.txt
@@ -10,16 +10,20 @@ namespace TestNamespace.Model
 {
     public class ModelInput
     {
-        [ColumnName("Label"), LoadColumn(0)]
-        public string Label { get; set; }
+        [ColumnName("userId"), LoadColumn(0)]
+        public float UserId { get; set; }
 
 
-        [ColumnName("userId"), LoadColumn(1)]
-        public string UserId { get; set; }
+        [ColumnName("movieId"), LoadColumn(1)]
+        public float MovieId { get; set; }
 
 
-        [ColumnName("movieId"), LoadColumn(2)]
-        public string MovieId { get; set; }
+        [ColumnName("rating"), LoadColumn(2)]
+        public float Rating { get; set; }
+
+
+        [ColumnName("timestamp"), LoadColumn(3)]
+        public float Timestamp { get; set; }
 
 
     }


### PR DESCRIPTION
This PR makes the Recommendation sample under docs easier to use, by pointing to an existing sample in machinelearning-samples repo:

Using the same datasets under [https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started/MatrixFactorization_MovieRecommendation/Data](https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started/MatrixFactorization_MovieRecommendation/Data)

The model generated using instructions in [here](https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/getting-started/MatrixFactorization_MovieRecommendation), produces metrics below:
```
MeanAbsoluteError: 0.619940823978848
MeanSquaredError: 0.947787365931922
RootMeanSquaredError: 0.973543715470406
RSquared: 0.43654475860194
```

Whereas using AutoML for Recommendation task with just 540 seconds training time (as seen in this PR), we can get a little over 100 models generated out of which the best produced has the improved metrics below:
```
Metrics of best model on test data --
MeanAbsoluteError: 0.578644904825423
MeanSquaredError: 0.747918695002957
RootMeanSquaredError: 0.864822926964218
RSquared: 0.555365766640444
```
--- 

Additionally in this PR I updated the CodeGeneratorTests a bit so that, the code generated in 
- CodeGeneratorTests.Recommendation_GenerateConsoleAppProjectContents_VerifyPredictProgram
- CodeGeneratorTests.Recommendation_GenerateConsoleAppProjectContents_VerifyPredictProject

can be used to test the model generated from running the Recommendation experiment in the doc\samples folder.

cc: @CESARDELATORRE, @eerhardt @LittleLittleCloud 