### PR TITLE
improve logging for Functional Tests

### DIFF
--- a/test/Microsoft.ML.Functional.Tests/SchemaDefinitionTests.cs
+++ b/test/Microsoft.ML.Functional.Tests/SchemaDefinitionTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.ML.Functional.Tests
             base.Initialize();
 
             _ml = new MLContext(42);
+            _ml.Log += LogTestOutput;
         }
 
         [Fact]

--- a/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
+++ b/test/Microsoft.ML.TestFramework/BaseTestBaseline.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Microsoft.ML.Internal.Utilities;
 using Microsoft.ML.Runtime;
 using Microsoft.ML.TestFramework;
+using Microsoft.ML.TestFrameworkCommon;
 using Microsoft.ML.Tools;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/Microsoft.ML.TestFrameworkCommon/TestLogger.cs
+++ b/test/Microsoft.ML.TestFrameworkCommon/TestLogger.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Text;
 using Xunit.Abstractions;
 
-namespace Microsoft.ML.TestFramework
+namespace Microsoft.ML.TestFrameworkCommon
 {
     public sealed class TestLogger : TextWriter
     {


### PR DESCRIPTION
Better logging for FT:
1. add test output logging handler and MessageKindToLog in FT base class
2. move TestLogger to TestFrameworkCommon project as this is more common test project and we might need to use TestLogger in future for FT
