### PR TITLE
add read share to all file read operation

### DIFF
--- a/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
+++ b/src/Microsoft.ML.Core/CommandLine/CmdParser.cs
@@ -976,7 +976,7 @@ namespace Microsoft.ML.CommandLine
             string args;
             try
             {
-                using (FileStream file = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+                using (FileStream file = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     args = (new StreamReader(file)).ReadToEnd();
                 }
@@ -1047,7 +1047,7 @@ namespace Microsoft.ML.CommandLine
             string nested;
             try
             {
-                using (FileStream file = new FileStream(path, FileMode.Open, FileAccess.Read))
+                using (FileStream file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     nested = (new StreamReader(file)).ReadToEnd();
                 }

--- a/src/Microsoft.ML.Core/Data/IFileHandle.cs
+++ b/src/Microsoft.ML.Core/Data/IFileHandle.cs
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Data
                 // Drop read streams that have already been disposed.
                 _streams.RemoveAll(s => !s.CanRead);
 
-                var stream = new FileStream(_fullPath, FileMode.Open, FileAccess.Read);
+                var stream = new FileStream(_fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
                 _streams.Add(stream);
                 return stream;
             }

--- a/src/Microsoft.ML.Core/Data/Repository.cs
+++ b/src/Microsoft.ML.Core/Data/Repository.cs
@@ -505,7 +505,7 @@ namespace Microsoft.ML
             string pathLower = pathEnt.ToLowerInvariant();
             if (PathMap.TryGetValue(pathLower, out pathAbs))
             {
-                stream = new FileStream(pathAbs, FileMode.Open, FileAccess.Read);
+                stream = new FileStream(pathAbs, FileMode.Open, FileAccess.Read, FileShare.Read);
             }
             else
             {
@@ -527,7 +527,7 @@ namespace Microsoft.ML
                     if (!PathMap.TryAdd(pathLower, pathTemp))
                         throw ExceptionContext.ExceptParam(nameof(name), "Duplicate entry: '{0}'", pathLower);
 
-                    stream = new FileStream(pathTemp, FileMode.Open, FileAccess.Read);
+                    stream = new FileStream(pathTemp, FileMode.Open, FileAccess.Read, FileShare.Read);
                 }
                 else
                 {

--- a/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
+++ b/src/Microsoft.ML.FastTree/TreeEnsembleFeaturizer.cs
@@ -632,7 +632,7 @@ namespace Microsoft.ML.Data
 
                     ch.Trace("Loading model");
                     IPredictor predictor;
-                    using (Stream strm = new FileStream(args.TrainedModelFile, FileMode.Open, FileAccess.Read))
+                    using (Stream strm = new FileStream(args.TrainedModelFile, FileMode.Open, FileAccess.Read, FileShare.Read))
                     using (var rep = RepositoryReader.Open(strm, ch))
                         ModelLoadContext.LoadModel<IPredictor, SignatureLoadModel>(host, out predictor, rep, ModelFileUtils.DirPredictor);
 

--- a/src/Microsoft.ML.ResultProcessor/ResultProcessor.cs
+++ b/src/Microsoft.ML.ResultProcessor/ResultProcessor.cs
@@ -465,7 +465,7 @@ namespace Microsoft.ML.ResultProcessor
                 {
                     Contracts.AssertNonEmpty(testArgs.InputModelFile);
                     string savedTrainCmd;
-                    using (Stream strm = new FileStream(testArgs.InputModelFile, FileMode.Open, FileAccess.Read))
+                    using (Stream strm = new FileStream(testArgs.InputModelFile, FileMode.Open, FileAccess.Read, FileShare.Read))
                     using (var rep = RepositoryReader.Open(strm))
                     {
                         var ent = rep.OpenEntryOrNull(ModelFileUtils.DirTrainingInfo, "Command.txt");


### PR DESCRIPTION
address file lock issue in test like below:

https://dev.azure.com/dnceng/public/_build/results?buildId=501414&view=logs&j=11c3dbcc-a5f4-5edd-335b-a8af5aa47d46&t=42ea9add-ee54-581f-d033-310ec15a7ff0
https://dev.azure.com/dnceng/public/_build/results?buildId=502370&view=logs&j=11c3dbcc-a5f4-5edd-335b-a8af5aa47d46&t=42ea9add-ee54-581f-d033-310ec15a7ff0
https://dev.azure.com/dnceng/public/_build/results?buildId=503598&view=logs&j=9dffbc46-9322-5a58-fb37-6d66c044e90d&t=11098bf6-eb78-583b-8eab-f14f48444a6b

allow other reader to read file when file is opened by file stream only for read

