### PR TITLE
Fixed model saving and loading of OneVersusAllTrainer to include SoftMax

### DIFF
--- a/test/Microsoft.ML.TestFramework/Attributes/LightGBMTheoryAttribute.cs
+++ b/test/Microsoft.ML.TestFramework/Attributes/LightGBMTheoryAttribute.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.ML.TestFrameworkCommon.Attributes;
+
+namespace Microsoft.ML.TestFramework.Attributes
+{
+    /// <summary>
+    /// A theory for tests requiring LightGBM.
+    /// </summary>
+    public sealed class LightGBMTheoryAttribute : EnvironmentSpecificTheoryAttribute
+    {
+        public LightGBMTheoryAttribute() : base("LightGBM is 64-bit only")
+        {
+        }
+
+        /// <inheritdoc />
+        protected override bool IsEnvironmentSupported()
+        {
+            return Environment.Is64BitProcess;
+        }
+    }
+}

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
@@ -303,14 +303,15 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         /// <summary>
         /// LightGbmMulticlass TrainerEstimator test with options
         /// </summary>
-        [LightGBMFact]
-        public void LightGbmMulticlassEstimatorWithOptions()
+        [LightGBMTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LightGbmMulticlassEstimatorWithOptions(bool softMax)
         {
             var options = new LightGbmMulticlassTrainer.Options
             {
                 EvaluationMetric = LightGbmMulticlassTrainer.Options.EvaluateMetricType.Default,
-                UseSoftmax = true
-
+                UseSoftmax = softMax
             };
 
             var (pipeline, dataView) = GetMulticlassPipeline();

--- a/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/TreeEstimators.cs
@@ -308,7 +308,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         {
             var options = new LightGbmMulticlassTrainer.Options
             {
-                EvaluationMetric = LightGbmMulticlassTrainer.Options.EvaluateMetricType.Default
+                EvaluationMetric = LightGbmMulticlassTrainer.Options.EvaluateMetricType.Default,
+                UseSoftmax = true
+
             };
 
             var (pipeline, dataView) = GetMulticlassPipeline();


### PR DESCRIPTION
When the model parameters from OnVersusAllTrainer are persisted, it currently writes a single bool byte to indicate what type of output formula to use during prediction. If that byte is false, it outputs raw values else it outputs probability values normalized to one. 
The sample code in this bug uses AutoML to request a softmax output. The code currently only checks whether the output type is ImplDist which excludes softmax output.

This PR changes the saved model format in a backward compatible way by continuing to write a single byte for output type and continues to use 0 for raw output, 1 for probability normalization but also adds 2 to indicate SoftMax. These values are already in alignment with the OutputFormula enum.

Fixes #4450 
Fixes #3647
Fixes #4051 