### PR TITLE
enable and disable some tests

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -25,7 +25,7 @@ jobs:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
         _includeBenchmarkData: true
-    runSpecific: true
+    innerLoop: true
     pool:
       name: Hosted Ubuntu 1604
 
@@ -34,7 +34,7 @@ jobs:
     name: Ubuntu_x64_NetCoreApp21
     buildScript: ./build.sh
     container: UbuntuContainer
-    runSpecific: true
+    innerLoop: true
     pool:
       name: Hosted Ubuntu 1604
 
@@ -42,7 +42,7 @@ jobs:
   parameters:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
-    runSpecific: true
+    innerLoop: true
     pool:
       name: Hosted macOS High Sierra
 
@@ -59,7 +59,7 @@ jobs:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
         _includeBenchmarkData: true
-    runSpecific: true
+    innerLoop: true
     pool:
       name: NetCorePublic-Pool
       queue: buildpool.windows.10.amd64.vs2017.open
@@ -68,7 +68,7 @@ jobs:
   parameters:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
-    runSpecific: true
+    innerLoop: true
     pool:
       name: Hosted VS2017
 
@@ -85,7 +85,7 @@ jobs:
         _configuration: Release-netfx
         _config_short: RFX
         _includeBenchmarkData: false
-    runSpecific: true
+    innerLoop: true
     pool:
       name: Hosted VS2017
 
@@ -94,6 +94,6 @@ jobs:
     name: Windows_x86_NetCoreApp21
     architecture: x86
     buildScript: build.cmd
-    runSpecific: true
+    innerLoop: true
     pool:
       name: Hosted VS2017

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -25,7 +25,7 @@ jobs:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
         _includeBenchmarkData: true
-    innerLoop: true
+    runSpecific: true
     pool:
       name: Hosted Ubuntu 1604
 
@@ -34,7 +34,7 @@ jobs:
     name: Ubuntu_x64_NetCoreApp21
     buildScript: ./build.sh
     container: UbuntuContainer
-    innerLoop: true
+    runSpecific: true
     pool:
       name: Hosted Ubuntu 1604
 
@@ -42,7 +42,7 @@ jobs:
   parameters:
     name: MacOS_x64_NetCoreApp21
     buildScript: ./build.sh
-    innerLoop: true
+    runSpecific: true
     pool:
       name: Hosted macOS High Sierra
 
@@ -59,7 +59,7 @@ jobs:
         _configuration: Release-netcoreapp3_0
         _config_short: RI
         _includeBenchmarkData: true
-    innerLoop: true
+    runSpecific: true
     pool:
       name: NetCorePublic-Pool
       queue: buildpool.windows.10.amd64.vs2017.open
@@ -68,7 +68,7 @@ jobs:
   parameters:
     name: Windows_x64_NetCoreApp21
     buildScript: build.cmd
-    innerLoop: true
+    runSpecific: true
     pool:
       name: Hosted VS2017
 
@@ -85,7 +85,7 @@ jobs:
         _configuration: Release-netfx
         _config_short: RFX
         _includeBenchmarkData: false
-    innerLoop: true
+    runSpecific: true
     pool:
       name: Hosted VS2017
 
@@ -94,6 +94,6 @@ jobs:
     name: Windows_x86_NetCoreApp21
     architecture: x86
     buildScript: build.cmd
-    innerLoop: true
+    runSpecific: true
     pool:
       name: Hosted VS2017

--- a/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/TestEntryPoints.cs
@@ -6366,6 +6366,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [TensorFlowFact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void EntryPointTensorFlowTransform()
         {
             Env.ComponentCatalog.RegisterAssembly(typeof(TensorFlowTransformer).Assembly);
@@ -6381,6 +6383,8 @@ namespace Microsoft.ML.RunTests
         }
 
         [TensorFlowFact]
+        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
+        [Trait("Category", "SkipInCI")]
         public void TestTensorFlowEntryPoint()
         {
             var dataPath = GetDataPath("Train-Tiny-28x28.txt");

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.ML.TestFramework.Attributes;
@@ -101,11 +102,12 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Fact]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
-        public void SavePipeSlidingWindow()
+        [Theory]
+        [IterationData(iterations: 1000)]
+        [Trait("Category", "RunSpecificTest")]
+        public void SavePipeSlidingWindow(int iterations)
         {
+            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                     new[]{"loader=Text{col=Input:R4:1}",
                     "xf=SlideWinTransform{src=Input name=Output wnd=3 l=0}" });
@@ -113,9 +115,12 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Fact]
-        public void SavePipeSlidingWindowW1L1()
+        [Theory]
+        [IterationData(iterations: 1000)]
+        [Trait("Category", "RunSpecificTest")]
+        public void SavePipeSlidingWindowW1L1(int iterations)
         {
+            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                 new[]{"loader=Text{col=Input:R4:1}",
                 "xf=SlideWinTransform{src=Input name=Output wnd=1 l=1}" });
@@ -123,11 +128,13 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Fact]
+        [Theory]
+        [IterationData(iterations: 1000)]
         //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "SkipInCI")]
-        public void SavePipeSlidingWindowW2L1()
+        [Trait("Category", "RunSpecificTest")]
+        public void SavePipeSlidingWindowW2L1(int iterations)
         {
+            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                     new[]{"loader=Text{col=Input:R4:1}",
                     "xf=SlideWinTransform{src=Input name=Output wnd=2 l=1}" });
@@ -135,9 +142,12 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Fact]
-        public void SavePipeSlidingWindowW1L2()
+        [Theory]
+        [IterationData(iterations: 1000)]
+        [Trait("Category", "RunSpecificTest")]
+        public void SavePipeSlidingWindowW1L2(int iterations)
         {
+            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                     new[]{"loader=Text{col=Input:R4:1}",
                     "xf=SlideWinTransform{src=Input name=Output wnd=1 l=2}" });

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
@@ -102,12 +102,9 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Theory]
-        [IterationData(iterations: 1000)]
-        [Trait("Category", "RunSpecificTest")]
-        public void SavePipeSlidingWindow(int iterations)
+        [Fact]
+        public void SavePipeSlidingWindow()
         {
-            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                     new[]{"loader=Text{col=Input:R4:1}",
                     "xf=SlideWinTransform{src=Input name=Output wnd=3 l=0}" });
@@ -115,12 +112,9 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Theory]
-        [IterationData(iterations: 1000)]
-        [Trait("Category", "RunSpecificTest")]
-        public void SavePipeSlidingWindowW1L1(int iterations)
+        [Fact]
+        public void SavePipeSlidingWindowW1L1()
         {
-            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                 new[]{"loader=Text{col=Input:R4:1}",
                 "xf=SlideWinTransform{src=Input name=Output wnd=1 l=1}" });
@@ -128,13 +122,9 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Theory]
-        [IterationData(iterations: 1000)]
-        //Skipping test temporarily. This test will be re-enabled once the cause of failures has been determined
-        [Trait("Category", "RunSpecificTest")]
-        public void SavePipeSlidingWindowW2L1(int iterations)
+        [Fact]
+        public void SavePipeSlidingWindowW2L1()
         {
-            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                     new[]{"loader=Text{col=Input:R4:1}",
                     "xf=SlideWinTransform{src=Input name=Output wnd=2 l=1}" });
@@ -142,12 +132,9 @@ namespace Microsoft.ML.RunTests
             Done();
         }
 
-        [Theory]
-        [IterationData(iterations: 1000)]
-        [Trait("Category", "RunSpecificTest")]
-        public void SavePipeSlidingWindowW1L2(int iterations)
+        [Fact]
+        public void SavePipeSlidingWindowW1L2()
         {
-            Console.WriteLine($"{iterations} - th run for SsaForecast");
             TestCore(null, true,
                     new[]{"loader=Text{col=Input:R4:1}",
                     "xf=SlideWinTransform{src=Input name=Output wnd=1 l=2}" });

--- a/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
+++ b/test/Microsoft.ML.TimeSeries.Tests/TimeSeries.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using System.Linq;
 using Microsoft.ML.TestFramework.Attributes;
-using Microsoft.ML.TestFrameworkCommon.Attributes;
 using Microsoft.ML.Transforms.TimeSeries;
 using Xunit;
 using Xunit.Abstractions;


### PR DESCRIPTION
1. re-enable SavePipeSlidingWindow related test, have a deeper look at these tests and they are also infected by the race condition issue in WatierWaiter that cause data load incomplete. Error look like below: System.InvalidOperationException : Right has more rows at position: 110
https://github.com/dotnet/machinelearning/pull/4829

2. Disable 2 tensorflow related test as we met below error: System.AccessViolationException : Attempted to read or write protected memory. This is often an indication that other memory is corrupt.

