### PR TITLE
add log for Ssaforecast test

### DIFF
--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -6,12 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.ML.Data;
-using Microsoft.ML.RunTests;
-using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFramework.Attributes;
 using Microsoft.ML.Transforms.TimeSeries;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.ML.Tests
 {

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -2,18 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.ML.Data;
+using Microsoft.ML.RunTests;
+using Microsoft.ML.TestFramework;
 using Microsoft.ML.TestFramework.Attributes;
 using Microsoft.ML.Transforms.TimeSeries;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.ML.Tests
 {
     public sealed class TimeSeries
     {
-
         private sealed class Prediction
         {
 #pragma warning disable CS0649
@@ -333,6 +336,9 @@ namespace Microsoft.ML.Tests
             List<Data> data = new List<Data>();
             var dataView = env.Data.LoadFromEnumerable(data);
 
+            List<string> logMessages = new List<string>();
+            env.Log += (sender, e) => logMessages.Add(e.Message);
+
             var args = new SsaForecastingTransformer.Options()
             {
                 ConfidenceLevel = 0.95f,
@@ -374,6 +380,11 @@ namespace Microsoft.ML.Tests
                 Assert.Equal(maxCnf[localIndex], row.MaxCnf[localIndex], precision: 7);
             }
 
+
+            foreach(var logMessage in logMessages)
+            {
+                Console.WriteLine($"Debug SsaForecast: {logMessage}.");
+            }
         }
 
         [LessThanNetCore30OrNotNetCoreFact("netcoreapp3.0 output differs from Baseline")]


### PR DESCRIPTION
Add logs to investigate SsaForecast test issue.

One example is in this build: https://dev.azure.com/dnceng/public/_build/results?buildId=480666&view=logs&j=4b233af4-7b14-5f68-27c6-9c4d7ac87519&t=6e2e87e8-8c33-50e6-544b-c271638494a5

Error message: 
[xUnit.net 00:00:02.58]     Microsoft.ML.Tests.TimeSeries.SsaForecast [FAIL]
  X Microsoft.ML.Tests.TimeSeries.SsaForecast [95ms]
  Error Message:
   Assert.Equal() Failure
Expected: 0.1914917 (rounded from 0.191491723060608)
Actual:   -8.1287222 (rounded from -8.12872219085693)
  Stack Trace:
     at Microsoft.ML.Tests.TimeSeries.SsaForecast() in /Users/runner/runners/2.163.1/work/1/s/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs:line 373


