### PR TITLE
Prevent exceptions from escaping FileSystemWatcher events

### DIFF
--- a/src/Microsoft.Extensions.ML/ModelLoaders/FileModelLoader.cs
+++ b/src/Microsoft.Extensions.ML/ModelLoaders/FileModelLoader.cs
@@ -64,20 +64,32 @@ namespace Microsoft.Extensions.ML
         private void WatcherChanged(object sender, FileSystemEventArgs e)
         {
             var timer = Stopwatch.StartNew();
-            Logger.FileReloadBegin(_logger, _filePath);
 
-            var previousToken = Interlocked.Exchange(ref _reloadToken, new ModelReloadToken());
-            lock (_lock)
+            try
             {
-                //TODO: We get here multiple times when you copy and paste a file
-                //because of the way file watchers work. Need to think through the
-                //ramifications.
-                LoadModel();
-                Logger.ReloadingFile(_logger, _filePath, timer.Elapsed);
+                Logger.FileReloadBegin(_logger, _filePath);
+
+                var previousToken = Interlocked.Exchange(ref _reloadToken, new ModelReloadToken());
+                lock (_lock)
+                {
+                    //TODO: We get here multiple times when you copy and paste a file
+                    //because of the way file watchers work. Need to think through the
+                    //ramifications.
+                    LoadModel();
+                    Logger.ReloadingFile(_logger, _filePath, timer.Elapsed);
+                }
+                previousToken.OnReload();
+                timer.Stop();
+                Logger.FileReloadEnd(_logger, _filePath, timer.Elapsed);
             }
-            previousToken.OnReload();
-            timer.Stop();
-            Logger.FileReloadEnd(_logger, _filePath, timer.Elapsed);
+            catch (OperationCanceledException)
+            {
+                // This is a cancellation - if the app is shutting down we want to ignore it.
+            }
+            catch (Exception ex)
+            {
+                Logger.FileReloadError(_logger, _filePath, timer.Elapsed, ex);
+            }
         }
 
         public override IChangeToken GetReloadToken()
@@ -116,6 +128,7 @@ namespace Microsoft.Extensions.ML
             public static readonly EventId FileReloadBegin = new EventId(100, "FileReloadBegin");
             public static readonly EventId FileReloadEnd = new EventId(101, "FileReloadEnd");
             public static readonly EventId FileReload = new EventId(102, "FileReload");
+            public static readonly EventId FileReloadError = new EventId(103, nameof(FileReloadError));
         }
 
         private static class Logger
@@ -130,6 +143,11 @@ namespace Microsoft.Extensions.ML
                 EventIds.FileReloadEnd,
                 "File reload for '{filePath}' completed after {ElapsedMilliseconds}ms");
 
+            private static readonly Action<ILogger, string, double, Exception> _fileReloadError = LoggerMessage.Define<string, double>(
+                LogLevel.Error,
+                EventIds.FileReloadError,
+                "File reload for '{filePath}' threw an unhandled exception after {ElapsedMilliseconds}ms");
+
             private static readonly Action<ILogger, string, double, Exception> _fileReLoad = LoggerMessage.Define<string, double>(
                 LogLevel.Information,
                 EventIds.FileReloadEnd,
@@ -143,6 +161,11 @@ namespace Microsoft.Extensions.ML
             public static void FileReloadEnd(ILogger logger, string filePath, TimeSpan duration)
             {
                 _fileLoadEnd(logger, filePath, duration.TotalMilliseconds, null);
+            }
+
+            public static void FileReloadError(ILogger logger, string filePath, TimeSpan duration, Exception exception)
+            {
+                _fileReloadError(logger, filePath, duration.TotalMilliseconds, exception);
             }
 
             public static void ReloadingFile(ILogger logger, string filePath, TimeSpan duration)


### PR DESCRIPTION
Exceptions in the handler of FileSystemWatcher events will terminate the process. This pull request updates the event handler to use a try/catch block that logs the error instead of crashing the process.

This fixes one known cause of test process failures.