### PR TITLE
Changed Binarizer node to be cast to the type of the predicted label …

### DIFF
--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Microsoft.ML.Internal.Utilities;
@@ -202,7 +203,15 @@ namespace Microsoft.ML.Data
             OnnxNode node;
             var binarizerOutput = ctx.AddIntermediateVariable(null, "BinarizerOutput", true);
 
-            node = ctx.CreateNode(opType, ctx.GetVariableName(outColumnNames[1]), binarizerOutput, ctx.GetNodeName(opType));
+            string scoreColumn;
+            if (Bindings.RowMapper.OutputSchema[Bindings.ScoreColumnIndex].Name == "Score")
+                scoreColumn = outColumnNames[1];
+            else
+            {
+                Host.Assert(Bindings.InfoCount >= 3);
+                scoreColumn = outColumnNames[2];
+            }
+            node = ctx.CreateNode(opType, ctx.GetVariableName(scoreColumn), binarizerOutput, ctx.GetNodeName(opType));
             node.AddAttribute("threshold", _threshold);
 
             opType = "Cast";

--- a/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
+++ b/src/Microsoft.ML.Data/Scorers/BinaryClassifierScorer.cs
@@ -216,10 +216,11 @@ namespace Microsoft.ML.Data
                 node = ctx.CreateNode(opType, ctx.GetVariableName(outColumnNames[1]), binarizerOutput, ctx.GetNodeName(opType));
                 node.AddAttribute("threshold", 0.0);
             }
+
             opType = "Cast";
             node = ctx.CreateNode(opType, binarizerOutput, ctx.GetVariableName(outColumnNames[0]), ctx.GetNodeName(opType), "");
-            var t = InternalDataKindExtensions.ToInternalDataKind(DataKind.Boolean).ToType();
-            node.AddAttribute("to", t);
+            var predictedLabelCol = OutputSchema.GetColumnOrNull(outColumnNames[0]);
+            node.AddAttribute("to", predictedLabelCol.HasValue ? predictedLabelCol.Value.Type.RawType : typeof(bool));
         }
 
         private protected override IDataTransform ApplyToDataCore(IHostEnvironment env, IDataView newSource)

--- a/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ExcludeVariablesInOnnxConversion.txt
+++ b/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ExcludeVariablesInOnnxConversion.txt
@@ -413,7 +413,7 @@
       },
       {
         "input": [
-          "Probability"
+          "Score"
         ],
         "output": [
           "BinarizerOutput"
@@ -423,7 +423,6 @@
         "attribute": [
           {
             "name": "threshold",
-            "f": 0.5,
             "type": "FLOAT"
           }
         ],

--- a/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ModelWithLessIO.txt
+++ b/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/ModelWithLessIO.txt
@@ -739,7 +739,7 @@
       },
       {
         "input": [
-          "Probability"
+          "Score"
         ],
         "output": [
           "BinarizerOutput"
@@ -749,7 +749,6 @@
         "attribute": [
           {
             "name": "threshold",
-            "f": 0.5,
             "type": "FLOAT"
           }
         ],

--- a/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/OneHotBagPipeline.txt
+++ b/test/BaselineOutput/Common/Onnx/BinaryClassification/BreastCancer/OneHotBagPipeline.txt
@@ -366,7 +366,7 @@
       },
       {
         "input": [
-          "Probability"
+          "Score"
         ],
         "output": [
           "BinarizerOutput"
@@ -376,7 +376,6 @@
         "attribute": [
           {
             "name": "threshold",
-            "f": 0.5,
             "type": "FLOAT"
           }
         ],


### PR DESCRIPTION
…column's data type

In BinaryClassifierScorer's SaveAsOnnxCore function we were always casting the output of the Binarizer to a bool. But in some cases BinaryClassifierScorer can output a key value (uint) and in this case we should cast the output to a uint. This fix changes the cast to be dependent on the output type of the predicted label. 