### PR TITLE
Prevent LatentDirichletAllocationTransformer from disposal prior to end of test

### DIFF
--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -1445,10 +1445,12 @@ namespace Microsoft.ML.RunTests
                 numberOfSummaryTermsPerTopic: 3, alphaSum: 3, numberOfThreads: 1, resetRandomGenerator: true);
             var est = ML.Transforms.Text.LatentDirichletAllocation(opt);
             var ldaTransformer = est.Fit(srcView);
-            var transformedData = ldaTransformer.Transform(srcView);
-
-            using (var cursor = transformedData.GetRowCursorForAllColumns())
+            try
             {
+                var transformedData = ldaTransformer.Transform(srcView);
+
+                using var cursor = transformedData.GetRowCursorForAllColumns();
+
                 var resultGetter = cursor.GetGetter<VBuffer<float>>(cursor.Schema[1]);
                 VBuffer<float> resultFirstRow = new VBuffer<float>();
                 VBuffer<float> resultSecondRow = new VBuffer<float>();
@@ -1474,6 +1476,10 @@ namespace Microsoft.ML.RunTests
                 Assert.True(resultThirdRow.GetItemOrDefault(0) == 0);
                 Assert.True(resultThirdRow.GetItemOrDefault(1) == 0);
                 Assert.True(resultThirdRow.GetItemOrDefault(2) == 1.0);
+            }
+            finally
+            {
+                ldaTransformer.Dispose();
             }
         }
 


### PR DESCRIPTION
Fixes test exceptions which look like this:

```text
  X Microsoft.ML.RunTests.TestDataPipeNoBaseline.TestLDATransform(iteration: 92) [198ms]
  Error Message:
   System.InvalidOperationException : Splitter/consolidator worker encountered exception while consuming source data
---- System.ObjectDisposedException : Safe handle has been closed
  Stack Trace:
     at Microsoft.ML.Data.DataViewUtils.Splitter.Batch.SetAll(OutPipe[] pipes) in D:\a\1\s\src\Microsoft.ML.Data\Data\DataViewUtils.cs:line 832
   at Microsoft.ML.Data.DataViewUtils.Splitter.Cursor.MoveNextCore() in D:\a\1\s\src\Microsoft.ML.Data\Data\DataViewUtils.cs:line 1102
   at Microsoft.ML.Data.RootCursorBase.MoveNext() in D:\a\1\s\src\Microsoft.ML.Core\Data\RootCursorBase.cs:line 65
   at Microsoft.ML.RunTests.TestDataPipeNoBaseline.TestLDATransform(Int32 iteration) in D:\a\1\s\test\Microsoft.ML.TestFramework\DataPipe\TestDataPipe.cs:line 1462
----- Inner Stack Trace -----
   at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
   at System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, Boolean& success)
   at Microsoft.ML.TextAnalytics.LdaInterface.InitializeBeforeTest(SafeLdaEngineHandle engine)
   at Microsoft.ML.Transforms.Text.LatentDirichletAllocationTransformer.LdaState.Output(VBuffer`1& src, VBuffer`1& dst, Int32 numBurninIter, Boolean reset) in D:\a\1\s\src\Microsoft.ML.Transforms\Text\LdaTransform.cs:line 470
   at Microsoft.ML.Transforms.Text.LatentDirichletAllocationTransformer.Mapper.<>c__DisplayClass5_0.<GetTopic>b__0(VBuffer`1& dst) in D:\a\1\s\src\Microsoft.ML.Transforms\Text\LdaTransform.cs:line 612
   at Microsoft.ML.Data.DataViewUtils.Splitter.InPipe.Impl`1.Fill() in D:\a\1\s\src\Microsoft.ML.Data\Data\DataViewUtils.cs:line 723
   at Microsoft.ML.Data.DataViewUtils.Splitter.<>c__DisplayClass5_1.<ConsolidateCore>b__2() in D:\a\1\s\src\Microsoft.ML.Data\Data\DataViewUtils.cs:line 415
```

The issue occurred because the finalizer for `LatentDirichletAllocationTransformer` was causing states to get disposed while they were still in use.