### PR TITLE
Updated langversion to 8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -92,7 +92,8 @@
  
   <!-- Language configuration -->
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)'=='.csproj'">8.0</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)'=='.fsproj'">4.7</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -92,7 +92,7 @@
  
   <!-- Language configuration -->
   <PropertyGroup>
-    <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
+    <LangVersion>8.0</LangVersion> <!-- default to allowing all language features -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -92,7 +92,7 @@
  
   <!-- Language configuration -->
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion> <!-- default to allowing all language features -->
+    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.csproj
+++ b/src/Microsoft.ML.CpuMath/Microsoft.ML.CpuMath.csproj
@@ -5,7 +5,6 @@
     <IncludeInPackage>Microsoft.ML.CpuMath</IncludeInPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);CPUMATH_INFRASTRUCTURE</DefineConstants>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
+++ b/test/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>8.0</LangVersion>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.ML.CpuMath.PerformanceTests/Microsoft.ML.CpuMath.PerformanceTests.csproj
+++ b/test/Microsoft.ML.CpuMath.PerformanceTests/Microsoft.ML.CpuMath.PerformanceTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.2</LangVersion>
     <GenerateProgramFile>false</GenerateProgramFile>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <!--

--- a/test/Microsoft.ML.FSharp.Tests/Microsoft.ML.FSharp.Tests.fsproj
+++ b/test/Microsoft.ML.FSharp.Tests/Microsoft.ML.FSharp.Tests.fsproj
@@ -5,6 +5,7 @@
     <PublicSign>false</PublicSign>
     <SourceLink></SourceLink>
     <PlatformTarget>$(TargetArchitecture)</PlatformTarget>
+    <LangVersion>4.7</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.ML.FSharp.Tests/Microsoft.ML.FSharp.Tests.fsproj
+++ b/test/Microsoft.ML.FSharp.Tests/Microsoft.ML.FSharp.Tests.fsproj
@@ -5,7 +5,6 @@
     <PublicSign>false</PublicSign>
     <SourceLink></SourceLink>
     <PlatformTarget>$(TargetArchitecture)</PlatformTarget>
-    <LangVersion>4.7</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #3786

We cannot use 7.3 because Utilities\ThreadUtils.cs uses static local functions which is available only in 8.0. I also had to set the langVersion to 4.7 for the F# project.

