### PR TITLE
Modified how data is saved to disk

### DIFF
--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -1144,7 +1144,7 @@ namespace Microsoft.ML.Vision
                 {
                     Directory.Delete(_options.WorkspacePath, true);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     //We do not want to stop pipeline due to failed cleanup.
                 }

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -1154,7 +1154,6 @@ namespace Microsoft.ML.Vision
             }
         }
 
-
         private (Session, Tensor, Tensor, Tensor) BuildEvaluationSession(int classCount)
         {
             var evalGraph = LoadMetaGraph(Path.Combine(Path.GetTempPath(), ResourceDir, ModelFileName[_options.Arch]));

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -1319,9 +1319,10 @@ namespace Microsoft.ML.Vision
             DownloadIfNeeded(env, modelFileName, _resourcePath, modelFileName, timeout);
             if (arch == Architecture.InceptionV3)
             {
+                var extrasPath = Path.Combine(_resourcePath, @"tfhub_modules");
                 DownloadIfNeeded(env, @"tfhub_modules.zip", _resourcePath, @"tfhub_modules.zip", timeout);
-                if (!Directory.Exists(@"tfhub_modules"))
-                    ZipFile.ExtractToDirectory(Path.Combine(_resourcePath, @"tfhub_modules.zip"), Path.Combine(_resourcePath, @"tfhub_modules"));
+                if (!Directory.Exists(extrasPath))
+                    ZipFile.ExtractToDirectory(Path.Combine(_resourcePath, @"tfhub_modules.zip"), extrasPath);
             }
 
             return new TensorFlowSessionWrapper(GetSession(env, modelFilePath, true), modelFilePath);

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -556,8 +556,8 @@ namespace Microsoft.ML.Vision
             }
             else if (arch == Architecture.InceptionV3)
             {
-                _bottleneckOperationName = "module_apply_default/hub_output/feature_vector/SpatialSqueeze";
-                _inputTensorName = "Placeholder";
+                _bottleneckOperationName = "InceptionV3/Logits/SpatialSqueeze";
+                _inputTensorName = "input";
             }
             else if (arch == Architecture.MobilenetV2)
             {
@@ -1317,14 +1317,6 @@ namespace Microsoft.ML.Vision
             var modelFilePath = Path.Combine(_resourcePath, modelFileName);
             int timeout = 10 * 60 * 1000;
             DownloadIfNeeded(env, modelFileName, _resourcePath, modelFileName, timeout);
-            if (arch == Architecture.InceptionV3)
-            {
-                var extrasPath = Path.Combine(_resourcePath, @"tfhub_modules");
-                DownloadIfNeeded(env, @"tfhub_modules.zip", _resourcePath, @"tfhub_modules.zip", timeout);
-                if (!Directory.Exists(extrasPath))
-                    ZipFile.ExtractToDirectory(Path.Combine(_resourcePath, @"tfhub_modules.zip"), extrasPath);
-            }
-
             return new TensorFlowSessionWrapper(GetSession(env, modelFilePath, true), modelFilePath);
         }
 

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -474,7 +474,6 @@ namespace Microsoft.ML.Vision
         private readonly bool _cleanupWorkspace;
         private int _classCount;
         private Graph Graph => _session.graph;
-
         private static readonly string _resourcePath = Path.Combine(Path.GetTempPath(), "MLNET");
 
         /// <summary>
@@ -522,10 +521,6 @@ namespace Microsoft.ML.Vision
             {
                 options.WorkspacePath = GetTemporaryDirectory();
                 _cleanupWorkspace = true;
-            }
-            else
-            {
-                _cleanupWorkspace = false;
             }
 
             if (!Directory.Exists(_resourcePath))
@@ -1138,9 +1133,10 @@ namespace Microsoft.ML.Vision
 
             trainSaver.save(_session, _checkpointPath);
             UpdateTransferLearningModelOnDisk(_classCount);
-            CleanUpTmpWorkspace();
+            TryCleanupTemporaryWorkspace();
         }
-        private void CleanUpTmpWorkspace()
+
+        private void TryCleanupTemporaryWorkspace()
         {
             if (_cleanupWorkspace && Directory.Exists(_options.WorkspacePath))
             {

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1289,6 +1289,7 @@ namespace Microsoft.ML.Scenarios
         [InlineData(ImageClassificationTrainer.Architecture.ResnetV2101)]
         [InlineData(ImageClassificationTrainer.Architecture.MobilenetV2)]
         [InlineData(ImageClassificationTrainer.Architecture.ResnetV250)]
+        [InlineData(ImageClassificationTrainer.Architecture.InceptionV3)]
         public void TensorFlowImageClassification(ImageClassificationTrainer.Architecture arch)
         {
             string assetsRelativePath = @"assets";

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1582,8 +1582,9 @@ namespace Microsoft.ML.Scenarios
 
             Assert.True(File.Exists(Path.Combine(options.WorkspacePath, options.TrainSetBottleneckCachedValuesFileName)));
             Assert.True(File.Exists(Path.Combine(options.WorkspacePath, options.ValidationSetBottleneckCachedValuesFileName)));
-            Assert.True(File.Exists(Path.Combine(options.WorkspacePath, ImageClassificationTrainer.ModelFileName[options.Arch])));
+            Assert.True(File.Exists(Path.Combine(options.WorkspacePath, "TrainingSetSize.txt")));
             Directory.Delete(options.WorkspacePath, true);
+            Assert.True(File.Exists(Path.Combine(Path.GetTempPath(), "MLNET", ImageClassificationTrainer.ModelFileName[options.Arch])));
         }
 
         [TensorFlowFact]


### PR DESCRIPTION
pre-trained meta files are now stored in one location always, this
allows multiple runs to re-use the same meta file without having to
redownload.

Additionally added the ability to cleanup the temporary workspace used
to train the model. This should prevent issues of running out of disk
space when running multiple training session sequentially.
