### PR TITLE
Fix for NgramTransform

### DIFF
--- a/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
+++ b/src/Microsoft.ML.Transforms/Text/NgramTransform.cs
@@ -768,7 +768,7 @@ namespace Microsoft.ML.Transforms.Text
                 }
             }
 
-            private void SaveAsOnnxCore(OnnxContext ctx, int iinfo, string srcVariableName, string dstVariableName )
+            private void SaveAsOnnxCore(OnnxContext ctx, int iinfo, string srcVariableName, string dstVariableName)
             {
                 VBuffer<ReadOnlyMemory<char>> slotNames = default;
                 GetSlotNames(iinfo, 0, ref slotNames);
@@ -777,13 +777,15 @@ namespace Microsoft.ML.Transforms.Text
 
                 // TfIdfVectorizer accepts strings, int32 and int64 tensors.
                 // But in the ML.NET implementation of the NGramTransform, it only accepts keys as inputs
-                // That are the result of ValueToKeyMapping transformer, which outputs UInt32 values
-                // So, if it is UInt32 or UInt64, cast the output here to Int32/Int64
+                // That are the result of ValueToKeyMapping transformer, which outputs UInt32 values,
+                // Or TokenizingByCharacters, which outputs UInt16 values
+                // So, if it is UInt32, UInt64, or UInt16, cast the output here to Int32/Int64
                 string opType;
                 var vectorType = _srcTypes[iinfo] as VectorDataViewType;
 
                 if ((vectorType != null) &&
-                    ((vectorType.RawType == typeof(VBuffer<UInt32>)) || (vectorType.RawType == typeof(VBuffer<UInt64>))))
+                    ((vectorType.RawType == typeof(VBuffer<UInt32>)) || (vectorType.RawType == typeof(VBuffer<UInt64>)) ||
+                    (vectorType.RawType == typeof(VBuffer<UInt16>))))
                 {
                     var dataKind = _srcTypes[iinfo] == NumberDataViewType.UInt32 ? DataKind.Int32 : DataKind.Int64;
 

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1205,7 +1205,7 @@ namespace Microsoft.ML.Tests
 
         [Theory]
         [CombinatorialData]
-        public void NgramOnnxConnversionTest(
+        public void NgramOnnxConversionTest(
             [CombinatorialValues(1, 2, 3)] int ngramLength,
             bool useAllLength,
             NgramExtractingEstimator.WeightingCriteria weighting)
@@ -1231,6 +1231,12 @@ namespace Microsoft.ML.Tests
                                             useAllLengths: useAllLength,
                                             weighting: weighting)),
 
+                mlContext.Transforms.Text.TokenizeIntoCharactersAsKeys("Tokens", "Text")
+                .Append(mlContext.Transforms.Text.ProduceNgrams("NGrams", "Tokens",
+                            ngramLength: ngramLength,
+                            useAllLengths: useAllLength,
+                            weighting: weighting)),
+
                 mlContext.Transforms.Text.ProduceWordBags("Tokens", "Text",
                                         ngramLength: ngramLength,
                                         useAllLengths: useAllLength,
@@ -1255,10 +1261,9 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxFilePath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedR4VectorColumns(transformedData.Schema[3].Name, outputNames[outputNames.Length-1], transformedData, onnxResult, 3);
+                    CompareSelectedR4VectorColumns(transformedData.Schema[transformedData.Schema.Count-1].Name, outputNames[outputNames.Length-1], transformedData, onnxResult, 3); //comparing Ngrams
                 }
             }
-
             Done();
         }
 


### PR DESCRIPTION
- Casting UInt16 -> Int64  inside NgramTransform, since it may now receive UInt16 keys from TokeningByCharacters
