### PR TITLE
Increase the code coverage run timeout

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -15,7 +15,7 @@ jobs:
     ${{ if and(eq(parameters.nightlyBuild, 'false'), eq(parameters.codeCoverage, 'false')) }}:
       timeoutInMinutes: 75
     ${{ if eq(parameters.codeCoverage, 'true') }}:
-      timeoutInMinutes: 60
+      timeoutInMinutes: 75
     variables:
       dotnetPath: $(Build.SourcesDirectory)/Tools/dotnetcli/dotnet
       nugetFeed: https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json


### PR DESCRIPTION
Most of the code coverage runs are timing out. Increase the timeout to match the value used for non-code-coverage builds.