### PR TITLE
Update Microsoft.Extensions.* to 3.0.1

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -52,6 +52,7 @@
   <PropertyGroup>
     <BenchmarkDotNetVersion>0.11.3</BenchmarkDotNetVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20080.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftExtensionsTestPackageVersion>3.0.1</MicrosoftExtensionsTestPackageVersion>
     <MicrosoftMLTestDatabasesPackageVersion>0.0.5-test</MicrosoftMLTestDatabasesPackageVersion>
     <MicrosoftMLTestModelsPackageVersion>0.0.6-test</MicrosoftMLTestModelsPackageVersion>
     <MicrosoftMLTensorFlowTestModelsVersion>0.0.11-test</MicrosoftMLTensorFlowTestModelsVersion>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -38,6 +38,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Make sure to use the updated version of Microsoft.Extensions.* in test projects -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsTestPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsTestPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsTestPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsTestPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference
       Condition="'$(UseMLCodeAnalyzer)' != 'false' and '$(MSBuildProjectExtension)' == '.csproj'"
       Include="$(MSBuildThisFileDirectory)\..\tools-local\Microsoft.ML.InternalCodeAnalyzer\Microsoft.ML.InternalCodeAnalyzer.csproj">

--- a/test/Microsoft.Extensions.ML.Tests/Microsoft.Extensions.ML.Tests.csproj
+++ b/test/Microsoft.Extensions.ML.Tests/Microsoft.Extensions.ML.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.ML.TestModels" Version="$(MicrosoftMLTestModelsPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
The 3.0 release includes a fix to cases where `ChangeToken.OnChange` would not unregister callbacks even when disposed.

See aspnet/Extensions#558, aspnet/Extensions#869