### PR TITLE
Add SQL command timeout option to database loader.

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Data
                     {
                         _command = Connection.CreateCommand();
                         _command.CommandText = _source.CommandText;
-                        _command.CommandTimeout = _source.CommandTimeout;
+                        _command.CommandTimeout = _source.CommandTimeoutInSeconds;
                     }
                     return _command;
                 }

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseLoaderCursor.cs
@@ -71,6 +71,7 @@ namespace Microsoft.ML.Data
                     {
                         _command = Connection.CreateCommand();
                         _command.CommandText = _source.CommandText;
+                        _command.CommandTimeout = _source.CommandTimeout;
                     }
                     return _command;
                 }

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ML.Data
     public sealed class DatabaseSource
     {
         /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
-        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
+        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>.</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
         public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText)
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Data
         }
 
         /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
-        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
+        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>.</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
         /// <param name="commandTimeoutInSeconds">The time in seconds to wait for the command to execute.</param>

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -14,8 +14,23 @@ namespace Microsoft.ML.Data
         /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
-        /// <param name="commandTimeout">The time in seconds to wait for the command to execute. Default is 30 sec.</param>
-        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeout = 30)
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText)
+        {
+            Contracts.CheckValue(providerFactory, nameof(providerFactory));
+            Contracts.CheckValue(connectionString, nameof(connectionString));
+            Contracts.CheckValue(commandText, nameof(commandText));
+
+            ProviderFactory = providerFactory;
+            ConnectionString = connectionString;
+            CommandText = commandText;
+        }
+
+        /// <summary>Creates a new instance of the <see cref="DatabaseSource" /> class.</summary>
+        /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
+        /// <param name="connectionString">The string used to open the connection.</param>
+        /// <param name="commandText">The text command to run against the data source.</param>
+        /// <param name="commandTimeout">The time in seconds to wait for the command to execute.</param>
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeout)
         {
             Contracts.CheckValue(providerFactory, nameof(providerFactory));
             Contracts.CheckValue(connectionString, nameof(connectionString));

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -29,8 +29,8 @@ namespace Microsoft.ML.Data
         /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
-        /// <param name="commandTimeout">The time in seconds to wait for the command to execute.</param>
-        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeout)
+        /// <param name="commandTimeoutInSeconds">The time in seconds to wait for the command to execute.</param>
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeoutInSeconds)
         {
             Contracts.CheckValue(providerFactory, nameof(providerFactory));
             Contracts.CheckValue(connectionString, nameof(connectionString));
@@ -39,14 +39,14 @@ namespace Microsoft.ML.Data
             ProviderFactory = providerFactory;
             ConnectionString = connectionString;
             CommandText = commandText;
-            CommandTimeout = commandTimeout;
+            CommandTimeoutInSeconds = commandTimeoutInSeconds;
         }
 
         /// <summary>Gets the text command to run against the data source.</summary>
         public string CommandText { get; }
 
         /// <summary>Gets the command timeout.</summary>
-        public int CommandTimeout { get; }
+        public int CommandTimeoutInSeconds { get; }
 
         /// <summary>Gets the string used to open the connection.</summary>
         public string ConnectionString { get; }

--- a/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Database/DatabaseSource.cs
@@ -14,7 +14,8 @@ namespace Microsoft.ML.Data
         /// <param name="providerFactory">The factory used to create the <see cref="DbConnection"/>..</param>
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <param name="commandText">The text command to run against the data source.</param>
-        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText)
+        /// <param name="commandTimeout">The time in seconds to wait for the command to execute. Default is 30 sec.</param>
+        public DatabaseSource(DbProviderFactory providerFactory, string connectionString, string commandText, int commandTimeout = 30)
         {
             Contracts.CheckValue(providerFactory, nameof(providerFactory));
             Contracts.CheckValue(connectionString, nameof(connectionString));
@@ -23,10 +24,14 @@ namespace Microsoft.ML.Data
             ProviderFactory = providerFactory;
             ConnectionString = connectionString;
             CommandText = commandText;
+            CommandTimeout = commandTimeout;
         }
 
         /// <summary>Gets the text command to run against the data source.</summary>
         public string CommandText { get; }
+
+        /// <summary>Gets the command timeout.</summary>
+        public int CommandTimeout { get; }
 
         /// <summary>Gets the string used to open the connection.</summary>
         public string ConnectionString { get; }

--- a/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/DatabaseLoaderTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Tests
         }
 
         [LightGBMFact]
-        public void IrisLightGbmConnectionTimeout()
+        public void IrisLightGbmCommandTimeout()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {


### PR DESCRIPTION
Fixes #4484 

This change adds a way to specify the SQL command timeout https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtimeout?view=netframework-4.8
while creating the DatabaseSource.

