### PR TITLE
Fix for ColumnSelecting issue

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
+++ b/src/Microsoft.ML.Data/Transforms/ColumnSelecting.cs
@@ -746,11 +746,6 @@ namespace Microsoft.ML.Transforms
 
                     droppedCols.Remove(srcCol.Index);
                 }
-
-                foreach (var srcCol in droppedCols)
-                {
-                    ctx.RemoveInputVariable(InputSchema[srcCol].Name);
-                }
             }
         }
 

--- a/test/BaselineOutput/Common/Onnx/Transforms/SelectColumns.txt
+++ b/test/BaselineOutput/Common/Onnx/Transforms/SelectColumns.txt
@@ -12,6 +12,31 @@
         "output": [
           "Size0"
         ],
+        "name": "Imputer",
+        "opType": "Imputer",
+        "attribute": [
+          {
+            "name": "replaced_value_float",
+            "f": "NaN",
+            "type": "FLOAT"
+          },
+          {
+            "name": "imputed_value_floats",
+            "floats": [
+              0
+            ],
+            "type": "FLOATS"
+          }
+        ],
+        "domain": "ai.onnx.ml"
+      },
+      {
+        "input": [
+          "Size0"
+        ],
+        "output": [
+          "Size1"
+        ],
         "name": "Identity",
         "opType": "Identity"
       },
@@ -47,7 +72,7 @@
       },
       {
         "input": [
-          "Size0"
+          "Size1"
         ],
         "output": [
           "Size.onnx"
@@ -110,7 +135,7 @@
         "name": "Thickness",
         "type": {
           "tensorType": {
-            "elemType": 6,
+            "elemType": 11,
             "shape": {
               "dim": [
                 {
@@ -128,7 +153,7 @@
         "name": "Size",
         "type": {
           "tensorType": {
-            "elemType": 6,
+            "elemType": 1,
             "shape": {
               "dim": [
                 {
@@ -159,6 +184,96 @@
             }
           }
         }
+      },
+      {
+        "name": "Adhesion",
+        "type": {
+          "tensorType": {
+            "elemType": 6,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "EpithelialSize",
+        "type": {
+          "tensorType": {
+            "elemType": 6,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "BlandChromatin",
+        "type": {
+          "tensorType": {
+            "elemType": 6,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "NormalNucleoli",
+        "type": {
+          "tensorType": {
+            "elemType": 6,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "Mitoses",
+        "type": {
+          "tensorType": {
+            "elemType": 6,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
       }
     ],
     "output": [
@@ -166,7 +281,7 @@
         "name": "Size.onnx",
         "type": {
           "tensorType": {
-            "elemType": 6,
+            "elemType": 1,
             "shape": {
               "dim": [
                 {
@@ -202,7 +317,7 @@
         "name": "Thickness.onnx",
         "type": {
           "tensorType": {
-            "elemType": 6,
+            "elemType": 11,
             "shape": {
               "dim": [
                 {
@@ -221,6 +336,26 @@
         "type": {
           "tensorType": {
             "elemType": 9,
+            "shape": {
+              "dim": [
+                {
+                  "dimValue": "1"
+                },
+                {
+                  "dimValue": "1"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "valueInfo": [
+      {
+        "name": "Size0",
+        "type": {
+          "tensorType": {
+            "elemType": 1,
             "shape": {
               "dim": [
                 {

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1473,8 +1473,8 @@ namespace Microsoft.ML.Tests
 
             var dataView = ML.Data.LoadFromTextFile(dataPath, new[] {
                 new TextLoader.Column("Label", DataKind.Boolean, 0),
-                new TextLoader.Column("Thickness", DataKind.Int32, 1),
-                new TextLoader.Column("Size", DataKind.Int32, 2),
+                new TextLoader.Column("Thickness", DataKind.Double, 1),
+                new TextLoader.Column("Size", DataKind.Single, 2),
                 new TextLoader.Column("Shape", DataKind.Int32, 3),
                 new TextLoader.Column("Adhesion", DataKind.Int32, 4),
                 new TextLoader.Column("EpithelialSize", DataKind.Int32, 5),
@@ -1483,7 +1483,7 @@ namespace Microsoft.ML.Tests
                 new TextLoader.Column("Mitoses", DataKind.Int32, 9),
             });
 
-            var pipeline = mlContext.Transforms.SelectColumns(new[] { "Size", "Shape", "Thickness", "Label" });
+            var pipeline = mlContext.Transforms.ReplaceMissingValues("Size").Append(mlContext.Transforms.SelectColumns(new[] { "Size", "Shape", "Thickness", "Label" }));
 
             var model = pipeline.Fit(dataView);
             var transformedData = model.Transform(dataView);
@@ -1510,9 +1510,9 @@ namespace Microsoft.ML.Tests
                 Assert.Equal("Thickness.onnx", outputNames[2]);
                 Assert.Equal("Label.onnx", outputNames[3]);
 
-                CompareSelectedScalarColumns<int>("Size", "Size.onnx", transformedData, onnxResult);
+                CompareSelectedScalarColumns<Single>("Size", "Size.onnx", transformedData, onnxResult);
                 CompareSelectedScalarColumns<int>("Shape", "Shape.onnx", transformedData, onnxResult);
-                CompareSelectedScalarColumns<int>("Thickness", "Thickness.onnx", transformedData, onnxResult);
+                CompareSelectedScalarColumns<double>("Thickness", "Thickness.onnx", transformedData, onnxResult);
                 CompareSelectedScalarColumns<bool>("Label", "Label.onnx", transformedData, onnxResult);
             }
 


### PR DESCRIPTION
There was an issue found when there's a transform prior to ColumnSelect that gets rid of the selected input variables in the ONNX graph. 

I modified the existing test to demonstrate this issue.

A (possibly temporary) fix is to not remove any of the input variables from the ONNX graph. 
   

