### PR TITLE
Change the dataset used for unit test to fix issue on Linux

### DIFF
--- a/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
+++ b/test/Microsoft.ML.AutoML.Tests/AutoFitTests.cs
@@ -65,16 +65,7 @@ namespace Microsoft.ML.AutoML.Test
                             .CreateMulticlassClassificationExperiment(0)
                             .Execute(trainDataset, testDataset, columnInference.ColumnInformation);
 
-            //Known issue, where on Ubuntu there is degradation in accuracy.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
-            {
-                Assert.Equal(0.778, result.BestRun.ValidationMetrics.MicroAccuracy, 3);
-            }
-            else
-            {
-                Assert.Equal(1, result.BestRun.ValidationMetrics.MicroAccuracy, 3);
-            }
+            Assert.Equal(1, result.BestRun.ValidationMetrics.MicroAccuracy, 3);
 
             var scoredData = result.BestRun.Model.Transform(trainData);
             Assert.Equal(TextDataViewType.Instance, scoredData.Schema[DefaultColumnNames.PredictedLabel].Type);

--- a/test/Microsoft.ML.AutoML.Tests/DatasetUtil.cs
+++ b/test/Microsoft.ML.AutoML.Tests/DatasetUtil.cs
@@ -116,6 +116,12 @@ namespace Microsoft.ML.AutoML.Test
         {
             var files = Directory.GetFiles(folder, "*",
                 searchOption: SearchOption.AllDirectories);
+            /*
+             * This is only needed as Linux can produce files in a different 
+             * order than other OSes. As this is a test case we want to maintain
+             * consistent accuracy across all OSes, so we sort to remove this discrepency.
+             */
+            Array.Sort(files);
             foreach (var file in files)
             {
                 var extension = Path.GetExtension(file).ToLower();

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1455,7 +1455,14 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowImageClassificationWithPolynomialLRScheduling()
         {
-            TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), 50);
+
+            /*
+             * Due to an issue with Nix based os performance is not as good,
+             * as such increase the number of epochs to produce a better model.
+             */
+            bool isNix = (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))));
+            TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), isNix ? 75: 50);
         }
 
         internal void TensorFlowImageClassificationWithLRScheduling(LearningRateScheduler  learningRateScheduler, int epoch)

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1286,22 +1286,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.2, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.2, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
         }
 
@@ -1382,22 +1368,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.2, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.2, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             // Testing TrySinglePrediction: Utilizing PredictionEngine for single
             // predictions. Here, two pre-selected images are utilized in testing
@@ -1535,22 +1507,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.99, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.99, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             // Testing TrySinglePrediction: Utilizing PredictionEngine for single
             // predictions. Here, two pre-selected images are utilized in testing
@@ -1677,23 +1635,9 @@ namespace Microsoft.ML.Scenarios
 
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
-            
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.2, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.2, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             //Assert that the training ran and stopped within half epochs due to EarlyStopping
             Assert.InRange(lastEpoch, 1, 49);
@@ -1772,22 +1716,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.2, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.2, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             //Assert that the training ran and stopped within half epochs due to EarlyStopping
             Assert.InRange(lastEpoch, 1, 49);
@@ -1902,12 +1832,6 @@ namespace Microsoft.ML.Scenarios
         public static string DownloadImageSet(string imagesDownloadFolder)
         {
             string fileName = "flower_photos_tiny_set_for_unit_tests.zip";
-            /*
-            string url = $"https://mlnetfilestorage.file.core.windows.net/imagesets" +
-                $"/flower_images/flower_photos_tiny_set_for_unit_tests.zip?st=2019" +
-                $"-08-29T00%3A07%3A21Z&se=2030-08-30T00%3A07%3A00Z&sp=rl&sv=2018" +
-                $"-03-28&sr=f&sig=N8HbLziTcT61kstprNLmn%2BDC0JoMrNwo6yRWb3hLLag%3D";
-            */
             string url = "https://tlcresources.blob.core.windows.net/datasets/flower_photos_tiny_set_for_unit_test.zip";
 
             Download(url, imagesDownloadFolder, fileName);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1286,22 +1286,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 3.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
         }
 
@@ -1382,22 +1368,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             // Testing TrySinglePrediction: Utilizing PredictionEngine for single
             // predictions. Here, two pre-selected images are utilized in testing
@@ -1456,13 +1428,7 @@ namespace Microsoft.ML.Scenarios
         public void TensorFlowImageClassificationWithPolynomialLRScheduling()
         {
 
-            /*
-             * Due to an issue with Nix based os performance is not as good,
-             * as such increase the number of epochs to produce a better model.
-             */
-            bool isNix = (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))));
-            TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), isNix ? 75: 50);
+            TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), 50);
         }
 
         internal void TensorFlowImageClassificationWithLRScheduling(LearningRateScheduler  learningRateScheduler, int epoch)
@@ -1542,22 +1508,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.3, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.3, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             // Testing TrySinglePrediction: Utilizing PredictionEngine for single
             // predictions. Here, two pre-selected images are utilized in testing
@@ -1685,22 +1637,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
             
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             //Assert that the training ran and stopped within half epochs due to EarlyStopping
             Assert.InRange(lastEpoch, 1, 49);
@@ -1779,22 +1717,8 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            // On Ubuntu the results seem to vary quite a bit but they can probably be 
-            // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
-            // seems to be unstable, there could be many reasons, will need to 
-            // investigate this further.
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
-            }
-            else
-            {
-                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
-            }
+            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
 
             //Assert that the training ran and stopped within half epochs due to EarlyStopping
             Assert.InRange(lastEpoch, 1, 49);
@@ -1877,6 +1801,11 @@ namespace Microsoft.ML.Scenarios
         {
             var files = Directory.GetFiles(folder, "*",
                 searchOption: SearchOption.AllDirectories);
+            /*
+             * This is only needed as Linux can produce files in a different 
+             * order than other OSs. As this is a test case we want to maintain
+             * consisten accuracy across all OSs, so we sort to remove this discrepency.
+             */
             Array.Sort(files);
             foreach (var file in files)
             {

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1455,14 +1455,7 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowImageClassificationWithPolynomialLRScheduling()
         {
-
-            /*
-             * Due to an issue with Nix based os performance is not as good,
-             * as such increase the number of epochs to produce a better model.
-             */
-            bool isNix = (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))));
-            TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), isNix ? 75: 50);
+            TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), 50);
         }
 
         internal void TensorFlowImageClassificationWithLRScheduling(LearningRateScheduler  learningRateScheduler, int epoch)
@@ -1550,8 +1543,8 @@ namespace Microsoft.ML.Scenarios
             if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
                 (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
             {
-                Assert.InRange(metrics.MicroAccuracy, 0.2, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.2, 1);
+                Assert.InRange(metrics.MicroAccuracy, 0.99, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.99, 1);
             }
             else
             {
@@ -1909,10 +1902,13 @@ namespace Microsoft.ML.Scenarios
         public static string DownloadImageSet(string imagesDownloadFolder)
         {
             string fileName = "flower_photos_tiny_set_for_unit_tests.zip";
+            /*
             string url = $"https://mlnetfilestorage.file.core.windows.net/imagesets" +
                 $"/flower_images/flower_photos_tiny_set_for_unit_tests.zip?st=2019" +
                 $"-08-29T00%3A07%3A21Z&se=2030-08-30T00%3A07%3A00Z&sp=rl&sv=2018" +
                 $"-03-28&sr=f&sig=N8HbLziTcT61kstprNLmn%2BDC0JoMrNwo6yRWb3hLLag%3D";
+            */
+            string url = "https://tlcresources.blob.core.windows.net/datasets/flower_photos_tiny_set_for_unit_test.zip";
 
             Download(url, imagesDownloadFolder, fileName);
             UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1286,8 +1286,22 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            // On Ubuntu the results seem to vary quite a bit but they can probably be 
+            // controlled by training more epochs, however that will slow the 
+            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
+            // seems to be unstable, there could be many reasons, will need to 
+            // investigate this further.
+            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+            }
+            else
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            }
 
         }
 
@@ -1368,8 +1382,22 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            // On Ubuntu the results seem to vary quite a bit but they can probably be 
+            // controlled by training more epochs, however that will slow the 
+            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
+            // seems to be unstable, there could be many reasons, will need to 
+            // investigate this further.
+            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+            }
+            else
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            }
 
             // Testing TrySinglePrediction: Utilizing PredictionEngine for single
             // predictions. Here, two pre-selected images are utilized in testing
@@ -1507,8 +1535,22 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            // On Ubuntu the results seem to vary quite a bit but they can probably be 
+            // controlled by training more epochs, however that will slow the 
+            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
+            // seems to be unstable, there could be many reasons, will need to 
+            // investigate this further.
+            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.4, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.4, 1);
+            }
+            else
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            }
 
             // Testing TrySinglePrediction: Utilizing PredictionEngine for single
             // predictions. Here, two pre-selected images are utilized in testing
@@ -1635,9 +1677,23 @@ namespace Microsoft.ML.Scenarios
 
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
-
-            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            
+            // On Ubuntu the results seem to vary quite a bit but they can probably be 
+            // controlled by training more epochs, however that will slow the 
+            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
+            // seems to be unstable, there could be many reasons, will need to 
+            // investigate this further.
+            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+            }
+            else
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            }
 
             //Assert that the training ran and stopped within half epochs due to EarlyStopping
             Assert.InRange(lastEpoch, 1, 49);
@@ -1716,8 +1772,22 @@ namespace Microsoft.ML.Scenarios
             IDataView predictions = trainedModel.Transform(testDataset);
             var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
 
-            Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
-            Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            // On Ubuntu the results seem to vary quite a bit but they can probably be 
+            // controlled by training more epochs, however that will slow the 
+            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
+            // seems to be unstable, there could be many reasons, will need to 
+            // investigate this further.
+            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+            }
+            else
+            {
+                Assert.InRange(metrics.MicroAccuracy, 0.8, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.8, 1);
+            }
 
             //Assert that the training ran and stopped within half epochs due to EarlyStopping
             Assert.InRange(lastEpoch, 1, 49);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1288,14 +1288,14 @@ namespace Microsoft.ML.Scenarios
 
             // On Ubuntu the results seem to vary quite a bit but they can probably be 
             // controlled by training more epochs, however that will slow the 
-            // build down. Accuracy values seen were 0.33, 0.66, 0.70+. The model
+            // build down. Accuracy values seen were 0.33, 0.66, 3.70+. The model
             // seems to be unstable, there could be many reasons, will need to 
             // investigate this further.
             if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
                 (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
             {
-                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
             }
             else
             {
@@ -1390,8 +1390,8 @@ namespace Microsoft.ML.Scenarios
             if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
                 (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
             {
-                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
             }
             else
             {
@@ -1543,8 +1543,8 @@ namespace Microsoft.ML.Scenarios
             if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
                 (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
             {
-                Assert.InRange(metrics.MicroAccuracy, 0.4, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.4, 1);
+                Assert.InRange(metrics.MicroAccuracy, 0.3, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.3, 1);
             }
             else
             {
@@ -1686,8 +1686,8 @@ namespace Microsoft.ML.Scenarios
             if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
                 (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
             {
-                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
             }
             else
             {
@@ -1780,8 +1780,8 @@ namespace Microsoft.ML.Scenarios
             if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
                 (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))))
             {
-                Assert.InRange(metrics.MicroAccuracy, 0.7, 1);
-                Assert.InRange(metrics.MacroAccuracy, 0.7, 1);
+                Assert.InRange(metrics.MicroAccuracy, 0.6, 1);
+                Assert.InRange(metrics.MacroAccuracy, 0.6, 1);
             }
             else
             {

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1803,8 +1803,8 @@ namespace Microsoft.ML.Scenarios
                 searchOption: SearchOption.AllDirectories);
             /*
              * This is only needed as Linux can produce files in a different 
-             * order than other OSs. As this is a test case we want to maintain
-             * consisten accuracy across all OSs, so we sort to remove this discrepency.
+             * order than other OSes. As this is a test case we want to maintain
+             * consistent accuracy across all OSes, so we sort to remove this discrepency.
              */
             Array.Sort(files);
             foreach (var file in files)

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1839,7 +1839,7 @@ namespace Microsoft.ML.Scenarios
         public static string DownloadImageSet(string imagesDownloadFolder)
         {
             string fileName = "flower_photos_tiny_set_for_unit_tests.zip";
-            string url = "https://tlcresources.blob.core.windows.net/datasets/flower_photos_tiny_set_for_unit_test.zip";
+            string url = "https://aka.ms/mlnet-resources/flower_photos_tiny_set_for_unit_test.zip";
 
             Download(url, imagesDownloadFolder, fileName);
             UnZip(Path.Combine(imagesDownloadFolder, fileName), imagesDownloadFolder);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1493,7 +1493,7 @@ namespace Microsoft.ML.Scenarios
                 .Fit(shuffledFullImagesDataset)
                 .Transform(shuffledFullImagesDataset);
 
-            // Split the data 80:10 into train and test sets, train and evaluate.
+            // Split the data 80:20 into train and test sets, train and evaluate.
             TrainTestData trainTestData = mlContext.Data.TrainTestSplit(
                 shuffledFullImagesDataset, testFraction: 0.2, seed: 1);
 
@@ -1877,6 +1877,7 @@ namespace Microsoft.ML.Scenarios
         {
             var files = Directory.GetFiles(folder, "*",
                 searchOption: SearchOption.AllDirectories);
+            Array.Sort(files);
             foreach (var file in files)
             {
                 if (Path.GetExtension(file) != ".jpg")


### PR DESCRIPTION
There is an issue with how some of the images were saved in the dataset
such that they were not being read properly on linux. As such accuracy
was dramatically reduced given the small size of the dataset to begin
with. Have corrected the images and made a new dataset such that this
issue should now be resolved.
