### PR TITLE
Adds PriorTrainer Onnx conversion

### DIFF
--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -197,16 +197,9 @@ namespace Microsoft.ML.Data
         public string FeatureColumnName { get; }
 
         /// <summary>
-        /// The name of the label column used by the prediction transformer.
-        /// </summary>
-        public string LabelColumnName { get; }
-
-        /// <summary>
         /// The type of the prediction transformer
         /// </summary>
         public DataViewType FeatureColumnType { get; }
-
-        public DataViewType LabelColumnType { get; }
 
         /// <summary>
         /// Initializes a new reference of <see cref="SingleFeaturePredictionTransformerBase{TModel}"/>.
@@ -225,20 +218,6 @@ namespace Microsoft.ML.Data
                 throw Host.ExceptSchemaMismatch(nameof(featureColumn), "feature", featureColumn);
             else
                 FeatureColumnType = trainSchema[col].Type;
-
-            BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, ModelAsPredictor);
-        }
-
-        private protected SingleFeaturePredictionTransformerBase(IHost host, TModel model, DataViewSchema trainSchema, string featureColumn, string labelColumn)
-            : base(host, model, trainSchema)
-        {
-            LabelColumnName = labelColumn;
-            if (labelColumn == null)
-                LabelColumnType = null;
-            else if (!trainSchema.TryGetColumnIndex(labelColumn, out int col))
-                throw Host.ExceptSchemaMismatch(nameof(labelColumn), "label", labelColumn);
-            else
-                LabelColumnType = trainSchema[col].Type;
 
             BindableMapper = ScoreUtils.GetSchemaBindableMapper(Host, ModelAsPredictor);
         }
@@ -391,6 +370,7 @@ namespace Microsoft.ML.Data
     {
         internal readonly string ThresholdColumn;
         internal readonly float Threshold;
+        internal readonly string LabelColumnName;
 
         [BestFriend]
         internal BinaryPredictionTransformer(IHostEnvironment env, TModel model, DataViewSchema inputSchema, string featureColumn,
@@ -405,11 +385,12 @@ namespace Microsoft.ML.Data
         }
         internal BinaryPredictionTransformer(IHostEnvironment env, TModel model, DataViewSchema inputSchema, string featureColumn, string labelColumn,
             float threshold = 0f, string thresholdColumn = DefaultColumnNames.Score)
-            : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(BinaryPredictionTransformer<TModel>)), model, inputSchema, featureColumn, labelColumn)
+            : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(BinaryPredictionTransformer<TModel>)), model, inputSchema, featureColumn)
         {
             Host.CheckNonEmpty(thresholdColumn, nameof(thresholdColumn));
             Threshold = threshold;
             ThresholdColumn = thresholdColumn;
+            LabelColumnName = labelColumn;
 
             SetScorer();
         }

--- a/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
+++ b/src/Microsoft.ML.Data/Scorers/PredictionTransformer.cs
@@ -383,6 +383,7 @@ namespace Microsoft.ML.Data
 
             SetScorer();
         }
+
         internal BinaryPredictionTransformer(IHostEnvironment env, TModel model, DataViewSchema inputSchema, string featureColumn, string labelColumn,
             float threshold = 0f, string thresholdColumn = DefaultColumnNames.Score)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(BinaryPredictionTransformer<TModel>)), model, inputSchema, featureColumn)

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -429,8 +429,9 @@ namespace Microsoft.ML.Data
             Contracts.Assert(Utils.Size(outputNames) == 3); // Predicted Label, Score and Probablity.
 
             // Prior doesn't have a feature column and uses the training label column to determine predicted labels
-            if (mapper.ToString().EndsWith("PriorModelParameters")) {
-                var labelColumnName = schema.Schema[0].Name;
+            if (!schema.Feature.HasValue) {
+                Contracts.Assert(schema.Label.HasValue);
+                var labelColumnName = schema.Label.Value.Name;
                 return mapper.SaveAsOnnx(ctx, outputNames, ctx.GetVariableName(labelColumnName));
             }
 
@@ -517,7 +518,7 @@ namespace Microsoft.ML.Data
 
             public IEnumerable<KeyValuePair<RoleMappedSchema.ColumnRole, string>> GetInputColumnRoles()
             {
-                yield return RoleMappedSchema.ColumnRole.Feature.Bind(InputRoleMappedSchema.Feature?.Name);
+                yield return (InputRoleMappedSchema.Feature.HasValue) ? RoleMappedSchema.ColumnRole.Feature.Bind(InputRoleMappedSchema.Feature?.Name) : RoleMappedSchema.ColumnRole.Label.Bind(InputRoleMappedSchema.Label?.Name);
             }
 
             private Delegate[] CreateGetters(DataViewRow input, bool[] active)

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -426,9 +426,15 @@ namespace Microsoft.ML.Data
 
             var mapper = ValueMapper as ISingleCanSaveOnnx;
             Contracts.CheckValue(mapper, nameof(mapper));
-            Contracts.Assert(schema.Feature.HasValue);
             Contracts.Assert(Utils.Size(outputNames) == 3); // Predicted Label, Score and Probablity.
 
+            // Prior doesn't have a feature column and uses the training label column to determine predicted labels
+            if (mapper.ToString().EndsWith("PriorModelParameters")) {
+                var labelColumnName = schema.Schema[0].Name;
+                return mapper.SaveAsOnnx(ctx, outputNames, ctx.GetVariableName(labelColumnName));
+            }
+
+            Contracts.Assert(schema.Feature.HasValue);
             var featName = schema.Feature.Value.Name;
             if (!ctx.ContainsColumn(featName))
                 return false;

--- a/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
+++ b/src/Microsoft.ML.Data/Scorers/SchemaBindablePredictorWrapper.cs
@@ -429,13 +429,13 @@ namespace Microsoft.ML.Data
             Contracts.Assert(Utils.Size(outputNames) == 3); // Predicted Label, Score and Probablity.
 
             // Prior doesn't have a feature column and uses the training label column to determine predicted labels
-            if (!schema.Feature.HasValue) {
+            if (!schema.Feature.HasValue)
+            {
                 Contracts.Assert(schema.Label.HasValue);
                 var labelColumnName = schema.Label.Value.Name;
                 return mapper.SaveAsOnnx(ctx, outputNames, ctx.GetVariableName(labelColumnName));
             }
 
-            Contracts.Assert(schema.Feature.HasValue);
             var featName = schema.Feature.Value.Name;
             if (!ctx.ContainsColumn(featName))
                 return false;

--- a/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
@@ -241,9 +241,9 @@ namespace Microsoft.ML.Trainers
         /// </summary>
         public BinaryPredictionTransformer<PriorModelParameters> Fit(IDataView input)
         {
-            RoleMappedData trainRoles = new RoleMappedData(input, feature: null, label: _labelColumnName, weight: _weightColumnName);
+            RoleMappedData trainRoles = new RoleMappedData(input, label: _labelColumnName, feature: null, weight: _weightColumnName);
             var pred = ((ITrainer<PriorModelParameters>)this).Train(new TrainContext(trainRoles));
-            return new BinaryPredictionTransformer<PriorModelParameters>(_host, pred, input.Schema, featureColumn: null);
+            return new BinaryPredictionTransformer<PriorModelParameters>(_host, pred, input.Schema, featureColumn: null, labelColumn: _labelColumnName);
         }
 
         private PriorModelParameters Train(TrainContext context)

--- a/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
@@ -8,6 +8,7 @@ using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Model;
+using Microsoft.ML.Model.OnnxConverter;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Trainers;
 
@@ -330,7 +331,7 @@ namespace Microsoft.ML.Trainers
     public sealed class PriorModelParameters :
         ModelParametersBase<float>,
         IDistPredictorProducing<float, float>,
-        IValueMapperDist
+        IValueMapperDist, ISingleCanSaveOnnx
     {
         internal const string LoaderSignature = "PriorPredictor";
         private static VersionInfo GetVersionInfo()
@@ -346,6 +347,7 @@ namespace Microsoft.ML.Trainers
 
         private readonly float _prob;
         private readonly float _raw;
+        bool ICanSaveOnnx.CanSaveOnnx(OnnxContext ctx) => true;
 
         /// <summary>
         /// Instantiates a model that returns the prior probability of the positive class in the training set.
@@ -395,6 +397,37 @@ namespace Microsoft.ML.Trainers
 
             Contracts.Assert(!float.IsNaN(_prob));
             ctx.Writer.Write(_prob);
+        }
+        bool ISingleCanSaveOnnx.SaveAsOnnx(OnnxContext ctx, string[] outputs, string labelColumn)
+        {
+            Host.CheckValue(ctx, nameof(ctx));
+            Host.Check(Utils.Size(outputs) >= 3);
+
+            string scoreVarName = outputs[1];
+            string probVarName = outputs[2];
+            var prob = ctx.AddInitializer(_prob, "probability");
+            var score = ctx.AddInitializer(_raw, "score");
+
+            var xorOutput = ctx.AddIntermediateVariable(null,"XorOutput", true);
+            string opType = "Xor";
+            ctx.CreateNode(opType, new[] { labelColumn, labelColumn }, new[] { xorOutput }, ctx.GetNodeName(opType), "");
+
+            var notOutput = ctx.AddIntermediateVariable(null, "NotOutput", true);
+            opType = "Not";
+            ctx.CreateNode(opType, xorOutput, notOutput, ctx.GetNodeName(opType), "");
+
+            var castOutput = ctx.AddIntermediateVariable(null, "CastOutput", true);
+            opType = "Cast";
+            var node = ctx.CreateNode(opType, notOutput, castOutput, ctx.GetNodeName(opType), "");
+            var t = InternalDataKindExtensions.ToInternalDataKind(DataKind.Single).ToType();
+            node.AddAttribute("to", t);
+
+            opType = "Mul";
+            ctx.CreateNode(opType, new[] { castOutput, prob }, new[] { probVarName }, ctx.GetNodeName(opType), "");
+
+            opType = "Mul";
+            ctx.CreateNode(opType, new[] { castOutput, score }, new[] { scoreVarName }, ctx.GetNodeName(opType), "");
+            return true;
         }
 
         private protected override PredictionKind PredictionKind => PredictionKind.BinaryClassification;

--- a/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/Simple/SimpleTrainers.cs
@@ -398,6 +398,7 @@ namespace Microsoft.ML.Trainers
             Contracts.Assert(!float.IsNaN(_prob));
             ctx.Writer.Write(_prob);
         }
+
         bool ISingleCanSaveOnnx.SaveAsOnnx(OnnxContext ctx, string[] outputs, string labelColumn)
         {
             Host.CheckValue(ctx, nameof(ctx));
@@ -408,7 +409,7 @@ namespace Microsoft.ML.Trainers
             var prob = ctx.AddInitializer(_prob, "probability");
             var score = ctx.AddInitializer(_raw, "score");
 
-            var xorOutput = ctx.AddIntermediateVariable(null,"XorOutput", true);
+            var xorOutput = ctx.AddIntermediateVariable(null, "XorOutput", true);
             string opType = "Xor";
             ctx.CreateNode(opType, new[] { labelColumn, labelColumn }, new[] { xorOutput }, ctx.GetNodeName(opType), "");
 

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -270,6 +270,7 @@ namespace Microsoft.ML.Tests
                 mlContext.BinaryClassification.Trainers.FastTree(),
                 mlContext.BinaryClassification.Trainers.LbfgsLogisticRegression(),
                 mlContext.BinaryClassification.Trainers.LinearSvm(),
+                mlContext.BinaryClassification.Trainers.Prior(),
                 mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(),
                 mlContext.BinaryClassification.Trainers.SdcaNonCalibrated(),
                 mlContext.BinaryClassification.Trainers.SgdCalibrated(),
@@ -301,8 +302,8 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedR4ScalarColumns(transformedData.Schema[5].Name, outputNames[3], transformedData, onnxResult, 3);
-                    CompareSelectedScalarColumns<Boolean>(transformedData.Schema[4].Name, outputNames[2], transformedData, onnxResult);
+                    CompareSelectedR4ScalarColumns(transformedData.Schema[5].Name, outputNames[3], transformedData, onnxResult, 3); //compare scores
+                    CompareSelectedScalarColumns<Boolean>(transformedData.Schema[4].Name, outputNames[2], transformedData, onnxResult); //compare predicted labels
                 }
             }
             Done();


### PR DESCRIPTION

1. Adding Onnx support for PriorTrainer 
       To follow the onnx construction pattern of other binary classifiers, this trainer uses the probability to predict labels, instead of score

