### PR TITLE
CpuMathNative assembly is not getting copied when using packages.config.

### DIFF
--- a/Microsoft.ML.sln
+++ b/Microsoft.ML.sln
@@ -289,6 +289,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ML.NightlyBuild.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ML.NugetPackageVersionUpdater", "test\Microsoft.ML.NugetPackageVersionUpdater\Microsoft.ML.NugetPackageVersionUpdater.csproj", "{C8DB58DC-6434-4431-A81F-263D86E2A5F3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{C91F81E3-B900-4968-A6DF-F53B515E97E1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netstandard2.0", "netstandard2.0", "{027DBA48-85B6-46F1-9487-0B49B5057FC0}"
+	ProjectSection(SolutionItems) = preProject
+		pkg\Microsoft.ML.CpuMath\build\netstandard2.0\Microsoft.ML.CpuMath.props = pkg\Microsoft.ML.CpuMath\build\netstandard2.0\Microsoft.ML.CpuMath.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1848,6 +1855,8 @@ Global
 		{A22FAD27-77E8-4460-8B92-EC7090B7173A} = {AED9C836-31E3-4F3F-8ABC-929555D3F3C4}
 		{A1CAC86F-F4BB-4B6D-9D18-E9AE15B3C66E} = {AED9C836-31E3-4F3F-8ABC-929555D3F3C4}
 		{C8DB58DC-6434-4431-A81F-263D86E2A5F3} = {AED9C836-31E3-4F3F-8ABC-929555D3F3C4}
+		{C91F81E3-B900-4968-A6DF-F53B515E97E1} = {BF66A305-DF10-47E4-8D81-42049B149D2B}
+		{027DBA48-85B6-46F1-9487-0B49B5057FC0} = {C91F81E3-B900-4968-A6DF-F53B515E97E1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {41165AF1-35BB-4832-A189-73060F82B01D}

--- a/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
+++ b/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.nupkgproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\common\CommonPackage.props" Pack="true" PackagePath="build\netstandard2.0\$(MSBuildProjectName).props" />
+    <Content Include="build\**\*" Pack="true" PackagePath="build" />
   </ItemGroup>
 
 </Project>

--- a/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.symbols.nupkgproj
+++ b/pkg/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.symbols.nupkgproj
@@ -2,4 +2,12 @@
 
   <Import Project="Microsoft.ML.CpuMath.nupkgproj" />
 
+  <PropertyGroup>
+    <!--
+      NU5129 is getting raised because the Microsoft.ML.CpuMath package contains a Microsoft.ML.CpuMath.props file.
+      But this package is named Microsoft.ML.CpuMath.symbols, so NuGet complains. However, we can ignore the warning.
+    -->
+    <NoWarn>$(NoWarn);NU5129</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/pkg/Microsoft.ML.CpuMath/build/netstandard2.0/Microsoft.ML.CpuMath.props
+++ b/pkg/Microsoft.ML.CpuMath/build/netstandard2.0/Microsoft.ML.CpuMath.props
@@ -1,0 +1,24 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+  NuGet packages.config doesn't support native assemblies automatically,
+  so copy the native assemblies to the output directory.
+  -->
+  <ItemGroup Condition="Exists('packages.config') OR
+                        Exists('$(MSBuildProjectName).packages.config') OR
+                        Exists('packages.$(MSBuildProjectName).config')">
+    <Content Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\nativeassets\netstandard2.0\*.dll"
+             Condition="'$(PlatformTarget)' == 'x64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+      <Link>%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\nativeassets\netstandard2.0\*.dll"
+             Condition="'$(PlatformTarget)' == 'x86'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+      <Link>%(Filename)%(Extension)</Link>
+    </Content>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
When we refactored CpuMath to support netcoreapp3.0, we broke the packages.config support to copy the native assembly. This fixes it again by copying the file from the correct location.

Fix #93
