### PR TITLE
Featurizers Nuget fix, DateTimeTransformer path fix

### DIFF
--- a/pkg/Microsoft.ML.Featurizers/Microsoft.ML.Featurizers.nupkgproj
+++ b/pkg/Microsoft.ML.Featurizers/Microsoft.ML.Featurizers.nupkgproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <PackageDescription>ML.NET featurizers with native code implementation</PackageDescription>
   </PropertyGroup>
 

--- a/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
+++ b/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
@@ -490,7 +490,7 @@ namespace Microsoft.ML.Featurizers
                     }
                     else
                     {
-                        dataRoot = Encoding.UTF8.GetBytes(Assembly.GetExecutingAssembly().Location + char.MinValue);
+                        dataRoot = Encoding.UTF8.GetBytes(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + char.MinValue);
                     }
 
                     fixed (byte* dataRootDir = dataRoot)
@@ -590,7 +590,18 @@ namespace Microsoft.ML.Featurizers
             private static unsafe extern bool CreateTransformerFromSavedDataNative(byte* rawData, IntPtr bufferSize, byte* dataRootDir, out IntPtr transformer, out IntPtr errorHandle);
             private protected override unsafe void CreateTransformerFromSavedDataHelper(byte* rawData, IntPtr dataSize)
             {
-                fixed (byte* dataRootDir = Encoding.UTF8.GetBytes(AppDomain.CurrentDomain.BaseDirectory + char.MinValue))
+                byte[] dataRoot;
+
+                if (Directory.Exists(AppDomain.CurrentDomain.BaseDirectory + "/Data/DateTimeFeaturizer"))
+                {
+                    dataRoot = Encoding.UTF8.GetBytes(AppDomain.CurrentDomain.BaseDirectory + char.MinValue);
+                }
+                else
+                {
+                    dataRoot = Encoding.UTF8.GetBytes(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + char.MinValue);
+                }
+
+                fixed (byte* dataRootDir = dataRoot)
                 {
                     var result = CreateTransformerFromSavedDataNative(rawData, dataSize, dataRootDir, out IntPtr transformer, out IntPtr errorHandle);
                     if (!result)

--- a/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
+++ b/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
@@ -482,7 +482,18 @@ namespace Microsoft.ML.Featurizers
                 }
                 else
                 {
-                    fixed (byte* dataRootDir = Encoding.UTF8.GetBytes(AppDomain.CurrentDomain.BaseDirectory + char.MinValue))
+                    byte[] dataRoot;
+
+                    if (Directory.Exists(AppDomain.CurrentDomain.BaseDirectory + "/Data/DateTimeFeaturizer"))
+                    {
+                        dataRoot = Encoding.UTF8.GetBytes(AppDomain.CurrentDomain.BaseDirectory + char.MinValue);
+                    }
+                    else
+                    {
+                        dataRoot = Encoding.UTF8.GetBytes(AppDomain.CurrentDomain.BaseDirectory + char.MinValue);
+                    }
+
+                    fixed (byte* dataRootDir = dataRoot)
                     fixed (byte* countryPointer = Encoding.UTF8.GetBytes(Enum.GetName(typeof(DateTimeEstimator.HolidayList), country) + char.MinValue))
                     {
                         success = CreateEstimatorHelper(countryPointer, dataRootDir, out estimator, out errorHandle);

--- a/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
+++ b/src/Microsoft.ML.Featurizers/DateTimeTransformer.cs
@@ -490,7 +490,7 @@ namespace Microsoft.ML.Featurizers
                     }
                     else
                     {
-                        dataRoot = Encoding.UTF8.GetBytes(AppDomain.CurrentDomain.BaseDirectory + char.MinValue);
+                        dataRoot = Encoding.UTF8.GetBytes(Assembly.GetExecutingAssembly().Location + char.MinValue);
                     }
 
                     fixed (byte* dataRootDir = dataRoot)


### PR DESCRIPTION
Fix the nuget package to also add in netcoreapp2.1 as a target framework.

Nimbus ML moves the native code DLL from where it is restored to a different location. This was causing issues with finding the data files required for DateTimeTransformer to do holidays correctly. This change makes the DateTimeTransformer look in 2 places for the existence of the data files, the restore location and the current location of the .dll, resolving the issues.