### PR TITLE
Added onnx export support for OptionalColumnTransform 

### DIFF
--- a/src/Microsoft.ML.Data/Model/Onnx/OnnxContext.cs
+++ b/src/Microsoft.ML.Data/Model/Onnx/OnnxContext.cs
@@ -128,24 +128,27 @@ namespace Microsoft.ML.Model.OnnxConverter
         /// </summary>
         /// <param name="value">The float number which is going to be added</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(float value, string name = null);
+        public abstract string AddInitializer(float value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
         /// Call this function can declare a global long
         /// </summary>
         /// <param name="value">The long number which is going to be added into the ONNX graph</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(long value, string name = null);
+        public abstract string AddInitializer(long value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
         /// Call this function can declare a global string
         /// </summary>
         /// <param name="value">The string which is going to be added into the ONNX graph</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(string value, string name = null);
+        public abstract string AddInitializer(string value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
         /// Call this function can declare a global float tensor
@@ -153,8 +156,9 @@ namespace Microsoft.ML.Model.OnnxConverter
         /// <param name="values">The floats which are going to be added into the ONNX graph</param>
         /// <param name="dims">The shape that the floats</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(IEnumerable<float> values, IEnumerable<long> dims, string name = null);
+        public abstract string AddInitializer(IEnumerable<float> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
 
         /// <summary>
         /// Call this function can declare a global long tensor
@@ -162,8 +166,9 @@ namespace Microsoft.ML.Model.OnnxConverter
         /// <param name="values">The longs which are going to be added into the ONNX graph</param>
         /// <param name="dims">The shape that the floats</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(IEnumerable<long> values, IEnumerable<long> dims, string name = null);
+        public abstract string AddInitializer(IEnumerable<long> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
 
         /// <summary>
         /// Call this function can declare a global string tensor
@@ -171,7 +176,8 @@ namespace Microsoft.ML.Model.OnnxConverter
         /// <param name="values">The strings which are going to be added into the ONNX graph</param>
         /// <param name="dims">The shape that the strings</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null);
+        public abstract string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
     }
 }

--- a/src/Microsoft.ML.OnnxConverter/OnnxContextImpl.cs
+++ b/src/Microsoft.ML.OnnxConverter/OnnxContextImpl.cs
@@ -200,11 +200,12 @@ namespace Microsoft.ML.Model.OnnxConverter
         /// there is a collision between names in the pipeline at any point.
         /// </summary>
         /// <param name="colName">IDataView column name.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be chosen for this variable.</param>
         /// <returns>Unique variable name.</returns>
-        public string AddVariable(string colName)
+        public string AddVariable(string colName, bool makeUniqueName = true)
         {
             _host.CheckNonEmpty(colName, nameof(colName));
-            _columnNameMap[colName] = GetUniqueName(colName, _variableNames.Contains);
+            _columnNameMap[colName] = makeUniqueName ? GetUniqueName(colName, _variableNames.Contains) : colName;
             _variableNames.Add(_columnNameMap[colName]);
             return _columnNameMap[colName];
         }
@@ -269,56 +270,56 @@ namespace Microsoft.ML.Model.OnnxConverter
         }
 
         /// Adds constant tensor into the graph.
-        public override string AddInitializer(float value, string name = null)
+        public override string AddInitializer(float value, string name = null, bool makeUniqueName = true)
         {
-            name = AddVariable(name ?? "float");
+            name = AddVariable(name ?? "float", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeFloat(name, value));
             return name;
         }
 
-        public override string AddInitializer(string value, string name = null)
+        public override string AddInitializer(string value, string name = null, bool makeUniqueName = true)
         {
-            name = AddVariable(name ?? "string");
+            name = AddVariable(name ?? "string", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeString(name, value));
             return name;
         }
 
-        public override string AddInitializer(long value, string name = null)
+        public override string AddInitializer(long value, string name = null, bool makeUniqueName = true)
         {
-            name = AddVariable(name ?? "int64");
+            name = AddVariable(name ?? "int64", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeInt64(name, value));
             return name;
         }
 
-        public override string AddInitializer(IEnumerable<float> values, IEnumerable<long> dims, string name = null)
+        public override string AddInitializer(IEnumerable<float> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
         {
             _host.CheckValue(values, nameof(values));
             if (dims != null)
                 _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
 
-            name = AddVariable(name ?? "floats");
+            name = AddVariable(name ?? "floats", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeFloats(name, values, dims));
             return name;
         }
 
-        public override string AddInitializer(IEnumerable<long> values, IEnumerable<long> dims, string name = null)
+        public override string AddInitializer(IEnumerable<long> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
         {
             _host.CheckValue(values, nameof(values));
             if (dims != null)
                 _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
 
-            name = AddVariable(name ?? "int64s");
+            name = AddVariable(name ?? "int64s", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeInt64s(name, values, dims));
             return name;
         }
 
-        public override string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null)
+        public override string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
         {
             _host.CheckValue(values, nameof(values));
             if (dims != null)
                 _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
 
-            name = AddVariable(name ?? "strings");
+            name = AddVariable(name ?? "strings", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeStrings(name, values, dims));
             return name;
         }

--- a/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
@@ -38,6 +38,10 @@ namespace Microsoft.ML.Transforms.Onnx
             /// </summary>
             public List<string> OutputNames { get; }
             /// <summary>
+            /// Initializers[i] is the name of the i-th initializer in <see cref="InitializersInfo"/>.
+            /// </summary>
+            public List<string> InitializerNames { get; }
+            /// <summary>
             /// Inputs of the containing <see cref="OnnxModel"/>.
             /// </summary>
             public OnnxVariableInfo[] InputsInfo { get; }
@@ -46,12 +50,19 @@ namespace Microsoft.ML.Transforms.Onnx
             /// </summary>
             public OnnxVariableInfo[] OutputsInfo { get; }
 
-            public OnnxModelInfo(IEnumerable<OnnxVariableInfo> inputsInfo, IEnumerable<OnnxVariableInfo> outputsInfo)
+            /// <summary>
+            /// Initializers of the containing <see cref="OnnxModel"/>
+            /// </summary>
+            public OnnxVariableInfo[] InitializersInfo { get; }
+
+            public OnnxModelInfo(IEnumerable<OnnxVariableInfo> inputsInfo, IEnumerable<OnnxVariableInfo> outputsInfo, IEnumerable<OnnxVariableInfo> initializersInfo)
             {
                 InputNames = inputsInfo.Select(val => val.Name).ToList();
                 InputsInfo = inputsInfo.ToArray();
                 OutputNames = outputsInfo.Select(val => val.Name).ToList();
                 OutputsInfo = outputsInfo.ToArray();
+                InitializerNames = initializersInfo.Select(val => val.Name).ToList();
+                InitializersInfo = initializersInfo.ToArray();
             }
 
             /// <summary>
@@ -60,10 +71,16 @@ namespace Microsoft.ML.Transforms.Onnx
             public OnnxVariableInfo GetInput(string name)
             {
                 var index = InputNames.IndexOf(name);
-                if (index < 0)
-                    throw Contracts.ExceptParamValue(name, nameof(name), $"Input tensor, {name}, does not exist in the ONNX model. " +
-                        $"Available input names are [{string.Join(",", InputNames)}].");
-                return InputsInfo[index];
+                if (index >= 0)
+                    return InputsInfo[index];
+
+                index = InitializerNames.IndexOf(name);
+                if (index >= 0)
+                    return InitializersInfo[index];
+
+                // If we dont find the index in the input, try find it in the initializers
+                throw Contracts.ExceptParamValue(name, nameof(name), $"Input tensor, {name}, does not exist in the ONNX model. " +
+                    $"Available input names are [{string.Join(",", InputNames)}]. Available initializers are [{string.Join(",", InitializerNames)}]");
             }
 
             /// <summary>
@@ -180,8 +197,12 @@ namespace Microsoft.ML.Transforms.Onnx
             var inputTypePool = new Dictionary<string, DataViewType>();
             foreach (var valueInfo in model.Graph.Input)
                 inputTypePool[valueInfo.Name] = OnnxTypeParser.GetDataViewType(valueInfo.Type);
-            var outputTypePool = new Dictionary<string, DataViewType>();
 
+            var initializerTypePool = new Dictionary<string, DataViewType>();
+            foreach (var valueInfo in model.Graph.Initializer)
+                initializerTypePool[valueInfo.Name] = OnnxTypeParser.GetScalarDataViewType(valueInfo.DataType);
+
+            var outputTypePool = new Dictionary<string, DataViewType>();
             // Build casters which maps NamedOnnxValue to .NET objects.
             var casterPool = new Dictionary<string, Func<NamedOnnxValue, object>>();
             foreach (var valueInfo in model.Graph.Output)
@@ -190,60 +211,31 @@ namespace Microsoft.ML.Transforms.Onnx
                 casterPool[valueInfo.Name] = OnnxTypeParser.GetDataViewValueCasterAndResultedType(valueInfo.Type, out Type actualType);
             }
 
-            var onnxRuntimeInputInfos = new List<OnnxVariableInfo>();
-            // Collect input information for this ONNX model from ONNXRuntime's perspective.
-            foreach (var pair in _session.InputMetadata)
+            var inputInfos = GetOnnxVariablesFromMetadata(_session.InputMetadata, shapeDictionary, inputTypePool, null);
+            var outputInfos = GetOnnxVariablesFromMetadata(_session.OutputMetadata, shapeDictionary, outputTypePool, casterPool);
+            var overrideableInitializers = GetOnnxVariablesFromMetadata(_session.OverridableInitializerMetadata, shapeDictionary, inputTypePool, null);
+
+            // Create a view to the used ONNX model from ONNXRuntime's perspective.
+            ModelInfo = new OnnxModelInfo(inputInfos, outputInfos, overrideableInitializers);
+        }
+
+        private List<OnnxVariableInfo> GetOnnxVariablesFromMetadata(IReadOnlyDictionary<string, NodeMetadata> nodeMetadata,
+            IDictionary<string, int[]> shapeDictionary,
+            Dictionary<string, DataViewType> typePool,
+            Dictionary<string, Func<NamedOnnxValue, object>> casterPool)
+        {
+            var onnxVariableInfos = new List<OnnxVariableInfo>();
+
+            foreach (var pair in nodeMetadata)
             {
                 var name = pair.Key;
                 var meta = pair.Value;
-                var dataViewType = inputTypePool[name];
+                var dataViewType = typePool[name];
+                var caster = casterPool?[name];
 
                 OnnxVariableInfo info = null;
                 if (shapeDictionary != null && shapeDictionary.ContainsKey(name))
                 {
-                    // If user provides a shape of a specific tensor, the provided shape overwrites the corresponding one loaded from
-                    // ONNX model file and the deduced DataViewVectorType.
-
-                    if (!CheckOnnxShapeCompatibility(shapeDictionary[name].ToList(), meta.Dimensions.ToList()))
-                        throw Contracts.ExceptParamValue(shapeDictionary[name], nameof(shapeDictionary),
-                            "The specified shape " + string.Join(",", shapeDictionary[name]) +
-                            " is not compatible with the shape " + string.Join(",", meta.Dimensions) +
-                            " loaded from the ONNX model file. Only unknown dimension can replace or " +
-                            "be replaced by another dimension.");
-
-                    if (dataViewType is VectorDataViewType vectorType)
-                    {
-                        if (shapeDictionary[name].All(value => value > 0))
-                            dataViewType = new VectorDataViewType(vectorType.ItemType, shapeDictionary[name]);
-                        else
-                            dataViewType = new VectorDataViewType(vectorType.ItemType);
-                    }
-
-                    info = new OnnxVariableInfo(name, shapeDictionary[name].ToList(), meta.ElementType, dataViewType, null);
-                }
-                else
-                {
-                    // No user-specified shape is found, so the shape loaded from ONNX model file is used.
-                    info = new OnnxVariableInfo(name, meta.Dimensions.ToList(), meta.ElementType, dataViewType, null);
-                }
-                onnxRuntimeInputInfos.Add(info);
-            }
-
-            var onnxRuntimeOutputInfos = new List<OnnxVariableInfo>();
-            // Collect output information for this ONNX model from ONNXRuntime's perspective.
-            foreach (var pair in _session.OutputMetadata)
-            {
-                var name = pair.Key;
-                var meta = pair.Value;
-                var dataViewType = outputTypePool[name];
-                var caster = casterPool[name];
-
-                OnnxVariableInfo info = null;
-                if (shapeDictionary != null && shapeDictionary.ContainsKey(name))
-                {
-                    // If user provide a shape of a specific tensor, the provided shape overwrites the corresponding one loaded from
-                    // ONNX model file.
-
                     if (!CheckOnnxShapeCompatibility(shapeDictionary[name].ToList(), meta.Dimensions.ToList()))
                         throw Contracts.ExceptParamValue(shapeDictionary[name], nameof(shapeDictionary),
                             "The specified shape " + string.Join(",", shapeDictionary[name]) +
@@ -267,11 +259,9 @@ namespace Microsoft.ML.Transforms.Onnx
                     info = new OnnxVariableInfo(name, meta.Dimensions.ToList(), meta.ElementType, dataViewType, caster);
                 }
 
-                onnxRuntimeOutputInfos.Add(info);
+                onnxVariableInfos.Add(info);
             }
-
-            // Create a view to the used ONNX model from ONNXRuntime's perspective.
-            ModelInfo = new OnnxModelInfo(onnxRuntimeInputInfos, onnxRuntimeOutputInfos);
+            return onnxVariableInfos;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -536,7 +536,8 @@ namespace Microsoft.ML.Transforms
 
             // REVIEW:
             // AddInitializer only supports long, float and string.
-            // Is it correct to cast double to float and ulong to long?
+            // Here we are casting double to float and ulong to long.
+            // Fixing this would involve adding additional functions to OnnxContext.
             if ((type == typeof(float)) || (type == typeof(double)))
                 ctx.AddInitializer(new float[size], new long[] { 1, size }, inputColumnName, false);
             else if ((type == typeof(long)) || (type == typeof(int)) || (type == typeof(short)) || (type == typeof(sbyte)) ||

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -509,10 +509,7 @@ namespace Microsoft.ML.Transforms
                 var columnType = _bindings.ColumnTypes[iinfo];
                 string inputColumnName = Source.Schema[_bindings.SrcCols[iinfo]].Name;
                 if (!ctx.ContainsColumn(inputColumnName))
-                {
-                    ctx.RemoveColumn(inputColumnName, false);
                     continue;
-                }
 
                 if (!SaveAsOnnxCore(ctx, iinfo, ctx.GetVariableName(inputColumnName),
                     ctx.AddIntermediateVariable(OutputSchema[_bindings.MapIinfoToCol(iinfo)].Type, inputColumnName)))

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -537,9 +537,13 @@ namespace Microsoft.ML.Transforms
             else
                 size = 1;
 
-            if (type == typeof(float))
+            // REVIEW:
+            // AddInitializer only supports long, float and string.
+            // Is it correct to cast double to float and ulong to long?
+            if ((type == typeof(float)) || (type == typeof(double)))
                 ctx.AddInitializer(new float[size], new long[] { 1, size }, inputColumnName, false);
-            else if (type == typeof(long))
+            else if ((type == typeof(long)) || (type == typeof(int)) || (type == typeof(short)) || (type == typeof(sbyte)) ||
+                     (type == typeof(ulong)) || (type == typeof(uint)) || (type == typeof(ushort)) || (type == typeof(byte)))
                 ctx.AddInitializer(new long[size], new long[] { 1, size }, inputColumnName, false);
             else if (type == typeof(string))
                 ctx.AddInitializer(new string[size], new long[] { 1, size }, inputColumnName, false);

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Data;
 using Microsoft.ML.Data.IO;
 using Microsoft.ML.EntryPoints;
 using Microsoft.ML.Internal.Utilities;
+using Microsoft.ML.Model.OnnxConverter;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 
@@ -29,7 +30,7 @@ namespace Microsoft.ML.Transforms
 {
     /// <include file='doc.xml' path='doc/members/member[@name="OptionalColumnTransform"]/*' />
     [BestFriend]
-    internal sealed class OptionalColumnTransform : RowToRowMapperTransformBase
+    internal sealed class OptionalColumnTransform : RowToRowMapperTransformBase, ITransformCanSaveOnnx
     {
         public sealed class Arguments : TransformInputBase
         {
@@ -496,6 +497,56 @@ namespace Microsoft.ML.Transforms
                 return (ValueGetter<VBuffer<T>>)((ref VBuffer<T> value) =>
                     VBufferUtils.Resize(ref value, length, 0));
             }
+        }
+
+        public void SaveAsOnnx(OnnxContext ctx)
+        {
+            Host.CheckValue(ctx, nameof(ctx));
+            Host.Assert(((ICanSaveOnnx)this).CanSaveOnnx(ctx));
+
+            for (int iinfo = 0; iinfo < _bindings.ColumnTypes.Length; ++iinfo)
+            {
+                var columnType = _bindings.ColumnTypes[iinfo];
+                string inputColumnName = Source.Schema[_bindings.SrcCols[iinfo]].Name;
+                if (!ctx.ContainsColumn(inputColumnName))
+                {
+                    ctx.RemoveColumn(inputColumnName, false);
+                    continue;
+                }
+
+                if (!SaveAsOnnxCore(ctx, iinfo, ctx.GetVariableName(inputColumnName),
+                    ctx.AddIntermediateVariable(OutputSchema[_bindings.MapIinfoToCol(iinfo)].Type, inputColumnName)))
+                {
+                    ctx.RemoveColumn(inputColumnName, true);
+                }
+            }
+        }
+
+        public bool CanSaveOnnx(OnnxContext ctx) => true;
+
+        private bool SaveAsOnnxCore(OnnxContext ctx, int iinfo, string srcVariableName, string dstVariableName)
+        {
+            var columnType = _bindings.ColumnTypes[iinfo];
+            string inputColumnName = Source.Schema[_bindings.SrcCols[iinfo]].Name;
+
+            Type type = columnType.RawType;
+
+            int size;
+            if (columnType is VectorDataViewType && columnType.IsKnownSizeVector())
+                size = columnType.GetVectorSize();
+            else
+                size = 1;
+
+            if (type == typeof(float))
+                ctx.AddInitializer(new float[size], new long[] { 1, size }, inputColumnName, false);
+            else if (type == typeof(long))
+                ctx.AddInitializer(new long[size], new long[] { 1, size }, inputColumnName, false);
+            else if (type == typeof(string))
+                ctx.AddInitializer(new string[size], new long[] { 1, size }, inputColumnName, false);
+            else
+                return false;
+
+            return true;
         }
 
         [TlcModule.EntryPoint(Desc = Summary,

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -997,6 +997,49 @@ namespace Microsoft.ML.Tests
             Done();
         }
 
+        [Fact]
+        public void OptionalColumnOnnxTest()
+        {
+            var mlContext = new MLContext(seed: 1);
+
+            var samples = new List<BreastCancerCatFeatureExample>()
+            {
+                new BreastCancerCatFeatureExample() { Label = false, F1 = 0.0f, F2 = "F2"},
+                new BreastCancerCatFeatureExample() { Label = true, F1 = 0.1f, F2 = "F2"},
+            };
+            IHostEnvironment env = mlContext as IHostEnvironment;
+            var dataView = mlContext.Data.LoadFromEnumerable(samples);
+            var args = new OptionalColumnTransform.Arguments { Columns = new[] { "F1" }, Data = dataView };
+            var transform = OptionalColumnTransform.MakeOptional(env, args);
+
+            var ctx = new OnnxContextImpl(mlContext, "model", "ML.NET", "0", 0, "machinelearning.dotnet", OnnxVersion.Stable);
+            var outputData = transform.OutputData;
+            LinkedList<ITransformCanSaveOnnx> transforms = null;
+            ModelProto onnxModel;
+            using (var ch = env.Start("ONNX conversion"))
+            {
+                SaveOnnxCommand.GetPipe(ctx, ch, outputData, out IDataView root, out IDataView sink, out transforms);
+                onnxModel = SaveOnnxCommand.ConvertTransformListToOnnxModel(ctx, ch, root, sink, transforms, null, null);
+            }
+
+            var onnxFileName = "optionalcol.onnx";
+            var onnxModelPath = GetOutputPath(onnxFileName);
+            var onnxTextFileName = "optionalcol.txt";
+            var onnxTextPath = GetOutputPath(onnxTextFileName);
+
+            SaveOnnxModel(onnxModel, onnxModelPath, onnxTextPath);
+            if (IsOnnxRuntimeSupported())
+            {
+                string[] inputNames = onnxModel.Graph.Input.Select(valueInfoProto => valueInfoProto.Name).ToArray();
+                string[] outputNames = onnxModel.Graph.Output.Select(valueInfoProto => valueInfoProto.Name).ToArray();
+                var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
+                var onnxTransformer = onnxEstimator.Fit(dataView);
+                var onnxResult = onnxTransformer.Transform(dataView);
+                //CompareSelectedVectorColumns<int>(model.LastTransformer.ColumnPairs[0].outputColumnName, outputNames[1], transformedData, onnxResult);
+            }
+            Done();
+        }
+
         private void CreateDummyExamplesToMakeComplierHappy()
         {
             var dummyExample = new BreastCancerFeatureVector() { Features = null };

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                //CompareSelectedVectorColumns<int>(model.LastTransformer.ColumnPairs[0].outputColumnName, outputNames[1], transformedData, onnxResult);
+                CompareSelectedR4ScalarColumns(transform.Model.OutputSchema[2].Name, outputNames[1], outputData, onnxResult);
             }
             Done();
         }


### PR DESCRIPTION
Optional columns in ML.NET are supported through initializers in Onnx runtime, support for which was added in the v1 release of ORT. This PR adds support for integrating initializers in ML.NET and adding the corresponding OptionalColumnTransform support in ML.NET.