### PR TITLE
Optimize generic MethodInfo for Func<TResult>

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.ML.Runtime;
+
+namespace Microsoft.ML.Internal.Utilities
+{
+    /// <summary>
+    /// Represents the <see cref="MethodInfo"/> for a generic function corresponding to <see cref="Func{TResult}"/>,
+    /// with the following characteristics:
+    ///
+    /// <list type="bullet">
+    /// <item><description>The method is an instance method on an object of type <typeparamref name="TTarget"/>.</description></item>
+    /// <item><description>One generic type argument.</description></item>
+    /// <item><description>A return value of <typeparamref name="TResult"/>.</description></item>
+    /// </list>
+    /// </summary>
+    /// <typeparam name="TTarget">The type of the receiver of the instance method.</typeparam>
+    /// <typeparam name="TResult">The type of the return value of the method.</typeparam>
+    internal sealed class FuncInstanceMethodInfo1<TTarget, TResult> : FuncMethodInfo1<TResult>
+        where TTarget : class
+    {
+        private static readonly string _targetTypeCheckMessage = $"Should have a target type of '{typeof(TTarget)}'";
+
+        public FuncInstanceMethodInfo1(Func<TResult> function)
+            : this(function.Method)
+        {
+        }
+
+        private FuncInstanceMethodInfo1(MethodInfo methodInfo)
+            : base(methodInfo)
+        {
+            Contracts.CheckParam(!GenericMethodDefinition.IsStatic, nameof(methodInfo), "Should be an instance method");
+            Contracts.CheckParam(GenericMethodDefinition.DeclaringType == typeof(TTarget), nameof(methodInfo), _targetTypeCheckMessage);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="FuncInstanceMethodInfo1{TTarget, TResult}"/> representing the <see cref="MethodInfo"/> for
+        /// a generic instance method. This helper method allows the instance to be created prior to the creation of any
+        /// instances of the target type. The following example shows the creation of an instance representing the
+        /// <see cref="object.GetHashCode"/> method:
+        ///
+        /// <code>
+        /// FuncInstanceMethodInfo1&lt;object, int&gt;.Create(obj => obj.GetHashCode)
+        /// </code>
+        /// </summary>
+        /// <param name="expression">The expression which creates the delegate for an instance of the target type.</param>
+        /// <returns>A <see cref="FuncInstanceMethodInfo1{TTarget, TResult}"/> representing the <see cref="MethodInfo"/>
+        /// for the generic instance method.</returns>
+        public static FuncInstanceMethodInfo1<TTarget, TResult> Create(Expression<Func<TTarget, Func<TResult>>> expression)
+        {
+            if (!(expression is { Body: UnaryExpression { Operand: MethodCallExpression methodCallExpression } }))
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
+
+            // Verify that we are calling MethodInfo.CreateDelegate(Type, object)
+            Contracts.CheckParam(methodCallExpression.Method.DeclaringType == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodCallExpression.Method.Name == nameof(MethodInfo.CreateDelegate), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodCallExpression.Method.GetParameters().Length == 2, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodCallExpression.Method.GetParameters()[0].ParameterType == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodCallExpression.Method.GetParameters()[1].ParameterType == typeof(object), nameof(expression), "Unexpected expression form");
+
+            // Verify that we are creating a delegate of type Func<TRet>
+            Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Arguments[0]).Type == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam((Type)((ConstantExpression)methodCallExpression.Arguments[0]).Value == typeof(Func<TResult>), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
+
+            // Check the MethodInfo
+            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Object).Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+
+            var methodInfo = (MethodInfo)((ConstantExpression)methodCallExpression.Object).Value;
+            Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
+
+            return new FuncInstanceMethodInfo1<TTarget, TResult>(methodInfo);
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Utilities/FuncMethodInfo1`1.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncMethodInfo1`1.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.ML.Runtime;
+
+namespace Microsoft.ML.Internal.Utilities
+{
+    /// <summary>
+    /// Represents the <see cref="MethodInfo"/> for a generic function corresponding to <see cref="Func{TResult}"/>,
+    /// with the following characteristics:
+    ///
+    /// <list type="bullet">
+    /// <item><description>One generic type argument.</description></item>
+    /// <item><description>A return value of <typeparamref name="TResult"/>.</description></item>
+    /// </list>
+    /// </summary>
+    /// <typeparam name="TResult">The type of the return value of the method.</typeparam>
+    internal abstract class FuncMethodInfo1<TResult> : FuncMethodInfo<TResult>
+    {
+        private ImmutableDictionary<Type, MethodInfo> _instanceMethodInfo;
+
+        private protected FuncMethodInfo1(MethodInfo methodInfo)
+            : base(methodInfo)
+        {
+            _instanceMethodInfo = ImmutableDictionary<Type, MethodInfo>.Empty;
+
+            Contracts.CheckParam(GenericMethodDefinition.GetGenericArguments().Length == 1, nameof(methodInfo),
+                "Should have exactly one generic type parameter but does not");
+        }
+
+        public MethodInfo MakeGenericMethod(Type typeArg1)
+        {
+            return ImmutableInterlocked.GetOrAdd(
+                ref _instanceMethodInfo,
+                typeArg1,
+                (typeArg, methodInfo) => methodInfo.MakeGenericMethod(typeArg),
+                GenericMethodDefinition);
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Utilities/FuncMethodInfo`1.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncMethodInfo`1.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Reflection;
+using Microsoft.ML.Runtime;
+
+namespace Microsoft.ML.Internal.Utilities
+{
+    internal abstract class FuncMethodInfo<TResult>
+    {
+        private protected FuncMethodInfo(MethodInfo methodInfo)
+        {
+            Contracts.CheckValue(methodInfo, nameof(methodInfo));
+            Contracts.CheckParam(methodInfo.IsGenericMethod, nameof(methodInfo), "Should be generic but is not");
+
+            GenericMethodDefinition = methodInfo.GetGenericMethodDefinition();
+            Contracts.CheckParam(typeof(TResult).IsAssignableFrom(GenericMethodDefinition.ReturnType), nameof(methodInfo), "Cannot be generic on return type");
+        }
+
+        protected MethodInfo GenericMethodDefinition { get; }
+    }
+}

--- a/src/Microsoft.ML.Core/Utilities/FuncStaticMethodInfo1`1.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncStaticMethodInfo1`1.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Reflection;
+using Microsoft.ML.Runtime;
+
+namespace Microsoft.ML.Internal.Utilities
+{
+    /// <summary>
+    /// Represents the <see cref="MethodInfo"/> for a generic function corresponding to <see cref="Func{TResult}"/>,
+    /// with the following characteristics:
+    ///
+    /// <list type="bullet">
+    /// <item><description>The method is static.</description></item>
+    /// <item><description>One generic type argument.</description></item>
+    /// <item><description>A return value of <typeparamref name="TResult"/>.</description></item>
+    /// </list>
+    /// </summary>
+    /// <typeparam name="TResult">The type of the return value of the method.</typeparam>
+    internal sealed class FuncStaticMethodInfo1<TResult> : FuncMethodInfo1<TResult>
+    {
+        public FuncStaticMethodInfo1(Func<TResult> function)
+            : base(function.Method)
+        {
+            Contracts.CheckParam(GenericMethodDefinition.IsStatic, nameof(function), "Should be a static method");
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Utilities/Utils.cs
+++ b/src/Microsoft.ML.Core/Utilities/Utils.cs
@@ -988,20 +988,32 @@ namespace Microsoft.ML.Internal.Utilities
         /// Because it is strongly typed, this can only be applied to methods whose return type
         /// is known at compile time, that is, that do not depend on the type parameter of the method itself.
         /// </summary>
-        /// <typeparam name="TRet">The return value</typeparam>
+        /// <typeparam name="TTarget">The type of the receiver of the instance method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method.</typeparam>
         /// <param name="func">A delegate that should be a generic method with a single type parameter.
         /// The generic method definition will be extracted, then a new method will be created with the
         /// given type parameter, then the method will be invoked.</param>
+        /// <param name="target">The target of the invocation.</param>
         /// <param name="genArg">The new type parameter for the generic method</param>
         /// <returns>The return value of the invoked function</returns>
-        public static TRet MarshalInvoke<TRet>(Func<TRet> func, Type genArg)
+        public static TResult MarshalInvoke<TTarget, TResult>(FuncInstanceMethodInfo1<TTarget, TResult> func, TTarget target, Type genArg)
+            where TTarget : class
         {
-            var meth = MarshalInvokeCheckAndCreate<TRet>(genArg, func);
-            return (TRet)meth.Invoke(func.Target, null);
+            var meth = func.MakeGenericMethod(genArg);
+            return (TResult)meth.Invoke(target, null);
         }
 
         /// <summary>
-        /// A one-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A static version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
+        /// </summary>
+        public static TResult MarshalInvoke<TResult>(FuncStaticMethodInfo1<TResult> func, Type genArg)
+        {
+            var meth = func.MakeGenericMethod(genArg);
+            return (TResult)meth.Invoke(null, null);
+        }
+
+        /// <summary>
+        /// A one-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TRet>(Func<TArg1, TRet> func, Type genArg, TArg1 arg1)
         {
@@ -1010,7 +1022,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A two-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A two-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TRet>(Func<TArg1, TArg2, TRet> func, Type genArg, TArg1 arg1, TArg2 arg2)
         {
@@ -1019,7 +1031,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A three-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A three-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TRet>(Func<TArg1, TArg2, TArg3, TRet> func, Type genArg,
             TArg1 arg1, TArg2 arg2, TArg3 arg3)
@@ -1029,7 +1041,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A four-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A four-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TArg4, TRet>(Func<TArg1, TArg2, TArg3, TArg4, TRet> func,
             Type genArg, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4)
@@ -1039,7 +1051,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A five-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A five-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TArg4, TArg5, TRet>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TRet> func,
             Type genArg, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5)
@@ -1049,7 +1061,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A six-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A six-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TRet>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TRet> func,
             Type genArg, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6)
@@ -1059,7 +1071,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A seven-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A seven-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TRet>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TRet> func,
             Type genArg, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7)
@@ -1069,7 +1081,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// An eight-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// An eight-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TRet>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TRet> func,
             Type genArg, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8)
@@ -1079,7 +1091,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A nine-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A nine-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TRet>(
             Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TRet> func,
@@ -1090,7 +1102,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A ten-argument version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A ten-argument version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TRet>(
             Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TRet> func,
@@ -1101,7 +1113,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A 1 argument and n type version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A 1 argument and n type version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TRet>(
             Func<TArg1, TRet> func,
@@ -1112,7 +1124,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// A 2 argument and n type version of <see cref="MarshalInvoke{TRet}"/>.
+        /// A 2 argument and n type version of <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>.
         /// </summary>
         public static TRet MarshalInvoke<TArg1, TArg2, TRet>(
             Func<TArg1, TArg2, TRet> func,
@@ -1147,7 +1159,7 @@ namespace Microsoft.ML.Internal.Utilities
         }
 
         /// <summary>
-        /// This is akin to <see cref="MarshalInvoke{TRet}(Func{TRet}, Type)"/>, except applied to
+        /// This is akin to <see cref="MarshalInvoke{TTarget, TResult}(FuncInstanceMethodInfo1{TTarget, TResult}, TTarget, Type)"/>, except applied to
         /// <see cref="Action"/> instead of <see cref="Func{TRet}"/>.
         /// </summary>
         /// <param name="act">A delegate that should be a generic method with a single type parameter.

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoader.cs
@@ -1240,6 +1240,9 @@ namespace Microsoft.ML.Data.IO
 
         private sealed class Cursor : RootCursorBase
         {
+            private static readonly FuncInstanceMethodInfo1<Cursor, Delegate> _noRowGetterMethodInfo
+                = FuncInstanceMethodInfo1<Cursor, Delegate>.Create(target => target.NoRowGetter<int>);
+
             private readonly BinaryLoader _parent;
             private readonly int[] _colToActivesIndex;
             private readonly TableOfContentsEntry[] _actives;
@@ -2071,7 +2074,7 @@ namespace Microsoft.ML.Data.IO
             /// a delegate that simply always throws.
             /// </summary>
             private Delegate GetNoRowGetter(DataViewType type)
-                => Utils.MarshalInvoke(NoRowGetter<int>, type.RawType);
+                => Utils.MarshalInvoke(_noRowGetterMethodInfo, this, type.RawType);
 
             private Delegate NoRowGetter<T>()
             {

--- a/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/FakeSchema.cs
@@ -15,6 +15,9 @@ namespace Microsoft.ML.Data.DataLoadSave
     [BestFriend]
     internal static class FakeSchemaFactory
     {
+        private static readonly FuncStaticMethodInfo1<Delegate> _getDefaultVectorGetterMethodInfo = new FuncStaticMethodInfo1<Delegate>(GetDefaultVectorGetter<int>);
+        private static readonly FuncStaticMethodInfo1<Delegate> _getDefaultGetterMethodInfo = new FuncStaticMethodInfo1<Delegate>(GetDefaultGetter<int>);
+
         private const int AllVectorSizes = 10;
         private const int AllKeySizes = 10;
 
@@ -31,9 +34,9 @@ namespace Microsoft.ML.Data.DataLoadSave
                     var metaColumnType = MakeColumnType(partialAnnotations[j]);
                     Delegate del;
                     if (metaColumnType is VectorDataViewType vectorType)
-                        del = Utils.MarshalInvoke(GetDefaultVectorGetter<int>, vectorType.ItemType.RawType);
+                        del = Utils.MarshalInvoke(_getDefaultVectorGetterMethodInfo, vectorType.ItemType.RawType);
                     else
-                        del = Utils.MarshalInvoke(GetDefaultGetter<int>, metaColumnType.RawType);
+                        del = Utils.MarshalInvoke(_getDefaultGetterMethodInfo, metaColumnType.RawType);
                     metaBuilder.Add(partialAnnotations[j].Name, metaColumnType, del);
                 }
                 builder.AddColumn(shape[i].Name, MakeColumnType(shape[i]), metaBuilder.ToAnnotations());

--- a/src/Microsoft.ML.Data/DataView/Transposer.cs
+++ b/src/Microsoft.ML.Data/DataView/Transposer.cs
@@ -1318,6 +1318,9 @@ namespace Microsoft.ML.Data
 
     internal static class TransposerUtils
     {
+        private static readonly FuncInstanceMethodInfo1<SlotCursor, Delegate> _slotCursorGetGetterMethodInfo
+            = FuncInstanceMethodInfo1<SlotCursor, Delegate>.Create(target => target.GetGetter<int>);
+
         /// <summary>
         /// This is a convenience method that extracts a single slot value's vector,
         /// while simultaneously verifying that there is exactly one value.
@@ -1359,9 +1362,7 @@ namespace Microsoft.ML.Data
             var genTypeArgs = type.GetGenericArguments();
             ctx.Assert(genTypeArgs.Length == 1);
 
-            Func<ValueGetter<VBuffer<int>>> del = cursor.GetGetter<int>;
-            var methodInfo = del.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(genTypeArgs[0]);
-            var getter = methodInfo.Invoke(cursor, null) as ValueGetter<TValue>;
+            var getter = Utils.MarshalInvoke(_slotCursorGetGetterMethodInfo, cursor, genTypeArgs[0]) as ValueGetter<TValue>;
             if (getter == null)
                 throw ctx.Except("Invalid TValue: '{0}'", typeof(TValue));
             return getter;

--- a/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
+++ b/src/Microsoft.ML.Data/EntryPoints/EntryPointNode.cs
@@ -293,9 +293,9 @@ namespace Microsoft.ML.EntryPoints
             _ectx.AssertValue(type);
 
             if (binding is ArrayIndexVariableBinding)
-                type = Utils.MarshalInvoke(MakeArray<int>, type);
+                type = type.MakeArrayType();
             else if (binding is DictionaryKeyVariableBinding)
-                type = Utils.MarshalInvoke(MakeDictionary<int>, type);
+                type = typeof(Dictionary<,>).MakeGenericType(typeof(string), type);
 
             EntryPointVariable v;
             if (!_vars.TryGetValue(binding.VariableName, out v))
@@ -306,16 +306,6 @@ namespace Microsoft.ML.EntryPoints
             else if (v.Type != type)
                 throw _ectx.Except($"Variable '{v.Name}' is used as {v.Type} and as {type}");
             v.MarkUsage(true);
-        }
-
-        private Type MakeArray<T>()
-        {
-            return typeof(T[]);
-        }
-
-        private Type MakeDictionary<T>()
-        {
-            return typeof(Dictionary<string, T>);
         }
 
         public void RemoveVariable(EntryPointVariable variable)

--- a/src/Microsoft.ML.Transforms/Expression/CodeGen.cs
+++ b/src/Microsoft.ML.Transforms/Expression/CodeGen.cs
@@ -99,11 +99,12 @@ namespace Microsoft.ML.Transforms
     {
         private sealed class Visitor : ExprVisitor
         {
+            private static readonly MethodInfo _methGetFalseBL = ((Func<BL>)BuiltinFunctions.False).GetMethodInfo();
+            private static readonly MethodInfo _methGetTrueBL = ((Func<BL>)BuiltinFunctions.True).GetMethodInfo();
+
             private MethodGenerator _meth;
             private ILGenerator _gen;
             private List<Error> _errors;
-            private readonly MethodInfo _methGetFalseBL;
-            private readonly MethodInfo _methGetTrueBL;
 
             private sealed class CachedWithLocal
             {
@@ -140,14 +141,6 @@ namespace Microsoft.ML.Transforms
             {
                 _meth = meth;
                 _gen = meth.Il;
-
-                Func<BL> f = BuiltinFunctions.False;
-                Contracts.Assert(f.Target == null);
-                _methGetFalseBL = f.GetMethodInfo();
-
-                Func<BL> t = BuiltinFunctions.True;
-                Contracts.Assert(t.Target == null);
-                _methGetTrueBL = t.GetMethodInfo();
 
                 _cacheWith = new List<CachedWithLocal>();
             }

--- a/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
+++ b/src/Microsoft.ML.Transforms/MissingValueReplacing.cs
@@ -371,14 +371,11 @@ namespace Microsoft.ML.Transforms
 
         private object GetDefault(DataViewType type)
         {
-            Func<object> func = GetDefault<int>;
-            var meth = func.GetMethodInfo().GetGenericMethodDefinition().MakeGenericMethod(type.GetItemType().RawType);
-            return meth.Invoke(this, null);
-        }
+            var rawType = type.GetItemType().RawType;
+            if (rawType.IsValueType)
+                return Activator.CreateInstance(rawType);
 
-        private object GetDefault<T>()
-        {
-            return default(T);
+            return null;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -245,6 +245,9 @@ namespace Microsoft.ML.Transforms
                 loaderAssemblyName: typeof(OptionalColumnTransform).Assembly.FullName);
         }
 
+        private static readonly FuncInstanceMethodInfo1<OptionalColumnTransform, Delegate> _makeGetterOneMethodInfo
+            = FuncInstanceMethodInfo1<OptionalColumnTransform, Delegate>.Create(target => target.MakeGetterOne<int>);
+
         private readonly Bindings _bindings;
 
         private const string RegistrationName = "OptionalColumn";
@@ -404,7 +407,7 @@ namespace Microsoft.ML.Transforms
             var columnType = _bindings.ColumnTypes[iinfo];
             if (columnType is VectorDataViewType vectorType)
                 return Utils.MarshalInvoke(MakeGetterVec<int>, vectorType.ItemType.RawType, vectorType.Size);
-            return Utils.MarshalInvoke(MakeGetterOne<int>, columnType.RawType);
+            return Utils.MarshalInvoke(_makeGetterOneMethodInfo, this, columnType.RawType);
         }
 
         private Delegate MakeGetterOne<T>()
@@ -420,6 +423,9 @@ namespace Microsoft.ML.Transforms
 
         private sealed class Cursor : SynchronizedCursorBase
         {
+            private static readonly FuncInstanceMethodInfo1<Cursor, Delegate> _makeGetterOneMethodInfo
+                = FuncInstanceMethodInfo1<Cursor, Delegate>.Create(target => target.MakeGetterOne<int>);
+
             private readonly Bindings _bindings;
             private readonly bool[] _active;
             private readonly Delegate[] _getters;
@@ -484,7 +490,7 @@ namespace Microsoft.ML.Transforms
                 var columnType = _bindings.ColumnTypes[iinfo];
                 if (columnType is VectorDataViewType vectorType)
                     return Utils.MarshalInvoke(MakeGetterVec<int>, vectorType.ItemType.RawType, vectorType.Size);
-                return Utils.MarshalInvoke(MakeGetterOne<int>, columnType.RawType);
+                return Utils.MarshalInvoke(_makeGetterOneMethodInfo, this, columnType.RawType);
             }
 
             private Delegate MakeGetterOne<T>()

--- a/test/Microsoft.ML.Predictor.Tests/CmdLine/CmdLineReverseTest.cs
+++ b/test/Microsoft.ML.Predictor.Tests/CmdLine/CmdLineReverseTest.cs
@@ -82,7 +82,8 @@ namespace Microsoft.ML.RunTests
         {
             var ml = new MLContext(1);
             ml.AddStandardComponents();
-            var classes = Utils.MarshalInvoke(ml.ComponentCatalog.FindLoadableClasses<int>, typeof(SignatureCalibrator));
+            var findLoadableClassesMethodInfo = new FuncInstanceMethodInfo1<ComponentCatalog, ComponentCatalog.LoadableClassInfo[]>(ml.ComponentCatalog.FindLoadableClasses<int>);
+            var classes = Utils.MarshalInvoke(findLoadableClassesMethodInfo, ml.ComponentCatalog, typeof(SignatureCalibrator));
             foreach (var cls in classes)
             {
                 var factory = CmdParser.CreateComponentFactory(typeof(IComponentFactory<ICalibratorTrainer>), typeof(SignatureCalibrator), cls.LoadNames[0]);


### PR DESCRIPTION
Repeated profiling showed MarshalInvoke as a _heavy_ performance bottleneck. Rather than remove the use of reflection at runtime altogether, this pull request demonstrates a strategy for caching the results of particularly expensive operations. The performance benefits come from two primary changes:

1. `RuntimeReflectionExtensions.GetMethodInfo(Delegate)` is only called once for a given method
2. `MethodInfo.GetGenericMethodDefinition()` is only called once for a given method

In this change, I am also caching the result of `MethodInfo.MakeGenericMethod`. It might not be necessary to cache this result, but it doesn't seem to hurt either.

📝 This pull request is a demonstration of the process required to fully convert the code from the current pattern to the new pattern. I have only converted `MarshalInvoke<TRet>`; each of the others will need to be converted in a similar fashion.