### PR TITLE
fix path in test that not working in linux and mac os

### DIFF
--- a/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/TestApi.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 {
     public partial class TestApi : BaseTestClass
     {
-        private const string OutputRelativePath = @"..\Common\Api";
+        private const string OutputRelativePath = @"../Common/Api";
 
         public TestApi(ITestOutputHelper output) : base(output)
         {

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -505,7 +505,7 @@ namespace Microsoft.ML.Tests
             foreach (var prediction in predictionColumn)
             {
                 if (k == 20)
-                    Assert.Equal(1, prediction.Prediction[0]);
+                    Assert.Equal(-1, prediction.Prediction[0]);
                 else
                     Assert.Equal(0, prediction.Prediction[0]);
                 k += 1;

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeriesDirectApi.cs
@@ -505,7 +505,7 @@ namespace Microsoft.ML.Tests
             foreach (var prediction in predictionColumn)
             {
                 if (k == 20)
-                    Assert.Equal(-1, prediction.Prediction[0]);
+                    Assert.Equal(1, prediction.Prediction[0]);
                 else
                     Assert.Equal(0, prediction.Prediction[0]);
                 k += 1;


### PR DESCRIPTION
Path in TestAPI is not working in linux and mac os and cause publish to artifacts fails:

https://dev.azure.com/dnceng/public/_build/results?buildId=501206&view=logs&j=5aa5c7df-492a-5eaf-973a-62b7b0f0ee3b

with error message:

Fail to upload '/home/vsts/work/1/a/AnyCPU.Release/Microsoft.ML.Tests/netcoreapp2.1/TestOutput/..\Common\Api/lambda-output.tsv' due to 'The following path is not valid: Ubuntu_x64_NetCoreApp21 R/AnyCPU.Release/Microsoft.ML.Tests/netcoreapp2.1/TestOutput/../Common/Api/lambda-output.tsv. Path segments must contain characters other than period and whitespace.'.

After fix, artifacts upload is success in all platform, below build is with this fix but an on purpose test fail, all builds fails and successfully uploads artifacts:
https://dev.azure.com/dnceng/public/_build/results?buildId=501376&view=results