### PR TITLE
Reenabling MacOS tests that had an issue with libgdiplus

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
-      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install --build-from-source mono-libgdiplus && brew install gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
-      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install --build-from-source mono-libgdiplus && brew install gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/DnnImageFeaturizerTest.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.ML.Data;
 using Microsoft.ML.Model;
 using Microsoft.ML.RunTests;
@@ -90,11 +89,6 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxFeaturizerWorkout()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var env = new MLContext(null);
             var imageHeight = 224;
             var imageWidth = 224;
@@ -203,11 +197,6 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void TestLoadFromDiskAndPredictionEngine()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
 

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 using Xunit.Abstractions;
 using Microsoft.ML.Transforms.Onnx;
 using Microsoft.ML.TestFrameworkCommon.Attributes;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.Tests
 {
@@ -202,11 +201,6 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxWorkout()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "squeezenet", "00000001", "model.onnx");
 
             var env = new MLContext();
@@ -397,11 +391,6 @@ namespace Microsoft.ML.Tests
         [OnnxFact]
         public void OnnxModelInMemoryImage()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             // Path of ONNX model. It's a multiclass classifier. It consumes an input "data_0" and produces an output "softmaxout_1".
             var modelFile = "squeezenet/00000001/model.onnx";
 

--- a/test/Microsoft.ML.Tests/ImagesTests.cs
+++ b/test/Microsoft.ML.Tests/ImagesTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.ML.Data;
 using Microsoft.ML.Model;
 using Microsoft.ML.RunTests;
@@ -27,11 +26,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestEstimatorChain()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var env = new MLContext();
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
@@ -107,11 +101,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestSaveImages()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var env = new MLContext();
             var dataFile = GetDataPath("images/images.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);
@@ -147,11 +136,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestGreyscaleTransformImages()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             var imageHeight = 150;
             var imageWidth = 100;
@@ -203,11 +187,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestGrayScaleInMemory()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             // Create an image list.
             var images = new List<ImageDataPoint>(){ new ImageDataPoint(10, 10, Color.Blue), new ImageDataPoint(10, 10, Color.Red) };
 
@@ -291,11 +270,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaInterleave()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -353,11 +327,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaInterleave()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -415,11 +384,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithDifferentOrder()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -479,11 +443,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaNoInterleave()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -541,11 +500,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaNoInterleave()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -603,11 +557,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaInterleaveNoOffset()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -666,11 +615,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaInterleaveNoOffset()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -728,11 +672,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithAlphaNoInterleaveNoOffset()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             var imageWidth = 130;
@@ -791,11 +730,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void TestBackAndForthConversionWithoutAlphaNoInterleaveNoOffset()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             IHostEnvironment env = new MLContext();
             const int imageHeight = 100;
             const int imageWidth = 130;
@@ -852,11 +786,6 @@ namespace Microsoft.ML.Tests
         [Fact]
         public void ImageResizerTransformResizingModeFill()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var env = new MLContext();
             var dataFile = GetDataPath("images/fillmode.tsv");
             var imageFolder = Path.GetDirectoryName(dataFile);

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -73,11 +73,6 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransforCifarEndToEndTest2()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var imageHeight = 32;
             var imageWidth = 32;
             var model_location = "cifar_model/frozen_model.pb";
@@ -939,11 +934,6 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransformCifar()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var modelLocation = "cifar_model/frozen_model.pb";
             var mlContext = new MLContext(seed: 1);
             List<string> logMessages = new List<string>();
@@ -1033,11 +1023,6 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransformCifarSavedModel()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var modelLocation = "cifar_saved_model";
             var mlContext = new MLContext(seed: 1);
             var tensorFlowModel = mlContext.Model.LoadTensorFlowModel(modelLocation);
@@ -1092,11 +1077,6 @@ namespace Microsoft.ML.Scenarios
         [TensorFlowFact]
         public void TensorFlowTransformCifarInvalidShape()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var modelLocation = "cifar_model/frozen_model.pb";
 
             var mlContext = new MLContext(seed: 1);

--- a/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
+++ b/test/Microsoft.ML.Tests/TensorFlowEstimatorTests.cs
@@ -14,7 +14,6 @@ using Microsoft.ML.Transforms;
 using Microsoft.ML.TensorFlow;
 using Xunit;
 using Xunit.Abstractions;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.ML.Tests
 {
@@ -144,11 +143,6 @@ namespace Microsoft.ML.Tests
         [TensorFlowFact]
         public void TestTensorFlow()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             var modelLocation = "cifar_model/frozen_model.pb";
 
             var mlContext = new MLContext(seed: 1);
@@ -190,11 +184,6 @@ namespace Microsoft.ML.Tests
         [TensorFlowFact]
         public void TestTensorFlowWithSchema()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return;
-            }
-
             const string modelLocation = "cifar_model/frozen_model.pb";
 
             var mlContext = new MLContext(seed: 1);


### PR DESCRIPTION
### Edited First Post:
PR #4492 disabled some tests that threw a `System.DllNotFoundException : Unable to load DLL 'libgdiplus'`, when trying to run them on our MacOS CI Pipeline.

As explained below in this thread, the problem was on homebrew's side, and this PR was meant to give a provitional solution for the problem. Nonetheless, this problem has just been fixed on homebrew's side, so now this PR simply reenables those tests.

-----------------------------

### Original First Post:
Solves the problem with MacOS Pipeline where certain tests threw a
`System.DllNotFoundException : Unable to load DLL 'libgdiplus': The specified module could not be found`

The issue was caused somewhere in homebrew's installation, and one way to solve this issue is to actually make homebrew to build the libgdiplus library after downloading it (instead of downloading a prebuilt version from [https://homebrew.bintray.com/bottles/mono-libgdiplus-6.0.4.high_sierra.bottle.tar.gz](https://homebrew.bintray.com/bottles/mono-libgdiplus-6.0.4.high_sierra.bottle.tar.gz) which is where it gets libgdiplus if homebrew doesn't build it). For some reason that's still unknown to me, this prebuilt version isn't working as expected, and the above exception is thrown.