### PR TITLE
Fixes None dimension bug

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -56,7 +56,7 @@
     <MicrosoftMLTestDatabasesPackageVersion>0.0.6-test</MicrosoftMLTestDatabasesPackageVersion>
     <MicrosoftMLTestModelsPackageVersion>0.0.6-test</MicrosoftMLTestModelsPackageVersion>
     <MicrosoftMLTensorFlowTestModelsVersion>0.0.11-test</MicrosoftMLTensorFlowTestModelsVersion>
-    <MicrosoftMLOnnxTestModelsVersion>0.0.5-test</MicrosoftMLOnnxTestModelsVersion>
+    <MicrosoftMLOnnxTestModelsVersion>0.0.6-test</MicrosoftMLOnnxTestModelsVersion>
     <SystemDataSqlClientVersion>4.6.1</SystemDataSqlClientVersion>
     <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>
     <SystemDataSQLiteCoreVersion>1.0.112.2</SystemDataSQLiteCoreVersion>

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
@@ -178,7 +178,7 @@ namespace Microsoft.ML.Transforms.Onnx
                 case OnnxCSharpToProtoWrapper.TensorShapeProto.Types.Dimension.ValueOneofCase.DimParam:
                     // Variable-length dimension is translated to 0.
                     break;
-                case 0:
+                case OnnxCSharpToProtoWrapper.TensorShapeProto.Types.Dimension.ValueOneofCase.None:
                     // Empty dimension is translated to 0.
                     break;
                 default:

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
@@ -181,8 +181,6 @@ namespace Microsoft.ML.Transforms.Onnx
                 case OnnxCSharpToProtoWrapper.TensorShapeProto.Types.Dimension.ValueOneofCase.None:
                     // Empty dimension is translated to 0.
                     break;
-                default:
-                    throw Contracts.ExceptParamValue(dim.DimValue, nameof(dim), $"Dimension {dim} in ONNX tensor is invalid.");
             }
             return value;
         }

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTypeParser.cs
@@ -177,10 +177,12 @@ namespace Microsoft.ML.Transforms.Onnx
                     break;
                 case OnnxCSharpToProtoWrapper.TensorShapeProto.Types.Dimension.ValueOneofCase.DimParam:
                     // Variable-length dimension is translated to 0.
-                    value = 0;
+                    break;
+                case 0:
+                    // Empty dimension is translated to 0.
                     break;
                 default:
-                    throw Contracts.ExceptParamValue(dim.DimValue, nameof(dim), $"Dimension {dim} in ONNX tensor cannot exceed the maximum of 32-bit signed integer.");
+                    throw Contracts.ExceptParamValue(dim.DimValue, nameof(dim), $"Dimension {dim} in ONNX tensor is invalid.");
             }
             return value;
         }

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -360,7 +360,7 @@ namespace Microsoft.ML.Tests
         {
             // Model contains None in input shape dimension
             // Model input dims: [None, 4]
-            var modelFile = Path.Combine(Directory.GetCurrentDirectory(), "unknowndimensions", "iris_sample.onnx");
+            var modelFile = Path.Combine(@"unknowndimensions/linear_regression.onnx");
             var mlContext = new MLContext();
             var data = new TestDataNoneDimension[]
             {

--- a/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
+++ b/test/Microsoft.ML.OnnxTransformerTest/OnnxTransformTests.cs
@@ -69,13 +69,13 @@ namespace Microsoft.ML.Tests
         private class TestDataNoneDimension
         {
             [VectorType(4)]
-            public float[] input;
+            public float[] features;
         }
 
         class PredictionNoneDimension
         {
             [VectorType(1)]
-            public long[] output_label { get; set; }
+            public float[] variable { get; set; }
         }
 
         private class TestDataUnknownDimensions
@@ -361,21 +361,21 @@ namespace Microsoft.ML.Tests
             // Model contains None in input shape dimension
             // Model input dims: [None, 4]
             var modelFile = Path.Combine(@"unknowndimensions/linear_regression.onnx");
-            var mlContext = new MLContext();
+            var mlContext = new MLContext(seed: 1);
             var data = new TestDataNoneDimension[]
             {
-                    new TestDataNoneDimension(){input = new float[] { 5.1f, 3.5f, 1.4f, 0.2f}},
-                    new TestDataNoneDimension(){input = new float[] { 7.0f, 3.2f, 4.7f, 1.4f }},
-                    new TestDataNoneDimension(){input = new float[] { 6.3f, 3.3f, 6.0f, 2.5f }},
+                    new TestDataNoneDimension(){features = new float[] { 5.1f, 3.5f, 1.4f, 0.2f}},
+                    new TestDataNoneDimension(){features = new float[] { 7.0f, 3.2f, 4.7f, 1.4f }},
+                    new TestDataNoneDimension(){features = new float[] { 6.3f, 3.3f, 6.0f, 2.5f }},
             };
             var idv = mlContext.Data.LoadFromEnumerable(data);
             var pipeline = ML.Transforms.ApplyOnnxModel(modelFile);
             var transformedValues = pipeline.Fit(idv).Transform(idv);
             var predictions = mlContext.Data.CreateEnumerable<PredictionNoneDimension>(transformedValues, reuseRowObject: false).ToArray();
 
-            Assert.Equal(0, predictions[0].output_label[0]);
-            Assert.Equal(1, predictions[1].output_label[0]);
-            Assert.Equal(2, predictions[2].output_label[0]);
+            Assert.Equal(-0.080, Math.Round(predictions[0].variable[0], 3));
+            Assert.Equal(1.204, Math.Round(predictions[1].variable[0], 3));
+            Assert.Equal(2.27, Math.Round(predictions[2].variable[0], 3));
         }
 
         /// <summary>


### PR DESCRIPTION
Bug: #4646 

ML.Net considers empty dimensions invalid. However, the "None" dimension is valid in OnnxRuntime.  