### PR TITLE
Improve key value mapping api docs

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -214,7 +214,7 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Create a <see cref="ValueToKeyMappingEstimator"/>, which converts categorical values into keys.
+        /// Create a <see cref="ValueToKeyMappingEstimator"/>, which converts categorical values into numerical keys.
         /// </summary>
         /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="outputColumnName">Name of the column containing the keys.</param>
@@ -225,7 +225,9 @@ namespace Microsoft.ML
         /// <param name="keyOrdinality">The order in which keys are assigned.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
-        /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
+        /// <param name="addKeyValueAnnotationsAsText">If set to true, use text type
+        /// for values, regardless of the actual input type. When doing the reverse
+        /// mapping, the values are text rather than the original input type.</param>
         /// <param name="keyData">Use a pre-defined mapping between values and keys, instead of building
         /// the mapping from the input data during training. If specified, this should be a single column <see cref="IDataView"/> containing the values.
         /// The keys are allocated based on the value of keyOrdinality.</param>
@@ -258,7 +260,9 @@ namespace Microsoft.ML
         /// <param name="keyOrdinality">The order in which keys are assigned.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
-        /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
+        /// <param name="addKeyValueAnnotationsAsText">If set to true, use text type
+        /// for values, regardless of the actual input type. When doing the reverse
+        /// mapping, the values are text rather than the original input type.</param>
         /// <param name="keyData">Use a pre-defined mapping between values and keys, instead of building
         /// the mapping from the input data during training. If specified, this should be a single column <see cref="IDataView"/> containing the values.
         /// The keys are allocated based on the value of keyOrdinality.</param>

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -214,20 +214,21 @@ namespace Microsoft.ML
         }
 
         /// <summary>
-        /// Create a <see cref="ValueToKeyMappingEstimator"/>, which converts value types into keys.
+        /// Create a <see cref="ValueToKeyMappingEstimator"/>, which converts categorical values into keys.
         /// </summary>
         /// <param name="catalog">The conversion transform's catalog.</param>
-        /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
-        /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.
+        /// <param name="outputColumnName">Name of the column containing the keys.</param>
+        /// <param name="inputColumnName">Name of the column containing the categorical values. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> is used.
         /// The input data types can be numeric, text, boolean, <see cref="System.DateTime"/> or <see cref="System.DateTimeOffset"/>.
         /// </param>
-        /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-        /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/> chosen they will be in the order encountered.
-        /// If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+        /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when training.</param>
+        /// <param name="keyOrdinality">The order applied to the mapping of categorical values to keys.
+        /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
+        /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
         /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
-        /// <param name="keyData">The data view containing the terms. If specified, this should be a single column data
-        /// view, and the key-values will be taken from that column. If unspecified, the key-values will be determined
-        /// from the input data upon fitting.</param>
+        /// <param name="keyData">Use a pre-defined mapping between values and keys, instead of building
+        /// the mapping from the input data during training. If specified, this should be a single column <see cref="IDataView"/> containing the values.
+        /// The keys are allocated based on the value of keyOrdinality.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[
@@ -246,20 +247,21 @@ namespace Microsoft.ML
                new[] { new ValueToKeyMappingEstimator.ColumnOptions(outputColumnName, inputColumnName, maximumNumberOfKeys, keyOrdinality, addKeyValueAnnotationsAsText) }, keyData);
 
         /// <summary>
-        /// Create a <see cref="ValueToKeyMappingEstimator"/>, which converts value types into keys.
+        /// Create a <see cref="ValueToKeyMappingEstimator"/>, which converts categorical values into keys.
         /// </summary>
-        /// <remarks>This transform can operate over several columns.</remarks>
+        /// <remarks>This transform can operate over multiple pairs of columns, creating a mapping for each pair.</remarks>
         /// <param name="catalog">The conversion transform's catalog.</param>
         /// <param name="columns">The input and output columns.
         /// The input data types can be numeric, text, boolean, <see cref="System.DateTime"/> or <see cref="System.DateTimeOffset"/>.
         /// </param>
-        /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-        /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/> chosen they will be in the order encountered.
-        /// If <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+        /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when training.</param>
+        /// <param name="keyOrdinality">The order applied to the mapping of categorical values to keys.
+        /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
+        /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
         /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
-        /// <param name="keyData">The data view containing the terms. If specified, this should be a single column data
-        /// view, and the key-values will be taken from that column. If unspecified, the key-values will be determined
-        /// from the input data upon fitting.</param>
+        /// <param name="keyData">Use a pre-defined mapping between values and keys, instead of building
+        /// the mapping from the input data during training. If specified, this should be a single column <see cref="IDataView"/> containing the values.
+        /// The keys are allocated based on the value of keyOrdinality.</param>
         /// <example>
         /// <format type="text/markdown">
         /// <![CDATA[

--- a/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
+++ b/src/Microsoft.ML.Data/Transforms/ConversionsExtensionsCatalog.cs
@@ -222,7 +222,7 @@ namespace Microsoft.ML
         /// The input data types can be numeric, text, boolean, <see cref="System.DateTime"/> or <see cref="System.DateTimeOffset"/>.
         /// </param>
         /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when training.</param>
-        /// <param name="keyOrdinality">The order applied to the mapping of categorical values to keys.
+        /// <param name="keyOrdinality">The order in which keys are assigned.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
         /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
@@ -255,7 +255,7 @@ namespace Microsoft.ML
         /// The input data types can be numeric, text, boolean, <see cref="System.DateTime"/> or <see cref="System.DateTimeOffset"/>.
         /// </param>
         /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when training.</param>
-        /// <param name="keyOrdinality">The order applied to the mapping of categorical values to keys.
+        /// <param name="keyOrdinality">The order in which keys are assigned.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
         /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -12,7 +12,8 @@ namespace Microsoft.ML.Transforms
     /// <summary>
     /// <see cref="IEstimator{TTransformer}"/> for the
     /// <see cref="ValueToKeyMappingTransformer"/>. Converts a set of categorical
-    /// values (for example, US state abbreviations) into key values (1-50).
+    /// values (for example, US state abbreviations) into numerical key values (e.g. 1-50).
+    /// The numerical key can be used directly by classification algorithms.
     /// </summary>
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[
@@ -32,6 +33,8 @@ namespace Microsoft.ML.Transforms
     /// If the key is not found in the dictionary, it is assigned the missing value
     /// indicator.
     /// If multiple columns are used, each column builds exactly one dictionary.
+    /// The dictionary data is stored as an annotation in the schema, to enable
+    /// the reverse mapping to occur using [KeyToValueMappingEstimator](xref:Microsoft.ML.Transforms.KeyToValueMappingEstimator)
     ///
     /// Check the See Also section for links to usage examples.
     /// ]]></format>
@@ -114,7 +117,9 @@ namespace Microsoft.ML.Transforms
             /// <param name="keyOrdinality">The order in which keys are assigned.
             /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
             /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
-            /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
+            /// <param name="addKeyValueAnnotationsAsText">If set to true, use text type
+            /// for values, regardless of the actual input type. When doing the reverse
+            /// mapping, the values are text rather than the original input type.</param>
             public ColumnOptions(string outputColumnName, string inputColumnName = null,
                 int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys,
                 KeyOrdinality keyOrdinality = Defaults.Ordinality,

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -10,7 +10,9 @@ namespace Microsoft.ML.Transforms
 {
 
     /// <summary>
-    /// Estimator for <see cref="ValueToKeyMappingTransformer"/>. Converts input values (words, numbers, etc.) <see cref="KeyDataViewType"/>.
+    /// <see cref="IEstimator{TTransformer}"/> for the
+    /// <see cref="ValueToKeyMappingTransformer"/>. Converts a set of categorical
+    /// values (for example, US state abbreviations) into key values (1-50).
     /// </summary>
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[
@@ -22,13 +24,14 @@ namespace Microsoft.ML.Transforms
     /// | Input column data type | Scalar or vector of numeric, boolean, [text](xref:Microsoft.ML.Data.TextDataViewType), [System.DateTime](xref:System.DateTime) and [key](xref:Microsoft.ML.Data.KeyDataViewType) type. |
     /// | Output column data type | Scalar or vector of [key](xref:Microsoft.ML.Data.KeyDataViewType) type. |
     ///
-    /// The ValueToKeyMappingEstimator builds up term vocabularies(dictionaries) mapping the input values to the keys on the dictionary.
-    /// If multiple columns are used, each column builds/uses exactly one vocabulary.
-    /// The output columns are KeyDataViewType-valued.
-    /// The Key value is the one-based index of the item in the dictionary.
-    /// If the key is not found in the dictionary, it is assigned the missing value indicator.
-    /// This dictionary mapping values to keys is most commonly learnt from the unique values in input data,
-    /// but can be defined through other means: either with the mapping defined, or as loaded from an external file.
+    /// The ValueToKeyMappingEstimator maps the input values to keys using a
+    /// dictionary that is built during training. The dictionary mapping values to
+    /// keys is most commonly learnt from the unique values in input data,
+    /// but can be pre-defined.
+    /// The key value is the one-based index of the item in the dictionary.
+    /// If the key is not found in the dictionary, it is assigned the missing value
+    /// indicator.
+    /// If multiple columns are used, each column builds exactly one dictionary.
     ///
     /// Check the See Also section for links to usage examples.
     /// ]]></format>

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -111,8 +111,9 @@ namespace Microsoft.ML.Transforms
             /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
             /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
             /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-            /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
-            /// If <see cref="KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
+            /// <param name="keyOrdinality">The order in which keys are assigned.
+            /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
+            /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
             /// <param name="addKeyValueAnnotationsAsText">Whether key value annotations should be text, regardless of the actual input type.</param>
             public ColumnOptions(string outputColumnName, string inputColumnName = null,
                 int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys,
@@ -134,7 +135,9 @@ namespace Microsoft.ML.Transforms
         /// <param name="outputColumnName">Name of the column resulting from the transformation of <paramref name="inputColumnName"/>.</param>
         /// <param name="inputColumnName">Name of the column to transform. If set to <see langword="null"/>, the value of the <paramref name="outputColumnName"/> will be used as source.</param>
         /// <param name="maximumNumberOfKeys">Maximum number of keys to keep per column when auto-training.</param>
-        /// <param name="keyOrdinality">How items should be ordered when vectorized. If <see cref="KeyOrdinality.ByOccurrence"/> choosen they will be in the order encountered.
+        /// <param name="keyOrdinality">The order in which keys are assigned.
+        /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
+        /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
         /// If <see cref="KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
         internal ValueToKeyMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys, KeyOrdinality keyOrdinality = Defaults.Ordinality) :
            this(env, new [] { new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, maximumNumberOfKeys, keyOrdinality) })

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingEstimator.cs
@@ -143,7 +143,6 @@ namespace Microsoft.ML.Transforms
         /// <param name="keyOrdinality">The order in which keys are assigned.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByOccurrence"/>, keys are assigned in the order encountered.
         /// If set to <see cref="ValueToKeyMappingEstimator.KeyOrdinality.ByValue"/>, values are sorted, and keys are assigned based on the sort order.</param>
-        /// If <see cref="KeyOrdinality.ByValue"/>, items are sorted according to their default comparison, for example, text sorting will be case sensitive (for example, 'A' then 'Z' then 'a').</param>
         internal ValueToKeyMappingEstimator(IHostEnvironment env, string outputColumnName, string inputColumnName = null, int maximumNumberOfKeys = Defaults.MaximumNumberOfKeys, KeyOrdinality keyOrdinality = Defaults.Ordinality) :
            this(env, new [] { new ColumnOptions(outputColumnName, inputColumnName ?? outputColumnName, maximumNumberOfKeys, keyOrdinality) })
         {

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -34,16 +34,15 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.ML.Transforms
 {
-    // TermTransform builds up term vocabularies (dictionaries).
-    // Notes:
-    // * Each column builds/uses exactly one "vocabulary" (dictionary).
-    // * Output columns are KeyType-valued.
-    // * The Key value is the one-based index of the item in the dictionary.
-    // * Not found is assigned the value zero.
-    /// <include file='doc.xml' path='doc/members/member[@name="TextToKey"]/*' />
     /// <summary>
     /// <see cref="ITransformer"/> resulting from fitting a <see cref="ValueToKeyMappingEstimator"/>.
     /// </summary>
+    /// <remarks>
+    /// Each column builds/uses exactly one dictionary.
+    /// Output columns are KeyType-valued.
+    /// The Key value is the one-based index of the item in the dictionary.
+    /// Not found is assigned the value zero.
+    /// </remarks>
     public sealed partial class ValueToKeyMappingTransformer : OneToOneTransformerBase
     {
         [BestFriend]

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -37,12 +37,6 @@ namespace Microsoft.ML.Transforms
     /// <summary>
     /// <see cref="ITransformer"/> resulting from fitting a <see cref="ValueToKeyMappingEstimator"/>.
     /// </summary>
-    /// <remarks>
-    /// Each column builds/uses exactly one dictionary.
-    /// Output columns are KeyType-valued.
-    /// The Key value is the one-based index of the item in the dictionary.
-    /// Not found is assigned the value zero.
-    /// </remarks>
     public sealed partial class ValueToKeyMappingTransformer : OneToOneTransformerBase
     {
         [BestFriend]

--- a/src/Microsoft.ML.DataView/KeyDataViewType.cs
+++ b/src/Microsoft.ML.DataView/KeyDataViewType.cs
@@ -13,11 +13,11 @@ namespace Microsoft.ML.Data
     /// the values of labels in multiclass classification models.
     /// </summary>
     /// <remarks>
-    /// The underlying .NET type is one of the unsigned integer types. Most commonly
-    /// this is <see cref="uint"/>, but could be <see cref="byte"/>,
+    /// The underlying .NET type is one of the unsigned integer types. The default is
+    /// <see cref="uint"/>, but it can also be <see cref="byte"/>,
     /// <see cref="ushort"/>, or <see cref="ulong"/>.
-    /// Despite this, the information is not inherently numeric, so typically,
-    /// arithmetic is not meaningful.
+    /// Despite keys being numerical types, the information is not inherently numeric,
+    /// so typically, arithmetic is not meaningful.
     ///
     /// Missing values are mapped to 0.
     ///

--- a/src/Microsoft.ML.DataView/KeyDataViewType.cs
+++ b/src/Microsoft.ML.DataView/KeyDataViewType.cs
@@ -9,24 +9,27 @@ using Microsoft.ML.Internal.DataView;
 namespace Microsoft.ML.Data
 {
     /// <summary>
-    /// This type is for data representing some enumerated value. This is an enumeration over a defined, known
-    /// cardinality set, as expressed through <see cref="Count"/>. The underlying .NET type is one of the unsigned
-    /// integer types. Most commonly this will be <see cref="uint"/>, but could alternately be <see cref="byte"/>,
-    /// <see cref="ushort"/>, or <see cref="ulong"/>. Despite this, the information is not inherently numeric, so,
-    /// typically, arithmetic is not meaningful. For example, in multi-class classification, the label is typically a
-    /// class number which is naturally a <see cref="KeyDataViewType"/>.
-    ///
-    /// Note that for data of this type, a value of 0, being the default value of the representation type, indicates
-    /// the missing value since it would not be sensible for the default value to correspond to any one particular specific
-    /// value of the set. The first non-missing value for the enumeration of the set is always <c>1</c>.
-    ///
-    /// For instance, if you had a key value with a <see cref="Count"/> of 3, then the <see cref="uint"/> value <c>0</c>
-    /// would correspond to the missing key value, and one of the values of <c>1</c>, <c>2</c>, or <c>3</c> would be one
-    /// of the valid values, and no other values should in principle be used.
-    ///
-    /// Note that in usage and structure, this is quite close in intended usage and structure to so-called "factor
-    /// variables" in R.
+    /// Type representing categorical or enumerated values, most commonly used for
+    /// the values of labels in multiclass classification models.
     /// </summary>
+    /// <remarks>
+    /// The underlying .NET type is one of the unsigned integer types. Most commonly
+    /// this is <see cref="uint"/>, but could be <see cref="byte"/>,
+    /// <see cref="ushort"/>, or <see cref="ulong"/>.
+    /// Despite this, the information is not inherently numeric, so typically,
+    /// arithmetic is not meaningful.
+    ///
+    /// Missing values are mapped to 0.
+    ///
+    /// The first non-missing value of the set is always <c>1</c>.
+    ///
+    /// The other values range up to the value of <see cref="Count"/>.
+    ///
+    /// For example, if you have a key value with a <see cref="Count"/> of 3, then
+    /// the <see cref="uint"/> value <c>0</c> corresponds to missing key values, and
+    /// one of the values of <c>1</c>, <c>2</c>, or <c>3</c> is of the valid values,
+    /// and no other values are used.
+    /// </remarks>
     public sealed class KeyDataViewType : PrimitiveDataViewType
     {
         /// <summary>


### PR DESCRIPTION
We received many comments that the documentation for value to key mapping and the reverse is not clear, including this issue: https://github.com/dotnet/docs/issues/13590.

This PR attempts to address those concerns.

Please review with a focus in clarity for the user of this API:
- what does this API do?
- when would I use each of the different methods?
- how does this API fit into the larger ML.NET framework?