### PR TITLE
Fix for KeyToValue Onnx export 

### DIFF
--- a/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
+++ b/src/Microsoft.ML.Data/Transforms/KeyToValue.cs
@@ -510,20 +510,40 @@ namespace Microsoft.ML.Transforms
                     var t = InternalDataKindExtensions.ToInternalDataKind(DataKind.Int64).ToType();
                     castNode.AddAttribute("to", t);
 
+                    var labelEncoderOutput = dstVariableName;
+                    var labelEncoderInput = srcVariableName;
+                    if (TypeOutput == NumberDataViewType.Double || TypeOutput == NumberDataViewType.Int64)
+                        labelEncoderOutput = ctx.AddIntermediateVariable(TypeOutput, "CastNodeOutput", true);
+
                     opType = "LabelEncoder";
-                    var node = ctx.CreateNode(opType, castNodeOutput, dstVariableName, ctx.GetNodeName(opType));
+                    var node = ctx.CreateNode(opType, castNodeOutput, labelEncoderOutput, ctx.GetNodeName(opType));
                     var keys = Array.ConvertAll<int, long>(Enumerable.Range(1, _values.Length).ToArray(), item => Convert.ToInt64(item));
                     node.AddAttribute("keys_int64s", keys);
 
                     if (TypeOutput == NumberDataViewType.Int64)
                     {
-                        long[] values = Array.ConvertAll<TValue, long>(_values.GetValues().ToArray(), item => Convert.ToInt64(item));
-                        node.AddAttribute("values_int64s", values);
+                        // LabelEncoder doesn't support mapping int64 -> int64, so values are converted to strings and later cast back to Int64s
+                        string[] values = Array.ConvertAll<TValue, string>(_values.GetValues().ToArray(), item => Convert.ToString(item));
+                        node.AddAttribute("values_strings", values);
+                        opType = "Cast";
+                        castNode = ctx.CreateNode(opType, labelEncoderOutput, dstVariableName, ctx.GetNodeName(opType), "");
+                        t = InternalDataKindExtensions.ToInternalDataKind(DataKind.Int64).ToType();
+                        castNode.AddAttribute("to", t);
                     }
-                    else if (TypeOutput == NumberDataViewType.Double || TypeOutput == NumberDataViewType.Single)
+                    else if (TypeOutput == NumberDataViewType.Single)
                     {
                         float[] values = Array.ConvertAll<TValue, float>(_values.GetValues().ToArray(), item => Convert.ToSingle(item));
                         node.AddAttribute("values_floats", values);
+                    }
+                    else if (TypeOutput == NumberDataViewType.Double)
+                    {
+                        // LabelEncoder doesn't support double tensors, so values are converted to floats and later cast back to doubles
+                        float[] values = Array.ConvertAll<TValue, float>(_values.GetValues().ToArray(), item => Convert.ToSingle(item));
+                        node.AddAttribute("values_floats", values);
+                        opType = "Cast";
+                        castNode = ctx.CreateNode(opType, labelEncoderOutput, dstVariableName, ctx.GetNodeName(opType), "");
+                        t = InternalDataKindExtensions.ToInternalDataKind(DataKind.Double).ToType();
+                        castNode.AddAttribute("to", t);
                     }
                     else if (TypeOutput == TextDataViewType.Instance)
                     {

--- a/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
+++ b/src/Microsoft.ML.Data/Transforms/ValueToKeyMappingTransformer.cs
@@ -803,6 +803,7 @@ namespace Microsoft.ML.Transforms
                 }
                 else if (info.TypeSrc.GetItemType().Equals(NumberDataViewType.Double))
                 {
+                    // LabelEncoder doesn't support double tensors, so values are cast to floats
                     var castOutput = ctx.AddIntermediateVariable(null, "castOutput", true);
                     castNode = ctx.CreateNode("Cast", srcVariableName, castOutput, ctx.GetNodeName(opType), "");
                     var t = InternalDataKindExtensions.ToInternalDataKind(DataKind.Single).ToType();
@@ -813,6 +814,7 @@ namespace Microsoft.ML.Transforms
                 }
                 else if (info.TypeSrc.GetItemType().Equals(NumberDataViewType.Int64))
                 {
+                    // LabelEncoder doesn't support mapping int64 -> int64, so values are cast to strings
                     var castOutput = ctx.AddIntermediateVariable(null, "castOutput", true);
                     castNode = ctx.CreateNode("Cast", srcVariableName, castOutput, ctx.GetNodeName(opType), "");
                     var t = InternalDataKindExtensions.ToInternalDataKind(DataKind.String).ToType();


### PR DESCRIPTION
- Like for ValueToKey,  mapping int64 -> int64 needs casting
- Cast float values back to doubles, when the valuetype is expected to be a double 

The current KeyToValue test makes it hard to test different value types, so I added KeyToValue to the ValueToKey pipeline, which is more flexible. Comparing the keys checks ValueToKey and comparing the value output checks KeyToValue. If this test is ok, I can remove the current KeyToValue test. Otherwise, I can modify the KeyToValue test to follow a similar format.   