### PR TITLE
Fix onnx output name for GcnTransform

### DIFF
--- a/src/Microsoft.ML.Transforms/GcnTransform.cs
+++ b/src/Microsoft.ML.Transforms/GcnTransform.cs
@@ -617,7 +617,8 @@ namespace Microsoft.ML.Transforms
                         continue;
                     }
 
-                    if (!SaveAsOnnxCore(ctx, iinfo, ctx.GetVariableName(inputColumnName), ctx.AddIntermediateVariable(_srcTypes[iinfo], inputColumnName)))
+                    string outputColumnName = _parent.ColumnPairs[iinfo].outputColumnName;
+                    if (!SaveAsOnnxCore(ctx, iinfo, ctx.GetVariableName(inputColumnName), ctx.AddIntermediateVariable(_srcTypes[iinfo], outputColumnName)))
                     {
                         ctx.RemoveColumn(inputColumnName, true);
                     }


### PR DESCRIPTION
Fixed typo in GcnTransform SaveAsOnnx(..) where input column name is used instead of output one.