### PR TITLE
Disable test parallelization in TimeSeries tests

### DIFF
--- a/test/Microsoft.ML.TimeSeries.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Extracted from #4569