### PR TITLE
modify base test class analyzer, allow to extend from ft base test class

### DIFF
--- a/tools-local/Microsoft.ML.InternalCodeAnalyzer/BaseTestClassAnalyzer.cs
+++ b/tools-local/Microsoft.ML.InternalCodeAnalyzer/BaseTestClassAnalyzer.cs
@@ -16,10 +16,10 @@ namespace Microsoft.ML.InternalCodeAnalyzer
         private const string Category = "Test";
         internal const string DiagnosticId = "MSML_ExtendBaseTestClass";
 
-        private const string Title = "Test classes should be derived from BaseTestClass";
-        private const string Format = "Test class '{0}' should extend BaseTestClass.";
+        private const string Title = "Test classes should be derived from BaseTestClass or FunctionalTestBaseClass";
+        private const string Format = "Test class '{0}' should extend BaseTestClass or FunctionalTestBaseClass.";
         private const string Description =
-            "Test classes should be derived from BaseTestClass.";
+            "Test classes should be derived from BaseTestClass or FunctionalTestBaseClass.";
 
         private static DiagnosticDescriptor Rule =
             new DiagnosticDescriptor(DiagnosticId, Title, Format, Category,
@@ -51,6 +51,7 @@ namespace Microsoft.ML.InternalCodeAnalyzer
             private readonly Compilation _compilation;
             private readonly INamedTypeSymbol _factAttribute;
             private readonly INamedTypeSymbol _baseTestClass;
+            private readonly INamedTypeSymbol _FTbaseTestClass;
             private readonly ConcurrentDictionary<INamedTypeSymbol, bool> _knownTestAttributes = new ConcurrentDictionary<INamedTypeSymbol, bool>();
 
             public AnalyzerImpl(Compilation compilation, INamedTypeSymbol factAttribute)
@@ -58,6 +59,7 @@ namespace Microsoft.ML.InternalCodeAnalyzer
                 _compilation = compilation;
                 _factAttribute = factAttribute;
                 _baseTestClass = _compilation.GetTypeByMetadataName("Microsoft.ML.TestFramework.BaseTestClass");
+                _FTbaseTestClass = _compilation.GetTypeByMetadataName("Microsoft.ML.Functional.Tests.FunctionalTestBaseClass");
             }
 
             public void AnalyzeNamedType(SymbolAnalysisContext context)
@@ -87,12 +89,14 @@ namespace Microsoft.ML.InternalCodeAnalyzer
 
             private bool ExtendsBaseTestClass(INamedTypeSymbol namedType)
             {
-                if (_baseTestClass is null)
+                if (_baseTestClass is null && 
+                    _FTbaseTestClass is null)
                     return false;
 
                 for (var current = namedType; current is object; current = current.BaseType)
                 {
-                    if (Equals(current, _baseTestClass))
+                    if (Equals(current, _baseTestClass) ||
+                        Equals(current, _FTbaseTestClass))
                         return true;
                 }
 


### PR DESCRIPTION
We have separate base test class for all functional tests: FunctionalTestBaseClass
The reason for that is FT is also runned on NightlyBuild pipeline which not take project dependency directly but take ML.NET related Nuget package as dependency and we don't want FT to take dependency from TestFramework.