### PR TITLE
set max thread to unlimited to avoid dead lock

### DIFF
--- a/test/Microsoft.ML.Core.Tests/xunit.runner.json
+++ b/test/Microsoft.ML.Core.Tests/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "longRunningTestSeconds": 120,
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "maxParallelThreads": -1
 }

--- a/test/Microsoft.ML.OnnxTransformerTest/xunit.runner.json
+++ b/test/Microsoft.ML.OnnxTransformerTest/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "longRunningTestSeconds": 120,
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "maxParallelThreads": -1
 }

--- a/test/Microsoft.ML.Sweeper.Tests/xunit.runner.json
+++ b/test/Microsoft.ML.Sweeper.Tests/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "longRunningTestSeconds": 120,
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "maxParallelThreads": -1
 }

--- a/test/Microsoft.ML.TestFramework/xunit.runner.json
+++ b/test/Microsoft.ML.TestFramework/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "longRunningTestSeconds": 120,
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "maxParallelThreads": -1
 }

--- a/test/Microsoft.ML.Tests/xunit.runner.json
+++ b/test/Microsoft.ML.Tests/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "longRunningTestSeconds": 120,
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "maxParallelThreads": -1
 }


### PR DESCRIPTION
Related to: https://github.com/dotnet/machinelearning/issues/4773: 
Set max threads to unlimited is mitigation for dead lock issue in xunit tests, we should change the way we are using async code to prevent dead lock in future.

Collection of test hanging are collected at: https://microsoft.sharepoint.com/teams/ML.NET/_layouts/OneNote.aspx?id=%2Fteams%2FML.NET%2FSiteAssets%2FML.NET%20Notebook&wd=target%28Tests.one%7C5E713C2E-6DCF-4AA3-9071-69CBBAF48985%2FLong%20running%20tests%7C54A981BE-BFF2-4188-9520-7DE3E2DF0EDF%2F%29
onenote:https://microsoft.sharepoint.com/teams/ML.NET/SiteAssets/ML.NET%20Notebook/Tests.one#Long%20running%20tests&section-id={5E713C2E-6DCF-4AA3-9071-69CBBAF48985}&page-id={54A981BE-BFF2-4188-9520-7DE3E2DF0EDF}&end 

Runned 7 builds, no test hanging found.

