### PR TITLE
crash test host process when test fails to take memory dump

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -59,7 +59,7 @@ jobs:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
         _includeBenchmarkData: true
-    innerLoop: true
+    innerLoop: false
     pool:
       name: NetCorePublic-Pool
       queue: buildpool.windows.10.amd64.vs2017.open
@@ -68,7 +68,7 @@ jobs:
   parameters:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
-    innerLoop: true
+    innerLoop: false
     pool:
       name: Hosted VS2017
 
@@ -85,7 +85,7 @@ jobs:
         _configuration: Release-netfx
         _config_short: RFX
         _includeBenchmarkData: false
-    innerLoop: true
+    innerLoop: false
     pool:
       name: Hosted VS2017
 
@@ -94,6 +94,6 @@ jobs:
     name: Windows_x86_NetCoreApp21
     architecture: x86
     buildScript: build.cmd
-    innerLoop: true
+    innerLoop: false
     pool:
       name: Hosted VS2017

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -2764,6 +2764,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void EntryPointSDCARegression()
         {
             TestEntryPointRoutine(TestDatasets.generatedRegressionDatasetmacro.trainFilename, "Trainers.StochasticDualCoordinateAscentRegressor", loader: TestDatasets.generatedRegressionDatasetmacro.loaderSettings);
@@ -3851,6 +3853,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void EntryPointChainedCrossValMacros()
         {
             string inputGraph = @"
@@ -6033,6 +6037,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestOvaMacro()
         {
             var dataPath = GetDataPath(@"iris.txt");

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -1536,6 +1536,8 @@ namespace Microsoft.ML.RunTests
             var twiceCalibratedFfModel = Calibrate.Platt(Env,
                 new Calibrate.NoArgumentsInput() { Data = splitOutput.TestData[0], UncalibratedPredictorModel = calibratedFfModel }).PredictorModel;
             var scoredFf = ScoreModel.Score(Env, new ScoreModel.Input() { Data = splitOutput.TestData[2], PredictorModel = twiceCalibratedFfModel }).ScoredData;
+
+            Done();
         }
 
         [Fact]

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -2764,8 +2764,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void EntryPointSDCARegression()
         {
             TestEntryPointRoutine(TestDatasets.generatedRegressionDatasetmacro.trainFilename, "Trainers.StochasticDualCoordinateAscentRegressor", loader: TestDatasets.generatedRegressionDatasetmacro.loaderSettings);
@@ -3853,8 +3851,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void EntryPointChainedCrossValMacros()
         {
             string inputGraph = @"
@@ -6037,8 +6033,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestOvaMacro()
         {
             var dataPath = GetDataPath(@"iris.txt");

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -170,7 +170,7 @@ namespace Microsoft.ML.RunTests
                 _passed = false;
                 var callStack = new System.Diagnostics.StackTrace().ToString();
                 Console.WriteLine($"---Debug---: Failed with callstack: {callStack}");
-                //CrashTestHostProcessorHelper.CrashTestHostProcess();
+                CrashTestHostProcessorHelper.CrashTestHostProcess();
             }
 
             Log("*** Failure: " + fmt, args);

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -170,7 +170,7 @@ namespace Microsoft.ML.RunTests
                 _passed = false;
                 var callStack = new System.Diagnostics.StackTrace().ToString();
                 Console.WriteLine($"---Debug---: Failed with callstack: {callStack}");
-                CrashTestHostProcessorHelper.CrashTestHostProcess();
+                //CrashTestHostProcessorHelper.CrashTestHostProcess();
             }
 
             Log("*** Failure: " + fmt, args);

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -168,7 +168,9 @@ namespace Microsoft.ML.RunTests
             if (!relax)
             {
                 _passed = false;
-                CrashTestHostProcessorHelper.CrashTestHostProcess();
+                var callStack = new System.Diagnostics.StackTrace().ToString();
+                Console.WriteLine($"---Debug---: Failed with callstack: {callStack}");
+                //CrashTestHostProcessorHelper.CrashTestHostProcess();
             }
 
             Log("*** Failure: " + fmt, args);

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.TestFramework;
+using Microsoft.ML.TestFrameworkCommon;
 using Microsoft.ML.Tools;
 using Xunit;
 using Xunit.Abstractions;
@@ -165,7 +166,10 @@ namespace Microsoft.ML.RunTests
         {
             Contracts.Assert(IsActive);
             if (!relax)
+            {
                 _passed = false;
+                CrashTestHostProcessorHelper.CrashTestHostProcess();
+            }
 
             Log("*** Failure: " + fmt, args);
         }
@@ -374,7 +378,7 @@ namespace Microsoft.ML.RunTests
             if (!CheckBaseFile(basePath))
                 return false;
 
-            bool res = CheckEqualityFromPathsCore(relPath, basePath, outPath, digitsOfPrecision: digitsOfPrecision, parseOption: parseOption);
+                bool res = CheckEqualityFromPathsCore(relPath, basePath, outPath, digitsOfPrecision: digitsOfPrecision, parseOption: parseOption);
 
             // No need to keep the raw (unnormalized) output file.
             if (normalize && res)

--- a/test/Microsoft.ML.TestFramework/GlobalBase.cs
+++ b/test/Microsoft.ML.TestFramework/GlobalBase.cs
@@ -12,7 +12,9 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.ML.Runtime;
+using Microsoft.ML.TestFrameworkCommon;
 using Xunit;
 
 namespace Microsoft.ML.Internal.Internallearn.Test
@@ -70,7 +72,7 @@ namespace Microsoft.ML.Internal.Internallearn.Test
 #endif
             {
                 Assert.True(false, $"Assert failed: {msg}");
-                System.Diagnostics.Debugger.Launch();
+                CrashTestHostProcessorHelper.CrashTestHostProcess();
             }
         }
 

--- a/test/Microsoft.ML.TestFramework/GlobalBase.cs
+++ b/test/Microsoft.ML.TestFramework/GlobalBase.cs
@@ -68,7 +68,10 @@ namespace Microsoft.ML.Internal.Internallearn.Test
             }
             else
 #endif
+            {
                 Assert.True(false, $"Assert failed: {msg}");
+                System.Diagnostics.Debugger.Launch();
+            }
         }
 
         public static void AssertHandlerTest()

--- a/test/Microsoft.ML.TestFrameworkCommon/CrashTestHostProcessorHelper.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/CrashTestHostProcessorHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.ML.TestFrameworkCommon
+{
+    public static class CrashTestHostProcessorHelper
+    {
+        public static void CrashTestHostProcess()
+        {
+            ThreadPool.QueueUserWorkItem(new WaitCallback(ignored =>
+            {
+                throw new Exception();
+            }));
+        }
+    }
+}

--- a/test/Microsoft.ML.TestFrameworkCommon/CrashTestHostProcessorHelper.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/CrashTestHostProcessorHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
@@ -9,10 +10,7 @@ namespace Microsoft.ML.TestFrameworkCommon
     {
         public static void CrashTestHostProcess()
         {
-            ThreadPool.QueueUserWorkItem(new WaitCallback(ignored =>
-            {
-                throw new Exception();
-            }));
+            Environment.FailFast("Crash on purpose here to take dump!");
         }
     }
 }

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -556,8 +556,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void CrossValidationIris()
             => CrossValidationOn(GetDataPath("iris.data"));
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -556,6 +556,8 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Fact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void CrossValidationIris()
             => CrossValidationOn(GetDataPath("iris.data"));
 

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.ML.Data;
 using Microsoft.ML.TestFramework.Attributes;
+using Microsoft.ML.TestFrameworkCommon;
 using Microsoft.ML.TestFrameworkCommon.Attributes;
 using Microsoft.ML.Transforms.TimeSeries;
 using Xunit;
@@ -372,6 +374,13 @@ namespace Microsoft.ML.Tests
 
             for (int localIndex = 0; localIndex < 4; localIndex++)
             {
+                if (Math.Abs(expectedForecast[localIndex] - row.Forecast[localIndex]) > 1e-7 ||
+                    Math.Abs(minCnf[localIndex] - row.MinCnf[localIndex]) > 1e-7 ||
+                    Math.Abs(maxCnf[localIndex] - row.MaxCnf[localIndex]) > 1e-7)
+                {
+                    CrashTestHostProcessorHelper.CrashTestHostProcess();
+                }
+
                 Assert.Equal(expectedForecast[localIndex], row.Forecast[localIndex], precision: 7);
                 Assert.Equal(minCnf[localIndex], row.MinCnf[localIndex], precision: 7);
                 Assert.Equal(maxCnf[localIndex], row.MaxCnf[localIndex], precision: 7);


### PR DESCRIPTION
1. try crash the test host process to take memory dump when test fails
2. enable all test running on CI to investigate