### PR TITLE
Image classification performance improvements and option to create validation set from train set.

### DIFF
--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ML.Samples
 
         internal static void RunAll()
         {
-            int samples = 0;
+            /*int samples = 0;
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
@@ -23,7 +23,8 @@ namespace Microsoft.ML.Samples
                 }
             }
 
-            Console.WriteLine("Number of samples that ran without any exception: " + samples);
+            Console.WriteLine("Number of samples that ran without any exception: " + samples);*/
+            ResnetV2101TransferLearningTrainTestSplit.Example();
         }
     }
 }

--- a/docs/samples/Microsoft.ML.Samples/Program.cs
+++ b/docs/samples/Microsoft.ML.Samples/Program.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ML.Samples
 
         internal static void RunAll()
         {
-            /*int samples = 0;
+            int samples = 0;
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 var sample = type.GetMethod("Example", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
@@ -23,8 +23,7 @@ namespace Microsoft.ML.Samples
                 }
             }
 
-            Console.WriteLine("Number of samples that ran without any exception: " + samples);*/
-            ResnetV2101TransferLearningTrainTestSplit.Example();
+            Console.WriteLine("Number of samples that ran without any exception: " + samples);
         }
     }
 }

--- a/src/Microsoft.ML.Core/Utilities/Stream.cs
+++ b/src/Microsoft.ML.Core/Utilities/Stream.cs
@@ -887,6 +887,26 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
+        /// If this return it will try to read exactly length bytes.
+        /// </summary>
+        /// <param name="s">The stream</param>
+        /// <param name="buff">The buffer into which to write the data.</param>
+        /// <param name="offset">The offset of the output array into which to write.</param>
+        /// <param name="length">The number of bytes to read.</param>
+        public static int TryReadBlock(this Stream s, byte[] buff, int offset, int length)
+        {
+            int pos = 0;
+            int read = -1;
+            while (pos != length && read != 0)
+            {
+                read = s.Read(buff, offset + pos, length - pos);
+                pos += read;
+            }
+
+            return pos;
+        }
+
+        /// <summary>
         /// Reads a LEB128 encoded unsigned integer.
         /// </summary>
         public static ulong ReadLeb128Int(this BinaryReader reader)

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -643,27 +643,15 @@ namespace Microsoft.ML.Transforms
                 {
                     if (_parent.Graph.graph_key != tf.get_default_graph().graph_key)
                         _parent.Session.graph.as_default();
-                    Runner runner = new Runner(_parent.Session);
+                    Runner runner = new Runner(_parent.Session, _parent.Inputs.ToArray(), _parent.Outputs.ToArray());
 
                     // Feed inputs to the graph.
-                     for (int i = 0; i < _parent.Inputs.Length; i++)
-                    {
-                        var tensor = srcTensorGetters[i].GetTensor();
-                        runner.AddInput(_parent.Inputs[i], tensor);
-                    }
-
-                    // Add outputs.
-                    for (int i = 0; i < _parent.Outputs.Length; i++)
-                        runner.AddOutputs(_parent.Outputs[i]);
+                    for (int i = 0; i < _parent.Inputs.Length; i++)
+                        runner.AddInput(srcTensorGetters[i].GetTensor(), i);
 
                     // Execute the graph.
                     var tensors = runner.Run();
-
-                    List<Tensor> inputTensors = runner.GetInputValues();
-                    foreach (Tensor inputTensor in inputTensors)
-                    {
-                        inputTensor.Dispose();
-                    }
+                    runner.Dispose();
 
                     Contracts.Assert(tensors.Length > 0);
 

--- a/src/Microsoft.ML.Vision/DnnRetrainTransform.cs
+++ b/src/Microsoft.ML.Vision/DnnRetrainTransform.cs
@@ -313,7 +313,17 @@ namespace Microsoft.ML.Transforms
                 ops = new[] { c_api.TF_GraphOperationByName(Graph, options.OptimizationOperation) };
 
             // Instantiate the graph.
-            Runner runner;
+            string[] outputs = null;
+            if (options.LossOperation != null && options.MetricOperation != null)
+                outputs = new[] { options.LossOperation, options.MetricOperation };
+            else if (options.LossOperation != null)
+                outputs = new[] { options.LossOperation };
+            else if (options.MetricOperation != null)
+                outputs = new[] { options.MetricOperation };
+
+            Runner runner = new Runner(_session, new[] { options.LearningRateOperation }.Concat(inputsForTraining).ToArray(),
+                outputs, new[] { options.OptimizationOperation }).AddInput(new Tensor(options.LearningRate), 0);
+
             var cols = input.Schema.Where(c => inputColIndices.Contains(c.Index));
 
             for (int epoch = 0; epoch < options.Epoch; epoch++)
@@ -340,22 +350,6 @@ namespace Microsoft.ML.Transforms
                             if (((cursor.Position + 1) % options.BatchSize) == 0)
                             {
                                 isDataLeft = false;
-                                runner = new Runner(_session);
-
-                                // Add Learning Rate.
-                                if (!string.IsNullOrEmpty(options.LearningRateOperation))
-                                    runner.AddInput(options.LearningRateOperation, new Tensor(options.LearningRate));
-
-                                // Add operations.
-                                if (!string.IsNullOrEmpty(options.OptimizationOperation))
-                                    runner.AddOperation(options.OptimizationOperation);
-
-                                // Add outputs.
-                                if (options.LossOperation != null)
-                                    runner.AddOutputs(options.LossOperation);
-                                if (options.MetricOperation != null)
-                                    runner.AddOutputs(options.MetricOperation);
-
                                 var (l, m) = ExecuteGraphAndRetrieveMetrics(inputsForTraining, srcTensorGetters, runner);
                                 loss += l;
                                 metric += m;
@@ -382,7 +376,7 @@ namespace Microsoft.ML.Transforms
             float loss = 0.0f;
             float metric = 0.0f;
             for (int i = 0; i < inputs.Length; i++)
-                runner.AddInput(inputs[i], srcTensorGetters[i].GetBufferedBatchTensor());
+                runner.AddInput(srcTensorGetters[i].GetBufferedBatchTensor(), i + 1);
 
             Tensor[] tensor = runner.Run();
             if (tensor.Length > 0 && tensor[0] != IntPtr.Zero)
@@ -391,6 +385,8 @@ namespace Microsoft.ML.Transforms
             if (tensor.Length > 1 && tensor[1] != IntPtr.Zero)
                 tensor[1].ToScalar<float>(ref metric);
 
+            tensor[0].Dispose();
+            tensor[1].Dispose();
             return (loss, metric);
         }
 
@@ -406,12 +402,10 @@ namespace Microsoft.ML.Transforms
                 // Save the model on disk
                 var path = Path.Combine(modelDir, DefaultModelFileNames.TmpMlnetModel);
                 //var input = GetOperationFromName(options.SaveLocationOperation, Session);
-                var runner = new Runner(_session); //, new[] { new TF_Output(input.Item1, input.Item2) }, null, new[] { c_api.TF_GraphOperationByName(Graph, options.SaveOperation) });
+                var runner = new Runner(_session, new[] { options.SaveLocationOperation },
+                    null, new[] { options.SaveOperation }).AddInput(new Tensor(path), 0);
 
-                runner.AddInput(options.SaveLocationOperation, new Tensor(path))
-                    .AddOperation(options.SaveOperation)
-                    .Run();
-
+                runner.Run();
                 // Preserve original files
                 var variablesPath = Path.Combine(modelDir, DefaultModelFileNames.VariablesFolder);
                 var archivePath = Path.Combine(variablesPath + "-" + Guid.NewGuid().ToString());
@@ -864,7 +858,7 @@ namespace Microsoft.ML.Transforms
                 return Utils.MarshalInvoke(MakeGetter<int>, type, input, iinfo, srcTensorGetters, activeOutputColNames, outputCache);
             }
 
-            private Delegate MakeGetter<T>(DataViewRow input, int iinfo, ITensorValueGetter[] srcTensorGetters, string[] activeOutputColNames, OutputCache outputCache) where T: unmanaged
+            private Delegate MakeGetter<T>(DataViewRow input, int iinfo, ITensorValueGetter[] srcTensorGetters, string[] activeOutputColNames, OutputCache outputCache) where T : unmanaged
             {
                 Host.AssertValue(input);
 
@@ -921,15 +915,14 @@ namespace Microsoft.ML.Transforms
                 {
                     if (_parent.Graph.graph_key != tf.get_default_graph().graph_key)
                         _parent._session.graph.as_default();
-                    Runner runner = new Runner(_parent._session);
+
+                    Runner runner = new Runner(_parent._session,
+                        _parent._inputs.Select(x => _parent._idvToTfMapping[x]).ToArray(),
+                        _parent._outputs.Select(x => _parent._idvToTfMapping[x]).ToArray());
 
                     // Feed the inputs.
                     for (int i = 0; i < _parent._inputs.Length; i++)
-                        runner.AddInput(_parent._idvToTfMapping[_parent._inputs[i]], srcTensorGetters[i].GetTensor());
-
-                    // Add outputs.
-                    for (int i = 0; i < _parent._outputs.Length; i++)
-                        runner.AddOutputs(_parent._idvToTfMapping[_parent._outputs[i]]);
+                        runner.AddInput(srcTensorGetters[i].GetTensor(), 0);
 
                     // Execute the graph.
                     var tensors = runner.Run();
@@ -1356,7 +1349,7 @@ namespace Microsoft.ML.Transforms
         {
             _host.CheckValue(input, nameof(input));
             if (_transformer == null)
-                _transformer =  new DnnRetrainTransformer(_host, _options, _tensorFlowModel, input);
+                _transformer = new DnnRetrainTransformer(_host, _options, _tensorFlowModel, input);
 
             // Validate input schema.
             _transformer.GetOutputSchema(input.Schema);

--- a/src/Microsoft.ML.Vision/DnnRetrainTransform.cs
+++ b/src/Microsoft.ML.Vision/DnnRetrainTransform.cs
@@ -380,13 +380,17 @@ namespace Microsoft.ML.Transforms
 
             Tensor[] tensor = runner.Run();
             if (tensor.Length > 0 && tensor[0] != IntPtr.Zero)
+            {
                 tensor[0].ToScalar<float>(ref loss);
+                tensor[0].Dispose();
+            }
 
             if (tensor.Length > 1 && tensor[1] != IntPtr.Zero)
+            {
                 tensor[1].ToScalar<float>(ref metric);
+                tensor[1].Dispose();
+            }
 
-            tensor[0].Dispose();
-            tensor[1].Dispose();
             return (loss, metric);
         }
 

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -1278,12 +1278,9 @@ namespace Microsoft.ML.Scenarios
 
             IDataView trainDataset = trainTestData.TrainSet;
             IDataView testDataset = trainTestData.TestSet;
-            var validationSet = mlContext.Transforms.LoadRawImageBytes("Image", fullImagesetFolderPath, "ImagePath")
-                    .Fit(testDataset)
-                    .Transform(testDataset);
 
             var pipeline = mlContext.Transforms.LoadRawImageBytes("Image", fullImagesetFolderPath, "ImagePath")
-                .Append(mlContext.MulticlassClassification.Trainers.ImageClassification("Label", "Image", validationSet: validationSet)
+                .Append(mlContext.MulticlassClassification.Trainers.ImageClassification("Label", "Image")
                 .Append(mlContext.Transforms.Conversion.MapKeyToValue(outputColumnName: "PredictedLabel", inputColumnName: "PredictedLabel"))); ;
 
             var trainedModel = pipeline.Fit(trainDataset);
@@ -1476,7 +1473,7 @@ namespace Microsoft.ML.Scenarios
             TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), 50);
         }
 
-        internal void TensorFlowImageClassificationWithLRScheduling(LearningRateScheduler  learningRateScheduler, int epoch)
+        internal void TensorFlowImageClassificationWithLRScheduling(LearningRateScheduler learningRateScheduler, int epoch)
         {
             string imagesDownloadFolderPath = Path.Combine(TensorFlowScenariosTestsFixture.assetsPath, "inputs",
                 "images");
@@ -1608,7 +1605,6 @@ namespace Microsoft.ML.Scenarios
 
             Assert.True(File.Exists(Path.Combine(options.WorkspacePath, options.TrainSetBottleneckCachedValuesFileName)));
             Assert.True(File.Exists(Path.Combine(options.WorkspacePath, options.ValidationSetBottleneckCachedValuesFileName)));
-            Assert.True(File.Exists(Path.Combine(options.WorkspacePath, "TrainingSetSize.txt")));
             Assert.True(File.Exists(Path.Combine(Path.GetTempPath(), "MLNET", ImageClassificationTrainer.ModelFileName[options.Arch])));
         }
 


### PR DESCRIPTION
This change improves the overall performance of image classification API and tensorflow transform by making the graph runner memory efficient and saving the bottleneck cached values in image classification API in binary format instead of text format.

This change also adds the option in Image Classification API to create validation set from train set in the event validation set is not provided by the user. Validation set is used for early stopping.