### PR TITLE
Throw exception in ImageClassificationTrainer when dataset contains only 1 class

### DIFF
--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -603,7 +603,8 @@ namespace Microsoft.ML.Vision
                     (string)labelType.ToString());
             }
 
-            Contracts.CheckParam(labelCount > 1, nameof(labelCount), "ImageClassificationTrainer requires more than 1 class in the training dataset");
+            var msg = $"Only one class found in {_options.LabelColumnName} column. To build a multiclass classification model, the number of classes needs to be 2 or greater";
+            Contracts.CheckParam(labelCount > 1, nameof(labelCount), msg);
 
             _classCount = (int)labelCount;
             var imageSize = ImagePreprocessingSize[_options.Arch];

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -603,7 +603,10 @@ namespace Microsoft.ML.Vision
                     (string)labelType.ToString());
             }
 
-            _classCount = labelCount == 1 ? 2 : (int)labelCount;
+            if (labelCount == 1)
+                throw new InvalidOperationException("Dataset contains only 1 class. ImageClassificationTrainer requires more than 1");
+
+            _classCount = (int)labelCount;
             var imageSize = ImagePreprocessingSize[_options.Arch];
             _session = LoadTensorFlowSessionFromMetaGraph(Host, _options.Arch).Session;
             _session.graph.as_default();

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -603,8 +603,7 @@ namespace Microsoft.ML.Vision
                     (string)labelType.ToString());
             }
 
-            if (labelCount == 1)
-                throw new InvalidOperationException("Dataset contains only 1 class. ImageClassificationTrainer requires more than 1");
+            Contracts.CheckParam(labelCount > 1, nameof(labelCount), "ImageClassificationTrainer requires more than 1 class in the training dataset");
 
             _classCount = (int)labelCount;
             var imageSize = ImagePreprocessingSize[_options.Arch];

--- a/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
+++ b/src/Microsoft.ML.Vision/ImageClassificationTrainer.cs
@@ -603,7 +603,7 @@ namespace Microsoft.ML.Vision
                     (string)labelType.ToString());
             }
 
-            var msg = $"Only one class found in {_options.LabelColumnName} column. To build a multiclass classification model, the number of classes needs to be 2 or greater";
+            var msg = $"Only one class found in the {_options.LabelColumnName} column. To build a multiclass classification model, the number of classes needs to be 2 or greater";
             Contracts.CheckParam(labelCount > 1, nameof(labelCount), msg);
 
             _classCount = (int)labelCount;


### PR DESCRIPTION
Throw exception in ImageClassificationTrainer when dataset contains only 1 class

Fixes #4660 

