### PR TITLE
Fixes cases of invalid image folder path and input column name

### DIFF
--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -68,8 +68,8 @@ namespace Microsoft.ML
         ///  [!code-csharp[LoadImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
         /// ]]></format>
         /// </example>
-        public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName = null)
-           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, true, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
+        public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName)
+           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, true, new[] { (outputColumnName, inputColumnName) });
 
         /// <summary>
         /// Create a <see cref="ImageLoadingEstimator"/>, which loads the data from the column specified in <paramref name="inputColumnName"/>
@@ -87,8 +87,8 @@ namespace Microsoft.ML
         ///  [!code-csharp[LoadImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
         /// ]]></format>
         /// </example>
-        public static ImageLoadingEstimator LoadRawImageBytes(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName = null)
-           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, false, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
+        public static ImageLoadingEstimator LoadRawImageBytes(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName)
+           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, false, new[] { (outputColumnName, inputColumnName) });
 
         /// <summary>
         /// Create a <see cref="ImagePixelExtractingEstimator"/>, which extracts pixels values from the data specified in column: <paramref name="inputColumnName"/>

--- a/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ExtensionsCatalog.cs
@@ -68,8 +68,8 @@ namespace Microsoft.ML
         ///  [!code-csharp[LoadImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
         /// ]]></format>
         /// </example>
-        public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName)
-           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, true, new[] { (outputColumnName, inputColumnName) });
+        public static ImageLoadingEstimator LoadImages(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName = null)
+           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, true, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
 
         /// <summary>
         /// Create a <see cref="ImageLoadingEstimator"/>, which loads the data from the column specified in <paramref name="inputColumnName"/>
@@ -87,8 +87,8 @@ namespace Microsoft.ML
         ///  [!code-csharp[LoadImages](~/../docs/samples/docs/samples/Microsoft.ML.Samples/Dynamic/Transforms/ImageAnalytics/LoadImages.cs)]
         /// ]]></format>
         /// </example>
-        public static ImageLoadingEstimator LoadRawImageBytes(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName)
-           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, false, new[] { (outputColumnName, inputColumnName) });
+        public static ImageLoadingEstimator LoadRawImageBytes(this TransformsCatalog catalog, string outputColumnName, string imageFolder, string inputColumnName = null)
+           => new ImageLoadingEstimator(CatalogUtils.GetEnvironment(catalog), imageFolder, false, new[] { (outputColumnName, inputColumnName ?? outputColumnName) });
 
         /// <summary>
         /// Create a <see cref="ImagePixelExtractingEstimator"/>, which extracts pixels values from the data specified in column: <paramref name="inputColumnName"/>

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -89,14 +89,8 @@ namespace Microsoft.ML.Data
         /// <param name="imageFolder">Folder where to look for images.</param>
         /// <param name="columns">Names of input and output columns.</param>
         internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder = null, params (string outputColumnName, string inputColumnName)[] columns)
-            : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
+            : this (env, imageFolder, type: true, columns)
         {
-            // Throws ArgumentException if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
-            if (imageFolder != null)
-                ImageFolder = Path.GetFullPath(imageFolder);
-            else
-                ImageFolder = null;
-            _useImageType = true;
         }
 
         /// <summary>

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -109,11 +109,8 @@ namespace Microsoft.ML.Data
         internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder, bool type = true, params (string outputColumnName, string inputColumnName)[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
         {
-            if (String.IsNullOrWhiteSpace(imageFolder) || !File.Exists(imageFolder))
-            {
-                throw new ArgumentException("The provided ImageFolder path {0} is invalid.", imageFolder);
-            }
-            ImageFolder = imageFolder;
+            // Throws ArgumentException if given path is invalid/empty, ArgumentNullException if given path is null
+            ImageFolder = Path.GetFullPath(imageFolder);
             _useImageType = type;
         }
 

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -88,9 +88,13 @@ namespace Microsoft.ML.Data
         /// <param name="env">The host environment.</param>
         /// <param name="imageFolder">Folder where to look for images.</param>
         /// <param name="columns">Names of input and output columns.</param>
-        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder = null, params (string outputColumnName, string inputColumnName)[] columns)
+        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder, params (string outputColumnName, string inputColumnName)[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
         {
+            if (String.IsNullOrWhiteSpace(imageFolder) || !File.Exists(imageFolder))
+            {
+                throw new ArgumentException("The provided ImageFolder path {0} is invalid.", imageFolder);
+            }
             ImageFolder = imageFolder;
             _useImageType = true;
         }
@@ -102,9 +106,13 @@ namespace Microsoft.ML.Data
         /// <param name="imageFolder">Folder where to look for images.</param>
         /// <param name="type">Image type flag - true for ImageDataViewType or false for VectorDataViewType. Defaults to true i.e. ImageDataViewType if not specified.</param>
         /// <param name="columns">Names of input and output columns.</param>
-        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder = null, bool type = true, params (string outputColumnName, string inputColumnName)[] columns)
+        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder, bool type = true, params (string outputColumnName, string inputColumnName)[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
         {
+            if (String.IsNullOrWhiteSpace(imageFolder) || !File.Exists(imageFolder))
+            {
+                throw new ArgumentException("The provided ImageFolder path {0} is invalid.", imageFolder);
+            }
             ImageFolder = imageFolder;
             _useImageType = type;
         }

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -88,14 +88,14 @@ namespace Microsoft.ML.Data
         /// <param name="env">The host environment.</param>
         /// <param name="imageFolder">Folder where to look for images.</param>
         /// <param name="columns">Names of input and output columns.</param>
-        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder, params (string outputColumnName, string inputColumnName)[] columns)
+        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder = null, params (string outputColumnName, string inputColumnName)[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
         {
-            if (String.IsNullOrWhiteSpace(imageFolder) || !File.Exists(imageFolder))
-            {
-                throw new ArgumentException("The provided ImageFolder path {0} is invalid.", imageFolder);
-            }
-            ImageFolder = imageFolder;
+            // Throws ArgumentException if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
+            if (imageFolder != null)
+                ImageFolder = Path.GetFullPath(imageFolder);
+            else
+                ImageFolder = null;
             _useImageType = true;
         }
 
@@ -106,11 +106,14 @@ namespace Microsoft.ML.Data
         /// <param name="imageFolder">Folder where to look for images.</param>
         /// <param name="type">Image type flag - true for ImageDataViewType or false for VectorDataViewType. Defaults to true i.e. ImageDataViewType if not specified.</param>
         /// <param name="columns">Names of input and output columns.</param>
-        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder, bool type = true, params (string outputColumnName, string inputColumnName)[] columns)
+        internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder = null, bool type = true, params (string outputColumnName, string inputColumnName)[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
         {
-            // Throws ArgumentException if given path is invalid/empty, ArgumentNullException if given path is null
-            ImageFolder = Path.GetFullPath(imageFolder);
+            // Throws ArgumentException if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
+            if (imageFolder != null)
+                ImageFolder = Path.GetFullPath(imageFolder);
+            else
+                ImageFolder = null;
             _useImageType = type;
         }
 


### PR DESCRIPTION
Fixes #4429 

Input column names and image folders can no longer be empty or null.