### PR TITLE
improve test stability

### DIFF
--- a/src/Microsoft.Extensions.ML/ModelReloadToken.cs
+++ b/src/Microsoft.Extensions.ML/ModelReloadToken.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Extensions.ML
         /// <summary>
         /// Used to trigger the change token when a reload occurs.
         /// </summary>
-        public void OnReload() => _cts.Cancel();
+        public void OnReload()
+        {
+            if (!_cts.IsCancellationRequested)
+                _cts.Cancel();
+            else
+                Console.WriteLine("ModelReloadToken has already been Canceled.");
+        }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/OrderedWaiter.cs
+++ b/src/Microsoft.ML.Core/Utilities/OrderedWaiter.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Internal.Utilities
                 ev = new WaitStats(position);
                 _waiters.Add(ev);
             }
-            ev.Event.Wait(token);
+            ev.Event.Wait(5*60*1000, token);
             if (_ex != null)
                 throw Contracts.Except(_ex, "Event we were waiting on was subject to an exception");
         }

--- a/src/Microsoft.ML.Data/Data/DataViewUtils.cs
+++ b/src/Microsoft.ML.Data/Data/DataViewUtils.cs
@@ -402,7 +402,7 @@ namespace Microsoft.ML.Data
                                             // The waiter event should never be null since this is only
                                             // called after a point where waiter.Register has been called.
                                             ch.AssertValue(waiterEvent);
-                                        waiterEvent.Wait();
+                                        waiterEvent.Wait(5*60*1000);
                                         waiterEvent = null;
                                         toConsume.Add(batch);
                                     }

--- a/test/Microsoft.ML.TestFramework/BaseTestClass.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestClass.cs
@@ -49,14 +49,14 @@ namespace Microsoft.ML.TestFramework
             TestName = test.TestCase.TestMethod.Method.Name;
 
             // write to the console when a test starts and stops so we can identify any test hangs/deadlocks in CI
-            Console.WriteLine($"Starting test: {FullTestName}");
+            Console.WriteLine($"[{DateTime.Now}] Starting test: {FullTestName}");
             Initialize();
         }
 
         void IDisposable.Dispose()
         {
             Cleanup();
-            Console.WriteLine($"Finished test: {FullTestName}");
+            Console.WriteLine($"[{DateTime.Now}] Finished test: {FullTestName}");
         }
 
         protected virtual void Initialize()


### PR DESCRIPTION
1. add datatime when start/finish tests
2. add timeout for thread waiting to prevent infinite wait
3. fix cancel token cancel twice issue

