### PR TITLE
Enable OnnxTransformer to accept KeyDataViewTypes as if they were UInt32

### DIFF
--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -389,7 +389,8 @@ namespace Microsoft.ML.Transforms.Onnx
                         throw Host.Except($"Variable length input columns not supported");
 
                     if (type.GetItemType() != inputNodeInfo.DataViewType.GetItemType())
-                        throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.Inputs[i], inputNodeInfo.DataViewType.GetItemType().ToString(), type.ToString());
+                        if(!(type.GetItemType() is KeyDataViewType && inputNodeInfo.DataViewType.GetItemType().RawType == typeof(UInt32)))
+                            throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.Inputs[i], inputNodeInfo.DataViewType.GetItemType().ToString(), type.ToString());
 
                     // If the column is one dimension we make sure that the total size of the Onnx shape matches.
                     // Compute the total size of the known dimensions of the shape.

--- a/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
+++ b/src/Microsoft.ML.OnnxTransformer/OnnxTransform.cs
@@ -389,8 +389,14 @@ namespace Microsoft.ML.Transforms.Onnx
                         throw Host.Except($"Variable length input columns not supported");
 
                     if (type.GetItemType() != inputNodeInfo.DataViewType.GetItemType())
-                        if(!(type.GetItemType() is KeyDataViewType && inputNodeInfo.DataViewType.GetItemType().RawType == typeof(UInt32)))
+                    {
+                        // If the ONNX model input node expects a type that mismatches with the type of the input IDataView column that is provided
+                        // then throw an exception.
+                        // This is done except in the case where the ONNX model input node expects a UInt32 but the input column is actually KeyDataViewType
+                        // This is done to support a corner case originated in NimbusML. For more info, see: https://github.com/microsoft/NimbusML/issues/426
+                        if (!(type.GetItemType() is KeyDataViewType && inputNodeInfo.DataViewType.GetItemType().RawType == typeof(UInt32)))
                             throw Host.ExceptSchemaMismatch(nameof(inputSchema), "input", _parent.Inputs[i], inputNodeInfo.DataViewType.GetItemType().ToString(), type.ToString());
+                    }
 
                     // If the column is one dimension we make sure that the total size of the Onnx shape matches.
                     // Compute the total size of the known dimensions of the shape.

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1475,7 +1475,8 @@ namespace Microsoft.ML.Tests
             var originalData = loader.Load(dataPath);
             var pipeline1 = mlContext.Transforms.Conversion.MapValueToKey("Label");
             var mappedData = pipeline1.Fit(originalData).Transform(originalData);
-            string mappedDataPath = @"C:\Users\anvelazq\Desktop\is22\data-new.idv";
+
+            string mappedDataPath = GetOutputPath("kdvt-as-uint32-mapped-data.idv");
             using (FileStream stream = new FileStream(mappedDataPath, FileMode.Create))
                 mlContext.Data.SaveAsBinary(mappedData, stream, keepHidden: false);
 

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -1505,8 +1505,9 @@ namespace Microsoft.ML.Tests
             var onnxResult = onnxEstimator.Fit(reloadedData).Transform(reloadedData);
 
             // Step 6: Compare results to an onnx model created using the mappedData IDataView
-            // Notice that this ONNX model would actually include the steps to do the ValueToKeyTransformer mapping
-            // And because of this, it can only be applied to reloadedData dataview, despite mappedData was used to create the model.
+            // Notice that this ONNX model would actually include the steps to do the ValueToKeyTransformer mapping,
+            // because mappedData actually includes the information to do the mapping, and so ONNX would that automatically.
+            // And because of this, it can only be applied to originalData dataview, despite mappedData was used to create the model.
             // If it's tried to apply this model to mappedData or reloadedData, it will throw an exception, since the ONNX model
             // will expect a Label input of type string (which only originalData provides).
             string onnxModelPath2 = GetOutputPath("onnxmodel2-kdvt-as-uint32.onnx");

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -711,12 +711,12 @@ namespace Microsoft.ML.Tests
             var pipeline = mlContext.Transforms.NormalizeMinMax("Features").
                 Append(mlContext.MulticlassClassification.Trainers.LbfgsMaximumEntropy(new LbfgsMaximumEntropyMulticlassTrainer.Options() { NumberOfThreads = 1 }));
 
-            var model = pipeline.Fit(data1);
-            var transformedData = model.Transform(data1);
-            var onnxModel = mlContext.Model.ConvertToOnnxProtobuf(model, data1);
+            var model = pipeline.Fit(data);
+            var transformedData = model.Transform(data);
+            var onnxModel = mlContext.Model.ConvertToOnnxProtobuf(model, data);
 
             var subDir = Path.Combine("..", "..", "BaselineOutput", "Common", "Onnx", "MultiClassClassification", "BreastCancer");
-            var onnxFileName = "MultiClassificationLogisticRegressionSaveModelToOnnxTest-WithoutMVTK.onnx";
+            var onnxFileName = "MultiClassificationLogisticRegressionSaveModelToOnnxTest.onnx";
             var onnxFilePath = GetOutputPath(subDir, onnxFileName);
             var onnxTextName = "MultiClassificationLogisticRegressionSaveModelToOnnxTest.txt";
             var onnxTextPath = GetOutputPath(subDir, onnxTextName);
@@ -1526,7 +1526,7 @@ namespace Microsoft.ML.Tests
         {
             var mlContext = new MLContext(seed: 1);
 
-            string dataPath = GetDataPath("breast -cancer.txt");
+            string dataPath = GetDataPath("breast-cancer.txt");
 
             var dataView = ML.Data.LoadFromTextFile(dataPath, new[] {
                 new TextLoader.Column("ScalarFloat", DataKind.Single, 6),

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -704,11 +704,8 @@ namespace Microsoft.ML.Tests
                 separatorChar: '\t',
                 hasHeader: true);
 
-            var pipeline1 = mlContext.Transforms.Conversion.MapValueToKey("Label");
-
-            var data1 = pipeline1.Fit(data).Transform(data);
-
             var pipeline = mlContext.Transforms.NormalizeMinMax("Features").
+                Append(mlContext.Transforms.Conversion.MapValueToKey("Label")).
                 Append(mlContext.MulticlassClassification.Trainers.LbfgsMaximumEntropy(new LbfgsMaximumEntropyMulticlassTrainer.Options() { NumberOfThreads = 1 }));
 
             var model = pipeline.Fit(data);


### PR DESCRIPTION
Addresses https://github.com/microsoft/NimbusML/issues/426

As discussed offline with @harishsk , @ganik and @pieths , the update in here is the best temporary solution to the problem.

Simply enables OnnxTransformer to accept a `KeyDataViewType` column as input of a model that actually expects an `UInt32` input column. This, because of the way that NimbusML works with Category columns in Pandas' DataFrames, by converting them into `KeyDataViewType` columns in ML.NET, without actually adding KeyToValueTransformers into the pipeline.