### PR TITLE
Make SVM Light loader create the correct schema in case of indices greater than int.MaxValue

### DIFF
--- a/src/Microsoft.ML.Transforms/SvmLight/SvmLightLoader.cs
+++ b/src/Microsoft.ML.Transforms/SvmLight/SvmLightLoader.cs
@@ -689,7 +689,7 @@ namespace Microsoft.ML.Data
                     var values = result.GetValues();
                     for (int i = 0; i < values.Length; ++i)
                     {
-                        if (!parser(in values[i], out var val))
+                        if (!parser(in values[i], out var val) || val > int.MaxValue)
                         {
                             missingCount++;
                             continue;
@@ -700,17 +700,10 @@ namespace Microsoft.ML.Data
                     }
                 }
                 if (missingCount > 0)
-                    ch.Warning("{0} of {1} detected keys were missing or unparsable", missingCount, count + missingCount);
+                    ch.Warning($"{missingCount} of {count + missingCount} detected keys were missing, unparsable or greater than {int.MaxValue}");
                 if (count == 0)
                     throw ch.Except("No int parsable keys found during key transform inference");
                 ch.Info("Observed max was {0}", keyMax);
-
-                if (keyMax > int.MaxValue)
-                {
-                    // Similarly for missing values/misparses, warn, but don't error.
-                    ch.Warning("Indices above {0} will be ignored.", int.MaxValue);
-                    keyMax = int.MaxValue;
-                }
             }
             return (uint)keyMax;
         }

--- a/test/Microsoft.ML.Tests/SvmLightTests.cs
+++ b/test/Microsoft.ML.Tests/SvmLightTests.cs
@@ -51,6 +51,8 @@ namespace Microsoft.ML.Tests
             data = ML.Data.LoadFromSvmLightFile(savingPath, inputSize: inputSize, zeroBased: zeroBased);
             CheckSameValues(ColumnSelectingTransformer.CreateDrop(Env, data, "Comment"),
                 ColumnSelectingTransformer.CreateDrop(Env, expectedData, "Comment"), checkId: false);
+
+            Done();
         }
 
         [Fact]
@@ -495,7 +497,7 @@ namespace Microsoft.ML.Tests
                 new SvmLightOutput() { Label = -1, Weight = 1, Features = new VBuffer<float>(6, 1, new[] { 5f }, new[] { 1 }) }
             }, schemaDef);
             var savingPath = DeleteOutputPath(TestName + "-saved-data.txt");
-            TestSvmLight(path, savingPath, 0, int.MaxValue, false, expectedData);
+            TestSvmLight(path, savingPath, 0, 6, false, expectedData);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #4689 .