### PR TITLE
remove build timeout as perf bump

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -61,8 +61,7 @@ jobs:
         _includeBenchmarkData: true
     innerLoop: true
     pool:
-      name: NetCorePublic-Pool
-      queue: buildpool.windows.10.amd64.vs2017.open
+      name: Hosted VS2017
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -61,7 +61,8 @@ jobs:
         _includeBenchmarkData: true
     innerLoop: true
     pool:
-      name: Hosted VS2017
+      name: NetCorePublic-Pool
+      queue: buildpool.windows.10.amd64.vs2017.open
 
 - template: /build/ci/job-template.yml
   parameters:

--- a/build/ci/job-template.yml
+++ b/build/ci/job-template.yml
@@ -53,7 +53,6 @@ jobs:
         displayName: Set LD_LIBRARY_PATH for Ubuntu to locate Native shared library in current running path
     - script: ${{ parameters.buildScript }} -$(_configuration) -buildArch=${{ parameters.architecture }}
       displayName: Build
-      timeoutInMinutes: 20
     - ${{ if eq(parameters.nightlyBuild, 'true') }}:
       - script: $(dotnetPath) restore $(nightlyBuildProjPath)
         displayName: Restore nightly build project


### PR DESCRIPTION
seeing build perf bump like below few builds:
https://dev.azure.com/dnceng/public/_build/results?buildId=510766&view=logs&j=4a5328fc-3628-53de-aa0c-9ba4571cae61&t=d953246d-9492-5686-12cd-f07513b595b7
https://dev.azure.com/dnceng/public/_build/results?buildId=510972&view=logs&j=11c3dbcc-a5f4-5edd-335b-a8af5aa47d46&s=d654deb9-056d-50a2-1717-90c08683d50a
https://dev.azure.com/dnceng/public/_build/results?buildId=510945&view=logs&j=4a5328fc-3628-53de-aa0c-9ba4571cae61&t=d953246d-9492-5686-12cd-f07513b595b7

this PR remove build timeout as perf bump

Can't use hosted agent pool for netcore3.0 due to space limitation:
https://dev.azure.com/dnceng/public/_build/results?buildId=512080&view=logs&jobId=4a5328fc-3628-53de-aa0c-9ba4571cae61&j=4a5328fc-3628-53de-aa0c-9ba4571cae61&t=d953246d-9492-5686-12cd-f07513b595b7

