### PR TITLE
Added Shuffle=false for all the Sdca related tests

### DIFF
--- a/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
+++ b/test/Microsoft.ML.Benchmarks/PredictionEngineBench.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Benchmarks
             var pipeline = new ColumnConcatenatingEstimator(env, "Features", new[] { "SepalLength", "SepalWidth", "PetalLength", "PetalWidth" })
                 .Append(env.Transforms.Conversion.MapValueToKey("Label"))
                 .Append(env.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1, ConvergenceTolerance = 1e-2f, }));
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1, ConvergenceTolerance = 1e-2f, Shuffle = false }));
 
             var model = pipeline.Fit(data);
 
@@ -93,7 +93,7 @@ namespace Microsoft.ML.Benchmarks
 
             var pipeline = mlContext.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .Append(mlContext.BinaryClassification.Trainers.SdcaNonCalibrated(
-                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, ConvergenceTolerance = 1e-2f, }));
+                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, ConvergenceTolerance = 1e-2f, Shuffle = false}));
 
             var model = pipeline.Fit(data);
 
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Benchmarks
             IDataView data = loader.Load(_breastCancerDataPath);
 
             var pipeline = env.BinaryClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, ConvergenceTolerance = 1e-2f, });
+                new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, ConvergenceTolerance = 1e-2f, Shuffle = false});
 
             var model = pipeline.Fit(data);
 

--- a/test/Microsoft.ML.Benchmarks/TextPredictionEngineCreation.cs
+++ b/test/Microsoft.ML.Benchmarks/TextPredictionEngineCreation.cs
@@ -28,7 +28,7 @@ namespace micro
             var pipeline = _context.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(_context)
                 .Append(_context.BinaryClassification.Trainers.SdcaNonCalibrated(
-                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Train.
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Functional.Tests/DataTransformation.cs
+++ b/test/Microsoft.ML.Functional.Tests/DataTransformation.cs
@@ -143,7 +143,7 @@ namespace Microsoft.ML.Functional.Tests
                     }, "SentimentText")
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
-                    new SdcaLogisticRegressionBinaryTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaLogisticRegressionBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Train the model.
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Functional.Tests/Debugging.cs
+++ b/test/Microsoft.ML.Functional.Tests/Debugging.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ML.Functional.Tests
             var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.Regression.Trainers.Sdca(
-                    new SdcaRegressionTrainer.Options { NumberOfThreads = 1, MaximumNumberOfIterations = 20 }));
+                    new SdcaRegressionTrainer.Options { NumberOfThreads = 1, MaximumNumberOfIterations = 20, Shuffle = false }));
 
             // Fit the pipeline to the data.
             var model = pipeline.Fit(data);
@@ -173,7 +173,7 @@ namespace Microsoft.ML.Functional.Tests
             var pipeline = mlContext.Transforms.Concatenate("Features", HousingRegression.Features)
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.Regression.Trainers.Sdca(
-                    new SdcaRegressionTrainer.Options { NumberOfThreads = 1, MaximumNumberOfIterations = 20 }));
+                    new SdcaRegressionTrainer.Options { NumberOfThreads = 1, MaximumNumberOfIterations = 20, Shuffle = false }));
 
             // Fit the pipeline to the data.
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Functional.Tests/Evaluation.cs
+++ b/test/Microsoft.ML.Functional.Tests/Evaluation.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Functional.Tests
             var pipeline = mlContext.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.BinaryClassification.Trainers.SdcaNonCalibrated(
-                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Train the model.
             var model = pipeline.Fit(data);
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Functional.Tests
                 .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Train the model.
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
@@ -218,7 +218,7 @@ namespace Microsoft.ML.Functional.Tests
             var pipeline = mlContext.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.BinaryClassification.Trainers.SdcaNonCalibrated(
-                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Fit the pipeline.
             var model = pipeline.Fit(data);
@@ -426,7 +426,9 @@ namespace Microsoft.ML.Functional.Tests
                 .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
                 new SdcaMaximumEntropyMulticlassTrainer.Options {
                     MaximumNumberOfIterations = 10,
-                    NumberOfThreads = 1 }));
+                    NumberOfThreads = 1,
+                    Shuffle = false
+                }));
         }
     }
 }

--- a/test/Microsoft.ML.Functional.Tests/Training.cs
+++ b/test/Microsoft.ML.Functional.Tests/Training.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Functional.Tests
 
             // Create a selection of learners.
             var sdcaTrainer = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
-                    new SdcaLogisticRegressionBinaryTrainer.Options { NumberOfThreads = 1 });
+                    new SdcaLogisticRegressionBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false });
 
             var fastTreeTrainer = mlContext.BinaryClassification.Trainers.FastTree(
                     new FastTreeBinaryTrainer.Options { NumberOfThreads = 1 });

--- a/test/Microsoft.ML.Tests/FeatureContributionTests.cs
+++ b/test/Microsoft.ML.Tests/FeatureContributionTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Tests
         public void TestSDCARegression()
         {
             TestFeatureContribution(ML.Regression.Trainers.Sdca(
-                new SdcaRegressionTrainer.Options { NumberOfThreads = 1, }), GetSparseDataset(numberOfInstances: 100), "SDCARegression");
+                new SdcaRegressionTrainer.Options { NumberOfThreads = 1, Shuffle = false }), GetSparseDataset(numberOfInstances: 100), "SDCARegression");
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Tests
         public void TestSDCABinary()
         {
             TestFeatureContribution(ML.BinaryClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, }), GetSparseDataset(TaskType.BinaryClassification, 100), "SDCABinary", precision: 5);
+                new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false}), GetSparseDataset(TaskType.BinaryClassification, 100), "SDCABinary", precision: 5);
         }
 
         [Fact]

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/DecomposableTrainAndPredict.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var pipeline = new ColumnConcatenatingEstimator (ml, "Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(new ValueToKeyMappingEstimator(ml, "Label"), TransformerScope.TrainTest)
                 .Append(ml.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1, }))
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = false, NumberOfThreads = 1, }))
                 .Append(new KeyToValueMappingEstimator(ml, "PredictedLabel"));
 
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/Extensibility.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
                 .Append(new CustomMappingEstimator<IrisData, IrisData>(ml, action, null), TransformerScope.TrainTest)
                 .Append(new ValueToKeyMappingEstimator(ml, "Label"), TransformerScope.TrainTest)
                 .Append(ml.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1 }))
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = false, NumberOfThreads = 1 }))
                 .Append(new KeyToValueMappingEstimator(ml, "PredictedLabel"));
 
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/MultithreadedPrediction.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(ml)
                 .Append(ml.BinaryClassification.Trainers.SdcaNonCalibrated(
-                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Train.
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/PredictAndMetadata.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var pipeline = ml.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(ml.Transforms.Conversion.MapValueToKey("Label"), TransformerScope.TrainTest)
                 .Append(ml.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1, }));
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = false, NumberOfThreads = 1, }));
 
             var model = pipeline.Fit(data).GetModelFor(TransformerScope.Scoring);
             var engine = ml.Model.CreatePredictionEngine<IrisDataNoLabel, IrisPredictionNotCasted>(model);
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var pipeline = mlContext.Transforms.Concatenate("Features", "SepalLength", "SepalWidth", "PetalLength", "PetalWidth")
                 .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
                 .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1, }));
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = false, NumberOfThreads = 1, }));
 
             var model = pipeline.Fit(data);
 

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/SimpleTrainAndPredict.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
             var pipeline = ml.Transforms.Text.FeaturizeText("Features", "SentimentText")
                 .AppendCacheCheckpoint(ml)
                 .Append(ml.BinaryClassification.Trainers.SdcaNonCalibrated(
-                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Train.
             var model = pipeline.Fit(data);

--- a/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/Estimators/TrainWithInitialPredictor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ML.Tests.Scenarios.Api
 
             // Train the first predictor.
             var trainer = ml.BinaryClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1 });
+                new SdcaNonCalibratedBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false });
 
             var firstModel = trainer.Fit(trainData);
 

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Scenarios
                             .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
                             .AppendCacheCheckpoint(mlContext)
                             .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                                new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1 }));
+                                new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Read training and test data sets
             string dataPath = GetDataPath(TestDatasets.iris.trainFilename);

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationWithStringLabelTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Scenarios
                 .Append(mlContext.Transforms.Conversion.MapValueToKey("Label", "IrisPlantType"), TransformerScope.TrainTest)
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1 }))
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1, Shuffle = false }))
                 .Append(mlContext.Transforms.Conversion.MapKeyToValue("Plant", "PredictedLabel"));
 
             // Train the pipeline

--- a/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/ScenariosWithDirectInstantiation/IrisPlantClassificationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Scenarios
                 .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
                 .AppendCacheCheckpoint(mlContext)
                 .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1 }));
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { NumberOfThreads = 1, Shuffle = false }));
 
             // Read training and test data sets
             string dataPath = GetDataPath(TestDatasets.iris.trainFilename);

--- a/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/MetalinearEstimators.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
         {
             var (pipeline, data) = GetMulticlassPipeline();
             var sdcaTrainer = ML.BinaryClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1 });
+                new SdcaNonCalibratedBinaryTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = false, NumberOfThreads = 1 });
 
             pipeline = pipeline.Append(ML.MulticlassClassification.Trainers.OneVersusAll(sdcaTrainer, useProbabilities: false))
                     .Append(new KeyToValueMappingEstimator(Env, "PredictedLabel"));
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             var (pipeline, data) = GetMulticlassPipeline();
 
             var sdcaTrainer = ML.BinaryClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = true, NumberOfThreads = 1 });
+                new SdcaNonCalibratedBinaryTrainer.Options { MaximumNumberOfIterations = 100, Shuffle = false, NumberOfThreads = 1 });
 
             pipeline = pipeline.Append(ML.MulticlassClassification.Trainers.PairwiseCoupling(sdcaTrainer))
                     .Append(ML.Transforms.Conversion.MapKeyToValue("PredictedLabelValue", "PredictedLabel"));
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                     LabelColumnName = "Label",
                     FeatureColumnName = "Vars",
                     MaximumNumberOfIterations = 100,
-                    Shuffle = true,
+                    Shuffle = false,
                     NumberOfThreads = 1,
                 });
 

--- a/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
+++ b/test/Microsoft.ML.Tests/TrainerEstimators/SdcaTests.cs
@@ -27,25 +27,25 @@ namespace Microsoft.ML.Tests.TrainerEstimators
                 .Fit(data).Transform(data);
 
             var binaryTrainer = ML.BinaryClassification.Trainers.SdcaLogisticRegression(
-                new SdcaLogisticRegressionBinaryTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10 });
+                new SdcaLogisticRegressionBinaryTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10, Shuffle= false });
             TestEstimatorCore(binaryTrainer, binaryData);
 
             var nonCalibratedBinaryTrainer = ML.BinaryClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedBinaryTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10 });
+                new SdcaNonCalibratedBinaryTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10, Shuffle = false });
             TestEstimatorCore(nonCalibratedBinaryTrainer, binaryData);
 
             var regressionTrainer = ML.Regression.Trainers.Sdca(
-                new SdcaRegressionTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10 });
+                new SdcaRegressionTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10, Shuffle = false });
 
             TestEstimatorCore(regressionTrainer, data);
             var mcData = ML.Transforms.Conversion.MapValueToKey("Label").Fit(data).Transform(data);
 
             var mcTrainer = ML.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                new SdcaMaximumEntropyMulticlassTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10 });
+                new SdcaMaximumEntropyMulticlassTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10, Shuffle = false });
             TestEstimatorCore(mcTrainer, mcData);
 
             var mcTrainerNonCalibrated = ML.MulticlassClassification.Trainers.SdcaNonCalibrated(
-                new SdcaNonCalibratedMulticlassTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10 });
+                new SdcaNonCalibratedMulticlassTrainer.Options { ConvergenceTolerance = 1e-2f, MaximumNumberOfIterations = 10, Shuffle = false });
             TestEstimatorCore(mcTrainerNonCalibrated, mcData);
 
             Done();
@@ -114,9 +114,9 @@ namespace Microsoft.ML.Tests.TrainerEstimators
 
             // SdcaLogisticRegression with and without weights.
             var sdcaWithoutWeightBinary = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
-                new SdcaLogisticRegressionBinaryTrainer.Options { NumberOfThreads = 1 });
+                new SdcaLogisticRegressionBinaryTrainer.Options { NumberOfThreads = 1, Shuffle = false });
             var sdcaWithWeightBinary = mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(
-                new SdcaLogisticRegressionBinaryTrainer.Options { ExampleWeightColumnName = "Weight", NumberOfThreads = 1 });
+                new SdcaLogisticRegressionBinaryTrainer.Options { ExampleWeightColumnName = "Weight", NumberOfThreads = 1, Shuffle = false });
 
             var modelWithoutWeights = sdcaWithoutWeightBinary.Fit(data);
             var modelWithWeights = sdcaWithWeightBinary.Fit(data);
@@ -169,11 +169,11 @@ namespace Microsoft.ML.Tests.TrainerEstimators
             // SdcaMaximumEntropy with and without weights.
             var sdcaWithoutWeightMulticlass = mlContext.Transforms.Conversion.MapValueToKey("LabelIndex", "Label").
                Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                   new SdcaMaximumEntropyMulticlassTrainer.Options { LabelColumnName = "LabelIndex", NumberOfThreads = 1 }));
+                   new SdcaMaximumEntropyMulticlassTrainer.Options { LabelColumnName = "LabelIndex", NumberOfThreads = 1, Shuffle = false }));
 
             var sdcaWithWeightMulticlass = mlContext.Transforms.Conversion.MapValueToKey("LabelIndex", "Label").
                 Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy(
-                    new SdcaMaximumEntropyMulticlassTrainer.Options { LabelColumnName = "LabelIndex", ExampleWeightColumnName = "Weight", NumberOfThreads = 1 }));
+                    new SdcaMaximumEntropyMulticlassTrainer.Options { LabelColumnName = "LabelIndex", ExampleWeightColumnName = "Weight", NumberOfThreads = 1, Shuffle = false }));
 
             var modelWithoutWeights = sdcaWithoutWeightMulticlass.Fit(data);
             var modelWithWeights = sdcaWithWeightMulticlass.Fit(data);


### PR DESCRIPTION
See discussion [here](https://github.com/dotnet/machinelearning/pull/4736)

Reviewers please check if any of them need to have to Shuffle=true.