### PR TITLE
fix issue in WaiterWaiter caused by race condition

### DIFF
--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -683,12 +683,10 @@ namespace Microsoft.ML.Data
                 foreach (var w in _waiters)
                     w.Wait(pos);
 
-                // Back ground thread is filling data view and change the _rowCount from -1 to real row count.
-                // Original is: return pos < _parent._rowCount || _parent._rowCount == -1;
-                // In some case the change to _rowCount happens
-                // after pos < _parent._rowCount finish but before _parent._rowCount == -1
-                // thus cause flakyness
-                return _parent._rowCount == -1 || pos < _parent._rowCount;
+                // _parent._rowCount may or may not be initialized at this point. Only read the value once
+                // to avoid race conditions.
+                var rowCount = _parent._rowCount;
+                return rowCount == -1 || pos < rowCount;
             }
 
             public static Wrapper Create(CacheDataView parent, Func<int, bool> pred)

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -682,7 +682,13 @@ namespace Microsoft.ML.Data
             {
                 foreach (var w in _waiters)
                     w.Wait(pos);
-                return pos < _parent._rowCount || _parent._rowCount == -1;
+
+                // Back ground thread is filling data view and change the _rowCount from -1 to real row count.
+                // Original is: return pos < _parent._rowCount || _parent._rowCount == -1;
+                // In some case the change to _rowCount happens
+                // after pos < _parent._rowCount finish but before _parent._rowCount == -1
+                // thus cause flakyness
+                return _parent._rowCount == -1 || pos < _parent._rowCount;
             }
 
             public static Wrapper Create(CacheDataView parent, Func<int, bool> pred)

--- a/src/Microsoft.ML.Data/DataView/CacheDataView.cs
+++ b/src/Microsoft.ML.Data/DataView/CacheDataView.cs
@@ -609,8 +609,9 @@ namespace Microsoft.ML.Data
 
             private TrivialWaiter(CacheDataView parent)
             {
-                Contracts.Assert(parent.GetRowCount().HasValue);
-                _lim = parent.GetRowCount().Value;
+                var rowCount = parent.GetRowCount();
+                Contracts.Assert(rowCount.HasValue);
+                _lim = rowCount.Value;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -686,7 +687,9 @@ namespace Microsoft.ML.Data
             {
                 foreach (var w in _waiters)
                     w.Wait(pos);
-                return !_parent.GetRowCount().HasValue || pos < _parent.GetRowCount().Value;
+
+                var rowCount = _parent.GetRowCount();
+                return !rowCount.HasValue || pos < rowCount.Value;
             }
 
             public static Wrapper Create(CacheDataView parent, Func<int, bool> pred)
@@ -1423,8 +1426,8 @@ namespace Microsoft.ML.Data
                     : base(parent, input, srcCol, waiter)
                 {
                     _getter = input.GetGetter<T>(input.Schema[srcCol]);
-                    if (parent.GetRowCount().HasValue)
-                        _values = new T[(int)parent.GetRowCount().Value];
+                    if (parent.GetRowCount() is { } rowCount)
+                        _values = new T[rowCount];
                 }
 
                 public override void CacheCurrent()

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -2640,8 +2640,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void EntryPointEvaluateRegression()
         {
             var dataPath = GetDataPath(TestDatasets.generatedRegressionDatasetmacro.trainFilename);
@@ -2752,8 +2750,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void EntryPointSdcaBinary()
         {
             TestEntryPointRoutine("breast-cancer.txt", "Trainers.StochasticDualCoordinateAscentBinaryClassifier");
@@ -2766,8 +2762,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void EntryPointSDCARegression()
         {
             TestEntryPointRoutine(TestDatasets.generatedRegressionDatasetmacro.trainFilename, "Trainers.StochasticDualCoordinateAscentRegressor", loader: TestDatasets.generatedRegressionDatasetmacro.loaderSettings);
@@ -3855,8 +3849,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void EntryPointChainedCrossValMacros()
         {
             string inputGraph = @"
@@ -5506,8 +5498,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestCrossValidationMacroWithStratification()
         {
             var dataPath = GetDataPath(@"breast-cancer.txt");
@@ -6039,8 +6029,6 @@ namespace Microsoft.ML.RunTests
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TestOvaMacro()
         {
             var dataPath = GetDataPath(@"iris.txt");

--- a/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
+++ b/test/Microsoft.ML.Functional.Tests/IntrospectiveTraining.cs
@@ -203,8 +203,6 @@ namespace Microsoft.ML.Functional.Tests
         /// Introspective Training: Linear model parameters may be inspected.
         /// </summary>
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void InpsectLinearModelParameters()
         {
             var mlContext = new MLContext(seed: 1);

--- a/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
+++ b/test/Microsoft.ML.Predictor.Tests/TestPredictors.cs
@@ -247,8 +247,6 @@ namespace Microsoft.ML.RunTests
         [X64Fact("x86 output differs from Baseline")]
         [TestCategory("Binary")]
         [TestCategory("SDCA")]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void LinearClassifierTest()
         {
             var binaryPredictors = new[]
@@ -324,8 +322,6 @@ namespace Microsoft.ML.RunTests
         ///</summary>
         [LessThanNetCore30OrNotNetCoreAndX64Fact("netcoreapp3.0 and x86 output differs from Baseline")]
         [TestCategory("Binary")]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void BinaryClassifierLogisticRegressionNonNegativeTest()
         {
             var binaryPredictors = new[] { TestLearners.logisticRegressionNonNegative };

--- a/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
+++ b/test/Microsoft.ML.TestFramework/DataPipe/TestDataPipe.cs
@@ -1022,8 +1022,6 @@ namespace Microsoft.ML.RunTests
 
         [TestCategory("DataPipeSerialization")]
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void SavePipeTrainAndScoreFccTransformStr()
         {
             TestCore(null, false,

--- a/test/Microsoft.ML.Tests/OnnxConversionTest.cs
+++ b/test/Microsoft.ML.Tests/OnnxConversionTest.cs
@@ -696,8 +696,6 @@ namespace Microsoft.ML.Tests
         }
 
         [LightGBMFact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void LightGbmBinaryClassificationOnnxConversionTest()
         {
             // Step 1: Create and train a ML.NET pipeline.

--- a/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/Api/CookbookSamples/CookbookSamplesDynamicApi.cs
@@ -204,8 +204,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TrainRegressionModel()
             => TrainRegression(GetDataPath(TestDatasets.generatedRegressionDataset.trainFilename), GetDataPath(TestDatasets.generatedRegressionDataset.testFilename),
                 DeleteOutputPath("cook_model.zip"));
@@ -293,8 +291,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TrainAndPredictOnIris()
             => PredictOnIris(TrainOnIris(GetDataPath("iris.data")));
 
@@ -629,8 +625,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void CrossValidationIris()
             => CrossValidationOn(GetDataPath("iris.data"));
 
@@ -708,8 +702,6 @@ namespace Microsoft.ML.Tests.Scenarios.Api.CookbookSamples
         }
 
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void CustomTransformer()
         {
             var mlContext = new MLContext(1);

--- a/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationTests.cs
+++ b/test/Microsoft.ML.Tests/Scenarios/IrisPlantClassificationTests.cs
@@ -15,8 +15,6 @@ namespace Microsoft.ML.Scenarios
     public partial class ScenariosTests : BaseTestClass
     {
         [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
         public void TrainAndPredictIrisModelTest()
         {
             var mlContext = new MLContext(seed: 1);


### PR DESCRIPTION
1. Fix issue in WaiterWaiter caused by race condition.
2. Re-enable affected tests as below:
EntryPointEvaluateRegression
EntryPointSdcaBinary
EntryPointSDCARegression
EntryPointChainedCrossValMacros
TestCrossValidationMacroWithStratification
TestOvaMacro
TrainAndPredictOnIris
CrossValidationIris
LinearClassifierTest
SavePipeTrainAndScoreFccTransformStr
BinaryClassifierLogisticRegressionNonNegativeTest
InpsectLinearModelParameters
TrainRegressionModel
CustomTransformer
TrainAndPredictIrisModelTest
LightGbmBinaryClassificationOnnxConversionTest