### PR TITLE
refine TensorFlowTransformer to avoid early dispose

### DIFF
--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -42,6 +42,7 @@ namespace Microsoft.ML.Transforms
         private readonly string _savedModelPath;
         private readonly bool _isTemporarySavedModel;
         private readonly bool _addBatchDimensionInput;
+        private readonly IHostEnvironment _env;
         internal readonly Session Session;
         internal readonly Runner Runner;
         internal readonly DataViewType[] OutputTypes;
@@ -195,6 +196,8 @@ namespace Microsoft.ML.Transforms
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(options, nameof(options));
+
+            _env = env;
         }
 
         private static ITensorValueGetter CreateTensorValueGetter<T>(DataViewRow input, bool isVector, int colIndex, TensorShape tfShape)
@@ -272,6 +275,8 @@ namespace Microsoft.ML.Transforms
             Host.CheckValue(session, nameof(session));
             Host.CheckNonEmpty(inputColumnNames, nameof(inputColumnNames));
             Host.CheckNonEmpty(outputColumnNames, nameof(outputColumnNames));
+
+            _env = env;
 
             _savedModelPath = savedModelPath;
             _isTemporarySavedModel = isTemporarySavedModel;
@@ -457,14 +462,21 @@ namespace Microsoft.ML.Transforms
             // that the Session is closed before deleting our temporary directory.
             try
             {
+                if (Session != null && Session.graph != IntPtr.Zero)
+                {
+                    Session.graph.Dispose();
+                }
+
                 if (Session != null && Session != IntPtr.Zero)
                 {
                     Session.close(); // invoked Dispose()
                 }
-
-                if (Session != null && Session.graph != IntPtr.Zero)
+            }
+            catch (ObjectDisposedException ex)
+            {
+                using (var channel = _env.Start("TensorflowTransform"))
                 {
-                    Session.graph.Dispose();
+                    channel.Warning($"Caught: {ex.Message} during TensorflowTransform dispose.");
                 }
             }
             finally

--- a/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowTransform.cs
@@ -42,7 +42,6 @@ namespace Microsoft.ML.Transforms
         private readonly string _savedModelPath;
         private readonly bool _isTemporarySavedModel;
         private readonly bool _addBatchDimensionInput;
-        private readonly IHostEnvironment _env;
         internal readonly Session Session;
         internal readonly Runner Runner;
         internal readonly DataViewType[] OutputTypes;
@@ -196,8 +195,6 @@ namespace Microsoft.ML.Transforms
         {
             Contracts.CheckValue(env, nameof(env));
             env.CheckValue(options, nameof(options));
-
-            _env = env;
         }
 
         private static ITensorValueGetter CreateTensorValueGetter<T>(DataViewRow input, bool isVector, int colIndex, TensorShape tfShape)
@@ -275,8 +272,6 @@ namespace Microsoft.ML.Transforms
             Host.CheckValue(session, nameof(session));
             Host.CheckNonEmpty(inputColumnNames, nameof(inputColumnNames));
             Host.CheckNonEmpty(outputColumnNames, nameof(outputColumnNames));
-
-            _env = env;
 
             _savedModelPath = savedModelPath;
             _isTemporarySavedModel = isTemporarySavedModel;
@@ -474,7 +469,7 @@ namespace Microsoft.ML.Transforms
             }
             catch (ObjectDisposedException ex)
             {
-                using (var channel = _env.Start("TensorflowTransform"))
+                using (var channel = Host.Start("TensorflowTransform"))
                 {
                     channel.Warning($"Caught: {ex.Message} during TensorflowTransform dispose.");
                 }


### PR DESCRIPTION
from build: https://dev.azure.com/dnceng/public/_build/results?buildId=468639&view=logs&j=d1af5113-e574-5a31-f7f3-02fc40ea7b26&t=167d9e7d-b609-5b0a-7efa-d26b0dafb88f

below unhandled exception:

```
Unhandled exception: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'The ThreadLocal object has been disposed.'.
at System.Threading.ThreadLocal`1.GetValueSlow()
at Tensorflow.Graph.DisposeManagedResources()
at Tensorflow.DisposableObject.internal_dispose(Boolean disposing)
at Tensorflow.DisposableObject.Dispose()
at Microsoft.ML.Transforms.TensorFlowTransformer.Dispose(Boolean disposing) in D:\a\1\s\src\Microsoft.ML.TensorFlow\TensorflowTransform.cs:line 467
at Microsoft.ML.Transforms.TensorFlowTransformer.Finalize() in D:\a\1\s\src\Microsoft.ML.TensorFlow\TensorflowTransform.cs:line 450
```


