### PR TITLE
Avoid running API Compat for design time builds

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,7 @@
 
 <!-- API Compat -->
   <PropertyGroup>
+    <RunApiCompat Condition="'$(DesignTimeBuild)' == 'true'">false</RunApiCompat>
     <RunApiCompat Condition="'$(RunApiCompat)' == ''">$(IsStableProject)</RunApiCompat>
     <ToolHostCmd>$(ToolsDir)dotnetcli/dotnet</ToolHostCmd>
 


### PR DESCRIPTION
This change prevents the API compat tool from failing design time builds and leaving the IDE project model in a bad state for development.
