### PR TITLE
can_reload_model test issue

### DIFF
--- a/test/Microsoft.Extensions.ML.Tests/Microsoft.Extensions.ML.Tests.csproj
+++ b/test/Microsoft.Extensions.ML.Tests/Microsoft.Extensions.ML.Tests.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\src\Microsoft.Extensions.ML\Microsoft.Extensions.ML.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.Transforms\Microsoft.ML.Transforms.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.ML.StandardTrainers\Microsoft.ML.StandardTrainers.csproj" />
+    <ProjectReference Include="..\Microsoft.ML.TestFrameworkCommon\Microsoft.ML.TestFrameworkCommon.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.ML.Tests/UriLoaderTests.cs
+++ b/test/Microsoft.Extensions.ML.Tests/UriLoaderTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.ML;
+using Microsoft.ML.TestFrameworkCommon;
 using Xunit;
 
 namespace Microsoft.Extensions.ML
@@ -45,7 +46,7 @@ namespace Microsoft.Extensions.ML
                         () => loaderUnderTest.GetReloadToken(),
                         () => changed.Set());
             
-            Assert.True(changed.WaitOne(60 * 1000), "UriLoader ChangeToken didn't fire before the allotted time.");
+            Assert.True(changed.WaitOne(AsyncTestHelper.UnexpectedTimeout), "UriLoader ChangeToken didn't fire before the allotted time.");
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.ML.Tests/UriLoaderTests.cs
+++ b/test/Microsoft.Extensions.ML.Tests/UriLoaderTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.ML
                         () => loaderUnderTest.GetReloadToken(),
                         () => changed.Set());
             
-            Assert.True(changed.WaitOne(1000), "UriLoader ChangeToken didn't fire before the allotted time.");
+            Assert.True(changed.WaitOne(60 * 1000), "UriLoader ChangeToken didn't fire before the allotted time.");
         }
 
         [Fact]

--- a/test/Microsoft.ML.TestFrameworkCommon/AsyncTestHelper.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/AsyncTestHelper.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.ML.TestFrameworkCommon
+{
+    public static class AsyncTestHelper
+    {
+        public static TimeSpan UnexpectedTimeout
+        {
+            get
+            {
+                return Debugger.IsAttached ? TimeSpan.FromHours(1) : TimeSpan.FromMinutes(1);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Increase wait time for can_reload_model test as we are observing some failures recently:

https://dev.azure.com/dnceng/public/_build/results?buildId=502691&view=logs&j=5aa5c7df-492a-5eaf-973a-62b7b0f0ee3b&t=ffdbd604-f3e2-5332-cf61-c8dd00799b47
https://dev.azure.com/dnceng/public/_build/results?buildId=502647&view=logs&j=5aa5c7df-492a-5eaf-973a-62b7b0f0ee3b&t=ffdbd604-f3e2-5332-cf61-c8dd00799b47
https://dev.azure.com/dnceng/public/_build/results?buildId=502589&view=logs&j=5aa5c7df-492a-5eaf-973a-62b7b0f0ee3b&t=ffdbd604-f3e2-5332-cf61-c8dd00799b47

tried several run with this fix, no can_reload_model failed again