### PR TITLE
TextLoader now checks for presence of source file with clear error message

### DIFF
--- a/src/Microsoft.ML.Core/ComponentModel/AssemblyLoadingUtils.cs
+++ b/src/Microsoft.ML.Core/ComponentModel/AssemblyLoadingUtils.cs
@@ -31,6 +31,10 @@ namespace Microsoft.ML.Runtime
                     {
                         // REVIEW: Will LoadFrom ever return null?
                         Contracts.CheckNonEmpty(path, nameof(path));
+                        if (!File.Exists(path))
+                        {
+                            throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
+                        }
                         var assem = LoadAssembly(env, path);
                         if (assem != null)
                             continue;

--- a/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Binary/BinaryLoaderSaverCatalog.cs
@@ -47,6 +47,10 @@ namespace Microsoft.ML
         public static IDataView LoadFromBinary(this DataOperationsCatalog catalog, string path)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
+            if (!File.Exists(path))
+            {
+                throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
+            }
 
             var env = catalog.GetEnvironment();
 

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML
             Contracts.CheckNonEmpty(path, nameof(path));
             if (!File.Exists(path))
             {
-                throw Contracts.ExceptDecode("File does not exist at path: {0}", path);
+                throw Contracts.ExceptParam("File does not exist at path: {0}", path);
             }
 
             var options = new TextLoader.Options
@@ -160,7 +160,7 @@ namespace Microsoft.ML
             Contracts.CheckNonEmpty(path, nameof(path));
             if (!File.Exists(path))
             {
-                throw Contracts.ExceptDecode("File does not exist at path: {0}", path);
+                throw Contracts.ExceptParam("File does not exist at path: {0}", path);
             }
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
@@ -189,7 +189,7 @@ namespace Microsoft.ML
             Contracts.CheckNonEmpty(path, nameof(path));
             if (!File.Exists(path))
             {
-                throw Contracts.ExceptDecode("File does not exist at path: {0}", path);
+                throw Contracts.ExceptParam("File does not exist at path: {0}", path);
             }
 
             var env = catalog.GetEnvironment();

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -112,6 +112,10 @@ namespace Microsoft.ML
             bool allowSparse = TextLoader.Defaults.AllowSparse)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
+            if (!File.Exists(path))
+            {
+                throw Contracts.ExceptDecode("File does not exist at path: {0}", path);
+            }
 
             var options = new TextLoader.Options
             {
@@ -154,6 +158,10 @@ namespace Microsoft.ML
             bool allowSparse = TextLoader.Defaults.AllowSparse)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
+            if (!File.Exists(path))
+            {
+                throw Contracts.ExceptDecode("File does not exist at path: {0}", path);
+            }
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
             // Therefore, we are going to disallow data sample.
@@ -179,6 +187,10 @@ namespace Microsoft.ML
             TextLoader.Options options = null)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
+            if (!File.Exists(path))
+            {
+                throw Contracts.ExceptDecode("File does not exist at path: {0}", path);
+            }
 
             var env = catalog.GetEnvironment();
             var source = new MultiFileSource(path);

--- a/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/Text/TextLoaderSaverCatalog.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML
             Contracts.CheckNonEmpty(path, nameof(path));
             if (!File.Exists(path))
             {
-                throw Contracts.ExceptParam("File does not exist at path: {0}", path);
+                throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
             }
 
             var options = new TextLoader.Options
@@ -160,7 +160,7 @@ namespace Microsoft.ML
             Contracts.CheckNonEmpty(path, nameof(path));
             if (!File.Exists(path))
             {
-                throw Contracts.ExceptParam("File does not exist at path: {0}", path);
+                throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
             }
 
             // REVIEW: it is almost always a mistake to have a 'trainable' text loader here.
@@ -189,7 +189,7 @@ namespace Microsoft.ML
             Contracts.CheckNonEmpty(path, nameof(path));
             if (!File.Exists(path))
             {
-                throw Contracts.ExceptParam("File does not exist at path: {0}", path);
+                throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
             }
 
             var env = catalog.GetEnvironment();

--- a/src/Microsoft.ML.Transforms/SvmLight/SvmLightLoaderSaverCatalog.cs
+++ b/src/Microsoft.ML.Transforms/SvmLight/SvmLightLoaderSaverCatalog.cs
@@ -65,6 +65,10 @@ namespace Microsoft.ML.Data
             bool zeroBased = false)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
+            if (!File.Exists(path))
+            {
+                throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
+            }
 
             var file = new MultiFileSource(path);
             var loader = catalog.CreateSvmLightLoader(numberOfRows, inputSize, zeroBased, file);
@@ -83,6 +87,10 @@ namespace Microsoft.ML.Data
             long? numberOfRows = null)
         {
             Contracts.CheckNonEmpty(path, nameof(path));
+            if (!File.Exists(path))
+            {
+                throw Contracts.ExceptParam(nameof(path), "File does not exist at path: {0}", path);
+            }
 
             var file = new MultiFileSource(path);
             var loader = catalog.CreateSvmLightLoaderWithFeatureNames(numberOfRows, file);

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -591,7 +591,7 @@ namespace Microsoft.ML.EntryPoints.Tests
         public void ThrowsExceptionWithMissingFile()
         {
             var mlContext = new MLContext(seed: 1);
-            var ex = Assert.Throws<FormatException>(() => mlContext.Data.LoadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt"));
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => mlContext.Data.LoadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt"));
             Assert.StartsWith("File does not exist at path: fakefile.txt", ex.Message);
         }
 

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -143,20 +143,6 @@ namespace Microsoft.ML.EntryPoints.Tests
         }
 
         [Fact]
-        public void ConstructorDoesntThrow()
-        {
-            var mlContext = new MLContext(seed: 1);
-
-            Assert.NotNull(mlContext.Data.LoadFromTextFile<Input>("fakeFile.txt"));
-            Assert.NotNull(mlContext.Data.LoadFromTextFile<Input>("fakeFile.txt", hasHeader: true));
-            Assert.NotNull(mlContext.Data.LoadFromTextFile<Input>("fakeFile.txt", hasHeader: false));
-            Assert.NotNull(mlContext.Data.LoadFromTextFile<Input>("fakeFile.txt", hasHeader: false, trimWhitespace: false, allowSparse: false));
-            Assert.NotNull(mlContext.Data.LoadFromTextFile<Input>("fakeFile.txt", hasHeader: false, allowSparse: false));
-            Assert.NotNull(mlContext.Data.LoadFromTextFile<Input>("fakeFile.txt", hasHeader: false, allowQuoting: false));
-            Assert.NotNull(mlContext.Data.LoadFromTextFile<InputWithUnderscore>("fakeFile.txt"));
-        }
-
-        [Fact]
         public void CanSuccessfullyApplyATransform()
         {
             string inputGraph = @"

--- a/test/Microsoft.ML.Tests/TextLoaderTests.cs
+++ b/test/Microsoft.ML.Tests/TextLoaderTests.cs
@@ -588,11 +588,11 @@ namespace Microsoft.ML.EntryPoints.Tests
         }
 
         [Fact]
-        public void ThrowsExceptionWithPropertyName()
+        public void ThrowsExceptionWithMissingFile()
         {
             var mlContext = new MLContext(seed: 1);
-            var ex = Assert.Throws<InvalidOperationException>(() => mlContext.Data.LoadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt"));
-            Assert.StartsWith($"Field 'String1' is missing the {nameof(LoadColumnAttribute)} attribute", ex.Message);
+            var ex = Assert.Throws<FormatException>(() => mlContext.Data.LoadFromTextFile<ModelWithoutColumnAttribute>("fakefile.txt"));
+            Assert.StartsWith("File does not exist at path: fakefile.txt", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Fixed #2461 

TextLoader now checks whether the given file in path exists. If the file is missing, a clear exception stating that the file is missing is given, instead of stating that some field is missing some unknown attribute.