### PR TITLE
Fixed bugs in OptionalColumnTransform and added bool support

### DIFF
--- a/src/Microsoft.ML.Data/Model/Onnx/OnnxContext.cs
+++ b/src/Microsoft.ML.Data/Model/Onnx/OnnxContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.ML.Data;
 
@@ -130,7 +131,16 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract List<long> RetrieveShapeOrNull(string variableName);
 
         /// <summary>
-        /// Call this function can declare a global float
+        /// Call this function to declare a global bool
+        /// </summary>
+        /// <param name="value">The boolean value which is going to be added</param>
+        /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
+        /// <returns>The initializer's ONNX name</returns>
+        public abstract string AddInitializer(bool value, string name = null, bool makeUniqueName = true);
+
+        /// <summary>
+        /// Call this function to declare a global float
         /// </summary>
         /// <param name="value">The float number which is going to be added</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
@@ -139,16 +149,17 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(float value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function can declare a global long
+        /// Call this function to declare a global float
         /// </summary>
-        /// <param name="value">The long number which is going to be added into the ONNX graph</param>
+        /// <param name="value">The float number which is going to be added</param>
+        /// <param name="type">The type of integer to be added, e.g. typeof(short). Use this for all integer types smaller than Int32</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
         /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(long value, string name = null, bool makeUniqueName = true);
+        public abstract string AddInitializer(int value, Type type, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function can declare a global string
+        /// Call this function to declare a global string
         /// </summary>
         /// <param name="value">The string which is going to be added into the ONNX graph</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
@@ -157,43 +168,103 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(string value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function can declare a global float tensor
+        /// Call this function to declare a global long
+        /// </summary>
+        /// <param name="value">The long number which is going to be added into the ONNX graph</param>
+        /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
+        /// <returns>The initializer's ONNX name</returns>
+        public abstract string AddInitializer(long value, string name = null, bool makeUniqueName = true);
+
+        /// <summary>
+        /// Call this function to declare a global double
+        /// </summary>
+        /// <param name="value">The double number which is going to be added into the ONNX graph</param>
+        /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
+        /// <returns>The initializer's ONNX name</returns>
+        public abstract string AddInitializer(double value, string name = null, bool makeUniqueName = true);
+
+        /// <summary>
+        /// Call this function to declare a global ulong or uint
+        /// </summary>
+        /// <param name="value">The long number which is going to be added into the ONNX graph</param>
+        /// <param name="isUint64">true if value contains a ulong value and false if it contains uint </param>
+        /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
+        /// <returns>The initializer's ONNX name</returns>
+        public abstract string AddInitializer(ulong value, bool isUint64, string name = null, bool makeUniqueName = true);
+
+        /// <summary>
+        /// Call this function to declare a global bool tensor
+        /// </summary>
+        /// <param name="values">The boolean values which are going to be added into the ONNX graph</param>
+        /// <param name="dims">The shape of values</param>
+        /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
+        /// <returns>The initializer's ONNX name</returns>
+        public abstract string AddInitializer(IEnumerable<bool> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
+
+        /// <summary>
+        /// Call this function to declare a global float tensor
         /// </summary>
         /// <param name="values">The floats which are going to be added into the ONNX graph</param>
-        /// <param name="dims">The shape that the floats</param>
+        /// <param name="dims">The shape of values</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
         /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
         public abstract string AddInitializer(IEnumerable<float> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function can declare a global long tensor
+        /// Call this function to declare a global long tensor
+        /// </summary>
+        /// <param name="values">The ints which are going to be added into the ONNX graph</param>
+        /// <param name="type">The type of ints which are going to be added into the ONNX graph, e.g. typeof(short). Use this for adding array initializers of integer types smaller than Int32</param>
+        /// <param name="dims">The shape of values</param>
+        /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
+        /// <returns>The initializer's ONNX name</returns>
+        public abstract string AddInitializer(IEnumerable<int> values, Type type, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
+
+        /// <summary>
+        /// Call this function to declare a global string tensor
+        /// </summary>
+        /// <param name="values">The strings which are going to be added into the ONNX graph</param>
+        /// <param name="dims">The shape of values</param>
+        /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
+        /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
+        /// <returns>The initializer's ONNX name</returns>
+        public abstract string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
+
+        /// <summary>
+        /// Call this function to declare a global long tensor
         /// </summary>
         /// <param name="values">The longs which are going to be added into the ONNX graph</param>
-        /// <param name="dims">The shape that the floats</param>
+        /// <param name="dims">The shape of values</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
         /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
         public abstract string AddInitializer(IEnumerable<long> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function can declare a global double tensor
+        /// Call this function to declare a global double tensor
         /// </summary>
         /// <param name="values">The doubles which are going to be added into the ONNX graph</param>
-        /// <param name="dims">The shape that the doubles</param>
+        /// <param name="dims">The shape of values</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
         /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
         public abstract string AddInitializer(IEnumerable<double> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function can declare a global string tensor
+        /// Call this function to declare a global double tensor
         /// </summary>
-        /// <param name="values">The strings which are going to be added into the ONNX graph</param>
-        /// <param name="dims">The shape that the strings</param>
+        /// <param name="values">The unsigned integers which are going to be added into the ONNX graph</param>
+        /// <param name="isUint64">Set to true if values contain ulong values false if they contain uint values</param>
+        /// <param name="dims">The shape of values</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
         /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
-        public abstract string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
+        public abstract string AddInitializer(IEnumerable<ulong> values, bool isUint64, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
     }
 }

--- a/src/Microsoft.ML.Data/Model/Onnx/OnnxContext.cs
+++ b/src/Microsoft.ML.Data/Model/Onnx/OnnxContext.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract List<long> RetrieveShapeOrNull(string variableName);
 
         /// <summary>
-        /// Call this function to declare a global bool
+        /// Call this function to declare a global bool scalar
         /// </summary>
         /// <param name="value">The boolean value which is going to be added</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
@@ -140,7 +140,7 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(bool value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global float
+        /// Call this function to declare a global float scalar
         /// </summary>
         /// <param name="value">The float number which is going to be added</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
@@ -149,17 +149,17 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(float value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global float
+        /// Call this function to declare a global integer scalar or smaller types
         /// </summary>
         /// <param name="value">The float number which is going to be added</param>
-        /// <param name="type">The type of integer to be added, e.g. typeof(short). Use this for all integer types smaller than Int32</param>
+        /// <param name="type">The type of integer to be added, e.g. typeof(short). Use this for all integer types Int32 and smaller</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
         /// <param name="makeUniqueName">Whether a unique name should be picked for this initializer.</param>
         /// <returns>The initializer's ONNX name</returns>
         public abstract string AddInitializer(int value, Type type, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global string
+        /// Call this function to declare a global string scalar
         /// </summary>
         /// <param name="value">The string which is going to be added into the ONNX graph</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
@@ -168,7 +168,7 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(string value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global long
+        /// Call this function to declare a global long scalar
         /// </summary>
         /// <param name="value">The long number which is going to be added into the ONNX graph</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
@@ -177,7 +177,7 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(long value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global double
+        /// Call this function to declare a global double scalar
         /// </summary>
         /// <param name="value">The double number which is going to be added into the ONNX graph</param>
         /// <param name="name">A string used as a seed to generate this initializer's name in the ONNX graph.</param>
@@ -186,7 +186,7 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(double value, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global ulong or uint
+        /// Call this function to declare a global ulong or uint scalar
         /// </summary>
         /// <param name="value">The long number which is going to be added into the ONNX graph</param>
         /// <param name="isUint64">true if value contains a ulong value and false if it contains uint </param>
@@ -216,7 +216,7 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(IEnumerable<float> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global long tensor
+        /// Call this function to declare a global tensor of integer or smaller types
         /// </summary>
         /// <param name="values">The ints which are going to be added into the ONNX graph</param>
         /// <param name="type">The type of ints which are going to be added into the ONNX graph, e.g. typeof(short). Use this for adding array initializers of integer types smaller than Int32</param>
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Model.OnnxConverter
         public abstract string AddInitializer(IEnumerable<double> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true);
 
         /// <summary>
-        /// Call this function to declare a global double tensor
+        /// Call this function to declare a global ulong tensor
         /// </summary>
         /// <param name="values">The unsigned integers which are going to be added into the ONNX graph</param>
         /// <param name="isUint64">Set to true if values contain ulong values false if they contain uint values</param>

--- a/src/Microsoft.ML.OnnxConverter/OnnxContextImpl.cs
+++ b/src/Microsoft.ML.OnnxConverter/OnnxContextImpl.cs
@@ -279,10 +279,24 @@ namespace Microsoft.ML.Model.OnnxConverter
         }
 
         /// Adds constant tensor into the graph.
+        public override string AddInitializer(bool value, string name = null, bool makeUniqueName = true)
+        {
+            name = AddVariable(name ?? "bool", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeInt32(name, typeof(bool), value ? 1 : 0));
+            return name;
+        }
+
         public override string AddInitializer(float value, string name = null, bool makeUniqueName = true)
         {
             name = AddVariable(name ?? "float", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeFloat(name, value));
+            return name;
+        }
+
+        public override string AddInitializer(int value, Type type, string name = null, bool makeUniqueName = true)
+        {
+            name = AddVariable(name ?? "int32", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeInt32(name, type, value));
             return name;
         }
 
@@ -300,6 +314,31 @@ namespace Microsoft.ML.Model.OnnxConverter
             return name;
         }
 
+        public override string AddInitializer(double value, string name = null, bool makeUniqueName = true)
+        {
+            name = AddVariable(name ?? "double", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeDouble(name, value));
+            return name;
+        }
+
+        public override string AddInitializer(ulong value, bool isUint64, string name = null, bool makeUniqueName = true)
+        {
+            name = AddVariable(name ?? "uint64", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeUInt(name, isUint64, value));
+            return name;
+        }
+
+        public override string AddInitializer(IEnumerable<bool> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
+        {
+            _host.CheckValue(values, nameof(values));
+            if (dims != null)
+                _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
+
+            name = AddVariable(name ?? "bools", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeInt32s(name, typeof(bool), values.Select(v => Convert.ToInt32(v)), dims));
+            return name;
+        }
+
         public override string AddInitializer(IEnumerable<float> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
         {
             _host.CheckValue(values, nameof(values));
@@ -308,6 +347,28 @@ namespace Microsoft.ML.Model.OnnxConverter
 
             name = AddVariable(name ?? "floats", makeUniqueName);
             _initializers.Add(OnnxUtils.MakeFloats(name, values, dims));
+            return name;
+        }
+
+        public override string AddInitializer(IEnumerable<int> values, Type type, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
+        {
+            _host.CheckValue(values, nameof(values));
+            if (dims != null)
+                _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
+
+            name = AddVariable(name ?? "int32s", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeInt32s(name, type, values, dims));
+            return name;
+        }
+
+        public override string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
+        {
+            _host.CheckValue(values, nameof(values));
+            if (dims != null)
+                _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
+
+            name = AddVariable(name ?? "strings", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeStrings(name, values, dims));
             return name;
         }
 
@@ -328,19 +389,19 @@ namespace Microsoft.ML.Model.OnnxConverter
             if (dims != null)
                 _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
 
-            name = AddVariable(name ?? "double", makeUniqueName);
-            _initializers.Add(OnnxUtils.MakeDouble(name, values, dims));
+            name = AddVariable(name ?? "doubles", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeDoubles(name, values, dims));
             return name;
         }
 
-        public override string AddInitializer(IEnumerable<string> values, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
+        public override string AddInitializer(IEnumerable<ulong> values, bool isUint64, IEnumerable<long> dims, string name = null, bool makeUniqueName = true)
         {
             _host.CheckValue(values, nameof(values));
             if (dims != null)
                 _host.Check(dims.Aggregate((x, y) => x * y) == values.Count(), "Number of elements doesn't match tensor size");
 
-            name = AddVariable(name ?? "strings", makeUniqueName);
-            _initializers.Add(OnnxUtils.MakeStrings(name, values, dims));
+            name = AddVariable(name ?? "uints", makeUniqueName);
+            _initializers.Add(OnnxUtils.MakeUInts(name, isUint64, values, dims));
             return name;
         }
 

--- a/src/Microsoft.ML.OnnxConverter/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxConverter/OnnxUtils.cs
@@ -410,8 +410,66 @@ namespace Microsoft.ML.Model.OnnxConverter
             return tensor;
         }
 
+        // Make int32 and smaller integer types scalar in ONNX from native C# number
+        public static TensorProto MakeInt32(string name, Type type, int value)
+        {
+            var tensor = new TensorProto();
+            tensor.Name = name;
+            tensor.DataType = (int)ConvertToTensorProtoType(type);
+            tensor.Int32Data.Add(value);
+            return tensor;
+        }
+
+        // Make int32 and smaller integer types vector (i.e., 1-D tensor) with dims=null. Otherwise, dims is used as the shape of the produced tensor.
+        public static TensorProto MakeInt32s(string name, Type type, IEnumerable<int> values, IEnumerable<long> dims = null)
+        {
+            var tensor = new TensorProto();
+            tensor.Name = name;
+            tensor.DataType = (int)ConvertToTensorProtoType(type);
+            tensor.Int32Data.AddRange(values);
+            if (dims != null)
+                tensor.Dims.AddRange(dims);
+            else
+                tensor.Dims.Add(values.Count());
+            return tensor;
+        }
+
+        // Make ulong and uint integer types scalar in ONNX from native C# number
+        public static TensorProto MakeUInt(string name, bool isUint64, ulong value)
+        {
+            var tensor = new TensorProto();
+            tensor.Name = name;
+            tensor.DataType = (int)ConvertToTensorProtoType(isUint64 ? typeof(ulong) : typeof(uint));
+            tensor.Uint64Data.Add(value);
+            return tensor;
+        }
+
+        // Make ulong and uint integer vector (i.e., 1-D tensor) with dims=null. Otherwise, dims is used as the shape of the produced tensor.
+        public static TensorProto MakeUInts(string name, bool isUint64, IEnumerable<ulong> values, IEnumerable<long> dims = null)
+        {
+            var tensor = new TensorProto();
+            tensor.Name = name;
+            tensor.DataType = (int)ConvertToTensorProtoType(isUint64 ? typeof(ulong) : typeof(uint));
+            tensor.Uint64Data.AddRange(values);
+            if (dims != null)
+                tensor.Dims.AddRange(dims);
+            else
+                tensor.Dims.Add(values.Count());
+            return tensor;
+        }
+
+        // Make int32 and smaller integer types scalar in ONNX from native C# number
+        public static TensorProto MakeDouble(string name, double value)
+        {
+            var tensor = new TensorProto();
+            tensor.Name = name;
+            tensor.DataType = (int)TensorProto.Types.DataType.Double;
+            tensor.DoubleData.Add(value);
+            return tensor;
+        }
+
         // Make double vector (i.e., 1-D tensor) with dims=null. Otherwise, dims is used as the shape of the produced tensor.
-        public static TensorProto MakeDouble(string name, IEnumerable<double> values, IEnumerable<long> dims = null)
+        public static TensorProto MakeDoubles(string name, IEnumerable<double> values, IEnumerable<long> dims = null)
         {
             var tensor = new TensorProto();
             tensor.Name = name;

--- a/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxUtils.cs
@@ -393,7 +393,9 @@ namespace Microsoft.ML.Transforms.Onnx
                      typeof(UInt32),
                      typeof(UInt64),
                      typeof(ReadOnlyMemory<Char>),
-                     typeof(Boolean)
+                     typeof(Boolean),
+                     typeof(SByte),
+                     typeof(Byte)
                 };
         private static Dictionary<Type, InternalDataKind> _typeToKindMap=
             new Dictionary<Type, InternalDataKind>
@@ -408,6 +410,8 @@ namespace Microsoft.ML.Transforms.Onnx
                     { typeof(UInt64) , InternalDataKind.U8},
                     { typeof(String) , InternalDataKind.TX},
                     { typeof(Boolean) , InternalDataKind.BL},
+                    { typeof(SByte) , InternalDataKind.I1},
+                    { typeof(Byte) , InternalDataKind.U1},
                 };
 
         /// <summary>

--- a/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
+++ b/src/Microsoft.ML.Transforms/OptionalColumnTransform.cs
@@ -534,19 +534,28 @@ namespace Microsoft.ML.Transforms
             else
                 size = 1;
 
-            // REVIEW:
-            // AddInitializer only supports long, float, double and string.
-            // Here we are casting ulong to long. Fixing this would involve
-            // adding additional functions to OnnxContext.
-            if (type == typeof(float))
+            if ((type == typeof(int)) ||
+                (type == typeof(short)) || (type == typeof(ushort)) ||
+                (type == typeof(sbyte)) || (type == typeof(byte)))
+                ctx.AddInitializer(new int[size], type, new long[] { 1, size }, inputColumnName, false);
+            else if (type == typeof(uint) || (type == typeof(ulong)))
+                ctx.AddInitializer(new ulong[size], type == typeof(ulong), new long[] { 1, size }, inputColumnName, false);
+            else if (type == typeof(bool))
+                ctx.AddInitializer(new bool[size], new long[] { 1, size }, inputColumnName, false);
+            else if (type == typeof(long))
+                ctx.AddInitializer(new long[size], new long[] { 1, size }, inputColumnName, false);
+            else if (type == typeof(float))
                 ctx.AddInitializer(new float[size], new long[] { 1, size }, inputColumnName, false);
             else if (type == typeof(double))
                 ctx.AddInitializer(new double[size], new long[] { 1, size }, inputColumnName, false);
-            else if ((type == typeof(long)) || (type == typeof(int)) || (type == typeof(short)) || (type == typeof(sbyte)) ||
-                     (type == typeof(ulong)) || (type == typeof(uint)) || (type == typeof(ushort)) || (type == typeof(byte)))
-                ctx.AddInitializer(new long[size], new long[] { 1, size }, inputColumnName, false);
-            else if (type == typeof(string))
-                ctx.AddInitializer(new string[size], new long[] { 1, size }, inputColumnName, false);
+            else if ((type == typeof(string)) || (columnType is TextDataViewType))
+            {
+                string[] values = new string[size];
+                for (int i = 0; i < size; i++)
+                    values[i] = "";
+
+                ctx.AddInitializer(values, new long[] { 1, size }, inputColumnName, false);
+            }
             else
                 return false;
 

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Tests
                 var onnxResult = onnxTransformer.Transform(data);
 
                 // Step 4: Compare ONNX and ML.NET results.
-                CompareSelectedR4ScalarColumns("Score", "Score.onnx", transformedData, onnxResult, 1);
+                CompareSelectedColumns<float>("Score", "Score.onnx", transformedData, onnxResult, 1);
             }
 
             // Step 5: Check ONNX model's text format. This test will be not necessary if Step 3 and Step 4 can run on Linux and
@@ -186,7 +186,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(data);
                 var onnxResult = onnxTransformer.Transform(data);
-                CompareSelectedR4VectorColumns("Score", "Score.onnx", transformedData, onnxResult, 3);
+                CompareSelectedColumns<float>("Score", "Score.onnx", transformedData, onnxResult, 3);
             }
 
             // Check ONNX model's text format. We save the produced ONNX model as a text file and compare it against
@@ -241,7 +241,7 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedR4ScalarColumns(transformedData.Schema[2].Name, outputNames[2], transformedData, onnxResult, 3); // compare score results 
+                    CompareSelectedColumns<float>(transformedData.Schema[2].Name, outputNames[2], transformedData, onnxResult, 3); // compare score results 
                 }
                 // Compare the Onnx graph to a baseline if OnnxRuntime is not supported
                 else
@@ -302,8 +302,8 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedR4ScalarColumns(transformedData.Schema[5].Name, outputNames[3], transformedData, onnxResult, 3); //compare scores
-                    CompareSelectedScalarColumns<Boolean>(transformedData.Schema[4].Name, outputNames[2], transformedData, onnxResult); //compare predicted labels
+                    CompareSelectedColumns<float>(transformedData.Schema[5].Name, outputNames[3], transformedData, onnxResult, 3); //compare scores
+                    CompareSelectedColumns<bool>(transformedData.Schema[4].Name, outputNames[2], transformedData, onnxResult); //compare predicted labels
                 }
             }
             Done();
@@ -337,8 +337,8 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedR4VectorColumns(transformedData.Schema[2].Name, outputNames[2], transformedData, onnxResult); // whitened1
-                CompareSelectedR4VectorColumns(transformedData.Schema[3].Name, outputNames[3], transformedData, onnxResult); // whitened2
+                CompareSelectedColumns<float>(transformedData.Schema[2].Name, outputNames[2], transformedData, onnxResult); // whitened1
+                CompareSelectedColumns<float>(transformedData.Schema[3].Name, outputNames[3], transformedData, onnxResult); // whitened2
             }
             Done();
         }
@@ -393,9 +393,9 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedR4ScalarColumns(transformedData.Schema[5].Name, outputNames[3], transformedData, onnxResult, 3); //compare scores
-                    CompareSelectedScalarColumns<Boolean>(transformedData.Schema[4].Name, outputNames[2], transformedData, onnxResult); //compare predicted labels
-                    CompareSelectedR4ScalarColumns(transformedData.Schema.Last().Name, outputNames.Last(), transformedData, onnxResult, 3); //compare probabilities
+                    CompareSelectedColumns<float>(transformedData.Schema[5].Name, outputNames[3], transformedData, onnxResult, 3); //compare scores
+                    CompareSelectedColumns<bool>(transformedData.Schema[4].Name, outputNames[2], transformedData, onnxResult); //compare predicted labels
+                    CompareSelectedColumns<float>(transformedData.Schema.Last().Name, outputNames.Last(), transformedData, onnxResult, 3); //compare probabilities
                 }
             }
             Done();
@@ -443,7 +443,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(data);
                 var onnxResult = onnxTransformer.Transform(data);
-                CompareSelectedR4ScalarColumns(transformedData.Schema.Last().Name, outputNames.Last(), transformedData, onnxResult, 3); //compare probabilities
+                CompareSelectedColumns<float>(transformedData.Schema.Last().Name, outputNames.Last(), transformedData, onnxResult, 3); //compare probabilities
             }
             Done();
         }
@@ -492,7 +492,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedR4VectorColumns(nameof(DataPoint.Features), outputNames[0], transformedData, onnxResult, 3);
+                CompareSelectedColumns<float>(nameof(DataPoint.Features), outputNames[0], transformedData, onnxResult, 3);
             }
 
             Done();
@@ -947,7 +947,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedVectorColumns<UInt16>(transformedData.Schema[2].Name, outputNames[2], transformedData, onnxResult); //compare scores
+                CompareSelectedColumns<ushort>(transformedData.Schema[2].Name, outputNames[2], transformedData, onnxResult); //compare scores
             }
             Done();
         }
@@ -956,8 +956,18 @@ namespace Microsoft.ML.Tests
         // These are the supported conversions
         // ML.NET does not allow any conversions between signed and unsigned numeric types
         // Onnx does not seem to support casting a string to any type
-        // Though the onnx docs claim support for byte and sbyte, 
-        // CreateNamedOnnxValue in OnnxUtils.cs throws a NotImplementedException for those two
+        [InlineData(DataKind.SByte, DataKind.SByte)]
+        [InlineData(DataKind.SByte, DataKind.Int16)]
+        [InlineData(DataKind.SByte, DataKind.Int32)]
+        [InlineData(DataKind.SByte, DataKind.Int64)]
+        [InlineData(DataKind.SByte, DataKind.Single)]
+        [InlineData(DataKind.SByte, DataKind.Double)]
+        [InlineData(DataKind.Byte, DataKind.Byte)]
+        [InlineData(DataKind.Byte, DataKind.UInt16)]
+        [InlineData(DataKind.Byte, DataKind.UInt32)]
+        [InlineData(DataKind.Byte, DataKind.UInt64)]
+        [InlineData(DataKind.Byte, DataKind.Single)]
+        [InlineData(DataKind.Byte, DataKind.Double)]
         [InlineData(DataKind.Int16, DataKind.Int16)]
         [InlineData(DataKind.Int16, DataKind.Int32)]
         [InlineData(DataKind.Int16, DataKind.Int64)]
@@ -1053,7 +1063,7 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedR4VectorColumns(model.ColumnPairs[0].outputColumnName, outputNames[2], transformedData, onnxResult);
+                    CompareSelectedColumns<float>(model.ColumnPairs[0].outputColumnName, outputNames[2], transformedData, onnxResult);
                 }
             }
 
@@ -1114,7 +1124,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedVectorColumns<int>(model.LastTransformer.ColumnPairs[0].outputColumnName, outputNames[1], transformedData, onnxResult);
+                CompareSelectedColumns<int>(model.LastTransformer.ColumnPairs[0].outputColumnName, outputNames[1], transformedData, onnxResult);
             }
 
             CheckEquality(subDir, onnxTextName, parseOption: NumberParseOption.UseSingle);
@@ -1156,7 +1166,7 @@ namespace Microsoft.ML.Tests
                 var onnxResult = onnxTransformer.Transform(dataView);
 
                 CompareResults(mlnetResult.Schema[2].Name, outputNames[2], mlnetResult, onnxResult); //compare output values
-                CompareSelectedVectorColumns<UInt32>(mlnetResult.Schema[1].Name, outputNames[1], mlnetResult, onnxResult); //compare keys
+                CompareSelectedColumns<uint>(mlnetResult.Schema[1].Name, outputNames[1], mlnetResult, onnxResult); //compare keys
             }
             Done();
         }
@@ -1197,7 +1207,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxFilePath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedVectorColumns<ReadOnlyMemory<char>>(transformedData.Schema[1].Name, outputNames[1], transformedData, onnxResult);
+                CompareSelectedColumns<ReadOnlyMemory<char>>(transformedData.Schema[1].Name, outputNames[1], transformedData, onnxResult);
             }
 
             Done();
@@ -1261,25 +1271,38 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxFilePath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedR4VectorColumns(transformedData.Schema[transformedData.Schema.Count-1].Name, outputNames[outputNames.Length-1], transformedData, onnxResult, 3); //comparing Ngrams
+                    CompareSelectedColumns<float>(transformedData.Schema[transformedData.Schema.Count-1].Name, outputNames[outputNames.Length-1], transformedData, onnxResult, 3); //comparing Ngrams
                 }
             }
             Done();
         }
 
-        [Fact]
-        public void OptionalColumnOnnxTest()
+        [Theory]
+        [InlineData(DataKind.Boolean)]
+        [InlineData(DataKind.SByte)]
+        [InlineData(DataKind.Byte)]
+        [InlineData(DataKind.Int16)]
+        [InlineData(DataKind.UInt16)]
+        [InlineData(DataKind.Int32)]
+        [InlineData(DataKind.UInt32)]
+        [InlineData(DataKind.Int64)]
+        [InlineData(DataKind.UInt64)]
+        [InlineData(DataKind.Single)]
+        [InlineData(DataKind.Double)]
+        [InlineData(DataKind.String)]
+        public void OptionalColumnOnnxTest(DataKind dataKind)
         {
             var mlContext = new MLContext(seed: 1);
 
-            var samples = new List<BreastCancerCatFeatureExample>()
-            {
-                new BreastCancerCatFeatureExample() { Label = false, F1 = 0.0f, F2 = "F2"},
-                new BreastCancerCatFeatureExample() { Label = true, F1 = 0.1f, F2 = "F2"},
-            };
+            string dataPath = GetDataPath("breast-cancer.txt");
+
+            var dataView = ML.Data.LoadFromTextFile(dataPath, new[] {
+                new TextLoader.Column("Label", dataKind, 0),
+                new TextLoader.Column("Thickness", DataKind.Single, 1),
+            });
+
             IHostEnvironment env = mlContext as IHostEnvironment;
-            var dataView = mlContext.Data.LoadFromEnumerable(samples);
-            var args = new OptionalColumnTransform.Arguments { Columns = new[] { "F1" }, Data = dataView };
+            var args = new OptionalColumnTransform.Arguments { Columns = new[] { "Label" }, Data = dataView };
             var transform = OptionalColumnTransform.MakeOptional(env, args);
 
             var ctx = new OnnxContextImpl(mlContext, "model", "ML.NET", "0", 0, "machinelearning.dotnet", OnnxVersion.Stable);
@@ -1292,7 +1315,7 @@ namespace Microsoft.ML.Tests
                 onnxModel = SaveOnnxCommand.ConvertTransformListToOnnxModel(ctx, ch, root, sink, transforms, null, null);
             }
 
-            var onnxFileName = "optionalcol.onnx";
+            var onnxFileName = $"optionalcol-{dataKind}.onnx";
             var onnxModelPath = GetOutputPath(onnxFileName);
             var onnxTextFileName = "optionalcol.txt";
             var onnxTextPath = GetOutputPath(onnxTextFileName);
@@ -1305,7 +1328,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedR4ScalarColumns(transform.Model.OutputSchema[2].Name, outputNames[1], outputData, onnxResult);
+                CompareResults("Label", "Label.onnx", outputData, onnxResult);
             }
             Done();
         }
@@ -1340,7 +1363,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedScalarColumns<ReadOnlyMemory<Char>>(transformedData.Schema[3].Name, outputNames[3], transformedData, onnxResult);
+                CompareSelectedColumns<ReadOnlyMemory<Char>>(transformedData.Schema[3].Name, outputNames[3], transformedData, onnxResult);
             }
 
             Done();
@@ -1410,8 +1433,8 @@ namespace Microsoft.ML.Tests
                     var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                     var onnxTransformer = onnxEstimator.Fit(dataView);
                     var onnxResult = onnxTransformer.Transform(dataView);
-                    CompareSelectedScalarColumns<uint>(transformedData.Schema[5].Name, outputNames[2], transformedData, onnxResult); //compare predicted labels
-                    CompareSelectedR4VectorColumns(transformedData.Schema[6].Name, outputNames[3], transformedData, onnxResult, 4); //compare scores
+                    CompareSelectedColumns<uint>(transformedData.Schema[5].Name, outputNames[2], transformedData, onnxResult); //compare predicted labels
+                    CompareSelectedColumns<float>(transformedData.Schema[6].Name, outputNames[3], transformedData, onnxResult, 4); //compare scores
                 }
             }
             Done();
@@ -1445,7 +1468,7 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedR4ScalarColumns(model.ColumnPairs[0].outputColumnName, outputNames[2], transformedData, onnxResult);
+                CompareSelectedColumns<float>(model.ColumnPairs[0].outputColumnName, outputNames[2], transformedData, onnxResult);
             }
             Done();
         }
@@ -1493,10 +1516,10 @@ namespace Microsoft.ML.Tests
                 var onnxEstimator = mlContext.Transforms.ApplyOnnxModel(outputNames, inputNames, onnxModelPath);
                 var onnxTransformer = onnxEstimator.Fit(dataView);
                 var onnxResult = onnxTransformer.Transform(dataView);
-                CompareSelectedR4ScalarColumns("FeatureSelectMIScalarFloat", "FeatureSelectMIScalarFloat.onnx", transformedData, onnxResult);
-                CompareSelectedR4VectorColumns("FeatureSelectMIVectorFloat", "FeatureSelectMIVectorFloat.onnx", transformedData, onnxResult);
-                CompareSelectedR4ScalarColumns("ScalFeatureSelectMissing690", "ScalFeatureSelectMissing690.onnx", transformedData, onnxResult);
-                CompareSelectedR8VectorColumns("VecFeatureSelectMissing690", "VecFeatureSelectMissing690.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<float>("FeatureSelectMIScalarFloat", "FeatureSelectMIScalarFloat.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<float>("FeatureSelectMIVectorFloat", "FeatureSelectMIVectorFloat.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<float>("ScalFeatureSelectMissing690", "ScalFeatureSelectMissing690.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<double>("VecFeatureSelectMissing690", "VecFeatureSelectMissing690.onnx", transformedData, onnxResult);
             }
             Done();
         }
@@ -1549,10 +1572,10 @@ namespace Microsoft.ML.Tests
                 Assert.Equal("Thickness.onnx", outputNames[2]);
                 Assert.Equal("Label.onnx", outputNames[3]);
 
-                CompareSelectedScalarColumns<Single>("Size", "Size.onnx", transformedData, onnxResult);
-                CompareSelectedScalarColumns<int>("Shape", "Shape.onnx", transformedData, onnxResult);
-                CompareSelectedScalarColumns<double>("Thickness", "Thickness.onnx", transformedData, onnxResult);
-                CompareSelectedScalarColumns<bool>("Label", "Label.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<Single>("Size", "Size.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<int>("Shape", "Shape.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<double>("Thickness", "Thickness.onnx", transformedData, onnxResult);
+                CompareSelectedColumns<bool>("Label", "Label.onnx", transformedData, onnxResult);
             }
 
             onnxFileName = "SelectColumns.txt";
@@ -1564,7 +1587,7 @@ namespace Microsoft.ML.Tests
             Done();
         }
 
-        private void CompareResults(string leftColumnName, string rightColumnName, IDataView left, IDataView right)
+        private void CompareResults(string leftColumnName, string rightColumnName, IDataView left, IDataView right, int precision = 6)
         {
             var leftColumn = left.Schema[leftColumnName];
             var rightColumn = right.Schema[rightColumnName];
@@ -1573,30 +1596,33 @@ namespace Microsoft.ML.Tests
             Assert.Equal(leftType, rightType);
 
             if (leftType == NumberDataViewType.SByte)
-                CompareSelectedVectorColumns<sbyte>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<sbyte>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.Byte)
-                CompareSelectedVectorColumns<byte>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<byte>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.Int16)
-                CompareSelectedVectorColumns<short>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<short>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.UInt16)
-                CompareSelectedVectorColumns<ushort>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<ushort>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.Int32)
-                CompareSelectedVectorColumns<int>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<int>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.UInt32)
-                CompareSelectedVectorColumns<uint>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<uint>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.Int64)
-                CompareSelectedVectorColumns<long>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<long>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.UInt64)
-                CompareSelectedVectorColumns<ulong>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<ulong>(leftColumnName, rightColumnName, left, right);
             else if (leftType == NumberDataViewType.Single)
-                CompareSelectedR4VectorColumns(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<float>(leftColumnName, rightColumnName, left, right, precision);
             else if (leftType == NumberDataViewType.Double)
-                CompareSelectedVectorColumns<double>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<double>(leftColumnName, rightColumnName, left, right, precision);
+            else if (leftType == BooleanDataViewType.Instance)
+                CompareSelectedColumns<bool>(leftColumnName, rightColumnName, left, right);
             else if (leftType == TextDataViewType.Instance)
-                CompareSelectedVectorColumns<ReadOnlyMemory<char>>(leftColumnName, rightColumnName, left, right);
+                CompareSelectedColumns<ReadOnlyMemory<char>>(leftColumnName, rightColumnName, left, right);
+
         }
 
-        private void CompareSelectedVectorColumns<T>(string leftColumnName, string rightColumnName, IDataView left, IDataView right)
+        private void CompareSelectedColumns<T>(string leftColumnName, string rightColumnName, IDataView left, IDataView right, int precision = 6)
         {
             var leftColumn = left.Schema[leftColumnName];
             var rightColumn = right.Schema[rightColumnName];
@@ -1604,130 +1630,57 @@ namespace Microsoft.ML.Tests
             using (var expectedCursor = left.GetRowCursor(leftColumn))
             using (var actualCursor = right.GetRowCursor(rightColumn))
             {
-                VBuffer<T> expected = default;
+                T expectedScalar = default;
+                VBuffer<T> expectedVector = default;
+
+                ValueGetter<T> expectedScalarGetter = default;
+                ValueGetter<VBuffer<T>> expectedVectorGetter = default;
+
                 VBuffer<T> actual = default;
-                var expectedGetter = expectedCursor.GetGetter<VBuffer<T>>(leftColumn);
+
+                if (leftColumn.Type is VectorDataViewType)
+                    expectedVectorGetter = expectedCursor.GetGetter<VBuffer<T>>(leftColumn);
+                else
+                    expectedScalarGetter = expectedCursor.GetGetter<T>(leftColumn);
+
                 var actualGetter = actualCursor.GetGetter<VBuffer<T>>(rightColumn);
                 while (expectedCursor.MoveNext() && actualCursor.MoveNext())
                 {
-                    expectedGetter(ref expected);
                     actualGetter(ref actual);
 
-                    Assert.Equal(expected.Length, actual.Length);
-                    for (int i = 0; i < expected.Length; ++i)
-                        if (typeof(T) == typeof(ReadOnlyMemory<char>))
-                            Assert.Equal(expected.GetItemOrDefault(i).ToString(), actual.GetItemOrDefault(i).ToString());
-                        else
-                            Assert.Equal(expected.GetItemOrDefault(i), actual.GetItemOrDefault(i));
-                }
-            }
-        }
-
-        private void CompareSelectedR8VectorColumns(string leftColumnName, string rightColumnName, IDataView left, IDataView right, int precision = 6)
-        {
-            var leftColumn = left.Schema[leftColumnName];
-            var rightColumn = right.Schema[rightColumnName];
-
-            using (var expectedCursor = left.GetRowCursor(leftColumn))
-            using (var actualCursor = right.GetRowCursor(rightColumn))
-            {
-                VBuffer<double> expected = default;
-                VBuffer<double> actual = default;
-                var expectedGetter = expectedCursor.GetGetter<VBuffer<double>>(leftColumn);
-                var actualGetter = actualCursor.GetGetter<VBuffer<double>>(rightColumn);
-                while (expectedCursor.MoveNext() && actualCursor.MoveNext())
-                {
-                    expectedGetter(ref expected);
-                    actualGetter(ref actual);
-
-                    Assert.Equal(expected.Length, actual.Length);
-                    for (int i = 0; i < expected.Length; ++i)
-                        Assert.Equal(expected.GetItemOrDefault(i), actual.GetItemOrDefault(i), precision);
-                }
-            }
-        }
-
-        private void CompareSelectedR4VectorColumns(string leftColumnName, string rightColumnName, IDataView left, IDataView right, int precision = 6)
-        {
-            var leftColumn = left.Schema[leftColumnName];
-            var rightColumn = right.Schema[rightColumnName];
-
-            using (var expectedCursor = left.GetRowCursor(leftColumn))
-            using (var actualCursor = right.GetRowCursor(rightColumn))
-            {
-                VBuffer<float> expected = default;
-                VBuffer<float> actual = default;
-                var expectedGetter = expectedCursor.GetGetter<VBuffer<float>>(leftColumn);
-                var actualGetter = actualCursor.GetGetter<VBuffer<float>>(rightColumn);
-                while (expectedCursor.MoveNext() && actualCursor.MoveNext())
-                {
-                    expectedGetter(ref expected);
-                    actualGetter(ref actual);
-
-                    Assert.Equal(expected.Length, actual.Length);
-                    for (int i = 0; i < expected.Length; ++i)
+                    if (leftColumn.Type is VectorDataViewType)
                     {
-                        // We are using float values. But the Assert.Equal function takes doubles.
-                        // And sometimes the converted doubles are different in their precision.
-                        // So make sure we compare floats
-                        float exp = expected.GetItemOrDefault(i);
-                        float act = actual.GetItemOrDefault(i);
-                        CompareNumbersWithTolerance(exp, act, null, precision);
+                        expectedVectorGetter(ref expectedVector);
+                        Assert.Equal(expectedVector.Length, actual.Length);
+
+                        for (int i = 0; i < expectedVector.Length; ++i)
+                            CompareScalarValues<T>(expectedVector.GetItemOrDefault(i), actual.GetItemOrDefault(i), precision);
+                    }
+                    else
+                    {
+                        expectedScalarGetter(ref expectedScalar);
+                        Assert.Equal(1, actual.Length);
+
+                        var actualVal = actual.GetItemOrDefault(0);
+                        CompareScalarValues<T>(expectedScalar, actualVal, precision);
                     }
                 }
             }
         }
 
-        private void CompareSelectedR4ScalarColumns(string leftColumnName, string rightColumnName, IDataView left, IDataView right, int precision = 6)
+        private void CompareScalarValues<T>(T expected, T actual, int precision)
         {
-            var leftColumn = left.Schema[leftColumnName];
-            var rightColumn = right.Schema[rightColumnName];
-
-            using (var expectedCursor = left.GetRowCursor(leftColumn))
-            using (var actualCursor = right.GetRowCursor(rightColumn))
-            {
-                float expected = default;
-                VBuffer<float> actual = default;
-                var expectedGetter = expectedCursor.GetGetter<float>(leftColumn);
-                var actualGetter = actualCursor.GetGetter<VBuffer<float>>(rightColumn);
-                while (expectedCursor.MoveNext() && actualCursor.MoveNext())
-                {
-                    expectedGetter(ref expected);
-                    actualGetter(ref actual);
-
-                    // Scalar such as R4 (float) is converted to [1, 1]-tensor in ONNX format for consitency of making batch prediction.
-                    Assert.Equal(1, actual.Length);
-                    CompareNumbersWithTolerance(expected, actual.GetItemOrDefault(0), null, precision);
-                }
-            }
-        }
-
-        private void CompareSelectedScalarColumns<T>(string leftColumnName, string rightColumnName, IDataView left, IDataView right)
-        {
-            var leftColumn = left.Schema[leftColumnName];
-            var rightColumn = right.Schema[rightColumnName];
-
-            using (var expectedCursor = left.GetRowCursor(leftColumn))
-            using (var actualCursor = right.GetRowCursor(rightColumn))
-            {
-                T expected = default;
-                VBuffer<T> actual = default;
-                var expectedGetter = expectedCursor.GetGetter<T>(leftColumn);
-                var actualGetter = actualCursor.GetGetter<VBuffer<T>>(rightColumn);
-                while (expectedCursor.MoveNext() && actualCursor.MoveNext())
-                {
-                    expectedGetter(ref expected);
-                    actualGetter(ref actual);
-                    var actualVal = actual.GetItemOrDefault(0);
-
-                    Assert.Equal(1, actual.Length);
-
-                    if (typeof(T) == typeof(ReadOnlyMemory<Char>))
-                        Assert.Equal(expected.ToString(), actualVal.ToString());
-                    else
-                        Assert.Equal(expected, actualVal);
-                }
-            }
+            if (typeof(T) == typeof(ReadOnlyMemory<Char>))
+                Assert.Equal(expected.ToString(), actual.ToString());
+            else if (typeof(T) == typeof(double))
+                Assert.Equal(Convert.ToDouble(expected), Convert.ToDouble(actual), precision);
+            else if (typeof(T) == typeof(float))
+                // We are using float values. But the Assert.Equal function takes doubles.
+                // And sometimes the converted doubles are different in their precision.
+                // So make sure we compare floats
+                CompareNumbersWithTolerance(Convert.ToSingle(expected), Convert.ToSingle(actual), null, precision);
+            else
+                Assert.Equal(expected, actual);
         }
 
         private void SaveOnnxModel(ModelProto model, string binaryFormatPath, string textFormatPath)


### PR DESCRIPTION
OptionalColumnTransform didn't have support for boolean initializers. When I went to add that I saw that the TensorProto data was being set incorrectly for a few other data types. I tried to fix that and I had to redo the AddInitializer functionality in OnnxContext and related plumbing in OnnxUtils.cs.
Then when I went to add tests for all the data types that are now supported in OptionalColumnTransform, I realized I needed to simplify the column comparison in OnnxConversionTest. In the process I also added support SByte and Byte in OnnxUtils - CreateNamedValue and fixed up the corresponding tests.

In summary:
- Cleaned up OnnxContext's initializer interface
- Cleaned up column comparison functionality on OnnxConversionTest
- Fixed bugs in OptionalColumnTransform's onnx export and added support for boolean initializers

