### PR TITLE
Ignore hidden columns in AutoML schema checks of validation data

### DIFF
--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -183,7 +183,7 @@ namespace Microsoft.ML.AutoML
 
             const string schemaMismatchError = "Training data and validation data schemas do not match.";
 
-            if (trainData.Schema.Count != validationData.Schema.Count)
+            if (trainData.Schema.Count(c => !c.IsHidden) != validationData.Schema.Count(c => !c.IsHidden))
             {
                 throw new ArgumentException($"{schemaMismatchError} Train data has '{trainData.Schema.Count}' columns," +
                     $"and validation data has '{validationData.Schema.Count}' columns.", nameof(validationData));
@@ -191,6 +191,11 @@ namespace Microsoft.ML.AutoML
 
             foreach (var trainCol in trainData.Schema)
             {
+                if (trainCol.IsHidden)
+                {
+                    continue;
+                }
+
                 var validCol = validationData.Schema.GetColumnOrNull(trainCol.Name);
                 if (validCol == null)
                 {

--- a/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
+++ b/src/Microsoft.ML.AutoML/Utils/UserInputValidationUtil.cs
@@ -189,6 +189,9 @@ namespace Microsoft.ML.AutoML
                     $"and validation data has '{validationData.Schema.Count}' columns.", nameof(validationData));
             }
 
+            // Validate that every active column in the train data corresponds to an active column in the validation data.
+            // (Indirectly, since we asserted above that the train and validation data have the same number of active columns, this also
+            // esnures the reverse -- that every active column in the validation data corresponds to an active column in the train data.)
             foreach (var trainCol in trainData.Schema)
             {
                 if (trainCol.IsHidden)


### PR DESCRIPTION
Closes #4491

When the AutoML API consumes data, it validates schema consistency between the train and validation data.

There are two bugs in this logic:

1. The API asserts that the count of columns in the train and validation data must be equal. This throws an exception if the two data views have the same number of active columns but a different number of hidden columns. This PR updates to assert that the # of active (not hidden) columns in the train and validation data are equal.

2. If either the train or validation data has a hidden column with a type that differs from an active column of the same name, an exception is thrown. This PR restricts type consistency checks to active columns only.