### PR TITLE
Fix PFI issue in binary classification

### DIFF
--- a/src/Microsoft.ML.Data/Evaluators/Metrics/CalibratedBinaryClassificationMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/CalibratedBinaryClassificationMetrics.cs
@@ -49,5 +49,15 @@ namespace Microsoft.ML.Data
             LogLossReduction = Fetch(BinaryClassifierEvaluator.LogLossReduction);
             Entropy = Fetch(BinaryClassifierEvaluator.Entropy);
         }
+
+        [BestFriend]
+        internal CalibratedBinaryClassificationMetrics(double auc, double accuracy, double positivePrecision, double positiveRecall,
+            double negativePrecision, double negativeRecall, double f1Score, double auprc, double logLoss, double logLossReduction, double entropy)
+            : base(auc, accuracy, positivePrecision, positiveRecall, negativePrecision, negativeRecall, f1Score, auprc)
+        {
+            LogLoss = logLoss;
+            LogLossReduction = logLossReduction;
+            Entropy = entropy;
+        }
     }
 }

--- a/src/Microsoft.ML.Data/Evaluators/Metrics/CalibratedBinaryClassificationMetrics.cs
+++ b/src/Microsoft.ML.Data/Evaluators/Metrics/CalibratedBinaryClassificationMetrics.cs
@@ -49,15 +49,5 @@ namespace Microsoft.ML.Data
             LogLossReduction = Fetch(BinaryClassifierEvaluator.LogLossReduction);
             Entropy = Fetch(BinaryClassifierEvaluator.Entropy);
         }
-
-        [BestFriend]
-        internal CalibratedBinaryClassificationMetrics(double auc, double accuracy, double positivePrecision, double positiveRecall,
-            double negativePrecision, double negativeRecall, double f1Score, double auprc, double logLoss, double logLossReduction, double entropy)
-            : base(auc, accuracy, positivePrecision, positiveRecall, negativePrecision, negativeRecall, f1Score, auprc)
-        {
-            LogLoss = logLoss;
-            LogLossReduction = logLossReduction;
-            Entropy = entropy;
-        }
     }
 }

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportance.cs
@@ -171,7 +171,7 @@ namespace Microsoft.ML.Transforms
                 int processedCnt = 0;
                 int nextFeatureIndex = 0;
                 var shuffleRand = RandomUtils.Create(host.Rand.Next());
-                using (var pch = host.StartProgressChannel("SDCA preprocessing with lookup"))
+                using (var pch = host.StartProgressChannel("Calculating Permutation Feature Importance"))
                 {
                     pch.SetHeader(new ProgressHeader("processed slots"), e => e.SetProgress(0, processedCnt));
                     foreach (var workingIndx in workingFeatureIndices)

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -146,32 +146,6 @@ namespace Microsoft.ML
                 int? numberOfExamplesToUse = null,
                 int permutationCount = 1) where TModel : class
         {
-            bool isCalibratedModel = false;
-            var type = predictionTransformer.Model.GetType();
-            if (type.IsGenericType)
-            {
-                var genArgs = type.GetGenericArguments();
-                if (Utils.Size(genArgs) == 2)
-                {
-                    var calibratedModelType = typeof(CalibratedModelParametersBase<,>).MakeGenericType(genArgs);
-                    if (calibratedModelType.IsAssignableFrom(type))
-                        isCalibratedModel = true;
-                }
-            }
-            if (isCalibratedModel)
-            {
-                return PermutationFeatureImportance<TModel, BinaryClassificationMetrics, BinaryClassificationMetricsStatistics>.GetImportanceMetricsMatrix(
-                    catalog.GetEnvironment(),
-                    predictionTransformer,
-                    data,
-                    () => new BinaryClassificationMetricsStatistics(),
-                    idv => catalog.Evaluate(idv, labelColumnName),
-                    BinaryClassifierDelta,
-                    predictionTransformer.FeatureColumnName,
-                    permutationCount,
-                    useFeatureWeightFilter,
-                    numberOfExamplesToUse);
-            }
             return PermutationFeatureImportance<TModel, BinaryClassificationMetrics, BinaryClassificationMetricsStatistics>.GetImportanceMetricsMatrix(
                 catalog.GetEnvironment(),
                 predictionTransformer,
@@ -197,23 +171,6 @@ namespace Microsoft.ML
                 negativeRecall: a.NegativeRecall - b.NegativeRecall,
                 f1Score: a.F1Score - b.F1Score,
                 auprc: a.AreaUnderPrecisionRecallCurve - b.AreaUnderPrecisionRecallCurve);
-        }
-
-        private static CalibratedBinaryClassificationMetrics CalibratedBinaryClassifierDelta(
-            CalibratedBinaryClassificationMetrics a, CalibratedBinaryClassificationMetrics b)
-        {
-            return new CalibratedBinaryClassificationMetrics(
-                auc: a.AreaUnderRocCurve - b.AreaUnderRocCurve,
-                accuracy: a.Accuracy - b.Accuracy,
-                positivePrecision: a.PositivePrecision - b.PositivePrecision,
-                positiveRecall: a.PositiveRecall - b.PositiveRecall,
-                negativePrecision: a.NegativePrecision - b.NegativePrecision,
-                negativeRecall: a.NegativeRecall - b.NegativeRecall,
-                f1Score: a.F1Score - b.F1Score,
-                auprc: a.AreaUnderPrecisionRecallCurve - b.AreaUnderPrecisionRecallCurve,
-                logLoss: a.LogLoss - b.LogLoss,
-                logLossReduction: a.LogLossReduction - b.LogLossReduction,
-                entropy: a.Entropy - b.Entropy);
         }
 
         #endregion Binary Classification

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -146,6 +146,32 @@ namespace Microsoft.ML
                 int? numberOfExamplesToUse = null,
                 int permutationCount = 1) where TModel : class
         {
+            bool isCalibratedModel = false;
+            var type = predictionTransformer.Model.GetType();
+            if (type.IsGenericType)
+            {
+                var genArgs = type.GetGenericArguments();
+                if (Utils.Size(genArgs) == 2)
+                {
+                    var calibratedModelType = typeof(CalibratedModelParametersBase<,>).MakeGenericType(genArgs);
+                    if (calibratedModelType.IsAssignableFrom(type))
+                        isCalibratedModel = true;
+                }
+            }
+            if (isCalibratedModel)
+            {
+                return PermutationFeatureImportance<TModel, BinaryClassificationMetrics, BinaryClassificationMetricsStatistics>.GetImportanceMetricsMatrix(
+                    catalog.GetEnvironment(),
+                    predictionTransformer,
+                    data,
+                    () => new BinaryClassificationMetricsStatistics(),
+                    idv => catalog.Evaluate(idv, labelColumnName),
+                    BinaryClassifierDelta,
+                    predictionTransformer.FeatureColumnName,
+                    permutationCount,
+                    useFeatureWeightFilter,
+                    numberOfExamplesToUse);
+            }
             return PermutationFeatureImportance<TModel, BinaryClassificationMetrics, BinaryClassificationMetricsStatistics>.GetImportanceMetricsMatrix(
                 catalog.GetEnvironment(),
                 predictionTransformer,
@@ -171,6 +197,23 @@ namespace Microsoft.ML
                 negativeRecall: a.NegativeRecall - b.NegativeRecall,
                 f1Score: a.F1Score - b.F1Score,
                 auprc: a.AreaUnderPrecisionRecallCurve - b.AreaUnderPrecisionRecallCurve);
+        }
+
+        private static CalibratedBinaryClassificationMetrics CalibratedBinaryClassifierDelta(
+            CalibratedBinaryClassificationMetrics a, CalibratedBinaryClassificationMetrics b)
+        {
+            return new CalibratedBinaryClassificationMetrics(
+                auc: a.AreaUnderRocCurve - b.AreaUnderRocCurve,
+                accuracy: a.Accuracy - b.Accuracy,
+                positivePrecision: a.PositivePrecision - b.PositivePrecision,
+                positiveRecall: a.PositiveRecall - b.PositiveRecall,
+                negativePrecision: a.NegativePrecision - b.NegativePrecision,
+                negativeRecall: a.NegativeRecall - b.NegativeRecall,
+                f1Score: a.F1Score - b.F1Score,
+                auprc: a.AreaUnderPrecisionRecallCurve - b.AreaUnderPrecisionRecallCurve,
+                logLoss: a.LogLoss - b.LogLoss,
+                logLossReduction: a.LogLossReduction - b.LogLossReduction,
+                entropy: a.Entropy - b.Entropy);
         }
 
         #endregion Binary Classification

--- a/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
+++ b/src/Microsoft.ML.Transforms/PermutationFeatureImportanceExtensions.cs
@@ -4,9 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.ML.Calibrators;
 using Microsoft.ML.Data;
-using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.Transforms;
 

--- a/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
+++ b/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
@@ -316,6 +316,24 @@ namespace Microsoft.ML.Tests
                             new TextLoader.Column("Features", DataKind.Single, 1, 9) });
             var model = ff.Fit(data);
             var pfi = ML.BinaryClassification.PermutationFeatureImportance(model, data);
+
+            // For the following metrics higher is better, so minimum delta means more important feature, and vice versa
+            Assert.Equal(7, MaxDeltaIndex(pfi, m => m.AreaUnderRocCurve.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.AreaUnderRocCurve.Mean));
+            Assert.Equal(3, MaxDeltaIndex(pfi, m => m.Accuracy.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.Accuracy.Mean));
+            Assert.Equal(3, MaxDeltaIndex(pfi, m => m.PositivePrecision.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.PositivePrecision.Mean));
+            Assert.Equal(3, MaxDeltaIndex(pfi, m => m.PositiveRecall.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.PositiveRecall.Mean));
+            Assert.Equal(3, MaxDeltaIndex(pfi, m => m.NegativePrecision.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.NegativePrecision.Mean));
+            Assert.Equal(2, MaxDeltaIndex(pfi, m => m.NegativeRecall.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.NegativeRecall.Mean));
+            Assert.Equal(3, MaxDeltaIndex(pfi, m => m.F1Score.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.F1Score.Mean));
+            Assert.Equal(7, MaxDeltaIndex(pfi, m => m.AreaUnderPrecisionRecallCurve.Mean));
+            Assert.Equal(1, MinDeltaIndex(pfi, m => m.AreaUnderPrecisionRecallCurve.Mean));
         }
         #endregion
 

--- a/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
+++ b/test/Microsoft.ML.Tests/PermutationFeatureImportanceTests.cs
@@ -305,6 +305,18 @@ namespace Microsoft.ML.Tests
 
             Done();
         }
+
+        [Fact]
+        public void TestBinaryClassificationWithoutCalibrator()
+        {
+            var dataPath = GetDataPath("breast-cancer.txt");
+            var ff = ML.BinaryClassification.Trainers.FastForest();
+            var data = ML.Data.LoadFromTextFile(dataPath,
+                            new[] { new TextLoader.Column("Label", DataKind.Boolean, 0),
+                            new TextLoader.Column("Features", DataKind.Single, 1, 9) });
+            var model = ff.Fit(data);
+            var pfi = ML.BinaryClassification.PermutationFeatureImportance(model, data);
+        }
         #endregion
 
         #region Multiclass Classification Tests


### PR DESCRIPTION
This change adds support for running PFI on binary classification models that do not contain a calibrator. Fixes #4517 .