### PR TITLE
Disable tests on macOS that depend on GDI+ library.

### DIFF
--- a/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.ML.Data;
 using Microsoft.ML.Model;
 using Microsoft.ML.RunTests;
@@ -89,6 +90,11 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxFeaturizerWorkout()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var env = new MLContext(null);
             var imageHeight = 224;
             var imageWidth = 224;
@@ -197,6 +203,11 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void TestLoadFromDiskAndPredictionEngine()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
 

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Microsoft.ML.Transforms.Onnx;
 using Microsoft.ML.TestFrameworkCommon.Attributes;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.Tests
 {
@@ -201,6 +202,11 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxWorkout()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "squeezenet", "00000001", "model.onnx");
 
             var env = new MLContext();
@@ -391,6 +397,11 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxModelInMemoryImage()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             // Path of ONNX model. It's a multiclass classifier. It consumes an input "data_0" and produces an output "softmaxout_1".
             var modelFile = "squeezenet/00000001/model.onnx";
 

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.ML.Data;
 using Microsoft.ML.Model;
 using Microsoft.ML.RunTests;
@@ -26,6 +27,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestEstimatorChain()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var env = new MLContext();
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
@@ -101,6 +107,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestSaveImages()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var env = new MLContext();
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
@@ -136,6 +147,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestGreyscaleTransformImages()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             var imageHeight = 150;
             var imageWidth = 100;
@@ -187,6 +203,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestGrayScaleInMemory()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             // Create an image list.
             var images = new List<ImageDataPoint>(){ new ImageDataPoint(10, 10, Color.Blue), new ImageDataPoint(10, 10, Color.Red) };
 
@@ -270,6 +291,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaInterleave()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -327,6 +353,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaInterleave()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -384,6 +415,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithDifferentOrder()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -443,6 +479,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaNoInterleave()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -500,6 +541,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaNoInterleave()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -557,6 +603,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaInterleaveNoOffset()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -615,6 +666,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaInterleaveNoOffset()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -672,6 +728,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaNoInterleaveNoOffset()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             var imageWidth = 130;
@@ -730,6 +791,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaNoInterleaveNoOffset()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -786,6 +852,11 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void ImageResizerTransformResizingModeFill()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var env = new MLContext();
             var dataFile = GetDataPath("images/fillmode.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -73,6 +73,11 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransforCifarEndToEndTest2()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var imageHeight = 32;
             var imageWidth = 32;
             var model_location = "cifar_model/frozen_model.pb";
@@ -934,6 +939,11 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransformCifar()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var modelLocation = "cifar_model/frozen_model.pb";
             var mlContext = new MLContext(seed: 1);
             List<string> logMessages = new List<string>();
@@ -1023,6 +1033,11 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransformCifarSavedModel()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var modelLocation = "cifar_saved_model";
             var mlContext = new MLContext(seed: 1);
             var tensorFlowModel = mlContext.Model.LoadTensorFlowModel(modelLocation);
@@ -1077,6 +1092,11 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransformCifarInvalidShape()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var modelLocation = "cifar_model/frozen_model.pb";
 
             var mlContext = new MLContext(seed: 1);

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -14,6 +14,7 @@ using Microsoft.ML.Transforms;
 using Microsoft.ML.TensorFlow;
 using Xunit;
 using Xunit.Abstractions;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.Tests
 {
@@ -143,6 +144,11 @@ namespace Microsoft.ML.Tests
         [TensorFlowFact]
         public void TestTensorFlow()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             var modelLocation = "cifar_model/frozen_model.pb";
 
             var mlContext = new MLContext(seed: 1);
@@ -184,6 +190,11 @@ namespace Microsoft.ML.Tests
         [TensorFlowFact]
         public void TestTensorFlowWithSchema()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
             const string modelLocation = "cifar_model/frozen_model.pb";
 
             var mlContext = new MLContext(seed: 1);


### PR DESCRIPTION
Disabling bitmap related tests temporarily on macOS to unblock PRs that are stalled because macOS CI images don't seem to have GDI+ or related library.