### PR TITLE
Test stable cross validation iris

### DIFF
--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -13,7 +13,7 @@ jobs:
     ${{ if eq(parameters.nightlyBuild, 'true') }}:
       timeoutInMinutes: 20
     ${{ if and(eq(parameters.nightlyBuild, 'false'), eq(parameters.codeCoverage, 'false')) }}:
-      timeoutInMinutes: 75
+      timeoutInMinutes: 120
     ${{ if eq(parameters.codeCoverage, 'true') }}:
       timeoutInMinutes: 75
     variables:

--- a/src/Microsoft.ML.DataView/DataViewRowId.cs
+++ b/src/Microsoft.ML.DataView/DataViewRowId.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Data
                             callStack.Contains("EntryPointChainedCrossValMacros") ||
                             callStack.Contains("TestOvaMacro")))
             {
-                Console.WriteLine($"call stack is {callStack}");
+                Console.WriteLine($"Debug: high is {high}, low is {low}, call stack is {callStack}");
             }
 
             Low = low;

--- a/src/Microsoft.ML.DataView/DataViewRowId.cs
+++ b/src/Microsoft.ML.DataView/DataViewRowId.cs
@@ -30,6 +30,15 @@ namespace Microsoft.ML.Data
         /// <param name="high">The high order <langword>ulong</langword>.</param>
         public DataViewRowId(ulong low, ulong high)
         {
+            var callStack = new StackTrace().ToString();
+
+            if(high > 0 && (callStack.Contains("CrossValidationIris") ||
+                            callStack.Contains("EntryPointChainedCrossValMacros") ||
+                            callStack.Contains("TestOvaMacro")))
+            {
+                Console.WriteLine($"call stack is {callStack}");
+            }
+
             Low = low;
             High = high;
         }

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
@@ -382,6 +382,7 @@ namespace Microsoft.ML.Trainers
                     DataViewRowId id = cursor.Id;
                     if (id.High > 0 || id.Low >= (ulong)maxTrainingExamples)
                     {
+                        Console.WriteLine($"Debug SdcaBinary: Count is {count}, id.High is {id.High}, id.Low is {id.Low}");
                         needLookup = true;
                         break;
                     }
@@ -407,6 +408,7 @@ namespace Microsoft.ML.Trainers
                     {
                         // The distribution of id.Low is sparse in [0, idLoMax].
                         // Building a lookup table is more memory efficient.
+                        Console.WriteLine($"Debug SdcaBinary: Count is {count}, idLoMax is {idLoMax}");
                         needLookup = true;
                     }
                 }

--- a/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
+++ b/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -382,7 +383,14 @@ namespace Microsoft.ML.Trainers
                     DataViewRowId id = cursor.Id;
                     if (id.High > 0 || id.Low >= (ulong)maxTrainingExamples)
                     {
-                        Console.WriteLine($"Debug SdcaBinary: Count is {count}, id.High is {id.High}, id.Low is {id.Low}");
+                        var callStack = new StackTrace().ToString();
+                        if (callStack.Contains("CrossValidationIris") ||
+                            callStack.Contains("EntryPointChainedCrossValMacros") ||
+                            callStack.Contains("TestOvaMacro"))
+                        {
+
+                            Console.WriteLine($"Debug SdcaBinary: Count is {count}, id.High is {id.High}, id.Low is {id.Low}, call stack is {callStack}");
+                        }
                         needLookup = true;
                         break;
                     }
@@ -408,7 +416,14 @@ namespace Microsoft.ML.Trainers
                     {
                         // The distribution of id.Low is sparse in [0, idLoMax].
                         // Building a lookup table is more memory efficient.
-                        Console.WriteLine($"Debug SdcaBinary: Count is {count}, idLoMax is {idLoMax}");
+                        var callStack = new StackTrace().ToString();
+                        if (callStack.Contains("CrossValidationIris") ||
+                            callStack.Contains("EntryPointChainedCrossValMacros") ||
+                            callStack.Contains("TestOvaMacro"))
+                        {
+                            Console.WriteLine($"Debug SdcaBinary: Count is {count}, idLoMax is {idLoMax}, call stack is {callStack}");
+                        }
+
                         needLookup = true;
                     }
                 }

--- a/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
@@ -486,6 +486,8 @@ namespace Microsoft.ML.TensorFlow
                 if (_session == IntPtr.Zero)
                     new ObjectDisposedException(nameof(_session));
 
+                _status.Check(true);
+
                 unsafe
                 {
                     c_api.TF_SessionRun(_session, null, _inputs, _inputValues,

--- a/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
+++ b/src/Microsoft.ML.TensorFlow/TensorflowUtils.cs
@@ -486,7 +486,14 @@ namespace Microsoft.ML.TensorFlow
                 if (_session == IntPtr.Zero)
                     new ObjectDisposedException(nameof(_session));
 
-                _status.Check(true);
+                try
+                {
+                    _status.Check(true);
+                }
+                catch (TensorflowException exception)
+                {
+                    Console.WriteLine($"Catch Tensorflow exception: {exception.Message} with TF code: {_status.Code}");
+                }
 
                 unsafe
                 {

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -6190,9 +6190,11 @@ namespace Microsoft.ML.RunTests
             }
         }
 
-        [Fact]
-        public void TestOvaMacroWithUncalibratedLearner()
+        [Theory]
+        [IterationData(iterations: 100)]
+        public void TestOvaMacroWithUncalibratedLearner(int iteration)
         {
+            Console.WriteLine($"{iteration}-th running...");
             var dataPath = GetDataPath(@"iris.txt");
             string inputGraph = @"
             {

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -3847,7 +3847,7 @@ namespace Microsoft.ML.RunTests
         }
 
         [Theory]
-        [IterationData(iterations: 10)]
+        [IterationData(iterations: 2)]
         public void EntryPointChainedCrossValMacros(int iteration)
         {
             Console.WriteLine($"{iteration}-th running...");
@@ -6029,7 +6029,7 @@ namespace Microsoft.ML.RunTests
         }
 
         [Theory]
-        [IterationData(iterations: 10)]
+        [IterationData(iterations: 2)]
         public void TestOvaMacro(int iteration)
         {
             Console.WriteLine($"{iteration}-th running...");

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -3846,11 +3846,9 @@ namespace Microsoft.ML.RunTests
             validateAuc(metrics);
         }
 
-        [Theory]
-        [IterationData(iterations: 1)]
-        public void EntryPointChainedCrossValMacros(int iteration)
+        [Fact]
+        public void EntryPointChainedCrossValMacros()
         {
-            Console.WriteLine($"{iteration}-th running...");
             string inputGraph = @"
                 {
                   'Nodes': [
@@ -6028,11 +6026,9 @@ namespace Microsoft.ML.RunTests
             }
         }
 
-        [Theory]
-        [IterationData(iterations: 1)]
-        public void TestOvaMacro(int iteration)
-        {
-            Console.WriteLine($"{iteration}-th running...");
+        [Fact]
+        public void TestOvaMacro()
+        { 
             var dataPath = GetDataPath(@"iris.txt");
             string inputGraph = @"
             {

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -19,6 +19,7 @@ using Microsoft.ML.Model.OnnxConverter;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.TestFramework.Attributes;
 using Microsoft.ML.TestFrameworkCommon;
+using Microsoft.ML.TestFrameworkCommon.Attributes;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Trainers.Ensemble;
 using Microsoft.ML.Trainers.FastTree;
@@ -3845,9 +3846,11 @@ namespace Microsoft.ML.RunTests
             validateAuc(metrics);
         }
 
-        [Fact]
-        public void EntryPointChainedCrossValMacros()
+        [Theory]
+        [IterationData(iterations: 10)]
+        public void EntryPointChainedCrossValMacros(int iteration)
         {
+            Console.WriteLine($"{iteration}-th running...");
             string inputGraph = @"
                 {
                   'Nodes': [
@@ -6025,9 +6028,11 @@ namespace Microsoft.ML.RunTests
             }
         }
 
-        [Fact]
-        public void TestOvaMacro()
+        [Theory]
+        [IterationData(iterations: 10)]
+        public void TestOvaMacro(int iteration)
         {
+            Console.WriteLine($"{iteration}-th running...");
             var dataPath = GetDataPath(@"iris.txt");
             string inputGraph = @"
             {

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -3847,7 +3847,7 @@ namespace Microsoft.ML.RunTests
         }
 
         [Theory]
-        [IterationData(iterations: 10)]
+        [IterationData(iterations: 1)]
         public void EntryPointChainedCrossValMacros(int iteration)
         {
             Console.WriteLine($"{iteration}-th running...");
@@ -6029,7 +6029,7 @@ namespace Microsoft.ML.RunTests
         }
 
         [Theory]
-        [IterationData(iterations: 10)]
+        [IterationData(iterations: 1)]
         public void TestOvaMacro(int iteration)
         {
             Console.WriteLine($"{iteration}-th running...");

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -3847,7 +3847,7 @@ namespace Microsoft.ML.RunTests
         }
 
         [Theory]
-        [IterationData(iterations: 2)]
+        [IterationData(iterations: 10)]
         public void EntryPointChainedCrossValMacros(int iteration)
         {
             Console.WriteLine($"{iteration}-th running...");
@@ -6029,7 +6029,7 @@ namespace Microsoft.ML.RunTests
         }
 
         [Theory]
-        [IterationData(iterations: 2)]
+        [IterationData(iterations: 10)]
         public void TestOvaMacro(int iteration)
         {
             Console.WriteLine($"{iteration}-th running...");

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -549,14 +549,12 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var model = fullLearningPipeline.Fit(data);
         }
 
-        [Theory]
-        [IterationData(iterations: 1)]
-        public void CrossValidationIris(int iteration)
-            => CrossValidationOn(GetDataPath("iris.data"), iteration);
+        [Fact]
+        public void CrossValidationIris()
+            => CrossValidationOn(GetDataPath("iris.data"));
 
-        private void CrossValidationOn(string dataPath, int iteration)
+        private void CrossValidationOn(string dataPath)
         {
-            Console.WriteLine($"{iteration}-th running..."); 
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -550,7 +550,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Theory]
-        [IterationData(iterations:2)]
+        [IterationData(iterations:5)]
         public void CrossValidationIris(int iteration)
             => CrossValidationOn(GetDataPath("iris.data"), iteration);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -550,7 +550,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Theory]
-        [IterationData(iterations:10)]
+        [IterationData(iterations:2)]
         public void CrossValidationIris(int iteration)
             => CrossValidationOn(GetDataPath("iris.data"), iteration);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -550,7 +550,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Theory]
-        [IterationData(iterations:5)]
+        [IterationData(iterations: 1)]
         public void CrossValidationIris(int iteration)
             => CrossValidationOn(GetDataPath("iris.data"), iteration);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -9,6 +9,7 @@ using Microsoft.ML.Data;
 using Microsoft.ML.RunTests;
 using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFrameworkCommon;
+using Microsoft.ML.TestFrameworkCommon.Attributes;
 using Microsoft.ML.Trainers;
 using Microsoft.ML.Transforms;
 using Microsoft.ML.Transforms.Text;
@@ -548,12 +549,14 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
             var model = fullLearningPipeline.Fit(data);
         }
 
-        [Fact]
-        public void CrossValidationIris()
-            => CrossValidationOn(GetDataPath("iris.data"));
+        [Theory]
+        [IterationData(iterations:10)]
+        public void CrossValidationIris(int iteration)
+            => CrossValidationOn(GetDataPath("iris.data"), iteration);
 
-        private void CrossValidationOn(string dataPath)
+        private void CrossValidationOn(string dataPath, int iteration)
         {
+            Console.WriteLine($"{iteration}-th running..."); 
             // Create a new context for ML.NET operations. It can be used for exception tracking and logging, 
             // as a catalog of available operations and as the source of randomness.
             var mlContext = new MLContext();

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/TensorflowTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.ML.DataOperationsCatalog;
 using Microsoft.ML.Trainers;
+using Microsoft.ML.TestFrameworkCommon.Attributes;
 
 namespace Microsoft.ML.Scenarios
 {
@@ -1466,10 +1467,11 @@ namespace Microsoft.ML.Scenarios
             TensorFlowImageClassificationWithLRScheduling(new ExponentialLRDecay(), 50);
         }
 
-        [TensorFlowFact]
-        public void TensorFlowImageClassificationWithPolynomialLRScheduling()
+        [Theory]
+        [IterationData]
+        public void TensorFlowImageClassificationWithPolynomialLRScheduling(int iteration)
         {
-
+            Console.WriteLine($"{iteration}-th running...");
             TensorFlowImageClassificationWithLRScheduling(new PolynomialLRDecay(), 50);
         }
 

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.ML.TestFramework.Attributes;
+using Microsoft.ML.TestFrameworkCommon.Attributes;
 using Microsoft.ML.Transforms.TimeSeries;
 using Xunit;
 using Xunit.Abstractions;
@@ -98,9 +100,11 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Fact]
-        public void SavePipeSlidingWindow()
+        [Theory]
+        [IterationData(iterations: 100)]
+        public void SavePipeSlidingWindow(int iteration)
         {
+            Console.WriteLine($"{iteration}-th running...");
             TestCore(null, true,
                     new[]{"loader=Text{col=Input:R4:1}",
                     "xf=SlideWinTransform{src=Input name=Output wnd=3 l=0}" });

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.ML.Data;
 using Microsoft.ML.TestFramework.Attributes;
+using Microsoft.ML.TestFrameworkCommon.Attributes;
 using Microsoft.ML.Transforms.TimeSeries;
 using Xunit;
 
@@ -322,9 +324,12 @@ namespace Microsoft.ML.Tests
             Assert.Equal(1.5292508189989167E-07, prediction.Change[3], precision: 5); // Martingale score
         }
 
-        [LessThanNetCore30OrNotNetCoreFact("netcoreapp3.0 output differs from Baseline")]
-        public void SsaForecast()
+        [Theory]
+        [IterationData]
+        public void SsaForecast(int iteration)
         {
+            Console.WriteLine($"{iteration}-th running...");
+
             var env = new MLContext();
             const int ChangeHistorySize = 10;
             const int SeasonalitySize = 10;
@@ -361,9 +366,15 @@ namespace Microsoft.ML.Tests
             // Get predictions
             var enumerator = env.Data.CreateEnumerable<ForecastPrediction>(output, true).GetEnumerator();
             ForecastPrediction row = null;
+#if NETCOREAPP3_0
+            List<float> expectedForecast = new List<float>() { 0.191492021f, 2.5399406f, 5.26454258f, 7.37313938f };
+            List<float> minCnf = new List<float>() { -3.97419858f, -2.36872721f, 0.0940769911f, 2.18899393f };
+            List<float> maxCnf = new List<float>() { 4.3571825f, 7.4486084f, 10.435008f, 12.5572853f };
+#else
             List<float> expectedForecast = new List<float>() { 0.191491723f, 2.53994083f, 5.26454258f, 7.37313938f };
             List<float> minCnf = new List<float>() { -3.9741993f, -2.36872721f, 0.09407653f, 2.18899345f };
             List<float> maxCnf = new List<float>() { 4.3571825f, 7.448609f, 10.435009f, 12.5572853f };
+#endif
             enumerator.MoveNext();
             row = enumerator.Current;
 


### PR DESCRIPTION
several fluky tests that call stack seems similar, add some debug log to help trouble shoot:

Microsoft.ML.Tests.Scenarios.Api.CookbookSamples.CookbookSamplesDynamicApi.CrossValidationIris [48s 317ms] 
Error Message: 
Assert failed: longIdx=32, invariants.Length=32 
Expected: True 
Actual: False 
Stack Trace: 
at Microsoft.ML.Internal.Internallearn.Test.GlobalBase.AssertHandler(String msg, IExceptionContext ectx) in F:\workspace\_work\1\s\test\Microsoft.ML.TestFramework\GlobalBase.cs:line 71 
at Microsoft.ML.Runtime.Contracts.DbgFailCore(String msg, IExceptionContext ctx) in F:\workspace\_work\1\s\src\Microsoft.ML.Core\Utilities\Contracts.cs:line 781 
at Microsoft.ML.Runtime.Contracts.DbgFail(String msg) in F:\workspace\_work\1\s\src\Microsoft.ML.Core\Utilities\Contracts.cs:line 794 
at Microsoft.ML.Runtime.Contracts.Assert(Boolean f, String msg) in F:\workspace\_work\1\s\src\Microsoft.ML.Core\Utilities\Contracts.cs:line 852 
at Microsoft.ML.Trainers.SdcaTrainerBase`3.TrainCore(IChannel ch, RoleMappedData data, LinearModelParameters predictor, Int32 weightSetCount) in F:\workspace\_work\1\s\src\Microsoft.ML.StandardTrainers\Standard\SdcaBinary.cs:line 574 
at Microsoft.ML.Trainers.StochasticTrainerBase`2.TrainModelCore(TrainContext context) in F:\workspace\_work\1\s\src\Microsoft.ML.StandardTrainers\Standard\StochasticTrainerBase.cs:line 43 
at Microsoft.ML.Trainers.TrainerEstimatorBase`2.TrainTransformer(IDataView trainSet, IDataView validationSet, IPredictor initPredictor) in F:\workspace\_work\1\s\src\Microsoft.ML.Data\Training\TrainerEstimatorBase.cs:line 157 
at Microsoft.ML.Trainers.TrainerEstimatorBase`2.Fit(IDataView input) in F:\workspace\_work\1\s\src\Microsoft.ML.Data\Training\TrainerEstimatorBase.cs:line 77 
at Microsoft.ML.Data.EstimatorChain`1.Fit(IDataView input) in F:\workspace\_work\1\s\src\Microsoft.ML.Data\DataLoadSave\EstimatorChain.cs:line 67 
at Microsoft.ML.TrainCatalogBase.CrossValidateTrain(IDataView data, IEstimator`1 estimator, Int32 numFolds, String samplingKeyColumn, Nullable`1 seed) in F:\workspace\_work\1\s\src\Microsoft.ML.Data\TrainCatalog.cs:line 104 
at Microsoft.ML.MulticlassClassificationCatalog.CrossValidate(IDataView data, IEstimator`1 estimator, Int32 numberOfFolds, String labelColumnName, String samplingKeyColumnName, Nullable`1 seed) in F:\workspace\_work\1\s\src\Microsoft.ML.Data\TrainCatalog.cs:line 535 
at Microsoft.ML.Tests.Scenarios.Api.CookbookSamples.CookbookSamplesDynamicApi.CrossValidationOn(String dataPath) in F:\workspace\_work\1\s\test\Microsoft.ML.Tests\Scenarios\Api\CookbookSamples\CookbookSamplesDynamicApi.cs:line 590 
at Microsoft.ML.Tests.Scenarios.Api.CookbookSamples.CookbookSamplesDynamicApi.CrossValidationIris() in F:\workspace\_work\1\s\test\Microsoft.ML.Tests\Scenarios\Api\CookbookSamples\CookbookSamplesDynamicApi.cs:line 553 


Microsoft.ML.RunTests.TestEntryPoints.TestOvaMacro [218ms] 
Error Message: 
Assert failed: longIdx=139, invariants.Length=139 
Expected: True 
Actual: False 
Stack Trace: 
at Microsoft.ML.Internal.Internallearn.Test.GlobalBase.AssertHandler(String msg, IExceptionContext ectx) in /__w/1/s/test/Microsoft.ML.TestFramework/GlobalBase.cs:line 71 
at Microsoft.ML.Runtime.Contracts.DbgFailCore(String msg, IExceptionContext ctx) in /__w/1/s/src/Microsoft.ML.Core/Utilities/Contracts.cs:line 781 
at Microsoft.ML.Runtime.Contracts.DbgFail(String msg) in /__w/1/s/src/Microsoft.ML.Core/Utilities/Contracts.cs:line 794 
at Microsoft.ML.Runtime.Contracts.Assert(Boolean f, String msg) in /__w/1/s/src/Microsoft.ML.Core/Utilities/Contracts.cs:line 852 
at Microsoft.ML.Trainers.SdcaTrainerBase`3.TrainCore(IChannel ch, RoleMappedData data, LinearModelParameters predictor, Int32 weightSetCount) in /__w/1/s/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs:line 574 
at Microsoft.ML.Trainers.StochasticTrainerBase`2.TrainModelCore(TrainContext context) in /__w/1/s/src/Microsoft.ML.StandardTrainers/Standard/StochasticTrainerBase.cs:line 43 
at Microsoft.ML.Trainers.TrainerEstimatorBase`2.Microsoft.ML.ITrainer<Microsoft.ML.IPredictor>.Train(TrainContext context) in /__w/1/s/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs:line 100 
at Microsoft.ML.Trainers.TrainerEstimatorBase`2.Microsoft.ML.ITrainer.Train(TrainContext context) in /__w/1/s/src/Microsoft.ML.Data/Training/TrainerEstimatorBase.cs:line 168 
at Microsoft.ML.Data.TrainUtils.TrainCore(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, RoleMappedData validData, IComponentFactory`1 calibrator, Int32 maxCalibrationExamples, Nullable`1 cacheData, IPredictor inputPredictor, RoleMappedData testData) in /__w/1/s/src/Microsoft.ML.Data/Commands/TrainCommand.cs:line 280 
at Microsoft.ML.Data.TrainUtils.Train(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, IComponentFactory`1 calibrator, Int32 maxCalibrationExamples) in /__w/1/s/src/Microsoft.ML.Data/Commands/TrainCommand.cs:line 249 
at Microsoft.ML.EntryPoints.TrainerEntryPointsUtils.Train[TArg,TOut](IHost host, TArg input, Func`1 createTrainer, Func`1 getLabel, Func`1 getWeight, Func`1 getGroup, Func`1 getName, Func`1 getCustom, ICalibratorTrainerFactory calibrator, Int32 maxCalibrationExamples) in /__w/1/s/src/Microsoft.ML.Data/EntryPoints/InputBase.cs:line 119 
at Microsoft.ML.Trainers.Sdca.TrainBinary(IHostEnvironment env, Options input) in /__w/1/s/src/Microsoft.ML.StandardTrainers/Standard/SdcaBinary.cs:line 2488 
Standard Output Messages: 
Test TestOvaMacro: aborted: passed 



[xUnit.net 00:00:46.41] Microsoft.ML.RunTests.TestEntryPoints.EntryPointChainedCrossValMacros(iteration: 44) [FAIL] 
77-th running... 
X Microsoft.ML.RunTests.TestEntryPoints.EntryPointChainedCrossValMacros(iteration: 44) [173ms] 
Error Message: 
Assert failed: longIdx=335, invariants.Length=335 
Expected: True 
Actual: False 
Stack Trace: 
at Microsoft.ML.Internal.Internallearn.Test.GlobalBase.AssertHandler(String msg, IExceptionContext ectx) in D:\a\1\s\test\Microsoft.ML.TestFramework\GlobalBase.cs:line 71 
at Microsoft.ML.Runtime.Contracts.DbgFailCore(String msg, IExceptionContext ctx) in D:\a\1\s\src\Microsoft.ML.Core\Utilities\Contracts.cs:line 781 
at Microsoft.ML.Runtime.Contracts.DbgFail(String msg) in D:\a\1\s\src\Microsoft.ML.Core\Utilities\Contracts.cs:line 794 
at Microsoft.ML.Runtime.Contracts.Assert(Boolean f, String msg) in D:\a\1\s\src\Microsoft.ML.Core\Utilities\Contracts.cs:line 852 
at Microsoft.ML.Trainers.SdcaTrainerBase`3.TrainCore(IChannel ch, RoleMappedData data, LinearModelParameters predictor, Int32 weightSetCount) in D:\a\1\s\src\Microsoft.ML.StandardTrainers\Standard\SdcaBinary.cs:line 574 
at Microsoft.ML.Trainers.StochasticTrainerBase`2.TrainModelCore(TrainContext context) in D:\a\1\s\src\Microsoft.ML.StandardTrainers\Standard\StochasticTrainerBase.cs:line 43 
at Microsoft.ML.Trainers.TrainerEstimatorBase`2.Microsoft.ML.ITrainer<Microsoft.ML.IPredictor>.Train(TrainContext context) in D:\a\1\s\src\Microsoft.ML.Data\Training\TrainerEstimatorBase.cs:line 100 
at Microsoft.ML.Trainers.TrainerEstimatorBase`2.Microsoft.ML.ITrainer.Train(TrainContext context) in D:\a\1\s\src\Microsoft.ML.Data\Training\TrainerEstimatorBase.cs:line 168 
at Microsoft.ML.Data.TrainUtils.TrainCore(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, RoleMappedData validData, IComponentFactory`1 calibrator, Int32 maxCalibrationExamples, Nullable`1 cacheData, IPredictor inputPredictor, RoleMappedData testData) in D:\a\1\s\src\Microsoft.ML.Data\Commands\TrainCommand.cs:line 280 
at Microsoft.ML.Data.TrainUtils.Train(IHostEnvironment env, IChannel ch, RoleMappedData data, ITrainer trainer, IComponentFactory`1 calibrator, Int32 maxCalibrationExamples) in D:\a\1\s\src\Microsoft.ML.Data\Commands\TrainCommand.cs:line 249 
at Microsoft.ML.EntryPoints.TrainerEntryPointsUtils.Train[TArg,TOut](IHost host, TArg input, Func`1 createTrainer, Func`1 getLabel, Func`1 getWeight, Func`1 getGroup, Func`1 getName, Func`1 getCustom, ICalibratorTrainerFactory calibrator, Int32 maxCalibrationExamples) in D:\a\1\s\src\Microsoft.ML.Data\EntryPoints\InputBase.cs:line 119 
at Microsoft.ML.Trainers.Sdca.TrainBinary(IHostEnvironment env, Options input) in D:\a\1\s\src\Microsoft.ML.StandardTrainers\Standard\SdcaBinary.cs:line 2488 
Standard Output Messages: 
Test EntryPointChainedCrossValMacros: aborted: passed 




