### PR TITLE
Added exception for non-existent directory in ImageLoader

### DIFF
--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Data
         internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder = null, bool type = true, params (string outputColumnName, string inputColumnName)[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
         {
-            // Throws ArgumentException if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
+            // Throws System.InvalidOperationException if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
             if (imageFolder != null)
                 if (Directory.Exists(imageFolder))
                     ImageFolder = Path.GetFullPath(imageFolder);

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -103,12 +103,12 @@ namespace Microsoft.ML.Data
         internal ImageLoadingTransformer(IHostEnvironment env, string imageFolder = null, bool type = true, params (string outputColumnName, string inputColumnName)[] columns)
             : base(Contracts.CheckRef(env, nameof(env)).Register(nameof(ImageLoadingTransformer)), columns)
         {
-            // Throws System.InvalidOperationException if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
+            // Throws ArgumentException  if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
             if (imageFolder != null)
                 if (Directory.Exists(imageFolder))
                     ImageFolder = Path.GetFullPath(imageFolder);
                 else
-                    throw Host.Except(String.Format("Directory \"{0}\" does not exist.", imageFolder));
+                    throw new ArgumentException(String.Format("Directory \"{0}\" does not exist.", imageFolder));
             else
                 ImageFolder = null;
             _useImageType = type;

--- a/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
+++ b/src/Microsoft.ML.ImageAnalytics/ImageLoader.cs
@@ -105,7 +105,10 @@ namespace Microsoft.ML.Data
         {
             // Throws ArgumentException if given imageFolder path is invalid or empty. Note: imageFolder may be null in this case.
             if (imageFolder != null)
-                ImageFolder = Path.GetFullPath(imageFolder);
+                if (Directory.Exists(imageFolder))
+                    ImageFolder = Path.GetFullPath(imageFolder);
+                else
+                    throw Host.Except(String.Format("Directory \"{0}\" does not exist.", imageFolder));
             else
                 ImageFolder = null;
             _useImageType = type;


### PR DESCRIPTION
Path.GetFullPath("C://non-Existant) was not throwing an exception. Hence there is a need to explicitly check for the existence of the imageFolder directory. Related to #4429 .  