### PR TITLE
fix mac os Install build dependencies error

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
-      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew unlink python@2 && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
-      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install python && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
-      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew upgrade python && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
-      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew install python && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - ${{ if eq(parameters.pool.name, 'Hosted macOS High Sierra') }}:
-      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew upgrade python && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
+      - script: brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f5b1ac99a7fba27c19cee0bc4f036775c889b359/Formula/libomp.rb && brew link --overwrite python && brew install mono-libgdiplus gettext && brew link gettext --force && brew link libomp --force
         displayName: Install build dependencies
     - ${{ if and( eq(parameters.nightlyBuild, 'true'), eq(parameters.name, 'Ubuntu_x64_NetCoreApp21')) }}:
       - bash: echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$(nightlyBuildRunPath):$LD_LIBRARY_PATH"


### PR DESCRIPTION
error message is:

==> Installing mono-libgdiplus dependency: python
==> Downloading https://homebrew.bintray.com/bottles/python-3.7.6.high_sierra.bottle.tar.gz
==> Downloading from https://akamai.bintray.com/85/853a5c89053fa747daf1779a515df60648b56968317aa8865dfdd058f1520bad?__gda__=exp=1577751065~hmac=55ee60182c766308e6945cb69742fe63e1a1cff345734c944bb682cf7d3900c8&response-content-disposition=attachment%3Bfilename%3D%22python-3.7.6.high_sierra.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1-bggRq2F1shc2wtnvALSz26IT4dCWuBsB4qZLdtxnnxtoGPpDVd7Emi-5FtMSiqaK3ejwg-IICAlAi4pHk9rEOR3laR8WtsVIJyHYdS4tKW0bHAs60S-r3UYAYWwsbbDpf0a7BBxilGg&response-X-Checksum-Sha1=84747f875e642c09a209da71f5e7986d002d6b68&response-X-Checksum-Sha2=853a5c89053fa747daf1779a515df60648b56968317aa8865dfdd058f1520bad
==> Pouring python-3.7.6.high_sierra.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink Frameworks/Python.framework/Headers
Target /usr/local/Frameworks/Python.framework/Headers
is a symlink belonging to python@2. You can unlink it:
  brew unlink python@2

To force the link and overwrite all conflicting files:
  brew link --overwrite python

To list all files that would be deleted:
  brew link --overwrite --dry-run python

Possible conflicting files are:
/usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Headers
/usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Python
/usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Resources
/usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Versions/Current
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install --force --verbose --install-scripts=/usr/local/Cellar/python/3.7.6/bin --install-lib=/usr/local/lib/python3.7/site-packages --single-version-externally-managed --record=installed.txt
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install --force --verbose --install-scripts=/usr/local/Cellar/python/3.7.6/bin --install-lib=/usr/local/lib/python3.7/site-packages --single-version-externally-managed --record=installed.txt
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install --force --verbose --install-scripts=/usr/local/Cellar/python/3.7.6/bin --install-lib=/usr/local/lib/python3.7/site-packages --single-version-externally-managed --record=installed.txt
==> Caveats
Python has been installed as
  /usr/local/bin/python3

Unversioned symlinks `python`, `python-config`, `pip` etc. pointing to
`python3`, `python3-config`, `pip3` etc., respectively, have been installed into
  /usr/local/opt/python/libexec/bin

If you need Homebrew's Python 2.7 run
  brew install python@2

You can install Python packages with
  pip3 install <package>
They will install into the site-package directory
  /usr/local/lib/python3.7/site-packages

